### PR TITLE
Add `other_application_creator_chain_id` method to base runtime

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -238,6 +238,18 @@ where
                 callback.respond(permissions);
             }
 
+            DescribeApplication {
+                application_id,
+                callback,
+            } => {
+                let description = self
+                    .state
+                    .system
+                    .describe_application(application_id, self.txn_tracker)
+                    .await?;
+                callback.respond(description);
+            }
+
             ContainsKey { id, key, callback } => {
                 let view = self.state.users.try_load_entry(&id).await?;
                 let result = match view {
@@ -1165,6 +1177,12 @@ pub enum ExecutionRequest {
     ApplicationPermissions {
         #[debug(skip)]
         callback: Sender<ApplicationPermissions>,
+    },
+
+    DescribeApplication {
+        application_id: ApplicationId,
+        #[debug(skip)]
+        callback: Sender<ApplicationDescription>,
     },
 
     ReadValueBytes {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -725,6 +725,12 @@ pub trait BaseRuntime {
     /// The current application creator's chain ID.
     fn application_creator_chain_id(&mut self) -> Result<ChainId, ExecutionError>;
 
+    /// Returns the chain ID that created the given application.
+    fn other_application_creator_chain_id(
+        &mut self,
+        application_id: ApplicationId,
+    ) -> Result<ChainId, ExecutionError>;
+
     /// The current application parameters.
     fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError>;
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -629,6 +629,22 @@ where
         Ok(application_creator_chain_id)
     }
 
+    fn other_application_creator_chain_id(
+        &mut self,
+        application_id: ApplicationId,
+    ) -> Result<ChainId, ExecutionError> {
+        let mut this = self.inner();
+        let description = this
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::DescribeApplication {
+                application_id,
+                callback,
+            })?
+            .recv_response()?;
+        this.resource_controller.track_runtime_application_id()?;
+        Ok(description.creator_chain_id)
+    }
+
     fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
         let mut this = self.inner();
         let parameters = this.current_application().description.parameters.clone();

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -119,6 +119,18 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Returns the chain ID that created the given application.
+    fn other_application_creator_chain_id(
+        caller: &mut Caller,
+        application_id: ApplicationId,
+    ) -> Result<ChainId, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .other_application_creator_chain_id(application_id)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Returns the application parameters provided when the application was created.
     fn application_parameters(caller: &mut Caller) -> Result<Vec<u8>, RuntimeError> {
         caller

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1409,3 +1409,43 @@ async fn test_message_receipt_spending_chain_balance(
 
     Ok(execution_result)
 }
+
+/// Tests that an application can query the creator chain ID of another application.
+#[tokio::test]
+async fn test_other_application_creator_chain_id() -> anyhow::Result<()> {
+    let (state, chain_id) = SystemExecutionState::dummy_chain_state(0);
+    let mut view = state.into_view().await;
+
+    let (caller_id, caller_application, caller_blobs) = view.register_mock_application(0).await?;
+    let (target_id, target_application, target_blobs) = view.register_mock_application(1).await?;
+
+    // The creator chain ID for mock applications is dummy_chain_description(1).id().
+    let expected_creator_chain_id = dummy_chain_description(1).id();
+
+    caller_application.expect_call(ExpectedCall::execute_operation(
+        move |runtime, _operation| {
+            let creator_chain_id = runtime.other_application_creator_chain_id(target_id)?;
+            assert_eq!(creator_chain_id, expected_creator_chain_id);
+            Ok(vec![])
+        },
+    ));
+
+    target_application.expect_call(ExpectedCall::default_finalize());
+    caller_application.expect_call(ExpectedCall::default_finalize());
+
+    let context = create_dummy_operation_context(chain_id);
+    let mut controller = ResourceController::default();
+    let mut txn_tracker =
+        TransactionTracker::new_replaying_blobs(caller_blobs.iter().chain(&target_blobs));
+    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(
+            context,
+            Operation::User {
+                application_id: caller_id,
+                bytes: vec![],
+            },
+        )
+        .await?;
+
+    Ok(())
+}

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -97,6 +97,11 @@ where
             .get_or_insert_with(|| base_wit::get_application_creator_chain_id().into())
     }
 
+    /// Returns the chain ID that created the given application.
+    pub fn other_application_creator_chain_id(&mut self, application_id: ApplicationId) -> ChainId {
+        base_wit::other_application_creator_chain_id(application_id.forget_abi().into()).into()
+    }
+
     /// Returns the ID of the current chain.
     pub fn chain_id(&mut self) -> ChainId {
         *self

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -53,6 +53,7 @@ where
     application_parameters: Option<Application::Parameters>,
     application_id: Option<ApplicationId<Application::Abi>>,
     application_creator_chain_id: Option<ChainId>,
+    application_creator_chain_ids: HashMap<ApplicationId, ChainId>,
     chain_id: Option<ChainId>,
     authenticated_owner: Option<Option<AccountOwner>>,
     block_height: Option<BlockHeight>,
@@ -103,6 +104,7 @@ where
             application_parameters: None,
             application_id: None,
             application_creator_chain_id: None,
+            application_creator_chain_ids: HashMap::new(),
             chain_id: None,
             authenticated_owner: None,
             block_height: None,
@@ -212,6 +214,41 @@ where
             "Application creator chain ID has not been mocked, \
             please call `MockContractRuntime::set_application_creator_chain_id` first",
         )
+    }
+
+    /// Configures the creator chain ID to return for a specific application during the test.
+    pub fn with_application_creator_chain_id_for(
+        mut self,
+        application_id: ApplicationId,
+        chain_id: ChainId,
+    ) -> Self {
+        self.application_creator_chain_ids
+            .insert(application_id, chain_id);
+        self
+    }
+
+    /// Configures the creator chain ID to return for a specific application during the test.
+    pub fn set_application_creator_chain_id_for(
+        &mut self,
+        application_id: ApplicationId,
+        chain_id: ChainId,
+    ) -> &mut Self {
+        self.application_creator_chain_ids
+            .insert(application_id, chain_id);
+        self
+    }
+
+    /// Returns the chain ID that created the given application.
+    pub fn other_application_creator_chain_id(&mut self, application_id: ApplicationId) -> ChainId {
+        *self
+            .application_creator_chain_ids
+            .get(&application_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Application creator chain ID for {application_id:?} has not been mocked, \
+                please call `MockContractRuntime::set_application_creator_chain_id_for` first"
+                )
+            })
     }
 
     /// Configures the chain ID to return during the test.

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -87,6 +87,11 @@ where
         })
     }
 
+    /// Returns the chain ID that created the given application.
+    pub fn other_application_creator_chain_id(&self, application_id: ApplicationId) -> ChainId {
+        base_wit::other_application_creator_chain_id(application_id.forget_abi().into()).into()
+    }
+
     /// Returns the ID of the current chain.
     pub fn chain_id(&self) -> ChainId {
         Self::fetch_value_through_cache(&self.chain_id, || base_wit::get_chain_id().into())

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -26,6 +26,7 @@ where
     application_parameters: Mutex<Option<Application::Parameters>>,
     application_id: Mutex<Option<ApplicationId<Application::Abi>>>,
     application_creator_chain_id: Mutex<Option<ChainId>>,
+    application_creator_chain_ids: Mutex<HashMap<ApplicationId, ChainId>>,
     chain_id: Mutex<Option<ChainId>>,
     next_block_height: Mutex<Option<BlockHeight>>,
     timestamp: Mutex<Option<Timestamp>>,
@@ -57,6 +58,7 @@ where
             application_parameters: Mutex::new(None),
             application_id: Mutex::new(None),
             application_creator_chain_id: Mutex::new(None),
+            application_creator_chain_ids: Mutex::new(HashMap::new()),
             chain_id: Mutex::new(None),
             next_block_height: Mutex::new(None),
             timestamp: Mutex::new(None),
@@ -147,6 +149,47 @@ where
             "Application creator chain ID has not been mocked, \
             please call `MockServiceRuntime::set_application_creator_chain_id` first",
         )
+    }
+
+    /// Configures the creator chain ID to return for a specific application during the test.
+    pub fn with_application_creator_chain_id_for(
+        self,
+        application_id: ApplicationId,
+        chain_id: ChainId,
+    ) -> Self {
+        self.application_creator_chain_ids
+            .lock()
+            .unwrap()
+            .insert(application_id, chain_id);
+        self
+    }
+
+    /// Configures the creator chain ID to return for a specific application during the test.
+    pub fn set_application_creator_chain_id_for(
+        &self,
+        application_id: ApplicationId,
+        chain_id: ChainId,
+    ) -> &Self {
+        self.application_creator_chain_ids
+            .lock()
+            .unwrap()
+            .insert(application_id, chain_id);
+        self
+    }
+
+    /// Returns the chain ID that created the given application.
+    pub fn other_application_creator_chain_id(&self, application_id: ApplicationId) -> ChainId {
+        *self
+            .application_creator_chain_ids
+            .lock()
+            .unwrap()
+            .get(&application_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Application creator chain ID for {application_id:?} has not been mocked, \
+                    please call `MockServiceRuntime::set_application_creator_chain_id_for` first"
+                )
+            })
     }
 
     /// Configures the chain ID to return during the test.

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -5,6 +5,7 @@ interface base-runtime-api {
     get-block-height: func() -> block-height;
     get-application-id: func() -> application-id;
     get-application-creator-chain-id: func() -> chain-id;
+    other-application-creator-chain-id: func(application-id: application-id) -> chain-id;
     application-parameters: func() -> list<u8>;
     get-chain-ownership: func() -> chain-ownership;
     get-application-permissions: func() -> application-permissions;


### PR DESCRIPTION
## Motivation

In some cases one application wants to grant permissions to other applications only if they were created by a specific chain.

## Proposal

Add `other_application_creator_chain_id` to get the creator chain ID.

## Test Plan

A test was added.

## Release Plan

- Backport to `testnet_conway` and
    - release in a new SDK.

## Links

- Closes #5335.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
