### PR TITLE
ci(bridge-e2e): switch GCP auth to Workload Identity Federation

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -23,6 +23,7 @@ env:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   bridge-e2e:
@@ -47,9 +48,12 @@ jobs:
 
       # Pull pre-built linera images from GCP registry
       - name: Auth to GCP
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
+          workload_identity_provider: >-
+            projects/886017272224/locations/global/workloadIdentityPools/github-apps-pool/providers/github-apps-provider
+          service_account: >-
+            actions-runner@linera-io-dev.iam.gserviceaccount.com
 
       - name: Configure Docker for GCP
         run: gcloud auth configure-docker us-docker.pkg.dev


### PR DESCRIPTION
## Summary

- Replaces legacy JSON service account key (`GCP_SA_ACTIONS_RUNNER_KEY` secret) with OIDC-based Workload Identity Federation for GCP authentication in the `bridge-e2e` workflow.
- Adds `id-token: write` permission required for OIDC token exchange.
- Upgrades `google-github-actions/auth` from v1 to v2.

Depends on linera-io/linera-infra#585 (adds the WIF IAM binding for `linera-io/linera-protocol`).

Closes linera-io/linera-infra#584

## Test plan

- [x] Merge linera-io/linera-infra#585 and apply terraform first
- [ ] Trigger `bridge-e2e` workflow dispatch to verify GCP auth works end-to-end