### PR TITLE
`default.nix`: add lld as dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@
   cargoExtraArgs = "-p linera-service";
   nativeBuildInputs = with pkgs; [
     clang
+    llvmPackages.bintools
     pkg-config
     rocksdb
     protobufc


### PR DESCRIPTION
## Motivation

As of #5469 we have gained lld as a dependency.

## Proposal

Add it to `default.nix` so we can continue to build.

## Test Plan

Tested locally.

## Release Plan

Follows #5469.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
