### PR TITLE
Add the binary_dir to LocalNet, LocalNetConfig, and the Wallet.

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -901,6 +901,7 @@ impl Runnable for Job {
                                         "50".to_string(),
                                         "--timings".to_string(),
                                     ],
+                                    None,
                                 )))
                             })
                             .collect::<Result<Vec<_>, anyhow::Error>>()?;

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -263,6 +263,7 @@ pub async fn handle_net_up_service(
         storage_config_builder,
         path_provider,
         block_exporters,
+        binary_dir: None,
     };
     let (mut net, client) = config.instantiate().await?;
     let faucet_service = print_messages_and_create_faucet(

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -110,6 +110,7 @@ impl ClientWrapper {
             id,
             on_drop,
             vec!["--wait-for-outgoing-messages".to_string()],
+            None,
         )
     }
 
@@ -120,6 +121,7 @@ impl ClientWrapper {
         id: usize,
         on_drop: OnClientDrop,
         extra_args: Vec<String>,
+        binary_dir: Option<PathBuf>,
     ) -> Self {
         let storage = format!(
             "rocksdb:{}/client_{}.db",
@@ -128,8 +130,9 @@ impl ClientWrapper {
         );
         let wallet = format!("wallet_{}.json", id);
         let keystore = format!("keystore_{}.json", id);
+        let binary_path = binary_dir.map(|dir| dir.join("linera"));
         Self {
-            binary_path: sync::Mutex::new(None),
+            binary_path: sync::Mutex::new(binary_path),
             testing_prng_seed,
             storage,
             wallet,


### PR DESCRIPTION
## Motivation

For the developer experience, it is advantageous to be able to run end-to-end tests. Something similar
to what we have for `local_net_tests.rs`. We have used this as 

## Proposal

Make the directory available in the `LocalNetConfig`, `LocalNet`, and `Wallet`.
If set to `None`, then the usual system is being used.


## Test Plan

The test `test_wasm_counter` of [linera_end_to_end_tests](https://github.com/MathieuDutSik/linera_end_to_end_tests)
demonstrates the functionality.

## Release Plan

It would be interesting to deploy it for `testnet_conway` since the question is more relevant there.

## Links

None