### PR TITLE
Filter notifications by listening mode in `process_notification`.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -4086,6 +4086,7 @@ impl<Env: Environment> ChainClient<Env> {
             debug!(
                 chain_id = %self.chain_id,
                 reason = ?notification.reason,
+                listening_mode = ?self.listening_mode(),
                 "Ignoring notification due to listening mode"
             );
             return Ok(());


### PR DESCRIPTION
## Motivation

This check whether a notification is relevant depending on the listening mode was added in https://github.com/linera-io/linera-protocol/pull/5232 but missed in the backport https://github.com/linera-io/linera-protocol/pull/5237.

## Proposal

Add it.

## Test Plan

This should not have caused any failures, only unnecessary downloads.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
