### PR TITLE
Only satisfy `mandatory_applications` with accepted messages, not rejected ones.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -37,8 +37,8 @@ use crate::{
     block::{Block, ConfirmedBlock},
     block_tracker::BlockExecutionTracker,
     data_types::{
-        BlockExecutionOutcome, ChainAndHeight, IncomingBundle, MessageBundle, ProposedBlock,
-        Transaction,
+        BlockExecutionOutcome, ChainAndHeight, IncomingBundle, MessageAction, MessageBundle,
+        ProposedBlock, Transaction,
     },
     inbox::{InboxError, InboxStateView},
     manager::ChainManager,
@@ -968,13 +968,16 @@ where
                         mandatory.remove(application_id);
                     }
                 }
-                Transaction::ReceiveMessages(incoming_bundle) => {
+                Transaction::ReceiveMessages(incoming_bundle)
+                    if incoming_bundle.action == MessageAction::Accept =>
+                {
                     for pending in incoming_bundle.messages() {
                         if let Message::User { application_id, .. } = &pending.message {
                             mandatory.remove(application_id);
                         }
                     }
                 }
+                Transaction::ReceiveMessages(_) => {}
             }
         }
         ensure!(


### PR DESCRIPTION
## Motivation

`check_app_permissions` considers the mandatory applications requirement satisfied for any incoming message, including rejected ones. But `mandatory_applications` is meant to give applications control over _all_ blocks on that chain.

## Proposal

Only consider the mandatory applications requirement satisfied with _accepted_ messages or operations.

## Test Plan

A test was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
(This is not easy to backport, since it makes blocks invalid that are currently valid on the testnet.)

## Links

- Related discussion: https://github.com/linera-io/linera-protocol/pull/5311#discussion_r2724262990
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
