### PR TITLE
Introduce the trait BaseAbi and make the Service use it instead of bcs.

### DIFF
--- a/examples/how-to/perform-http-requests/src/unit_tests/service.rs
+++ b/examples/how-to/perform-http-requests/src/unit_tests/service.rs
@@ -75,7 +75,7 @@ fn service_sends_http_response_to_contract() {
 
     service.handle_query(request).blocking_wait();
 
-    let operations = service.runtime.scheduled_operations::<Operation>();
+    let operations = service.runtime.scheduled_operations();
 
     assert_eq!(
         operations,
@@ -92,7 +92,7 @@ fn service_requests_contract_to_perform_http_request() {
 
     service.handle_query(request).blocking_wait();
 
-    let operations = service.runtime.scheduled_operations::<Operation>();
+    let operations = service.runtime.scheduled_operations();
 
     assert_eq!(operations, vec![Operation::PerformHttpRequest]);
 }
@@ -107,7 +107,7 @@ fn service_requests_contract_to_use_it_as_an_oracle() {
 
     service.handle_query(request).blocking_wait();
 
-    let operations = service.runtime.scheduled_operations::<Operation>();
+    let operations = service.runtime.scheduled_operations();
 
     assert_eq!(operations, vec![Operation::UseServiceAsOracle]);
 }

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -97,6 +97,7 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
         pub struct #mutation_root_name<Application>
         where
             Application: #crate_root::Service,
+            Application::Abi: #crate_root::abi::ContractAbi<Operation = #enum_name>,
             #crate_root::ServiceRuntime<Application>: Send + Sync,
         {
             runtime: ::std::sync::Arc<#crate_root::ServiceRuntime<Application>>,
@@ -106,6 +107,7 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
         impl<Application> #mutation_root_name<Application>
         where
             Application: #crate_root::Service,
+            Application::Abi: #crate_root::abi::ContractAbi<Operation = #enum_name>,
             #crate_root::ServiceRuntime<Application>: Send + Sync,
         {
             #(#methods)*
@@ -114,6 +116,7 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
         impl<Application> #crate_root::graphql::GraphQLMutationRoot<Application> for #enum_name
         where
             Application: #crate_root::Service,
+            Application::Abi: #crate_root::abi::ContractAbi<Operation = #enum_name>,
             #crate_root::ServiceRuntime<Application>: Send + Sync,
         {
             type MutationRoot = #mutation_root_name<Application>;
@@ -163,6 +166,7 @@ pub mod tests {
             pub struct SomeOperationMutationRoot<Application>
             where
                 Application: linera_sdk::Service,
+                Application::Abi: linera_sdk::abi::ContractAbi<Operation = SomeOperation>,
                 linera_sdk::ServiceRuntime<Application>: Send + Sync,
             {
                 runtime: ::std::sync::Arc<linera_sdk::ServiceRuntime<Application>>,
@@ -172,6 +176,7 @@ pub mod tests {
             impl<Application> SomeOperationMutationRoot<Application>
             where
                 Application: linera_sdk::Service,
+                Application::Abi: linera_sdk::abi::ContractAbi<Operation = SomeOperation>,
                 linera_sdk::ServiceRuntime<Application>: Send + Sync,
             {
                 async fn tuple_variant(&self, field0: String,) -> [u8; 0] {
@@ -197,6 +202,7 @@ pub mod tests {
                 for SomeOperation
             where
                 Application: linera_sdk::Service,
+                Application::Abi: linera_sdk::abi::ContractAbi<Operation = SomeOperation>,
                 linera_sdk::ServiceRuntime<Application>: Send + Sync,
             {
                 type MutationRoot = SomeOperationMutationRoot<Application>;

--- a/linera-sdk/src/abis/evm.rs
+++ b/linera-sdk/src/abis/evm.rs
@@ -22,7 +22,6 @@ impl ContractAbi for EvmAbi {
     fn serialize_operation(operation: &Self::Operation) -> Result<Vec<u8>, String> {
         Ok(operation.to_vec())
     }
-
     fn deserialize_response(response: Vec<u8>) -> Result<Self::Response, String> {
         Ok(response)
     }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -249,7 +249,7 @@ where
         application: ApplicationId<A>,
         call: &A::Operation,
     ) -> A::Response {
-        let call_bytes = A::serialize_operation(call)
+        let call_bytes = <A as ContractAbi>::serialize_operation(call)
             .expect("Failed to serialize `Operation` in cross-application call");
 
         let response_bytes = contract_wit::try_call_application(

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -862,7 +862,7 @@ where
         application: ApplicationId<A>,
         call: &A::Operation,
     ) -> A::Response {
-        let call_bytes = A::serialize_operation(call)
+        let call_bytes = <A as ContractAbi>::serialize_operation(call)
             .expect("Failed to serialize `Operation` in test runtime cross-application call");
 
         let handler = self.call_application_handler.as_mut().expect(

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -6,12 +6,11 @@
 use std::sync::Mutex;
 
 use linera_base::{
-    abi::ServiceAbi,
+    abi::{ContractAbi, ServiceAbi},
     data_types::{Amount, BlockHeight, Timestamp},
     http,
     identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
 };
-use serde::Serialize;
 
 use super::wit::{base_runtime_api as base_wit, service_runtime_api as service_wit};
 use crate::{KeyValueStore, Service, ViewStorageContext};
@@ -174,9 +173,10 @@ where
 
     /// Schedules an operation to be included in the block being built.
     ///
-    /// The operation is serialized using BCS.
-    pub fn schedule_operation(&self, operation: &impl Serialize) {
-        let bytes = bcs::to_bytes(operation).expect("Failed to serialize application operation");
+    /// The operation is serialized using the application ABI.
+    pub fn schedule_operation(&self, operation: &<Application::Abi as ContractAbi>::Operation) {
+        let bytes = <Application::Abi as ContractAbi>::serialize_operation(operation)
+            .expect("Failed to serialize application operation");
 
         service_wit::schedule_operation(&bytes);
     }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -132,8 +132,8 @@ impl BlockBuilder {
 
     /// Adds a user `operation` to this block.
     ///
-    /// The operation is serialized using [`bcs`] and added to the block, marked to be executed by
-    /// `application`.
+    /// The operation is serialized using the application ABI and added to the block, marked to be
+    /// executed by `application`.
     pub fn with_operation<Abi>(
         &mut self,
         application_id: ApplicationId<Abi>,
@@ -142,7 +142,7 @@ impl BlockBuilder {
     where
         Abi: ContractAbi,
     {
-        let operation = Abi::serialize_operation(&operation)
+        let operation = <Abi as ContractAbi>::serialize_operation(&operation)
             .expect("Failed to serialize `Operation` in BlockBuilder");
         self.with_raw_operation(application_id.forget_abi(), operation)
     }


### PR DESCRIPTION
## Motivation

The trait `ContractAbi` provides explicit functions for serializing and deserializing operations.
This leaves the impression that it suffices to change those functions in order to switch from
one serialization to another.

That is incorrect since the `Service` has the `schedule_operation` implemented as
```rust
    pub fn schedule_operation(&self, operation: &impl Serialize) {
        let bytes = bcs::to_bytes(operation).expect("Failed to serialize application operation");

        service_wit::schedule_operation(&bytes);
    }
```

This is unavoidable since the `schedule_operation` is a Service function and so needs operations.

## Proposal

Introduce a `BaseAbi` trait that implements those functions.

## Test Plan

It works. By replacing `bcs` by `bincode` the wasm test pass.
The `evm_call_wasm` test does not pass since we do not have bincode serialization for solidity
in `serde_generate`.

## Release Plan

The PR is mostly a cleanup because the serialization has not been changed and experiments with `bincode`
indicate that it is not necessarily better.

## Links

None,