### PR TITLE
Update graphql account type

### DIFF
--- a/examples/native-fungible/index.html
+++ b/examples/native-fungible/index.html
@@ -178,7 +178,7 @@
               const query = gql(`mutation(
                   $donor: AccountOwner!,
                   $amount: Amount!,
-                  $recipient: Account!,
+                  $recipient: FungibleAccount!,
               ) {
                   transfer(owner: $donor, amount: $amount, targetAccount: $recipient)
               }`, {


### PR DESCRIPTION
Replace Account! with FungibleAccount!

in `fungible.rs` the `Account` type [is being renamed](https://github.com/linera-io/linera-protocol/blob/da2bdd6f8b5f67c73b9f999cc1dce74eac0f9d6a/linera-sdk/src/abis/fungible.rs#L175) to `FungibleAccount!:
```rs
#[graphql(input_name = "FungibleAccount")]
pub struct Account {
```