### PR TITLE
Enable frame pointers for x86_64-linux-gnu local builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@ linker = "aarch64-linux-gnu-gcc"
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes"]
 
 [build]
 # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.


### PR DESCRIPTION
## Motivation

Local cross-compilation to `x86_64-linux-gnu` doesn't enable frame pointers, while Docker
production builds do (via `RUSTFLAGS="-C force-frame-pointers=yes"` in the Dockerfile).
This makes locally-built binaries harder to profile with CPU profilers like perf and
Pyroscope's eBPF sampler, which rely on frame pointers for accurate stack unwinding.

## Proposal

Add `-C force-frame-pointers=yes` to the existing
`[target.x86_64-unknown-linux-gnu].rustflags` in `.cargo/config.toml`, making local
cross-compilation consistent with Docker builds.
This should make local debugging less painful.

## Test Plan

- Verified `cargo check -p linera-base` compiles successfully with the updated config.
- CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
