### PR TITLE
[main] Port: do not retry tasks if they were unassigned from the worker (#5523)

### DIFF
--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -119,14 +119,18 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
                 }
                 Some(result) = self.batch_receiver.recv() => {
                     self.in_flight_apps.remove(&result.application_id);
-                    if let Some(retry_at) = result.retry_at {
-                        self.deadlines.push(Reverse((
-                            retry_at,
-                            Some(result.application_id),
-                        )));
-                    } else {
-                        // Re-process immediately to pick up new tasks.
-                        self.process_actions(vec![result.application_id]).await;
+                    // The application could have been unassigned from this processor
+                    // in the meantime - do not retry if that is the case.
+                    if self.application_ids.contains(&result.application_id) {
+                        if let Some(retry_at) = result.retry_at {
+                            self.deadlines.push(Reverse((
+                                retry_at,
+                                Some(result.application_id),
+                            )));
+                        } else {
+                            // Re-process immediately to pick up new tasks.
+                            self.process_actions(vec![result.application_id]).await;
+                        }
                     }
                 }
                 Some(update) = self.update_receiver.recv() => {
@@ -196,6 +200,10 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
 
     async fn process_actions(&mut self, application_ids: Vec<ApplicationId>) {
         for application_id in application_ids {
+            if !self.application_ids.contains(&application_id) {
+                debug!("Skipping {application_id}: it's no longer assigned to this processor");
+                continue;
+            }
             if self.in_flight_apps.contains(&application_id) {
                 debug!("Skipping {application_id}: tasks already in flight");
                 continue;


### PR DESCRIPTION
## Motivation

Unassigning a service from a worker sometimes doesn't stop the worker from processing the service's tasks.

## Proposal

Only re-process actions from an application after receiving a result from it if it is still assigned to the worker.

## Test Plan

CI will catch regressions

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- port of #5523 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
