### PR TITLE
fix(ci): restore self-hosted CI runners

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   benchmark-test:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   compose:
     if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
 
   publish-docs:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 20
 
     # We only publish docs for the main branch.
@@ -57,7 +57,7 @@ jobs:
         force_orphan: true
 
   test-crates-and-docrs:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 60
 
     steps:

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -47,7 +47,7 @@ jobs:
   test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   indexer-check:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   indexer-integration-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   check-all-features-partition:
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -53,7 +53,7 @@ jobs:
 
   lint-check-all-features:
     needs: check-all-features-partition
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     if: always()
     steps:
     - run: |

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   long-faucet-chain-test:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   performance-summary:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/remote-kubernetes-net-test.yml
+++ b/.github/workflows/remote-kubernetes-net-test.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   remote-kubernetes-net-test:
     if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/remote-net-test.yml
+++ b/.github/workflows/remote-net-test.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   remote-net-test:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest-8-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -55,7 +55,7 @@ jobs:
               - '!CONTRIBUTING.md'
               - '!INSTALL.md'
   changed-files-kubernetes:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -73,7 +73,7 @@ jobs:
   execution-wasmtime-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
     steps:
@@ -86,7 +86,7 @@ jobs:
   metrics-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
     steps:
@@ -99,7 +99,7 @@ jobs:
   wasm-application-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 15
 
     steps:
@@ -120,7 +120,7 @@ jobs:
   linera-sdk-tests-fixtures:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
     steps:
@@ -146,7 +146,7 @@ jobs:
   default-features-and-witty-integration-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest-8-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
 
     steps:
@@ -170,7 +170,7 @@ jobs:
   check-outdated-cli-md:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
     steps:
@@ -192,7 +192,7 @@ jobs:
   ethereum-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 30
 
     steps:
@@ -258,7 +258,7 @@ jobs:
   storage-service-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
@@ -286,7 +286,7 @@ jobs:
   check-wit-files:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -297,7 +297,7 @@ jobs:
   lint-unexpected-chain-load-operations:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 2
 
     steps:
@@ -309,7 +309,7 @@ jobs:
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 2
 
     steps:
@@ -326,7 +326,7 @@ jobs:
   lint-cargo-machete:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 2
 
     steps:
@@ -345,7 +345,7 @@ jobs:
   lint-cargo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 2
 
     steps:
@@ -361,7 +361,7 @@ jobs:
   lint-taplo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 5
 
     steps:
@@ -375,7 +375,7 @@ jobs:
   lint-check-for-outdated-readme:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 5
 
     steps:
@@ -404,7 +404,7 @@ jobs:
   lint-wasm-applications:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 10
 
     steps:
@@ -429,7 +429,7 @@ jobs:
   lint-cargo-clippy:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 20
 
     steps:
@@ -455,7 +455,7 @@ jobs:
   lint-cargo-doc:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 25
 
     steps:
@@ -475,7 +475,7 @@ jobs:
   lint-check-linera-service-graphql-schema:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -34,7 +34,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 50
 
     steps:

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   test-readme-scripts:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   changed-files:
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -57,7 +57,7 @@ jobs:
   web:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary

- OVH github-runner-pool is back online
- Reverts all 18 workflow files (43 runs-on lines) from GitHub-hosted runners back to `linera-io-self-hosted-ci`
- Reverts #5597

## Test plan

- [ ] CI jobs pick up self-hosted runners
- [ ] No jobs stuck in Pending