### PR TITLE
Fix flaky `test_staggered_parallel_retry_on_failure` by increasing delays

### DIFF
--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -1363,7 +1363,7 @@ mod tests {
             })
             .collect();
 
-        let staggered_delay = Duration::from_millis(10);
+        let staggered_delay = Duration::from_millis(100);
 
         // Store public keys for comparison
         let node0_key = nodes[0].public_key;
@@ -1451,7 +1451,7 @@ mod tests {
 
         // First call should be at ~0ms
         assert!(
-            times[0].1.as_millis() < 10,
+            times[0].1.as_millis() < 50,
             "First peer should be called immediately, was called at {}ms",
             times[0].1.as_millis()
         );
@@ -1461,20 +1461,20 @@ mod tests {
         if times.len() > 1 {
             let delay = times[1].1.as_millis();
             assert!(
-                delay < 10,
+                delay < 50,
                 "Second peer should be called immediately on first failure, got {}ms",
                 delay
             );
         }
 
-        // Total time should be significantly less than sequential.
-        // With aggressive retry: node0 fails immediately (~0ms), node1 starts immediately,
-        // node1 takes 20ms (and might fail or timeout), node2 starts at ~10ms (scheduled delay)
-        // and succeeds at ~15ms total (10ms + 5ms internal delay)
+        // Total time should be significantly less than sequential (which would be
+        // ~650ms: 200ms + 200ms + 50ms + 200ms). With parallel staggered retry:
+        // node0 fails immediately, node1 starts immediately, the next delay is
+        // 200ms (peer_index=2), node2 starts at ~200ms and succeeds at ~250ms.
         let total_time = Instant::now().duration_since(start_time).as_millis();
         assert!(
-            total_time < 50,
-            "Total time should be less than 50ms, got {}ms",
+            total_time < 500,
+            "Total time should be less than 500ms (sequential would be ~650ms), got {}ms",
             total_time
         );
     }


### PR DESCRIPTION
## Motivation

This failed in an unrelated PR because it was slightly too slow: https://github.com/linera-io/linera-protocol/actions/runs/22444813834/job/64996349635

```
Total time should be less than 50ms, got 53ms
```

## Proposal

Increase `staggered_delay` from 10ms to 100ms so the expected parallel time (~250ms) is well-separated from the sequential time (~650ms). The previous 10ms delays left only ~25ms of headroom in a 50ms threshold, which was easily exceeded by CI scheduling jitter.

## Test Plan

CI; see if it is stable now.

## Release Plan

- Maybe backport to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
