### PR TITLE
[testnet] Make the task processor cursor a String. (#5471)

### DIFF
--- a/examples/task-processor/src/service.rs
+++ b/examples/task-processor/src/service.rs
@@ -81,7 +81,7 @@ impl QueryRoot {
     }
 
     /// Returns the pending tasks and callback requests for the task processor.
-    async fn next_actions(&self, _cursor: Option<Vec<u8>>, _now: Timestamp) -> ProcessorActions {
+    async fn next_actions(&self, _cursor: Option<String>, _now: Timestamp) -> ProcessorActions {
         let mut actions = ProcessorActions::default();
 
         // Get all pending tasks from the queue.

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -27,7 +27,7 @@ pub struct ProcessorActions {
     pub request_callback: Option<Timestamp>,
     /// An optional cursor for the task processor to store and pass to the application
     /// upon the next query for actions.
-    pub set_cursor: Option<Vec<u8>>,
+    pub set_cursor: Option<String>,
     /// The application is requesting the execution of the given tasks.
     pub execute_tasks: Vec<Task>,
 }

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -56,7 +56,7 @@ struct BatchResult {
 pub struct TaskProcessor<Env: linera_core::Environment> {
     chain_id: ChainId,
     application_ids: Vec<ApplicationId>,
-    cursors: BTreeMap<ApplicationId, Vec<u8>>,
+    cursors: BTreeMap<ApplicationId, String>,
     chain_client: ChainClient<Env>,
     cancellation_token: CancellationToken,
     notifications: NotificationStream,
@@ -328,7 +328,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     async fn query_actions(
         &mut self,
         application_id: ApplicationId,
-        cursor: Option<Vec<u8>>,
+        cursor: Option<String>,
         now: Timestamp,
     ) -> Result<ProcessorActions, anyhow::Error> {
         let query = format!(


### PR DESCRIPTION
Backport of #5471.

## Motivation

`Vec<u8>` is unreadable in the logs.

## Proposal

Make the task processor cursor a `String`. Apps are encouraged to use a readable format, e.g. JSON.

## Test Plan

CI

## Release Plan

- Release in a new SDK.

## Links

- PR to main: #5471.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
