### PR TITLE
[testnet] Handle different epochs in the integration tests.

### DIFF
--- a/examples/how-to/perform-http-requests/tests/http_requests.rs
+++ b/examples/how-to/perform-http-requests/tests/http_requests.rs
@@ -32,6 +32,9 @@ async fn service_query_performs_http_request() -> anyhow::Result<()> {
                 .insert("localhost".to_owned());
         })
         .await;
+    // Tests that we can create test chains after the change of epoch
+    // due to the change of policy.
+    validator.new_chain().await;
 
     let QueryOutcome { response, .. } = chain
         .graphql_query(application_id, "query { performHttpRequest }")

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -316,14 +316,27 @@ impl TestValidator {
             .get(&admin_chain_id)
             .expect("Admin chain should be created when the `TestValidator` is constructed");
 
-        let (epoch, _) = self.committee.lock().await.clone();
-
         let open_chain_config = OpenChainConfig {
             ownership: ChainOwnership::single(owner),
             balance: Amount::from_tokens(10),
             application_permissions: ApplicationPermissions::default(),
         };
-        let new_chain_config = open_chain_config.init_chain_config(epoch, epoch, epoch);
+
+        // Query the admin chain's committees to get the correct min/max active epochs,
+        // matching what the execution does in `SystemExecutionStateView::open_chain`.
+        let chain_state = self
+            .worker
+            .chain_state_view(admin_chain_id)
+            .await
+            .expect("Failed to read admin chain state");
+        let committees = chain_state.execution_state.system.committees.get();
+        let epoch = *chain_state.execution_state.system.epoch.get();
+        let min_active_epoch = committees.keys().min().copied().unwrap_or(Epoch::ZERO);
+        let max_active_epoch = committees.keys().max().copied().unwrap_or(Epoch::ZERO);
+        drop(chain_state);
+
+        let new_chain_config =
+            open_chain_config.init_chain_config(epoch, min_active_epoch, max_active_epoch);
 
         let (certificate, _) = admin_chain
             .add_block(|block| {


### PR DESCRIPTION
## Motivation

Handling different epochs is important for integration test since changing the policy lead to a change of epoch.

## Proposal

Determine the min_epoch/max_epoch in order to create the right ChainDescription.

## Test Plan

The test `http_request.rs` adds the creation of a chain that led to the discovery of this problem

## Release Plan

To testnet_conway

## Links

None.