### PR TITLE
Linera web client turns of user application logs by default.

### DIFF
--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -71,9 +71,8 @@ pub fn initialize(options: Option<InitializeOptions>) {
     let options = options.unwrap_or_default();
     // If no log filter is provided, disable the user application log by default, to avoid
     // overwhelming the console with logs from the client library itself.
-    // Everything else defaults to INFO due to `with_default_directive` below.
     let log_filter = if options.log.is_empty() {
-        "user_application_log=off"
+        "user_application_log=off,linera_client=info"
     } else {
         &options.log
     };


### PR DESCRIPTION
## Motivation

Make defaults more convenient.

## Proposal

If no log filter string is passed we set logging filter to `user_application_log=off,linera_client=info`.

## Test Plan

Verified manually it works as expected.

## Release Plan

- These changes should be backported to `main`.
- These chagnes should be included in the next SDK release.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
