### PR TITLE
fix(ci): check actual Cloud Build status in docker workflow

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -103,19 +103,22 @@ jobs:
             echo "Streaming logs for $BUILD_NAME (ID: $BUILD_ID)"
             echo "========================================"
 
-            gcloud builds log "$BUILD_ID" --stream
+            # Stream logs (exit code only reflects log streaming, not build result)
+            gcloud builds log "$BUILD_ID" --stream || true
 
-            local EXIT_CODE=$?
-            if [[ $EXIT_CODE -eq 0 ]]; then
+            # Check the actual Cloud Build status
+            local BUILD_STATUS
+            BUILD_STATUS=$(gcloud builds describe "$BUILD_ID" --format="value(status)")
+
+            if [[ "$BUILD_STATUS" == "SUCCESS" ]]; then
               echo ""
-              echo "$BUILD_NAME completed successfully"
+              echo "$BUILD_NAME completed successfully (status: $BUILD_STATUS)"
             else
               echo ""
-              echo "$BUILD_NAME failed (exit code: $EXIT_CODE)"
+              echo "$BUILD_NAME failed (status: $BUILD_STATUS)"
               echo "Logs: https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=linera-io-dev"
+              return 1
             fi
-
-            return $EXIT_CODE
           }
 
           echo "Submitting builds to GCP Cloud Build..."


### PR DESCRIPTION
## Summary

- `gcloud builds log --stream` returns exit code 0 as long as log streaming succeeds, regardless of whether the Cloud Build itself failed
- This caused failed image builds (e.g. exporter with missing `bridge` feature) to be silently reported as successful, making the entire CI job green
- Fix: use `gcloud builds describe` to check the actual build status after streaming logs

## Test plan

- [ ] Trigger a Docker Image workflow run and verify a failing build correctly fails the job
- [ ] Verify successful builds still report green