### PR TITLE
`linera-sdk`: remove `yield_once` from the system view API

### DIFF
--- a/linera-sdk/src/util.rs
+++ b/linera-sdk/src/util.rs
@@ -5,41 +5,11 @@
 
 use std::{
     future::Future,
-    pin::{pin, Pin},
+    pin::pin,
     task::{Context, Poll},
 };
 
 use futures::task;
-
-/// Yields the current asynchronous task so that other tasks may progress if possible.
-///
-/// After other tasks progress, this task resumes as soon as possible. More explicitly, it is
-/// scheduled to be woken up as soon as possible.
-pub fn yield_once() -> YieldOnce {
-    YieldOnce::default()
-}
-
-/// A [`Future`] that returns [`Poll::Pending`] once and immediately schedules itself to wake up.
-#[derive(Default)]
-pub struct YieldOnce {
-    yielded: bool,
-}
-
-impl Future for YieldOnce {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        let mut this = self.as_mut();
-
-        if this.yielded {
-            Poll::Ready(())
-        } else {
-            this.yielded = true;
-            context.waker().wake_by_ref();
-            Poll::Pending
-        }
-    }
-}
 
 /// An extension trait to block on a [`Future`] until it completes.
 pub trait BlockingWait {
@@ -59,12 +29,11 @@ where
     type Output = AnyFuture::Output;
 
     fn blocking_wait(self) -> Self::Output {
-        let waker = task::noop_waker();
-        let mut task_context = Context::from_waker(&waker);
+        let mut context = Context::from_waker(task::noop_waker_ref());
         let mut future = pin!(self);
 
         loop {
-            match future.as_mut().poll(&mut task_context) {
+            match future.as_mut().poll(&mut context) {
                 Poll::Pending => continue,
                 Poll::Ready(output) => return output,
             }
@@ -75,37 +44,16 @@ where
 /// Unit tests for the helpers defined in the `util` module.
 #[cfg(test)]
 mod tests {
-    use std::task::{Context, Poll};
-
-    use futures::{future::poll_fn, task::noop_waker, FutureExt as _};
-
-    use super::{yield_once, BlockingWait};
-
-    /// Tests the behavior of the [`YieldOnce`] future.
-    ///
-    /// Checks the internal state before and after the first and second polls, and ensures that
-    /// only the first poll returns [`Poll::Pending`].
-    #[test]
-    #[expect(clippy::bool_assert_comparison)]
-    fn yield_once_returns_pending_only_on_first_call() {
-        let mut future = yield_once();
-
-        let waker = noop_waker();
-        let mut context = Context::from_waker(&waker);
-
-        assert_eq!(future.yielded, false);
-        assert!(future.poll_unpin(&mut context).is_pending());
-        assert_eq!(future.yielded, true);
-        assert!(future.poll_unpin(&mut context).is_ready());
-        assert_eq!(future.yielded, true);
-    }
-
     /// Tests the behavior of the [`BlockingWait`] extension.
     #[test]
     fn blocking_wait_blocks_until_future_is_ready() {
+        use std::task::Poll;
+
+        use super::BlockingWait as _;
+
         let mut remaining_polls = 100;
 
-        let future = poll_fn(|_context| {
+        let future = futures::future::poll_fn(|_context| {
             if remaining_polls == 0 {
                 Poll::Ready(())
             } else {

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -21,7 +21,6 @@ use crate::{
         contract_runtime_api::{self, WriteOperation},
     },
     service::wit::base_runtime_api as service_wit,
-    util::yield_once,
 };
 
 /// We need to have a maximum key size that handles all possible underlying
@@ -121,7 +120,6 @@ impl ReadableKeyValueStore for KeyValueStore {
             KeyValueStoreError::KeyTooLong
         );
         let promise = self.wit_api.contains_key_new(key);
-        yield_once().await;
         Ok(self.wit_api.contains_key_wait(promise))
     }
 
@@ -133,7 +131,6 @@ impl ReadableKeyValueStore for KeyValueStore {
             );
         }
         let promise = self.wit_api.contains_keys_new(keys);
-        yield_once().await;
         Ok(self.wit_api.contains_keys_wait(promise))
     }
 
@@ -148,7 +145,6 @@ impl ReadableKeyValueStore for KeyValueStore {
             );
         }
         let promise = self.wit_api.read_multi_values_bytes_new(keys);
-        yield_once().await;
         Ok(self.wit_api.read_multi_values_bytes_wait(promise))
     }
 
@@ -158,7 +154,6 @@ impl ReadableKeyValueStore for KeyValueStore {
             KeyValueStoreError::KeyTooLong
         );
         let promise = self.wit_api.read_value_bytes_new(key);
-        yield_once().await;
         Ok(self.wit_api.read_value_bytes_wait(promise))
     }
 
@@ -171,7 +166,6 @@ impl ReadableKeyValueStore for KeyValueStore {
             KeyValueStoreError::KeyTooLong
         );
         let promise = self.wit_api.find_keys_new(key_prefix);
-        yield_once().await;
         Ok(self.wit_api.find_keys_wait(promise))
     }
 
@@ -184,7 +178,6 @@ impl ReadableKeyValueStore for KeyValueStore {
             KeyValueStoreError::KeyTooLong
         );
         let promise = self.wit_api.find_key_values_new(key_prefix);
-        yield_once().await;
         Ok(self.wit_api.find_key_values_wait(promise))
     }
 }


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/5318 attempts to save gas by removing `async` from our storage mechanisms in the `linera-sdk`, making a copy of `linera-views` that is exactly the same but with `async` removed (since all our syscalls, including storage syscalls, are synchronous on the guest side).  However, this entails a large amount of code duplication.  Instead, the compiler should be able to optimize away the async code when the implementation is known to not yield.

So I went digging for what was stopping the async machinery being folded away in `linera-sdk` and I found [this](https://github.com/linera-io/linera-protocol/blob/main/linera-sdk/src/views/system_api.rs): the reason our SDK futures weren't being optimized away when they're actually sync is that they weren't actually sync, they all contain a yield_once future that forces them to yield up through the async machinery to our blocking_wait loop (which, of course, immediately polled them again).  Without this there's no async in the resulting code after code folding (i.e. no poll function is ever called) even without making any changes to the `linera-views` traits.

## Proposal

Remove `yield_once` from `linera-sdk`.

## Test Plan

Checked locally that no `poll` function is ever called after this change, using `cargo rustc -- --emit=asm`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
