### PR TITLE
[testnet] Allow having multiple http endpoints and allow http endpoints in tests

### DIFF
--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -486,7 +486,7 @@ pub enum ClientCommand {
         http_request_timeout_ms: Option<u64>,
 
         /// Set the list of hosts that contracts and services can send HTTP requests to.
-        #[arg(long)]
+        #[arg(long, value_delimiter = ',')]
         http_request_allow_list: Option<Vec<String>>,
     },
 
@@ -674,7 +674,7 @@ pub enum ClientCommand {
         http_request_timeout_ms: Option<u64>,
 
         /// Set the list of hosts that contracts and services can send HTTP requests to.
-        #[arg(long)]
+        #[arg(long, value_delimiter = ',')]
         http_request_allow_list: Option<Vec<String>>,
 
         /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -250,6 +250,7 @@ pub async fn handle_net_up_service(
         num_shards,
         num_proxies,
         policy_config,
+        http_request_allow_list: None,
         cross_chain_config,
         storage_config_builder,
         path_provider,

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -188,6 +188,7 @@ pub struct LocalNetConfig {
     pub num_shards: usize,
     pub num_proxies: usize,
     pub policy_config: ResourceControlPolicyConfig,
+    pub http_request_allow_list: Option<Vec<String>>,
     pub cross_chain_config: CrossChainConfig,
     pub storage_config_builder: InnerStorageConfigBuilder,
     pub path_provider: PathProvider,
@@ -341,6 +342,7 @@ impl LocalNetConfig {
             storage_config_builder,
             path_provider,
             block_exporters: ExportersSetup::Local(vec![]),
+            http_request_allow_list: Some(vec!["localhost".to_string()]),
         }
     }
 }
@@ -381,7 +383,9 @@ impl LineraNetConfig for LocalNetConfig {
                 self.num_other_initial_chains,
                 self.initial_amount,
                 self.policy_config,
-                Some(vec!["localhost".to_owned()]),
+                self.http_request_allow_list
+                    .clone()
+                    .or_else(|| Some(vec!["localhost".to_owned()])),
             )
             .await?;
         net.run().await?;


### PR DESCRIPTION
## Motivation

We want to be able to test http endpoint in end-to-end tests and allow to run validators with multiple http endpoints.
Backport of #5381 

## Proposal

Implement those features and correct them is

## Test Plan

This has been tested separately

## Release Plan

This is the backport to testnet_conway.

## Links

None.