### PR TITLE
[testnet] SDK: Add `read_application_description` to the runtime. (#5346)

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1077,7 +1077,7 @@ pub enum OracleResponse {
 impl BcsHashable<'_> for OracleResponse {}
 
 /// Description of a user application.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize, WitType, WitLoad, WitStore)]
 pub struct ApplicationDescription {
     /// The unique ID of the bytecode to use for the application.
     pub module_id: ModuleId,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -739,6 +739,12 @@ pub trait BaseRuntime {
     /// The current application creator's chain ID.
     fn application_creator_chain_id(&mut self) -> Result<ChainId, ExecutionError>;
 
+    /// Returns the description of the given application.
+    fn read_application_description(
+        &mut self,
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, ExecutionError>;
+
     /// The current application parameters.
     fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError>;
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -630,6 +630,23 @@ where
         Ok(application_creator_chain_id)
     }
 
+    fn read_application_description(
+        &mut self,
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, ExecutionError> {
+        let mut this = self.inner();
+        let description = this
+            .execution_state_sender
+            .send_request(|callback| ExecutionRequest::ReadApplicationDescription {
+                application_id,
+                callback,
+            })?
+            .recv_response()?;
+        this.resource_controller
+            .track_runtime_application_description(&description)?;
+        Ok(description)
+    }
+
     fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
         let mut this = self.inner();
         let parameters = this.current_application().description.parameters.clone();

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -5,7 +5,8 @@ use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Bytecode, SendMessageRequest, Timestamp,
+        Amount, ApplicationDescription, ApplicationPermissions, BlockHeight, Bytecode,
+        SendMessageRequest, Timestamp,
     },
     http,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, StreamName},
@@ -118,6 +119,18 @@ where
             .user_data_mut()
             .runtime
             .application_creator_chain_id()
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Returns the description of the given application.
+    fn read_application_description(
+        caller: &mut Caller,
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .read_application_description(application_id)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -5,10 +5,13 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, ApplicationPermissions, BlockHeight, TimeDelta, Timestamp},
+    data_types::{
+        Amount, ApplicationDescription, ApplicationPermissions, BlockHeight, TimeDelta, Timestamp,
+    },
     http,
-    identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
+    identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash, ModuleId},
     ownership::{ChainOwnership, TimeoutConfig},
+    vm::VmRuntime,
 };
 
 use crate::{
@@ -183,6 +186,42 @@ macro_rules! impl_from_wit {
         impl From<$wit_base_api::HttpHeader> for http::Header {
             fn from(header: $wit_base_api::HttpHeader) -> http::Header {
                 http::Header::new(header.name, header.value)
+            }
+        }
+
+        impl From<$wit_base_api::VmRuntime> for VmRuntime {
+            fn from(vm_runtime: $wit_base_api::VmRuntime) -> Self {
+                match vm_runtime {
+                    $wit_base_api::VmRuntime::Wasm => VmRuntime::Wasm,
+                    $wit_base_api::VmRuntime::Evm => VmRuntime::Evm,
+                }
+            }
+        }
+
+        impl From<$wit_base_api::ModuleId> for ModuleId {
+            fn from(module_id: $wit_base_api::ModuleId) -> Self {
+                ModuleId::new(
+                    module_id.contract_blob_hash.into(),
+                    module_id.service_blob_hash.into(),
+                    module_id.vm_runtime.into(),
+                )
+            }
+        }
+
+        impl From<$wit_base_api::ApplicationDescription> for ApplicationDescription {
+            fn from(description: $wit_base_api::ApplicationDescription) -> Self {
+                ApplicationDescription {
+                    module_id: description.module_id.into(),
+                    creator_chain_id: description.creator_chain_id.into(),
+                    block_height: description.block_height.into(),
+                    application_index: description.application_index,
+                    parameters: description.parameters,
+                    required_application_ids: description
+                        .required_application_ids
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                }
             }
         }
     };

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -6,8 +6,8 @@
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Bytecode, Resources, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationDescription, ApplicationPermissions, BlockHeight, Bytecode, Resources,
+        SendMessageRequest, Timestamp,
     },
     ensure, http,
     identifiers::{
@@ -98,6 +98,14 @@ where
         *self
             .application_creator_chain_id
             .get_or_insert_with(|| base_wit::get_application_creator_chain_id().into())
+    }
+
+    /// Returns the description of the given application.
+    pub fn read_application_description(
+        &mut self,
+        application_id: ApplicationId,
+    ) -> ApplicationDescription {
+        base_wit::read_application_description(application_id.forget_abi().into()).into()
     }
 
     /// Returns the ID of the current chain.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -11,8 +11,8 @@ use std::{
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Bytecode, Resources, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationDescription, ApplicationPermissions, BlockHeight, Bytecode, Resources,
+        SendMessageRequest, Timestamp,
     },
     ensure, http,
     identifiers::{
@@ -56,6 +56,7 @@ where
     application_parameters: Option<Application::Parameters>,
     application_id: Option<ApplicationId<Application::Abi>>,
     application_creator_chain_id: Option<ChainId>,
+    application_descriptions: HashMap<ApplicationId, ApplicationDescription>,
     chain_id: Option<ChainId>,
     authenticated_signer: Option<Option<AccountOwner>>,
     block_height: Option<BlockHeight>,
@@ -106,6 +107,7 @@ where
             application_parameters: None,
             application_id: None,
             application_creator_chain_id: None,
+            application_descriptions: HashMap::new(),
             chain_id: None,
             authenticated_signer: None,
             block_height: None,
@@ -215,6 +217,44 @@ where
             "Application creator chain ID has not been mocked, \
             please call `MockContractRuntime::set_application_creator_chain_id` first",
         )
+    }
+
+    /// Configures the application description to return for a specific application during the test.
+    pub fn with_application_description(
+        mut self,
+        application_id: ApplicationId,
+        description: ApplicationDescription,
+    ) -> Self {
+        self.application_descriptions
+            .insert(application_id, description);
+        self
+    }
+
+    /// Configures the application description to return for a specific application during the test.
+    pub fn set_application_description(
+        &mut self,
+        application_id: ApplicationId,
+        description: ApplicationDescription,
+    ) -> &mut Self {
+        self.application_descriptions
+            .insert(application_id, description);
+        self
+    }
+
+    /// Returns the description of the given application.
+    pub fn read_application_description(
+        &mut self,
+        application_id: ApplicationId,
+    ) -> ApplicationDescription {
+        self.application_descriptions
+            .get(&application_id)
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Application description for {application_id:?} has not been mocked, \
+                    please call `MockContractRuntime::set_application_description` first"
+                )
+            })
     }
 
     /// Configures the chain ID to return during the test.

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 
 use linera_base::{
     abi::ServiceAbi,
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, ApplicationDescription, BlockHeight, Timestamp},
     http,
     identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
 };
@@ -86,6 +86,14 @@ where
         Self::fetch_value_through_cache(&self.application_creator_chain_id, || {
             base_wit::get_application_creator_chain_id().into()
         })
+    }
+
+    /// Returns the description of the given application.
+    pub fn read_application_description(
+        &self,
+        application_id: ApplicationId,
+    ) -> ApplicationDescription {
+        base_wit::read_application_description(application_id.forget_abi().into()).into()
     }
 
     /// Returns the ID of the current chain.

--- a/linera-sdk/src/service/test_runtime.rs
+++ b/linera-sdk/src/service/test_runtime.rs
@@ -11,7 +11,7 @@ use std::{
 
 use linera_base::{
     abi::ServiceAbi,
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, ApplicationDescription, BlockHeight, Timestamp},
     hex, http,
     identifiers::{AccountOwner, ApplicationId, ChainId, DataBlobHash},
 };
@@ -27,6 +27,7 @@ where
     application_parameters: Mutex<Option<Application::Parameters>>,
     application_id: Mutex<Option<ApplicationId<Application::Abi>>>,
     application_creator_chain_id: Mutex<Option<ChainId>>,
+    application_descriptions: Mutex<HashMap<ApplicationId, ApplicationDescription>>,
     chain_id: Mutex<Option<ChainId>>,
     next_block_height: Mutex<Option<BlockHeight>>,
     timestamp: Mutex<Option<Timestamp>>,
@@ -58,6 +59,7 @@ where
             application_parameters: Mutex::new(None),
             application_id: Mutex::new(None),
             application_creator_chain_id: Mutex::new(None),
+            application_descriptions: Mutex::new(HashMap::new()),
             chain_id: Mutex::new(None),
             next_block_height: Mutex::new(None),
             timestamp: Mutex::new(None),
@@ -148,6 +150,50 @@ where
             "Application creator chain ID has not been mocked, \
             please call `MockServiceRuntime::set_application_creator_chain_id` first",
         )
+    }
+
+    /// Configures the application description to return for a specific application during the test.
+    pub fn with_application_description(
+        self,
+        application_id: ApplicationId,
+        description: ApplicationDescription,
+    ) -> Self {
+        self.application_descriptions
+            .lock()
+            .unwrap()
+            .insert(application_id, description);
+        self
+    }
+
+    /// Configures the application description to return for a specific application during the test.
+    pub fn set_application_description(
+        &self,
+        application_id: ApplicationId,
+        description: ApplicationDescription,
+    ) -> &Self {
+        self.application_descriptions
+            .lock()
+            .unwrap()
+            .insert(application_id, description);
+        self
+    }
+
+    /// Returns the description of the given application.
+    pub fn read_application_description(
+        &self,
+        application_id: ApplicationId,
+    ) -> ApplicationDescription {
+        self.application_descriptions
+            .lock()
+            .unwrap()
+            .get(&application_id)
+            .cloned()
+            .unwrap_or_else(|| {
+                panic!(
+                    "Application description for {application_id:?} has not been mocked, \
+                    please call `MockServiceRuntime::set_application_description` first"
+                )
+            })
     }
 
     /// Configures the chain ID to return during the test.

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -5,6 +5,7 @@ interface base-runtime-api {
     get-block-height: func() -> block-height;
     get-application-id: func() -> application-id;
     get-application-creator-chain-id: func() -> chain-id;
+    read-application-description: func(application-id: application-id) -> application-description;
     application-parameters: func() -> list<u8>;
     get-chain-ownership: func() -> chain-ownership;
     get-application-permissions: func() -> application-permissions;
@@ -39,6 +40,15 @@ interface base-runtime-api {
 
     record amount {
         inner0: u128,
+    }
+
+    record application-description {
+        module-id: module-id,
+        creator-chain-id: chain-id,
+        block-height: block-height,
+        application-index: u32,
+        parameters: list<u8>,
+        required-application-ids: list<application-id>,
     }
 
     record application-id {
@@ -125,6 +135,12 @@ interface base-runtime-api {
         trace,
     }
 
+    record module-id {
+        contract-blob-hash: crypto-hash,
+        service-blob-hash: crypto-hash,
+        vm-runtime: vm-runtime,
+    }
+
     record time-delta {
         inner0: u64,
     }
@@ -141,4 +157,9 @@ interface base-runtime-api {
     }
 
     type u128 = tuple<u64, u64>;
+
+    enum vm-runtime {
+        wasm,
+        evm,
+    }
 }


### PR DESCRIPTION
Backport of #5346.

## Motivation

In some cases one application wants to grant permissions to other applications only if they were created by a specific chain.

## Proposal

Add `read_application_description` to get the description, which contains the creator chain ID and other data.

## Test Plan

A test was added.

## Release Plan

This adds a new runtime method, so technically it makes more blocks valid. But if we update the validators before releasing the SDK, nobody should accidentally propose such a block.

- Update all validators.
- Release in a new SDK.

## Links

- PR To main: #5346
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
