### PR TITLE
Retry on h2 protocol error Internal gRPC error

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -80,6 +80,13 @@ impl GrpcClient {
                 trace!("Unexpected gRPC status: {status:?}; retrying");
                 true
             }
+            Code::Internal if status.message().contains("h2 protocol error") => {
+                // HTTP/2 connection reset errors are transient network issues, not real
+                // internal errors. This happens when the server restarts and the
+                // connection is forcibly closed.
+                trace!("gRPC connection reset: {status:?}; retrying");
+                true
+            }
             Code::NotFound => false, // This code is used if e.g. the validator is missing blobs.
             Code::InvalidArgument
             | Code::AlreadyExists


### PR DESCRIPTION
## Motivation

When validators (proxy/shards) restart, long-running gRPC notification streams terminate with an HTTP/2 protocol
error. This error has status code `Internal` with message `"h2 protocol error: error reading a body from connection"`.

Currently, `Internal` errors are not retryable, causing clients (like pm-infra workers) to permanently lose their
notification subscriptions after a validator restart, even if `maxRetries` is set to a high value.

## Proposal

Make HTTP/2 protocol errors retryable by adding a special case in `is_retryable()` for `Code::Internal` errors that
contain `"h2 protocol error"` in their message.

These errors are transient network issues (connection forcibly closed by server restart), not actual internal server
errors, and should be retried like other transient errors (`Unavailable`, `DeadlineExceeded`, etc.).

## Test Plan

1. Deployed a pm-infra worker with the fix against a test network
2. Restarted validator proxy/shards while worker was subscribed to notifications
3. Verified worker reconnected and continued receiving notifications after validator came back up
4. Previously, the same scenario caused the worker to permanently stop receiving notifications
