### PR TITLE
Replace `usize` by `u32` in the view definitions.

### DIFF
--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -108,7 +108,7 @@ fn generate_view_code(input: &ItemStruct, root: bool) -> Result<TokenStream2, Er
         let idx_u32 = u32::try_from(idx).expect("number of fields exceeds u32::MAX");
         let derive_key_logic = quote! {
             let __linera_reserved_index: u32 = #idx_u32;
-            let __linera_reserved_base_key = context.base_key().derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            let __linera_reserved_base_key = context.base_key().derive_tag_key(linera_views::views::MIN_VIEW_TAG, &__linera_reserved_index)?;
         };
 
         pre_load_keys_quotes.push(quote! {

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -89,7 +89,6 @@ fn generate_view_code(input: &ItemStruct, root: bool) -> Result<TokenStream2, Er
     let mut num_init_keys_quotes = Vec::new();
     let mut pre_load_keys_quotes = Vec::new();
     let mut post_load_keys_quotes = Vec::new();
-    let num_fields = input.fields.len();
     for (idx, e) in input.fields.iter().enumerate() {
         let name = e.ident.clone().unwrap();
         let delete_view_ident = format_ident!("deleted{}", idx);
@@ -106,19 +105,10 @@ fn generate_view_code(input: &ItemStruct, root: bool) -> Result<TokenStream2, Er
         });
         num_init_keys_quotes.push(quote! { #g :: NUM_INIT_KEYS });
 
-        let derive_key_logic = if num_fields < 256 {
-            let idx_u8 = idx as u8;
-            quote! {
-                let __linera_reserved_index = #idx_u8;
-                let __linera_reserved_base_key = context.base_key().derive_tag_key(linera_views::views::MIN_VIEW_TAG, &__linera_reserved_index)?;
-            }
-        } else {
-            assert!(num_fields < 65536);
-            let idx_u16 = idx as u16;
-            quote! {
-                let __linera_reserved_index = #idx_u16;
-                let __linera_reserved_base_key = context.base_key().derive_tag_key(linera_views::views::MIN_VIEW_TAG, &__linera_reserved_index)?;
-            }
+        let idx_u32 = u32::try_from(idx).expect("number of fields exceeds u32::MAX");
+        let derive_key_logic = quote! {
+            let __linera_reserved_index: u32 = #idx_u32;
+            let __linera_reserved_base_key = context.base_key().derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         };
 
         pre_load_keys_quotes.push(quote! {
@@ -133,18 +123,10 @@ fn generate_view_code(input: &ItemStruct, root: bool) -> Result<TokenStream2, Er
         });
     }
 
-    // derive_key_logic above adds one byte to the key as a tag, and then either one or two more
-    // bytes for field indices, depending on how many fields there are. Thus, we need to trim 2
-    // bytes if there are less than 256 child fields (then the field index fits within one byte),
-    // or 3 bytes if there are more.
-    let trim_key_logic = if num_fields < 256 {
-        quote! {
-            let __bytes_to_trim = 2;
-        }
-    } else {
-        quote! {
-            let __bytes_to_trim = 3;
-        }
+    // derive_key_logic above adds one byte to the key as a tag, plus four bytes for the
+    // `u32`-encoded field index, so we trim 5 bytes total.
+    let trim_key_logic = quote! {
+        let __bytes_to_trim = 5;
     };
 
     let first_name_quote = name_quotes

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<C> linera_views::views::View for TestView<C>
 where
@@ -24,33 +24,27 @@ where
     type Context = C;
     fn context(&self) -> C {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 C,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 C,
@@ -66,13 +60,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -83,13 +74,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -34,7 +34,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 C,
@@ -44,7 +47,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 C,
@@ -63,7 +69,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -77,7 +86,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -35,7 +35,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 C,
@@ -45,7 +48,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 C,
@@ -64,7 +70,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -78,7 +87,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<C, MyParam> linera_views::views::View for TestView<C, MyParam>
 where
@@ -25,33 +25,27 @@ where
     type Context = C;
     fn context(&self) -> C {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 C,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 C,
@@ -67,13 +61,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<C, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -84,13 +75,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
         let collection = CollectionView::<

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -39,7 +39,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 CustomContext,
@@ -49,7 +52,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 CustomContext,
@@ -68,7 +74,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -82,7 +91,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl linera_views::views::View for TestView
 where
@@ -27,7 +27,7 @@ where
     type Context = CustomContext;
     fn context(&self) -> CustomContext {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -36,26 +36,20 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 CustomContext,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 CustomContext,
@@ -71,13 +65,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -88,13 +79,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
@@ -28,7 +28,7 @@ where
     type Context = CustomContext;
     fn context(&self) -> CustomContext {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -37,26 +37,20 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 CustomContext,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 CustomContext,
@@ -72,13 +66,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -89,13 +80,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -40,7 +40,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 CustomContext,
@@ -50,7 +53,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 CustomContext,
@@ -69,7 +75,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -83,7 +92,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 CustomContext,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -39,7 +39,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 custom::GenericContext<T>,
@@ -49,7 +52,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 custom::GenericContext<T>,
@@ -68,7 +74,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -82,7 +91,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl linera_views::views::View for TestView
 where
@@ -27,7 +27,7 @@ where
     type Context = custom::GenericContext<T>;
     fn context(&self) -> custom::GenericContext<T> {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -36,26 +36,20 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 custom::GenericContext<T>,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 custom::GenericContext<T>,
@@ -71,13 +65,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -88,13 +79,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -40,7 +40,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 custom::GenericContext<T>,
@@ -50,7 +53,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 custom::GenericContext<T>,
@@ -69,7 +75,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -83,7 +92,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
@@ -28,7 +28,7 @@ where
     type Context = custom::GenericContext<T>;
     fn context(&self) -> custom::GenericContext<T> {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -37,26 +37,20 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 custom::GenericContext<T>,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 custom::GenericContext<T>,
@@ -72,13 +66,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -89,13 +80,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::GenericContext<T>,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -39,7 +39,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 custom::path::to::ContextType,
@@ -49,7 +52,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 custom::path::to::ContextType,
@@ -68,7 +74,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -82,7 +91,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl linera_views::views::View for TestView
 where
@@ -27,7 +27,7 @@ where
     type Context = custom::path::to::ContextType;
     fn context(&self) -> custom::path::to::ContextType {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -36,26 +36,20 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 custom::path::to::ContextType,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 custom::path::to::ContextType,
@@ -71,13 +65,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -88,13 +79,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -40,7 +40,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             RegisterView::<
                 custom::path::to::ContextType,
@@ -50,7 +53,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         keys.extend(
             CollectionView::<
                 custom::path::to::ContextType,
@@ -69,7 +75,10 @@ where
         let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -83,7 +92,10 @@ where
         let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
+            .derive_tag_key(
+                linera_views::views::MIN_VIEW_TAG,
+                &__linera_reserved_index,
+            )?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
@@ -28,7 +28,7 @@ where
     type Context = custom::path::to::ContextType;
     fn context(&self) -> custom::path::to::ContextType {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -37,26 +37,20 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             RegisterView::<
                 custom::path::to::ContextType,
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         keys.extend(
             CollectionView::<
                 custom::path::to::ContextType,
@@ -72,13 +66,10 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
         let register = RegisterView::<
@@ -89,13 +80,10 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
-            .derive_tag_key(
-                linera_views::views::MIN_VIEW_TAG,
-                &__linera_reserved_index,
-            )?;
+            .derive_tag_key(linera_views::views::MIN_VIEW_TAG, __linera_reserved_index)?;
         let __linera_reserved_pos_next = __linera_reserved_pos
             + CollectionView::<
                 custom::path::to::ContextType,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<C> linera_views::views::View for TestView<C>
 where
@@ -24,14 +24,14 @@ where
     type Context = C;
     fn context(&self) -> C {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -44,7 +44,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -66,7 +66,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -83,7 +83,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<C, MyParam> linera_views::views::View for TestView<C, MyParam>
 where
@@ -25,14 +25,14 @@ where
     type Context = C;
     fn context(&self) -> C {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -45,7 +45,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -67,7 +67,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -84,7 +84,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl linera_views::views::View for TestView
 where
@@ -27,7 +27,7 @@ where
     type Context = CustomContext;
     fn context(&self) -> CustomContext {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -36,7 +36,7 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -49,7 +49,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -71,7 +71,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -88,7 +88,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
@@ -28,7 +28,7 @@ where
     type Context = CustomContext;
     fn context(&self) -> CustomContext {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -37,7 +37,7 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -50,7 +50,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -72,7 +72,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -89,7 +89,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl linera_views::views::View for TestView
 where
@@ -27,7 +27,7 @@ where
     type Context = custom::GenericContext<T>;
     fn context(&self) -> custom::GenericContext<T> {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -36,7 +36,7 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -49,7 +49,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -71,7 +71,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -88,7 +88,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
@@ -28,7 +28,7 @@ where
     type Context = custom::GenericContext<T>;
     fn context(&self) -> custom::GenericContext<T> {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -37,7 +37,7 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -50,7 +50,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -72,7 +72,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -89,7 +89,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl linera_views::views::View for TestView
 where
@@ -27,7 +27,7 @@ where
     type Context = custom::path::to::ContextType;
     fn context(&self) -> custom::path::to::ContextType {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -36,7 +36,7 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -49,7 +49,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -71,7 +71,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -88,7 +88,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -1,6 +1,6 @@
 ---
 source: linera-views-derive/src/lib.rs
-expression: "pretty(generate_view_code(input, true).unwrap())"
+expression: "pretty(generate_view_code(&input, true).unwrap())"
 ---
 impl<MyParam> linera_views::views::View for TestView<MyParam>
 where
@@ -28,7 +28,7 @@ where
     type Context = custom::path::to::ContextType;
     fn context(&self) -> custom::path::to::ContextType {
         use linera_views::context::Context as _;
-        let __bytes_to_trim = 2;
+        let __bytes_to_trim = 5;
         let context = self.register.context();
         context.clone_with_trimmed_key(__bytes_to_trim)
     }
@@ -37,7 +37,7 @@ where
     ) -> Result<Vec<Vec<u8>>, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut keys = Vec::new();
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -50,7 +50,7 @@ where
                 usize,
             >::pre_load(&context.clone_with_base_key(__linera_reserved_base_key))?,
         );
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -72,7 +72,7 @@ where
     ) -> Result<Self, linera_views::ViewError> {
         use linera_views::context::Context as _;
         let mut __linera_reserved_pos = 0;
-        let __linera_reserved_index = 0u8;
+        let __linera_reserved_index: u32 = 0u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(
@@ -89,7 +89,7 @@ where
             &values[__linera_reserved_pos..__linera_reserved_pos_next],
         )?;
         __linera_reserved_pos = __linera_reserved_pos_next;
-        let __linera_reserved_index = 1u8;
+        let __linera_reserved_index: u32 = 1u32;
         let __linera_reserved_base_key = context
             .base_key()
             .derive_tag_key(

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -49,18 +49,11 @@ impl BaseKey {
         key
     }
 
-    /// Obtains the `Vec<u8>` key from the key by serialization and using the base key.
-    pub fn derive_key(&self, index: u32) -> Result<Vec<u8>, bcs::Error> {
-        let mut key = self.bytes.clone();
-        bcs::serialize_into(&mut key, &index)?;
-        Ok(key)
-    }
-
     /// Obtains the `Vec<u8>` key from the key by serialization and using the `base_key`.
-    pub fn derive_tag_key(&self, tag: u8, index: u32) -> Result<Vec<u8>, bcs::Error> {
+    pub fn derive_tag_key<I: Serialize>(&self, tag: u8, index: &I) -> Result<Vec<u8>, bcs::Error> {
         assert!(tag >= MIN_VIEW_TAG, "tag should be at least MIN_VIEW_TAG");
         let mut key = self.base_tag(tag);
-        bcs::serialize_into(&mut key, &index)?;
+        bcs::serialize_into(&mut key, index)?;
         Ok(key)
     }
 

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -50,21 +50,17 @@ impl BaseKey {
     }
 
     /// Obtains the `Vec<u8>` key from the key by serialization and using the base key.
-    pub fn derive_key<I: Serialize>(&self, index: &I) -> Result<Vec<u8>, bcs::Error> {
+    pub fn derive_key(&self, index: u32) -> Result<Vec<u8>, bcs::Error> {
         let mut key = self.bytes.clone();
-        bcs::serialize_into(&mut key, index)?;
-        assert!(
-            key.len() > self.bytes.len(),
-            "Empty indices are not allowed"
-        );
+        bcs::serialize_into(&mut key, &index)?;
         Ok(key)
     }
 
     /// Obtains the `Vec<u8>` key from the key by serialization and using the `base_key`.
-    pub fn derive_tag_key<I: Serialize>(&self, tag: u8, index: &I) -> Result<Vec<u8>, bcs::Error> {
+    pub fn derive_tag_key(&self, tag: u8, index: u32) -> Result<Vec<u8>, bcs::Error> {
         assert!(tag >= MIN_VIEW_TAG, "tag should be at least MIN_VIEW_TAG");
         let mut key = self.base_tag(tag);
-        bcs::serialize_into(&mut key, index)?;
+        bcs::serialize_into(&mut key, &index)?;
         Ok(key)
     }
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -4,6 +4,7 @@
 use std::collections::{vec_deque::IterMut, VecDeque};
 
 use allocative::Allocative;
+use linera_base::data_types::ArithmeticError;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -54,16 +55,16 @@ struct BucketStore {
     /// with index 0 (front bucket) and will be ignored.
     descriptions: Vec<BucketDescription>,
     /// The position of the front value in the front bucket.
-    front_position: usize,
+    front_position: u32,
 }
 
 /// The description of a bucket in storage.
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 struct BucketDescription {
     /// The length of the bucket (at most N).
-    length: usize,
+    length: u32,
     /// The index of the bucket in storage.
-    index: usize,
+    index: u32,
 }
 
 impl BucketStore {
@@ -76,22 +77,22 @@ impl BucketStore {
 #[derive(Copy, Clone, Debug, Allocative)]
 struct Cursor {
     /// The offset of the bucket in the vector of stored buckets.
-    offset: usize,
+    offset: u32,
     /// The position of the value in the stored bucket.
-    position: usize,
+    position: u32,
 }
 
 /// The state of a stored bucket in memory.
 #[derive(Clone, Debug, Allocative)]
 enum State<T> {
     Loaded { data: Vec<T> },
-    NotLoaded { length: usize },
+    NotLoaded { length: u32 },
 }
 
 impl<T> Bucket<T> {
-    fn len(&self) -> usize {
+    fn len(&self) -> u32 {
         match &self.state {
-            State::Loaded { data } => data.len(),
+            State::Loaded { data } => data.len() as u32,
             State::NotLoaded { length } => *length,
         }
     }
@@ -115,7 +116,7 @@ impl<T> Bucket<T> {
 #[derive(Clone, Debug, Allocative)]
 struct Bucket<T> {
     /// The index in storage.
-    index: usize,
+    index: u32,
     /// The state of the bucket.
     state: State<T>,
 }
@@ -126,8 +127,8 @@ struct Bucket<T> {
 /// seems adequate.
 //#[allocative(bound = "T: Allocative")]
 #[derive(Debug, Allocative)]
-#[allocative(bound = "C, T: Allocative, const N: usize")]
-pub struct BucketQueueView<C, T, const N: usize> {
+#[allocative(bound = "C, T: Allocative, const N: u32")]
+pub struct BucketQueueView<C, T, const N: u32> {
     /// The view context.
     #[allocative(skip)]
     context: C,
@@ -136,7 +137,7 @@ pub struct BucketQueueView<C, T, const N: usize> {
     /// The newly inserted back values.
     new_back_values: VecDeque<T>,
     /// The position for the stored front value in the first stored bucket.
-    stored_front_position: usize,
+    stored_front_position: u32,
     /// The current position of the front value if it is in the stored buckets, and `None`
     /// otherwise.
     cursor: Option<Cursor>,
@@ -144,7 +145,7 @@ pub struct BucketQueueView<C, T, const N: usize> {
     delete_storage_first: bool,
 }
 
-impl<C, T, const N: usize> View for BucketQueueView<C, T, N>
+impl<C, T, const N: u32> View for BucketQueueView<C, T, N>
 where
     C: Context,
     T: Send + Sync + Clone + Serialize + DeserializeOwned,
@@ -247,7 +248,7 @@ where
             stored_front_position = 0;
         } else if let Some(cursor) = self.cursor {
             // Delete buckets that are before the cursor
-            for i in 0..cursor.offset {
+            for i in 0..cursor.offset as usize {
                 let bucket = &self.stored_buckets[i];
                 let index = bucket.index;
                 let key = self.get_bucket_key(index)?;
@@ -255,13 +256,13 @@ where
             }
             stored_front_position = cursor.position;
             // Build descriptions for remaining buckets
-            let first_index = self.stored_buckets[cursor.offset].index;
+            let first_index = self.stored_buckets[cursor.offset as usize].index;
             let start_offset = if first_index != 0 {
                 // Need to move the first remaining bucket to index 0
                 let key = self.get_bucket_key(first_index)?;
                 batch.delete_key(key);
                 let key = self.get_bucket_key(0)?;
-                let bucket = &self.stored_buckets[cursor.offset];
+                let bucket = &self.stored_buckets[cursor.offset as usize];
                 let State::Loaded { data } = &bucket.state else {
                     unreachable!("The front bucket is always loaded.");
                 };
@@ -274,7 +275,7 @@ where
             } else {
                 cursor.offset
             };
-            for bucket in self.stored_buckets.range(start_offset..) {
+            for bucket in self.stored_buckets.range(start_offset as usize..) {
                 descriptions.push(bucket.to_description());
             }
         }
@@ -291,17 +292,19 @@ where
                 // This shouldn't happen if stored_count() > 0
                 0
             };
-            let mut start = 0;
+            let mut start = 0_usize;
             while start < self.new_back_values.len() {
-                let end = std::cmp::min(start + N, self.new_back_values.len());
+                let end = std::cmp::min(start + N as usize, self.new_back_values.len());
                 let value_chunk: Vec<_> = self.new_back_values.range(start..end).collect();
                 let key = self.get_bucket_key(index)?;
                 batch.put_key_value(key, &value_chunk)?;
                 descriptions.push(BucketDescription {
                     index,
-                    length: end - start,
+                    length: (end - start) as u32,
                 });
-                index += 1;
+                index = index
+                    .checked_add(1)
+                    .ok_or(ArithmeticError::Overflow)?;
                 start = end;
             }
         }
@@ -340,7 +343,7 @@ where
             };
             let new_back_values = std::mem::take(&mut self.new_back_values);
             let new_back_values = new_back_values.into_iter().collect::<Vec<_>>();
-            for value_chunk in new_back_values.chunks(N) {
+            for value_chunk in new_back_values.chunks(N as usize) {
                 self.stored_buckets.push_back(Bucket {
                     index,
                     state: State::Loaded {
@@ -366,7 +369,7 @@ where
     }
 }
 
-impl<C: Clone, T: Clone, const N: usize> ClonableView for BucketQueueView<C, T, N>
+impl<C: Clone, T: Clone, const N: u32> ClonableView for BucketQueueView<C, T, N>
 where
     Self: View,
 {
@@ -382,9 +385,9 @@ where
     }
 }
 
-impl<C: Context, T, const N: usize> BucketQueueView<C, T, N> {
+impl<C: Context, T, const N: u32> BucketQueueView<C, T, N> {
     /// Gets the key corresponding to this bucket index.
-    fn get_bucket_key(&self, index: usize) -> Result<Vec<u8>, ViewError> {
+    fn get_bucket_key(&self, index: u32) -> Result<Vec<u8>, ViewError> {
         Ok(if index == 0 {
             self.context.base_key().base_tag(KeyTag::Front as u8)
         } else {
@@ -413,12 +416,11 @@ impl<C: Context, T, const N: usize> BucketQueueView<C, T, N> {
             let Some(cursor) = self.cursor else {
                 return 0;
             };
-            let mut stored_count = 0;
-            for offset in cursor.offset..self.stored_buckets.len() {
-                stored_count += self.stored_buckets[offset].len();
+            let mut stored_count = 0_usize;
+            for offset in (cursor.offset as usize)..self.stored_buckets.len() {
+                stored_count += self.stored_buckets[offset].len() as usize;
             }
-            stored_count -= cursor.position;
-            stored_count
+            stored_count - cursor.position as usize
         }
     }
 
@@ -439,7 +441,7 @@ impl<C: Context, T, const N: usize> BucketQueueView<C, T, N> {
     }
 }
 
-impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C, T, N> {
+impl<C: Context, T: DeserializeOwned + Clone, const N: u32> BucketQueueView<C, T, N> {
     /// Gets a reference on the front value if any.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -456,11 +458,11 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
     pub fn front(&self) -> Option<&T> {
         match self.cursor {
             Some(Cursor { offset, position }) => {
-                let bucket = &self.stored_buckets[offset];
+                let bucket = &self.stored_buckets[offset as usize];
                 let State::Loaded { data } = &bucket.state else {
                     unreachable!("The front bucket should always be loaded");
                 };
-                Some(&data[position])
+                Some(&data[position as usize])
             }
             None => self.new_back_values.front(),
         }
@@ -486,13 +488,13 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
             Some(Cursor { offset, position }) => {
                 let bucket = self
                     .stored_buckets
-                    .get_mut(offset)
+                    .get_mut(offset as usize)
                     .expect("cursor.offset must be a valid index into stored_buckets");
                 let State::Loaded { data } = &mut bucket.state else {
                     unreachable!("The front bucket should always be loaded");
                 };
                 Some(
-                    data.get_mut(position)
+                    data.get_mut(position as usize)
                         .expect("cursor.position must be a valid index within the front bucket"),
                 )
             }
@@ -518,15 +520,17 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
             Some(cursor) => {
                 let mut offset = cursor.offset;
                 let mut position = cursor.position + 1;
-                if self.stored_buckets[offset].len() == position {
+                let mut offset_usize = offset as usize;
+                if self.stored_buckets[offset_usize].len() == position {
                     offset += 1;
                     position = 0;
+                    offset_usize += 1;
                 }
-                if offset == self.stored_buckets.len() {
+                if offset_usize == self.stored_buckets.len() {
                     self.cursor = None;
                 } else {
-                    if !self.stored_buckets[offset].is_loaded() {
-                        let index = self.stored_buckets[offset].index;
+                    if !self.stored_buckets[offset_usize].is_loaded() {
+                        let index = self.stored_buckets[offset_usize].index;
                         let key = self.get_bucket_key(index)?;
                         let data = self.context.store().read_value(&key).await?;
                         let data = match data {
@@ -537,7 +541,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                                 ));
                             }
                         };
-                        self.stored_buckets[offset].state = State::Loaded { data };
+                        self.stored_buckets[offset_usize].state = State::Loaded { data };
                     }
                     self.cursor = Some(Cursor { offset, position });
                 }
@@ -644,9 +648,10 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
         if let Some(cursor) = cursor {
             let mut keys = Vec::new();
             let mut position = cursor.position;
-            for offset in cursor.offset..self.stored_buckets.len() {
+            let offset_start = cursor.offset as usize;
+            for offset in offset_start..self.stored_buckets.len() {
                 let bucket = &self.stored_buckets[offset];
-                let size = bucket.len() - position;
+                let size = (bucket.len() - position) as usize;
                 if !bucket.is_loaded() {
                     let key = self.get_bucket_key(bucket.index)?;
                     keys.push(key);
@@ -661,9 +666,9 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
             let mut value_pos = 0;
             count_remain = count;
             let mut position = cursor.position;
-            for offset in cursor.offset..self.stored_buckets.len() {
+            for offset in offset_start..self.stored_buckets.len() {
                 let bucket = &self.stored_buckets[offset];
-                let size = bucket.len() - position;
+                let size = (bucket.len() - position) as usize;
                 let data = match &bucket.state {
                     State::Loaded { data } => data,
                     State::NotLoaded { .. } => {
@@ -679,7 +684,8 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                         &bcs::from_bytes::<Vec<T>>(value)?
                     }
                 };
-                elements.extend(data[position..].iter().take(count_remain).cloned());
+                let position_usize = position as usize;
+                elements.extend(data[position_usize..].iter().take(count_remain).cloned());
                 if size >= count_remain {
                     return Ok(elements);
                 }
@@ -740,14 +746,16 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                 unreachable!("Cursor should be Some when stored_count > 0");
             };
             let mut position = cursor.position;
-            for offset in cursor.offset..self.stored_buckets.len() {
-                let size = self.stored_buckets[offset].len() - position;
+            let offset_start = cursor.offset as usize;
+            for offset in offset_start..self.stored_buckets.len() {
+                let size = (self.stored_buckets[offset].len() - position) as usize;
                 if increment < size {
                     return self
                         .read_context(
                             Some(Cursor {
-                                offset,
-                                position: position + increment,
+                                offset: u32::try_from(offset)
+                                    .map_err(|_| ArithmeticError::Overflow)?,
+                                position: position + increment as u32,
                             }),
                             count,
                         )
@@ -794,7 +802,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
     }
 }
 
-impl<C: Context, T: Serialize + DeserializeOwned + Send + Sync + Clone, const N: usize> HashableView
+impl<C: Context, T: Serialize + DeserializeOwned + Send + Sync + Clone, const N: u32> HashableView
     for BucketQueueView<C, T, N>
 where
     Self: View,
@@ -816,16 +824,18 @@ where
 }
 
 /// Type wrapping `QueueView` while memoizing the hash.
-pub type HashedBucketQueueView<C, T, const N: usize> =
+pub type HashedBucketQueueView<C, T, const N: u32> =
     WrappedHashableContainerView<C, BucketQueueView<C, T, N>, HasherOutput>;
 
 /// Wrapper around `BucketQueueView` to compute hashes based on the history of changes.
-pub type HistoricallyHashedBucketQueueView<C, T, const N: usize> =
+pub type HistoricallyHashedBucketQueueView<C, T, const N: u32> =
     HistoricallyHashableView<C, BucketQueueView<C, T, N>>;
 
 #[cfg(with_graphql)]
 mod graphql {
     use std::borrow::Cow;
+
+    use linera_base::data_types::ArithmeticError;
 
     use super::BucketQueueView;
     use crate::{
@@ -833,7 +843,7 @@ mod graphql {
         graphql::{hash_name, mangle},
     };
 
-    impl<C: Send + Sync, T: async_graphql::OutputType, const N: usize> async_graphql::TypeName
+    impl<C: Send + Sync, T: async_graphql::OutputType, const N: u32> async_graphql::TypeName
         for BucketQueueView<C, T, N>
     {
         fn type_name() -> Cow<'static, str> {
@@ -847,14 +857,15 @@ mod graphql {
     }
 
     #[async_graphql::Object(cache_control(no_cache), name_type)]
-    impl<C: Context, T: async_graphql::OutputType, const N: usize> BucketQueueView<C, T, N>
+    impl<C: Context, T: async_graphql::OutputType, const N: u32> BucketQueueView<C, T, N>
     where
         C: Send + Sync,
         T: serde::ser::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
     {
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count() as u32)
+            Ok(u32::try_from(self.count())
+                .map_err(|_| ArithmeticError::Overflow)?)
         }
 
         async fn entries(&self, count: Option<usize>) -> async_graphql::Result<Vec<T>> {

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -391,7 +391,7 @@ impl<C: Context, T, const N: u32> BucketQueueView<C, T, N> {
         } else {
             self.context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, index)?
+                .derive_tag_key(KeyTag::Index as u8, &index)?
         })
     }
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -391,7 +391,7 @@ impl<C: Context, T, const N: u32> BucketQueueView<C, T, N> {
         } else {
             self.context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, &index)?
+                .derive_tag_key(KeyTag::Index as u8, index)?
         })
     }
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -302,9 +302,7 @@ where
                     index,
                     length: (end - start) as u32,
                 });
-                index = index
-                    .checked_add(1)
-                    .ok_or(ArithmeticError::Overflow)?;
+                index = index.checked_add(1).ok_or(ArithmeticError::Overflow)?;
                 start = end;
             }
         }
@@ -864,8 +862,7 @@ mod graphql {
     {
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(u32::try_from(self.count())
-                .map_err(|_| ArithmeticError::Overflow)?)
+            Ok(u32::try_from(self.count()).map_err(|_| ArithmeticError::Overflow)?)
         }
 
         async fn entries(&self, count: Option<usize>) -> async_graphql::Result<Vec<T>> {

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -123,7 +123,7 @@ where
                 let key = self
                     .context
                     .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, count)?;
+                    .derive_tag_key(KeyTag::Index as u8, &count)?;
                 batch.put_key_value(key, value)?;
                 count += 1;
             }
@@ -237,7 +237,7 @@ where
             let key = self
                 .context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, index_u32)?;
+                .derive_tag_key(KeyTag::Index as u8, &index_u32)?;
             self.context.store().read_value(&key).await?
         } else {
             self.new_values
@@ -290,7 +290,7 @@ where
                 let key = self
                     .context
                     .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, index_u32)?;
+                    .derive_tag_key(KeyTag::Index as u8, &index_u32)?;
                 keys.push(key);
                 vec_positions.push(positions);
             }
@@ -339,7 +339,7 @@ where
             let key = self
                 .context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, index_u32)?;
+                .derive_tag_key(KeyTag::Index as u8, &index_u32)?;
             keys.push(key);
         }
         let mut values = Vec::with_capacity(count);

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -121,8 +121,8 @@ where
                 batch.put_key_value(key, value)?;
                 count += 1;
             }
-            let new_values_len = u32::try_from(self.new_values.len())
-                .map_err(|_| ArithmeticError::Overflow)?;
+            let new_values_len =
+                u32::try_from(self.new_values.len()).map_err(|_| ArithmeticError::Overflow)?;
             let count_u32 = self
                 .stored_count
                 .checked_add(new_values_len)
@@ -139,9 +139,7 @@ where
         }
         self.stored_count = self
             .stored_count
-            .checked_add(
-                u32::try_from(self.new_values.len()).expect("verified in pre_save"),
-            )
+            .checked_add(u32::try_from(self.new_values.len()).expect("verified in pre_save"))
             .expect("verified in pre_save");
         self.new_values.clear();
         self.delete_storage_first = false;
@@ -468,8 +466,7 @@ mod graphql {
     {
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(u32::try_from(self.count())
-                .map_err(|_| ArithmeticError::Overflow)?)
+            Ok(u32::try_from(self.count()).map_err(|_| ArithmeticError::Overflow)?)
         }
 
         async fn entries(

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use allocative::Allocative;
+use linera_base::data_types::ArithmeticError;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use serde::{de::DeserializeOwned, Serialize};
@@ -58,7 +59,7 @@ pub struct LogView<C, T> {
     /// Whether to clear storage before applying updates.
     delete_storage_first: bool,
     /// The number of entries persisted in storage.
-    stored_count: usize,
+    stored_count: u32,
     /// New values not yet persisted to storage.
     new_values: Vec<T>,
 }
@@ -111,7 +112,7 @@ where
         }
         if !self.new_values.is_empty() {
             delete_view = false;
-            let mut count = self.stored_count;
+            let mut count = self.stored_count as usize;
             for value in &self.new_values {
                 let key = self
                     .context
@@ -120,8 +121,14 @@ where
                 batch.put_key_value(key, value)?;
                 count += 1;
             }
+            let new_values_len = u32::try_from(self.new_values.len())
+                .map_err(|_| ArithmeticError::Overflow)?;
+            let count_u32 = self
+                .stored_count
+                .checked_add(new_values_len)
+                .ok_or(ArithmeticError::Overflow)?;
             let key = self.context.base_key().base_tag(KeyTag::Count as u8);
-            batch.put_key_value(key, &count)?;
+            batch.put_key_value(key, &count_u32)?;
         }
         Ok(delete_view)
     }
@@ -130,7 +137,12 @@ where
         if self.delete_storage_first {
             self.stored_count = 0;
         }
-        self.stored_count += self.new_values.len();
+        self.stored_count = self
+            .stored_count
+            .checked_add(
+                u32::try_from(self.new_values.len()).expect("verified in pre_save"),
+            )
+            .expect("verified in pre_save");
         self.new_values.clear();
         self.delete_storage_first = false;
     }
@@ -192,7 +204,7 @@ where
         if self.delete_storage_first {
             self.new_values.len()
         } else {
-            self.stored_count + self.new_values.len()
+            self.stored_count as usize + self.new_values.len()
         }
     }
 
@@ -222,14 +234,16 @@ where
     pub async fn get(&self, index: usize) -> Result<Option<T>, ViewError> {
         let value = if self.delete_storage_first {
             self.new_values.get(index).cloned()
-        } else if index < self.stored_count {
+        } else if index < self.stored_count as usize {
             let key = self
                 .context
                 .base_key()
                 .derive_tag_key(KeyTag::Index as u8, &index)?;
             self.context.store().read_value(&key).await?
         } else {
-            self.new_values.get(index - self.stored_count).cloned()
+            self.new_values
+                .get(index - self.stored_count as usize)
+                .cloned()
         };
         Ok(value)
     }
@@ -259,11 +273,15 @@ where
         } else {
             let mut index_to_positions = BTreeMap::<usize, Vec<usize>>::new();
             for (pos, index) in indices.into_iter().enumerate() {
-                if index < self.stored_count {
+                if index < self.stored_count as usize {
                     index_to_positions.entry(index).or_default().push(pos);
                     result.push(None);
                 } else {
-                    result.push(self.new_values.get(index - self.stored_count).cloned());
+                    result.push(
+                        self.new_values
+                            .get(index - self.stored_count as usize)
+                            .cloned(),
+                    );
                 }
             }
             let mut keys = Vec::new();
@@ -356,7 +374,7 @@ where
         let effective_stored_count = if self.delete_storage_first {
             0
         } else {
-            self.stored_count
+            self.stored_count as usize
         };
         let end = match range.end_bound() {
             Bound::Included(end) => *end + 1,
@@ -424,6 +442,8 @@ pub type HistoricallyHashedLogView<C, T> = HistoricallyHashableView<C, LogView<C
 mod graphql {
     use std::borrow::Cow;
 
+    use linera_base::data_types::ArithmeticError;
+
     use super::LogView;
     use crate::{
         context::Context,
@@ -448,7 +468,8 @@ mod graphql {
     {
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count() as u32)
+            Ok(u32::try_from(self.count())
+                .map_err(|_| ArithmeticError::Overflow)?)
         }
 
         async fn entries(

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -112,21 +112,21 @@ where
         }
         if !self.new_values.is_empty() {
             delete_view = false;
-            let mut count = self.stored_count as usize;
-            for value in &self.new_values {
-                let key = self
-                    .context
-                    .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, &count)?;
-                batch.put_key_value(key, value)?;
-                count += 1;
-            }
             let new_values_len =
                 u32::try_from(self.new_values.len()).map_err(|_| ArithmeticError::Overflow)?;
             let count_u32 = self
                 .stored_count
                 .checked_add(new_values_len)
                 .ok_or(ArithmeticError::Overflow)?;
+            let mut count = self.stored_count;
+            for value in &self.new_values {
+                let key = self
+                    .context
+                    .base_key()
+                    .derive_tag_key(KeyTag::Index as u8, count)?;
+                batch.put_key_value(key, value)?;
+                count += 1;
+            }
             let key = self.context.base_key().base_tag(KeyTag::Count as u8);
             batch.put_key_value(key, &count_u32)?;
         }
@@ -233,10 +233,11 @@ where
         let value = if self.delete_storage_first {
             self.new_values.get(index).cloned()
         } else if index < self.stored_count as usize {
+            let index_u32 = index as u32;
             let key = self
                 .context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, &index)?;
+                .derive_tag_key(KeyTag::Index as u8, index_u32)?;
             self.context.store().read_value(&key).await?
         } else {
             self.new_values
@@ -285,10 +286,11 @@ where
             let mut keys = Vec::new();
             let mut vec_positions = Vec::new();
             for (index, positions) in index_to_positions {
+                let index_u32 = index as u32;
                 let key = self
                     .context
                     .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, &index)?;
+                    .derive_tag_key(KeyTag::Index as u8, index_u32)?;
                 keys.push(key);
                 vec_positions.push(positions);
             }
@@ -333,10 +335,11 @@ where
         let count = range.len();
         let mut keys = Vec::with_capacity(count);
         for index in range {
+            let index_u32 = index as u32;
             let key = self
                 .context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, &index)?;
+                .derive_tag_key(KeyTag::Index as u8, index_u32)?;
             keys.push(key);
         }
         let mut values = Vec::with_capacity(count);

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -133,7 +133,7 @@ where
                 let key = self
                     .context
                     .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, &index)?;
+                    .derive_tag_key(KeyTag::Index as u8, index)?;
                 batch.delete_key(key);
             }
         }
@@ -143,7 +143,7 @@ where
                 let key = self
                     .context
                     .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, &new_stored_indices.end)?;
+                    .derive_tag_key(KeyTag::Index as u8, new_stored_indices.end)?;
                 batch.put_key_value(key, value)?;
                 new_stored_indices.end = new_stored_indices
                     .end
@@ -214,7 +214,7 @@ where
         let key = self
             .context
             .base_key()
-            .derive_tag_key(KeyTag::Index as u8, &index)?;
+            .derive_tag_key(KeyTag::Index as u8, index)?;
         Ok(self.context.store().read_value(&key).await?)
     }
 
@@ -328,7 +328,7 @@ where
             let key = self
                 .context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, &index)?;
+                .derive_tag_key(KeyTag::Index as u8, index)?;
             keys.push(key)
         }
         let mut values = Vec::with_capacity(count);

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -413,8 +413,8 @@ where
                     .cloned(),
             );
         } else {
-            let stored_consumed = u32::try_from(count - new_back_len)
-                .map_err(|_| ArithmeticError::Overflow)?;
+            let stored_consumed =
+                u32::try_from(count - new_back_len).map_err(|_| ArithmeticError::Overflow)?;
             let start = self.stored_indices.end - stored_consumed;
             values.extend(self.read_context(start..self.stored_indices.end).await?);
             values.extend(self.new_back_values.iter().cloned());
@@ -537,8 +537,7 @@ mod graphql {
     {
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(u32::try_from(self.count())
-                .map_err(|_| ArithmeticError::Overflow)?)
+            Ok(u32::try_from(self.count()).map_err(|_| ArithmeticError::Overflow)?)
         }
 
         async fn entries(&self, count: Option<usize>) -> async_graphql::Result<Vec<T>> {

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -133,7 +133,7 @@ where
                 let key = self
                     .context
                     .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, index)?;
+                    .derive_tag_key(KeyTag::Index as u8, &index)?;
                 batch.delete_key(key);
             }
         }
@@ -143,7 +143,7 @@ where
                 let key = self
                     .context
                     .base_key()
-                    .derive_tag_key(KeyTag::Index as u8, new_stored_indices.end)?;
+                    .derive_tag_key(KeyTag::Index as u8, &new_stored_indices.end)?;
                 batch.put_key_value(key, value)?;
                 new_stored_indices.end = new_stored_indices
                     .end
@@ -214,7 +214,7 @@ where
         let key = self
             .context
             .base_key()
-            .derive_tag_key(KeyTag::Index as u8, index)?;
+            .derive_tag_key(KeyTag::Index as u8, &index)?;
         Ok(self.context.store().read_value(&key).await?)
     }
 
@@ -328,7 +328,7 @@ where
             let key = self
                 .context
                 .base_key()
-                .derive_tag_key(KeyTag::Index as u8, index)?;
+                .derive_tag_key(KeyTag::Index as u8, &index)?;
             keys.push(key)
         }
         let mut values = Vec::with_capacity(count);

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -9,7 +9,7 @@ use std::{
 use allocative::Allocative;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
-use linera_base::visit_allocative_simple;
+use linera_base::{data_types::ArithmeticError, visit_allocative_simple};
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -58,9 +58,9 @@ pub struct QueueView<C, T> {
     context: C,
     /// The range of indices for entries persisted in storage.
     #[allocative(visit = visit_allocative_simple)]
-    stored_indices: Range<usize>,
+    stored_indices: Range<u32>,
     /// The number of entries to delete from the front.
-    front_delete_count: usize,
+    front_delete_count: u32,
     /// Whether to clear storage before applying updates.
     delete_storage_first: bool,
     /// New values added to the back, not yet persisted to storage.
@@ -124,7 +124,10 @@ where
             batch.delete_key_prefix(key_prefix);
             new_stored_indices = Range::default();
         } else if self.front_delete_count > 0 {
-            let deletion_range = self.stored_indices.clone().take(self.front_delete_count);
+            let deletion_range = self
+                .stored_indices
+                .clone()
+                .take(self.front_delete_count as usize);
             new_stored_indices.start += self.front_delete_count;
             for index in deletion_range {
                 let key = self
@@ -142,7 +145,10 @@ where
                     .base_key()
                     .derive_tag_key(KeyTag::Index as u8, &new_stored_indices.end)?;
                 batch.put_key_value(key, value)?;
-                new_stored_indices.end += 1;
+                new_stored_indices.end = new_stored_indices
+                    .end
+                    .checked_add(1)
+                    .ok_or(ArithmeticError::Overflow)?;
             }
         }
         if !self.delete_storage_first || !new_stored_indices.is_empty() {
@@ -159,7 +165,8 @@ where
             self.stored_indices.start += self.front_delete_count;
         }
         if !self.new_back_values.is_empty() {
-            self.stored_indices.end += self.new_back_values.len();
+            self.stored_indices.end +=
+                u32::try_from(self.new_back_values.len()).expect("verified in pre_save");
             self.new_back_values.clear();
         }
         self.front_delete_count = 0;
@@ -189,11 +196,11 @@ where
 }
 
 impl<C, T> QueueView<C, T> {
-    fn stored_count(&self) -> usize {
+    fn stored_count(&self) -> u32 {
         if self.delete_storage_first {
             0
         } else {
-            self.stored_indices.len() - self.front_delete_count
+            (self.stored_indices.end - self.stored_indices.start) - self.front_delete_count
         }
     }
 }
@@ -203,7 +210,7 @@ where
     C: Context,
     T: Send + Sync + Clone + Serialize + DeserializeOwned,
 {
-    async fn get(&self, index: usize) -> Result<Option<T>, ViewError> {
+    async fn get(&self, index: u32) -> Result<Option<T>, ViewError> {
         let key = self
             .context
             .base_key()
@@ -306,7 +313,7 @@ where
     /// # })
     /// ```
     pub fn count(&self) -> usize {
-        self.stored_count() + self.new_back_values.len()
+        self.stored_count() as usize + self.new_back_values.len()
     }
 
     /// Obtains the extra data.
@@ -314,8 +321,8 @@ where
         self.context.extra()
     }
 
-    async fn read_context(&self, range: Range<usize>) -> Result<Vec<T>, ViewError> {
-        let count = range.len();
+    async fn read_context(&self, range: Range<u32>) -> Result<Vec<T>, ViewError> {
+        let count = (range.end - range.start) as usize;
         let mut keys = Vec::with_capacity(count);
         for index in range {
             let key = self
@@ -360,13 +367,14 @@ where
         if !self.delete_storage_first {
             let stored_remainder = self.stored_count();
             let start = self.stored_indices.end - stored_remainder;
-            if count <= stored_remainder {
-                values.extend(self.read_context(start..(start + count)).await?);
+            if count <= stored_remainder as usize {
+                let count_u32 = count as u32;
+                values.extend(self.read_context(start..(start + count_u32)).await?);
             } else {
                 values.extend(self.read_context(start..self.stored_indices.end).await?);
                 values.extend(
                     self.new_back_values
-                        .range(0..(count - stored_remainder))
+                        .range(0..(count - stored_remainder as usize))
                         .cloned(),
                 );
             }
@@ -405,7 +413,9 @@ where
                     .cloned(),
             );
         } else {
-            let start = self.stored_indices.end + new_back_len - count;
+            let stored_consumed = u32::try_from(count - new_back_len)
+                .map_err(|_| ArithmeticError::Overflow)?;
+            let start = self.stored_indices.end - stored_consumed;
             values.extend(self.read_context(start..self.stored_indices.end).await?);
             values.extend(self.new_back_values.iter().cloned());
         }
@@ -435,7 +445,7 @@ where
             let stored_remainder = self.stored_count();
             let start = self.stored_indices.end - stored_remainder;
             let elements = self.read_context(start..self.stored_indices.end).await?;
-            let shift = self.stored_indices.end - start;
+            let shift = (self.stored_indices.end - start) as usize;
             for elt in elements {
                 self.new_back_values.push_back(elt);
             }
@@ -501,6 +511,8 @@ pub type HistoricallyHashedQueueView<C, T> = HistoricallyHashableView<C, QueueVi
 mod graphql {
     use std::borrow::Cow;
 
+    use linera_base::data_types::ArithmeticError;
+
     use super::QueueView;
     use crate::{
         context::Context,
@@ -525,7 +537,8 @@ mod graphql {
     {
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count() as u32)
+            Ok(u32::try_from(self.count())
+                .map_err(|_| ArithmeticError::Overflow)?)
         }
 
         async fn entries(&self, count: Option<usize>) -> async_graphql::Result<Vec<T>> {


### PR DESCRIPTION
## Motivation

When constructing views we are using usize which has a specific serialization. This pose problem because
usize is specific to an architecture. Sure, most laptop are 64-bit but WebAssembly is mostly 32-bits.

Fixes #4970 

## Proposal

Switch the definition of view of `BucketQueueView`, `QueueView`, and `LogView` to `u64` from `usize`.
All the other view do not have `usize` in their definition.

## Test Plan

CI.

## Release Plan

A testnet release to testnet_conway is possible since it can safely be assumed that all the validators
are all 64-bits and so usize=u64 in that case.

## Links

None.