### PR TITLE
Register benchmark chains with ChainListener

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -945,6 +945,7 @@ impl<Env: Environment> ClientContext<Env> {
     ) -> Result<(), Error> {
         if close_chains {
             info!("Closing chains...");
+            let chain_ids: Vec<_> = chain_clients.iter().map(|c| c.chain_id()).collect();
             let stream = stream::iter(chain_clients)
                 .map(|chain_client| async move {
                     Benchmark::<Env>::close_benchmark_chain(&chain_client).await?;
@@ -953,6 +954,10 @@ impl<Env: Environment> ClientContext<Env> {
                 })
                 .buffer_unordered(wrap_up_max_in_flight);
             stream.try_collect::<Vec<_>>().await?;
+            // Remove closed chains from wallet (the chain listener may have added them).
+            for chain_id in chain_ids {
+                let _ = self.wallet().remove(chain_id).await;
+            }
         } else {
             info!("Processing inbox for all chains...");
             let stream = stream::iter(chain_clients.clone())

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -798,12 +798,13 @@ impl Runnable for Job {
 
                         let shared_context =
                             std::sync::Arc::new(futures::lock::Mutex::new(context));
+                        let (command_sender, command_receiver) = mpsc::unbounded_channel();
                         let chain_listener = ChainListener::new(
                             listener_config,
                             shared_context.clone(),
                             storage.clone(),
                             shutdown_notifier.clone(),
-                            mpsc::unbounded_channel().1,
+                            command_receiver,
                             true, // Enabling background sync for benchmarks
                         );
                         let all_chain_ids: Vec<ChainId> =
@@ -843,6 +844,7 @@ impl Runnable for Job {
                             runtime_in_seconds,
                             delay_between_chains_ms,
                             chain_listener,
+                            command_sender,
                             &shutdown_notifier,
                         )
                         .await?;


### PR DESCRIPTION
## Motivation

When `close_chains = true`, benchmark chains are not added to the wallet. `ChainListener::run()` reads chains from
the wallet, so it never sets up validator notification listeners for benchmark chains. Without listeners, the local
node never discovers incoming cross-chain messages (e.g. token returns from the pm-engine after order matching), so
`pending_message_bundles()` always returns empty and chains run out of BASE tokens.

## Proposal

Have `run_benchmark` accept an `mpsc::UnboundedSender<ListenerCommand>` and send a `ListenerCommand::Listen(...)` to
the `ChainListener` with the benchmark chain IDs right after spawning it. This uses the existing command channel
infrastructure — no changes to `ChainListener` itself.

Changes:
- `linera-client/src/benchmark.rs`: Add `command_sender` parameter to `run_benchmark`, build a `BTreeMap<ChainId,
Option<AccountOwner>>` from the chain clients, and send `ListenerCommand::Listen` after spawning the listener task.
- Bh callers (`linera-service` CLI and `pm-benchmark`) updated to keep the sender half of the unbounded channel and
pass it through.

## Test Plan

- `cargo check` and `cargo clippy -- -D warnings` pass on both linera-protocol and pm-benchmark workspaces.
- Manual test: run pm-benchmark with a small number of chains, verify that after orders match, tokens are received
back (chain listener logs should show "received command to listen to new chains" and "Processing inbox for ...").
