### PR TITLE
Simulate in-app KeepAlive frames 

### DIFF
--- a/linera-indexer/lib/src/grpc/mod.rs
+++ b/linera-indexer/lib/src/grpc/mod.rs
@@ -12,7 +12,7 @@ use futures::{stream::BoxStream, Stream, StreamExt};
 use linera_base::{data_types::Blob, identifiers::BlobId};
 use linera_chain::types::ConfirmedBlockCertificate;
 use tonic::{transport::Server, Request, Response, Status, Streaming};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use crate::{
     db::{sqlite::SqliteError, IndexerDatabase},
@@ -177,8 +177,8 @@ where
                 Ok(Some(()))
             }
             None => {
-                warn!("Received empty element");
-                Err(ProcessingError::EmptyPayload)
+                tracing::trace!("received keepalive element, skipping");
+                Ok(None)
             }
         }
     }

--- a/linera-indexer/lib/src/grpc/tests.rs
+++ b/linera-indexer/lib/src/grpc/tests.rs
@@ -139,8 +139,8 @@ async fn test_process_element_empty_payload() {
     let element = Element { payload: None };
 
     match IndexerGrpcServer::process_element(&database, &mut pending_blobs, element).await {
-        Err(ProcessingError::EmptyPayload) => {}
-        _ => panic!("Expected EmptyPayload error"),
+        Ok(None) => {}
+        _ => panic!("Expected Ok(None) for empty payload"),
     }
 }
 


### PR DESCRIPTION
## Motivation

We're seeing that indexer exporter destination fail on bidirectional stream to the indexer. The main theory right now is that either nginx or load balancer (or both) are terminating the connection.

## Proposal

Send an empty protobuf message every 30 seconds. Indexer doesn't respond, load balancer doesn't count the response frames.

## Test Plan

Manual.

## Release Plan

- These changes have to be released to testnet conway. Once confirmed to work,
- backport to `main`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
