### PR TITLE
Add Prometheus metrics for WASM bytecode sizes

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
@@ -5172,6 +5172,332 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "Size distribution of WASM bytecodes passed to the module cache (after metering for contracts, raw for services)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 164
+      },
+      "id": 67,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_bytecode_size_bytes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_bytecode_size_bytes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_bytecode_size_bytes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Wasm Bytecode Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size distribution of WASM bytecodes after decompression from on-chain blobs (before metering instrumentation)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p99"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 164
+      },
+      "id": 68,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.6.0-83314",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(linera_wasm_bytecode_decompressed_size_bytes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum(rate(linera_wasm_bytecode_decompressed_size_bytes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p90",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(linera_wasm_bytecode_decompressed_size_bytes_bucket{validator=~\"$validator\"}[1m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Wasm Decompressed Bytecode Size",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "Amount of WebAssembly execution fuel consumed per block",
       "fieldConfig": {
         "defaults": {
@@ -5273,7 +5599,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 164
+        "y": 172
       },
       "id": 34,
       "options": {
@@ -5436,7 +5762,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 164
+        "y": 172
       },
       "id": 35,
       "options": {
@@ -5599,7 +5925,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 172
+        "y": 180
       },
       "id": 36,
       "options": {
@@ -5762,7 +6088,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 172
+        "y": 180
       },
       "id": 37,
       "options": {

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1228,6 +1228,11 @@ impl CompressedBytecode {
         let _decompression_latency = metrics::BYTECODE_DECOMPRESSION_LATENCY.measure_latency();
         let bytes = zstd::stream::decode_all(&**self.compressed_bytes)?;
 
+        #[cfg(with_metrics)]
+        metrics::BYTECODE_DECOMPRESSED_SIZE_BYTES
+            .with_label_values(&[])
+            .observe(bytes.len() as f64);
+
         Ok(Bytecode { bytes })
     }
 }
@@ -1271,6 +1276,11 @@ impl CompressedBytecode {
                 .read_to_end(&mut bytes)
                 .expect("Reading from a slice in memory should not result in I/O errors");
         }
+
+        #[cfg(with_metrics)]
+        BYTECODE_DECOMPRESSED_SIZE_BYTES
+            .with_label_values(&[])
+            .observe(bytes.len() as f64);
 
         Ok(Bytecode { bytes })
     }
@@ -1689,7 +1699,9 @@ mod metrics {
 
     use prometheus::HistogramVec;
 
-    use crate::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use crate::prometheus_util::{
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
+    };
 
     /// The time it takes to compress a bytecode.
     pub static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -1708,6 +1720,15 @@ mod metrics {
             "Bytecode decompression latency",
             &[],
             exponential_bucket_latencies(10.0),
+        )
+    });
+
+    pub static BYTECODE_DECOMPRESSED_SIZE_BYTES: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "wasm_bytecode_decompressed_size_bytes",
+            "Decompressed size in bytes of WASM bytecodes stored on-chain",
+            &[],
+            exponential_bucket_interval(10_000.0, 100_000_000.0),
         )
     });
 }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -45,7 +45,9 @@ use crate::{
 mod metrics {
     use std::sync::LazyLock;
 
-    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use linera_base::prometheus_util::{
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
+    };
     use prometheus::HistogramVec;
 
     pub static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -63,6 +65,15 @@ mod metrics {
             "Wasm service instantiation latency",
             &[],
             exponential_bucket_latencies(1.0),
+        )
+    });
+
+    pub static WASM_BYTECODE_SIZE_BYTES: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "wasm_bytecode_size_bytes",
+            "Size in bytes of WASM bytecodes being loaded",
+            &["type"],
+            exponential_bucket_interval(10_000.0, 100_000_000.0),
         )
     });
 }

--- a/linera-execution/src/wasm/module_cache.rs
+++ b/linera-execution/src/wasm/module_cache.rs
@@ -46,11 +46,18 @@ impl<Module> ModuleCache<Module> {
 impl<Module: Clone> ModuleCache<Module> {
     /// Returns a `Module` for the requested `bytecode`, creating it with `module_builder` and
     /// adding it to the cache if it doesn't already exist in the cache.
+    #[cfg_attr(not(with_metrics), allow(unused_variables))]
     pub fn get_or_insert_with<E>(
         &mut self,
         bytecode: Bytecode,
+        bytecode_type: &str,
         module_builder: impl FnOnce(Bytecode) -> Result<Module, E>,
     ) -> Result<Module, E> {
+        #[cfg(with_metrics)]
+        super::metrics::WASM_BYTECODE_SIZE_BYTES
+            .with_label_values(&[bytecode_type])
+            .observe(bytecode.as_ref().len() as f64);
+
         if let Some(module) = self.get(&bytecode) {
             Ok(module)
         } else {

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -60,7 +60,7 @@ impl WasmContractModule {
     pub async fn from_wasmer(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
         let (engine, module) = contract_cache
-            .get_or_insert_with(contract_bytecode, CachedContractModule::new)
+            .get_or_insert_with(contract_bytecode, "contract", CachedContractModule::new)
             .map_err(WasmExecutionError::LoadContractModule)?
             .create_execution_instance()
             .map_err(WasmExecutionError::LoadContractModule)?;
@@ -95,7 +95,7 @@ impl WasmServiceModule {
     pub async fn from_wasmer(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
         let module = service_cache
-            .get_or_insert_with(service_bytecode, |bytecode| {
+            .get_or_insert_with(service_bytecode, "service", |bytecode| {
                 wasmer::Module::new(&*SERVICE_ENGINE, bytecode).map_err(anyhow::Error::from)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -61,7 +61,7 @@ impl WasmContractModule {
     pub async fn from_wasmtime(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
         let module = contract_cache
-            .get_or_insert_with(contract_bytecode, |bytecode| {
+            .get_or_insert_with(contract_bytecode, "contract", |bytecode| {
                 Module::new(&CONTRACT_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadContractModule)?;
@@ -97,7 +97,7 @@ impl WasmServiceModule {
     pub async fn from_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
         let module = service_cache
-            .get_or_insert_with(service_bytecode, |bytecode| {
+            .get_or_insert_with(service_bytecode, "service", |bytecode| {
                 Module::new(&SERVICE_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;


### PR DESCRIPTION
## Motivation

We have no visibility into the size distribution of WASM bytecodes being loaded or
stored on-chain. This makes it harder to reason about memory pressure, cache
effectiveness, and on-chain storage costs.

## Proposal

Add two new Prometheus histogram metrics:

- **`wasm_bytecode_size_bytes`** — Records the size of every bytecode passed to
`ModuleCache::get_or_insert_with` (both cache hits and misses). Labeled with `type`
(`"contract"` or `"service"`) to distinguish them. This captures the size after metering
instrumentation (for contracts) or raw (for services).

- **`wasm_bytecode_decompressed_size_bytes`** — Records the decompressed size of
bytecodes right after zstd decompression in `CompressedBytecode::decompress()`. This
captures the raw on-chain bytecode size before any instrumentation.

Both use `exponential_bucket_interval(10_000.0, 100_000_000.0)` for buckets spanning
10KB to 100MB, following existing patterns.

Adds corresponding Grafana panels to the execution dashboard in the Wasm section.

## Test Plan

CI
