### PR TITLE
Better error types on the Web (#5483)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6321,7 +6321,6 @@ dependencies = [
  "num-traits",
  "serde",
  "serde-wasm-bindgen 0.6.5",
- "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",

--- a/web/@linera/client/Cargo.toml
+++ b/web/@linera/client/Cargo.toml
@@ -24,7 +24,6 @@ log.workspace = true
 num-traits.workspace = true
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true

--- a/web/@linera/client/build.bash
+++ b/web/@linera/client/build.bash
@@ -36,6 +36,9 @@ wasm-bindgen \
     --target web \
     --split-linked-modules
 
+# wasm-bindgen generates a `package.json` with the requisite dependencies, which is missing its `module: true` attribute.  This confuses `tsc`, and isn't necessary since we're embedding the output in a larger package with its own `package.json`.
+rm src/wasm/package.json
+
 mkdir -p dist
 cp -r src/wasm dist/
 

--- a/web/@linera/client/src/client.rs
+++ b/web/@linera/client/src/client.rs
@@ -9,7 +9,7 @@ use linera_client::chain_listener::{ChainListener, ClientContext as _};
 use wasm_bindgen::prelude::*;
 use web_sys::wasm_bindgen;
 
-use crate::{chain::Chain, signer::Signer, storage, wallet::Wallet, Environment, JsResult};
+use crate::{chain::Chain, signer::Signer, storage, wallet::Wallet, Environment, Result};
 
 /// The full client API, exposed to the wallet implementation. Calls
 /// to this API can be trusted to have originated from the user's
@@ -46,7 +46,7 @@ impl Client {
         mut wallet: Wallet,
         signer: Signer,
         options: Option<linera_client::Options>,
-    ) -> Result<Client, JsError> {
+    ) -> Result<Client> {
         let options = options.unwrap_or_default();
 
         wallet.lock().await?;
@@ -104,7 +104,7 @@ impl Client {
     ///
     /// If the wallet could not be read or chain synchronization fails.
     #[wasm_bindgen]
-    pub async fn chain(&self, chain: ChainId, options: Option<ChainOptions>) -> JsResult<Chain> {
+    pub async fn chain(&self, chain: ChainId, options: Option<ChainOptions>) -> Result<Chain> {
         let options = options.unwrap_or_default();
         let mut chain_client = self
             .client_context

--- a/web/@linera/client/src/error/index.ts
+++ b/web/@linera/client/src/error/index.ts
@@ -1,0 +1,6 @@
+export class LockError extends Error {
+  constructor(message: string, stack?: string) {
+    super(message);
+    if (stack) this.stack = stack;
+  }
+}

--- a/web/@linera/client/src/error/mod.rs
+++ b/web/@linera/client/src/error/mod.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use wasm_bindgen::{prelude::wasm_bindgen, JsError, JsValue};
+
+use crate::lock;
+
+#[wasm_bindgen(module = "/src/error/index.ts")]
+extern "C" {
+    type LockError;
+
+    #[wasm_bindgen(constructor)]
+    fn new(message: String) -> LockError;
+}
+
+pub enum Error {
+    Lock(lock::Error),
+    Other(JsError),
+}
+
+impl From<lock::Error> for Error {
+    fn from(error: lock::Error) -> Self {
+        Self::Lock(error)
+    }
+}
+
+impl<E: std::error::Error> From<E> for Error {
+    fn from(error: E) -> Self {
+        Self::Other(error.into())
+    }
+}
+
+impl Error {
+    pub fn new(message: &str) -> Self {
+        Self::Other(JsError::new(message))
+    }
+}
+
+impl From<Error> for JsValue {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::Lock(error) => LockError::new(error.to_string()).into(),
+            Error::Other(error) => error.into(),
+        }
+    }
+}

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -27,6 +27,8 @@ pub mod client;
 pub use client::Client;
 pub mod chain;
 pub use chain::Chain;
+pub mod error;
+pub use error::Error;
 pub mod faucet;
 pub mod lock;
 
@@ -40,7 +42,8 @@ pub use wallet::Wallet;
 pub type Network = linera_rpc::node_provider::NodeProvider;
 pub type Environment = linera_core::environment::Impl<Storage, Network, Signer, Wallet>;
 
-type JsResult<T> = Result<T, JsError>;
+type JsResult<T> = std::result::Result<T, JsError>;
+type Result<T> = std::result::Result<T, Error>;
 
 #[derive(serde::Deserialize, Default, tsify::Tsify)]
 #[tsify(from_wasm_abi)]

--- a/web/@linera/client/src/lock.rs
+++ b/web/@linera/client/src/lock.rs
@@ -19,15 +19,23 @@
 //!
 //! [Web Locks API]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
 
+use std::fmt;
+
 use wasm_bindgen::{JsCast as _, JsValue, UnwrapThrowExt as _};
 use wasm_bindgen_futures::JsFuture;
 
 /// Errors that can occur when acquiring a lock.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum Error {
     /// The lock could not be acquired because another context already holds it.
-    #[error("wallet {name} already in use")]
     Contended { name: String },
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self::Contended { name } = self;
+        write!(f, "wallet {name} already in use")
+    }
 }
 
 /// An exclusive lock on a named resource, backed by the Web Locks API.


### PR DESCRIPTION
## Motivation

We'd like to be able to handle different errors differently in the frontends.

## Proposal

Add different error classes for error cases we might want to distinguish (currently just `LockError`, but open for extension) in `error/index.ts`.

Then, instead of using `wasm_bindgen::JsError` everywhere (which becomes an `Error` on the JavaScript side) add our own `Error` type with a custom conversion to `JsValue` that constructs the appropriate error class depending on the enum variant.

It would be nice if `tsify` did this for us.

## Test Plan

Tested locally.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)