### PR TITLE
Linera web client turns off user application logs by default. (#5418)

### DIFF
--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -69,6 +69,13 @@ pub fn initialize(options: Option<InitializeOptions>) {
     }
 
     let options = options.unwrap_or_default();
+    // If no log filter is provided, disable the user application log by default, to avoid
+    // overwhelming the console with logs from the client library itself.
+    let log_filter = if options.log.is_empty() {
+        "user_application_log=off,linera_client=info"
+    } else {
+        &options.log
+    };
 
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
@@ -76,7 +83,7 @@ pub fn initialize(options: Option<InitializeOptions>) {
         .with(
             EnvFilter::builder()
                 .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-                .parse_lossy(options.log),
+                .parse_lossy(log_filter),
         )
         .with(
             tracing_subscriber::fmt::layer()


### PR DESCRIPTION
Backport of #5418 

## Motivation

Make defaults more convenient.

## Proposal

If no log filter string is passed we set logging filter to `user_application_log=off,linera_client=info`.

## Test Plan

Verified manually it works as expected.

## Release Plan

- Nothing to do.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)