### PR TITLE
[testnet] integration tests wasm expenses

### DIFF
--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -69,7 +69,7 @@ async fn collect_pledges() {
     let mut pledges_and_transfers = Vec::new();
 
     for (backer_chain, backer_account, _balance) in &backers {
-        let pledge_certificate = backer_chain
+        let (pledge_certificate, _) = backer_chain
             .add_block(|block| {
                 block.with_operation(
                     campaign_id,
@@ -171,7 +171,7 @@ async fn cancel_successful_campaign() {
     let mut pledges_and_transfers = Vec::new();
 
     for (backer_chain, backer_account, _balance) in &backers {
-        let pledge_certificate = backer_chain
+        let (pledge_certificate, _) = backer_chain
             .add_block(|block| {
                 block.with_operation(
                     campaign_id,

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -114,9 +114,10 @@ pub async fn create_with_accounts(
             })
             .await;
 
+        let (claim_certificate, _) = claim_certificate;
         assert_eq!(claim_certificate.outgoing_message_count(), 1);
 
-        let transfer_certificate = token_chain
+        let (transfer_certificate, _) = token_chain
             .add_block(|block| {
                 block.with_messages_from(&claim_certificate);
             })
@@ -124,7 +125,7 @@ pub async fn create_with_accounts(
 
         assert_eq!(transfer_certificate.outgoing_message_count(), 1);
 
-        chain
+        let _ = chain
             .add_block(|block| {
                 block.with_messages_from(&transfer_certificate);
             })

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -40,19 +40,17 @@ async fn test_cross_chain_transfer() {
 
     let (_, resources) = sender_chain
         .add_block(|block| {
-            for _ in 0..700 {
-                block.with_operation(
-                    application_id,
-                    FungibleOperation::Transfer {
-                        owner: sender_account,
-                        amount: transfer_amount,
-                        target_account: Account {
-                            chain_id: receiver_chain.id(),
-                            owner: receiver_account,
-                        },
+            block.with_operation(
+                application_id,
+                FungibleOperation::Transfer {
+                    owner: sender_account,
+                    amount: transfer_amount,
+                    target_account: Account {
+                        chain_id: receiver_chain.id(),
+                        owner: receiver_account,
                     },
-                );
-            }
+                },
+            );
         })
         .await;
     println!("Transfer block: {resources}");

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -21,7 +21,7 @@ async fn hex_game() {
     let (validator, app_id, creation_chain) =
         TestValidator::with_current_application::<HexAbi, _, _>((), Timeouts::default()).await;
 
-    let certificate = creation_chain
+    let (certificate, _) = creation_chain
         .add_block(|block| {
             let operation = Operation::Start {
                 board_size: 2,
@@ -102,7 +102,7 @@ async fn hex_game_clock() {
             .saturating_sub(TimeDelta::from_millis(1)),
     );
 
-    let certificate = creation_chain
+    let (certificate, _) = creation_chain
         .add_block(|block| {
             let operation = Operation::Start {
                 board_size: 2,

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -147,7 +147,7 @@ async fn single_transaction() {
             price,
         };
         let operation = Operation::ExecuteOrder { order };
-        let bid_certificate = user_chain_a
+        let (bid_certificate, _) = user_chain_a
             .add_block(|block| {
                 block.with_operation(matching_id, operation);
             })
@@ -199,7 +199,7 @@ async fn single_transaction() {
             price,
         };
         let operation = Operation::ExecuteOrder { order };
-        let ask_certificate = user_chain_b
+        let (ask_certificate, _) = user_chain_b
             .add_block(|block| {
                 block.with_operation(matching_id, operation);
             })
@@ -252,7 +252,7 @@ async fn single_transaction() {
         order_id: order_ids_a[0],
     };
     let operation = Operation::ExecuteOrder { order };
-    let order_certificate = user_chain_a
+    let (order_certificate, _) = user_chain_a
         .add_block(|block| {
             block.with_operation(matching_id, operation);
         })

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -31,7 +31,7 @@ async fn chain_balance_transfers() {
     let funding_chain = validator.get_chain(&validator.admin_chain_id());
     let recipient = Account::chain(recipient_chain.id());
 
-    let transfer_certificate = funding_chain
+    let (transfer_certificate, _) = funding_chain
         .add_block(|block| {
             block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
         })
@@ -69,7 +69,7 @@ async fn transfer_to_owner() {
     let owner = AccountOwner::from(CryptoHash::test_hash("owner"));
     let recipient = Account::new(recipient_chain.id(), owner);
 
-    let transfer_certificate = funding_chain
+    let (transfer_certificate, _) = funding_chain
         .add_block(|block| {
             block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
         })
@@ -111,7 +111,7 @@ async fn transfer_to_multiple_owners() {
         .copied()
         .map(|account_owner| Account::new(recipient_chain.id(), account_owner));
 
-    let transfer_certificate = funding_chain
+    let (transfer_certificate, _) = funding_chain
         .add_block(|block| {
             for (recipient, transfer_amount) in recipients.zip(transfer_amounts.clone()) {
                 block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
@@ -152,7 +152,7 @@ async fn emptied_account_disappears_from_queries() {
     let owner = AccountOwner::from(recipient_chain.public_key());
     let recipient = Account::new(recipient_chain.id(), owner);
 
-    let transfer_certificate = funding_chain
+    let (transfer_certificate, _) = funding_chain
         .add_block(|block| {
             block.with_native_token_transfer(AccountOwner::CHAIN, recipient, transfer_amount);
         })

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -400,12 +400,15 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         #[cfg(with_metrics)]
         crate::chain::metrics::track_block_metrics(&self.resource_controller.tracker);
 
+        let resource_tracker = self.resource_controller.tracker;
+
         (
             self.messages,
             self.oracle_responses,
             self.events,
             self.blobs,
             self.operation_results,
+            resource_tracker,
         )
     }
 }
@@ -416,4 +419,5 @@ pub(crate) type FinalizeExecutionResult = (
     Vec<Vec<Event>>,
     Vec<Vec<Blob>>,
     Vec<OperationResult>,
+    ResourceTracker,
 );

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -223,7 +223,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
     );
 
     // The valid block is accepted...
-    let outcome = chain
+    let (outcome, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await
         .unwrap();
@@ -323,7 +323,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .with_operation(app_operation.clone())
         .with_operation(another_app_operation.clone());
 
-    let outcome = chain
+    let (outcome, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
 
@@ -356,7 +356,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
     let valid_block = make_child_block(&value)
         .with_operation(app_operation.clone())
         .with_operation(another_app_operation.clone());
-    let outcome = chain
+    let (outcome, _) = chain
         .execute_block(&valid_block, time, None, &[], None)
         .await?;
     let value = ConfirmedBlock::new(outcome.with(valid_block));
@@ -563,7 +563,10 @@ async fn test_service_as_oracle_response_size_limit(
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    chain.execute_block(&block, time, None, &[], None).await
+    chain
+        .execute_block(&block, time, None, &[], None)
+        .await
+        .map(|(outcome, _)| outcome)
 }
 
 /// Tests contract HTTP response size limit.
@@ -619,7 +622,10 @@ async fn test_contract_http_response_size_limit(
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    chain.execute_block(&block, time, None, &[], None).await
+    chain
+        .execute_block(&block, time, None, &[], None)
+        .await
+        .map(|(outcome, _)| outcome)
 }
 
 /// Tests service HTTP response size limit.
@@ -675,7 +681,10 @@ async fn test_service_http_response_size_limit(
 
     application.expect_call(ExpectedCall::default_finalize());
 
-    chain.execute_block(&block, time, None, &[], None).await
+    chain
+        .execute_block(&block, time, None, &[], None)
+        .await
+        .map(|(outcome, _)| outcome)
 }
 
 /// Sets up a test with a dummy [`MockApplication`].

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -26,7 +26,7 @@ use linera_chain::{
 };
 use linera_execution::{
     system::EventSubscriptions, ExecutionStateView, Query, QueryContext, QueryOutcome,
-    ServiceRuntimeEndpoint, ServiceSyncRuntime,
+    ResourceTracker, ServiceRuntimeEndpoint, ServiceSyncRuntime,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::context::{Context, InactiveContext};
@@ -110,7 +110,7 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
         #[debug(skip)]
-        callback: oneshot::Sender<Result<(Block, ChainInfoResponse), WorkerError>>,
+        callback: oneshot::Sender<Result<(Block, ChainInfoResponse, ResourceTracker), WorkerError>>,
     },
 
     /// Process a leader timeout issued for this multi-owner chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1555,7 +1555,7 @@ impl<Env: Environment> Client<Env> {
                     .await?;
                 continue; // We found the missing blob: retry.
             }
-            if let Ok((block, _)) = &result {
+            if let Ok((block, _, _)) = &result {
                 let hash = CryptoHash::new(block);
                 let notification = Notification {
                     chain_id: block.header.chain_id,
@@ -1566,7 +1566,8 @@ impl<Env: Environment> Client<Env> {
                 };
                 self.notifier.notify(&[notification]);
             }
-            return Ok(result?);
+            let (block, response, _resource_tracker) = result?;
+            return Ok((block, response));
         }
     }
 }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -18,7 +18,7 @@ use linera_chain::{
     types::{Block, GenericCertificate},
     ChainStateView,
 };
-use linera_execution::{committee::Committee, BlobState, Query, QueryOutcome};
+use linera_execution::{committee::Committee, BlobState, Query, QueryOutcome, ResourceTracker};
 use linera_storage::Storage;
 use linera_views::ViewError;
 use thiserror::Error;
@@ -139,7 +139,7 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse), LocalNodeError> {
+    ) -> Result<(Block, ChainInfoResponse, ResourceTracker), LocalNodeError> {
         Ok(self
             .node
             .state

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -779,7 +779,7 @@ where
         .await
         .unwrap();
     // Stage execution to get the block for certificate creation.
-    let (block, _) = env
+    let (block, _, _) = env
         .worker()
         .stage_block_execution(proposed_block, None, vec![])
         .await?;
@@ -803,7 +803,7 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    let (block, _) = env
+    let (block, _, _) = env
         .worker()
         .stage_block_execution(proposed_block, None, vec![])
         .await?;
@@ -826,7 +826,7 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    let (block, _) = env
+    let (block, _, _) = env
         .worker()
         .stage_block_execution(proposed_block, None, vec![])
         .await?;
@@ -3466,7 +3466,7 @@ where
             timeout_config: TimeoutConfig::default(),
         })
         .with_authenticated_signer(Some(owner0));
-    let (block0, _) = env
+    let (block0, _, _) = env
         .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
@@ -3528,7 +3528,7 @@ where
 
     // Now owner 0 can propose a block, but owner 1 can't.
     let proposed_block1 = make_child_block(&value0).with_simple_transfer(chain_1, small_transfer);
-    let (block1, _) = env
+    let (block1, _, _) = env
         .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
@@ -3578,7 +3578,7 @@ where
     // Create block2, also at height 1, but different from block 1.
     let amount = Amount::from_tokens(1);
     let proposed_block2 = make_child_block(&value0.clone()).with_simple_transfer(chain_1, amount);
-    let (block2, _) = env
+    let (block2, _, _) = env
         .worker()
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;
@@ -3717,7 +3717,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = env
+    let (block0, _, _) = env
         .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
@@ -3822,7 +3822,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (change_ownership_block, _) = env
+    let (change_ownership_block, _, _) = env
         .worker()
         .stage_block_execution(change_ownership_block, None, vec![])
         .await?;
@@ -3852,7 +3852,7 @@ where
         .into_proposal_with_round(owner, &signer, Round::MultiLeader(0))
         .await
         .unwrap();
-    let (block, _) = env
+    let (block, _, _) = env
         .worker()
         .stage_block_execution(proposal.content.block.clone(), None, vec![])
         .await?;
@@ -3901,7 +3901,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _) = env
+    let (block0, _, _) = env
         .worker()
         .stage_block_execution(proposed_block0, None, vec![])
         .await?;
@@ -3929,7 +3929,7 @@ where
         .into_proposal_with_round(owner0, &signer, Round::Fast)
         .await
         .unwrap();
-    let (block1, _) = env
+    let (block1, _, _) = env
         .worker()
         .stage_block_execution(proposed_block1.clone(), None, vec![])
         .await?;
@@ -3986,7 +3986,7 @@ where
     env.worker().handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
-    let (block2, _) = env
+    let (block2, _, _) = env
         .worker()
         .stage_block_execution(proposed_block2.clone(), None, vec![])
         .await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -30,7 +30,7 @@ use linera_chain::{
     },
     ChainError, ChainStateView,
 };
-use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome};
+use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome, ResourceTracker};
 use linera_storage::Storage;
 use linera_views::{context::InactiveContext, ViewError};
 use serde::{Deserialize, Serialize};
@@ -645,7 +645,7 @@ where
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse), WorkerError> {
+    ) -> Result<(Block, ChainInfoResponse, ResourceTracker), WorkerError> {
         self.query_chain_worker(block.chain_id, move |callback| {
             ChainWorkerRequest::StageBlockExecution {
                 block,

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -3,7 +3,7 @@
 
 //! This module tracks the resources used during the execution of a transaction.
 
-use std::{sync::Arc, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 use custom_debug_derive::Debug;
 use linera_base::{
@@ -158,6 +158,118 @@ impl ResourceTracker {
             VmRuntime::Wasm => self.wasm_fuel,
             VmRuntime::Evm => self.evm_fuel,
         }
+    }
+}
+
+impl fmt::Display for ResourceTracker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut lines = Vec::new();
+
+        let mut block_parts = Vec::new();
+        if self.block_size != 0 {
+            block_parts.push(format!("size={}", self.block_size));
+        }
+        if self.operations != 0 {
+            block_parts.push(format!("operations={}", self.operations));
+        }
+        if self.operation_bytes != 0 {
+            block_parts.push(format!("operation_bytes={}", self.operation_bytes));
+        }
+        if !block_parts.is_empty() {
+            lines.push(format!("block: {}", block_parts.join(", ")));
+        }
+
+        let mut fuel_parts = Vec::new();
+        if self.wasm_fuel != 0 {
+            fuel_parts.push(format!("wasm={}", self.wasm_fuel));
+        }
+        if self.evm_fuel != 0 {
+            fuel_parts.push(format!("evm={}", self.evm_fuel));
+        }
+        if !fuel_parts.is_empty() {
+            lines.push(format!("fuel: {}", fuel_parts.join(", ")));
+        }
+
+        let mut storage_parts = Vec::new();
+        if self.read_operations != 0 {
+            storage_parts.push(format!("reads={}", self.read_operations));
+        }
+        if self.write_operations != 0 {
+            storage_parts.push(format!("writes={}", self.write_operations));
+        }
+        if self.bytes_runtime != 0 {
+            storage_parts.push(format!("runtime_bytes={}", self.bytes_runtime));
+        }
+        if self.bytes_read != 0 {
+            storage_parts.push(format!("bytes_read={}", self.bytes_read));
+        }
+        if self.bytes_written != 0 {
+            storage_parts.push(format!("bytes_written={}", self.bytes_written));
+        }
+        if self.bytes_stored != 0 {
+            storage_parts.push(format!("bytes_stored={}", self.bytes_stored));
+        }
+        if !storage_parts.is_empty() {
+            lines.push(format!("storage: {}", storage_parts.join(", ")));
+        }
+
+        let mut blob_parts = Vec::new();
+        if self.blobs_read != 0 {
+            blob_parts.push(format!("read={}", self.blobs_read));
+        }
+        if self.blobs_published != 0 {
+            blob_parts.push(format!("published={}", self.blobs_published));
+        }
+        if self.blob_bytes_read != 0 {
+            blob_parts.push(format!("bytes_read={}", self.blob_bytes_read));
+        }
+        if self.blob_bytes_published != 0 {
+            blob_parts.push(format!("bytes_published={}", self.blob_bytes_published));
+        }
+        if !blob_parts.is_empty() {
+            lines.push(format!("blobs: {}", blob_parts.join(", ")));
+        }
+
+        let mut message_parts = Vec::new();
+        if self.messages != 0 {
+            message_parts.push(format!("count={}", self.messages));
+        }
+        if self.message_bytes != 0 {
+            message_parts.push(format!("bytes={}", self.message_bytes));
+        }
+        if self.grants != Amount::ZERO {
+            message_parts.push(format!("grants={}", self.grants));
+        }
+        if !message_parts.is_empty() {
+            lines.push(format!("messages: {}", message_parts.join(", ")));
+        }
+
+        let mut http_service_parts = Vec::new();
+        if self.http_requests != 0 {
+            http_service_parts.push(format!("http_requests={}", self.http_requests));
+        }
+        if self.service_oracle_queries != 0 {
+            http_service_parts.push(format!("service_queries={}", self.service_oracle_queries));
+        }
+        if self.service_oracle_execution != Duration::ZERO {
+            http_service_parts.push(format!(
+                "service_execution={:?}",
+                self.service_oracle_execution
+            ));
+        }
+        if !http_service_parts.is_empty() {
+            lines.push(format!("http/service: {}", http_service_parts.join(", ")));
+        }
+
+        let mut lines_iter = lines.into_iter();
+        if let Some(first) = lines_iter.next() {
+            write!(f, "{}", first)?;
+            for line in lines_iter {
+                write!(f, "\n  {}", line)?;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -19,7 +19,7 @@ use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_core::worker::WorkerError;
-use linera_execution::{system::SystemOperation, Operation};
+use linera_execution::{system::SystemOperation, Operation, ResourceTracker};
 
 use super::TestValidator;
 
@@ -198,11 +198,12 @@ impl BlockBuilder {
     }
 
     /// Tries to sign the prepared block with the [`TestValidator`]'s keys and return the
-    /// resulting [`Certificate`]. Returns an error if block execution fails.
+    /// resulting [`Certificate`] and the [`ResourceTracker`] with execution costs.
+    /// Returns an error if block execution fails.
     pub(crate) async fn try_sign(
         self,
         blobs: &[Blob],
-    ) -> Result<ConfirmedBlockCertificate, WorkerError> {
+    ) -> Result<(ConfirmedBlockCertificate, ResourceTracker), WorkerError> {
         let published_blobs = self
             .block
             .published_blob_ids()
@@ -215,7 +216,7 @@ impl BlockBuilder {
                     .clone()
             })
             .collect();
-        let (block, _) = self
+        let (block, _, resource_tracker) = self
             .validator
             .worker()
             .stage_block_execution(self.block, None, published_blobs)
@@ -235,6 +236,6 @@ impl BlockBuilder {
             .expect("Failed to sign block")
             .expect("Committee has more than one test validator");
 
-        Ok(certificate)
+        Ok((certificate, resource_tracker))
     }
 }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -27,7 +27,7 @@ use linera_chain::{types::ConfirmedBlockCertificate, ChainExecutionContext};
 use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
     system::{SystemOperation, SystemQuery, SystemResponse},
-    ExecutionError, Operation, Query, QueryOutcome, QueryResponse,
+    ExecutionError, Operation, Query, QueryOutcome, QueryResponse, ResourceTracker,
 };
 use linera_storage::Storage as _;
 use serde::Serialize;
@@ -209,10 +209,12 @@ impl ActiveChain {
     ///
     /// The `block_builder` parameter is a closure that should use the [`BlockBuilder`] parameter
     /// to provide the block's contents.
+    ///
+    /// Returns the block certificate and a [`ResourceTracker`] containing execution costs.
     pub async fn add_block(
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),
-    ) -> ConfirmedBlockCertificate {
+    ) -> (ConfirmedBlockCertificate, ResourceTracker) {
         self.try_add_block(block_builder)
             .await
             .expect("Failed to execute block.")
@@ -222,11 +224,13 @@ impl ActiveChain {
     ///
     /// The `block_builder` parameter is a closure that should use the [`BlockBuilder`] parameter
     /// to provide the block's contents.
+    ///
+    /// Returns the block certificate and a [`ResourceTracker`] containing execution costs.
     pub async fn add_block_with_blobs(
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),
         blobs: Vec<Blob>,
-    ) -> ConfirmedBlockCertificate {
+    ) -> (ConfirmedBlockCertificate, ResourceTracker) {
         self.try_add_block_with_blobs(block_builder, blobs)
             .await
             .expect("Failed to execute block.")
@@ -236,10 +240,12 @@ impl ActiveChain {
     ///
     /// The `block_builder` parameter is a closure that should use the [`BlockBuilder`] parameter
     /// to provide the block's contents.
+    ///
+    /// Returns the block certificate and a [`ResourceTracker`] containing execution costs.
     pub async fn try_add_block(
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),
-    ) -> Result<ConfirmedBlockCertificate, WorkerError> {
+    ) -> Result<(ConfirmedBlockCertificate, ResourceTracker), WorkerError> {
         self.try_add_block_with_blobs(block_builder, vec![]).await
     }
 
@@ -250,11 +256,13 @@ impl ActiveChain {
     ///
     /// The blobs are either all written to storage, if executing the block fails due to a missing
     /// blob, or none are written to storage if executing the block succeeds without the blobs.
+    ///
+    /// Returns the block certificate and a [`ResourceTracker`] containing execution costs.
     async fn try_add_block_with_blobs(
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),
         blobs: Vec<Blob>,
-    ) -> Result<ConfirmedBlockCertificate, WorkerError> {
+    ) -> Result<(ConfirmedBlockCertificate, ResourceTracker), WorkerError> {
         let mut tip = self.tip.lock().await;
         let mut block = BlockBuilder::new(
             self.description.id(),
@@ -267,7 +275,7 @@ impl ActiveChain {
         block_builder(&mut block);
 
         // TODO(#2066): Remove boxing once call-stack is shallower
-        let certificate = Box::pin(block.try_sign(&blobs)).await?;
+        let (certificate, resource_tracker) = Box::pin(block.try_sign(&blobs)).await?;
 
         let result = self
             .validator
@@ -287,7 +295,7 @@ impl ActiveChain {
 
         *tip = Some(certificate.clone());
 
-        Ok(certificate)
+        Ok((certificate, resource_tracker))
     }
 
     /// Receives all queued messages in all inboxes of this microchain.
@@ -395,7 +403,7 @@ impl ActiveChain {
 
         let module_id = ModuleId::new(contract_blob_hash, service_blob_hash, vm_runtime);
 
-        let certificate = self
+        let (certificate, _) = self
             .add_block_with_blobs(
                 |block| {
                     block.with_system_operation(SystemOperation::PublishModule { module_id });
@@ -544,7 +552,7 @@ impl ActiveChain {
         let parameters = serde_json::to_vec(&parameters).unwrap();
         let instantiation_argument = serde_json::to_vec(&instantiation_argument).unwrap();
 
-        let creation_certificate = self
+        let (creation_certificate, _) = self
             .add_block(|block| {
                 block.with_system_operation(SystemOperation::CreateApplication {
                     module_id: module_id.forget_abi(),
@@ -719,7 +727,7 @@ impl ActiveChain {
     {
         let QueryOutcome { operations, .. } = self.try_graphql_query(application_id, query).await?;
 
-        let certificate = self
+        let (certificate, _) = self
             .try_add_block(|block| {
                 for operation in operations {
                     match operation {

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -24,7 +24,7 @@ pub use {
         data_types::MessageAction, test::HttpServer, ChainError, ChainExecutionContext,
     },
     linera_core::worker::WorkerError,
-    linera_execution::{ExecutionError, QueryOutcome, WasmExecutionError},
+    linera_execution::{ExecutionError, QueryOutcome, ResourceTracker, WasmExecutionError},
 };
 
 #[cfg(with_testing)]

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -325,7 +325,7 @@ impl TestValidator {
         };
         let new_chain_config = open_chain_config.init_chain_config(epoch, epoch, epoch);
 
-        let certificate = admin_chain
+        let (certificate, _) = admin_chain
             .add_block(|block| {
                 block.with_system_operation(SystemOperation::OpenChain(open_chain_config));
             })

--- a/linera-sdk/tests/fixtures/contract-call/tests/integration.rs
+++ b/linera-sdk/tests/fixtures/contract-call/tests/integration.rs
@@ -29,7 +29,7 @@ async fn test_contract_call_integration() {
 
     let transfer_amount = Amount::from_tokens(100);
     let funding_chain = validator.get_chain(&validator.admin_chain_id());
-    let transfer_certificate = funding_chain
+    let (transfer_certificate, _) = funding_chain
         .add_block(|block| {
             block.with_native_token_transfer(AccountOwner::CHAIN, account1, transfer_amount);
         })


### PR DESCRIPTION
## Motivation

Backport of #5260. This is the tracking of resources.
The backport is justified since it is useful to know the wasm fuel usage on `testnet_conway` just as it is important for `main`.

## Proposal

The difference is that event costs are not tracked in `testnet_conway`.

## Test Plan

CI and the output has been tested locally.

## Release Plan

On testnet_conway.

## Links

None