### PR TITLE
Ignore `CLAUDE.local.md`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ linera-web/**/*-lock.json
 # Claude
 .claude
 CLAUDE.md
+CLAUDE.local.md
 .serena
 docs/
 


### PR DESCRIPTION
## Motivation

`CLAUDE.md` is actually meant to be checked-in (also see https://github.com/linera-io/linera-protocol/issues/5579). `CLAUDE.local.md` is the file that should be in `.gitignore`.

## Proposal

Add `CLAUDE.local.md` to `.gitignore`. (We can remove `CLAUDE.md` later.)

## Test Plan

I did `git commit -a` and it didn't commit my `CLAUDE.local.md`.

## Release Plan

- We also need this in `testnet_conway`. (I included it in #5588.)

## Links

- Related: #5579
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
