### PR TITLE
Replace `last_requested_callback` with a custom cursor

### DIFF
--- a/examples/task-processor/src/service.rs
+++ b/examples/task-processor/src/service.rs
@@ -81,11 +81,7 @@ impl QueryRoot {
     }
 
     /// Returns the pending tasks and callback requests for the task processor.
-    async fn next_actions(
-        &self,
-        _last_requested_callback: Option<Timestamp>,
-        _now: Timestamp,
-    ) -> ProcessorActions {
+    async fn next_actions(&self, _cursor: Option<Vec<u8>>, _now: Timestamp) -> ProcessorActions {
         let mut actions = ProcessorActions::default();
 
         // Get all pending tasks from the queue.

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -25,6 +25,9 @@ use crate::data_types::Timestamp;
 pub struct ProcessorActions {
     /// The application is requesting to be called back no later than the given timestamp.
     pub request_callback: Option<Timestamp>,
+    /// An optional cursor for the task processor to store and pass to the application
+    /// upon the next query for actions.
+    pub set_cursor: Option<Vec<u8>>,
     /// The application is requesting the execution of the given tasks.
     pub execute_tasks: Vec<Task>,
 }

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -47,7 +47,7 @@ type Deadline = Reverse<(Timestamp, Option<ApplicationId>)>;
 pub struct TaskProcessor<Env: linera_core::Environment> {
     chain_id: ChainId,
     application_ids: Vec<ApplicationId>,
-    last_requested_callbacks: BTreeMap<ApplicationId, Timestamp>,
+    cursors: BTreeMap<ApplicationId, Vec<u8>>,
     chain_client: ChainClient<Env>,
     cancellation_token: CancellationToken,
     notifications: NotificationStream,
@@ -75,7 +75,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         Self {
             chain_id,
             application_ids,
-            last_requested_callbacks: BTreeMap::new(),
+            cursors: BTreeMap::new(),
             chain_client,
             cancellation_token,
             notifications,
@@ -139,7 +139,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         let old_app_set: BTreeSet<_> = self.application_ids.iter().cloned().collect();
 
         // Retain only last_requested_callbacks for applications that are still active
-        self.last_requested_callbacks
+        self.cursors
             .retain(|app_id, _| new_app_set.contains(app_id));
 
         // Update the application_ids
@@ -178,12 +178,8 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
         for application_id in application_ids {
             debug!("Processing actions for {application_id}");
             let now = Timestamp::now();
-            let last_requested_callback =
-                self.last_requested_callbacks.get(&application_id).cloned();
-            let actions = match self
-                .query_actions(application_id, last_requested_callback, now)
-                .await
-            {
+            let app_cursor = self.cursors.get(&application_id).cloned();
+            let actions = match self.query_actions(application_id, app_cursor, now).await {
                 Ok(actions) => actions,
                 Err(error) => {
                     error!("Error reading application actions: {error}");
@@ -196,9 +192,11 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 }
             };
             if let Some(timestamp) = actions.request_callback {
-                self.last_requested_callbacks.insert(application_id, now);
                 self.deadlines
                     .push(Reverse((timestamp, Some(application_id))));
+            }
+            if let Some(cursor) = actions.set_cursor {
+                self.cursors.insert(application_id, cursor);
             }
             if !actions.execute_tasks.is_empty() {
                 let sender = self.outcome_sender.clone();
@@ -286,12 +284,12 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     async fn query_actions(
         &mut self,
         application_id: ApplicationId,
-        last_requested_callback: Option<Timestamp>,
+        cursor: Option<Vec<u8>>,
         now: Timestamp,
     ) -> Result<ProcessorActions, anyhow::Error> {
         let query = format!(
-            "query {{ nextActions(lastRequestedCallback: {}, now: {}) }}",
-            last_requested_callback.to_value(),
+            "query {{ nextActions(cursor: {}, now: {}) }}",
+            cursor.to_value(),
             now.to_value(),
         );
         let bytes = serde_json::to_vec(&json!({"query": query}))?;


### PR DESCRIPTION
## Motivation

Sometimes when the `TaskProcessor` queries an application for `next_actions`, passing just the last callback timestamp is not enough data for the application.

## Proposal

Allow applications to return custom cursors from `next_actions`, which will be passed upon the next callback.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- Closes #5444 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
