### PR TITLE
Remove task processor cursor.

### DIFF
--- a/examples/task-processor/src/service.rs
+++ b/examples/task-processor/src/service.rs
@@ -85,8 +85,8 @@ impl QueryRoot {
         let mut actions = ProcessorActions::default();
 
         // Get all pending tasks from the queue.
-        let total_count = self.state.pending_tasks.count();
-        if let Ok(pending_tasks) = self.state.pending_tasks.read_front(total_count).await {
+        let count = self.state.pending_tasks.count();
+        if let Ok(pending_tasks) = self.state.pending_tasks.read_front(count).await {
             for pending in pending_tasks {
                 actions.execute_tasks.push(Task {
                     operator: pending.operator,

--- a/examples/task-processor/src/service.rs
+++ b/examples/task-processor/src/service.rs
@@ -81,25 +81,19 @@ impl QueryRoot {
     }
 
     /// Returns the pending tasks and callback requests for the task processor.
-    async fn next_actions(&self, cursor: Option<String>, _now: Timestamp) -> ProcessorActions {
+    async fn next_actions(&self, _now: Timestamp) -> ProcessorActions {
         let mut actions = ProcessorActions::default();
-
-        // Parse cursor as the number of tasks already dispatched (default 0).
-        let already_dispatched: usize = cursor.as_deref().and_then(|s| s.parse().ok()).unwrap_or(0);
 
         // Get all pending tasks from the queue.
         let total_count = self.state.pending_tasks.count();
         if let Ok(pending_tasks) = self.state.pending_tasks.read_front(total_count).await {
-            for pending in pending_tasks.into_iter().skip(already_dispatched) {
+            for pending in pending_tasks {
                 actions.execute_tasks.push(Task {
                     operator: pending.operator,
                     input: pending.input,
                 });
             }
         }
-
-        // Always advance the cursor to the total pending count.
-        actions.set_cursor = Some(total_count.to_string());
 
         actions
     }

--- a/linera-base/src/task_processor.rs
+++ b/linera-base/src/task_processor.rs
@@ -14,7 +14,7 @@ use crate::data_types::Timestamp;
 /// On-chain applications should be ready to respond to GraphQL queries of the form:
 /// ```ignore
 /// query {
-///   nextActions(lastRequestedCallback: Timestamp, now: Timestamp!): ProcessorActions!
+///   nextActions(now: Timestamp!): ProcessorActions!
 /// }
 ///
 /// query {
@@ -25,9 +25,6 @@ use crate::data_types::Timestamp;
 pub struct ProcessorActions {
     /// The application is requesting to be called back no later than the given timestamp.
     pub request_callback: Option<Timestamp>,
-    /// An optional cursor for the task processor to store and pass to the application
-    /// upon the next query for actions.
-    pub set_cursor: Option<String>,
     /// The application is requesting the execution of the given tasks.
     pub execute_tasks: Vec<Task>,
 }


### PR DESCRIPTION
## Motivation

Using `in_flight_apps` we now make sure that we only `query_actions` after submitting the previous outcomes—or after failing, in which case we want to retry them.

Currently we use the updated cursor even when we should retry, so we don't actually retry the failed tasks.

## Proposal

Remove the cursor entirely! The only case where we `query_actions` without submitting the previous ones is when we are retrying. In either case, all the relevant information is already on-chain.

## Test Plan

A regression test was added, then the issue was fixed by removing the cursor.

## Release Plan

- Backport to `testnet_conway`.
- Release a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
