### PR TITLE
Generic benchmark operation generator (frontport of #5438)

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -27,7 +27,7 @@ use tracing::{debug, info, warn};
 #[cfg(not(web))]
 use {
     crate::{
-        benchmark::{Benchmark, BenchmarkError},
+        benchmark::{fungible_transfer, Benchmark, BenchmarkError},
         client_metrics::ClientMetrics,
     },
     futures::stream,
@@ -40,7 +40,7 @@ use {
         system::{OpenChainConfig, SystemOperation},
         Operation,
     },
-    std::{collections::HashSet, iter, path::Path},
+    std::{collections::HashSet, path::Path},
     tokio::{sync::mpsc, task},
 };
 #[cfg(feature = "fs")]
@@ -875,7 +875,8 @@ impl<Env: Environment> ClientContext<Env> {
         fungible_application_id: Option<ApplicationId>,
         pub_keys: Vec<AccountPublicKey>,
         chains_config_path: Option<&Path>,
-    ) -> Result<(Vec<ChainClient<Env>>, Vec<ChainId>), Error> {
+        close_chains: bool,
+    ) -> Result<Vec<ChainClient<Env>>, Error> {
         let start = Instant::now();
         // Below all block proposals are supposed to succeed without retries, we
         // must make sure that all incoming payments have been accepted on-chain
@@ -893,6 +894,7 @@ impl<Env: Environment> ClientContext<Env> {
                 tokens_per_chain,
                 pub_keys,
                 chains_config_path.is_some(),
+                close_chains,
             )
             .await?;
         info!(
@@ -935,7 +937,7 @@ impl<Env: Environment> ClientContext<Env> {
             }
         }
 
-        Ok((chain_clients, all_chains))
+        Ok(chain_clients)
     }
 
     pub async fn wrap_up_benchmark(
@@ -1029,44 +1031,50 @@ impl<Env: Environment> ClientContext<Env> {
 
     /// Creates chains if necessary, and returns a map of exactly `num_chains` chain IDs
     /// with key pairs, as well as a map of the chain clients.
+    ///
+    /// If `close_chains` is true, chains are not looked up from or stored in the wallet,
+    /// since they will be closed after the benchmark and shouldn't be reused.
     async fn make_benchmark_chains(
         &mut self,
         num_chains: usize,
         balance: Amount,
         pub_keys: Vec<AccountPublicKey>,
         wallet_only: bool,
+        close_chains: bool,
     ) -> Result<(Vec<(ChainId, AccountOwner)>, Vec<ChainClient<Env>>), Error> {
         let mut chains_found_in_wallet = 0;
         let mut benchmark_chains = Vec::with_capacity(num_chains);
         let mut chain_clients = Vec::with_capacity(num_chains);
         let start = Instant::now();
-        let mut owned_chain_ids = std::pin::pin!(self.wallet().owned_chain_ids());
-        while let Some(chain_id) = owned_chain_ids.next().await {
-            let chain_id = chain_id.map_err(error::Inner::wallet)?;
-            if chains_found_in_wallet == num_chains {
-                break;
+
+        // When close_chains is true and we're creating our own chains (not wallet_only),
+        // skip wallet lookup to avoid picking up existing chains that would then be closed.
+        // When wallet_only is true, chains were pre-created by the parent process and must
+        // be read from the wallet.
+        if !close_chains || wallet_only {
+            let mut owned_chain_ids = std::pin::pin!(self.wallet().owned_chain_ids());
+            while let Some(chain_id) = owned_chain_ids.next().await {
+                let chain_id = chain_id.map_err(error::Inner::wallet)?;
+                if chains_found_in_wallet == num_chains {
+                    break;
+                }
+                let chain_client = self.make_chain_client(chain_id).await?;
+                let ownership = chain_client.chain_info().await?.manager.ownership;
+                if !ownership.owners.is_empty() || ownership.super_owners.len() != 1 {
+                    continue;
+                }
+                let owner = *ownership.super_owners.first().unwrap();
+                chain_client.process_inbox().await?;
+                benchmark_chains.push((chain_id, owner));
+                chain_clients.push(chain_client);
+                chains_found_in_wallet += 1;
             }
-            let chain_client = self.make_chain_client(chain_id).await?;
-            let ownership = chain_client.chain_info().await?.manager.ownership;
-            if !ownership.owners.is_empty() || ownership.super_owners.len() != 1 {
-                continue;
-            }
-            chain_client.process_inbox().await?;
-            benchmark_chains.push((
-                chain_id,
-                *ownership
-                    .super_owners
-                    .first()
-                    .expect("should have a super owner"),
-            ));
-            chain_clients.push(chain_client);
-            chains_found_in_wallet += 1;
+            info!(
+                "Got {} chains from the wallet in {} ms",
+                benchmark_chains.len(),
+                start.elapsed().as_millis()
+            );
         }
-        info!(
-            "Got {} chains from the wallet in {} ms",
-            benchmark_chains.len(),
-            start.elapsed().as_millis()
-        );
 
         let num_chains_to_create = num_chains - chains_found_in_wallet;
 
@@ -1086,20 +1094,23 @@ impl<Env: Environment> ClientContext<Env> {
             let operations_per_block = 900; // Over this we seem to hit the block size limits.
             for i in (0..num_chains_to_create).step_by(operations_per_block) {
                 let num_new_chains = operations_per_block.min(num_chains_to_create - i);
-                let pub_key = pub_keys_iter.next().unwrap();
-                let owner = pub_key.into();
+                // Each chain gets its own unique owner (previously all chains in a batch
+                // shared one owner, which could cause conflicts during benchmarking).
+                let owners: Vec<AccountOwner> = (&mut pub_keys_iter)
+                    .take(num_new_chains)
+                    .map(|pk| pk.into())
+                    .collect();
 
                 let certificate = Self::execute_open_chains_operations(
-                    num_new_chains,
                     &default_chain_client,
                     balance,
-                    owner,
+                    owners.clone(),
                 )
                 .await?;
                 info!("Block executed successfully");
 
                 let block = certificate.block();
-                for i in 0..num_new_chains {
+                for (i, owner) in owners.into_iter().enumerate() {
                     let chain_id = block.body.blobs[i]
                         .iter()
                         .find(|blob| blob.id().blob_type == BlobType::ChainDescription)
@@ -1131,9 +1142,12 @@ impl<Env: Environment> ClientContext<Env> {
             );
         }
 
-        info!("Updating wallet from client");
-        self.update_wallet_from_client(&default_chain_client)
-            .await?;
+        // Only update wallet if chains will be reused (not closed after benchmark)
+        if !close_chains {
+            info!("Updating wallet from client");
+            self.update_wallet_from_client(&default_chain_client)
+                .await?;
+        }
         info!("Retrying pending outgoing messages");
         default_chain_client
             .retry_pending_outgoing_messages()
@@ -1152,22 +1166,22 @@ impl<Env: Environment> ClientContext<Env> {
     }
 
     async fn execute_open_chains_operations(
-        num_new_chains: usize,
         chain_client: &ChainClient<Env>,
         balance: Amount,
-        owner: AccountOwner,
+        owners: Vec<AccountOwner>,
     ) -> Result<ConfirmedBlockCertificate, Error> {
-        let config = OpenChainConfig {
-            ownership: ChainOwnership::single_super(owner),
-            balance,
-            application_permissions: Default::default(),
-        };
-        let operations = iter::repeat_n(
-            Operation::system(SystemOperation::OpenChain(config)),
-            num_new_chains,
-        )
-        .collect();
-        info!("Executing {} OpenChain operations", num_new_chains);
+        let operations: Vec<_> = owners
+            .iter()
+            .map(|owner| {
+                let config = OpenChainConfig {
+                    ownership: ChainOwnership::single_super(*owner),
+                    balance,
+                    application_permissions: Default::default(),
+                };
+                Operation::system(SystemOperation::OpenChain(config))
+            })
+            .collect();
+        info!("Executing {} OpenChain operations", operations.len());
         Ok(chain_client
             .execute_operations(operations, vec![])
             .await?
@@ -1194,13 +1208,7 @@ impl<Env: Environment> ClientContext<Env> {
         let operations: Vec<Operation> = key_pairs
             .iter()
             .map(|(chain_id, owner)| {
-                Benchmark::<Env>::fungible_transfer(
-                    application_id,
-                    *chain_id,
-                    default_key,
-                    *owner,
-                    amount,
-                )
+                fungible_transfer(application_id, *chain_id, default_key, *owner, amount)
             })
             .collect();
         let chain_client = self.make_chain_client(default_chain_id).await?;

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -75,7 +75,7 @@ pub struct BenchmarkOptions {
     /// The application ID of a fungible token on the wallet's default chain.
     /// If none is specified, the benchmark uses the native token.
     #[arg(long)]
-    pub fungible_application_id: Option<linera_base::identifiers::ApplicationId>,
+    pub fungible_application_id: Option<ApplicationId>,
 
     /// The fixed BPS (Blocks Per Second) rate that block proposals will be sent at.
     #[arg(long, default_value_t = DEFAULT_BPS)]

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -48,7 +48,10 @@ use linera_base::{
     time::{Duration, Instant},
 };
 use linera_client::{
-    benchmark::BenchmarkConfig,
+    benchmark::{
+        BenchmarkConfig, FungibleTransferGenerator, NativeFungibleTransferGenerator,
+        OperationGenerator,
+    },
     chain_listener::{ChainListener, ChainListenerConfig, ClientContext as _},
     config::{CommitteeConfig, GenesisConfig},
 };
@@ -783,13 +786,14 @@ impl Runnable for Job {
                         let mut context = options
                             .create_client_context(storage.clone(), wallet, signer.into_value())
                             .await?;
-                        let (chain_clients, all_chains) = context
+                        let chain_clients = context
                             .prepare_for_benchmark(
                                 num_chains,
                                 tokens_per_chain,
                                 fungible_application_id,
                                 pub_keys,
                                 config_path.as_deref(),
+                                close_chains,
                             )
                             .await?;
 
@@ -836,18 +840,44 @@ impl Runnable for Job {
                             mpsc::unbounded_channel().1,
                             true, // Enabling background sync for benchmarks
                         );
+                        let all_chain_ids: Vec<ChainId> =
+                            chain_clients.iter().map(|c| c.chain_id()).collect();
+                        let generators: Vec<Box<dyn OperationGenerator>> = chain_clients
+                            .iter()
+                            .map(|client| -> anyhow::Result<Box<dyn OperationGenerator>> {
+                                let source = client.chain_id();
+                                let destinations: Vec<ChainId> = all_chain_ids
+                                    .iter()
+                                    .copied()
+                                    .filter(|id| *id != source)
+                                    .collect();
+                                if let Some(app_id) = fungible_application_id {
+                                    Ok(Box::new(FungibleTransferGenerator::new(
+                                        app_id,
+                                        source,
+                                        destinations,
+                                        single_destination_per_block,
+                                    )?))
+                                } else {
+                                    Ok(Box::new(NativeFungibleTransferGenerator::new(
+                                        source,
+                                        destinations,
+                                        single_destination_per_block,
+                                    )?))
+                                }
+                            })
+                            .collect::<Result<_, _>>()?;
+
                         linera_client::benchmark::Benchmark::run_benchmark(
                             bps,
                             chain_clients.clone(),
-                            all_chains,
+                            generators,
                             transactions_per_block,
-                            fungible_application_id,
                             health_check_endpoints.clone(),
                             runtime_in_seconds,
                             delay_between_chains_ms,
                             chain_listener,
                             &shutdown_notifier,
-                            single_destination_per_block,
                         )
                         .await?;
 
@@ -900,6 +930,8 @@ impl Runnable for Job {
                                         "--storage-max-stream-queries".to_string(),
                                         "50".to_string(),
                                         "--timings".to_string(),
+                                        "--max-new-events-per-block".to_string(),
+                                        "10000".to_string(),
                                     ],
                                 )))
                             })


### PR DESCRIPTION
## Motivation

Frontport of #5438 from `testnet_conway` to `main`.

## Proposal

Cherry-pick of #5438 with conflict resolution:
- Adopted `OperationGenerator` trait replacing `main`'s inline
`generate_operations`/`create_operation`/`ChainDestinationManager`
- Kept `ChainListenerStartupError` variant from `main`
- Made `fungible_transfer` a module-level function
- Removed unused `single_destination_per_block` parameter from internal benchmark methods (generators encapsulate this
logic)

## Test Plan

CI.
