### PR TITLE
Extract  from the linera binary into linera-service library

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -223,9 +223,6 @@ Client implementation and command-line tool for the Linera blockchain
 * `--wallet <WALLET_STATE_PATH>` — Sets the file storing the private state of user chains (an empty one will be created if missing)
 * `--keystore <KEYSTORE_PATH>` — Sets the file storing the keystore state
 * `-w`, `--with-wallet <WITH_WALLET>` — Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet storage config from the environment variables `LINERA_WALLET_{X}` and `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and `LINERA_STORAGE`
-* `--chrome-trace-exporter` — Enable OpenTelemetry Chrome JSON exporter for trace data analysis
-* `--chrome-trace-file <CHROME_TRACE_FILE>` — Output file path for Chrome trace JSON format. Can be visualized in chrome://tracing or Perfetto UI
-* `--otlp-exporter-endpoint <OTLP_EXPORTER_ENDPOINT>` — OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature)
 * `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
 * `--storage-max-concurrent-queries <STORAGE_MAX_CONCURRENT_QUERIES>` — The maximal number of simultaneous queries to the database
 * `--storage-max-stream-queries <STORAGE_MAX_STREAM_QUERIES>` — The maximal number of simultaneous stream queries to the database
@@ -262,6 +259,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--with-application-logs` — Output log messages from contract execution
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
 * `--tokio-blocking-threads <TOKIO_BLOCKING_THREADS>` — The number of Tokio blocking threads to use
+* `--chrome-trace-exporter` — Enable OpenTelemetry Chrome JSON exporter for trace data analysis
+* `--chrome-trace-file <CHROME_TRACE_FILE>` — Output file path for Chrome trace JSON format. Can be visualized in chrome://tracing or Perfetto UI
+* `--otlp-exporter-endpoint <OTLP_EXPORTER_ENDPOINT>` — OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature)
 
 
 

--- a/linera-service/src/cli/common_options.rs
+++ b/linera-service/src/cli/common_options.rs
@@ -1,0 +1,172 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! CLI options shared between the Linera CLI and other tools (e.g. pm-benchmark).
+
+use std::{env, path::PathBuf};
+
+use anyhow::{anyhow, bail, Error};
+use linera_base::crypto::InMemorySigner;
+use linera_client::config::GenesisConfig;
+use linera_execution::WasmRuntime;
+use linera_persistent as persistent;
+use tracing::{debug, info};
+
+use crate::{
+    storage::{CommonStorageOptions, StorageConfig},
+    Wallet,
+};
+
+/// Wallet, keystore, and storage configuration options common to all Linera client tools.
+#[derive(Clone, clap::Parser)]
+pub struct CommonCliOptions {
+    /// Sets the file storing the private state of user chains (an empty one will be created
+    /// if missing).
+    #[arg(long = "wallet")]
+    pub wallet_state_path: Option<PathBuf>,
+
+    /// Sets the file storing the keystore state.
+    #[arg(long = "keystore")]
+    pub keystore_path: Option<PathBuf>,
+
+    /// Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet
+    /// storage config from the environment variables `LINERA_WALLET_{X}` and
+    /// `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and
+    /// `LINERA_STORAGE`.
+    #[arg(long, short = 'w', value_parser = crate::util::parse_ascii_alphanumeric_string)]
+    pub with_wallet: Option<String>,
+
+    /// Storage configuration for the blockchain history.
+    #[arg(long = "storage", global = true)]
+    pub storage_config: Option<String>,
+
+    /// Common storage options.
+    #[command(flatten)]
+    pub common_storage_options: CommonStorageOptions,
+
+    /// The WebAssembly runtime to use.
+    #[arg(long)]
+    pub wasm_runtime: Option<WasmRuntime>,
+
+    /// Output log messages from contract execution.
+    #[arg(long = "with-application-logs", env = "LINERA_APPLICATION_LOGS")]
+    pub application_logs: bool,
+
+    /// The number of Tokio worker threads to use.
+    #[arg(long, env = "LINERA_CLIENT_TOKIO_THREADS")]
+    pub tokio_threads: Option<usize>,
+
+    /// The number of Tokio blocking threads to use.
+    #[arg(long, env = "LINERA_CLIENT_TOKIO_BLOCKING_THREADS")]
+    pub tokio_blocking_threads: Option<usize>,
+}
+
+impl CommonCliOptions {
+    pub fn suffix(&self) -> String {
+        self.with_wallet
+            .as_ref()
+            .map(|x| format!("_{}", x))
+            .unwrap_or_default()
+    }
+
+    pub fn config_path() -> Result<PathBuf, Error> {
+        let mut config_dir = dirs::config_dir().ok_or_else(|| {
+            anyhow!(
+                "Default wallet directory is not supported in this platform: \
+                 please specify storage and wallet paths"
+            )
+        })?;
+        config_dir.push("linera");
+        if !config_dir.exists() {
+            debug!("Creating default wallet directory {}", config_dir.display());
+            fs_err::create_dir_all(&config_dir)?;
+        }
+        info!("Using default wallet directory {}", config_dir.display());
+        Ok(config_dir)
+    }
+
+    pub fn storage_config(&self) -> Result<StorageConfig, Error> {
+        if let Some(config) = &self.storage_config {
+            return config.parse();
+        }
+        let suffix = self.suffix();
+        let storage_env_var = env::var(format!("LINERA_STORAGE{suffix}")).ok();
+        if let Some(config) = storage_env_var {
+            return config.parse();
+        }
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "rocksdb")] {
+                let spawn_mode =
+                    linera_views::rocks_db::RocksDbSpawnMode::get_spawn_mode_from_runtime();
+                let inner_storage_config = crate::storage::InnerStorageConfig::RocksDb {
+                    path: Self::config_path()?.join("wallet.db"),
+                    spawn_mode,
+                };
+                let namespace = linera_storage::DEFAULT_NAMESPACE.to_string();
+                Ok(StorageConfig {
+                    inner_storage_config,
+                    namespace,
+                })
+            } else {
+                bail!("Cannot apply default storage because the feature 'rocksdb' was not selected");
+            }
+        }
+    }
+
+    pub fn wallet_path(&self) -> Result<PathBuf, Error> {
+        if let Some(path) = &self.wallet_state_path {
+            return Ok(path.clone());
+        }
+        let suffix = self.suffix();
+        let wallet_env_var = env::var(format!("LINERA_WALLET{suffix}")).ok();
+        if let Some(path) = wallet_env_var {
+            return Ok(path.parse()?);
+        }
+        let config_path = Self::config_path()?;
+        Ok(config_path.join("wallet.json"))
+    }
+
+    pub fn keystore_path(&self) -> Result<PathBuf, Error> {
+        if let Some(path) = &self.keystore_path {
+            return Ok(path.clone());
+        }
+        let suffix = self.suffix();
+        let keystore_env_var = env::var(format!("LINERA_KEYSTORE{suffix}")).ok();
+        if let Some(path) = keystore_env_var {
+            return Ok(path.parse()?);
+        }
+        let config_path = Self::config_path()?;
+        Ok(config_path.join("keystore.json"))
+    }
+
+    pub fn wallet(&self) -> Result<Wallet, Error> {
+        Ok(Wallet::read(&self.wallet_path()?)?)
+    }
+
+    pub fn signer(&self) -> Result<persistent::File<InMemorySigner>, Error> {
+        Ok(persistent::File::read(&self.keystore_path()?)?)
+    }
+
+    pub fn create_wallet(&self, genesis_config: GenesisConfig) -> Result<Wallet, Error> {
+        let wallet_path = self.wallet_path()?;
+        if wallet_path.exists() {
+            bail!("Wallet already exists: {}", wallet_path.display());
+        }
+        let wallet = Wallet::create(&wallet_path, genesis_config)?;
+        wallet.save()?;
+        Ok(wallet)
+    }
+
+    pub fn create_keystore(
+        &self,
+        testing_prng_seed: Option<u64>,
+    ) -> Result<persistent::File<InMemorySigner>, Error> {
+        let keystore_path = self.keystore_path()?;
+        if keystore_path.exists() {
+            bail!("Keystore already exists: {}", keystore_path.display());
+        }
+        Ok(persistent::File::read_or_create(&keystore_path, || {
+            Ok(InMemorySigner::new(testing_prng_seed))
+        })?)
+    }
+}

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1890,12 +1890,12 @@ fn init_tracing(options: &Options) {
 
 fn main() -> anyhow::Result<process::ExitCode> {
     let options = Options::init();
-    let mut runtime = if options.tokio_threads == Some(1) {
+    let mut runtime = if options.common.tokio_threads == Some(1) {
         tokio::runtime::Builder::new_current_thread()
     } else {
         let mut builder = tokio::runtime::Builder::new_multi_thread();
 
-        if let Some(threads) = options.tokio_threads {
+        if let Some(threads) = options.common.tokio_threads {
             builder.worker_threads(threads);
         }
 
@@ -1904,12 +1904,12 @@ fn main() -> anyhow::Result<process::ExitCode> {
 
     // The default stack size 2 MiB causes some stack overflows in ValidatorUpdater methods.
     runtime.thread_stack_size(4 << 20);
-    if let Some(blocking_threads) = options.tokio_blocking_threads {
+    if let Some(blocking_threads) = options.common.tokio_blocking_threads {
         runtime.max_blocking_threads(blocking_threads);
     }
 
     let span = tracing::info_span!("linera::main");
-    if let Some(wallet_id) = &options.with_wallet {
+    if let Some(wallet_id) = &options.common.with_wallet {
         span.record("wallet_id", wallet_id);
     }
 
@@ -2258,7 +2258,7 @@ async fn run(options: &Options) -> Result<i32, Error> {
                     *block_exporter_port,
                     path,
                     // Not using the default value for storage
-                    &options.storage_config,
+                    &options.common.storage_config,
                     external_protocol.clone(),
                     *with_faucet,
                     *faucet_chain,

--- a/linera-service/src/cli/mod.rs
+++ b/linera-service/src/cli/mod.rs
@@ -4,5 +4,6 @@
 //! Helper module for the Linera CLI binary.
 
 pub mod command;
+pub mod common_options;
 pub mod net_up_utils;
 pub mod validator;

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -1,19 +1,19 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, path::PathBuf};
+use std::path::PathBuf;
 
-use anyhow::{anyhow, bail, Error};
+use anyhow::Error;
 use linera_base::crypto::InMemorySigner;
 use linera_client::{client_context::ClientContext, config::GenesisConfig};
-use linera_execution::{WasmRuntime, WithWasmDefault as _};
+use linera_execution::WithWasmDefault as _;
 use linera_persistent as persistent;
 use linera_service::{
-    cli::command::ClientCommand,
-    storage::{CommonStorageOptions, Runnable, RunnableWithStore, StorageConfig},
+    cli::{command::ClientCommand, common_options::CommonCliOptions},
+    storage::{Runnable, RunnableWithStore, StorageConfig},
     Wallet,
 };
-use tracing::{debug, info};
+use tracing::debug;
 
 #[derive(Clone, clap::Parser)]
 #[command(
@@ -26,20 +26,9 @@ pub struct Options {
     #[command(flatten)]
     pub client_options: linera_client::Options,
 
-    /// Sets the file storing the private state of user chains (an empty one will be created if missing)
-    #[arg(long = "wallet")]
-    pub wallet_state_path: Option<PathBuf>,
-
-    /// Sets the file storing the keystore state.
-    #[arg(long = "keystore")]
-    pub keystore_path: Option<PathBuf>,
-
-    /// Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet
-    /// storage config from the environment variables `LINERA_WALLET_{X}` and
-    /// `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and
-    /// `LINERA_STORAGE`.
-    #[arg(long, short = 'w', value_parser = crate::util::parse_ascii_alphanumeric_string)]
-    pub with_wallet: Option<String>,
+    /// Common wallet, keystore, and storage options.
+    #[command(flatten)]
+    pub common: CommonCliOptions,
 
     /// Enable OpenTelemetry Chrome JSON exporter for trace data analysis.
     #[arg(long)]
@@ -53,30 +42,6 @@ pub struct Options {
     /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
     #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
     pub otlp_exporter_endpoint: Option<String>,
-
-    /// Storage configuration for the blockchain history.
-    #[arg(long = "storage", global = true)]
-    pub storage_config: Option<String>,
-
-    /// Common storage options.
-    #[command(flatten)]
-    pub common_storage_options: CommonStorageOptions,
-
-    /// The WebAssembly runtime to use.
-    #[arg(long)]
-    pub wasm_runtime: Option<WasmRuntime>,
-
-    /// Output log messages from contract execution.
-    #[arg(long = "with-application-logs", env = "LINERA_APPLICATION_LOGS")]
-    pub application_logs: bool,
-
-    /// The number of Tokio worker threads to use.
-    #[arg(long, env = "LINERA_CLIENT_TOKIO_THREADS")]
-    pub tokio_threads: Option<usize>,
-
-    /// The number of Tokio blocking threads to use.
-    #[arg(long, env = "LINERA_CLIENT_TOKIO_BLOCKING_THREADS")]
-    pub tokio_blocking_threads: Option<usize>,
 
     /// Subcommand.
     #[command(subcommand)]
@@ -117,10 +82,10 @@ impl Options {
         let storage_config = self.storage_config()?;
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
-            storage_config.add_common_storage_options(&self.common_storage_options)?;
+            storage_config.add_common_storage_options(&self.common.common_storage_options)?;
         let output = Box::pin(store_config.run_with_storage(
-            self.wasm_runtime.with_wasm_default(),
-            self.application_logs,
+            self.common.wasm_runtime.with_wasm_default(),
+            self.common.application_logs,
             job,
         ))
         .await?;
@@ -136,7 +101,7 @@ impl Options {
         let storage_config = self.storage_config()?;
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
-            storage_config.add_common_storage_options(&self.common_storage_options)?;
+            storage_config.add_common_storage_options(&self.common.common_storage_options)?;
         if assert_storage_v1 {
             store_config
                 .clone()
@@ -157,114 +122,39 @@ impl Options {
         let storage_config = self.storage_config()?;
         debug!("Initializing storage using configuration: {storage_config}");
         let store_config =
-            storage_config.add_common_storage_options(&self.common_storage_options)?;
+            storage_config.add_common_storage_options(&self.common.common_storage_options)?;
         let wallet = self.wallet()?;
         store_config.initialize(wallet.genesis_config()).await?;
         Ok(())
     }
 
-    pub fn wallet(&self) -> Result<Wallet, Error> {
-        Ok(Wallet::read(&self.wallet_path()?)?)
-    }
+    // Delegation methods to CommonCliOptions, keeping the existing API surface
+    // for call sites in main.rs.
 
-    pub fn signer(&self) -> Result<persistent::File<InMemorySigner>, Error> {
-        Ok(persistent::File::read(&self.keystore_path()?)?)
-    }
-
-    pub fn suffix(&self) -> String {
-        self.with_wallet
-            .as_ref()
-            .map(|x| format!("_{}", x))
-            .unwrap_or_default()
-    }
-
-    pub fn config_path() -> Result<PathBuf, Error> {
-        let mut config_dir = dirs::config_dir().ok_or_else(|| anyhow!(
-            "Default wallet directory is not supported in this platform: please specify storage and wallet paths"
-        ))?;
-        config_dir.push("linera");
-        if !config_dir.exists() {
-            debug!("Creating default wallet directory {}", config_dir.display());
-            fs_err::create_dir_all(&config_dir)?;
-        }
-        info!("Using default wallet directory {}", config_dir.display());
-        Ok(config_dir)
-    }
-
-    pub fn storage_config(&self) -> Result<StorageConfig, Error> {
-        if let Some(config) = &self.storage_config {
-            return config.parse();
-        }
-        let suffix = self.suffix();
-        let storage_env_var = env::var(format!("LINERA_STORAGE{suffix}")).ok();
-        if let Some(config) = storage_env_var {
-            return config.parse();
-        }
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "rocksdb")] {
-                let spawn_mode =
-                    linera_views::rocks_db::RocksDbSpawnMode::get_spawn_mode_from_runtime();
-                let inner_storage_config = linera_service::storage::InnerStorageConfig::RocksDb {
-                    path: Self::config_path()?.join("wallet.db"),
-                    spawn_mode,
-                };
-                let namespace = linera_storage::DEFAULT_NAMESPACE.to_string();
-                Ok(StorageConfig {
-                    inner_storage_config,
-                    namespace,
-                })
-            } else {
-                bail!("Cannot apply default storage because the feature 'rocksdb' was not selected");
-            }
-        }
+    fn storage_config(&self) -> Result<StorageConfig, Error> {
+        self.common.storage_config()
     }
 
     pub fn wallet_path(&self) -> Result<PathBuf, Error> {
-        if let Some(path) = &self.wallet_state_path {
-            return Ok(path.clone());
-        }
-        let suffix = self.suffix();
-        let wallet_env_var = env::var(format!("LINERA_WALLET{suffix}")).ok();
-        if let Some(path) = wallet_env_var {
-            return Ok(path.parse()?);
-        }
-        let config_path = Self::config_path()?;
-        Ok(config_path.join("wallet.json"))
+        self.common.wallet_path()
     }
 
-    pub fn keystore_path(&self) -> Result<PathBuf, Error> {
-        if let Some(path) = &self.keystore_path {
-            return Ok(path.clone());
-        }
-        let suffix = self.suffix();
-        let keystore_env_var = env::var(format!("LINERA_KEYSTORE{suffix}")).ok();
-        if let Some(path) = keystore_env_var {
-            return Ok(path.parse()?);
-        }
-        let config_path = Self::config_path()?;
-        Ok(config_path.join("keystore.json"))
+    pub fn wallet(&self) -> Result<Wallet, Error> {
+        self.common.wallet()
+    }
+
+    pub fn signer(&self) -> Result<persistent::File<InMemorySigner>, Error> {
+        self.common.signer()
     }
 
     pub fn create_wallet(&self, genesis_config: GenesisConfig) -> Result<Wallet, Error> {
-        let wallet_path = self.wallet_path()?;
-        if wallet_path.exists() {
-            bail!("Wallet already exists: {}", wallet_path.display());
-        }
-        let wallet = Wallet::create(&wallet_path, genesis_config)?;
-        wallet.save()?;
-        Ok(wallet)
+        self.common.create_wallet(genesis_config)
     }
 
     pub fn create_keystore(
         &self,
         testing_prng_seed: Option<u64>,
     ) -> Result<persistent::File<InMemorySigner>, Error> {
-        let keystore_path = self.keystore_path()?;
-        if keystore_path.exists() {
-            bail!("Keystore already exists: {}", keystore_path.display());
-        }
-        Ok(persistent::File::read_or_create(&keystore_path, || {
-            Ok(InMemorySigner::new(testing_prng_seed))
-        })?)
+        self.common.create_keystore(testing_prng_seed)
     }
 }


### PR DESCRIPTION
## Motivation

The `linera` binary's CLI `Options` struct bundles wallet, keystore, and storage
configuration fields that other tools (e.g. `pm-benchmark`) also need. Currently these
fields and their associated methods live in a private module of the binary
(`linera-service/src/cli/options.rs`), so external consumers must duplicate them.

## Proposal

Extract the shared wallet/keystore/storage CLI options into a new public struct
`CommonClientOptions` in the linera-service library crate
(`linera-service/src/cli/common_options.rs`). The binary's `Options` struct now flattens
`CommonClientOptions` via `#[command(flatten)]` and provides thin delegation methods to
preserve the existing API surface used by `main.rs`.

The CLI behavior is unchanged — all flags, env vars, and defaults remain identical.

## Test Plan

- CI
