### PR TITLE
Implement `{Map,Set,Collection}View` variants with count.

### DIFF
--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -120,7 +120,7 @@ pub use generic_array;
 #[doc(hidden)]
 pub use sha3;
 pub use views::{
-    bucket_queue_view, collection_view, hashable_wrapper, historical_hash_wrapper,
+    bucket_queue_view, collection_view, count_view, hashable_wrapper, historical_hash_wrapper,
     key_value_store_view, log_view, map_view, queue_view, reentrant_collection_view, register_view,
     set_view,
 };

--- a/linera-views/src/views/count_view.rs
+++ b/linera-views/src/views/count_view.rs
@@ -1,0 +1,557 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Count-tracking variants of map/set/collection views.
+
+use std::{
+    borrow::Borrow,
+    ops::{Deref, DerefMut},
+};
+
+use allocative::Allocative;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    batch::Batch,
+    common::from_bytes_option_or_default,
+    context::Context,
+    views::{
+        collection_view::CollectionView, map_view::MapView, set_view::SetView, ClonableView,
+        HashableView, Hasher, ReplaceContext, View, ViewError, MIN_VIEW_TAG,
+    },
+};
+
+/// Key tags used by count views.
+#[repr(u8)]
+enum KeyTag {
+    /// Stores the persisted count.
+    Count = MIN_VIEW_TAG,
+    /// Prefix for the inner subview.
+    Subview,
+}
+
+/// A map view variant with O(1) `count`.
+#[derive(Debug, Allocative)]
+#[allocative(bound = "C, I, V: Allocative")]
+pub struct MapCountView<C, I, V> {
+    #[allocative(skip)]
+    context: C,
+    map: MapView<C, I, V>,
+    stored_count: usize,
+    count: usize,
+}
+
+impl<C, C2, I, V> ReplaceContext<C2> for MapCountView<C, I, V>
+where
+    C: Context,
+    C2: Context,
+    I: Send + Sync + Serialize,
+    V: Send + Sync + Serialize + Clone,
+{
+    type Target = MapCountView<C2, I, V>;
+
+    async fn with_context(
+        &mut self,
+        ctx: impl FnOnce(&Self::Context) -> C2 + Clone,
+    ) -> Self::Target {
+        let context = ctx(&self.context);
+        let subview_base = context.base_key().base_tag(KeyTag::Subview as u8);
+        let subview_context = context.clone_with_base_key(subview_base);
+        MapCountView {
+            context,
+            map: self.map.with_context(|_| subview_context.clone()).await,
+            stored_count: self.stored_count,
+            count: self.count,
+        }
+    }
+}
+
+impl<C, I, V> View for MapCountView<C, I, V>
+where
+    C: Context,
+    I: Send + Sync + Serialize,
+    V: Send + Sync + Serialize,
+{
+    const NUM_INIT_KEYS: usize = 1;
+
+    type Context = C;
+
+    fn context(&self) -> C {
+        self.context.clone()
+    }
+
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![context.base_key().base_tag(KeyTag::Count as u8)])
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let stored_count =
+            from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
+        let subview_base = context.base_key().base_tag(KeyTag::Subview as u8);
+        let subview_context = context.clone_with_base_key(subview_base);
+        let map = MapView::post_load(subview_context, &[])?;
+        Ok(Self {
+            context,
+            map,
+            stored_count,
+            count: stored_count,
+        })
+    }
+
+    fn rollback(&mut self) {
+        self.map.rollback();
+        self.count = self.stored_count;
+    }
+
+    async fn has_pending_changes(&self) -> bool {
+        self.count != self.stored_count || self.map.has_pending_changes().await
+    }
+
+    fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
+        let delete_subview = self.map.pre_save(batch)?;
+        if self.count != self.stored_count {
+            let count_key = self.context.base_key().base_tag(KeyTag::Count as u8);
+            if self.count == 0 {
+                batch.delete_key(count_key);
+            } else {
+                batch.put_key_value(count_key, &self.count)?;
+            }
+        }
+        Ok(delete_subview && self.count == 0)
+    }
+
+    fn post_save(&mut self) {
+        self.map.post_save();
+        self.stored_count = self.count;
+    }
+
+    fn clear(&mut self) {
+        self.map.clear();
+        self.count = 0;
+    }
+}
+
+impl<C, I, V> ClonableView for MapCountView<C, I, V>
+where
+    C: Context,
+    I: Send + Sync + Serialize,
+    V: Send + Sync + Serialize + Clone,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(Self {
+            context: self.context.clone(),
+            map: self.map.clone_unchecked()?,
+            stored_count: self.stored_count,
+            count: self.count,
+        })
+    }
+}
+
+impl<C, I, V> Deref for MapCountView<C, I, V> {
+    type Target = MapView<C, I, V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<C, I, V> DerefMut for MapCountView<C, I, V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.map
+    }
+}
+
+impl<C, I, V> MapCountView<C, I, V>
+where
+    C: Context,
+    I: Serialize,
+{
+    /// Inserts or resets a value at an index and updates the count in O(1).
+    pub async fn insert<Q>(&mut self, index: &Q, value: V) -> Result<(), ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        if !self.map.contains_key(index).await? {
+            self.count += 1;
+        }
+        self.map.insert(index, value)
+    }
+
+    /// Removes a value and updates the count in O(1).
+    pub async fn remove<Q>(&mut self, index: &Q) -> Result<(), ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        if self.map.contains_key(index).await? {
+            self.count -= 1;
+        }
+        self.map.remove(index)
+    }
+
+    /// Returns the number of entries in O(1).
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        Ok(self.count)
+    }
+}
+
+impl<C, I, V> HashableView for MapCountView<C, I, V>
+where
+    Self: View,
+    MapView<C, I, V>: HashableView,
+{
+    type Hasher = <MapView<C, I, V> as HashableView>::Hasher;
+
+    async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.map.hash_mut().await
+    }
+
+    async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.map.hash().await
+    }
+}
+
+/// A set view variant with O(1) `count`.
+#[derive(Debug, Allocative)]
+#[allocative(bound = "C, I")]
+pub struct SetCountView<C, I> {
+    #[allocative(skip)]
+    context: C,
+    set: SetView<C, I>,
+    stored_count: usize,
+    count: usize,
+}
+
+impl<C: Context, C2: Context, I: Send + Sync + Serialize> ReplaceContext<C2>
+    for SetCountView<C, I>
+{
+    type Target = SetCountView<C2, I>;
+
+    async fn with_context(
+        &mut self,
+        ctx: impl FnOnce(&Self::Context) -> C2 + Clone,
+    ) -> Self::Target {
+        let context = ctx(&self.context);
+        let subview_base = context.base_key().base_tag(KeyTag::Subview as u8);
+        let subview_context = context.clone_with_base_key(subview_base);
+        SetCountView {
+            context,
+            set: self.set.with_context(|_| subview_context.clone()).await,
+            stored_count: self.stored_count,
+            count: self.count,
+        }
+    }
+}
+
+impl<C: Context, I: Send + Sync + Serialize> View for SetCountView<C, I> {
+    const NUM_INIT_KEYS: usize = 1;
+
+    type Context = C;
+
+    fn context(&self) -> C {
+        self.context.clone()
+    }
+
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![context.base_key().base_tag(KeyTag::Count as u8)])
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let stored_count =
+            from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
+        let subview_base = context.base_key().base_tag(KeyTag::Subview as u8);
+        let subview_context = context.clone_with_base_key(subview_base);
+        let set = SetView::post_load(subview_context, &[])?;
+        Ok(Self {
+            context,
+            set,
+            stored_count,
+            count: stored_count,
+        })
+    }
+
+    fn rollback(&mut self) {
+        self.set.rollback();
+        self.count = self.stored_count;
+    }
+
+    async fn has_pending_changes(&self) -> bool {
+        self.count != self.stored_count || self.set.has_pending_changes().await
+    }
+
+    fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
+        let delete_subview = self.set.pre_save(batch)?;
+        if self.count != self.stored_count {
+            let count_key = self.context.base_key().base_tag(KeyTag::Count as u8);
+            if self.count == 0 {
+                batch.delete_key(count_key);
+            } else {
+                batch.put_key_value(count_key, &self.count)?;
+            }
+        }
+        Ok(delete_subview && self.count == 0)
+    }
+
+    fn post_save(&mut self) {
+        self.set.post_save();
+        self.stored_count = self.count;
+    }
+
+    fn clear(&mut self) {
+        self.set.clear();
+        self.count = 0;
+    }
+}
+
+impl<C, I> ClonableView for SetCountView<C, I>
+where
+    C: Context,
+    I: Send + Sync + Serialize,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(Self {
+            context: self.context.clone(),
+            set: self.set.clone_unchecked()?,
+            stored_count: self.stored_count,
+            count: self.count,
+        })
+    }
+}
+
+impl<C, I> Deref for SetCountView<C, I> {
+    type Target = SetView<C, I>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.set
+    }
+}
+
+impl<C, I> DerefMut for SetCountView<C, I> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.set
+    }
+}
+
+impl<C: Context, I: Serialize> SetCountView<C, I> {
+    /// Inserts a value and updates the count in O(1).
+    pub async fn insert<Q>(&mut self, index: &Q) -> Result<(), ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        if !self.set.contains(index).await? {
+            self.count += 1;
+        }
+        self.set.insert(index)
+    }
+
+    /// Removes a value and updates the count in O(1).
+    pub async fn remove<Q>(&mut self, index: &Q) -> Result<(), ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        if self.set.contains(index).await? {
+            self.count -= 1;
+        }
+        self.set.remove(index)
+    }
+
+    /// Returns the number of entries in O(1).
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        Ok(self.count)
+    }
+}
+
+impl<C, I> HashableView for SetCountView<C, I>
+where
+    Self: View,
+    SetView<C, I>: HashableView,
+{
+    type Hasher = <SetView<C, I> as HashableView>::Hasher;
+
+    async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.set.hash_mut().await
+    }
+
+    async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.set.hash().await
+    }
+}
+
+/// A collection view variant with O(1) `count`.
+#[derive(Debug, Allocative)]
+#[allocative(bound = "C, I, W: Allocative")]
+pub struct CollectionCountView<C, I, W> {
+    #[allocative(skip)]
+    context: C,
+    collection: CollectionView<C, I, W>,
+    stored_count: usize,
+    count: usize,
+}
+
+impl<C, I, W> View for CollectionCountView<C, I, W>
+where
+    C: Context,
+    I: Send + Sync + Serialize + DeserializeOwned,
+    W: View<Context = C>,
+{
+    const NUM_INIT_KEYS: usize = 1;
+
+    type Context = C;
+
+    fn context(&self) -> C {
+        self.context.clone()
+    }
+
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![context.base_key().base_tag(KeyTag::Count as u8)])
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let stored_count =
+            from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
+        let subview_base = context.base_key().base_tag(KeyTag::Subview as u8);
+        let subview_context = context.clone_with_base_key(subview_base);
+        let collection = CollectionView::post_load(subview_context, &[])?;
+        Ok(Self {
+            context,
+            collection,
+            stored_count,
+            count: stored_count,
+        })
+    }
+
+    fn rollback(&mut self) {
+        self.collection.rollback();
+        self.count = self.stored_count;
+    }
+
+    async fn has_pending_changes(&self) -> bool {
+        self.count != self.stored_count || self.collection.has_pending_changes().await
+    }
+
+    fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
+        let delete_subview = self.collection.pre_save(batch)?;
+        if self.count != self.stored_count {
+            let count_key = self.context.base_key().base_tag(KeyTag::Count as u8);
+            if self.count == 0 {
+                batch.delete_key(count_key);
+            } else {
+                batch.put_key_value(count_key, &self.count)?;
+            }
+        }
+        Ok(delete_subview && self.count == 0)
+    }
+
+    fn post_save(&mut self) {
+        self.collection.post_save();
+        self.stored_count = self.count;
+    }
+
+    fn clear(&mut self) {
+        self.collection.clear();
+        self.count = 0;
+    }
+}
+
+impl<C, I, W> ClonableView for CollectionCountView<C, I, W>
+where
+    C: Context,
+    I: Send + Sync + Serialize + DeserializeOwned,
+    W: ClonableView<Context = C>,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(Self {
+            context: self.context.clone(),
+            collection: self.collection.clone_unchecked()?,
+            stored_count: self.stored_count,
+            count: self.count,
+        })
+    }
+}
+
+impl<C, I, W> Deref for CollectionCountView<C, I, W> {
+    type Target = CollectionView<C, I, W>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.collection
+    }
+}
+
+impl<C, I, W> DerefMut for CollectionCountView<C, I, W> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.collection
+    }
+}
+
+impl<C, I, W> CollectionCountView<C, I, W>
+where
+    C: Context,
+    I: Serialize,
+    W: View<Context = C>,
+{
+    /// Loads a mutable entry and updates the count if a new entry is created.
+    pub async fn load_entry_mut<Q>(&mut self, index: &Q) -> Result<&mut W, ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        let existed = self.collection.try_load_entry(index).await?.is_some();
+        let view = self.collection.load_entry_mut(index).await?;
+        if !existed {
+            self.count += 1;
+        }
+        Ok(view)
+    }
+
+    /// Resets an entry and updates the count if a new entry is created.
+    pub async fn reset_entry_to_default<Q>(&mut self, index: &Q) -> Result<(), ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        let existed = self.collection.try_load_entry(index).await?.is_some();
+        self.collection.reset_entry_to_default(index)?;
+        if !existed {
+            self.count += 1;
+        }
+        Ok(())
+    }
+
+    /// Removes an entry and updates the count in O(1).
+    pub async fn remove_entry<Q>(&mut self, index: &Q) -> Result<(), ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        let existed = self.collection.try_load_entry(index).await?.is_some();
+        self.collection.remove_entry(index)?;
+        if existed {
+            self.count -= 1;
+        }
+        Ok(())
+    }
+
+    /// Returns the number of entries in O(1).
+    pub async fn count(&self) -> Result<usize, ViewError> {
+        Ok(self.count)
+    }
+}
+
+impl<C, I, W> HashableView for CollectionCountView<C, I, W>
+where
+    Self: View,
+    CollectionView<C, I, W>: HashableView,
+{
+    type Hasher = <CollectionView<C, I, W> as HashableView>::Hasher;
+
+    async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.collection.hash_mut().await
+    }
+
+    async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.collection.hash().await
+    }
+}

--- a/linera-views/src/views/count_view.rs
+++ b/linera-views/src/views/count_view.rs
@@ -193,6 +193,26 @@ where
     }
 }
 
+impl<C, I, V> MapCountView<C, I, V>
+where
+    C: Context,
+    I: Serialize,
+    V: Default + DeserializeOwned + 'static,
+{
+    /// Obtains a mutable reference to a value at a given position, creating it with default
+    /// if missing, and updates the count in O(1).
+    pub async fn get_mut_or_default<Q>(&mut self, index: &Q) -> Result<&mut V, ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Sync + Send + Serialize + ?Sized,
+    {
+        if !self.map.contains_key(index).await? {
+            self.count += 1;
+        }
+        self.map.get_mut_or_default(index).await
+    }
+}
+
 impl<C, I, V> HashableView for MapCountView<C, I, V>
 where
     Self: View,

--- a/linera-views/src/views/count_view.rs
+++ b/linera-views/src/views/count_view.rs
@@ -34,8 +34,6 @@ enum KeyTag {
 #[derive(Debug, Allocative)]
 #[allocative(bound = "C, I, V: Allocative")]
 pub struct MapCountView<C, I, V> {
-    #[allocative(skip)]
-    context: C,
     map: MapView<C, I, V>,
     stored_count: usize,
     count: usize,
@@ -54,11 +52,11 @@ where
         &mut self,
         ctx: impl FnOnce(&Self::Context) -> C2 + Clone,
     ) -> Self::Target {
-        let context = ctx(&self.context);
+        let old_context = self.context();
+        let context = ctx(&old_context);
         let subview_base = context.base_key().base_tag(KeyTag::Subview as u8);
         let subview_context = context.clone_with_base_key(subview_base);
         MapCountView {
-            context,
             map: self.map.with_context(|_| subview_context.clone()).await,
             stored_count: self.stored_count,
             count: self.count,
@@ -77,7 +75,8 @@ where
     type Context = C;
 
     fn context(&self) -> C {
-        self.context.clone()
+        // The inner context has our base key + the KeyTag::Subview byte.
+        self.map.context().clone_with_trimmed_key(1)
     }
 
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
@@ -91,7 +90,6 @@ where
         let subview_context = context.clone_with_base_key(subview_base);
         let map = MapView::post_load(subview_context, &[])?;
         Ok(Self {
-            context,
             map,
             stored_count,
             count: stored_count,
@@ -110,7 +108,7 @@ where
     fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
         let delete_subview = self.map.pre_save(batch)?;
         if self.count != self.stored_count {
-            let count_key = self.context.base_key().base_tag(KeyTag::Count as u8);
+            let count_key = self.context().base_key().base_tag(KeyTag::Count as u8);
             if self.count == 0 {
                 batch.delete_key(count_key);
             } else {
@@ -139,7 +137,6 @@ where
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(Self {
-            context: self.context.clone(),
             map: self.map.clone_unchecked()?,
             stored_count: self.stored_count,
             count: self.count,
@@ -216,8 +213,6 @@ where
 #[derive(Debug, Allocative)]
 #[allocative(bound = "C, I")]
 pub struct SetCountView<C, I> {
-    #[allocative(skip)]
-    context: C,
     set: SetView<C, I>,
     stored_count: usize,
     count: usize,
@@ -232,11 +227,11 @@ impl<C: Context, C2: Context, I: Send + Sync + Serialize> ReplaceContext<C2>
         &mut self,
         ctx: impl FnOnce(&Self::Context) -> C2 + Clone,
     ) -> Self::Target {
-        let context = ctx(&self.context);
+        let old_context = self.context();
+        let context = ctx(&old_context);
         let subview_base = context.base_key().base_tag(KeyTag::Subview as u8);
         let subview_context = context.clone_with_base_key(subview_base);
         SetCountView {
-            context,
             set: self.set.with_context(|_| subview_context.clone()).await,
             stored_count: self.stored_count,
             count: self.count,
@@ -250,7 +245,8 @@ impl<C: Context, I: Send + Sync + Serialize> View for SetCountView<C, I> {
     type Context = C;
 
     fn context(&self) -> C {
-        self.context.clone()
+        // The inner context has our base key + the KeyTag::Subview byte.
+        self.set.context().clone_with_trimmed_key(1)
     }
 
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
@@ -264,7 +260,6 @@ impl<C: Context, I: Send + Sync + Serialize> View for SetCountView<C, I> {
         let subview_context = context.clone_with_base_key(subview_base);
         let set = SetView::post_load(subview_context, &[])?;
         Ok(Self {
-            context,
             set,
             stored_count,
             count: stored_count,
@@ -283,7 +278,7 @@ impl<C: Context, I: Send + Sync + Serialize> View for SetCountView<C, I> {
     fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
         let delete_subview = self.set.pre_save(batch)?;
         if self.count != self.stored_count {
-            let count_key = self.context.base_key().base_tag(KeyTag::Count as u8);
+            let count_key = self.context().base_key().base_tag(KeyTag::Count as u8);
             if self.count == 0 {
                 batch.delete_key(count_key);
             } else {
@@ -311,7 +306,6 @@ where
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(Self {
-            context: self.context.clone(),
             set: self.set.clone_unchecked()?,
             stored_count: self.stored_count,
             count: self.count,
@@ -384,8 +378,6 @@ where
 #[derive(Debug, Allocative)]
 #[allocative(bound = "C, I, W: Allocative")]
 pub struct CollectionCountView<C, I, W> {
-    #[allocative(skip)]
-    context: C,
     collection: CollectionView<C, I, W>,
     stored_count: usize,
     count: usize,
@@ -402,7 +394,8 @@ where
     type Context = C;
 
     fn context(&self) -> C {
-        self.context.clone()
+        // The inner context has our base key + the KeyTag::Subview byte.
+        self.collection.context().clone_with_trimmed_key(1)
     }
 
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
@@ -416,7 +409,6 @@ where
         let subview_context = context.clone_with_base_key(subview_base);
         let collection = CollectionView::post_load(subview_context, &[])?;
         Ok(Self {
-            context,
             collection,
             stored_count,
             count: stored_count,
@@ -435,7 +427,7 @@ where
     fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
         let delete_subview = self.collection.pre_save(batch)?;
         if self.count != self.stored_count {
-            let count_key = self.context.base_key().base_tag(KeyTag::Count as u8);
+            let count_key = self.context().base_key().base_tag(KeyTag::Count as u8);
             if self.count == 0 {
                 batch.delete_key(count_key);
             } else {
@@ -464,7 +456,6 @@ where
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(Self {
-            context: self.context.clone(),
             collection: self.collection.clone_unchecked()?,
             stored_count: self.stored_count,
             count: self.count,

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -36,6 +36,9 @@ pub mod set_view;
 /// The `CollectionView` implements a map structure whose keys are ordered and the values are views.
 pub mod collection_view;
 
+/// Count-tracking variants of map, set and collection views.
+pub mod count_view;
+
 /// The `ReentrantCollectionView` implements a map structure whose keys are ordered and the values are views with concurrent access.
 pub mod reentrant_collection_view;
 

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use linera_views::{
     bucket_queue_view::HashedBucketQueueView,
     collection_view::{CollectionView, HashedCollectionView},
+    count_view::{CollectionCountView, MapCountView},
     context::{Context, MemoryContext},
     key_value_store_view::{KeyValueStoreView, SizeData},
     map_view::{HashedByteMapView, MapView},
@@ -116,6 +117,110 @@ async fn classic_collection_view_check() -> Result<()> {
                 assert_eq!(test_view, test_map);
             }
             // Checking the keys
+            let key_values = view.key_values().await;
+            assert_eq!(key_values, new_map);
+        }
+        if save {
+            if map != new_map {
+                assert!(view.has_pending_changes().await);
+            }
+            map = new_map.clone();
+            view.save().await?;
+            assert!(!view.has_pending_changes().await);
+        }
+    }
+    Ok(())
+}
+
+#[derive(CryptoHashRootView)]
+struct CollectionCountStateView<C> {
+    pub v: CollectionCountView<C, u8, RegisterView<C, u32>>,
+}
+
+impl<C> CollectionCountStateView<C>
+where
+    C: Context,
+{
+    async fn key_values(&self) -> BTreeMap<u8, u32> {
+        let mut map = BTreeMap::new();
+        let keys = self.v.indices().await.unwrap();
+        for key in keys {
+            let subview = self.v.try_load_entry(&key).await.unwrap().unwrap();
+            let value = subview.get();
+            map.insert(key, *value);
+        }
+        map
+    }
+}
+
+#[tokio::test]
+async fn classic_collection_count_view_check() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    let mut rng = make_deterministic_rng();
+    let mut map = BTreeMap::<u8, u32>::new();
+    let n = 20;
+    let nmax: u8 = 25;
+    for _ in 0..n {
+        let mut view = CollectionCountStateView::load(context.clone()).await?;
+        let hash = view.crypto_hash_mut().await?;
+        let save = rng.gen::<bool>();
+        let count_oper = rng.gen_range(0..25);
+        let mut new_map = map.clone();
+        for _ in 0..count_oper {
+            let choice = rng.gen_range(0..6);
+            if choice == 0 {
+                let pos = rng.gen_range(0..nmax);
+                view.v.remove_entry(&pos).await?;
+                new_map.remove(&pos);
+            }
+            if choice == 1 {
+                let n_ins = rng.gen_range(0..5);
+                for _i in 0..n_ins {
+                    let pos = rng.gen_range(0..nmax);
+                    let value = rng.gen::<u32>();
+                    let subview = view.v.load_entry_mut(&pos).await?;
+                    *subview.get_mut() = value;
+                    new_map.insert(pos, value);
+                }
+            }
+            if choice == 2 {
+                let n_load = rng.gen_range(0..5);
+                for _i in 0..n_load {
+                    let pos = rng.gen_range(0..nmax);
+                    let _subview = view.v.load_entry_mut(&pos).await?;
+                    new_map.entry(pos).or_insert(0);
+                }
+            }
+            if choice == 3 {
+                let n_reset = rng.gen_range(0..5);
+                for _i in 0..n_reset {
+                    let pos = rng.gen_range(0..nmax);
+                    view.v.reset_entry_to_default(&pos).await?;
+                    new_map.insert(pos, 0);
+                }
+            }
+            if choice == 4 {
+                view.clear();
+                new_map.clear();
+            }
+            if choice == 5 {
+                view.rollback();
+                assert!(!view.has_pending_changes().await);
+                new_map = map.clone();
+            }
+            assert_eq!(view.v.count().await?, new_map.len());
+            let new_hash = view.crypto_hash_mut().await?;
+            if map == new_map {
+                assert_eq!(new_hash, hash);
+            } else {
+                assert_ne!(new_hash, hash);
+            }
+            for _ in 0..10 {
+                let pos = rng.gen::<u8>();
+                let test_view = view.v.try_load_entry(&pos).await?.is_some();
+                let test_map = new_map.contains_key(&pos);
+                assert_eq!(test_view, test_map);
+            }
             let key_values = view.key_values().await;
             assert_eq!(key_values, new_map);
         }
@@ -398,6 +503,143 @@ async fn map_view_mutability() -> Result<()> {
     let mut rng = make_deterministic_rng();
     for _ in 0..5 {
         run_map_view_mutability(&mut rng).await?;
+    }
+    Ok(())
+}
+
+#[derive(CryptoHashRootView)]
+pub struct MapCountStateView<C> {
+    pub map: MapCountView<C, Vec<u8>, u8>,
+}
+
+async fn run_map_count_view_mutability<R: RngCore + Clone>(rng: &mut R) -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    let mut state_map = BTreeMap::new();
+    let mut all_keys = BTreeSet::new();
+    let n = 10;
+    for _ in 0..n {
+        let mut view = MapCountStateView::load(context.clone()).await?;
+        let save = rng.gen::<bool>();
+        let read_state = view
+            .map
+            .index_values()
+            .await?
+            .into_iter()
+            .collect::<BTreeMap<_, _>>();
+        let read_hash = view.crypto_hash_mut().await?;
+        let state_vec = state_map.clone().into_iter().collect::<Vec<_>>();
+        assert_eq!(state_map, read_state);
+        let count_oper = rng.gen_range(0..25);
+        let mut new_state_map = state_map.clone();
+        let mut new_state_vec = state_vec.clone();
+        for _ in 0..count_oper {
+            let choice = rng.gen_range(0..6);
+            let count = view.map.count().await?;
+            if choice == 0 {
+                let n_ins = rng.gen_range(0..10);
+                for _ in 0..n_ins {
+                    let len = rng.gen_range(1..6);
+                    let key = rng
+                        .clone()
+                        .sample_iter(Uniform::from(0..4))
+                        .take(len)
+                        .collect::<Vec<_>>();
+                    all_keys.insert(key.clone());
+                    let value = rng.gen::<u8>();
+                    view.map.insert(&key, value).await?;
+                    new_state_map.insert(key, value);
+                }
+            }
+            if choice == 1 && count > 0 {
+                let n_remove = rng.gen_range(0..count);
+                for _ in 0..n_remove {
+                    let pos = rng.gen_range(0..new_state_vec.len());
+                    let vec = new_state_vec[pos].clone();
+                    view.map.remove(&vec.0).await?;
+                    new_state_map.remove(&vec.0);
+                }
+            }
+            if choice == 2 {
+                view.clear();
+                new_state_map.clear();
+            }
+            if choice == 3 {
+                view.rollback();
+                assert!(!view.has_pending_changes().await);
+                new_state_map = state_map.clone();
+            }
+            if choice == 4 && count > 0 {
+                let pos = rng.gen_range(0..new_state_vec.len());
+                let vec = new_state_vec[pos].clone();
+                let key = vec.0;
+                let result = view.map.get_mut(&key).await?.unwrap();
+                let new_value = rng.gen::<u8>();
+                *result = new_value;
+                new_state_map.insert(key, new_value);
+            }
+            if choice == 5 {
+                let key = if rng.gen::<bool>() && !new_state_vec.is_empty() {
+                    let pos = rng.gen_range(0..new_state_vec.len());
+                    new_state_vec[pos].0.clone()
+                } else {
+                    let len = rng.gen_range(1..6);
+                    rng.clone()
+                        .sample_iter(Uniform::from(0..4))
+                        .take(len)
+                        .collect::<Vec<_>>()
+                };
+                let test_view = view.map.contains_key(&key).await?;
+                let test_map = new_state_map.contains_key(&key);
+                assert_eq!(test_view, test_map);
+                let result = view.map.get_mut_or_default(&key).await?;
+                let new_value = rng.gen::<u8>();
+                *result = new_value;
+                new_state_map.insert(key, new_value);
+            }
+            new_state_vec = new_state_map.clone().into_iter().collect();
+            assert_eq!(view.map.count().await?, new_state_vec.len());
+            let new_hash = view.crypto_hash_mut().await?;
+            if state_map == new_state_map {
+                assert_eq!(new_hash, read_hash);
+            } else {
+                assert_ne!(new_hash, read_hash);
+            }
+            let new_key_values = view
+                .map
+                .index_values()
+                .await?
+                .into_iter()
+                .collect::<BTreeMap<_, _>>();
+            assert_eq!(new_state_map, new_key_values);
+            let keys_vec = all_keys.iter().cloned().collect::<Vec<_>>();
+            let values = view.map.multi_get(keys_vec.iter()).await?;
+            for i in 0..keys_vec.len() {
+                let key = &keys_vec[i];
+                let test_map = new_state_map.contains_key(key);
+                let test_view1 = view.map.get(key).await?.is_some();
+                let test_view2 = view.map.contains_key(key).await?;
+                assert_eq!(test_map, test_view1);
+                assert_eq!(test_map, test_view2);
+                assert_eq!(test_map, values[i].is_some());
+            }
+        }
+        if save {
+            if state_map != new_state_map {
+                assert!(view.has_pending_changes().await);
+            }
+            state_map = new_state_map.clone();
+            view.save().await?;
+            assert!(!view.has_pending_changes().await);
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn map_count_view_mutability() -> Result<()> {
+    let mut rng = make_deterministic_rng();
+    for _ in 0..5 {
+        run_map_count_view_mutability(&mut rng).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Motivation

For some applications, we need a variant that keeps track of the count and is fast.

## Proposal

Use Deref/Deref and nest the inner container for that purpose.

## Test Plan

CI.
Tests were added.

## Release Plan

This change could be backported to testnet_conway.

## Links

None.