### PR TITLE
Address authentication issue in `native-fungible`.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1807,6 +1807,7 @@ dependencies = [
  "async-graphql",
  "fungible",
  "linera-sdk",
+ "native-fungible",
  "serde",
  "serde_json",
  "tokio",

--- a/examples/crowd-funding/Cargo.toml
+++ b/examples/crowd-funding/Cargo.toml
@@ -14,6 +14,7 @@ serde_json.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+native-fungible.workspace = true
 tokio.workspace = true
 
 [[bin]]

--- a/examples/crowd-funding/tests/native_fungible_campaign.rs
+++ b/examples/crowd-funding/tests/native_fungible_campaign.rs
@@ -13,9 +13,7 @@
 use crowd_funding::{CrowdFundingAbi, InstantiationArgument, Operation};
 use fungible::{FungibleTokenAbi, InitialState, Parameters};
 use linera_sdk::{
-    linera_base_types::{
-        Account, AccountOwner, Amount, ApplicationId, Timestamp,
-    },
+    linera_base_types::{Account, AccountOwner, Amount, ApplicationId, Timestamp},
     test::TestValidator,
 };
 
@@ -93,11 +91,7 @@ async fn collect_pledges_native_fungible() {
         let recipient = Account::new(backer_chain.id(), backer_account);
         let (transfer_cert, _) = admin_chain
             .add_block(|block| {
-                block.with_native_token_transfer(
-                    AccountOwner::CHAIN,
-                    recipient,
-                    initial_amount,
-                );
+                block.with_native_token_transfer(AccountOwner::CHAIN, recipient, initial_amount);
             })
             .await;
 
@@ -169,6 +163,9 @@ async fn collect_pledges_native_fungible() {
     // Verify backer balances: each should have (initial - pledge) in their owner account.
     for (backer_chain, backer_account) in &backers {
         let remaining = backer_chain.owner_balance(backer_account).await;
-        assert_eq!(remaining, Some(initial_amount.saturating_sub(pledge_amount)));
+        assert_eq!(
+            remaining,
+            Some(initial_amount.saturating_sub(pledge_amount))
+        );
     }
 }

--- a/examples/crowd-funding/tests/native_fungible_campaign.rs
+++ b/examples/crowd-funding/tests/native_fungible_campaign.rs
@@ -1,0 +1,174 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for Crowd-Funding with Native Fungible Token.
+//!
+//! These tests exercise the `transfer_auth_depth` / `claim_auth_depth` code path:
+//! crowd-funding calls native-fungible, which in turn calls `transfer_auth_depth(1, ...)`
+//! to authenticate the transfer using the caller (crowd-funding) rather than itself
+//! (native-fungible).
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use crowd_funding::{CrowdFundingAbi, InstantiationArgument, Operation};
+use fungible::{FungibleTokenAbi, InitialState, Parameters};
+use linera_sdk::{
+    linera_base_types::{
+        Account, AccountOwner, Amount, ApplicationId, Timestamp,
+    },
+    test::TestValidator,
+};
+
+/// Test creating a campaign backed by native-fungible tokens and collecting pledges.
+///
+/// This exercises the critical `transfer_auth_depth` code path: when crowd-funding
+/// collects pledges, it transfers from its own app-owned account via native-fungible.
+/// Without `transfer_auth_depth`, the system transfer would fail because
+/// native-fungible's own app ID would be used for authentication instead of
+/// crowd-funding's app ID.
+#[tokio::test(flavor = "multi_thread")]
+async fn collect_pledges_native_fungible() {
+    let initial_amount = Amount::from_tokens(5);
+    let target_amount = Amount::from_tokens(6);
+    let pledge_amount = Amount::from_tokens(3);
+
+    let (validator, crowd_funding_module_id) = TestValidator::with_current_module::<
+        CrowdFundingAbi,
+        ApplicationId<FungibleTokenAbi>,
+        InstantiationArgument,
+    >()
+    .await;
+
+    // Create the campaign chain.
+    let mut campaign_chain = validator.new_chain().await;
+    let campaign_account = AccountOwner::from(campaign_chain.public_key());
+
+    // Publish native-fungible bytecode.
+    let native_fungible_publisher = validator.new_chain().await;
+    let native_fungible_module_id = native_fungible_publisher
+        .publish_bytecode_files_in::<FungibleTokenAbi, Parameters, InitialState>(
+            "../native-fungible",
+        )
+        .await;
+
+    // Create the native-fungible application on a dedicated chain.
+    let mut native_fungible_chain = validator.new_chain().await;
+    let native_fungible_params = Parameters::new("NAT");
+    let native_fungible_initial_state = fungible::InitialStateBuilder::default().build();
+    let native_fungible_id = native_fungible_chain
+        .create_application(
+            native_fungible_module_id,
+            native_fungible_params,
+            native_fungible_initial_state,
+            vec![],
+        )
+        .await;
+
+    // Create the crowd-funding campaign with native-fungible as the token.
+    let campaign_state = InstantiationArgument {
+        owner: campaign_account,
+        deadline: Timestamp::from(u64::MAX),
+        target: target_amount,
+    };
+    let campaign_id = campaign_chain
+        .create_application(
+            crowd_funding_module_id,
+            native_fungible_id,
+            campaign_state,
+            vec![native_fungible_id.forget_abi()],
+        )
+        .await;
+
+    // Create backer chains and fund them with native tokens in their owner accounts.
+    let num_backers = 3;
+    let mut backers = Vec::new();
+    let admin_chain = validator.get_chain(&validator.admin_chain_id());
+
+    for _ in 0..num_backers {
+        let backer_chain = validator.new_chain().await;
+        let backer_account = AccountOwner::from(backer_chain.public_key());
+
+        // Transfer native tokens from the admin chain balance to the backer's
+        // owner account on the backer chain.
+        let recipient = Account::new(backer_chain.id(), backer_account);
+        let (transfer_cert, _) = admin_chain
+            .add_block(|block| {
+                block.with_native_token_transfer(
+                    AccountOwner::CHAIN,
+                    recipient,
+                    initial_amount,
+                );
+            })
+            .await;
+
+        // Receive the transfer on the backer chain.
+        backer_chain
+            .add_block(|block| {
+                block.with_messages_from(&transfer_cert);
+            })
+            .await;
+
+        backers.push((backer_chain, backer_account));
+    }
+
+    // Each backer pledges to the campaign. This calls crowd-funding on the backer chain,
+    // which calls native-fungible's Transfer operation via call_application.
+    // Native-fungible then calls transfer_auth_depth(owner, target, amount, 1).
+    let mut pledge_certificates = Vec::new();
+    for (backer_chain, backer_account) in &backers {
+        let (pledge_cert, _) = backer_chain
+            .add_block(|block| {
+                block.with_operation(
+                    campaign_id,
+                    Operation::Pledge {
+                        owner: *backer_account,
+                        amount: pledge_amount,
+                    },
+                );
+            })
+            .await;
+
+        pledge_certificates.push(pledge_cert);
+    }
+
+    // Receive all pledge messages on the campaign chain.
+    campaign_chain
+        .add_block(|block| {
+            for cert in &pledge_certificates {
+                block.with_messages_from(cert);
+            }
+        })
+        .await;
+
+    // The crowd-funding app's account on the campaign chain should now hold
+    // the pledged native tokens (3 backers * 3 tokens = 9 tokens).
+    let crowd_funding_owner: AccountOwner = campaign_id.forget_abi().into();
+    let crowd_funding_balance = campaign_chain.owner_balance(&crowd_funding_owner).await;
+    assert_eq!(
+        crowd_funding_balance,
+        Some(pledge_amount.saturating_mul(num_backers as u128)),
+    );
+
+    // Collect pledges. This is the critical test: crowd-funding calls native-fungible
+    // to transfer from crowd-funding's app-owned account to the campaign owner.
+    // native-fungible uses transfer_auth_depth(1, ...) so the system sees
+    // crowd-funding (the caller) as the authenticated app, not native-fungible.
+    campaign_chain
+        .add_block(|block| {
+            block.with_operation(campaign_id, Operation::Collect);
+        })
+        .await;
+
+    // The campaign owner should now have received the collected pledges.
+    let campaign_owner_balance = campaign_chain.owner_balance(&campaign_account).await;
+    assert_eq!(
+        campaign_owner_balance,
+        Some(pledge_amount.saturating_mul(num_backers as u128)),
+    );
+
+    // Verify backer balances: each should have (initial - pledge) in their owner account.
+    for (backer_chain, backer_account) in &backers {
+        let remaining = backer_chain.owner_balance(backer_account).await;
+        assert_eq!(remaining, Some(initial_amount.saturating_sub(pledge_amount)));
+    }
+}

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -69,10 +69,6 @@ impl Contract for NativeFungibleTokenContract {
                 amount,
                 target_account,
             } => {
-                self.runtime
-                    .check_account_permission(owner)
-                    .expect("Permission for Transfer operation");
-
                 let fungible_target_account = target_account;
                 let target_account = self.normalize_account(target_account);
 
@@ -99,10 +95,6 @@ impl Contract for NativeFungibleTokenContract {
                 amount,
                 target_account,
             } => {
-                self.runtime
-                    .check_account_permission(source_account.owner)
-                    .expect("Permission for Claim operation");
-
                 let fungible_source_account = source_account;
                 let fungible_target_account = target_account;
 

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -83,7 +83,8 @@ impl Contract for NativeFungibleTokenContract {
                     amount
                 );
 
-                self.runtime.transfer_auth_depth(owner, target_account, amount, 1);
+                self.runtime
+                    .transfer_auth_depth(owner, target_account, amount, 1);
 
                 self.transfer(fungible_target_account.chain_id);
                 FungibleResponse::Ok
@@ -108,7 +109,8 @@ impl Contract for NativeFungibleTokenContract {
                 let source_account = self.normalize_account(source_account);
                 let target_account = self.normalize_account(target_account);
 
-                self.runtime.claim_auth_depth(source_account, target_account, amount, 1);
+                self.runtime
+                    .claim_auth_depth(source_account, target_account, amount, 1);
                 self.claim(
                     fungible_source_account.chain_id,
                     fungible_target_account.chain_id,

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -83,7 +83,7 @@ impl Contract for NativeFungibleTokenContract {
                     amount
                 );
 
-                self.runtime.transfer(owner, target_account, amount);
+                self.runtime.transfer_auth_depth(owner, target_account, amount, 1);
 
                 self.transfer(fungible_target_account.chain_id);
                 FungibleResponse::Ok
@@ -108,7 +108,7 @@ impl Contract for NativeFungibleTokenContract {
                 let source_account = self.normalize_account(source_account);
                 let target_account = self.normalize_account(target_account);
 
-                self.runtime.claim(source_account, target_account, amount);
+                self.runtime.claim_auth_depth(source_account, target_account, amount, 1);
                 self.claim(
                     fungible_source_account.chain_id,
                     fungible_target_account.chain_id,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -199,7 +199,7 @@ where
                 let maybe_message = self
                     .state
                     .system
-                    .transfer(signer, Some(application_id), source, destination, amount)
+                    .transfer(signer, application_id, source, destination, amount)
                     .await?;
                 self.txn_tracker.add_outgoing_messages(maybe_message);
                 callback.respond(());
@@ -218,7 +218,7 @@ where
                     .system
                     .claim(
                         signer,
-                        Some(application_id),
+                        application_id,
                         source.owner,
                         source.chain_id,
                         destination,
@@ -1197,7 +1197,8 @@ pub enum ExecutionRequest {
         amount: Amount,
         #[debug(skip_if = Option::is_none)]
         signer: Option<AccountOwner>,
-        application_id: ApplicationId,
+        #[debug(skip_if = Option::is_none)]
+        application_id: Option<ApplicationId>,
         #[debug(skip)]
         callback: Sender<()>,
     },
@@ -1208,7 +1209,8 @@ pub enum ExecutionRequest {
         amount: Amount,
         #[debug(skip_if = Option::is_none)]
         signer: Option<AccountOwner>,
-        application_id: ApplicationId,
+        #[debug(skip_if = Option::is_none)]
+        application_id: Option<ApplicationId>,
         #[debug(skip)]
         callback: Sender<()>,
     },

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -961,12 +961,36 @@ pub trait ContractRuntime: BaseRuntime {
         amount: Amount,
     ) -> Result<(), ExecutionError>;
 
+    /// Transfers amount from source to destination, using the application ID at the
+    /// given depth in the call stack for authentication. Depth 0 is the immediate caller,
+    /// depth 1 is the caller before that, etc. If the depth exceeds the call stack size,
+    /// `None` is used as the authenticated application ID.
+    fn transfer_auth_depth(
+        &mut self,
+        source: AccountOwner,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
+    ) -> Result<(), ExecutionError>;
+
     /// Claims amount from source to destination.
     fn claim(
         &mut self,
         source: Account,
         destination: Account,
         amount: Amount,
+    ) -> Result<(), ExecutionError>;
+
+    /// Claims amount from source to destination, using the application ID at the
+    /// given depth in the call stack for authentication. Depth 0 is the immediate caller,
+    /// depth 1 is the caller before that, etc. If the depth exceeds the call stack size,
+    /// `None` is used as the authenticated application ID.
+    fn claim_auth_depth(
+        &mut self,
+        source: Account,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
     ) -> Result<(), ExecutionError>;
 
     /// Calls another application. Forwarded sessions will now be visible to

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -357,6 +357,19 @@ impl<UserInstance: WithContext> SyncRuntimeInternal<UserInstance> {
             .expect("Call stack is unexpectedly empty")
     }
 
+    /// Returns the application ID at the given depth from the top of the call stack.
+    /// Depth 0 is the current (topmost) application, depth 1 is the one before it, etc.
+    /// Returns `None` if the depth exceeds the call stack size.
+    fn application_id_at_depth(&self, depth: u32) -> Option<ApplicationId> {
+        let depth = depth as usize;
+        let len = self.call_stack.len();
+        if depth < len {
+            Some(self.call_stack[len - 1 - depth].id)
+        } else {
+            None
+        }
+    }
+
     /// Inserts a new [`ApplicationStatus`] to the end of the `call_stack`.
     ///
     /// Ensures the application's ID is also tracked in the `active_applications` set.
@@ -1289,8 +1302,32 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     ) -> Result<(), ExecutionError> {
         let this = self.inner();
         let current_application = this.current_application();
-        let application_id = current_application.id;
+        let application_id = Some(current_application.id);
         let signer = current_application.signer;
+
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::Transfer {
+                source,
+                destination,
+                amount,
+                signer,
+                application_id,
+                callback,
+            })?
+            .recv_response()?;
+        Ok(())
+    }
+
+    fn transfer_auth_depth(
+        &mut self,
+        source: AccountOwner,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
+    ) -> Result<(), ExecutionError> {
+        let this = self.inner();
+        let signer = this.current_application().signer;
+        let application_id = this.application_id_at_depth(auth_depth);
 
         this.execution_state_sender
             .send_request(|callback| ExecutionRequest::Transfer {
@@ -1313,8 +1350,32 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
     ) -> Result<(), ExecutionError> {
         let this = self.inner();
         let current_application = this.current_application();
-        let application_id = current_application.id;
+        let application_id = Some(current_application.id);
         let signer = current_application.signer;
+
+        this.execution_state_sender
+            .send_request(|callback| ExecutionRequest::Claim {
+                source,
+                destination,
+                amount,
+                signer,
+                application_id,
+                callback,
+            })?
+            .recv_response()?;
+        Ok(())
+    }
+
+    fn claim_auth_depth(
+        &mut self,
+        source: Account,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
+    ) -> Result<(), ExecutionError> {
+        let this = self.inner();
+        let signer = this.current_application().signer;
+        let application_id = this.application_id_at_depth(auth_depth);
 
         this.execution_state_sender
             .send_request(|callback| ExecutionRequest::Claim {

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -503,6 +503,23 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Transfers an `amount` of native tokens from `source` owner account (or the current chain's
+    /// balance) to `destination`, using the application ID at the given depth in the call stack
+    /// for authentication.
+    fn transfer_auth_depth(
+        caller: &mut Caller,
+        source: AccountOwner,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
+    ) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .transfer_auth_depth(source, destination, amount, auth_depth)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Claims an `amount` of native tokens from a `source` account to a `destination` account.
     fn claim(
         caller: &mut Caller,
@@ -514,6 +531,22 @@ where
             .user_data_mut()
             .runtime
             .claim(source, destination, amount)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Claims an `amount` of native tokens from a `source` account to a `destination` account,
+    /// using the application ID at the given depth in the call stack for authentication.
+    fn claim_auth_depth(
+        caller: &mut Caller,
+        source: Account,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
+    ) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .claim_auth_depth(source, destination, amount, auth_depth)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -250,9 +250,39 @@ where
         contract_wit::transfer(source.into(), destination.into(), amount.into())
     }
 
+    /// Transfers an `amount` of native tokens from `source` owner account (or the current chain's
+    /// balance) to `destination`, using the application ID at the given depth in the call stack
+    /// for authentication. Depth 0 is the current application, depth 1 is the caller, etc.
+    /// If the depth exceeds the call stack size, `None` is used as the authenticated
+    /// application ID.
+    pub fn transfer_auth_depth(
+        &mut self,
+        source: AccountOwner,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
+    ) {
+        contract_wit::transfer_auth_depth(source.into(), destination.into(), amount.into(), auth_depth)
+    }
+
     /// Claims an `amount` of native tokens from a `source` account to a `destination` account.
     pub fn claim(&mut self, source: Account, destination: Account, amount: Amount) {
         contract_wit::claim(source.into(), destination.into(), amount.into())
+    }
+
+    /// Claims an `amount` of native tokens from a `source` account to a `destination` account,
+    /// using the application ID at the given depth in the call stack for authentication.
+    /// Depth 0 is the current application, depth 1 is the caller, etc.
+    /// If the depth exceeds the call stack size, `None` is used as the authenticated
+    /// application ID.
+    pub fn claim_auth_depth(
+        &mut self,
+        source: Account,
+        destination: Account,
+        amount: Amount,
+        auth_depth: u32,
+    ) {
+        contract_wit::claim_auth_depth(source.into(), destination.into(), amount.into(), auth_depth)
     }
 
     /// Calls another application.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -262,7 +262,12 @@ where
         amount: Amount,
         auth_depth: u32,
     ) {
-        contract_wit::transfer_auth_depth(source.into(), destination.into(), amount.into(), auth_depth)
+        contract_wit::transfer_auth_depth(
+            source.into(),
+            destination.into(),
+            amount.into(),
+            auth_depth,
+        )
     }
 
     /// Claims an `amount` of native tokens from a `source` account to a `destination` account.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -584,6 +584,19 @@ where
             .expect("Account balance overflow");
     }
 
+    /// Transfers an `amount` of native tokens from `source` owner account (or the current chain's
+    /// balance) to `destination`, using the application ID at the given depth in the call stack
+    /// for authentication. In tests, this behaves the same as `transfer`.
+    pub fn transfer_auth_depth(
+        &mut self,
+        source: AccountOwner,
+        destination: Account,
+        amount: Amount,
+        _auth_depth: u32,
+    ) {
+        self.transfer(source, destination, amount)
+    }
+
     /// Returns the outgoing transfers scheduled during the test so far.
     pub fn outgoing_transfers(&self) -> &HashMap<Account, Amount> {
         &self.outgoing_transfers
@@ -604,6 +617,19 @@ where
             amount,
             destination,
         });
+    }
+
+    /// Claims an `amount` of native tokens from a `source` account to a `destination` account,
+    /// using the application ID at the given depth in the call stack for authentication.
+    /// In tests, this behaves the same as `claim`.
+    pub fn claim_auth_depth(
+        &mut self,
+        source: Account,
+        destination: Account,
+        amount: Amount,
+        _auth_depth: u32,
+    ) {
+        self.claim(source, destination, amount)
     }
 
     /// Returns the list of claims made during the test so far.

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -7,7 +7,9 @@ interface contract-runtime-api {
     authenticated-caller-id: func() -> option<application-id>;
     send-message: func(message: send-message-request);
     transfer: func(source: account-owner, destination: account, amount: amount);
+    transfer-auth-depth: func(source: account-owner, destination: account, amount: amount, auth-depth: u32);
     claim: func(source: account, destination: account, amount: amount);
+    claim-auth-depth: func(source: account, destination: account, amount: amount, auth-depth: u32);
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
     close-chain: func() -> result<tuple<>, manage-chain-error>;
     change-ownership: func(ownership: chain-ownership) -> result<tuple<>, manage-chain-error>;


### PR DESCRIPTION
## Motivation

Issue #4416 that is being considered here is about authentication. We have one authentication going on in `native-fungible` contract code:
```rust
                self.runtime
                    .check_account_permission(owner)
                    .expect("Permission for Transfer operation");
```
This one is done with the authenticated_caller_id being equal to the contract that was calling it.

This is followed in the function `fn transfer` of `linera-execution/src/system.rs` by the following:
```rust
            ensure!(
                authenticated_owner == Some(source)
                    || authenticated_application_id.map(AccountOwner::from) == Some(source),
                ExecutionError::UnauthenticatedTransferOwner
            );
```
It looks the same, but it is not: The authenticated caller id in question is this time the one of the `native-fungible` contract.

This means that we cannot expect the `native-fungible` to behave in a way identical to the `fungible` contract despite them having the same API.

Fixes #4416 

## Proposal

It would be very inappropriate to remove the authentication for transfer or to be able to put what should be used.
But we need a degree of choice here. What we have is the `authenticated_owner` and the `authenticated_caller_id`.
The `authenticated_owner` is the first entry in the call stack. The `authenticated_caller_id` is the last entry.

Therefore, it seems appropriate to give the option of choosing the account used for authentication in the call stack.
This is done by having some function `transfer_auth_depth` which specifies the depth at which we do the authentication.
At level 0, this is the `authenticated_caller_id`. At level 1, it is the level before that.

Is this the final design of authentication? Probably not, but it does address the problem.

## Test Plan

CI.
A test has been added in the `crowd-funding` to make it run with the `native-fungible`. The test passes on this branch and fails on `main`.

## Release Plan

We want a token on mainnet, so this could be backported to `testnet_conway`.

## Links

None