### PR TITLE
`@linera/client`: give search params precedence over application-provided logging spec (#5419)

### DIFF
--- a/web/@linera/client/src/index.ts
+++ b/web/@linera/client/src/index.ts
@@ -15,11 +15,14 @@ function isBrokenSafari(): boolean {
 
 export async function initialize(options?: wasm.InitializeOptions) {
   if (window.location) {
+    // Allow overriding the application's log filters using the `LINERA_LOG` and
+    // `LINERA_PROFILING` search params, for debugging.
     const params = new URL(window.location.href).searchParams;
-    const defaults: wasm.InitializeOptions = {};
-    defaults.profiling = params.get('LINERA_PROFILING') !== null;
-    defaults.log = params.get('LINERA_LOG') || '';
-    options = { ...defaults, ...options };
+    const log = params.get('LINERA_LOG');
+
+    if (!options) options = {};
+    if (params.get('LINERA_PROFILING')) options.profiling = true;
+    if (log) options.log = log;
   }
 
   const exports = await wasm.default();
@@ -27,9 +30,9 @@ export async function initialize(options?: wasm.InitializeOptions) {
   // Safari 26.2 crashes with shared WebAssembly memory during
   // multi-threaded operation (WebKit #303387). Rust's wasm32 allocator
   // (dlmalloc) uses via memory.grow to decide how much memory is left
-  // so starting with INITIAL and MAXIMUM values that are too close 
+  // so starting with INITIAL and MAXIMUM values that are too close
   // to the actual memory limit causes it to grow memory and crash.
-  // Pre-allocating a large block while still single-threaded prevents the crash — 
+  // Pre-allocating a large block while still single-threaded prevents the crash —
   // avoids memory.grow calls once worker threads are running.
   if (isBrokenSafari()) {
     const PREALLOC_BYTES = 768 * 1024 * 1024;


### PR DESCRIPTION
## Motivation

We'd like to be able to override the log filters for debug purposes even if the application has a preferred default.

## Proposal

Give the search params precedence over the `log` option.

## Test Plan

Manual.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)