### PR TITLE
Preferred chain owners on the Web

### DIFF
--- a/examples/counter/metamask/index.html
+++ b/examples/counter/metamask/index.html
@@ -70,12 +70,16 @@
      document.getElementById('chain-id').innerText = chainId;
 
      // For autosigning: first we set up a local (in-memory) signer, and provide it to the
-     // client along with the MetaMask signer
+     // client along with the MetaMask signer.
+     // We set it as the default owner of the chain in the wallet.
      const autosigner = linera.signer.PrivateKey.createRandom();
-     const client = await new linera.Client(wallet, new linera.signer.Composite(autosigner, signer));
+     wallet.setOwner(chainId, autosigner.address());
 
-     // Connect to our user chain.
-     const chain = await client.chain(chainId);
+     const client = await new linera.Client(wallet, new linera.signer.Composite(autosigner, signer));
+     const chain = await client.chain(chainId, { owner });
+
+     // For autosigning: we then add the in-memory signer as an owner of the chain to allow it to sign transactions.
+     await chain.addOwner(autosigner.address());
 
      // Connect to the counter application on the chain.
      const counter = await chain.application(import.meta.env.LINERA_APPLICATION_ID);
@@ -87,12 +91,6 @@
          addLogEntry(newBlock);
          updateCount(newBlock.hash);
      });
-
-     // For autosigning: we then add the in-memory signer as an owner of the chain in the
-     // wallet, and set it as the default owner (so it will be used to process messages and
-     // events).
-     await chain.addOwner(autosigner.address());
-     wallet.setOwner(chainId, autosigner.address());
 
      function addLogEntry(block) {
          const entry = logs.getElementsByTagName('template')[0].content.cloneNode(true);
@@ -109,9 +107,7 @@
      updateCount();
 
      incrementButton.addEventListener('click', () => {
-         // For autosigning: when we make user-initiated mutations, we explicitly make them with
-         // the original (MetaMask) owner by providing the `owner` option to the `query` call.
-         counter.query('{ "query": "mutation { increment(value: 1) }" }', { owner });
+         counter.query('{ "query": "mutation { increment(value: 1) }" }');
      });
     </script>
   </body>

--- a/web/@linera/client/src/chain/application.rs
+++ b/web/@linera/client/src/chain/application.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::identifiers::{AccountOwner, ApplicationId};
+use linera_base::identifiers::ApplicationId;
 use linera_core::client::ChainClient;
 use wasm_bindgen::prelude::*;
 use web_sys::wasm_bindgen;
@@ -19,10 +19,9 @@ pub struct Application {
 #[serde(rename_all = "camelCase")]
 #[tsify(from_wasm_abi)]
 pub struct QueryOptions {
+    // TODO(#5377): should this be in `ChainOptions`?
     #[serde(default)]
     pub block_hash: Option<String>,
-    #[serde(default)]
-    pub owner: Option<AccountOwner>,
 }
 
 #[wasm_bindgen]
@@ -43,11 +42,8 @@ impl Application {
     // TODO(#5152) a lot of this logic is shared with `linera_service::node_service`
     pub async fn query(&self, query: &str, options: Option<QueryOptions>) -> JsResult<String> {
         tracing::debug!("querying application: {query}");
-        let QueryOptions { block_hash, owner } = options.unwrap_or_default();
-        let mut chain_client = self.chain_client.clone();
-        if let Some(owner) = owner {
-            chain_client.set_preferred_owner(owner);
-        }
+        let QueryOptions { block_hash } = options.unwrap_or_default();
+        let chain_client = self.chain_client.clone();
         let block_hash = if let Some(hash) = block_hash {
             Some(hash.as_str().parse()?)
         } else {

--- a/web/@linera/client/src/client.rs
+++ b/web/@linera/client/src/client.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use futures::{future::FutureExt as _, lock::Mutex as AsyncMutex};
-use linera_base::identifiers::ChainId;
+use linera_base::identifiers::{AccountOwner, ChainId};
 use linera_client::chain_listener::{ChainListener, ClientContext as _};
 use wasm_bindgen::prelude::*;
 use web_sys::wasm_bindgen;
@@ -23,6 +23,15 @@ pub struct Client {
     // It does nothing here in this single-threaded context, but is
     // hard-coded by `ChainListener`.
     pub(crate) client_context: Arc<AsyncMutex<linera_client::ClientContext<Environment>>>,
+}
+
+#[derive(Default, serde::Deserialize, tsify::Tsify)]
+#[tsify(from_wasm_abi)]
+#[serde(default)]
+/// Options for `Client.chain`.
+pub struct ChainOptions {
+    /// The owner to use for operations on this chain.
+    owner: Option<AccountOwner>,
 }
 
 #[wasm_bindgen]
@@ -96,14 +105,20 @@ impl Client {
     ///
     /// If the wallet could not be read or chain synchronization fails.
     #[wasm_bindgen]
-    pub async fn chain(&self, chain: ChainId) -> JsResult<Chain> {
+    pub async fn chain(&self, chain: ChainId, options: Option<ChainOptions>) -> JsResult<Chain> {
+        let options = options.unwrap_or_default();
+        let mut chain_client = self
+            .client_context
+            .lock()
+            .await
+            .make_chain_client(chain)
+            .await?;
+        if let Some(owner) = options.owner {
+            chain_client.set_preferred_owner(owner);
+        }
+
         Ok(Chain {
-            chain_client: self
-                .client_context
-                .lock()
-                .await
-                .make_chain_client(chain)
-                .await?,
+            chain_client,
             client: self.clone(),
         })
     }


### PR DESCRIPTION
## Motivation

Previously we added the ability for application queries to be given a particular owner.  However, to do autosigning right we need to be able to set the owner when setting chain owners (with `setOwner`).

## Proposal

Add a notion of chain options that includes the chain owner used for queries to the chain.  Move the `owner` option from `Application.query` into the chain options in `Client.chain`.

## Test Plan

Checked locally with the MetaMask fungible example (which changes are included here).

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
