### PR TITLE
Change CanonicalState sharing model.

### DIFF
--- a/linera-service/src/exporter/metrics.rs
+++ b/linera-service/src/exporter/metrics.rs
@@ -96,14 +96,6 @@ pub(crate) static NOTIFICATIONS_RECEIVED: LazyLock<IntCounter> = LazyLock::new(|
     )
 });
 
-pub(crate) static BLOCKS_INDEXED: LazyLock<IntCounter> = LazyLock::new(|| {
-    prometheus_util::register_int_counter_with_subsystem(
-        "exporter",
-        "blocks_indexed",
-        "Number of blocks indexed into canonical state",
-    )
-});
-
 pub(crate) static CANONICAL_STATE_HEIGHT: LazyLock<IntGauge> = LazyLock::new(|| {
     prometheus_util::register_int_gauge_with_subsystem(
         "exporter",

--- a/linera-service/src/exporter/runloops/block_processor/mod.rs
+++ b/linera-service/src/exporter/runloops/block_processor/mod.rs
@@ -243,7 +243,7 @@ mod test {
             queue_front: rx,
         };
         let storage = DbStorage::<MemoryDatabase, _>::make_test_storage(None).await;
-        let (block_processor_storage, mut exporter_storage) =
+        let (block_processor_storage, exporter_storage) =
             BlockProcessorStorage::load(storage.clone(), 0, vec![], LimitsConfig::default())
                 .await?;
         let token = CancellationToken::new();
@@ -374,7 +374,7 @@ mod test {
             queue_front: rx,
         };
         let storage = DbStorage::<MemoryDatabase, _>::make_test_storage(None).await;
-        let (block_processor_storage, mut exporter_storage) =
+        let (block_processor_storage, exporter_storage) =
             BlockProcessorStorage::load(storage.clone(), 0, vec![], LimitsConfig::default())
                 .await?;
         let token = CancellationToken::new();
@@ -495,7 +495,7 @@ mod test {
             queue_front: rx,
         };
         let storage = DbStorage::<MemoryDatabase, _>::make_test_storage(None).await;
-        let (block_processor_storage, mut exporter_storage) =
+        let (block_processor_storage, exporter_storage) =
             BlockProcessorStorage::load(storage.clone(), 0, vec![], LimitsConfig::default())
                 .await?;
         let token = CancellationToken::new();
@@ -583,7 +583,7 @@ mod test {
             queue_front: rx,
         };
         let storage = DbStorage::<MemoryDatabase, _>::make_test_storage(None).await;
-        let (block_processor_storage, mut exporter_storage) =
+        let (block_processor_storage, exporter_storage) =
             BlockProcessorStorage::load(storage.clone(), 0, vec![], LimitsConfig::default())
                 .await?;
         let token = CancellationToken::new();
@@ -693,7 +693,7 @@ mod test {
             queue_front: rx,
         };
         let storage = DbStorage::<MemoryDatabase, _>::make_test_storage(None).await;
-        let (block_processor_storage, mut exporter_storage) =
+        let (block_processor_storage, exporter_storage) =
             BlockProcessorStorage::load(storage.clone(), 0, vec![], LimitsConfig::default())
                 .await?;
         let token = CancellationToken::new();
@@ -783,7 +783,7 @@ mod test {
         // Store the committee blob
         storage.write_blobs(&[committee_blob]).await?;
 
-        let (block_processor_storage, mut exporter_storage) =
+        let (block_processor_storage, exporter_storage) =
             BlockProcessorStorage::load(storage.clone(), 0, vec![], LimitsConfig::default())
                 .await?;
         let token = CancellationToken::new();

--- a/linera-service/src/exporter/runloops/block_processor/walker.rs
+++ b/linera-service/src/exporter/runloops/block_processor/walker.rs
@@ -78,7 +78,7 @@ where
             let block_id = node_visitor.node.block;
             if self.index_block(&block_id).await? {
                 let block_to_push = CanonicalBlock::new(block_id.hash, &blobs_to_send);
-                self.storage.push_block(block_to_push);
+                self.storage.push_block(block_to_push).await;
                 for blob in blobs_to_index_block_with {
                     self.storage.index_blob(blob).ok();
                 }

--- a/linera-service/src/exporter/runloops/block_processor/walker.rs
+++ b/linera-service/src/exporter/runloops/block_processor/walker.rs
@@ -79,8 +79,6 @@ where
             if self.index_block(&block_id).await? {
                 let block_to_push = CanonicalBlock::new(block_id.hash, &blobs_to_send);
                 self.storage.push_block(block_to_push);
-                #[cfg(with_metrics)]
-                crate::metrics::BLOCKS_INDEXED.inc();
                 for blob in blobs_to_index_block_with {
                     self.storage.index_blob(blob).ok();
                 }

--- a/linera-service/src/exporter/runloops/indexer/indexer_exporter.rs
+++ b/linera-service/src/exporter/runloops/indexer/indexer_exporter.rs
@@ -51,7 +51,7 @@ impl Exporter {
     pub(crate) async fn run_with_shutdown<S, F: IntoFuture<Output = ()>>(
         self,
         shutdown_signal: F,
-        mut storage: ExporterStorage<S>,
+        storage: ExporterStorage<S>,
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,

--- a/linera-service/src/exporter/runloops/mod.rs
+++ b/linera-service/src/exporter/runloops/mod.rs
@@ -262,7 +262,7 @@ where
     use linera_base::identifiers::BlobType;
     use linera_execution::{system::AdminOperation, Operation, SystemOperation};
 
-    let latest_index = exporter_storage.get_latest_index();
+    let latest_index = exporter_storage.get_latest_index().await;
     if latest_index == 0 {
         tracing::info!("No blocks in canonical state to scan");
         return None;
@@ -915,11 +915,13 @@ mod test {
 
             block_processor_storage.index_block(&block1_id).await?;
             block_processor_storage
-                .push_block(crate::common::CanonicalBlock::new(block1_id.hash, &[]));
+                .push_block(crate::common::CanonicalBlock::new(block1_id.hash, &[]))
+                .await;
 
             block_processor_storage.index_block(&block2_id).await?;
             block_processor_storage
-                .push_block(crate::common::CanonicalBlock::new(block2_id.hash, &[]));
+                .push_block(crate::common::CanonicalBlock::new(block2_id.hash, &[]))
+                .await;
 
             // Save but don't persist the committee blob ID
             block_processor_storage.save().await?;

--- a/linera-service/src/exporter/runloops/validator_exporter.rs
+++ b/linera-service/src/exporter/runloops/validator_exporter.rs
@@ -49,7 +49,7 @@ impl Exporter {
     pub(super) async fn run_with_shutdown<S, F: IntoFuture<Output = ()>>(
         self,
         shutdown_signal: F,
-        mut storage: ExporterStorage<S>,
+        storage: ExporterStorage<S>,
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,


### PR DESCRIPTION
## Motivation

The exporter's `CanonicalState` is cloned via `clone_unchecked()`, giving the exporter a `LogView` with a frozen `stored_count`. After flush persists entries to DB, the exporter's `LogView` still can't read them – `LogView::get()` routes `index >= stored_count` to `new_values` (empty in the clone), never hitting the DB. This means the in-memory buffer can never be cleared and grows without bound.

## Proposal

Share a single `CanonicalState` behind `Arc<tokio::sync::RwLock>` instead of cloning it. Both the block processor and exporter use the same `LogView`, so `stored_count` stays consistent. After flush +`post_save()`, the buffer is safely drained — subsequent reads fall through to the `LogView` which has the correct `stored_count`.

### `CanonicalState`
  - Removed `flushed_count` field (flush now drains the entire buffer)
  - Replaced `Arc<papaya::HashMap<usize, CanonicalBlock>>` with `Vec<CanonicalBlock>` (`RwLock` provides concurrency; entries are sequential)
  - Removed `clone()` (no more `clone_unchecked()`) and `next_index()`
  - `flush()` now uses `buffer.drain(..)` instead of iterating `flushed_count..count`

### `SharedStorage`
  - `shared_canonical_state` field is now `Arc<tokio::sync::RwLock<CanonicalState<C>>>`
  - `clone()` is infallible (Arc clone) — kept `Result` return type to avoid touching 13+ call sites
  - `push_block()` is now async (acquires write lock)

  ### `ExporterStorage` / `BlockProcessorStorage`
  - Read operations (`get_block_with_blob_ids`, `get_block_with_blobs`, `get_latest_index`) acquire a read lock
  - Write operations (`push_block`, `save`) acquire a write lock
  - `clone()` takes `&self` instead of `&mut self`

## Test Plan

- `cargo build -p linera-service` — compiles with no errors
- `cargo test -p linera-service --bin linera-exporter` — all existing tests pass (including `test_committee_destination`)

## Release Plan

  - These changes should be released to testnet, and then
  - Backported to `main`.

## Links
  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)