### PR TITLE
Fix timestamp handling in SDK test framework's `BlockBuilder`

### DIFF
--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -88,7 +88,7 @@ impl BlockBuilder {
     /// The timestamp must be at least as large as the parent block's timestamp (which is used as
     /// the default). It must also be at least as large as the timestamp of any incoming message
     /// bundle added via [`with_messages_from`](Self::with_messages_from) or
-    /// [`with_incoming_bundles`](Self::with_incoming_bundles).
+    /// [`with_messages_from_by_action`](Self::with_messages_from_by_action).
     pub fn with_timestamp(&mut self, timestamp: Timestamp) -> &mut Self {
         self.block.timestamp = timestamp;
         self


### PR DESCRIPTION
## Motivation

The SDK test framework sets block timestamps to `0` by default. In `handle_new_events`, the caller doesn't even get a chance to change that, so this fails if the parent block has a nonzero timestamp.

## Proposal

Default block timestamps to `max(parent_timestamp, clock_time)` instead, and auto-advance timestamps when adding incoming message bundles. This prevents `InvalidBlockTimestamp` and `IncorrectBundleTimestamp` errors.

## Test Plan

We will use this soon in a test for an application external to this repository.

## Release Plan

- Backport to `testnet_conway`.
- Released a new SDK.

## Links

- Fixes #5384
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
