### PR TITLE
[testnet] Do not retry tasks if they were unassigned from the worker

### DIFF
--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -200,6 +200,10 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
 
     async fn process_actions(&mut self, application_ids: Vec<ApplicationId>) {
         for application_id in application_ids {
+            if !self.application_ids.contains(&application_id) {
+                debug!("Skipping {application_id}: it's no longer assigned to this processor");
+                continue;
+            }
             if self.in_flight_apps.contains(&application_id) {
                 debug!("Skipping {application_id}: tasks already in flight");
                 continue;


### PR DESCRIPTION
## Motivation

Unassigning a service from a worker sometimes doesn't stop the worker from processing the service's tasks.

## Proposal

Only re-process actions from an application after receiving a result from it if it is still assigned to the worker.

## Test Plan

CI will catch regressions

## Release Plan

- These changes should be released in a new SDK,

## Links

- closes #5503
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
