### PR TITLE
Remove eprintln usage from tracing_opentelemetry (frontport of #5394)

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -55,5 +55,5 @@ jobs:
         until nc -z "$STORAGE_HOST" "$STORAGE_PORT"; do sleep 1; done
     - name: Run the benchmark test
       run: |
-        cargo build --locked -p linera-service --bin linera-benchmark --features storage-service
-        cargo test --locked -p linera-service --features storage-service benchmark
+        cargo build --locked -p linera-service --bin linera-benchmark --features storage-service,opentelemetry
+        cargo test --locked -p linera-service --features storage-service,opentelemetry benchmark

--- a/.github/workflows/remote-kubernetes-net-test.yml
+++ b/.github/workflows/remote-kubernetes-net-test.yml
@@ -57,15 +57,15 @@ jobs:
         which helmfile && helmfile --version
     - name: Build binaries
       run: |
-        cargo build --features storage-service --bin linera-server --bin linera-proxy --bin linera
+        cargo build --features storage-service,opentelemetry --bin linera-server --bin linera-proxy --bin linera
     - name: Run the validators with Kubernetes and wait for faucet
       run: |
         mkdir /tmp/local-linera-net
         FAUCET_PORT=$(echo "$LINERA_FAUCET_URL" | cut -d: -f3)
         LOG_FILE="/tmp/linera-net-up-kubernetes.log"
-        cargo run --bin linera --features kubernetes -- net up --kubernetes --policy-config testnet --path /tmp/local-linera-net --validators 1 --shards 2 --with-faucet --faucet-port $FAUCET_PORT --faucet-amount 1000 > "$LOG_FILE" 2>&1 &
+        cargo run --bin linera --features kubernetes,opentelemetry -- net up --kubernetes --policy-config testnet --path /tmp/local-linera-net --validators 1 --shards 2 --with-faucet --faucet-port $FAUCET_PORT --faucet-amount 1000 > "$LOG_FILE" 2>&1 &
         NETWORK_PID=$!
         bash scripts/wait-for-kubernetes-service.sh "$LINERA_FAUCET_URL" "$NETWORK_PID" "$LOG_FILE"
     - name: Run the Kubernetes tests
       run: |
-        cargo test -p linera-service remote_net_grpc --features remote-net
+        cargo test -p linera-service remote_net_grpc --features remote-net,opentelemetry

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -275,7 +275,7 @@ jobs:
         until nc -z "$STORAGE_HOST" "$STORAGE_PORT"; do sleep 1; done
     - name: Run the storage-service tests
       run: |
-        cargo test --features storage-service -- storage_service --nocapture
+        cargo test --features storage-service,opentelemetry -- storage_service --nocapture
 
   check-wit-files:
     needs: changed-files

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [features]
 ethereum = []
-default = ["wasmer", "rocksdb", "storage-service", "opentelemetry"]
+default = ["wasmer", "rocksdb", "storage-service"]
 revm = [
     "linera-base/revm",
     "linera-execution/revm",

--- a/linera-service/src/tracing/opentelemetry.rs
+++ b/linera-service/src/tracing/opentelemetry.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! OpenTelemetry integration for tracing with OTLP export and Chrome trace export.
+//! OpenTelemetry integration for tracing with OTLP export.
 
 use opentelemetry::{global, propagation::TextMapCompositePropagator, trace::TracerProvider};
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
@@ -132,12 +132,12 @@ pub fn init(log_name: &str, otlp_endpoint: Option<&str>) {
         _ => match std::env::var("LINERA_OTLP_EXPORTER_ENDPOINT") {
             Ok(ep) if !ep.is_empty() => ep,
             _ => {
-                eprintln!(
+                crate::tracing::init(log_name);
+                tracing::warn!(
                     "LINERA_OTLP_EXPORTER_ENDPOINT not set and no endpoint provided. \
-                     Falling back to standard tracing without OpenTelemetry span export.\
+                     Falling back to standard tracing without OpenTelemetry span export. \
                      Baggage propagation is still enabled."
                 );
-                crate::tracing::init(log_name);
                 return;
             }
         },


### PR DESCRIPTION
## Motivation

Addresses #5333: improve code quality in `tracing_opentelemetry.rs` by
replacing `eprintln!` with proper
`tracing::warn!` logging.

## Proposal

Replace `eprintln!` with `tracing::warn!` in both
`init_with_opentelemetry` implementations:

1. **With `opentelemetry` feature**: When no OTLP endpoint is
configured, initialize tracing first, then log a warning
via `tracing::warn!` before falling back to standard tracing.

2. **Without `opentelemetry` feature**: Similarly, initialize tracing
first, then warn that the feature is not
enabled.

This ensures fallback messages go through the proper logging
infrastructure rather than directly to stderr, making
them filterable and consistent with the rest of the codebase.

## Test Plan

- CI
