### PR TITLE
Add missing linera-bridge COPY to indexer Dockerfile

### DIFF
--- a/docker/Dockerfile.exporter
+++ b/docker/Dockerfile.exporter
@@ -67,7 +67,6 @@ COPY linera-views-derive linera-views-derive
 COPY web web
 COPY linera-witty linera-witty
 COPY linera-witty-macros linera-witty-macros
-COPY linera-bridge linera-bridge
 COPY scripts scripts
 COPY rust-toolchain* Cargo.* ./
 

--- a/docker/Dockerfile.indexer
+++ b/docker/Dockerfile.indexer
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y \
 
 COPY examples examples
 COPY linera-base linera-base
+COPY linera-bridge linera-bridge
 COPY linera-chain linera-chain
 COPY linera-client linera-client
 COPY linera-core linera-core


### PR DESCRIPTION
## Summary
- Add missing `COPY linera-bridge linera-bridge` to `Dockerfile.indexer`, fixing the
workspace resolution failure during the indexer Docker build on `testnet_conway`
- Remove duplicate `COPY linera-bridge linera-bridge` from `Dockerfile.exporter`
(present at both line 45 and line 70)

## Motivation

The `linera-bridge` crate was added to the workspace members in commit 32bd7928a6b but
`Dockerfile.indexer` was never updated to copy it into the Docker build context. When
Cargo resolves the workspace, it finds `linera-bridge` in the members list but the
directory doesn't exist, causing:

```
error: failed to load manifest for workspace member /linera-bridge
failed to read /linera-bridge/Cargo.toml
No such file or directory (os error 2)
```

This broke the `build-and-push` CI job:
https://github.com/linera-io/linera-protocol/actions/runs/22497940147/job/65177257202

## Test Plan
- [ ] Verify `build-and-push` CI job passes (indexer image builds successfully)
