### PR TITLE
lock @types/node to 22.7.5 as required by ethers

### DIFF
--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -62,9 +62,12 @@ importers:
         specifier: ^6.15.0
         version: 6.15.0
     devDependencies:
+      '@types/node':
+        specifier: 22.7.5
+        version: 22.7.5
       vite:
         specifier: 7.1.7
-        version: 7.1.7(yaml@2.8.1)
+        version: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
 
   counter/metamask:
     dependencies:
@@ -77,7 +80,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^5.4.11
-        version: 5.4.20(@types/node@22.7.5)
+        version: 5.4.20(@types/node@25.0.10)
 
   native-fungible:
     dependencies:
@@ -90,7 +93,7 @@ importers:
     devDependencies:
       vite:
         specifier: 7.1.7
-        version: 7.1.7(yaml@2.8.1)
+        version: 7.1.7(@types/node@25.0.10)(yaml@2.8.1)
 
 packages:
 
@@ -662,6 +665,9 @@ packages:
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
+  '@types/node@25.0.10':
+    resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1176,6 +1182,9 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1754,6 +1763,11 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/node@25.0.10':
+    dependencies:
+      undici-types: 7.16.0
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@vitest/browser@3.2.4(playwright@1.54.0)(vite@5.4.20(@types/node@22.7.5))(vitest@3.2.4)':
@@ -2283,6 +2297,9 @@ snapshots:
 
   undici-types@6.19.8: {}
 
+  undici-types@7.16.0:
+    optional: true
+
   util-deprecate@1.0.2: {}
 
   uuid@9.0.1: {}
@@ -2314,7 +2331,16 @@ snapshots:
       '@types/node': 22.7.5
       fsevents: 2.3.3
 
-  vite@7.1.7(yaml@2.8.1):
+  vite@5.4.20(@types/node@25.0.10):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.52.2
+    optionalDependencies:
+      '@types/node': 25.0.10
+      fsevents: 2.3.3
+
+  vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2323,6 +2349,20 @@ snapshots:
       rollup: 4.52.2
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 22.7.5
+      fsevents: 2.3.3
+      yaml: 2.8.1
+
+  vite@7.1.7(@types/node@25.0.10)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.10
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.52.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.0.10
       fsevents: 2.3.3
       yaml: 2.8.1
 

--- a/web/.cargo/config.toml
+++ b/web/.cargo/config.toml
@@ -1,7 +1,7 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
     # support threading
-    "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals,+reference-types",
+    "-C", "target-feature=+atomics,+mutable-globals,+reference-types",
     # allow linking C code (for `rust_secp256k1`)
     "--cfg=web_sys_unstable_apis",
     "-Z", "wasm_c_abi=spec",

--- a/web/@linera/client/package.json
+++ b/web/@linera/client/package.json
@@ -40,6 +40,7 @@
     "ethers": "^6.15.0"
   },
   "devDependencies": {
+    "@types/node": "22.7.5",
     "@vitest/browser": "^3.2.4",
     "playwright": "1.54.0",
     "prettier": "3.5.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -12,9 +12,12 @@ importers:
         specifier: ^6.15.0
         version: 6.15.0
     devDependencies:
+      '@types/node':
+        specifier: 22.7.5
+        version: 22.7.5
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(playwright@1.54.0)(vite@7.1.9(yaml@2.8.1))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.54.0)(vite@7.1.9(@types/node@22.7.5)(yaml@2.8.1))(vitest@3.2.4)
       playwright:
         specifier: 1.54.0
         version: 1.54.0
@@ -35,7 +38,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@vitest/browser@3.2.4)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)(yaml@2.8.1)
 
   '@linera/metamask':
     dependencies:
@@ -1474,16 +1477,16 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@vitest/browser@3.2.4(playwright@1.54.0)(vite@7.1.9(yaml@2.8.1))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.54.0)(vite@7.1.9(@types/node@22.7.5)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@7.1.9(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@22.7.5)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.19
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@vitest/browser@3.2.4)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)(yaml@2.8.1)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.54.0
@@ -1501,13 +1504,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.9(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@22.7.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.9(yaml@2.8.1)
+      vite: 7.1.9(@types/node@22.7.5)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1977,13 +1980,13 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  vite-node@3.2.4(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@22.7.5)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.9(yaml@2.8.1)
+      vite: 7.1.9(@types/node@22.7.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -1998,7 +2001,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.9(yaml@2.8.1):
+  vite@7.1.9(@types/node@22.7.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2007,14 +2010,15 @@ snapshots:
       rollup: 4.52.4
       tinyglobby: 0.2.15
     optionalDependencies:
+      '@types/node': 22.7.5
       fsevents: 2.3.3
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/debug@4.1.12)(@vitest/browser@3.2.4)(yaml@2.8.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.9(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@22.7.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2032,12 +2036,13 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.9(yaml@2.8.1)
-      vite-node: 3.2.4(yaml@2.8.1)
+      vite: 7.1.9(@types/node@22.7.5)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.7.5)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
-      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.1.9(yaml@2.8.1))(vitest@3.2.4)
+      '@types/node': 22.7.5
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.1.9(@types/node@22.7.5)(yaml@2.8.1))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
## Motivation

Fresh build fails.

## Proposal

Pin version.

## Test Plan

During deploy.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
