### PR TITLE
Add migration flag for mandatory apps to require accepted messages

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -97,6 +97,11 @@ pub const FLAG_ZERO_HASH: &str = "FLAG_ZERO_HASH.linera.network";
 /// messages are free of charge if they are bouncing, and operation outcomes are counted only
 /// by payload size, so that rejecting messages is free.
 pub const FLAG_FREE_REJECT: &str = "FLAG_FREE_REJECT.linera.network";
+/// The flag that makes mandatory application checks require accepted messages. If this is
+/// present, only accepted incoming messages (not rejected ones) satisfy the mandatory
+/// applications requirement for a block.
+pub const FLAG_MANDATORY_APPS_NEED_ACCEPTED_MESSAGE: &str =
+    "FLAG_MANDATORY_APPS_NEED_ACCEPTED_MESSAGE.linera.network";
 
 /// An implementation of [`UserContractModule`].
 #[derive(Clone)]


### PR DESCRIPTION
## Motivation

`check_app_permissions` considers the mandatory applications requirement satisfied for any incoming message, including rejected ones. But `mandatory_applications` is meant to give applications control over _all_ blocks on that chain.

## Proposal

Only consider the mandatory applications requirement satisfied with _accepted_ messages or operations.

This changes execution semantics, however, so on the testnet we have to do it as a migration after all validators and most users have updated. Adding `FLAG_MANDATORY_APPS_NEED_ACCEPTED_MESSAGE.linera.network` to the `http_request_allow_list` will enable it.

## Test Plan

A test was added.

## Release Plan

- Release a new SDK.
- Update the validators.
- Create a new epoch with `FLAG_MANDATORY_APPS_NEED_ACCEPTED_MESSAGE.linera.network` added to the `http_request_allow_list` (in addition to the entries that are already there).

## Links

- Related discussion: https://github.com/linera-io/linera-protocol/pull/5311#discussion_r2724262990
- PR to main (without migration): https://github.com/linera-io/linera-protocol/pull/5353
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
