### PR TITLE
[testnet] Fix flaky `test_controller`

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4842,6 +4842,10 @@ async fn test_controller(config: impl LineraNetConfig) -> Result<()> {
     assert_eq!(state.local_services.len(), 1);
     assert_eq!(state.local_services[0].name, "test-service");
 
+    // Sync the service chain on node_service1 so that it downloads the ChainDescription blob
+    // from validators. Without this, the query can fail with BlobsNotFound because the chain
+    // was opened on a different node and has no blocks yet.
+    node_service1.sync(&service_chain).await?;
     let task_app = node_service1.make_application(&service_chain, &task_processor_id)?;
     let task_count: u64 = task_app.query_json("taskCount").await?;
     assert_eq!(task_count, 0, "Initial task count should be 0");


### PR DESCRIPTION
(Motivated by https://github.com/linera-io/linera-protocol/pull/5524, but ownership management was reverted on `testnet_conway` in #5539, so most of it does not apply.)

## Motivation

The service client's node service used `ProcessInbox::Automatic`, which could non-deterministically process inbox messages and create extra blocks on the service chain before the `RequestTask` mutation, shifting hardcoded block heights and causing test failures.

Also, when `node_service1` queries `taskCount` on `service_chain`, it doesn't have the chain description yet. Since `service_chain` has no blocks yet, there are no notifications to trigger blob download. (On `main`, `change_application_permissions` creates block 0 and a notification.

## Proposal

Use `ProcessInbox::Skip`. Call `node_service1.sync(&service_chain).await?` to fetch the chain description.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- Revisit once ownership management is backported. (See #5539)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
