### PR TITLE
Disable remote-net-test from automated CI triggers

### DIFF
--- a/.github/workflows/remote-net-test.yml
+++ b/.github/workflows/remote-net-test.yml
@@ -1,10 +1,6 @@
 name: Remote Net Test
 
 on:
-  push:
-    branches: [ 'devnet_*', 'testnet_*' ]
-  pull_request:
-  merge_group:
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull requests
@@ -34,7 +30,6 @@ permissions:
 
 jobs:
   remote-net-test:
-    if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 


### PR DESCRIPTION
## Motivation

The `remote-net-test` CI workflow is failing on the merge queue.

## Proposal

Disable the `remote-net-test` workflow from automated CI triggers (`push`,
`pull_request`, `merge_group`) while keeping it available for manual runs via
`workflow_dispatch`. This is the same approach used in #5531 for
`remote-kubernetes-net-test`.

This should unblock the merge queue until we get the test fixed.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
