### PR TITLE
PM benchmark client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ linera-web/**/*-lock.json
 .claude
 CLAUDE.md
 .serena
+docs/
 
 # Zed
 /.zed/

--- a/CLI.md
+++ b/CLI.md
@@ -24,6 +24,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera benchmark`↴](#linera-benchmark)
 * [`linera benchmark single`↴](#linera-benchmark-single)
 * [`linera benchmark multi`↴](#linera-benchmark-multi)
+* [`linera benchmark pm`↴](#linera-benchmark-pm)
 * [`linera create-genesis-config`↴](#linera-create-genesis-config)
 * [`linera watch`↴](#linera-watch)
 * [`linera service`↴](#linera-service)
@@ -534,6 +535,7 @@ Run benchmarks to test network performance
 
 * `single` — Start a single benchmark process, maintaining a given TPS
 * `multi` — Run multiple benchmark processes in parallel
+* `pm` — Benchmark PM (Prediction Market) order submission
 
 
 
@@ -554,7 +556,6 @@ Start a single benchmark process, maintaining a given TPS
 * `--transactions-per-block <TRANSACTIONS_PER_BLOCK>` — How many transactions to put in each block
 
   Default value: `1`
-* `--fungible-application-id <FUNGIBLE_APPLICATION_ID>` — The application ID of a fungible token on the wallet's default chain. If none is specified, the benchmark uses the native token
 * `--bps <BPS>` — The fixed BPS (Blocks Per Second) rate that block proposals will be sent at
 
   Default value: `10`
@@ -567,6 +568,8 @@ Start a single benchmark process, maintaining a given TPS
 * `--runtime-in-seconds <RUNTIME_IN_SECONDS>` — How long to run the benchmark for. If not provided, the benchmark will run until it is interrupted
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
+* `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
+* `--fungible-application-id <FUNGIBLE_APPLICATION_ID>` — The application ID of a fungible token on the wallet's default chain. If none is specified, the benchmark uses the native token
 
 
 
@@ -587,7 +590,6 @@ Run multiple benchmark processes in parallel
 * `--transactions-per-block <TRANSACTIONS_PER_BLOCK>` — How many transactions to put in each block
 
   Default value: `1`
-* `--fungible-application-id <FUNGIBLE_APPLICATION_ID>` — The application ID of a fungible token on the wallet's default chain. If none is specified, the benchmark uses the native token
 * `--bps <BPS>` — The fixed BPS (Blocks Per Second) rate that block proposals will be sent at
 
   Default value: `10`
@@ -600,6 +602,8 @@ Run multiple benchmark processes in parallel
 * `--runtime-in-seconds <RUNTIME_IN_SECONDS>` — How long to run the benchmark for. If not provided, the benchmark will run until it is interrupted
 * `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
 * `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
+* `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
+* `--fungible-application-id <FUNGIBLE_APPLICATION_ID>` — The application ID of a fungible token on the wallet's default chain. If none is specified, the benchmark uses the native token
 * `--processes <PROCESSES>` — The number of benchmark processes to run in parallel
 
   Default value: `1`
@@ -609,6 +613,57 @@ Run multiple benchmark processes in parallel
 
   Default value: `10`
 * `--cross-wallet-transfers` — Whether to send transfers between chains in different wallets
+
+
+
+## `linera benchmark pm`
+
+Benchmark PM (Prediction Market) order submission
+
+**Usage:** `linera benchmark pm [OPTIONS] --faucet <FAUCET> --pm-faucet <PM_FAUCET> --pm-engine-id <PM_ENGINE_ID> --market-chain-id <MARKET_CHAIN_ID>`
+
+###### **Options:**
+
+* `--num-chains <NUM_CHAINS>` — How many chains to use
+
+  Default value: `10`
+* `--tokens-per-chain <TOKENS_PER_CHAIN>` — How many tokens to assign to each newly created chain. These need to cover the transaction fees per chain for the benchmark
+
+  Default value: `0.1`
+* `--transactions-per-block <TRANSACTIONS_PER_BLOCK>` — How many transactions to put in each block
+
+  Default value: `1`
+* `--bps <BPS>` — The fixed BPS (Blocks Per Second) rate that block proposals will be sent at
+
+  Default value: `10`
+* `--close-chains` — If provided, will close the chains after the benchmark is finished. Keep in mind that closing the chains might take a while, and will increase the validator latency while they're being closed
+* `--health-check-endpoints <HEALTH_CHECK_ENDPOINTS>` — A comma-separated list of host:port pairs to query for health metrics. If provided, the benchmark will check these endpoints for validator health and terminate if any validator is unhealthy. Example: "127.0.0.1:21100,validator-1.some-network.linera.net:21100"
+* `--wrap-up-max-in-flight <WRAP_UP_MAX_IN_FLIGHT>` — The maximum number of in-flight requests to validators when wrapping up the benchmark. While wrapping up, this controls the concurrency level when processing inboxes and closing chains
+
+  Default value: `5`
+* `--confirm-before-start` — Confirm before starting the benchmark
+* `--runtime-in-seconds <RUNTIME_IN_SECONDS>` — How long to run the benchmark for. If not provided, the benchmark will run until it is interrupted
+* `--delay-between-chains-ms <DELAY_BETWEEN_CHAINS_MS>` — The delay between chains, in milliseconds. For example, if set to 200ms, the first chain will start, then the second will start 200 ms after the first one, the third 200 ms after the second one, and so on. This is used for slowly ramping up the TPS, so we don't pound the validators with the full TPS all at once
+* `--config-path <CONFIG_PATH>` — Path to YAML file containing chain IDs to send transfers to. If not provided, only transfers between chains in the same wallet
+* `--single-destination-per-block` — Transaction distribution mode. If false (default), distributes transactions evenly across chains within each block. If true, sends all transactions in each block to a single chain, rotating through chains for subsequent blocks
+* `--faucet <FAUCET>` — The Linera faucet URL (for creating trader chains)
+* `--pm-faucet <PM_FAUCET>` — The PM faucet URL (for distributing BASE tokens to traders)
+* `--pm-engine-id <PM_ENGINE_ID>` — The PM engine application ID (from pm-infra data/engines/engine-X.json)
+* `--market-chain-id <MARKET_CHAIN_ID>` — The market chain ID (from pm-infra data/engines/engine-X.json)
+* `--order-pattern <ORDER_PATTERN>` — The order generation pattern
+
+  Default value: `matching`
+
+  Possible values:
+  - `matching`:
+    All orders will match. Generates YES bid + NO bid pairs at complementary prices
+  - `mixed`:
+    Mix of matching and non-matching orders. Use --match-probability to configure what fraction of orders will match (default: 0.5)
+
+* `--price-scale <PRICE_SCALE>` — The price scale for orders (e.g., 1000 means price 500 = 0.5)
+
+  Default value: `1000`
+* `--match-probability <MATCH_PROBABILITY>` — Probability of generating matching orders (0.0-1.0). Only used with --order-pattern mixed. Defaults to 0.5 if not specified
 
 
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, warn};
 #[cfg(not(web))]
 use {
     crate::{
-        benchmark::{Benchmark, BenchmarkError},
+        benchmark::{fungible_transfer, Benchmark, BenchmarkError},
         client_metrics::ClientMetrics,
     },
     futures::stream,
@@ -40,7 +40,7 @@ use {
         system::{OpenChainConfig, SystemOperation},
         Operation,
     },
-    std::{collections::HashSet, iter, path::Path},
+    std::{collections::HashSet, path::Path},
     tokio::{sync::mpsc, task},
 };
 #[cfg(feature = "fs")]
@@ -856,12 +856,12 @@ impl<Env: Environment> ClientContext<Env> {
     pub async fn prepare_for_benchmark(
         &mut self,
         num_chains: usize,
-        transactions_per_block: usize,
         tokens_per_chain: Amount,
         fungible_application_id: Option<ApplicationId>,
         pub_keys: Vec<AccountPublicKey>,
         chains_config_path: Option<&Path>,
-    ) -> Result<(Vec<ChainClient<Env>>, Vec<Vec<Operation>>), Error> {
+        close_chains: bool,
+    ) -> Result<Vec<ChainClient<Env>>, Error> {
         let start = Instant::now();
         // Below all block proposals are supposed to succeed without retries, we
         // must make sure that all incoming payments have been accepted on-chain
@@ -879,6 +879,7 @@ impl<Env: Environment> ClientContext<Env> {
                 tokens_per_chain,
                 pub_keys,
                 chains_config_path.is_some(),
+                close_chains,
             )
             .await?;
         info!(
@@ -921,14 +922,7 @@ impl<Env: Environment> ClientContext<Env> {
             }
         }
 
-        let blocks_infos = Benchmark::<Env>::make_benchmark_block_info(
-            benchmark_chains,
-            transactions_per_block,
-            fungible_application_id,
-            all_chains,
-        )?;
-
-        Ok((chain_clients, blocks_infos))
+        Ok(chain_clients)
     }
 
     pub async fn wrap_up_benchmark(
@@ -1022,39 +1016,47 @@ impl<Env: Environment> ClientContext<Env> {
 
     /// Creates chains if necessary, and returns a map of exactly `num_chains` chain IDs
     /// with key pairs, as well as a map of the chain clients.
+    ///
+    /// If `close_chains` is true, chains are not looked up from or stored in the wallet,
+    /// since they will be closed after the benchmark and shouldn't be reused.
     async fn make_benchmark_chains(
         &mut self,
         num_chains: usize,
         balance: Amount,
         pub_keys: Vec<AccountPublicKey>,
         wallet_only: bool,
+        close_chains: bool,
     ) -> Result<(Vec<(ChainId, AccountOwner)>, Vec<ChainClient<Env>>), Error> {
         let mut chains_found_in_wallet = 0;
         let mut benchmark_chains = Vec::with_capacity(num_chains);
         let mut chain_clients = Vec::with_capacity(num_chains);
         let start = Instant::now();
-        let mut owned_chain_ids = std::pin::pin!(self.wallet().owned_chain_ids());
-        while let Some(chain_id) = owned_chain_ids.next().await {
-            let chain_id = chain_id.map_err(error::Inner::wallet)?;
-            if chains_found_in_wallet == num_chains {
-                break;
+
+        // When close_chains is true, skip wallet lookup - always create fresh chains
+        if !close_chains {
+            let mut owned_chain_ids = std::pin::pin!(self.wallet().owned_chain_ids());
+            while let Some(chain_id) = owned_chain_ids.next().await {
+                let chain_id = chain_id.map_err(error::Inner::wallet)?;
+                if chains_found_in_wallet == num_chains {
+                    break;
+                }
+                let chain_client = self.make_chain_client(chain_id).await?;
+                let ownership = chain_client.chain_info().await?.manager.ownership;
+                if !ownership.owners.is_empty() || ownership.super_owners.len() != 1 {
+                    continue;
+                }
+                let owner = *ownership.super_owners.first().unwrap();
+                chain_client.process_inbox().await?;
+                benchmark_chains.push((chain_id, owner));
+                chain_clients.push(chain_client);
+                chains_found_in_wallet += 1;
             }
-            let chain_client = self.make_chain_client(chain_id).await?;
-            let ownership = chain_client.chain_info().await?.manager.ownership;
-            if !ownership.owners.is_empty() || ownership.super_owners.len() != 1 {
-                continue;
-            }
-            let owner = *ownership.super_owners.first().unwrap();
-            chain_client.process_inbox().await?;
-            benchmark_chains.push((chain_id, owner));
-            chain_clients.push(chain_client);
-            chains_found_in_wallet += 1;
+            info!(
+                "Got {} chains from the wallet in {} ms",
+                benchmark_chains.len(),
+                start.elapsed().as_millis()
+            );
         }
-        info!(
-            "Got {} chains from the wallet in {} ms",
-            benchmark_chains.len(),
-            start.elapsed().as_millis()
-        );
 
         let num_chains_to_create = num_chains - chains_found_in_wallet;
 
@@ -1074,20 +1076,22 @@ impl<Env: Environment> ClientContext<Env> {
             let operations_per_block = 900; // Over this we seem to hit the block size limits.
             for i in (0..num_chains_to_create).step_by(operations_per_block) {
                 let num_new_chains = operations_per_block.min(num_chains_to_create - i);
-                let pub_key = pub_keys_iter.next().unwrap();
-                let owner = pub_key.into();
+                // Collect one owner per chain in this batch
+                let owners: Vec<AccountOwner> = (&mut pub_keys_iter)
+                    .take(num_new_chains)
+                    .map(|pk| pk.into())
+                    .collect();
 
                 let certificate = Self::execute_open_chains_operations(
-                    num_new_chains,
                     &default_chain_client,
                     balance,
-                    owner,
+                    owners.clone(),
                 )
                 .await?;
                 info!("Block executed successfully");
 
                 let block = certificate.block();
-                for i in 0..num_new_chains {
+                for (i, owner) in owners.into_iter().enumerate() {
                     let chain_id = block.body.blobs[i]
                         .iter()
                         .find(|blob| blob.id().blob_type == BlobType::ChainDescription)
@@ -1118,9 +1122,12 @@ impl<Env: Environment> ClientContext<Env> {
             );
         }
 
-        info!("Updating wallet from client");
-        self.update_wallet_from_client(&default_chain_client)
-            .await?;
+        // Only update wallet if chains will be reused (not closed after benchmark)
+        if !close_chains {
+            info!("Updating wallet from client");
+            self.update_wallet_from_client(&default_chain_client)
+                .await?;
+        }
         info!("Retrying pending outgoing messages");
         default_chain_client
             .retry_pending_outgoing_messages()
@@ -1133,22 +1140,22 @@ impl<Env: Environment> ClientContext<Env> {
     }
 
     async fn execute_open_chains_operations(
-        num_new_chains: usize,
         chain_client: &ChainClient<Env>,
         balance: Amount,
-        owner: AccountOwner,
+        owners: Vec<AccountOwner>,
     ) -> Result<ConfirmedBlockCertificate, Error> {
-        let config = OpenChainConfig {
-            ownership: ChainOwnership::single_super(owner),
-            balance,
-            application_permissions: Default::default(),
-        };
-        let operations = iter::repeat_n(
-            Operation::system(SystemOperation::OpenChain(config)),
-            num_new_chains,
-        )
-        .collect();
-        info!("Executing {} OpenChain operations", num_new_chains);
+        let operations: Vec<_> = owners
+            .iter()
+            .map(|owner| {
+                let config = OpenChainConfig {
+                    ownership: ChainOwnership::single_super(*owner),
+                    balance,
+                    application_permissions: Default::default(),
+                };
+                Operation::system(SystemOperation::OpenChain(config))
+            })
+            .collect();
+        info!("Executing {} OpenChain operations", operations.len());
         Ok(chain_client
             .execute_operations(operations, vec![])
             .await?
@@ -1175,13 +1182,7 @@ impl<Env: Environment> ClientContext<Env> {
         let operations: Vec<Operation> = key_pairs
             .iter()
             .map(|(chain_id, owner)| {
-                Benchmark::<Env>::fungible_transfer(
-                    application_id,
-                    *chain_id,
-                    default_key,
-                    *owner,
-                    amount,
-                )
+                fungible_transfer(application_id, *chain_id, default_key, *owner, amount)
             })
             .collect();
         let chain_client = self.make_chain_client(default_chain_id).await?;

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -858,6 +858,7 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
                 close_chains: true,
                 ..Default::default()
             },
+            fungible_application_id: None,
         })
         .await?;
     assert_eq!(client.load_wallet()?.num_chains(), 3);
@@ -887,10 +888,10 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
                 transactions_per_block: 10,
                 bps: 2,
                 runtime_in_seconds: Some(5),
-                fungible_application_id: Some(application_id.forget_abi()),
                 close_chains: true,
                 ..Default::default()
             },
+            fungible_application_id: Some(application_id.forget_abi()),
         })
         .await?;
 


### PR DESCRIPTION
## Motivation

Add support for benchmarking PM (Prediction Market) order submission to measure performance under load. This enables stress testing the prediction market infrastructure with configurable order patterns.

## Proposal

Adds a new `linera benchmark pm` subcommand that:

- Creates benchmark chains and funds them via the standard Linera faucet
- Claims BASE tokens from the PM faucet for each benchmark chain
- Generates PM orders (YES/NO bids) and submits them to the market chain
- Supports configurable order patterns:
- `matching`: Generates complementary YES+NO bid pairs that will match
- `mixed`: Configurable mix of matching and non-matching orders

AMM not supported yet.

Key changes:
- New `BenchmarkMode` enum to distinguish between native transfer, fungible transfer, and PM benchmarks
- `PmOrderGenerator` for generating order book operations with realistic price distributions (does not query and follow the actual market value)
- Refactored `BenchmarkOperationGenerator` (renamed from `ChainDestinationManager`) to handle different operation
types

## Test Plan

- Manual testing against deployed PM infrastructure on andre-test-c77l3j network
- Verified benchmark chains are created and funded correctly
- Confirmed orders are submitted at the target BPS rate
