### PR TITLE
Add k8sattributes processor to enrich trace spans with Kubernetes metadata

### DIFF
--- a/kubernetes/linera-validator/values-observability-alloy.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-observability-alloy.yaml.gotmpl
@@ -205,10 +205,9 @@ alloy:
       }
       {{- end }}
 
-      {{- if eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
-      // ==================== Tempo Traces Collection ====================
-      // Receives traces via OTLP and forwards to BOTH local Tempo (preserves local monitoring)
-      // AND central Tempo (external monitoring stack)
+      // ==================== Trace Pipeline (always active) ====================
+      // Receives traces via OTLP, enriches with k8s metadata, forwards to local Tempo.
+      // If TEMPO_ENABLED, also forwards to central Tempo.
 
       // OTLP receiver for traces
       otelcol.receiver.otlp "default" {
@@ -221,16 +220,39 @@ alloy:
         }
 
         output {
-          // Fan-out to both local and central Tempo
+          traces = [otelcol.processor.k8sattributes.default.input]
+        }
+      }
+
+      otelcol.processor.k8sattributes "default" {
+        extract {
+          metadata = [
+            "k8s.namespace.name",
+            "k8s.pod.name",
+            "k8s.container.name",
+            "k8s.node.name",
+            "k8s.deployment.name",
+            "k8s.statefulset.name",
+          ]
+        }
+
+        pod_association {
+          source {
+            from = "connection"
+          }
+        }
+
+        output {
           traces = [
             otelcol.exporter.otlp.local_tempo.input,
+            {{- if eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
             otelcol.exporter.otlphttp.central.input,
+            {{- end }}
           ]
         }
       }
 
-      // Export traces to LOCAL Tempo (preserves existing local monitoring)
-      // Uses gRPC OTLP to local Tempo in tempo namespace
+      // Export traces to LOCAL Tempo (always active)
       otelcol.exporter.otlp "local_tempo" {
         client {
           endpoint = "tempo.tempo.svc.cluster.local:4317"
@@ -241,6 +263,7 @@ alloy:
         }
       }
 
+      {{- if eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
       // Export traces to external/central Tempo
       otelcol.exporter.otlphttp "central" {
         client {


### PR DESCRIPTION
## Motivation

The central Grafana's "Related logs" feature on trace spans needs to filter Loki logs by
the specific container that produced the span. The Tempo `tracesToLogsV2` config maps
`k8s.container.name` → Loki `container` label, but spans currently lack this attribute.

## Proposal

Insert `otelcol.processor.k8sattributes` into the observability-alloy trace pipeline in
`values-observability-alloy.yaml.gotmpl`. The pipeline becomes:

```
OTLP receiver → k8sattributes → [local Tempo, central Tempo]
```

The processor uses `from = "connection"` to look up the sending pod's IP in the K8s API
and adds resource attributes including `k8s.container.name`, `k8s.pod.name`,
`k8s.namespace.name`, etc. The existing RBAC (upstream Alloy chart ClusterRole) already
has the required permissions.

## Test Plan

- CI
- Will try to deploy a network with this
