### PR TITLE
[testnet] Don't automatically retry operations on conflict. (#5234)

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1768,6 +1768,12 @@ pub enum ChainClientError {
         chain_id: ChainId,
         height: BlockHeight,
     },
+
+    #[error(
+        "A different block was already committed at this height. \
+         The committed certificate hash is {0}"
+    )]
+    Conflict(CryptoHash),
 }
 
 impl From<Infallible> for ChainClientError {
@@ -2655,7 +2661,7 @@ impl<Env: Environment> ChainClient<Env> {
             // TODO(#2066): Remove boxing once the call-stack is shallower
             tracing::debug!("calling execute_block");
             match Box::pin(self.execute_block(operations.clone(), blobs.clone())).await {
-                Ok(ExecuteBlockOutcome::Executed(certificate)) => {
+                Ok(ClientOutcome::Committed(certificate)) => {
                     tracing::debug!(
                         execute_block_ms = execute_block_start.elapsed().as_millis(),
                         "execute_block succeeded"
@@ -2663,14 +2669,15 @@ impl<Env: Environment> ChainClient<Env> {
                     self.send_timing(execute_block_start, TimingType::ExecuteBlock);
                     break Ok(ClientOutcome::Committed(certificate));
                 }
-                Ok(ExecuteBlockOutcome::WaitForTimeout(timeout)) => {
+                Ok(ClientOutcome::WaitForTimeout(timeout)) => {
                     break Ok(ClientOutcome::WaitForTimeout(timeout));
                 }
-                Ok(ExecuteBlockOutcome::Conflict(certificate)) => {
+                Ok(ClientOutcome::Conflict(certificate)) => {
                     info!(
                         height = %certificate.block().header.height,
-                        "Another block was committed; retrying."
+                        "Another block was committed."
                     );
+                    break Ok(ClientOutcome::Conflict(certificate));
                 }
                 Err(ChainClientError::CommunicationError(CommunicationError::Trusted(
                     NodeError::UnexpectedBlockHeight {
@@ -2714,7 +2721,7 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         operations: Vec<Operation>,
         blobs: Vec<Blob>,
-    ) -> Result<ExecuteBlockOutcome, ChainClientError> {
+    ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
         #[cfg(with_metrics)]
         let _latency = metrics::EXECUTE_BLOCK_LATENCY.measure_latency();
 
@@ -2728,10 +2735,13 @@ impl<Env: Environment> ChainClient<Env> {
         // TODO(#5092): We shouldn't need to call this explicitly.
         match self.process_pending_block_without_prepare().await? {
             ClientOutcome::Committed(Some(certificate)) => {
-                return Ok(ExecuteBlockOutcome::Conflict(certificate))
+                return Ok(ClientOutcome::Conflict(Box::new(certificate)))
             }
             ClientOutcome::WaitForTimeout(timeout) => {
-                return Ok(ExecuteBlockOutcome::WaitForTimeout(timeout))
+                return Ok(ClientOutcome::WaitForTimeout(timeout))
+            }
+            ClientOutcome::Conflict(certificate) => {
+                return Ok(ClientOutcome::Conflict(certificate))
             }
             ClientOutcome::Committed(None) => {}
         }
@@ -2753,18 +2763,17 @@ impl<Env: Environment> ChainClient<Env> {
 
         match self.process_pending_block_without_prepare().await? {
             ClientOutcome::Committed(Some(certificate)) if certificate.block() == &block => {
-                Ok(ExecuteBlockOutcome::Executed(certificate))
+                Ok(ClientOutcome::Committed(certificate))
             }
             ClientOutcome::Committed(Some(certificate)) => {
-                Ok(ExecuteBlockOutcome::Conflict(certificate))
+                Ok(ClientOutcome::Conflict(Box::new(certificate)))
             }
             // Should be unreachable: We did set a pending block.
             ClientOutcome::Committed(None) => Err(ChainClientError::BlockProposalError(
                 "Unexpected block proposal error",
             )),
-            ClientOutcome::WaitForTimeout(timeout) => {
-                Ok(ExecuteBlockOutcome::WaitForTimeout(timeout))
-            }
+            ClientOutcome::Conflict(certificate) => Ok(ClientOutcome::Conflict(certificate)),
+            ClientOutcome::WaitForTimeout(timeout) => Ok(ClientOutcome::WaitForTimeout(timeout)),
         }
     }
 
@@ -3465,36 +3474,31 @@ impl<Env: Environment> ChainClient<Env> {
         new_owner: AccountOwner,
         new_weight: u64,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, ChainClientError> {
-        loop {
-            let ownership = self.prepare_chain().await?.manager.ownership;
-            ensure!(
-                ownership.is_active(),
-                ChainError::InactiveChain(self.chain_id)
-            );
-            let mut owners = ownership.owners.into_iter().collect::<Vec<_>>();
-            owners.extend(ownership.super_owners.into_iter().zip(iter::repeat(100)));
-            owners.push((new_owner, new_weight));
-            let operations = vec![Operation::system(SystemOperation::ChangeOwnership {
-                super_owners: Vec::new(),
-                owners,
-                multi_leader_rounds: ownership.multi_leader_rounds,
-                open_multi_leader_rounds: ownership.open_multi_leader_rounds,
-                timeout_config: ownership.timeout_config,
-            })];
-            match self.execute_block(operations, vec![]).await? {
-                ExecuteBlockOutcome::Executed(certificate) => {
-                    return Ok(ClientOutcome::Committed(certificate));
-                }
-                ExecuteBlockOutcome::Conflict(certificate) => {
-                    info!(
-                        height = %certificate.block().header.height,
-                        "Another block was committed; retrying."
-                    );
-                }
-                ExecuteBlockOutcome::WaitForTimeout(timeout) => {
-                    return Ok(ClientOutcome::WaitForTimeout(timeout));
-                }
-            };
+        let ownership = self.prepare_chain().await?.manager.ownership;
+        ensure!(
+            ownership.is_active(),
+            ChainError::InactiveChain(self.chain_id)
+        );
+        let mut owners = ownership.owners.into_iter().collect::<Vec<_>>();
+        owners.extend(ownership.super_owners.into_iter().zip(iter::repeat(100)));
+        owners.push((new_owner, new_weight));
+        let operations = vec![Operation::system(SystemOperation::ChangeOwnership {
+            super_owners: Vec::new(),
+            owners,
+            multi_leader_rounds: ownership.multi_leader_rounds,
+            open_multi_leader_rounds: ownership.open_multi_leader_rounds,
+            timeout_config: ownership.timeout_config,
+        })];
+        match self.execute_block(operations, vec![]).await? {
+            ClientOutcome::Committed(certificate) => Ok(ClientOutcome::Committed(certificate)),
+            ClientOutcome::Conflict(certificate) => {
+                info!(
+                    height = %certificate.block().header.height,
+                    "Another block was committed."
+                );
+                Ok(ClientOutcome::Conflict(certificate))
+            }
+            ClientOutcome::WaitForTimeout(timeout) => Ok(ClientOutcome::WaitForTimeout(timeout)),
         }
     }
 
@@ -3570,43 +3574,43 @@ impl<Env: Environment> ChainClient<Env> {
         balance: Amount,
     ) -> Result<ClientOutcome<(ChainDescription, ConfirmedBlockCertificate)>, ChainClientError>
     {
-        loop {
-            let config = OpenChainConfig {
-                ownership: ownership.clone(),
-                balance,
-                application_permissions: application_permissions.clone(),
-            };
-            let operation = Operation::system(SystemOperation::OpenChain(config));
-            let certificate = match self.execute_block(vec![operation], vec![]).await? {
-                ExecuteBlockOutcome::Executed(certificate) => certificate,
-                ExecuteBlockOutcome::Conflict(_) => continue,
-                ExecuteBlockOutcome::WaitForTimeout(timeout) => {
-                    return Ok(ClientOutcome::WaitForTimeout(timeout));
-                }
-            };
-            // The only operation, i.e. the last transaction, created the new chain.
-            let chain_blob = certificate
-                .block()
-                .body
-                .blobs
-                .last()
-                .and_then(|blobs| blobs.last())
-                .ok_or_else(|| ChainClientError::InternalError("Failed to create a new chain"))?;
-            let description = bcs::from_bytes::<ChainDescription>(chain_blob.bytes())?;
-            // If we have a key for any owner, add it to the list of tracked chains.
-            for owner in ownership.all_owners() {
-                if self.client.has_key_for(owner).await? {
-                    self.client
-                        .extend_chain_mode(description.id(), ListeningMode::FullChain);
-                    break;
-                }
+        let config = OpenChainConfig {
+            ownership: ownership.clone(),
+            balance,
+            application_permissions: application_permissions.clone(),
+        };
+        let operation = Operation::system(SystemOperation::OpenChain(config));
+        let certificate = match self.execute_block(vec![operation], vec![]).await? {
+            ClientOutcome::Committed(certificate) => certificate,
+            ClientOutcome::Conflict(certificate) => {
+                return Ok(ClientOutcome::Conflict(certificate));
             }
-            self.client
-                .local_node
-                .retry_pending_cross_chain_requests(self.chain_id)
-                .await?;
-            return Ok(ClientOutcome::Committed((description, certificate)));
+            ClientOutcome::WaitForTimeout(timeout) => {
+                return Ok(ClientOutcome::WaitForTimeout(timeout));
+            }
+        };
+        // The only operation, i.e. the last transaction, created the new chain.
+        let chain_blob = certificate
+            .block()
+            .body
+            .blobs
+            .last()
+            .and_then(|blobs| blobs.last())
+            .ok_or_else(|| ChainClientError::InternalError("Failed to create a new chain"))?;
+        let description = bcs::from_bytes::<ChainDescription>(chain_blob.bytes())?;
+        // If we have a key for any owner, add it to the list of tracked chains.
+        for owner in ownership.all_owners() {
+            if self.client.has_key_for(owner).await? {
+                self.client
+                    .extend_chain_mode(description.id(), ListeningMode::FullChain);
+                break;
+            }
         }
+        self.client
+            .local_node
+            .retry_pending_cross_chain_requests(self.chain_id)
+            .await?;
+        Ok(ClientOutcome::Committed((description, certificate)))
     }
 
     /// Closes the chain (and loses everything in it!!).
@@ -3779,6 +3783,7 @@ impl<Env: Environment> ChainClient<Env> {
         {
             ClientOutcome::Committed(_) => {}
             outcome @ ClientOutcome::WaitForTimeout(_) => return Ok(outcome),
+            outcome @ ClientOutcome::Conflict(_) => return Ok(outcome),
         }
         let epoch = Box::pin(self.chain_info()).await?.epoch.try_add_one()?;
         Box::pin(
@@ -3821,9 +3826,9 @@ impl<Env: Environment> ChainClient<Env> {
             // will be epoch changes, receiving messages and processing event stream
             // updates, if any are pending.
             match self.execute_block(vec![], vec![]).await {
-                Ok(ExecuteBlockOutcome::Executed(certificate))
-                | Ok(ExecuteBlockOutcome::Conflict(certificate)) => certificates.push(certificate),
-                Ok(ExecuteBlockOutcome::WaitForTimeout(timeout)) => {
+                Ok(ClientOutcome::Committed(certificate)) => certificates.push(certificate),
+                Ok(ClientOutcome::Conflict(certificate)) => certificates.push(*certificate),
+                Ok(ClientOutcome::WaitForTimeout(timeout)) => {
                     return Ok((certificates, Some(timeout)));
                 }
                 // Nothing in the inbox and no stream updates to be processed.
@@ -4408,19 +4413,6 @@ impl<Env: Environment> ChainClient<Env> {
             .await
             .unwrap();
     }
-}
-
-/// The outcome of trying to commit a list of incoming messages and operations to the chain.
-#[derive(Debug)]
-enum ExecuteBlockOutcome {
-    /// A block with the messages and operations was committed.
-    Executed(ConfirmedBlockCertificate),
-    /// A different block was already proposed and got committed. Check whether the messages and
-    /// operations are still suitable, and try again at the next block height.
-    Conflict(ConfirmedBlockCertificate),
-    /// We are not the round leader and cannot do anything. Try again at the specified time or
-    /// or whenever the round or block height changes.
-    WaitForTimeout(RoundTimeout),
 }
 
 /// Wrapper for `AbortHandle` that aborts when its dropped.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -16,6 +16,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{ChainAndHeight, IncomingBundle, MessageBundle},
     manager::ChainManagerInfo,
+    types::ConfirmedBlockCertificate,
     ChainStateView,
 };
 use linera_execution::{committee::Committee, ExecutionRuntimeContext};
@@ -345,6 +346,8 @@ pub enum ClientOutcome<T> {
     /// We are not the round leader and cannot do anything. Try again at the specified time
     /// or whenever the round or block height changes.
     WaitForTimeout(RoundTimeout),
+    /// A different block was committed at the current block height.
+    Conflict(Box<ConfirmedBlockCertificate>),
 }
 
 #[derive(Debug)]
@@ -370,13 +373,16 @@ impl<T> ClientOutcome<T> {
         match self {
             ClientOutcome::Committed(t) => t,
             ClientOutcome::WaitForTimeout(timeout) => panic!("unexpected timeout: {timeout}"),
+            ClientOutcome::Conflict(certificate) => {
+                panic!("unexpected conflict: {}", certificate.hash())
+            }
         }
     }
 
     pub fn expect(self, msg: &'static str) -> T {
         match self {
             ClientOutcome::Committed(t) => t,
-            ClientOutcome::WaitForTimeout(_) => panic!("{}", msg),
+            ClientOutcome::WaitForTimeout(_) | ClientOutcome::Conflict(_) => panic!("{}", msg),
         }
     }
 
@@ -387,6 +393,7 @@ impl<T> ClientOutcome<T> {
         match self {
             ClientOutcome::Committed(t) => ClientOutcome::Committed(f(t)),
             ClientOutcome::WaitForTimeout(timeout) => ClientOutcome::WaitForTimeout(timeout),
+            ClientOutcome::Conflict(certificate) => ClientOutcome::Conflict(certificate),
         }
     }
 
@@ -397,6 +404,7 @@ impl<T> ClientOutcome<T> {
         match self {
             ClientOutcome::Committed(t) => Ok(ClientOutcome::Committed(f(t)?)),
             ClientOutcome::WaitForTimeout(timeout) => Ok(ClientOutcome::WaitForTimeout(timeout)),
+            ClientOutcome::Conflict(certificate) => Ok(ClientOutcome::Conflict(certificate)),
         }
     }
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1450,8 +1450,8 @@ where
     client_1b.prepare_chain().await?;
     let certificate = client_1b
         .execute_operation(SystemOperation::VerifyBlob { blob_id: blob0_id })
-        .await?
-        .unwrap();
+        .await
+        .unwrap_ok_committed();
     assert_eq!(certificate.round, Round::MultiLeader(0));
     // The blob is not new on this chain, so it is not required.
     assert!(!certificate.block().requires_or_creates_blob(&blob0_id));
@@ -1523,31 +1523,17 @@ where
         *info2_b.manager.requested_locking.unwrap()
     );
     let recipient = Account::burn_address(client_2b.chain_id());
-    let bt_certificate = client_2b
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), recipient)
-        .await
-        .unwrap_ok_committed();
+    let outcome = client_2b
+        .transfer_to_account(AccountOwner::CHAIN, Amount::ONE, recipient)
+        .await?;
 
-    let certificate_values = client_2b
-        .read_confirmed_blocks_downward(bt_certificate.hash(), 2)
-        .await
-        .unwrap();
+    let ClientOutcome::Conflict(certificate) = outcome else {
+        panic!("Unexpected outcome: {outcome:?}");
+    };
 
-    // Latest block should be the burn
-    assert!(certificate_values[0].block().body.operations().any(|op| *op
-        == Operation::system(SystemOperation::Transfer {
-            owner: AccountOwner::CHAIN,
-            recipient,
-            amount: Amount::from_tokens(1),
-        })));
-
-    // Block before that should be b0
+    // The conflicting block should be b0
     assert_eq!(
-        certificate_values[1]
-            .block()
-            .body
-            .operations()
-            .collect::<Vec<_>>(),
+        certificate.block().body.operations().collect::<Vec<_>>(),
         blob_0_1_operations.iter().collect::<Vec<_>>(),
     );
 
@@ -1749,15 +1735,18 @@ where
     //     );
     // }
 
-    // Once all validators are functional again, a new proposal should succeed.
+    // Once all validators are functional again, one of the blocks should get finalized.
     builder.set_fault_type([0, 1, 2, 3], FaultType::Honest);
 
     client1.synchronize_from_validators().await.unwrap();
-    client1.publish_data_blob(b"foo".to_vec()).await?;
+    assert_matches!(
+        client1.publish_data_blob(b"foo".to_vec()).await,
+        Ok(ClientOutcome::Conflict(_))
+    );
 
     assert_eq!(
         client1.chain_info().await?.next_block_height,
-        BlockHeight::from(3)
+        BlockHeight::from(2)
     );
     Ok(())
 }
@@ -1974,39 +1963,17 @@ where
 
     client3_c.synchronize_from_validators().await.unwrap();
     let blob4_data = b"blob4".to_vec();
-    let blob4 = Blob::new(BlobContent::new_data(blob4_data.clone()));
-    let bt_certificate = client3_c
-        .publish_data_blob(blob4_data)
-        .await
-        .unwrap_ok_committed();
+    let outcome = client3_c.publish_data_blob(blob4_data).await?;
 
-    let certificate_values = client3_c
-        .read_confirmed_blocks_downward(bt_certificate.hash(), 3)
-        .await
-        .unwrap();
+    let ClientOutcome::Conflict(certificate) = outcome else {
+        panic!("Unexpected outcome: {outcome:?}");
+    };
 
-    // Latest block should be the burn
-    assert!(certificate_values[0].block().body.operations().any(|op| *op
-        == Operation::system(SystemOperation::PublishDataBlob {
-            blob_hash: blob4.id().hash
-        })));
-
-    // Block before that should be b1
+    // The conflicting block should be b1
     assert_eq!(
-        certificate_values[1]
-            .block()
-            .body
-            .operations()
-            .collect::<Vec<_>>(),
+        certificate.block().body.operations().collect::<Vec<_>>(),
         blob_2_3_operations.iter().collect::<Vec<_>>(),
     );
-
-    // Previous should be the `ChangeOwnership` operation
-    assert!(certificate_values[2]
-        .block()
-        .body
-        .operations()
-        .any(|op| *op == owner_change_op));
     Ok(())
 }
 
@@ -2108,6 +2075,7 @@ where
         .unwrap();
     let timeout = match result {
         ClientOutcome::Committed(_) => panic!("Committed a block where we aren't the leader."),
+        ClientOutcome::Conflict(_) => panic!("Got conflict where we aren't the leader."),
         ClientOutcome::WaitForTimeout(timeout) => timeout,
     };
     client.clear_pending_proposal();
@@ -2244,6 +2212,12 @@ where
                 it's the leader in the validator's current round and completed the transfer."
             );
         }
+        Ok(ClientOutcome::Conflict(_)) => {
+            panic!(
+                "Transfer returned Conflict, but the client should have discovered \
+                it's the leader in the validator's current round and completed the transfer."
+            );
+        }
         Err(e) => {
             panic!(
                 "Transfer failed with error: {e:?}. The client should have handled the \
@@ -2334,31 +2308,28 @@ where
     );
     assert!(client0.pending_proposal().is_some());
 
-    // Client 0 now only tries to transfer 1 token. Before that, they automatically finalize the
-    // pending block, which publishes the blob, leaving 10 - 1 = 9.
-    client0
-        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
-        .await
-        .unwrap();
+    // Client 0 now only tries to transfer 1 token. But instead, they automatically finalize the
+    // pending block, which publishes the blob.
+    assert_matches!(
+        client0.burn(AccountOwner::CHAIN, Amount::ONE).await,
+        Ok(ClientOutcome::Conflict(_))
+    );
     client0.synchronize_from_validators().await.unwrap();
     client0.process_inbox().await.unwrap();
     assert_eq!(
         client0.local_balance().await.unwrap(),
-        Amount::from_tokens(9)
+        Amount::from_tokens(10)
     );
     assert!(client0.pending_proposal().is_none());
 
-    // Transfer another token so Client 1 sees that the blob is already published
+    // Transfer a token so Client 1 sees that the blob is already published
     client1.prepare_chain().await.unwrap();
-    client1
-        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
-        .await
-        .unwrap();
+    client1.burn(AccountOwner::CHAIN, Amount::ONE).await?;
     client1.synchronize_from_validators().await.unwrap();
     client1.process_inbox().await.unwrap();
     assert_eq!(
         client1.local_balance().await.unwrap(),
-        Amount::from_tokens(8)
+        Amount::from_tokens(9)
     );
     assert!(client1.pending_proposal().is_none());
     Ok(())
@@ -2389,14 +2360,15 @@ where
     // Now three validators are online again.
     builder.set_fault_type([2], FaultType::Honest);
 
-    // The client tries to burn another token. Before that, they automatically finalize the
-    // pending block, which transfers 3 tokens, leaving 10 - 3 - 1 = 6.
-    client.burn(AccountOwner::CHAIN, Amount::ONE).await.unwrap();
-    client.synchronize_from_validators().await.unwrap();
-    client.process_inbox().await.unwrap();
+    // The client tries to burn another token. But instead, they finalize the
+    // pending block, which transfers 3 tokens, leaving 10 - 3 = 7.
+    assert_matches!(
+        client.burn(AccountOwner::CHAIN, Amount::ONE).await,
+        Ok(ClientOutcome::Conflict(_))
+    );
     assert_eq!(
         client.local_balance().await.unwrap(),
-        Amount::from_tokens(6)
+        Amount::from_tokens(7)
     );
     Ok(())
 }
@@ -2497,16 +2469,18 @@ where
     );
     assert_eq!(manager.current_round, Round::MultiLeader(1));
     assert!(client1.pending_proposal().is_some());
-    client1
-        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
-        .await
-        .unwrap();
+    assert_matches!(
+        client1
+            .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
+            .await,
+        Ok(ClientOutcome::Conflict(_))
+    );
 
-    // Burning 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
+    // Burning 3 tokens got finalized; the pending 2 and the new 4 got skipped.
     client0.synchronize_from_validators().await.unwrap();
     assert_eq!(
         client0.local_balance().await.unwrap(),
-        Amount::from_tokens(3)
+        Amount::from_tokens(7)
     );
     Ok(())
 }
@@ -2606,13 +2580,34 @@ where
     builder.set_fault_type([0, 1, 2], FaultType::Honest);
     client1.synchronize_from_validators().await.unwrap();
     assert!(client1.pending_proposal().is_some());
-    client1
-        .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
-        .await
-        .unwrap();
-    // Round 0 needs to time out again, so client 1 is actually allowed to propose.
-    clock.add(TimeDelta::from_secs(5));
-    client1.process_pending_block().await.unwrap();
+    // This test involves timeouts and potential conflicts. Handle them appropriately.
+    loop {
+        match client1
+            .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
+            .await
+        {
+            Ok(ClientOutcome::Committed(_)) => break,
+            Ok(ClientOutcome::WaitForTimeout(_)) => {
+                // Round 0 needs to time out again, so client 1 is actually allowed to propose.
+                clock.add(TimeDelta::from_secs(5));
+            }
+            Ok(ClientOutcome::Conflict(_)) => {
+                // A different block was committed. Sync and check if we're done.
+                client1.synchronize_from_validators().await.unwrap();
+                // The conflicting block might have included our burn. Check balance.
+                if client1.local_balance().await.unwrap() == Amount::from_tokens(1) {
+                    break; // The expected final state - we're done.
+                }
+            }
+            Err(_) => {
+                // Might get an error if balance is insufficient - operations already committed.
+                break;
+            }
+        }
+    }
+    // Process any pending block. If pending proposal was already committed via conflict,
+    // this will return None for the certificate.
+    let _ = client1.process_pending_block().await;
 
     // Burning 3 and 4 tokens got finalized; the pending 2 tokens got skipped.
     client0.synchronize_from_validators().await.unwrap();

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1393,11 +1393,35 @@ impl StorageBuilder for ScyllaDbStorageBuilder {
 }
 
 pub trait ClientOutcomeResultExt<T, E> {
+    /// Unwraps the result and panics if it's not `Committed`.
+    /// Use this when you expect the operation to succeed without conflicts.
     fn unwrap_ok_committed(self) -> T;
+
+    /// Unwraps the result, accepting both `Committed` and `Conflict` outcomes.
+    /// Returns the committed value or the conflicting certificate (boxed).
+    fn unwrap_ok_or_conflict(self) -> Result<T, Box<ConfirmedBlockCertificate>>;
 }
 
 impl<T, E: std::fmt::Debug> ClientOutcomeResultExt<T, E> for Result<ClientOutcome<T>, E> {
     fn unwrap_ok_committed(self) -> T {
-        self.unwrap().unwrap()
+        match self.unwrap() {
+            ClientOutcome::Committed(t) => t,
+            ClientOutcome::WaitForTimeout(timeout) => {
+                panic!("unexpected timeout: {timeout}")
+            }
+            ClientOutcome::Conflict(certificate) => {
+                panic!("unexpected conflict: {}", certificate.hash())
+            }
+        }
+    }
+
+    fn unwrap_ok_or_conflict(self) -> Result<T, Box<ConfirmedBlockCertificate>> {
+        match self.unwrap() {
+            ClientOutcome::Committed(t) => Ok(t),
+            ClientOutcome::Conflict(certificate) => Err(certificate),
+            ClientOutcome::WaitForTimeout(timeout) => {
+                panic!("unexpected timeout: {timeout}")
+            }
+        }
     }
 }

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -729,6 +729,14 @@ where
                 Self::send_err(requests, error_msg.clone());
                 return Ok(());
             }
+            Ok(ClientOutcome::Conflict(certificate)) => {
+                let error_msg = format!(
+                    "A different block was committed at this height: {}",
+                    certificate.hash(),
+                );
+                Self::send_err(requests, error_msg.clone());
+                return Ok(());
+            }
         };
 
         // Parse chain descriptions from the block's blobs

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1448,6 +1448,9 @@ impl Runnable for Job {
                     ClientOutcome::WaitForTimeout(timeout) => {
                         info!("Please try again at {}", timeout.timestamp)
                     }
+                    ClientOutcome::Conflict(certificate) => {
+                        info!("A different block was committed: {}", certificate.hash())
+                    }
                 }
                 context.update_wallet_from_client(&chain_client).await?;
                 info!(


### PR DESCRIPTION
Backport of #5234.

## Motivation

The chain client currently automatically retries the same operations at the next block height if a conflicting block got committed at the current height. But the same operations are not necessarily desired at the new chain state anymore.

## Proposal

Remove the automatic retry behavior, and return a `ClientOutcome::Conflict` instead, to let the caller decide.

## Test Plan

The tests were updated.

## Release Plan

- These changes should be released in a new SDK.

## Links

- PR to main: #5234
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
