### PR TITLE
Add validator address to subscription stream error logs

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -308,6 +308,7 @@ impl ValidatorNode for GrpcClient {
         let retry_delay = self.retry_delay;
         let max_retries = self.max_retries;
         let max_backoff = self.max_backoff;
+        let address = self.address.clone();
         // Use shared atomic counter so unfold can reset it on successful reconnection.
         let retry_count = Arc::new(AtomicU32::new(0));
         let subscription_request = SubscriptionRequest {
@@ -382,12 +383,12 @@ impl ValidatorNode for GrpcClient {
                     true
                 })
             })
-            .filter_map(|result| {
+            .filter_map(move |result| {
                 future::ready(match result {
                     Ok(notification @ Some(_)) => notification,
                     Ok(None) => None,
                     Err(err) => {
-                        warn!("{}", err);
+                        warn!(%address, "{}", err);
                         None
                     }
                 })


### PR DESCRIPTION
## Motivation

The subscription notification stream error logs (e.g. h2 protocol errors like #5578)
don't include which validator is affected, making it difficult to diagnose
infrastructure issues.

## Proposal

Add the validator address to the `warn!` log emitted when a subscription stream
encounters a retryable error in `linera-rpc/src/grpc/client.rs`. This makes it
immediately clear which validator(s) are experiencing connectivity problems.

## Test Plan

- CI

