### PR TITLE
[testnet] Retry in the task processor (#5464)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -735,6 +735,9 @@ Run a GraphQL service to explore and extend the chains of the wallet
 * `--operator-application-ids <OPERATOR_APPLICATION_IDS>` — Application IDs of operator applications to watch. When specified, a task processor is started alongside the node service
 * `--controller-id <CONTROLLER_APPLICATION_ID>` — A controller to execute a dynamic set of applications running on a dynamic set of chains
 * `--operators <OPERATORS>` — Supported operators and their binary paths. Format: `name=path` or just `name` (uses name as path). Example: `--operators my-operator=/path/to/binary`
+* `--task-retry-delay-secs <TASK_RETRY_DELAY_SECS>` — Delay in seconds before retrying a failed operator task batch. Only relevant when operators are configured via `--operator-application-ids` or `--controller-id`
+
+  Default value: `5`
 * `--read-only` — Run in read-only mode: disallow mutations and prevent queries from scheduling operations. Use this when exposing the service to untrusted clients
 
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -774,6 +774,12 @@ pub enum ClientCommand {
         #[arg(long = "operators", value_parser = parse_operator)]
         operators: Vec<(String, PathBuf)>,
 
+        /// Delay in seconds before retrying a failed operator task batch.
+        /// Only relevant when operators are configured via `--operator-application-ids`
+        /// or `--controller-id`.
+        #[arg(long, default_value = "5")]
+        task_retry_delay_secs: u64,
+
         /// Run in read-only mode: disallow mutations and prevent queries from scheduling
         /// operations. Use this when exposing the service to untrusted clients.
         #[arg(long)]


### PR DESCRIPTION
Backport of #5464.

## Motivation

The task processor currently doesn't retry failed tasks.

## Proposal

In each batch, we submit as many task outcomes to the chain as possible, in the correct order.

When a task fails to produce an outcome or cannot be submitted to the chain, it is retried with a configurable delay (default 5 seconds). Exceptions:
* If it fails due to a conflicting block, it is retried immediately.
* If it fails because we are not the round leader on the chain, it is retried when the round times out.

## Test Plan

This is mostly about relatively simple but hard-to-isolate time-based retry logic, so it's difficult to write tests without actual `sleep`s. CI should catch any regressions.

## Release Plan

* Release a new SDK.

## Links

- PR to main: #5464
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
