### PR TITLE
Fix client owner wallet overwrite (#5408)

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -411,9 +411,16 @@ impl<Env: Environment> ClientContext<Env> {
     ) -> Result<(), Error> {
         let info = client.chain_info().await?;
         let chain_id = info.chain_id;
+        let existing_owner = self
+            .wallet()
+            .get(chain_id)
+            .await
+            .map_err(error::Inner::wallet)?
+            .and_then(|chain| chain.owner);
+
         let new_chain = wallet::Chain {
             pending_proposal: client.pending_proposal().clone(),
-            owner: client.preferred_owner(),
+            owner: existing_owner,
             ..info.as_ref().into()
         };
 


### PR DESCRIPTION
- #5408

## Motivation

Currently there's an issue with `Wallet::update_from_client` method overwrites wallet's (preferred) owner. This manifests itself in apps with autosigning set up for incoming bundles: when an autosigning key is overwritten by the chain's (session) key during command execution leading to a behavior where proposals are being signed using chain's key (not autosigner).


## Proposal

Don't overwrite wallet owner from client

## Test Plan

Test was added (fails w/o the fix).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #5408 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
