### PR TITLE
Replace archived watchtower with maintained fork to fix Docker Compose CI

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -226,7 +226,7 @@ services:
       - ./dashboards:/var/lib/grafana/dashboards
 
   watchtower:
-    image: containrrr/watchtower:latest
+    image: nickfedor/watchtower:1.14.2
     container_name: watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Motivation

The Docker Compose CI workflow is failing with `container watchtower exited (1)` on all
PRs entering the merge queue (e.g. PR #5464 runs [22143187360](https://github.com/linera
-io/linera-protocol/actions/runs/22143187360/job/64012766399) and
[22142346586](https://github.com/linera-io/linera-protocol/actions/runs/22142346586)).

The root cause is that the GitHub Actions runner image (`ubuntu24/20260209.23`) now
ships **Docker 29.1.5**, which raised the minimum supported API version to 1.44. The
`containrrr/watchtower:latest` image hardcodes its Docker client to API version 1.25,
causing it to crash immediately on startup. This is a [well-documented breaking
change](https://github.com/containrrr/watchtower/issues/2126) that affects all users of
the original watchtower with Docker 29+.

The `containrrr/watchtower` project was [archived on December 17,
2025](https://github.com/containrrr/watchtower/discussions/2135) and will never receive
a fix.

## Proposal

Replace `containrrr/watchtower:latest` with `nickfedor/watchtower:1.14.2`, a [maintained
community fork](https://github.com/nicholas-fedor/watchtower) that is a drop-in
replacement (same CLI flags, same watchtower labels). The image is pinned to a specific
version to prevent future surprise breakage.

## Test Plan

- The Docker Compose CI workflow should pass on this PR's merge queue run, since the new
watchtower image is compatible with Docker 29+.
- The watchtower labels on other services (`com.centurylinklabs.watchtower.enable:
"true"`) are still recognized by the fork.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
