### PR TITLE
Backport: Replace `last_requested_callback` with a custom cursor (#5450)

### DIFF
--- a/examples/task-processor/src/service.rs
+++ b/examples/task-processor/src/service.rs
@@ -81,11 +81,7 @@ impl QueryRoot {
     }
 
     /// Returns the pending tasks and callback requests for the task processor.
-    async fn next_actions(
-        &self,
-        _last_requested_callback: Option<Timestamp>,
-        _now: Timestamp,
-    ) -> ProcessorActions {
+    async fn next_actions(&self, _cursor: Option<Vec<u8>>, _now: Timestamp) -> ProcessorActions {
         let mut actions = ProcessorActions::default();
 
         // Get all pending tasks from the queue.

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -25,6 +25,9 @@ use crate::data_types::Timestamp;
 pub struct ProcessorActions {
     /// The application is requesting to be called back no later than the given timestamp.
     pub request_callback: Option<Timestamp>,
+    /// An optional cursor for the task processor to store and pass to the application
+    /// upon the next query for actions.
+    pub set_cursor: Option<Vec<u8>>,
     /// The application is requesting the execution of the given tasks.
     pub execute_tasks: Vec<Task>,
 }


### PR DESCRIPTION
## Motivation

Sometimes when the `TaskProcessor` queries an application for `next_actions`, passing just the last callback timestamp is not enough data for the application.

## Proposal

Allow applications to return custom cursors from `next_actions`, which will be passed upon the next callback.

This is a backport of #5450

## Test Plan

CI

## Release Plan

- These changes should be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
