### PR TITLE
Include source maps when packaging linera web client.

### DIFF
--- a/web/@linera/client/tsconfig.json
+++ b/web/@linera/client/tsconfig.json
@@ -6,9 +6,11 @@
         "module": "Node16",
         "moduleResolution": "node16",
         "sourceMap": true,
+        "inlineSources": true,
+        "declaration": true,
+        "declarationMap": true,
         "outDir": "dist/",
         "rootDir": "src",
-        "declaration": true,
         "paths": {
             "web-thread:wasm-shim": ["./src/wasm/index.js"]
         }


### PR DESCRIPTION
## Motivation

Without them it's much harder to debug or measure.

## Proposal

Inline sources which provides full debugging capability without shipping a separate `src/` folder.

## Test Plan

Tested manually. The size increase if negligible: it's ~8kB increase for ~27MB client.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes should be forward-ported to `main`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
