### PR TITLE
Cache subdirectory target dirs in Wasm CI jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          examples -> target
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -123,6 +126,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          linera-sdk/tests/fixtures -> target
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:


### PR DESCRIPTION
## Motivation

Fix #5433. The CI jobs `wasm-application-test` and `linera-sdk-tests-fixtures` are extremely slow (~13 min and ~6 min respectively), even on subsequent runs, because their subdirectory `target/` directories are not cached between CI runs.

The root cause is that `actions-rust-lang/setup-rust-toolchain@v1` uses `Swatinem/rust-cache` under the hood, which [defaults to caching only `./target/`](https://github.com/Swatinem/rust-cache/blob/master/README.md). Since these jobs build in `examples/` and `linera-sdk/tests/fixtures/`, their `target/` directories are never persisted.

## Proposal

Add the `cache-workspaces` parameter to the `setup-rust-toolchain` action in both jobs, pointing to the correct
subdirectory target dirs:

- `wasm-application-test`: `examples -> target`
- `linera-sdk-tests-fixtures`: `linera-sdk/tests/fixtures -> target`

## Test Plan

- The first CI run after merging will still be slow (cold cache).
- The second run on the same branch showed around a 25% improvement, it seems

## Release Plan

- Nothing to do / These changes follow the usual release cycle.