### PR TITLE
Fix premature quorum failure in `communicate_with_quorum`

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -220,7 +220,7 @@ where
         [] => CommunicationError::NoConsensus(committee.quorum_threshold(), scores),
         [(_, score), ..] if *score >= committee.validity_threshold() => {
             // At least one honest validator returned this error.
-            CommunicationError::Trusted(sample.remove(0).0)
+            CommunicationError::Trusted(sample.into_iter().next().unwrap().0)
         }
         // Otherwise no specific error is available to report reliably.}
         _ => CommunicationError::Sample(sample),


### PR DESCRIPTION
## Motivation

The early return on trusted errors used `validity_threshold` (N/3), which could abort when a quorum was still achievable. With 6 weight-100 validators `validity_threshold` is 200 (see https://github.com/linera-io/linera-protocol/pull/4978) but `quorum_threshold` is 400, so 2 errors (weight 200) still left room for 4 successes (weight 400).

This made at least one test flaky, because it could happen that:
* A client requested a chain, and the faucet created it with the help of 4 validators (a quorum).
* Then the client tried to sync the chain, but the first 2 validators (validity threshold!) to respond were the ones that do not know about the new chain yet, so they send back errors.

## Proposal

Use only the `total_votes - quorum_threshold` criterium instead, so we only give up when remaining validators truly cannot form a quorum. Determine whether any error is trusted at the end.

## Test Plan

`test_end_to_end_receipt_of_old_remove_committee_messages` should not be flaky anymore. (Confirmed locally.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- (No need to backport: on testnet, the quorum would still be 401 in that scenario.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
