### PR TITLE
Use libunwind for jemalloc memory profiling stack traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5021,23 +5021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "jemalloc_pprof"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ff642505c7ce8d31c0d43ec0e235c6fd4585d9b8172d8f9dd04d36590200b5"
-dependencies = [
- "anyhow",
- "libc",
- "mappings",
- "once_cell",
- "pprof_util",
- "tempfile",
- "tikv-jemalloc-ctl",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5949,6 +5932,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "linera-jemalloc-ctl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "098410db64dbf9b74f23f99e43e58674620b21be840367637dcf0b6d3c4d0e42"
+dependencies = [
+ "libc",
+ "linera-jemalloc-sys",
+ "paste",
+]
+
+[[package]]
+name = "linera-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e77f5478fd8bd96552edc59ec5bdb2cff8c470e0f5284cd38a70b9f5782dbfc"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "linera-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8630abf3d99c33454e1c035a0226717a28c028c7254e151abb866b6ebd59af1b"
+dependencies = [
+ "libc",
+ "linera-jemalloc-sys",
+]
+
+[[package]]
 name = "linera-kywasmtime"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5965,8 +5979,11 @@ version = "0.16.0"
 dependencies = [
  "anyhow",
  "axum",
- "jemalloc_pprof",
+ "linera-jemalloc-ctl",
+ "mappings",
+ "pprof_util",
  "prometheus",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -6140,6 +6157,7 @@ dependencies = [
  "linera-exporter",
  "linera-faucet-client",
  "linera-faucet-server",
+ "linera-jemallocator",
  "linera-metrics",
  "linera-persistent",
  "linera-rpc",
@@ -6178,7 +6196,6 @@ dependencies = [
  "test-log",
  "test-strategy",
  "thiserror 1.0.69",
- "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -10693,37 +10710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
-]
-
-[[package]]
-name = "tikv-jemalloc-ctl"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
-dependencies = [
- "libc",
- "paste",
- "tikv-jemalloc-sys",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,6 @@ indexed-db = "0.4.2"
 insta = "1.36.1"
 is-terminal = "0.4.12"
 itertools = "0.14.0"
-jemalloc_pprof = "0.8.1"
 js-sys = "0.3.70"
 k256 = { version = "0.13.4", default-features = false, features = [
     "ecdsa",
@@ -163,10 +162,13 @@ k256 = { version = "0.13.4", default-features = false, features = [
 ] }
 k8s-openapi = { version = "0.21.1", features = ["v1_28"] }
 kube = "0.88.1"
+linera-jemalloc-ctl = { version = "0.6.1", features = ["use_std"] }
+linera-jemallocator = "0.6.1"
 linera-kywasmtime = "0.1.0"
 linked-hash-map = "0.5.6"
 log = "0.4.21"
 lru = "0.15.0"
+mappings = "0.7.1"
 mini-moka = "0.10.3"
 nonzero_lit = "0.1.2"
 num-bigint = "0.4.3"
@@ -186,6 +188,7 @@ opentelemetry_sdk = { version = "0.30.0", features = ["trace", "rt-tokio"] }
 papaya = "0.2.3"
 pathdiff = "0.2.1"
 port-selector = "0.1.6"
+pprof_util = { version = "0.8.0", features = ["flamegraph", "symbolize"] }
 prettyplease = "0.2.16"
 proc-macro-error = "1.0.4"
 proc-macro2 = "1.0"
@@ -267,7 +270,6 @@ test-log = { version = "0.2.15", default-features = false, features = [
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
 thiserror-context = "0.1.1"
-tikv-jemallocator = "0.6.0"
 tokio = "1.36.0"
 tokio-stream = "0.1.14"
 tokio-test = "0.4.3"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
 ARG build_features=scylladb,metrics,jemalloc
-ARG rustflags="-C force-frame-pointers=yes"
+ARG rustflags="-C force-frame-pointers=yes -L /usr/lib/x86_64-linux-gnu"
 
 FROM rust:1.86-slim-bookworm AS builder
 ARG git_commit
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     protobuf-compiler \
     clang \
-    make
+    make \
+    libunwind-dev
 
 COPY . .
 
@@ -71,7 +72,8 @@ LABEL build_date=$build_date
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    openssl
+    openssl \
+    libunwind8
 RUN update-ca-certificates
 
 COPY --from=binaries \

--- a/linera-metrics/Cargo.toml
+++ b/linera-metrics/Cargo.toml
@@ -15,16 +15,16 @@ version.workspace = true
 workspace = true
 
 [features]
-jemalloc = ["jemalloc_pprof"]
+jemalloc = ["linera-jemalloc-ctl", "mappings", "pprof_util", "tempfile"]
 
 [dependencies]
 anyhow.workspace = true
 axum.workspace = true
-jemalloc_pprof = { workspace = true, features = [
-    "symbolize",
-    "flamegraph",
-], optional = true }
+linera-jemalloc-ctl = { workspace = true, optional = true }
+mappings = { workspace = true, optional = true }
+pprof_util = { workspace = true, optional = true }
 prometheus.workspace = true
+tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true

--- a/linera-metrics/src/memory_profiler.rs
+++ b/linera-metrics/src/memory_profiler.rs
@@ -1,17 +1,28 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Safe jemalloc memory profiling with jemalloc_pprof integration
+//! Safe jemalloc memory profiling with pprof output.
 //!
 //! This module provides HTTP endpoints for pprof format profiles using pull model.
 //! Profiles are generated on-demand when endpoints are requested by Grafana Alloy.
+
+use std::{
+    ffi::CString,
+    io::BufReader,
+    sync::{Arc, LazyLock},
+    time::Instant,
+};
 
 use axum::{
     http::{header, StatusCode},
     response::IntoResponse,
 };
-use jemalloc_pprof::PROF_CTL;
+use linera_jemalloc_ctl::raw;
+use mappings::MAPPINGS;
+use pprof_util::{parse_jeheap, FlamegraphOptions, ProfStartTime};
+use tempfile::NamedTempFile;
 use thiserror::Error;
+use tokio::sync::Mutex;
 use tracing::{error, info, trace};
 
 #[derive(Debug, Error)]
@@ -26,14 +37,73 @@ pub enum MemoryProfilerError {
     ActivationFailed(String),
 }
 
-/// Memory profiler using safe jemalloc_pprof wrapper (pull model only)
+/// Per-process singleton for controlling jemalloc profiling.
+static PROF_CTL: LazyLock<Option<Arc<Mutex<JemallocProfCtl>>>> =
+    LazyLock::new(|| JemallocProfCtl::get().map(|ctl| Arc::new(Mutex::new(ctl))));
+
+/// A handle to control jemalloc profiling.
+struct JemallocProfCtl {
+    start_time: Option<ProfStartTime>,
+}
+
+impl JemallocProfCtl {
+    fn get() -> Option<Self> {
+        // SAFETY: `opt.prof` is documented as readable and returning a bool.
+        let prof_enabled: bool = unsafe { raw::read(b"opt.prof\0") }.ok()?;
+        if !prof_enabled {
+            return None;
+        }
+        // SAFETY: `opt.prof_active` is documented as readable and returning a bool.
+        let prof_active: bool = unsafe { raw::read(b"opt.prof_active\0") }.ok()?;
+        let start_time = prof_active.then_some(ProfStartTime::TimeImmemorial);
+        Some(Self { start_time })
+    }
+
+    fn activated(&self) -> bool {
+        self.start_time.is_some()
+    }
+
+    fn activate(&mut self) -> Result<(), linera_jemalloc_ctl::Error> {
+        // SAFETY: `prof.active` is documented as writable and taking a bool.
+        unsafe { raw::write(b"prof.active\0", true) }?;
+        if self.start_time.is_none() {
+            self.start_time = Some(ProfStartTime::Instant(Instant::now()));
+        }
+        Ok(())
+    }
+
+    fn dump(&self) -> anyhow::Result<std::fs::File> {
+        let f = NamedTempFile::new()?;
+        let path = CString::new(f.path().as_os_str().as_encoded_bytes())?;
+        // SAFETY: `prof.dump` is documented as writable and taking a C string.
+        unsafe { raw::write(b"prof.dump\0", path.as_ptr()) }?;
+        Ok(f.into_file())
+    }
+
+    fn dump_pprof(&self) -> anyhow::Result<Vec<u8>> {
+        let f = self.dump()?;
+        let profile = parse_jeheap(BufReader::new(f), MAPPINGS.as_deref())?;
+        Ok(profile.to_pprof(("inuse_space", "bytes"), ("space", "bytes"), None))
+    }
+
+    fn dump_flamegraph(&self) -> anyhow::Result<Vec<u8>> {
+        let mut opts = FlamegraphOptions::default();
+        opts.title = "inuse_space".to_string();
+        opts.count_name = "bytes".to_string();
+        let f = self.dump()?;
+        let profile = parse_jeheap(BufReader::new(f), MAPPINGS.as_deref())?;
+        profile.to_flamegraph(&mut opts)
+    }
+}
+
+/// Memory profiler using linera-jemalloc-ctl directly (pull model only).
 pub struct MemoryProfiler;
 
 impl MemoryProfiler {
     /// Activates jemalloc profiling at runtime.
     ///
-    /// This enables sampling (prof_active) which is off by default to avoid
-    /// the libgcc DWARF unwinder livelock (jemalloc/jemalloc#2282).
+    /// Sampling (prof_active) is off by default to avoid the libgcc DWARF
+    /// unwinder livelock (jemalloc/jemalloc#2282).
     pub async fn activate() -> Result<(), MemoryProfilerError> {
         if let Some(prof_ctl) = PROF_CTL.as_ref() {
             let mut prof_ctl = prof_ctl.lock().await;
@@ -50,7 +120,6 @@ impl MemoryProfiler {
     }
 
     pub fn check_prof_ctl() -> Result<(), MemoryProfilerError> {
-        // Check if jemalloc profiling is available
         if let Some(prof_ctl) = PROF_CTL.as_ref() {
             let prof_ctl = prof_ctl
                 .try_lock()
@@ -110,51 +179,33 @@ impl MemoryProfiler {
         }
     }
 
-    /// Collect heap profile on-demand using safe jemalloc_pprof wrapper
     async fn collect_heap_profile() -> anyhow::Result<Vec<u8>> {
-        if let Some(prof_ctl) = PROF_CTL.as_ref() {
-            let mut prof_ctl = prof_ctl.lock().await;
+        let prof_ctl = PROF_CTL
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("PROF_CTL not available"))?;
+        let prof_ctl = prof_ctl.lock().await;
 
-            if !prof_ctl.activated() {
-                return Err(anyhow::anyhow!("jemalloc profiling not activated"));
-            }
-
-            match prof_ctl.dump_pprof() {
-                Ok(profile) => {
-                    trace!("✓ Collected heap profile ({} bytes)", profile.len());
-                    Ok(profile)
-                }
-                Err(e) => {
-                    error!("Failed to dump pprof profile: {}", e);
-                    Err(anyhow::anyhow!("Failed to dump pprof profile: {}", e))
-                }
-            }
-        } else {
-            Err(anyhow::anyhow!("PROF_CTL not available"))
+        if !prof_ctl.activated() {
+            return Err(anyhow::anyhow!("jemalloc profiling not activated"));
         }
+
+        let profile = prof_ctl.dump_pprof()?;
+        trace!("✓ Collected heap profile ({} bytes)", profile.len());
+        Ok(profile)
     }
 
-    /// Collect heap flamegraph using prof_ctl.dump_flamegraph()
     async fn collect_heap_flamegraph() -> anyhow::Result<Vec<u8>> {
-        if let Some(prof_ctl) = PROF_CTL.as_ref() {
-            let mut prof_ctl = prof_ctl.lock().await;
+        let prof_ctl = PROF_CTL
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("PROF_CTL not available"))?;
+        let prof_ctl = prof_ctl.lock().await;
 
-            if !prof_ctl.activated() {
-                return Err(anyhow::anyhow!("jemalloc profiling not activated"));
-            }
-
-            match prof_ctl.dump_flamegraph() {
-                Ok(flamegraph_bytes) => {
-                    trace!("✓ Generated flamegraph ({} bytes)", flamegraph_bytes.len());
-                    Ok(flamegraph_bytes)
-                }
-                Err(e) => {
-                    error!("Failed to dump flamegraph: {}", e);
-                    Err(anyhow::anyhow!("Failed to dump flamegraph: {}", e))
-                }
-            }
-        } else {
-            Err(anyhow::anyhow!("PROF_CTL not available"))
+        if !prof_ctl.activated() {
+            return Err(anyhow::anyhow!("jemalloc profiling not activated"));
         }
+
+        let flamegraph = prof_ctl.dump_flamegraph()?;
+        trace!("✓ Generated flamegraph ({} bytes)", flamegraph.len());
+        Ok(flamegraph)
     }
 }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -65,8 +65,8 @@ metrics = [
     "linera-metrics",
 ]
 jemalloc = [
-    "tikv-jemallocator",
-    "tikv-jemallocator/profiling",
+    "linera-jemallocator",
+    "linera-jemallocator/profiling_libunwind",
     "linera-metrics/jemalloc",
 ]
 storage-service = [
@@ -115,6 +115,10 @@ linera-execution = { workspace = true, features = ["fs"] }
 linera-exporter = { workspace = true, default-features = false }
 linera-faucet-client.workspace = true
 linera-faucet-server.workspace = true
+linera-jemallocator = { workspace = true, features = [
+    "profiling",
+    "unprefixed_malloc_on_supported_platforms",
+], optional = true }
 linera-metrics = { workspace = true, optional = true }
 linera-persistent = { workspace = true, features = ["fs"] }
 linera-rpc = { workspace = true, features = [
@@ -147,10 +151,6 @@ serde_json.workspace = true
 stdext = { workspace = true, optional = true }
 tempfile.workspace = true
 thiserror.workspace = true
-tikv-jemallocator = { workspace = true, features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-], optional = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
 tokio-util.workspace = true

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: linera_jemallocator::Jemalloc = linera_jemallocator::Jemalloc;
 
 /// Configure jemalloc profiling infrastructure at startup with sampling disabled.
 /// Profiling is activated at runtime only when `--enable-memory-profiling` is passed.

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -3,7 +3,7 @@
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: linera_jemallocator::Jemalloc = linera_jemallocator::Jemalloc;
 
 /// Configure jemalloc profiling infrastructure at startup with sampling disabled.
 /// Profiling is activated at runtime only when `--enable-memory-profiling` is passed.

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+static ALLOC: linera_jemallocator::Jemalloc = linera_jemallocator::Jemalloc;
 
 /// Configure jemalloc profiling infrastructure at startup with sampling disabled.
 /// Profiling is activated at runtime only when `--enable-memory-profiling` is passed.


### PR DESCRIPTION
## Motivation

The default libgcc DWARF unwinder (`_Unwind_Find_FDE`) used by jemalloc for profiling
stack traces has a known livelock
([jemalloc/jemalloc#2282](https://github.com/jemalloc/jemalloc/issues/2282)) — one
thread hangs in `_Unwind_Find_FDE` and all others block on futex_wait. We've hit this in
production on validator shards.

## Proposal

Switch jemalloc's stack unwinder to libunwind by building with
`--enable-prof-libunwind`.

- Point `tikv-jemallocator` at
[linera-io/jemallocator](https://github.com/linera-io/jemallocator) fork which adds a
`profiling_libunwind` feature (upstream doesn't support it yet —
[tikv/jemallocator#146](https://github.com/tikv/jemallocator/issues/146))
- Enable `profiling_libunwind` in the `jemalloc` feature
- Add `libunwind-dev` (builder) and `libunwind8` (runtime) to `docker/Dockerfile`

## Test Plan

- CI
- Verify memory profiling works end-to-end in a temporary network deployment

## Release Plan

- These changes shobe backported to `testnet_conway`.

## Links

- Fork PR: https://github.com/linera-io/jemallocator/pull/1
- Upstream issue:
[tikv/jemallocator#146](https://github.com/tikv/jemallocator/issues/146)
- Jemalloc livelock:
[jemalloc/jemalloc#2282](https://github.com/jemalloc/jemalloc/issues/2282)
