### PR TITLE
[testnet] Change account CLI syntax from `chain:owner` to `owner@chain` (#5305)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -412,7 +412,7 @@ NOTE: The local balance does not reflect messages that are waiting to be picked 
 
 ###### **Arguments:**
 
-* `<ACCOUNT>` — The account to read, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the chain balance. By default, we read the chain balance of the default chain in the wallet
+* `<ACCOUNT>` — The account to read, written as `OWNER@CHAIN-ID` or simply `CHAIN-ID` for the chain balance. By default, we read the chain balance of the default chain in the wallet
 
 
 
@@ -426,7 +426,7 @@ NOTE: The balance does not reflect messages that have not been synchronized from
 
 ###### **Arguments:**
 
-* `<ACCOUNT>` — The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the chain balance. By default, we read the chain balance of the default chain in the wallet
+* `<ACCOUNT>` — The account to query, written as `OWNER@CHAIN-ID` or simply `CHAIN-ID` for the chain balance. By default, we read the chain balance of the default chain in the wallet
 
 
 
@@ -440,7 +440,7 @@ This command is deprecated. Use `linera sync && linera query-balance` instead.
 
 ###### **Arguments:**
 
-* `<ACCOUNT>` — The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the chain balance. By default, we read the chain balance of the default chain in the wallet
+* `<ACCOUNT>` — The account to query, written as `OWNER@CHAIN-ID` or simply `CHAIN-ID` for the chain balance. By default, we read the chain balance of the default chain in the wallet
 
 
 

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ linera query-balance "$CHAIN1"
 linera query-balance "$CHAIN2"
 
 # Now let's fund the user balances.
-linera transfer 5 --from "$CHAIN1" --to "$CHAIN1:$ACCOUNT1"
-linera transfer 2 --from "$CHAIN1:$ACCOUNT1" --to "$CHAIN2:$ACCOUNT2"
+linera transfer 5 --from "$CHAIN1" --to "$ACCOUNT1@$CHAIN1"
+linera transfer 2 --from "$ACCOUNT1@$CHAIN1" --to "$ACCOUNT2@$CHAIN2"
 
 # Query user balances again.
-linera query-balance "$CHAIN1:$ACCOUNT1"
-linera query-balance "$CHAIN2:$ACCOUNT2"
+linera query-balance "$ACCOUNT1@$CHAIN1"
+linera query-balance "$ACCOUNT2@$CHAIN2"
 ```
 
 More complex examples may be found in our [developer manual](https://linera.dev) as well

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -145,7 +145,7 @@ impl Account {
 
 impl fmt::Display for Account {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.chain_id, self.owner)
+        write!(f, "{}@{}", self.owner, self.chain_id)
     }
 }
 
@@ -153,19 +153,14 @@ impl std::str::FromStr for Account {
     type Err = anyhow::Error;
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
-        let mut parts = string.splitn(2, ':');
-
-        let chain_id = parts
-            .next()
-            .context(
-                "Expecting an account formatted as `chain-id` or `chain-id:owner-type:address`",
-            )?
-            .parse()?;
-
-        if let Some(owner_string) = parts.next() {
+        if let Some((owner_string, chain_string)) = string.rsplit_once('@') {
             let owner = owner_string.parse::<AccountOwner>()?;
+            let chain_id = chain_string.parse()?;
             Ok(Account::new(chain_id, owner))
         } else {
+            let chain_id = string
+                .parse()
+                .context("Expecting an account formatted as `chain-id` or `owner@chain-id`")?;
             Ok(Account::chain(chain_id))
         }
     }
@@ -1077,7 +1072,7 @@ impl std::str::FromStr for AccountOwner {
             } else if s.len() == 40 {
                 let address = hex::decode(s)?;
                 if address.len() != 20 {
-                    anyhow::bail!("Invalid address length: {}", s);
+                    anyhow::bail!("Invalid address length: {s}");
                 }
                 let address = <[u8; 20]>::try_from(address.as_slice()).unwrap();
                 return Ok(AccountOwner::Address20(address));
@@ -1090,7 +1085,7 @@ impl std::str::FromStr for AccountOwner {
                 }
             }
         }
-        anyhow::bail!("Invalid address value: {}", s);
+        anyhow::bail!("Invalid address value: {s}");
     }
 }
 
@@ -1208,6 +1203,7 @@ mod tests {
     #[test]
     fn addresses() {
         assert_eq!(&AccountOwner::Reserved(0).to_string(), "0x00");
+        assert_eq!(AccountOwner::from_str("0x00").unwrap(), AccountOwner::CHAIN);
 
         let address = AccountOwner::from_str("0x10").unwrap();
         assert_eq!(address, AccountOwner::Reserved(16));
@@ -1236,6 +1232,31 @@ mod tests {
             "5487b70625ce71f7ee29154ad32aefa1c526cb483bdb783dea2e1d17bc497844"
         )
         .is_err());
+    }
+
+    #[test]
+    fn accounts() {
+        use super::{Account, ChainId};
+
+        const CHAIN: &str = "76e3a8c7b2449e6bc238642ac68b4311a809cb57328bea0a1ef9122f08a0053d";
+        const OWNER: &str = "0x5487b70625ce71f7ee29154ad32aefa1c526cb483bdb783dea2e1d17bc497844";
+
+        let chain_id = ChainId::from_str(CHAIN).unwrap();
+        let owner = AccountOwner::from_str(OWNER).unwrap();
+
+        // Chain-only account.
+        let account = Account::from_str(CHAIN).unwrap();
+        assert_eq!(
+            account,
+            Account::from_str(&format!("0x00@{CHAIN}")).unwrap()
+        );
+        assert_eq!(account, Account::chain(chain_id));
+        assert_eq!(account.to_string(), format!("0x00@{CHAIN}"));
+
+        // Account with owner.
+        let account = Account::from_str(&format!("{OWNER}@{CHAIN}")).unwrap();
+        assert_eq!(account, Account::new(chain_id, owner));
+        assert_eq!(account.to_string(), format!("{OWNER}@{CHAIN}"));
     }
 
     #[test]

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -311,7 +311,7 @@ pub enum ClientCommand {
     /// `linera sync` then either `linera query-balance` or `linera process-inbox &&
     /// linera local-balance` for a consolidated balance.
     LocalBalance {
-        /// The account to read, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the
+        /// The account to read, written as `OWNER@CHAIN-ID` or simply `CHAIN-ID` for the
         /// chain balance. By default, we read the chain balance of the default chain in
         /// the wallet.
         account: Option<Account>,
@@ -323,7 +323,7 @@ pub enum ClientCommand {
     /// NOTE: The balance does not reflect messages that have not been synchronized from
     /// validators yet. Call `linera sync` first to do so.
     QueryBalance {
-        /// The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the
+        /// The account to query, written as `OWNER@CHAIN-ID` or simply `CHAIN-ID` for the
         /// chain balance. By default, we read the chain balance of the default chain in
         /// the wallet.
         account: Option<Account>,
@@ -334,7 +334,7 @@ pub enum ClientCommand {
     ///
     /// This command is deprecated. Use `linera sync && linera query-balance` instead.
     SyncBalance {
-        /// The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the
+        /// The account to query, written as `OWNER@CHAIN-ID` or simply `CHAIN-ID` for the
         /// chain balance. By default, we read the chain balance of the default chain in
         /// the wallet.
         account: Option<Account>,


### PR DESCRIPTION
Backport of #5305 

## Motivation

On the CLI we use the syntax `chain:owner` for an account, whereas we use `owner@chain` on the web.

## Proposal

Use `owner@chain` on the CLI, too.

`0x00@chain` and just `chain` are equivalent, but the former is printed by the `Display` impl.

## Test Plan

A unit test for the string representation was added.

## Release Plan

- These changes should be backported to `testnet_conway`, then
    - be released in a new SDK.

## Links

- PR to main #5305
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
