### PR TITLE
Concurrent read-only chain actor read requests.

### DIFF
--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -27,8 +27,8 @@ pub(super) use self::delivery_notifier::DeliveryNotifier;
 pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::{
     actor::{
-        ChainActorEndpoint, ChainActorReceivers, ChainWorkerActor, ChainWorkerRequest,
-        EventSubscriptionsResult,
+        chain_actor_channel, ChainActorEndpoint, ChainActorReceivers, ChainWorkerActor,
+        ChainWorkerRequest, EventSubscriptionsResult,
     },
     config::ChainWorkerConfig,
     state::BlockOutcome,


### PR DESCRIPTION
## Motivation

Read-only requests to the chain actor could be handled concurrently.

## Proposal

Build on https://github.com/linera-io/linera-protocol/pull/5468 to handle all read requests concurrently.

## Test Plan

CI; we should benchmark this and compare.

## Release Plan

- Backport to `testnet_conway`.
- Release a new SDK.

## Links

- Extends https://github.com/linera-io/linera-protocol/pull/5468.
- Closes #2237.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
