### PR TITLE
Lock the wallet on the Web (#5385)

### DIFF
--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -25,7 +25,7 @@ env:
   RUST_BACKTRACE: short
   # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warnings --cfg=web_sys_unstable_apis
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
   DOCKER_COMPOSE_WAIT: "true"

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -21,7 +21,6 @@ env:
   RUST_BACKTRACE: full
   # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
-  RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: linera=debug
   RUST_LOG_FORMAT: plain
@@ -70,6 +69,8 @@ jobs:
       run: |
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        rustflags: ""
     - uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6267,6 +6267,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde-wasm-bindgen 0.6.5",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",

--- a/web/@linera/client/Cargo.toml
+++ b/web/@linera/client/Cargo.toml
@@ -24,6 +24,7 @@ log.workspace = true
 num-traits.workspace = true
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
@@ -69,5 +70,12 @@ features = ["web", "indexeddb"]
 workspace = true
 
 [dependencies.web-sys]
-features = ["console", "Window"]
+features = [
+    "console",
+    "Lock",
+    "LockManager",
+    "LockOptions",
+    "Navigator",
+    "Window",
+]
 workspace = true

--- a/web/@linera/client/src/client.rs
+++ b/web/@linera/client/src/client.rs
@@ -43,25 +43,29 @@ impl Client {
     /// unavailable, or if `options` is incorrectly structured.
     #[wasm_bindgen(constructor)]
     pub async fn new(
-        wallet: &Wallet,
+        mut wallet: Wallet,
         signer: Signer,
         options: Option<linera_client::Options>,
     ) -> Result<Client, JsError> {
         let options = options.unwrap_or_default();
 
-        let mut storage = storage::get_storage().await?;
+        wallet.lock().await?;
+        let mut storage = storage::get_storage(&wallet.name()).await?;
         wallet
             .genesis_config
             .initialize_storage(&mut storage)
             .await?;
 
+        let default = wallet.default;
+        let genesis_config = wallet.genesis_config.clone();
+
         let client = linera_client::ClientContext::new(
             storage.clone(),
-            wallet.chains.clone(),
+            wallet,
             signer,
             &options,
-            wallet.default,
-            wallet.genesis_config.clone(),
+            default,
+            genesis_config,
         )
         .await?;
         // The `Arc` here is useless, but it is required by the `ChainListener` API.

--- a/web/@linera/client/src/faucet.rs
+++ b/web/@linera/client/src/faucet.rs
@@ -29,6 +29,7 @@ impl Faucet {
             chains: std::rc::Rc::new(wallet::Memory::default()),
             default: None,
             genesis_config: self.0.genesis_config().await?,
+            lock: None,
         })
     }
 
@@ -57,9 +58,10 @@ impl Faucet {
                 ..description.into()
             },
         );
+        let chain_id_str = chain_id.to_string();
         if wallet.default.is_none() {
             wallet.default = Some(chain_id);
         }
-        Ok(chain_id.to_string())
+        Ok(chain_id_str)
     }
 }

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -20,8 +20,6 @@ key directly in memory and uses it to sign.
 #![allow(clippy::unused_async)]
 #![recursion_limit = "256"]
 
-use std::rc::Rc;
-
 use wasm_bindgen::prelude::*;
 use web_sys::wasm_bindgen;
 
@@ -30,6 +28,7 @@ pub use client::Client;
 pub mod chain;
 pub use chain::Chain;
 pub mod faucet;
+pub mod lock;
 
 pub mod signer;
 pub use signer::Signer;
@@ -39,8 +38,7 @@ pub mod wallet;
 pub use wallet::Wallet;
 
 pub type Network = linera_rpc::node_provider::NodeProvider;
-pub type Environment =
-    linera_core::environment::Impl<Storage, Network, Signer, Rc<linera_core::wallet::Memory>>;
+pub type Environment = linera_core::environment::Impl<Storage, Network, Signer, Wallet>;
 
 type JsResult<T> = Result<T, JsError>;
 

--- a/web/@linera/client/src/lock.rs
+++ b/web/@linera/client/src/lock.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Browser-based wallet locking using the Web Locks API.
+//!
+//! This module provides a mechanism to ensure exclusive access to a wallet within a
+//! browser context. It uses the [Web Locks API] to coordinate between multiple tabs or
+//! windows that might try to access the same wallet simultaneously.
+//!
+//! The lock is automatically released when the [`Lock`] is dropped.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let lock = Lock::try_acquire("my-wallet").await?;
+//! // Wallet is now exclusively locked for this context
+//! // Lock is automatically released when `lock` goes out of scope
+//! ```
+//!
+//! [Web Locks API]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
+
+use wasm_bindgen::{JsCast as _, JsValue, UnwrapThrowExt as _};
+use wasm_bindgen_futures::JsFuture;
+
+/// Errors that can occur when acquiring a lock.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The lock could not be acquired because another context already holds it.
+    #[error("wallet {name} already in use")]
+    Contended { name: String },
+}
+
+/// An exclusive lock on a named resource, backed by the Web Locks API.
+///
+/// This struct represents an acquired lock. The lock is held for as long as this value
+/// exists and is automatically released when dropped.
+///
+/// The struct is serializable to allow transfer across WASM boundaries while preserving
+/// the underlying JavaScript objects.
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct Lock {
+    /// The underlying Web Locks API lock object.
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    lock: web_sys::Lock,
+    /// A JavaScript function that, when called, resolves the promise and releases the lock.
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    release: js_sys::Function,
+}
+
+impl Lock {
+    /// Attempts to acquire an exclusive lock on the given name without blocking.
+    ///
+    /// This uses the Web Locks API with the `ifAvailable` option, meaning it will
+    /// immediately return an error if the lock is already held rather than waiting.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the lock to acquire. This should uniquely identify the
+    ///   resource being protected (e.g., a wallet identifier).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Contended`] if the lock is already held by another context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if not running in a browser context with access to `window.navigator.locks`.
+    pub async fn try_acquire(name: &str) -> Result<Self, Error> {
+        let options = web_sys::LockOptions::new();
+        options.set_if_available(true);
+
+        let value = JsFuture::from(js_sys::Promise::new(&mut |resolve, _reject| {
+            let callback =
+                wasm_bindgen::closure::Closure::once(move |lock: Option<web_sys::Lock>| {
+                    js_sys::Promise::new(&mut |release, _reject| {
+                        let value = if let Some(lock) = &lock {
+                            Some(Self {
+                                lock: lock.clone(),
+                                release,
+                            })
+                        } else {
+                            release.call0(&JsValue::NULL).unwrap_throw();
+                            None
+                        };
+
+                        resolve
+                            .call1(
+                                &JsValue::NULL,
+                                &serde_wasm_bindgen::to_value(&value).unwrap_throw(),
+                            )
+                            .unwrap_throw();
+
+                        std::mem::forget(value);
+                    })
+                });
+
+            let _: js_sys::Promise = web_sys::window()
+                .expect("we need to run in a document context")
+                .navigator()
+                .locks()
+                .request_with_options_and_callback(
+                    name,
+                    &options,
+                    callback.as_ref().unchecked_ref(),
+                );
+
+            callback.forget();
+        }))
+        .await
+        .unwrap_throw();
+
+        serde_wasm_bindgen::from_value::<Option<Self>>(value)
+            .unwrap_throw()
+            .ok_or_else(|| Error::Contended { name: name.into() })
+    }
+}
+
+impl Drop for Lock {
+    fn drop(&mut self) {
+        let _: JsValue = self.release.call0(&JsValue::UNDEFINED).unwrap_throw();
+    }
+}

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -10,12 +10,12 @@ pub type Storage = linera_storage::DbStorage<
 ///
 /// # Errors
 /// If the storage can't be initialized.
-pub async fn get_storage() -> Result<Storage, linera_views::ViewError> {
+pub async fn get_storage(namespace: &str) -> Result<Storage, linera_views::ViewError> {
     Ok(linera_storage::DbStorage::maybe_create_and_connect(
         &linera_views::indexed_db::IndexedDbStoreConfig {
             max_stream_queries: 1,
         },
-        "linera",
+        namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
     )
     .await?

--- a/web/@linera/client/src/wallet.rs
+++ b/web/@linera/client/src/wallet.rs
@@ -10,6 +10,7 @@ use wasm_bindgen::prelude::*;
 use web_sys::wasm_bindgen;
 
 use super::JsResult;
+use crate::lock::Lock;
 
 /// A wallet that stores the user's chains and keys in memory.
 #[wasm_bindgen]
@@ -18,6 +19,7 @@ pub struct Wallet {
     pub(crate) chains: Rc<wallet::Memory>,
     pub(crate) default: Option<ChainId>,
     pub(crate) genesis_config: GenesisConfig,
+    pub(crate) lock: Option<Rc<Lock>>,
 }
 
 #[wasm_bindgen]
@@ -36,5 +38,29 @@ impl Wallet {
             .ok_or(JsError::new(&format!(
                 "chain {chain_id} doesn't exist in wallet"
             )))
+    }
+
+    #[must_use]
+    /// Get the name of the wallet. Wallets with different names should use different
+    /// storage; only one wallet can use the same name at a time.
+    pub fn name(&self) -> String {
+        self.default
+            .map_or_else(|| "default".into(), |name| name.to_string())
+    }
+
+    /// Lock the wallet, preventing anyone else from using a wallet with this name.
+    ///
+    /// # Errors
+    /// If the wallet is already locked.
+    pub async fn lock(&mut self) -> JsResult<()> {
+        self.lock = Some(Rc::new(Lock::try_acquire(&self.name()).await?));
+        Ok(())
+    }
+}
+
+impl std::ops::Deref for Wallet {
+    type Target = wallet::Memory;
+    fn deref(&self) -> &Self::Target {
+        &*self.chains
     }
 }


### PR DESCRIPTION
## Motivation

With the introduction of persistent storage on the Web, we create the possibility that different clients (e.g. running in different tabs) may share storage. This is illegal wrt the Linera data model, which assumes exclusive access to the storage for performance reasons.

## Proposal

Put different wallets (as defined by their default chains) in different storage namespaces. Where the same wallet is used in different contexts, use the [Web Locks
API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API) to fail immediately on client initialization.

## Test Plan

Tested locally with the `counter` example.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
