### PR TITLE
Fix misleading Grafana dashboard metrics

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -1096,10 +1096,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_network_transmit_bytes_total{validator=~\"$validator\",pod=~\"shards-.*\"}[60s]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{validator=~\"$validator\",pod=~\"(proxy|shards)-.*\"}[60s]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "tx - Total shards",
+          "legendFormat": "tx - Total",
           "range": true,
           "refId": "D"
         }
@@ -1208,10 +1208,10 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_network_receive_bytes_total{validator=~\"$validator\",pod=~\"shards-.*\"}[60s]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{validator=~\"$validator\",pod=~\"(proxy|shards)-.*\"}[60s]))",
           "hide": false,
           "instant": false,
-          "legendFormat": "tx - Total shards",
+          "legendFormat": "rx - Total",
           "range": true,
           "refId": "D"
         }
@@ -1519,25 +1519,12 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{validator=~\"$validator\",container=~\"linera-.*\"}[60s])) by (container)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{container}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "prometheus"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(container_cpu_usage_seconds_total{validator=~\"$validator\"}[60s]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{validator=~\"$validator\",pod=~\"(proxy|shards)-.*\"}[60s]))",
           "hide": false,
           "instant": false,
           "legendFormat": "Total",
           "range": true,
-          "refId": "C"
+          "refId": "B"
         }
       ],
       "title": "Container CPU Usage",

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
@@ -2139,10 +2139,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_contains_blobs{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_contains_blobs{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_contains_blobs{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Contains Blobs Rate",
@@ -2235,10 +2247,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_contains_blob_state{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_contains_blob_state{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_contains_blob_state{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Contains Blob State Rate",
@@ -2331,10 +2355,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_write_event{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_write_event{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_write_event{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Write Event Rate",
@@ -2427,10 +2463,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_event{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_event{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_event{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Read Event Rate",
@@ -2523,7 +2571,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_certificates{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_certificates{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -2631,10 +2679,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_certificate{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_certificate{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_certificate{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Read Certificate Rate (single)",
@@ -2727,10 +2787,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_blob_states{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_blob_states{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_blob_states{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Read Blob States Rate (batch)",
@@ -2823,10 +2895,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_blob_state{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_blob_state{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_blob_state{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Read Blob State Rate (single)",
@@ -2919,10 +3003,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_write_blob{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_write_blob{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_write_blob{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Write Blob Rate",
@@ -3015,10 +3111,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_blob{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_blob{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_blob{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Read Blob Rate",
@@ -3111,7 +3219,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_write_certificate{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_write_certificate{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
@@ -3219,10 +3327,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_read_confirmed_block{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_read_confirmed_block{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_read_confirmed_block{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Read Confirmed Block Rate",
@@ -3315,10 +3435,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_contains_blob{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_contains_blob{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_contains_blob{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Contains Blob Rate",
@@ -3411,10 +3543,22 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(linera_contains_certificate{validator=~\"$validator\"}[1m])) by (pod)",
+          "expr": "sum(rate(linera_contains_certificate{validator=~\"$validator\",pod!=\"\"}[1m])) by (pod)",
           "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_contains_certificate{validator=~\"$validator\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Contains Certificate Rate",


### PR DESCRIPTION
## Motivation

Several Grafana dashboard panels show misleading or incorrect metrics:
- "Container CPU Usage" total sums ALL pods instead of just proxy + shards
- Network TX/RX totals only include shards, missing proxy traffic
- Network RX total legend says "tx" instead of "rx" (copy-paste bug)
- Storage rate panels lack a "Total" series (inconsistent with other panels)
- Storage rate panels show ghost "Value" series from metrics with empty pod labels

## Proposal

**general.json:**
- Add `pod=~"(proxy|shards)-.*"` filter to CPU "Total" query and remove redundant
per-container query
- Fix Network TX/RX total queries to include both proxy and shards (was shards-only)
- Fix RX total legend from "tx - Total shards" to "rx - Total"

**storage/storage.json:**
- Add "Total" query to all 12 rate panels that were missing it, matching the pattern
already used by Read Certificates Rate and Write Certificate Rate
- Add `pod!=""` filter to all per-pod rate queries to eliminate ghost "Value" series
from metrics without pod labels

## Test Plan

Loaded the modified dashboard JSON directly into the central monitoring
(monitoring.infra.linera.net) and verified:
- CPU Total now shows only proxy + shards CPU
- Network TX/RX totals include both proxy and shards
- All storage rate panels show per-pod breakdown + Total
- No more ghost "Value" series

