### PR TITLE
Fix the path filter for image rebuild

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -3,9 +3,8 @@ name: Bridge E2E
 on:
   merge_group:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - 'testnet_*'
+  push:
+    branches: [ 'testnet_*', 'main']
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'


### PR DESCRIPTION
## Motivation

Docker.bridge was rebuilt too often.

`- '!linera-bridge/tests/e2e/**'` matches ALL directories that ARE NOT this path.. basically whole repository.

## Proposal

Replace with the non-`!` filters that capture directories we want to track.

Task takes ~5minutes and majority of the PRs won't affect its result – run it only after push to `testnet_*` or `main` branches.

## Test Plan

CI

## Release Plan

None at the moment.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
