### PR TITLE
Lower process inbox log level if no blocks created.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -787,6 +787,10 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                 debug!(%chain_id, "Cannot find key for chain");
             }
             Err(error) => warn!(%error, "Failed to process inbox."),
+            Ok((certs, None)) if certs.is_empty() => debug!(
+                %chain_id,
+                "done processing inbox: no blocks created",
+            ),
             Ok((certs, None)) => info!(
                 %chain_id,
                 created_block_count = %certs.len(),


### PR DESCRIPTION
## Motivation

The `done processing inbox` log message is quite spammy: it even shows up if there were no messages in the inbox.

## Proposal

Lower it to DEBUG if no blocks were created.

## Test Plan

Revisit this if the remaining logs are still too spammy.

## Release Plan

- Backport to `testnet_conway`.
- Release SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
