### PR TITLE
[testnet] Reduce log noise caused by lagging validators. (#5454)

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -358,6 +358,54 @@ impl NodeError {
     }
 }
 
+impl NodeError {
+    /// Returns whether this error is an expected part of the protocol flow.
+    ///
+    /// Expected errors are those that validators return during normal operation and that
+    /// the client handles automatically (e.g. by supplying missing data and retrying).
+    /// Unexpected errors indicate genuine network issues, validator misbehavior, or
+    /// internal problems.
+    pub fn is_expected(&self) -> bool {
+        match self {
+            // Expected: validators return these during normal operation and the client
+            // handles them automatically by supplying missing data and retrying.
+            NodeError::BlobsNotFound(_)
+            | NodeError::EventsNotFound(_)
+            | NodeError::MissingCrossChainUpdate { .. }
+            | NodeError::WrongRound(_)
+            | NodeError::UnexpectedBlockHeight { .. }
+            | NodeError::InactiveChain(_)
+            | NodeError::MissingCertificateValue => true,
+
+            // Unexpected: network issues, validator misbehavior, or internal problems.
+            NodeError::CryptoError { .. }
+            | NodeError::ArithmeticError { .. }
+            | NodeError::ViewError { .. }
+            | NodeError::ChainError { .. }
+            | NodeError::WorkerError { .. }
+            | NodeError::MissingCertificates(_)
+            | NodeError::MissingVoteInValidatorResponse(_)
+            | NodeError::InvalidChainInfoResponse
+            | NodeError::UnexpectedCertificateValue
+            | NodeError::InvalidDecoding
+            | NodeError::UnexpectedMessage
+            | NodeError::GrpcError { .. }
+            | NodeError::ClientIoError { .. }
+            | NodeError::CannotResolveValidatorAddress { .. }
+            | NodeError::SubscriptionError { .. }
+            | NodeError::SubscriptionFailed { .. }
+            | NodeError::InvalidCertificateForBlob(_)
+            | NodeError::DuplicatesInBlobsNotFound
+            | NodeError::UnexpectedEntriesInBlobsNotFound
+            | NodeError::UnexpectedCertificates { .. }
+            | NodeError::EmptyBlobsNotFound
+            | NodeError::ResponseHandlingError { .. }
+            | NodeError::MissingCertificatesByHeights { .. }
+            | NodeError::TooManyCertificatesReturned { .. } => false,
+        }
+    }
+}
+
 impl From<tonic::Status> for NodeError {
     fn from(status: tonic::Status) -> Self {
         Self::GrpcError {

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -217,7 +217,7 @@ impl ValidatorNode for GrpcClient {
         self.address.clone()
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_block_proposal(
         &self,
         proposal: data_types::BlockProposal,
@@ -239,7 +239,7 @@ impl ValidatorNode for GrpcClient {
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_lite_certificate, request)?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_confirmed_certificate(
         &self,
         certificate: GenericCertificate<ConfirmedBlock>,
@@ -257,7 +257,7 @@ impl ValidatorNode for GrpcClient {
         )?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_validated_certificate(
         &self,
         certificate: GenericCertificate<ValidatedBlock>,
@@ -270,7 +270,7 @@ impl ValidatorNode for GrpcClient {
         )?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_timeout_certificate(
         &self,
         certificate: GenericCertificate<Timeout>,
@@ -283,7 +283,7 @@ impl ValidatorNode for GrpcClient {
         )?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_chain_info_query(
         &self,
         query: linera_core::data_types::ChainInfoQuery,


### PR DESCRIPTION
Backport of #5454.

## Motivation

Client logs can be very spammy: We print a warning in the gRPC client code for every "error" validators return, including errors like missing blobs or messages, which are part of the normal flow.

## Proposal

Reduce the level to `DEBUG` for those; add warning logs for other errors to the updater directly.

## Test Plan

Use it; it's only log changes. We will tweak those further in the future if we find more noisy logs.

## Release Plan

- Release a new SDK.

## Links

- PR to main: #5454
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
