### PR TITLE
Disable remote-kubernetes-net-test from automated CI triggers

### DIFF
--- a/.github/workflows/remote-kubernetes-net-test.yml
+++ b/.github/workflows/remote-kubernetes-net-test.yml
@@ -1,10 +1,6 @@
 name: Remote Kubernetes Net Test
 
 on:
-  push:
-    branches: [ 'devnet_*', 'testnet_*' ]
-  pull_request:
-  merge_group:
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull requests
@@ -34,7 +30,6 @@ permissions:
 
 jobs:
   remote-kubernetes-net-test:
-    if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 90
 


### PR DESCRIPTION
## Motivation

The `remote-kubernetes-net-test` workflow is currently failing on every merge queue run.

## Proposal

Restrict the workflow to `workflow_dispatch` only (manual trigger), removing it from
`merge_group`, `pull_request`, and `push` triggers. This unblocks the merge queue
immediately. The fix for the underlying bug and re-enablement will follow in a separate
PR.

## Test Plan

- CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
