### PR TITLE
Use lld linker for x86_64 Linux builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,10 @@
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+
 [build]
 # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
 rustdocflags = ["-Arustdoc::redundant_explicit_links"]


### PR DESCRIPTION
### Motivation

Linking is a significant bottleneck in Rust build times, especially for large workspaces
with debug info enabled. The default GNU linker (BFD ld) is notably slower than modern
alternatives.

### Proposal

Configure the project to use LLVM's `lld` linker for `x86_64-unknown-linux-gnu` builds
via `.cargo/config.toml`. This improves link times by 20-50% for both CI runners and
Linux developers.

This is the same linker that Rust 1.90.0 will use by default for this target
(see [Rust blog
post](https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/)),
so this change simply opts in early on stable 1.86.0.

### Details

- Only affects `x86_64-unknown-linux-gnu` — macOS and WASM targets are unchanged
- WASM targets (`wasm32-unknown-unknown`) already use `rust-lld` by default
- Requires `clang` and `lld` to be available on the build machine
- GitHub Actions ubuntu runners ship with clang pre-installed
- `lld` may need `sudo apt-get install -y d` if not already present
- Linux developers will need to install `lld` and `clang` locally
(`sudo apt install lld clang`)

### Test Plan

- CI
