### PR TITLE
Log listening mode when ignoring notifications.

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2512,13 +2512,15 @@ impl<Env: Environment> ChainClient<Env> {
         mut local_node: LocalNodeClient<Env::Storage>,
         notification: Notification,
     ) -> Result<(), Error> {
-        let dominated = self
-            .listening_mode()
-            .is_none_or(|mode| !mode.is_relevant(&notification.reason));
-        if dominated {
+        let listening_mode = self.listening_mode();
+        let relevant = listening_mode
+            .as_ref()
+            .is_some_and(|mode| mode.is_relevant(&notification.reason));
+        if !relevant {
             debug!(
                 chain_id = %self.chain_id,
                 reason = ?notification.reason,
+                ?listening_mode,
                 "Ignoring notification due to listening mode"
             );
             return Ok(());


### PR DESCRIPTION
## Motivation

Depending on a chain's listening mode we ignore some notifications; e.g. `FollowOnly` chains don't care about incoming message bundles.

## Proposal

Add the listening mode to the log message.

Use a local variable `relevant` instead of the unnecessarily negated (and unclearly named) `dominated`.

## Test Plan

CI

## Release Plan

- These changes could be backported to `testnet_conway`. (Low priority)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
