### PR TITLE
Restore lint-check-all-features skip behavior on PRs

### DIFF
--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
   pull_request:
-    paths:
-      - '.github/workflows/lint-check-all-features.yml'
   merge_group:
   workflow_dispatch:
 
@@ -30,6 +28,7 @@ permissions:
 
 jobs:
   check-all-features-partition:
+    if: github.event_name != 'pull_request'
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 30
     strategy:
@@ -58,6 +57,7 @@ jobs:
     if: always()
     steps:
     - run: |
-        if [ "${{ needs.check-all-features-partition.result }}" != "success" ]; then
+        result="${{ needs.check-all-features-partition.result }}"
+        if [ "$result" != "success" ] && [ "$result" != "skipped" ]; then
           exit 1
         fi


### PR DESCRIPTION
## Motivation

PR #5543 changed the `pull_request` trigger to use a `paths` filter, so the workflow
only fires when the workflow file itself is modified. This causes
`lint-check-all-features` to show as permanently "pending" on all other PRs because the
required status check is never reported to branch protection.

## Proposal

Restore the pattern used before #5543: trigger on all PRs but skip the expensive
partition jobs with `if: github.event_name != 'pull_request'`. The summary job accepts
`skipped` as a passing result, so it reports success immediately without using any
self-hosted runner time.

- Remove `paths` filter from `pull_request` trigger
- Add `if: github.event_name != 'pull_request'` on the partition jobs
- Accept `skipped` as a passing result in the summary job

## Test Plan

- Verify on this PR that `lint-check-all-features` reports as passing (not pending)
- Verify the partition jobs are skipped (no self-hosted runner usage on PRs)
- Merge queue still runs the full check
