### PR TITLE
Add the `wasm-opt` to the created WebAssembly files.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -192,6 +192,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - uses: jetli/wasm-pack-action@v0.4.0
     - uses: foundry-rs/foundry-toolchain@v1.4.0
     - name: Ensure Solc Directory Exists
       run: mkdir -p /home/runner/.solc

--- a/linera-base/src/util/mod.rs
+++ b/linera-base/src/util/mod.rs
@@ -7,3 +7,4 @@ Utilities used throughout the Linera codebase.
 
 pub mod future;
 pub mod traits;
+pub mod wasm;

--- a/linera-base/src/util/wasm.rs
+++ b/linera-base/src/util/wasm.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helpers for optimizing WebAssembly binaries.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Optimizes a single WebAssembly file in-place using `wasm-opt -O4`.
+pub fn optimize_wasm_file(path: &Path) -> Result<(), io::Error> {
+    let optimized_path = optimized_output_path(path)?;
+    let output = Command::new("wasm-opt")
+        .args(["-O4"])
+        .arg(path)
+        .arg("-o")
+        .arg(&optimized_path)
+        .output()?;
+
+    if !output.status.success() {
+        return Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!(
+                "Failed to optimize Wasm binary with wasm-opt.\nstdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        ));
+    }
+
+    std::fs::rename(&optimized_path, path)?;
+    Ok(())
+}
+
+/// Optimizes all `.wasm` files in the given directory in-place.
+pub fn optimize_wasm_files_in(output_directory: &Path) -> Result<(), io::Error> {
+    for entry in std::fs::read_dir(output_directory)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("wasm") {
+            continue;
+        }
+        optimize_wasm_file(&path)?;
+    }
+    Ok(())
+}
+
+fn optimized_output_path(path: &Path) -> Result<PathBuf, io::Error> {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("wasm") {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Expected a .wasm file, got {}", path.display()),
+        ));
+    }
+
+    Ok(path.with_extension("wasm.opt"))
+}

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -344,6 +344,7 @@ pub mod test {
 
     #[cfg(with_fs)]
     use super::{WasmContractModule, WasmRuntime, WasmServiceModule};
+    use linera_base::util::wasm::optimize_wasm_files_in;
 
     fn build_applications_in_directory(dir: &str) -> Result<(), std::io::Error> {
         let output = std::process::Command::new("cargo")
@@ -359,6 +360,8 @@ pub mod test {
                 String::from_utf8_lossy(&output.stderr),
             );
         }
+        let output_directory = Path::new(dir).join("target/wasm32-unknown-unknown/release");
+        optimize_wasm_files_in(&output_directory)?;
         Ok(())
     }
 

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -21,6 +21,7 @@ use linera_base::{
         CompressedBytecode, Epoch,
     },
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
+    util::wasm::optimize_wasm_files_in,
     vm::VmRuntime,
 };
 use linera_chain::{types::ConfirmedBlockCertificate, ChainExecutionContext};
@@ -438,6 +439,11 @@ impl ActiveChain {
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
+
+        let output_directory = Self::find_output_directory_of_sync(repository)
+            .expect("Failed to look for output binaries");
+        optimize_wasm_files_in(&output_directory)
+            .expect("Failed to optimize Wasm binaries with wasm-opt");
     }
 
     /// Searches the Cargo manifest of the crate calling this method for binaries to use as the
@@ -508,6 +514,25 @@ impl ActiveChain {
         let mut output_path = current_directory.join(output_sub_directory);
 
         while !fs::try_exists(&output_path).await? {
+            current_directory = current_directory.parent().unwrap_or_else(|| {
+                panic!(
+                    "Failed to find Wasm binary output directory in {}",
+                    repository.display()
+                )
+            });
+
+            output_path = current_directory.join(output_sub_directory);
+        }
+
+        Ok(output_path)
+    }
+
+    fn find_output_directory_of_sync(repository: &Path) -> Result<PathBuf, io::Error> {
+        let output_sub_directory = Path::new("target/wasm32-unknown-unknown/release");
+        let mut current_directory = repository;
+        let mut output_path = current_directory.join(output_sub_directory);
+
+        while std::fs::metadata(&output_path).is_err() {
             current_directory = current_directory.parent().unwrap_or_else(|| {
                 panic!(
                     "Failed to find Wasm binary output directory in {}",

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -28,6 +28,7 @@ use linera_base::{
     identifiers::{
         Account, AccountOwner, ApplicationId, ChainId, IndexAndEvent, ModuleId, StreamId,
     },
+    util::wasm::optimize_wasm_file,
     vm::VmRuntime,
 };
 use linera_client::client_options::ResourceControlPolicyConfig;
@@ -1228,6 +1229,9 @@ impl ClientWrapper {
 
         let contract = release_dir.join(format!("{}_contract.wasm", name.replace('-', "_")));
         let service = release_dir.join(format!("{}_service.wasm", name.replace('-', "_")));
+
+        optimize_wasm_file(&contract)?;
+        optimize_wasm_file(&service)?;
 
         let contract_size = fs_err::tokio::metadata(&contract).await?.len();
         let service_size = fs_err::tokio::metadata(&service).await?.len();


### PR DESCRIPTION
## Motivation

The running of WebAssembly programs has some costs associated with it.
We want to minimize as much as possible the Wasm fuels. 

## Proposal

Apply the `wasm-opt` to the created Wasm files. Running the `wasm-opt` is very fast
so this is not a problem for the tests.

## Test Plan

The CI.
Running on the fungible example, we get a 1.6% improvement in performance.

## Release Plan

This can be backported to TestNet Conway.

## Links

None.