### PR TITLE
Move CI concurrency groups from workflow level to per-job

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -34,6 +29,9 @@ permissions:
 
 jobs:
   benchmark-test:
+    concurrency:
+      group: 'benchmark-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}"
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -30,6 +25,9 @@ permissions:
 
 jobs:
   compose:
+    concurrency:
+      group: 'compose @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -12,11 +12,6 @@ on:
       - 'scripts/**'
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} ${{ github.ref }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -32,6 +27,9 @@ permissions:
 jobs:
 
   publish-docs:
+    concurrency:
+      group: 'publish-docs @ ${{ github.ref }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 20
 
@@ -57,6 +55,9 @@ jobs:
         force_orphan: true
 
   test-crates-and-docrs:
+    concurrency:
+      group: 'test-crates-and-docrs @ ${{ github.ref }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 60
 

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -14,11 +14,6 @@ on:
       - 'linera-service/src/storage.rs'
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -34,6 +29,9 @@ permissions:
 jobs:
 
   test:
+    concurrency:
+      group: 'dynamodb-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -8,11 +8,6 @@ on:
       - "**"
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -27,6 +22,9 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
+    concurrency:
+      group: 'explorer-changed-files @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
@@ -45,6 +43,9 @@ jobs:
               - '!INSTALL.md'
 
   test:
+    concurrency:
+      group: 'explorer-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -26,6 +21,9 @@ permissions:
 
 jobs:
   indexer-check:
+    concurrency:
+      group: 'indexer-check @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
@@ -47,6 +45,9 @@ jobs:
         cargo test --locked -p linera-indexer --lib -- --skip db::postgres
 
   indexer-integration-tests:
+    concurrency:
+      group: 'indexer-integration-tests @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 20

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -28,6 +23,9 @@ permissions:
 
 jobs:
   check-all-features-partition:
+    concurrency:
+      group: 'check-all-features-partition @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: github.event_name != 'pull_request'
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 30
@@ -52,6 +50,9 @@ jobs:
         cargo hack check --each-feature --workspace --all-targets --partition ${{ matrix.partition }}/3
 
   lint-check-all-features:
+    concurrency:
+      group: 'lint-check-all-features @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: check-all-features-partition
     runs-on: linera-io-self-hosted-ci
     if: always()

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -23,6 +18,9 @@ env:
 
 jobs:
   long-faucet-chain-test:
+    concurrency:
+      group: 'long-faucet-chain-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -8,17 +8,15 @@ on:
       - completed
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.head_ref || github.event.workflow_run.head_commit.id || github.event.workflow_run.id || github.run_id }}'
-  cancel-in-progress: true
-
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
   performance-summary:
+    concurrency:
+      group: 'performance-summary @ ${{ github.head_ref || github.event.workflow_run.head_commit.id || github.event.workflow_run.id || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:

--- a/.github/workflows/remote-kubernetes-net-test.yml
+++ b/.github/workflows/remote-kubernetes-net-test.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -34,6 +29,9 @@ permissions:
 
 jobs:
   remote-kubernetes-net-test:
+    concurrency:
+      group: 'remote-kubernetes-net-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 90

--- a/.github/workflows/remote-net-test.yml
+++ b/.github/workflows/remote-net-test.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -34,6 +29,9 @@ permissions:
 
 jobs:
   remote-net-test:
+    concurrency:
+      group: 'remote-net-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,11 +9,6 @@ on:
       - "**"
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -37,6 +32,9 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
+    concurrency:
+      group: 'changed-files @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
@@ -55,6 +53,9 @@ jobs:
               - '!CONTRIBUTING.md'
               - '!INSTALL.md'
   changed-files-kubernetes:
+    concurrency:
+      group: 'changed-files-kubernetes @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
@@ -71,6 +72,9 @@ jobs:
               - '!CONTRIBUTING.md'
               - '!INSTALL.md'
   execution-wasmtime-test:
+    concurrency:
+      group: 'execution-wasmtime-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -84,6 +88,9 @@ jobs:
         cargo test --locked -p linera-execution --features wasmtime
 
   metrics-test:
+    concurrency:
+      group: 'metrics-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -97,6 +104,9 @@ jobs:
         cargo test --locked -p linera-base --features metrics
 
   wasm-application-test:
+    concurrency:
+      group: 'wasm-application-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -118,6 +128,9 @@ jobs:
         cargo test --locked
 
   linera-sdk-tests-fixtures:
+    concurrency:
+      group: 'linera-sdk-tests-fixtures @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -144,6 +157,9 @@ jobs:
         cargo clippy --all-targets --all-features --target wasm32-unknown-unknown --locked
 
   default-features-and-witty-integration-test:
+    concurrency:
+      group: 'default-features-and-witty-integration-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -168,6 +184,9 @@ jobs:
         cargo test -p linera-witty --features wasmer,wasmtime
 
   check-outdated-cli-md:
+    concurrency:
+      group: 'check-outdated-cli-md @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -190,6 +209,9 @@ jobs:
         fi
 
   ethereum-tests:
+    concurrency:
+      group: 'ethereum-tests @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -256,6 +278,9 @@ jobs:
 
 
   storage-service-tests:
+    concurrency:
+      group: 'storage-service-tests @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -284,6 +309,9 @@ jobs:
         cargo test --features storage-service,opentelemetry -- storage_service --nocapture
 
   check-wit-files:
+    concurrency:
+      group: 'check-wit-files @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -295,6 +323,9 @@ jobs:
         cargo run --bin wit-generator -- -c
 
   lint-unexpected-chain-load-operations:
+    concurrency:
+      group: 'lint-unexpected-chain-load-operations @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -307,6 +338,9 @@ jobs:
         ./scripts/check_chain_loads.sh
 
   lint-check-copyright-headers:
+    concurrency:
+      group: 'lint-check-copyright-headers @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -324,6 +358,9 @@ jobs:
         | xargs -0 scripts/target/release/check_copyright_header
 
   lint-cargo-machete:
+    concurrency:
+      group: 'lint-cargo-machete @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -343,6 +380,9 @@ jobs:
         cargo machete
 
   lint-cargo-fmt:
+    concurrency:
+      group: 'lint-cargo-fmt @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -359,6 +399,9 @@ jobs:
         cargo fmt -- --check
 
   lint-taplo-fmt:
+    concurrency:
+      group: 'lint-taplo-fmt @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -373,6 +416,9 @@ jobs:
       run: taplo fmt --check --diff
 
   lint-check-for-outdated-readme:
+    concurrency:
+      group: 'lint-check-for-outdated-readme @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -402,6 +448,9 @@ jobs:
         done
 
   lint-wasm-applications:
+    concurrency:
+      group: 'lint-wasm-applications @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -427,6 +476,9 @@ jobs:
         cargo fmt -- --check
 
   lint-cargo-clippy:
+    concurrency:
+      group: 'lint-cargo-clippy @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -453,6 +505,9 @@ jobs:
           -p linera-views
 
   lint-cargo-doc:
+    concurrency:
+      group: 'lint-cargo-doc @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci
@@ -473,6 +528,9 @@ jobs:
         cargo doc --locked --all-features
 
   lint-check-linera-service-graphql-schema:
+    concurrency:
+      group: 'lint-check-linera-service-graphql-schema @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -14,11 +14,6 @@ on:
       - 'linera-service/src/storage.rs'
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -34,6 +29,9 @@ permissions:
 jobs:
 
   test:
+    concurrency:
+      group: 'scylladb-test @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 50
 

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -7,11 +7,6 @@ on:
   merge_group:
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -34,6 +29,9 @@ permissions:
 
 jobs:
   test-readme-scripts:
+    concurrency:
+      group: 'test-readme-scripts @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -9,11 +9,6 @@ on:
       - "**"
   workflow_dispatch:
 
-# This allows a subsequently queued workflow run to interrupt previous runs on pull requests
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
@@ -35,6 +30,9 @@ permissions:
 
 jobs:
   changed-files:
+    concurrency:
+      group: 'web-changed-files @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
@@ -55,6 +53,9 @@ jobs:
               - '!INSTALL.md'
 
   web:
+    concurrency:
+      group: 'web @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+      cancel-in-progress: true
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: linera-io-self-hosted-ci


### PR DESCRIPTION
## Motivation

Re-running a failed CI job currently cancels all other jobs in the same workflow that
are still running, because all jobs share a single workflow-level concurrency group with
`cancel-in-progress: true`. This is especially painful in the `rust.yml` workflow which
has 21 independent jobs — a transient failure in a fast 2-minute lint job forces slow
40-minute test jobs to restart from scratch.

## Proposal

Move the `concurrency` block from the workflow level to each individual job, keyed on
the job name + PR identifier. Since none of the jobs within each workflow depend on each
other (except for `changed-files` gate jobs), each job only needs to cancel a previous
run of *itself*.

Before:
```yaml
concurrency:
group: '${{ github.workflow }} @ ${{ ... }}'
cancel-in-progress: true
```

After (per job):
```yaml
jobs:
some-job:
concurrency:
group: 'some-job @ ${{ ... }}'
cancel-in-progress: true
```

Applied consistently to all 15 workflow files that had workflow-level concurrency (43
jobs total). For jobs with generic names like `test` (in dynamodb.yml, scylladb.yml),
the group key is prefixed with the workflow name to avoid cross-workflow collisions.

| Scenario | Before | After |
|----------|--------|-------|
| New push to PR | All old jobs cancelled at once | Each old job cancelled individually
when its new counterpart starts |
| Re-run a failed job | All still-running jobs cancelled | Only that job is affected |

## Test Plan

- CI

## Release Plan

- These changes should be backported to the latest `testnet` branch
