### PR TITLE
Remove temporary pull_request trigger from bridge-e2e workflow

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -3,8 +3,6 @@ name: Bridge E2E
 on:
   merge_group:
   workflow_dispatch:
-  pull_request:
-    branches: [ 'testnet_conway' ]
   push:
     branches: [ 'testnet_*', 'main']
 


### PR DESCRIPTION
## Motivation

PR #5583 added a `pull_request` trigger to `.github/workflows/bridge-e2e.yml`
targeting `testnet_conway` so the bridge E2E test would run on that PR. The PR
description explicitly noted this should be removed before merge, but it was
merged with the trigger still in place.

## Proposal

Remove the two-line `pull_request` trigger that was left behind. No other
changes.

## Test Plan

- Visual inspection — this only removes a CI trigger.
