### PR TITLE
Fix benchmark close chain race condition

### DIFF
--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -11,12 +11,13 @@ use std::{
 };
 
 use linera_base::{
-    data_types::Amount,
+    data_types::{Amount, Timestamp},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
     time::Instant,
 };
 use linera_core::{
     client::{ChainClient, ChainClientError},
+    data_types::ClientOutcome,
     Environment,
 };
 use linera_execution::{system::SystemOperation, Operation};
@@ -605,10 +606,32 @@ impl<Env: Environment> Benchmark<Env> {
         chain_client: &ChainClient<Env>,
     ) -> Result<(), BenchmarkError> {
         let start = Instant::now();
-        chain_client
-            .execute_operation(Operation::system(SystemOperation::CloseChain))
-            .await?
-            .expect("Close chain operation should not fail!");
+        loop {
+            let result = chain_client
+                .execute_operation(Operation::system(SystemOperation::CloseChain))
+                .await?;
+            match result {
+                ClientOutcome::Committed(_) => break,
+                ClientOutcome::Conflict(certificate) => {
+                    info!(
+                        "Conflict while closing chain {:?}: {}. Retrying...",
+                        chain_client.chain_id(),
+                        certificate.hash()
+                    );
+                }
+                ClientOutcome::WaitForTimeout(timeout) => {
+                    info!(
+                        "Waiting for timeout while closing chain {:?}: {}",
+                        chain_client.chain_id(),
+                        timeout
+                    );
+                    linera_base::time::timer::sleep(
+                        timeout.timestamp.duration_since(Timestamp::now()),
+                    )
+                    .await;
+                }
+            }
+        }
 
         debug!(
             "Closed chain {:?} in {} ms",


### PR DESCRIPTION
## Motivation

The benchmark test is flaky because `close_benchmark_chain` can fail when there are still in-flight requests from
benchmark tasks. When the shutdown signal is received, pending requests may still be committed as blocks, causing a
conflict when we try to close the chain. The current code panics on this conflict instead of handling it gracefully.

Example failure: https://github.com/linera-io/linera-protocol/actions/runs/21718806404/job/62642487443?pr=5391

## Proposal

Replace the `.expect()` call in `close_benchmark_chain` with a retry loop that properly handles both `ClientOutcome`
variants:

- **`Conflict`**: Log at info level and retry immediately (another block was committed, we just need to try again)
- **`WaitForTimeout`**: Log at info level and sleep until the timeout timestamp expires before retrying (we're not the
round leader)

This follows the same patterns used elsewhere in the codebase (e.g., `wait_for_next_round` in
`linera-client/src/util.rs`).

## Test Plan

- CI
