### PR TITLE
Fix Cloud Build Docker image builds

### DIFF
--- a/docker/build-explorer-image.yaml
+++ b/docker/build-explorer-image.yaml
@@ -1,6 +1,8 @@
 steps:
-  - name: "docker:latest"
+  - name: "gcr.io/cloud-builders/docker"
     entrypoint: "docker"
+    env:
+      - "DOCKER_BUILDKIT=1"
     args:
       [
         "build",

--- a/docker/build-exporter-image.yaml
+++ b/docker/build-exporter-image.yaml
@@ -1,6 +1,8 @@
 steps:
-  - name: "docker:latest"
+  - name: "gcr.io/cloud-builders/docker"
     entrypoint: "docker"
+    env:
+      - "DOCKER_BUILDKIT=1"
     args:
       [
         "build",

--- a/docker/build-image.yaml
+++ b/docker/build-image.yaml
@@ -1,6 +1,8 @@
 steps:
-  - name: "docker:latest"
+  - name: "gcr.io/cloud-builders/docker"
     entrypoint: "docker"
+    env:
+      - "DOCKER_BUILDKIT=1"
     args:
       [
         "build",

--- a/docker/build-indexer-image.yaml
+++ b/docker/build-indexer-image.yaml
@@ -1,6 +1,8 @@
 steps:
-  - name: "docker:latest"
+  - name: "gcr.io/cloud-builders/docker"
     entrypoint: "docker"
+    env:
+      - "DOCKER_BUILDKIT=1"
     args:
       [
         "build",


### PR DESCRIPTION
## Motivation

Cloud Build Docker image builds were failing with two issues:
1. docker:latest has Docker API version 1.52, but Cloud Build only supports up to 1.41
2. Multi-stage Dockerfiles with conditional stages (e.g., `builder_copy`) were failing because unused stages were still
being built

## Proposal

Update all Cloud Build YAML files to:
1. Use gcr.io/cloud-builders/docker instead of docker:latest for API compatibility
2. Enable BuildKit (DOCKER_BUILDKIT=1) so Docker only builds stages that are actually needed for the final image

## Test Plan

I can build images now

