### PR TITLE
Log application logs via tracing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5511,7 +5511,6 @@ dependencies = [
  "tracing-subscriber 0.3.19",
  "url",
  "wasmtime",
- "web-sys",
  "web-thread-pool",
  "web-thread-select",
 ]

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -35,13 +35,7 @@ fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
 wasmer = ["dep:wasmer", "wasmer/enable-serde", "linera-witty/wasmer"]
 wasmtime = ["dep:wasmtime", "linera-witty/wasmtime"]
-web = [
-    "linera-base/web",
-    "linera-views/web",
-    "js-sys",
-    "web-sys",
-    "web-thread-select/web",
-]
+web = ["linera-base/web", "linera-views/web", "js-sys", "web-thread-select/web"]
 
 [dependencies]
 allocative.workspace = true
@@ -107,7 +101,6 @@ tracing = { workspace = true, features = ["log"] }
 url.workspace = true
 wasm-instrument = { workspace = true, features = ["sign_ext"] }
 wasmtime = { workspace = true, optional = true }
-web-sys = { workspace = true, optional = true, features = ["console"] }
 web-thread-pool.workspace = true
 web-thread-select.workspace = true
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -715,18 +715,20 @@ where
             }
 
             #[cfg(web)]
-            Log { message, level } => {
-                // Output directly to browser console with clean formatting
-                let formatted: js_sys::JsString = format!("[CONTRACT {level}] {message}").into();
-                match level {
-                    tracing::log::Level::Trace | tracing::log::Level::Debug => {
-                        web_sys::console::debug_1(&formatted)
-                    }
-                    tracing::log::Level::Info => web_sys::console::log_1(&formatted),
-                    tracing::log::Level::Warn => web_sys::console::warn_1(&formatted),
-                    tracing::log::Level::Error => web_sys::console::error_1(&formatted),
+            Log { message, level } => match level {
+                tracing::log::Level::Trace | tracing::log::Level::Debug => {
+                    tracing::debug!(target: "user_application_log", message = %message);
                 }
-            }
+                tracing::log::Level::Info => {
+                    tracing::info!(target: "user_application_log", message = %message);
+                }
+                tracing::log::Level::Warn => {
+                    tracing::warn!(target: "user_application_log", message = %message);
+                }
+                tracing::log::Level::Error => {
+                    tracing::error!(target: "user_application_log", message = %message);
+                }
+            },
         }
 
         Ok(())


### PR DESCRIPTION
## Motivation

Before this PR, application logging on the web were log via ` web_sys::console::*` but that meant they weren't adhering to `tracing`'s filtering rules. Which we can now use in the constructor of web client since https://github.com/linera-io/linera-protocol/pull/5373.

## Proposal

Use `tracing` crate instead. Add a special `target` to the log lines – `user_application_log` so that it can be filtered out (or turned off) like `RUST_LOG=user_application_log=off`.

## Test Plan

Verified manually.

## Release Plan

- These changes should be backported to `main`.
- These changes should be included in the next SDK release.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
