### PR TITLE
Add --staging-bundles-time-budget-ms for time-budgeted bundle staging

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -139,6 +139,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-new-events-per-block <MAX_NEW_EVENTS_PER_BLOCK>` — The maximum number of new stream events to include in a block proposal
 
   Default value: `10`
+* `--staging-bundles-time-budget-ms <STAGING_BUNDLES_TIME_BUDGET>` — Time budget for staging message bundles in milliseconds. When set, limits bundle execution by time rather than by count. This overrides `max_pending_message_bundles` for bundle limiting purposes
 * `--chain-worker-ttl-ms <CHAIN_WORKER_TTL>` — The duration in milliseconds after which an idle chain worker will free its memory
 
   Default value: `30000`

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -57,7 +57,7 @@ impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
     }
 
     /// Test helper that calls `execute_block` with default test parameters:
-    /// `round = None`, `replayed_oracle_responses = None`, `policy = Abort`.
+    /// `round = None`, `replayed_oracle_responses = None`, `on_failure = Abort`.
     #[cfg(with_testing)]
     pub async fn execute_test_block_simple(
         &mut self,
@@ -71,7 +71,7 @@ impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
             None,
             published_blobs,
             None,
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await
     }

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -66,6 +66,12 @@ pub struct Options {
     #[arg(long, default_value = "10")]
     pub max_new_events_per_block: usize,
 
+    /// Time budget for staging message bundles in milliseconds. When set, limits bundle
+    /// execution by time rather than by count. This overrides `max_pending_message_bundles`
+    /// for bundle limiting purposes.
+    #[arg(long = "staging-bundles-time-budget-ms", value_parser = util::parse_millis)]
+    pub staging_bundles_time_budget: Option<Duration>,
+
     /// The duration in milliseconds after which an idle chain worker will free its memory.
     #[arg(
         long = "chain-worker-ttl-ms",
@@ -281,6 +287,7 @@ impl Options {
             max_pending_message_bundles: self.max_pending_message_bundles,
             max_block_limit_errors: self.max_block_limit_errors,
             max_new_events_per_block: self.max_new_events_per_block,
+            staging_bundles_time_budget: self.staging_bundles_time_budget,
             message_policy,
             cross_chain_message_delivery,
             quorum_grace_period: self.quorum_grace_period,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -935,7 +935,7 @@ where
                         None,
                         &published_blobs,
                         oracle_responses,
-                        BundleExecutionPolicy::Abort,
+                        BundleExecutionPolicy::committed(),
                     )
                     .await?;
                 verified
@@ -1433,7 +1433,7 @@ where
                 block,
                 round,
                 published_blobs,
-                BundleExecutionPolicy::Abort,
+                BundleExecutionPolicy::committed(),
             )
             .await?;
         Ok((executed_block, response, resource_tracker))
@@ -1603,7 +1603,7 @@ where
                 local_time,
                 round.multi_leader(),
                 &published_blobs,
-                BundleExecutionPolicy::Abort,
+                BundleExecutionPolicy::committed(),
             ))
             .await?;
             executed_block

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -23,8 +23,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        BlockExecutionOutcome, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
-        OperationResult, OutgoingMessageExt,
+        BlockExecutionOutcome, BundleExecutionPolicy, BundleFailurePolicy, IncomingBundle,
+        MessageAction, MessageBundle, OperationResult, OutgoingMessageExt,
     },
     test::{make_child_block, make_first_block, BlockTestExt},
     types::ConfirmedBlock,
@@ -520,7 +520,10 @@ where
             proposed_block.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::AutoRetry { max_failures: 3 },
+            BundleExecutionPolicy {
+                on_failure: BundleFailurePolicy::AutoRetry { max_failures: 3 },
+                time_budget: None,
+            },
         )
         .await?;
 
@@ -546,7 +549,7 @@ where
             modified_block.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await?;
 


### PR DESCRIPTION
## Motivation

Currently, block staging limits incoming message bundles by _count_ (`max_pending_message_bundles`), which doesn't
account for the variable cost of executing different bundles. Expensive bundles can cause high block execution latency
even when the count is low, while cheap bundles underutilize capacity.

This adds a time-based budget that gives operators direct control over block execution latency: the client includes
as many bundles as fit within a wall-clock time budget, producing more balanced blocks automatically.

Related issue: https://github.com/linera-io/linera-protocol/issues/5386

## Proposal

Add `--staging-bundles-time-budget-ms` (`Option<Duration>`) CLI option. When set, instead of including up to
`max_pending_message_bundles` bundles per block, the client includes as many bundles as can be executed within the
time budget.

**Semantics:**

- Only `ReceiveMessages` (bundles) are time-budgeted; `ExecuteOperation` transactions always execute
- After each bundle execution, cumulative bundle time is checked against the budget
- The bundle that pushes cumulative time over the budget IS included (already executed)
- Remaining bundles are selectively discarded (operations still execute)
- When `None`, behavior is unchanged (uses `max_pending_message_bundles` count limit)

**Refactoring:** `BundleExecutionPolicy` was split into `BundleFailurePolicy` (Abort/AutoRetry) and a
`BundleExecutionPolicy` struct that combines the failure policy with the optional time budget.

## Test Plan

- CI
- Manual testing: run a worker with `--staging-bundles-time-budget-ms 500` and verify the slow blocks issue is
resolved