### PR TITLE
[backport] Move proxy metrics into tower middleware (#5534)

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -26,8 +26,10 @@ use linera_core::{
 };
 #[cfg(with_metrics)]
 use linera_metrics::monitoring_server;
+#[cfg(all(with_metrics, feature = "opentelemetry"))]
+use linera_rpc::propagation::get_traffic_type_from_request;
 #[cfg(feature = "opentelemetry")]
-use linera_rpc::propagation::{get_traffic_type_from_request, OtelContextLayer};
+use linera_rpc::propagation::OtelContextLayer;
 use linera_rpc::{
     config::{ProxyConfig, ShardConfig, TlsConfig, ValidatorInternalNetworkConfig},
     grpc::{
@@ -125,10 +127,10 @@ impl<S> Layer<S> for PrometheusMetricsMiddlewareLayer {
     }
 }
 
-impl<S, B> Service<http::Request<B>> for PrometheusMetricsMiddlewareService<S>
+impl<S, B, ResponseBody> Service<http::Request<B>> for PrometheusMetricsMiddlewareService<S>
 where
+    S: Service<http::Request<B>, Response = http::Response<ResponseBody>> + Send,
     S::Future: Send + 'static,
-    S: Service<http::Request<B>> + std::marker::Send,
     B: Send + 'static,
 {
     type Response = S::Response;
@@ -143,9 +145,21 @@ where
         #[cfg(with_metrics)]
         let start = linera_base::time::Instant::now();
 
-        // Extract traffic type from request extensions (set by OtelContextLayer).
-        // Falls back to "unknown" if opentelemetry feature is disabled.
-        // When opentelemetry is enabled but no baggage is set, defaults to "organic".
+        // Extract the gRPC method name from the URI path. gRPC paths have the form
+        // `/{package}.{Service}/{Method}` — the first segment always contains a dot.
+        // Non-gRPC requests (bot probes, health checks, etc.) are bucketed as
+        // "non_grpc" to prevent unbounded label cardinality.
+        #[cfg(with_metrics)]
+        let method_name = {
+            let path = request.uri().path();
+            let parts: Vec<&str> = path.splitn(3, '/').collect();
+            if parts.len() == 3 && parts[1].contains('.') {
+                parts[2].to_owned()
+            } else {
+                "non_grpc".to_owned()
+            }
+        };
+
         #[cfg(all(with_metrics, feature = "opentelemetry"))]
         let traffic_type: &'static str = get_traffic_type_from_request(&request);
         #[cfg(all(with_metrics, not(feature = "opentelemetry")))]
@@ -162,6 +176,23 @@ where
                 metrics::PROXY_REQUEST_COUNT
                     .with_label_values(&[traffic_type])
                     .inc();
+
+                let is_error = !response.status().is_success()
+                    || response
+                        .headers()
+                        .get("grpc-status")
+                        .and_then(|v| v.to_str().ok())
+                        .is_some_and(|s| s != "0");
+
+                if is_error {
+                    metrics::PROXY_REQUEST_ERROR
+                        .with_label_values(&[&method_name, traffic_type])
+                        .inc();
+                } else {
+                    metrics::PROXY_REQUEST_SUCCESS
+                        .with_label_values(&[&method_name, traffic_type])
+                        .inc();
+                }
             }
             Ok(response)
         }
@@ -343,19 +374,6 @@ where
         }
     }
 
-    /// Extracts traffic type from request for metrics labeling.
-    /// Returns "organic", "synthetic", or "unknown".
-    #[cfg(feature = "opentelemetry")]
-    fn extract_traffic_type<R>(request: &Request<R>) -> &'static str {
-        get_traffic_type_from_request(request)
-    }
-
-    /// Returns "unknown" traffic type when opentelemetry is disabled.
-    #[cfg(not(feature = "opentelemetry"))]
-    fn extract_traffic_type<R>(_request: &Request<R>) -> &'static str {
-        "unknown"
-    }
-
     /// Creates a tonic::Request with OpenTelemetry context injected for forwarding.
     ///
     /// Gets the context from the current tracing span (which has the parent set by
@@ -390,31 +408,6 @@ where
             .worker_client_for_shard(&shard)
             .map_err(|_| Status::internal("could not connect to shard"))?;
         Ok((client, inner))
-    }
-
-    #[allow(clippy::result_large_err)]
-    fn log_and_return_proxy_request_outcome(
-        result: Result<Response<ChainInfoResult>, Status>,
-        method_name: &str,
-        traffic_type: &str,
-    ) -> Result<Response<ChainInfoResult>, Status> {
-        #![allow(unused_variables)]
-        match result {
-            Ok(chain_info_result) => {
-                #[cfg(with_metrics)]
-                metrics::PROXY_REQUEST_SUCCESS
-                    .with_label_values(&[method_name, traffic_type])
-                    .inc();
-                Ok(chain_info_result)
-            }
-            Err(status) => {
-                #[cfg(with_metrics)]
-                metrics::PROXY_REQUEST_ERROR
-                    .with_label_values(&[method_name, traffic_type])
-                    .inc();
-                Err(status)
-            }
-        }
     }
 
     /// Returns the appropriate gRPC status for the given [`ViewError`].
@@ -545,14 +538,10 @@ where
         &self,
         request: Request<BlockProposal>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        Self::log_and_return_proxy_request_outcome(
-            client.handle_block_proposal(forwarding_request).await,
-            "handle_block_proposal",
-            traffic_type,
-        )
+        client
+            .handle_block_proposal(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(skip_all, err(Display), fields(method = "handle_lite_certificate"))]
@@ -560,14 +549,10 @@ where
         &self,
         request: Request<LiteCertificate>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        Self::log_and_return_proxy_request_outcome(
-            client.handle_lite_certificate(forwarding_request).await,
-            "handle_lite_certificate",
-            traffic_type,
-        )
+        client
+            .handle_lite_certificate(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(
@@ -579,16 +564,10 @@ where
         &self,
         request: Request<api::HandleConfirmedCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        Self::log_and_return_proxy_request_outcome(
-            client
-                .handle_confirmed_certificate(forwarding_request)
-                .await,
-            "handle_confirmed_certificate",
-            traffic_type,
-        )
+        client
+            .handle_confirmed_certificate(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(
@@ -600,16 +579,10 @@ where
         &self,
         request: Request<api::HandleValidatedCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        Self::log_and_return_proxy_request_outcome(
-            client
-                .handle_validated_certificate(forwarding_request)
-                .await,
-            "handle_validated_certificate",
-            traffic_type,
-        )
+        client
+            .handle_validated_certificate(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(skip_all, err(Display), fields(method = "handle_timeout_certificate"))]
@@ -617,14 +590,10 @@ where
         &self,
         request: Request<api::HandleTimeoutCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        Self::log_and_return_proxy_request_outcome(
-            client.handle_timeout_certificate(forwarding_request).await,
-            "handle_timeout_certificate",
-            traffic_type,
-        )
+        client
+            .handle_timeout_certificate(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(skip_all, err(Display), fields(method = "handle_chain_info_query"))]
@@ -632,14 +601,10 @@ where
         &self,
         request: Request<api::ChainInfoQuery>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        Self::log_and_return_proxy_request_outcome(
-            client.handle_chain_info_query(forwarding_request).await,
-            "handle_chain_info_query",
-            traffic_type,
-        )
+        client
+            .handle_chain_info_query(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(skip_all, err(Display), fields(method = "subscribe"))]
@@ -720,27 +685,10 @@ where
         &self,
         request: Request<PendingBlobRequest>,
     ) -> Result<Response<PendingBlobResult>, Status> {
-        #[cfg_attr(not(with_metrics), allow(unused_variables))]
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        #[cfg_attr(not(with_metrics), expect(clippy::needless_match))]
-        match client.download_pending_blob(forwarding_request).await {
-            Ok(blob_result) => {
-                #[cfg(with_metrics)]
-                metrics::PROXY_REQUEST_SUCCESS
-                    .with_label_values(&["download_pending_blob", traffic_type])
-                    .inc();
-                Ok(blob_result)
-            }
-            Err(status) => {
-                #[cfg(with_metrics)]
-                metrics::PROXY_REQUEST_ERROR
-                    .with_label_values(&["download_pending_blob", traffic_type])
-                    .inc();
-                Err(status)
-            }
-        }
+        client
+            .download_pending_blob(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(skip_all, err(Display), fields(method = "handle_pending_blob"))]
@@ -748,27 +696,10 @@ where
         &self,
         request: Request<HandlePendingBlobRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        #[cfg_attr(not(with_metrics), allow(unused_variables))]
-        let traffic_type = Self::extract_traffic_type(&request);
         let (mut client, inner) = self.worker_client(request)?;
-        let forwarding_request = Self::create_forwarding_request(inner);
-        #[cfg_attr(not(with_metrics), expect(clippy::needless_match))]
-        match client.handle_pending_blob(forwarding_request).await {
-            Ok(blob_result) => {
-                #[cfg(with_metrics)]
-                metrics::PROXY_REQUEST_SUCCESS
-                    .with_label_values(&["handle_pending_blob", traffic_type])
-                    .inc();
-                Ok(blob_result)
-            }
-            Err(status) => {
-                #[cfg(with_metrics)]
-                metrics::PROXY_REQUEST_ERROR
-                    .with_label_values(&["handle_pending_blob", traffic_type])
-                    .inc();
-                Err(status)
-            }
-        }
+        client
+            .handle_pending_blob(Self::create_forwarding_request(inner))
+            .await
     }
 
     #[instrument(skip_all, err(Display), fields(method = "download_certificate"))]


### PR DESCRIPTION
## Motivation

Backport of the tower middleware metrics refactor from #5534 (commit `4df8540`) to
`testnet_conway`.

On `main`, per-handler success/error metric tracking was moved into the
`PrometheusMetricsMiddlewareService` tower layer so that every gRPC endpoint gets
automatic coverage. This eliminates the class of bugs where a new or modified handler
forgets to call the metric helpers (exactly what caused the cardinality panic fixed by
#5534).

## Proposal

- Move `PROXY_REQUEST_SUCCESS` / `PROXY_REQUEST_ERROR` tracking into the tower
middleware by inspecting the HTTP status and `grpc-status` header on every response.
- Extract the method name from the URI path in the middleware.
- Remove `extract_traffic_type` and `log_and_return_proxy_request_outcome` helper
methods
(no longer needed).
- Simplify all 8 proxy handler bodies to just forward the request and return the result.
- Preserve Conway's `create_forwarding_request` for OpenTelemetry context propagation on
pending blob handlers (which `main` never had — not regressing that).

Note: the cardinality fix commit (`0d96715`) was **not** backported because that bug
only
existed on `main` (introduced during the forward-port of #5334). The CI workflow commit
(`8572862`) was also skipped because `remote-kubernetes-net-test.yml` doesn't exist on
`testnet_conway`.

## Test Plan

- CI
- Will deploy this on my test network to make sure everything is ok
