### PR TITLE
fix(ci): switch to GitHub-hosted runners temporarily

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
           mdbook test -L ../target/debug/deps/
 
   formatting:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   bridge-e2e:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   compose:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
 
   publish-rust-docs:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     # We only publish docs for the main branch.
@@ -58,7 +58,7 @@ jobs:
         force_orphan: true
 
   test-crates-and-docrs:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -49,7 +49,7 @@ jobs:
   test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   indexer-check:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -51,7 +51,7 @@ jobs:
 
   indexer-integration-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   lint-check-all-features:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   long-faucet-chain-test:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   performance-summary:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -43,7 +43,7 @@ permissions:
 
 jobs:
   remote-net-test:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -60,7 +60,7 @@ jobs:
   remote-net-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 40
 
     steps:
@@ -99,7 +99,7 @@ jobs:
   execution-wasmtime-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -112,7 +112,7 @@ jobs:
   bridge-format-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
@@ -167,7 +167,7 @@ jobs:
   metrics-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -180,7 +180,7 @@ jobs:
   wasm-application-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
@@ -201,7 +201,7 @@ jobs:
   linera-sdk-tests-fixtures:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -227,7 +227,7 @@ jobs:
   default-features-and-witty-integration-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 40
 
     steps:
@@ -251,7 +251,7 @@ jobs:
   check-outdated-cli-md:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -273,7 +273,7 @@ jobs:
   benchmark-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:
@@ -297,7 +297,7 @@ jobs:
   ethereum-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -360,7 +360,7 @@ jobs:
   storage-service-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -386,7 +386,7 @@ jobs:
   check-wit-files:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -397,7 +397,7 @@ jobs:
   lint-unexpected-chain-load-operations:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -409,7 +409,7 @@ jobs:
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -426,7 +426,7 @@ jobs:
   lint-cargo-machete:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -445,7 +445,7 @@ jobs:
   lint-cargo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -461,7 +461,7 @@ jobs:
   lint-taplo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -475,7 +475,7 @@ jobs:
   lint-check-for-outdated-readme:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -504,7 +504,7 @@ jobs:
   lint-wasm-applications:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -529,7 +529,7 @@ jobs:
   lint-cargo-clippy:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -555,7 +555,7 @@ jobs:
   lint-cargo-doc:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -575,7 +575,7 @@ jobs:
   lint-check-linera-service-graphql-schema:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   test-readme-scripts:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -59,7 +59,7 @@ jobs:
   web:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary

- Self-hosted runner node pool (`github-runner-pool`) on OVH is stuck in `DOWNSCALING` state
- Switches all 18 workflow files from `linera-io-self-hosted-ci` to right-sized GitHub-hosted runners:
  - `ubuntu-latest` (34 jobs): lints, light builds, checks
  - `ubuntu-latest-8-cores` (5 jobs): medium builds (dynamodb, scylladb, etc.)
  - `ubuntu-latest-16-cores` (6 jobs): heavy builds (storage-service, docker-compose, etc.)

Tracking issue: linera-io/linera-infra#623

## Revert plan

Once OVH clears the stuck pool, revert by replacing GitHub-hosted runners back to `linera-io-self-hosted-ci`. Reference: #5542

## Test plan

- [ ] Verify CI workflows trigger and run on GitHub-hosted runners
- [ ] Monitor for OOM issues on large Rust compilation jobs