### PR TITLE
Standardize naming for admin chain ID references

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -70,14 +70,16 @@ impl TestEnvironment {
         };
         let origin = ChainOrigin::Root(0);
         let admin_chain_description = ChainDescription::new(origin, config, Default::default());
-        let admin_id = admin_chain_description.id();
+        let admin_chain_id = admin_chain_description.id();
         Self {
             admin_chain_description: admin_chain_description.clone(),
-            created_descriptions: [(admin_id, admin_chain_description)].into_iter().collect(),
+            created_descriptions: [(admin_chain_id, admin_chain_description)]
+                .into_iter()
+                .collect(),
         }
     }
 
-    fn admin_id(&self) -> ChainId {
+    fn admin_chain_id(&self) -> ChainId {
         self.admin_chain_description.id()
     }
 
@@ -110,7 +112,7 @@ impl TestEnvironment {
         (
             ApplicationDescription {
                 module_id,
-                creator_chain_id: self.admin_id(),
+                creator_chain_id: self.admin_chain_id(),
                 block_height: BlockHeight(2),
                 application_index: 0,
                 required_application_ids: vec![],
@@ -127,7 +129,7 @@ impl TestEnvironment {
         config: InitialChainConfig,
     ) -> ChainDescription {
         let origin = ChainOrigin::Child {
-            parent: self.admin_id(),
+            parent: self.admin_chain_id(),
             block_height: BlockHeight(height),
             chain_index: 0,
         };
@@ -198,7 +200,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
         .with_authenticated_owner(Some(owner))
         .with_operation(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Account::chain(env.admin_id()),
+            recipient: Account::chain(env.admin_chain_id()),
             amount: Amount::ONE,
         });
 
@@ -207,7 +209,7 @@ async fn test_block_size_limit() -> anyhow::Result<()> {
         .clone()
         .with_operation(SystemOperation::Transfer {
             owner: AccountOwner::CHAIN,
-            recipient: Account::chain(env.admin_id()),
+            recipient: Account::chain(env.admin_chain_id()),
             amount: Amount::ONE,
         });
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -79,8 +79,8 @@ pub trait ClientContext {
 
     fn client(&self) -> &Arc<linera_core::client::Client<Self::Environment>>;
 
-    fn admin_chain(&self) -> ChainId {
-        self.client().admin_chain()
+    fn admin_chain_id(&self) -> ChainId {
+        self.client().admin_chain_id()
     }
 
     /// Gets the timing sender for benchmarking, if available.
@@ -250,7 +250,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
     pub async fn run(mut self) -> Result<impl Future<Output = Result<(), Error>>, Error> {
         let chain_ids = {
             let guard = self.context.lock().await;
-            let admin_chain_id = guard.admin_chain();
+            let admin_chain_id = guard.admin_chain_id();
             guard
                 .make_chain_client(admin_chain_id)
                 .await?

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -316,7 +316,7 @@ where
                 signer,
                 wallet,
             },
-            genesis_config.admin_id(),
+            genesis_config.admin_chain_id(),
             options.long_lived_services,
             chain_modes,
             name,
@@ -359,8 +359,8 @@ impl<Env: Environment> ClientContext<Env> {
     }
 
     /// Returns the ID of the admin chain.
-    pub fn admin_chain(&self) -> ChainId {
-        self.client.admin_chain()
+    pub fn admin_chain_id(&self) -> ChainId {
+        self.client.admin_chain_id()
     }
 
     /// Retrieve the default account. Current this is the common account of the default
@@ -376,11 +376,11 @@ impl<Env: Environment> ClientContext<Env> {
     }
 
     pub async fn first_non_admin_chain(&self) -> Result<ChainId, Error> {
-        let admin_id = self.admin_chain();
+        let admin_chain_id = self.admin_chain_id();
         std::pin::pin!(self
             .wallet()
             .chain_ids()
-            .try_filter(|chain_id| futures::future::ready(*chain_id != admin_id)))
+            .try_filter(|chain_id| futures::future::ready(*chain_id != admin_chain_id)))
         .next()
         .await
         .expect("No non-admin chain specified in wallet with no non-admin chain")

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -145,7 +145,7 @@ impl GenesisConfig {
         &self.chains[0]
     }
 
-    pub fn admin_id(&self) -> ChainId {
+    pub fn admin_chain_id(&self) -> ChainId {
         self.admin_chain_description().id()
     }
 
@@ -201,7 +201,7 @@ impl GenesisConfig {
             genesis_config_hash: CryptoHash::new(self),
             genesis_timestamp: self.timestamp,
             genesis_committee_blob_hash: self.committee_blob().id().hash,
-            admin_chain_id: self.admin_id(),
+            admin_chain_id: self.admin_chain_id(),
         }
     }
 }

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -99,7 +99,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let client1 = builder.add_root_chain(1, Amount::ONE).await?;
     // Start a chain listener for chain 0 with a new key.
     let genesis_config = GenesisConfig::new_testing(&builder);
-    let admin_id = genesis_config.admin_id();
+    let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
     let epoch0 = client0.chain_info().await?.epoch;
     let epoch1 = client1.chain_info().await?.epoch;
@@ -112,7 +112,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
                 signer,
                 wallet: environment::TestWallet::default(),
             },
-            admin_id,
+            admin_chain_id,
             false,
             [(chain_id0, ListeningMode::FullChain)],
             format!("Client node for {:.8}", chain_id0),
@@ -209,7 +209,7 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
     let chain_b_id = chain_b.chain_id();
 
     let genesis_config = GenesisConfig::new_testing(&builder);
-    let admin_id = genesis_config.admin_id();
+    let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
     let chain_a_info = chain_a.chain_info().await?;
     let chain_b_info = chain_b.chain_info().await?;
@@ -222,7 +222,7 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
                 signer,
                 wallet: environment::TestWallet::default(),
             },
-            admin_id,
+            admin_chain_id,
             false,
             [
                 (chain_a_id, ListeningMode::FollowChain),
@@ -369,7 +369,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer.clone()).await?;
     let client0 = builder.add_root_chain(0, Amount::ONE).await?;
     let genesis_config = GenesisConfig::new_testing(&builder);
-    let admin_id = genesis_config.admin_id();
+    let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
 
     let context = ClientContext {
@@ -380,7 +380,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
                 signer,
                 wallet: environment::TestWallet::default(),
             },
-            admin_id,
+            admin_chain_id,
             false,
             std::iter::empty::<(ChainId, ListeningMode)>(),
             "Client node with no chains".to_string(),
@@ -444,7 +444,7 @@ async fn test_chain_listener_listen_command_adds_chains_to_wallet() -> anyhow::R
     let chain_id0 = client0.chain_id();
 
     let genesis_config = GenesisConfig::new_testing(&builder);
-    let admin_id = genesis_config.admin_id();
+    let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
 
     let context = ClientContext {
@@ -455,7 +455,7 @@ async fn test_chain_listener_listen_command_adds_chains_to_wallet() -> anyhow::R
                 signer,
                 wallet: environment::TestWallet::default(),
             },
-            admin_id,
+            admin_chain_id,
             false,
             std::iter::empty::<(ChainId, ListeningMode)>(),
             "Client node with no chains".to_string(),

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1293,14 +1293,14 @@ where
     async fn vote_for_fallback(&mut self) -> Result<(), WorkerError> {
         let chain = &mut self.chain;
         let epoch = *chain.execution_state.system.epoch.get();
-        let Some(admin_id) = chain.execution_state.system.admin_id.get() else {
+        let Some(admin_chain_id) = chain.execution_state.system.admin_chain_id.get() else {
             return Ok(());
         };
 
         // Check if epoch e+1 exists on the admin chain and when it was created.
         let next_epoch_index = epoch.0.saturating_add(1);
         let event_id = EventId {
-            chain_id: *admin_id,
+            chain_id: *admin_chain_id,
             stream_id: StreamId::system(EPOCH_STREAM_NAME),
             index: next_epoch_index,
         };

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -385,8 +385,8 @@ impl<Env: Environment> ChainClient<Env> {
 
     /// Gets the ID of the admin chain.
     #[instrument(level = "trace", skip(self))]
-    pub fn admin_id(&self) -> ChainId {
-        self.client.admin_id
+    pub fn admin_chain_id(&self) -> ChainId {
+        self.client.admin_chain_id
     }
 
     /// Gets the currently preferred owner for signing the blocks.
@@ -432,9 +432,9 @@ impl<Env: Environment> ChainClient<Env> {
                 map
             },
         );
-        if self.chain_id != self.client.admin_id {
+        if self.chain_id != self.client.admin_chain_id {
             publishers.insert(
-                self.client.admin_id,
+                self.client.admin_chain_id,
                 vec![
                     StreamId::system(EPOCH_STREAM_NAME),
                     StreamId::system(REMOVED_EPOCH_STREAM_NAME),
@@ -693,7 +693,7 @@ impl<Env: Environment> ChainClient<Env> {
 
         if info.epoch > self.client.admin_committees().await?.0 {
             self.client
-                .synchronize_chain_state(self.client.admin_id)
+                .synchronize_chain_state(self.client.admin_chain_id)
                 .await?;
         }
 
@@ -776,7 +776,7 @@ impl<Env: Environment> ChainClient<Env> {
         let chain_ids = subscriptions
             .iter()
             .map(|((chain_id, _), _)| *chain_id)
-            .chain(iter::once(self.client.admin_id))
+            .chain(iter::once(self.client.admin_chain_id))
             .filter(|chain_id| *chain_id != self.chain_id)
             .collect::<BTreeSet<_>>();
         stream::iter(
@@ -2358,7 +2358,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// exists in storage.
     async fn has_admin_event(&self, stream_name: &[u8], index: u32) -> Result<bool, Error> {
         let event_id = EventId {
-            chain_id: self.client.admin_id,
+            chain_id: self.client.admin_chain_id,
             stream_id: StreamId::system(stream_name),
             index,
         };

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -237,7 +237,7 @@ pub struct Client<Env: Environment> {
     /// Manages the requests sent to validator nodes.
     requests_scheduler: RequestsScheduler<Env>,
     /// The admin chain ID.
-    admin_id: ChainId,
+    admin_chain_id: ChainId,
     /// Chains that should be tracked by the client, along with their listening mode.
     /// The presence of a chain in this map means it is tracked by the local node.
     chain_modes: Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>,
@@ -255,7 +255,7 @@ impl<Env: Environment> Client<Env> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         environment: Env,
-        admin_id: ChainId,
+        admin_chain_id: ChainId,
         long_lived_services: bool,
         chain_modes: impl IntoIterator<Item = (ChainId, ListeningMode)>,
         name: impl Into<String>,
@@ -287,7 +287,7 @@ impl<Env: Environment> Client<Env> {
             local_node,
             requests_scheduler,
             chains: papaya::HashMap::new(),
-            admin_id,
+            admin_chain_id,
             chain_modes,
             notifier: Arc::new(ChannelNotifier::default()),
             options,
@@ -295,8 +295,8 @@ impl<Env: Environment> Client<Env> {
     }
 
     /// Returns the chain ID of the admin chain.
-    pub fn admin_chain(&self) -> ChainId {
-        self.admin_id
+    pub fn admin_chain_id(&self) -> ChainId {
+        self.admin_chain_id
     }
 
     /// Returns the storage client used by this client's local node.
@@ -415,7 +415,7 @@ impl<Env: Environment> Client<Env> {
             Ok(info) => Ok(info),
             Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
                 // Make sure the admin chain is up to date.
-                self.synchronize_chain_state(self.admin_id).await?;
+                self.synchronize_chain_state(self.admin_chain_id).await?;
                 // If the chain is missing then the error is a WorkerError
                 // and so a BlobsNotFound
                 self.update_local_node_with_blobs_from(blob_ids, validators)
@@ -623,13 +623,13 @@ impl<Env: Environment> Client<Env> {
     async fn admin_committees(
         &self,
     ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), LocalNodeError> {
-        let info = self.chain_info_with_committees(self.admin_id).await?;
+        let info = self.chain_info_with_committees(self.admin_chain_id).await?;
         Ok((info.epoch, info.into_committees()?))
     }
 
     /// Obtains the committee for the latest epoch on the admin chain.
     pub async fn admin_committee(&self) -> Result<(Epoch, Committee), LocalNodeError> {
-        let info = self.chain_info_with_committees(self.admin_id).await?;
+        let info = self.chain_info_with_committees(self.admin_chain_id).await?;
         Ok((info.epoch, info.into_current_committee()?))
     }
 
@@ -670,7 +670,7 @@ impl<Env: Environment> Client<Env> {
             return Ok(bcs::from_bytes(blob.bytes())?);
         };
         // Recover history from the current validators, according to the admin chain.
-        self.synchronize_chain_state(self.admin_id).await?;
+        self.synchronize_chain_state(self.admin_chain_id).await?;
         let nodes = self.validator_nodes().await?;
         let blob = self
             .update_local_node_with_blobs_from(vec![chain_desc_id], &nodes)
@@ -814,7 +814,7 @@ impl<Env: Environment> Client<Env> {
                 let mut updater = ValidatorUpdater {
                     remote_node,
                     client: self.clone(),
-                    admin_id: self.admin_id,
+                    admin_chain_id: self.admin_chain_id,
                 };
                 let certificate = latest_certificate.clone();
                 Box::pin(async move {
@@ -850,7 +850,7 @@ impl<Env: Environment> Client<Env> {
                 let mut updater = ValidatorUpdater {
                     remote_node,
                     client: self.clone(),
-                    admin_id: self.admin_id,
+                    admin_chain_id: self.admin_chain_id,
                 };
                 let action = action.clone();
                 Box::pin(async move { updater.send_chain_update(action).await })

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1008,7 +1008,7 @@ where
         result
     }
 
-    pub fn admin_id(&self) -> ChainId {
+    pub fn admin_chain_id(&self) -> ChainId {
         self.admin_description
             .as_ref()
             .expect("admin chain not initialized")
@@ -1066,7 +1066,7 @@ where
                 signer: self.signer.clone(),
                 wallet: TestWallet::default(),
             },
-            self.admin_id(),
+            self.admin_chain_id(),
             false,
             [(chain_id, mode)],
             format!("Client node for {:.8}", chain_id),

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -75,9 +75,9 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
         self.epoch.get()
     }
 
-    #[graphql(derived(name = "admin_id"))]
-    async fn _admin_id(&self) -> &Option<ChainId> {
-        self.admin_id.get()
+    #[graphql(derived(name = "admin_chain_id"))]
+    async fn _admin_chain_id(&self) -> &Option<ChainId> {
+        self.admin_chain_id.get()
     }
 
     #[graphql(derived(name = "committees"))]

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -26,7 +26,7 @@ use crate::{
 pub struct SystemExecutionState {
     pub description: Option<ChainDescription>,
     pub epoch: Epoch,
-    pub admin_id: Option<ChainId>,
+    pub admin_chain_id: Option<ChainId>,
     pub committees: BTreeMap<Epoch, Committee>,
     pub ownership: ChainOwnership,
     pub balance: Amount,
@@ -48,11 +48,11 @@ impl SystemExecutionState {
         let ownership = description.config().ownership.clone();
         let balance = description.config().balance;
         let epoch = description.config().epoch;
-        let admin_id = Some(dummy_chain_description(0).id());
+        let admin_chain_id = Some(dummy_chain_description(0).id());
         SystemExecutionState {
             epoch,
             description: Some(description),
-            admin_id,
+            admin_chain_id,
             ownership,
             balance,
             committees: dummy_committees(),
@@ -92,7 +92,7 @@ impl SystemExecutionState {
         let SystemExecutionState {
             description,
             epoch,
-            admin_id,
+            admin_chain_id,
             committees,
             ownership,
             balance,
@@ -127,7 +127,7 @@ impl SystemExecutionState {
             .expect("Loading from memory should work");
         view.system.description.set(description);
         view.system.epoch.set(epoch);
-        view.system.admin_id.set(admin_id);
+        view.system.admin_chain_id.set(admin_chain_id);
         view.system.committees.set(committees);
         view.system.ownership.set(ownership);
         view.system.balance.set(balance);

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -26,7 +26,7 @@ async fn new_view_and_context() -> (
     let state = SystemExecutionState {
         description: Some(description),
         epoch: Epoch(1),
-        admin_id: Some(dummy_chain_description(0).id()),
+        admin_chain_id: Some(dummy_chain_description(0).id()),
         committees: BTreeMap::new(),
         ..SystemExecutionState::default()
     };

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -312,10 +312,10 @@ impl TestValidator {
     ///
     /// Returns the [`ChainDescription`] of the new chain.
     async fn request_new_chain_from_admin_chain(&self, owner: AccountOwner) -> ChainDescription {
-        let admin_id = self.admin_chain_id;
+        let admin_chain_id = self.admin_chain_id;
         let pinned = self.chains.pin();
         let admin_chain = pinned
-            .get(&admin_id)
+            .get(&admin_chain_id)
             .expect("Admin chain should be created when the `TestValidator` is constructed");
 
         let (epoch, _) = self.committee.lock().await.clone();

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -132,7 +132,7 @@ query Chain(
       system {
         description
         epoch
-        adminId
+        adminChainId
         ownership
         balance
         timestamp

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -1416,7 +1416,7 @@ type SubscriptionRoot {
 type SystemExecutionStateView {
 	description: ChainDescription
 	epoch: Epoch!
-	adminId: ChainId
+	adminChainId: ChainId
 	committees: JSONObject!
 	ownership: ChainOwnership!
 	balance: Amount!

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -534,11 +534,11 @@ impl Runnable for Job {
                     .await?;
 
                 // ResourceControlPolicy doesn't need version checks
-                let admin_id = context.admin_chain();
-                let chain_client = context.make_chain_client(admin_id).await?;
+                let admin_chain_id = context.admin_chain_id();
+                let chain_client = context.make_chain_client(admin_chain_id).await?;
                 // Synchronize the chain state to make sure we're applying the changes to the
                 // latest committee.
-                chain_client.synchronize_chain_state(admin_id).await?;
+                chain_client.synchronize_chain_state(admin_chain_id).await?;
                 let maybe_certificate = context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();
@@ -688,7 +688,7 @@ impl Runnable for Job {
                     .await?;
 
                 let chain_client = context
-                    .make_chain_client(context.wallet().genesis_admin_chain())
+                    .make_chain_client(context.wallet().genesis_admin_chain_id())
                     .await?;
 
                 // Remove the old committees.

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -351,7 +351,7 @@ async fn print_messages_and_create_faucet(
             Some(
                 chains
                     .into_iter()
-                    .filter(|chain_id| *chain_id != wallet.genesis_admin_chain())
+                    .filter(|chain_id| *chain_id != wallet.genesis_admin_chain_id())
                     .nth(faucet_chain_idx as usize)
                     .expect("there should be at least one non-admin chain"),
             )

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -252,11 +252,11 @@ impl Add {
                 .await?;
         }
 
-        let admin_id = context.admin_chain();
-        let chain_client = context.make_chain_client(admin_id).await?;
+        let admin_chain_id = context.admin_chain_id();
+        let chain_client = context.make_chain_client(admin_chain_id).await?;
 
         // Synchronize the chain state
-        chain_client.synchronize_chain_state(admin_id).await?;
+        chain_client.synchronize_chain_state(admin_chain_id).await?;
 
         let maybe_certificate = context
             .apply_client_command(&chain_client, |chain_client| {
@@ -372,8 +372,8 @@ impl Update {
         let mut removes = Vec::new();
 
         // Get current committee to determine if operation is add or modify
-        let admin_id = context.client().admin_chain();
-        let chain_client = context.make_chain_client(admin_id).await?;
+        let admin_chain_id = context.client().admin_chain_id();
+        let chain_client = context.make_chain_client(admin_chain_id).await?;
         let current_committee = chain_client.local_committee().await?;
         let current_validators = current_committee.validators();
 
@@ -496,11 +496,11 @@ impl Update {
             }
         }
 
-        let admin_id = context.admin_chain();
-        let chain_client = context.make_chain_client(admin_id).await?;
+        let admin_chain_id = context.admin_chain_id();
+        let chain_client = context.make_chain_client(admin_chain_id).await?;
 
         // Synchronize the chain state
-        chain_client.synchronize_chain_state(admin_id).await?;
+        chain_client.synchronize_chain_state(admin_chain_id).await?;
 
         let batch_clone = batch.clone();
         let maybe_certificate = context
@@ -694,11 +694,11 @@ impl Remove {
         tracing::info!("Starting operation to remove validator");
         let time_start = std::time::Instant::now();
 
-        let admin_id = context.admin_chain();
-        let chain_client = context.make_chain_client(admin_id).await?;
+        let admin_chain_id = context.admin_chain_id();
+        let chain_client = context.make_chain_client(admin_chain_id).await?;
 
         // Synchronize the chain state
-        chain_client.synchronize_chain_state(admin_id).await?;
+        chain_client.synchronize_chain_state(admin_chain_id).await?;
 
         let maybe_certificate = context
             .apply_client_command(&chain_client, |chain_client| {

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -37,7 +37,7 @@ impl ChainDetails {
         };
         ChainDetails {
             is_default: Some(chain_id) == *wallet.default.read().unwrap(),
-            is_admin: chain_id == wallet.genesis_config.admin_id(),
+            is_admin: chain_id == wallet.genesis_config.admin_chain_id(),
             chain_id,
             origin: wallet
                 .genesis_config
@@ -235,8 +235,8 @@ impl Wallet {
         &self.0.genesis_config
     }
 
-    pub fn genesis_admin_chain(&self) -> ChainId {
-        self.0.genesis_config.admin_id()
+    pub fn genesis_admin_chain_id(&self) -> ChainId {
+        self.0.genesis_config.admin_chain_id()
     }
 
     // TODO(#5082): now that wallets only store chains, not keys, there's not much point in

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -57,7 +57,7 @@ pub async fn new_test_client_context(
                 signer,
                 wallet,
             },
-            genesis_config.admin_id(),
+            genesis_config.admin_chain_id(),
             false,
             chain_modes,
             name,
@@ -91,7 +91,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer.clone()).await?;
     builder.add_root_chain(0, Amount::ONE).await?;
-    let chain_id = builder.admin_id();
+    let chain_id = builder.admin_chain_id();
 
     let genesis_config = GenesisConfig::new_testing(&builder);
 


### PR DESCRIPTION
## Motivation

We sometimes use `admin_chain`, `admin_id` or `admin_chain_id` for the ID of the admin chain. (See https://github.com/linera-io/linera-protocol/pull/5285#discussion_r2712884566)

## Proposal

Use `admin_chain_id` consistently.

## Test Plan

CI

## Release Plan

- These changes should be backported to `testnet_conway`.

## Links

- Discussion: https://github.com/linera-io/linera-protocol/pull/5285#discussion_r2712884566
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
