### PR TITLE
Make time budget and count limit work together for bundle staging

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -130,7 +130,7 @@ Client implementation and command-line tool for the Linera blockchain
   Default value: `4000`
 * `--max-pending-message-bundles <MAX_PENDING_MESSAGE_BUNDLES>` — The maximum number of incoming message bundles to include in a block proposal
 
-  Default value: `10`
+  Default value: `300`
 * `--max-block-limit-errors <MAX_BLOCK_LIMIT_ERRORS>` — Maximum number of message bundles to discard from a block proposal due to block limit errors before discarding all remaining bundles.
 
    Discarded bundles can be retried in the next block.
@@ -139,7 +139,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-new-events-per-block <MAX_NEW_EVENTS_PER_BLOCK>` — The maximum number of new stream events to include in a block proposal
 
   Default value: `10`
-* `--staging-bundles-time-budget-ms <STAGING_BUNDLES_TIME_BUDGET>` — Time budget for staging message bundles in milliseconds. When set, limits bundle execution by time rather than by count. This overrides `max_pending_message_bundles` for bundle limiting purposes
+* `--staging-bundles-time-budget-ms <STAGING_BUNDLES_TIME_BUDGET>` — Time budget for staging message bundles in milliseconds. When set, limits bundle execution by wall-clock time, in addition to the count limit from `max_pending_message_bundles`
 * `--chain-worker-ttl-ms <CHAIN_WORKER_TTL>` — The duration in milliseconds after which an idle chain worker will free its memory
 
   Default value: `30000`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -52,7 +52,7 @@ pub struct Options {
     pub recv_timeout: Duration,
 
     /// The maximum number of incoming message bundles to include in a block proposal.
-    #[arg(long, default_value = "10")]
+    #[arg(long, default_value = "300")]
     pub max_pending_message_bundles: usize,
 
     /// Maximum number of message bundles to discard from a block proposal due to block limit
@@ -67,8 +67,8 @@ pub struct Options {
     pub max_new_events_per_block: usize,
 
     /// Time budget for staging message bundles in milliseconds. When set, limits bundle
-    /// execution by time rather than by count. This overrides `max_pending_message_bundles`
-    /// for bundle limiting purposes.
+    /// execution by wall-clock time, in addition to the count limit from
+    /// `max_pending_message_bundles`.
     #[arg(long = "staging-bundles-time-budget-ms", value_parser = util::parse_millis)]
     pub staging_bundles_time_budget: Option<Duration>,
 


### PR DESCRIPTION
## Motivation

Follow-up to #5393. Post-merge feedback from @ma2bd and @afck pointed out that when
`--staging-bundles-time-budget-ms` is set, the count limit
(`max_pending_message_bundles`) is completely bypassed by taking `usize::MAX` bundles at
selection time. Both limits should apply together — the count limit caps how many
bundles are selected, and the time budget caps how long execution runs.

## Proposal

- Remove the `usize::MAX` override so `max_pending_message_bundles` always applies,
regardless of whether a time budget is set. Both limits now act as a conjunction.
- Increase the default `max_pending_message_bundles` from 10 to 300, so that when a time
budget is active the count limit doesn't unnecessarily constrain it (the time budget
becomes the effective limiter in practice).
- Update doc comments to say the time budget works "in addition to" the count limit, not
"rather than" / "overrides" it.

## Test Plan

- CI

