### PR TITLE
Fix bridge E2E workflow to build wrapped-fungible instead of fungible

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -113,8 +113,8 @@ jobs:
           BRANCH="${{ github.base_ref || github.ref_name }}"
           docker push "${GCP_REGISTRY}/linera-bridge:${BRANCH}"
 
-      - name: Build fungible example Wasm
-        run: cargo build --release --target wasm32-unknown-unknown -p fungible
+      - name: Build wrapped-fungible example Wasm
+        run: cargo build --release --target wasm32-unknown-unknown -p wrapped-fungible
         working-directory: examples
 
       - name: Run bridge E2E test


### PR DESCRIPTION
## Motivation

The bridge E2E test has been failing since #5592 switched the bridge from `fungible` to
`wrapped-fungible`. The CI workflow still builds `-p fungible`, producing
`fungible_contract.wasm`/`fungible_service.wasm`, but the test now loads
`wrapped_fungible_contract.wasm`/`wrapped_fungible_service.wasm` — causing `No such file
or directory (os error 2)`.

## Proposal

Update the WASM build step in `bridge-e2e.yml` from `-p fungible` to `-p
wrapped-fungible`.

## Test Plan

CI — the `pull_request` trigger is temporarily added so the bridge E2E job runs on this
PR. Will be removed before merging.
