### PR TITLE
Fix zombie validator subscription entries in ChainListener

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -4556,6 +4556,7 @@ impl<Env: Environment> ChainClient<Env> {
             .flatten();
             let (stream, abort) = stream::abortable(stream);
             let mut stream = Box::pin(stream);
+            let abort_on_exit = abort.clone();
             let this = self.clone();
             let local_node = local_node.clone();
             let remote_node = RemoteNode { public_key, node };
@@ -4578,6 +4579,12 @@ impl<Env: Environment> ChainClient<Env> {
                         );
                     }
                 }
+                warn!(
+                    chain_id = %this.chain_id,
+                    address = remote_node.address(),
+                    "Validator notification stream ended; will reconnect on next update"
+                );
+                abort_on_exit.abort();
             });
             entry.insert(abort);
         }


### PR DESCRIPTION
## Motivation

When a validator's gRPC notification stream ends naturally (retries exhausted or
non-retryable error), the `AbortHandle` entry in `senders` remains forever.
`AbortHandle::is_aborted()` only returns `true` if `abort()` was explicitly called —
when the stream ends naturally, nobody calls it. The `retain` check keeps the dead
entry, and `Entry::Vacant` skips the validator on every subsequent
`update_notification_streams` call, permanently preventing reconnection for the lifetime
of the `listen()` call.

This causes silent, permanent loss of notification sources. Each validator that has a
transient outage long enough to exhaust retries becomes a zombie entry, degrading the
client's notification fanout with no visibility.

## Proposal

Clone the `AbortHandle` into the validator task. When the stream ends naturally (the
`while let` loop exits), call `abort()` on the clone and log a warning. Since
`AbortHandle` is backed by `Arc<AbortInner>`, both clones share the same `AtomicBool` —
calling `abort()` on either sets the flag that `is_aborted()` reads. On the next
`update_notification_streams` call (triggered by any `NewBlock` from another validator),
`retain` sees `is_aborted() == true`, removes the entry, and the validator gets a fresh
subscription.

The downside of this is that a validator that is down or returning non retryable gRPC responses
will effectively continue to be retried forever. So I'll have a follow up PR so that we can have a metric
labelled by validator that tracks this. So we can alert on it, and remove the offending ones.
Since we do the exponential backoff on the retries, they'll hopefully not be too overwhelming until we
remove the offending validator.

## Test Plan

CI