### PR TITLE
Fix handle block when open_multi_leader_rounds is true

### DIFF
--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -153,6 +153,7 @@ impl ChainOwnership {
         !self.super_owners.is_empty()
             || !self.owners.is_empty()
             || self.timeout_config.fallback_duration == TimeDelta::ZERO
+            || self.open_multi_leader_rounds
     }
 
     /// Returns `true` if this is an owner or super owner.

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -488,9 +488,13 @@ impl<Env: Environment> ClientContext<Env> {
             .extend_chain_mode(chain_id, ListeningMode::FullChain);
         let client = self.make_chain_client(chain_id).await?;
         let chain_description = client.get_chain_description().await?;
-        let config = chain_description.config();
+        // let config = chain_description.config();
 
-        if !config.ownership.is_owner(&owner) {
+        let info = client.chain_info().await?;
+
+        if !info.manager.ownership.is_owner(&owner)
+            && !info.manager.ownership.open_multi_leader_rounds
+        {
             tracing::error!(
                 "The chain with the ID returned by the faucet is not owned by you. \
                 Please make sure you are connecting to a genuine faucet."

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1528,7 +1528,8 @@ where
         block.check_proposal_size(policy.maximum_block_proposal_size)?;
         // Check the authentication of the block.
         ensure!(
-            chain.manager.can_propose(&owner, proposal.content.round),
+            chain.manager.can_propose(&owner, proposal.content.round)
+                || chain.ownership().open_multi_leader_rounds,
             WorkerError::InvalidOwner
         );
         let old_round = self.chain.manager.current_round();

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -653,7 +653,7 @@ impl<Env: Environment> ChainClient<Env> {
         let is_owner = manager.ownership.is_owner(&preferred_owner)
             || fallback_owners.contains(&preferred_owner);
 
-        if !is_owner {
+        if !is_owner && !manager.ownership.open_multi_leader_rounds {
             warn!(
                 chain_id = %self.chain_id,
                 ownership = ?manager.ownership,
@@ -1913,7 +1913,9 @@ impl<Env: Environment> ChainClient<Env> {
             .values()
             .map(|v| (AccountOwner::from(v.account_public_key), v.votes))
             .collect();
-        if manager.should_propose(identity, round, seed, &current_committee) {
+        if manager.should_propose(identity, round, seed, &current_committee)
+            || manager.ownership.open_multi_leader_rounds
+        {
             return Ok(Either::Left(round));
         }
         if let Some(timeout) = info.round_timeout() {


### PR DESCRIPTION
## Motivation

In default, we always have owner in super_owners or owners of a microchain. But when open_multi_leader_rounds is true, super_owners and owners may be empty set. This case is not processed correctly right now.

## Proposal

Fix the case of open_multi_leader_rounds is true at wallet and validator side.

## Test Plan

CI

## Release Plan

be released in a new SDK

## Links

<!--
Optional section for related PRs, related issues, and other references.
