### PR TITLE
Simplify how initial committee exporters are spawned.

### DIFF
--- a/linera-service/src/exporter/runloops/block_processor/mod.rs
+++ b/linera-service/src/exporter/runloops/block_processor/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     future::{Future, IntoFuture},
     str::FromStr,
     time::{Duration, Instant},
@@ -83,7 +83,7 @@ where
         let mut interval = interval(Duration::from_millis(persistence_period.into()));
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-        self.exporters_tracker.start_startup_exporters();
+        self.exporters_tracker.spawn_exporters();
 
         loop {
             tokio::select! {
@@ -123,7 +123,8 @@ where
                                     }
                                 };
 
-                                let committee_destinations = committee.validator_addresses().map(|(_, address)| DestinationId::validator(address.to_owned())).collect::<Vec<_>>();
+                                let committee_destinations = committee.validator_addresses().map(|(_, address)| DestinationId::validator(address.to_owned()))
+                                    .collect::<HashSet<_>>();
                                 self.exporters_tracker.shutdown_old_committee(committee_destinations.clone());
                                 self.storage.new_committee(committee_destinations.clone());
                                 self.storage.set_latest_committee_blob(new_committee_blob);
@@ -208,6 +209,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashSet;
+
     use linera_base::{
         crypto::CryptoHash,
         data_types::{Round, Timestamp},
@@ -257,6 +260,7 @@ mod test {
             signal.clone(),
             exporter_storage.clone()?,
             vec![],
+            HashSet::new(),
         );
         let mut block_processor = BlockProcessor::new(
             exporters_tracker,
@@ -387,6 +391,7 @@ mod test {
             signal.clone(),
             exporter_storage.clone()?,
             vec![],
+            HashSet::new(),
         );
         let mut block_processor = BlockProcessor::new(
             exporters_tracker,
@@ -507,6 +512,7 @@ mod test {
             signal.clone(),
             exporter_storage.clone()?,
             vec![],
+            HashSet::new(),
         );
         let mut block_processor = BlockProcessor::new(
             exporters_tracker,
@@ -594,6 +600,7 @@ mod test {
             signal.clone(),
             exporter_storage.clone()?,
             vec![],
+            HashSet::new(),
         );
         let mut block_processor = BlockProcessor::new(
             exporters_tracker,
@@ -703,6 +710,7 @@ mod test {
             signal.clone(),
             exporter_storage.clone()?,
             vec![],
+            HashSet::new(),
         );
         let mut block_processor = BlockProcessor::new(
             exporters_tracker,
@@ -792,6 +800,7 @@ mod test {
             signal.clone(),
             exporter_storage.clone()?,
             vec![],
+            HashSet::new(),
         );
 
         let mut block_processor = BlockProcessor::new(

--- a/linera-service/src/exporter/storage.rs
+++ b/linera-service/src/exporter/storage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     marker::PhantomData,
     sync::{atomic::AtomicU64, Arc},
 };
@@ -329,7 +329,7 @@ where
         self.shared_storage.push_block(block)
     }
 
-    pub(super) fn new_committee(&mut self, committee_destinations: Vec<DestinationId>) {
+    pub(super) fn new_committee(&mut self, committee_destinations: HashSet<DestinationId>) {
         committee_destinations.into_iter().for_each(|id| {
             let state = match self.shared_storage.destination_states.get(&id) {
                 None => {


### PR DESCRIPTION
## Motivation

Currently, the startup committee exporters are initialized and spawned bypassing the `ExportersTracker` logic for managing the newly-spawned exporters.

## Proposal

Find the set of destinations we want to run (comittee destinations) and pass it to the constructor of the `ExportersTracker`. Those are later spawned (via `ExportersTracker::spawn_exporters`) in `block_processor.run_with_shutdown`.

## Test Plan

CI.

## Release Plan

- These changes should be released to testnet
- These changes should be backported to `main`

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
