### PR TITLE
Eliminate web feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,8 @@
 linker = "aarch64-linux-gnu-gcc"
 
 [env]
-# Makes `--target wasm32-linera-chain` and `--target wasm32-unknown-js-web` resolve to
-# linera-service/wasm32-linera-chain.json and linera-service/wasm32-unknown-js-web.json
+# Makes `--target wasm32-linera-chain` and `--target wasm32-web-unknown` resolve to
+# linera-service/wasm32-linera-chain.json and linera-service/wasm32-web-unknown.json
 # anywhere in the repo.
 RUST_TARGET_PATH = { value = "linera-service", relative = true }
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,8 @@
 linker = "aarch64-linux-gnu-gcc"
 
 [env]
-# Makes `--target wasm32-linera-chain` resolve to linera-service/wasm32-linera-chain.json
+# Makes `--target wasm32-linera-chain` and `--target wasm32-unknown-js-web` resolve to
+# linera-service/wasm32-linera-chain.json and linera-service/wasm32-unknown-js-web.json
 # anywhere in the repo.
 RUST_TARGET_PATH = { value = "linera-service", relative = true }
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -567,7 +567,9 @@ jobs:
         cargo clippy --locked --all-targets --all-features
         cargo clippy --locked --no-default-features --features kubernetes
         cargo clippy --locked --no-default-features
-        cargo clippy --locked --target wasm32-unknown-unknown --no-default-features --features web-default \
+        RUSTFLAGS="$RUSTFLAGS -Zunstable-options" cargo clippy --locked \
+          --target wasm32-web-unknown -Zbuild-std=panic_abort,std -Zjson-target-spec \
+          --no-default-features --features web-default \
           -p linera-client \
           -p linera-rpc \
           -p linera-views

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,7 +3500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6249,12 +6249,12 @@ dependencies = [
 [[package]]
 name = "linera-wasmer"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "bytes",
  "cfg-if",
  "derivative",
- "indexmap 1.9.3",
+ "indexmap 2.10.0",
  "js-sys",
  "linera-wasmer-compiler",
  "linera-wasmer-compiler-cranelift",
@@ -6279,7 +6279,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6309,7 +6309,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler-cranelift"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -6327,7 +6327,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler-singlepass"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -6345,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-vm"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "backtrace",
  "cc",
@@ -6356,7 +6356,7 @@ dependencies = [
  "derivative",
  "enum-iterator",
  "fnv",
- "indexmap 1.9.3",
+ "indexmap 2.10.0",
  "lazy_static",
  "libc",
  "mach2",
@@ -8757,7 +8757,6 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.12.3",
- "indexmap 1.9.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -8915,7 +8914,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11676,16 +11675,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb32f0d231b591e4c8a65e81d4647fa3180496d71a123d4948dba8551bba9c2"
+version = "4.4.0-linera.7"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
  "getrandom 0.2.16",
  "hex",
- "indexmap 1.9.3",
+ "indexmap 2.10.0",
  "more-asserts",
  "rkyv",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -285,8 +285,8 @@ wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "=0.4.50"
 wasm-bindgen-test = "0.3.42"
 wasm-instrument = { package = "linera-wasm-instrument", git = "https://github.com/linera-io/wasm-instrument", branch = "bulk-memory-support" }
-wasmer = { package = "linera-wasmer", git = "https://github.com/linera-io/wasmer", branch = "fix-rust-probestack", default-features = false }
-wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", git = "https://github.com/linera-io/wasmer", branch = "fix-rust-probestack", default-features = false, features = [
+wasmer = { package = "linera-wasmer", git = "https://github.com/linera-io/wasmer", branch = "wasmer-types-indexmap2", default-features = false }
+wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", git = "https://github.com/linera-io/wasmer", branch = "wasmer-types-indexmap2", default-features = false, features = [
     "std",
     "unwind",
     "avx",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3124,6 +3124,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "gol-challenge"
 version = "0.1.0"
 dependencies = [
@@ -3834,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3918,9 +3931,11 @@ dependencies = [
  "derive_more 1.0.0",
  "ed25519-dalek",
  "futures",
+ "getrandom 0.2.15",
  "hex",
  "is-terminal",
  "k256",
+ "linera-kywasmtime",
  "linera-witty",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3944,10 +3959,13 @@ dependencies = [
  "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-web",
  "trait-set",
  "trait-variant",
  "tsify",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
  "zstd",
 ]
 
@@ -4023,6 +4041,7 @@ dependencies = [
  "trait-set",
  "trait-variant",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-thread-pool",
 ]
 
@@ -4062,6 +4081,7 @@ dependencies = [
  "derive_more 1.0.0",
  "dyn-clone",
  "futures",
+ "js-sys",
  "linera-base",
  "linera-views",
  "linera-views-derive",
@@ -4085,6 +4105,17 @@ dependencies = [
  "url",
  "web-thread-pool",
  "web-thread-select",
+]
+
+[[package]]
+name = "linera-kywasmtime"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01150702de5ca202f8800452d13560ab93e7c63e46819182202de6f0781668dc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4211,6 +4242,7 @@ dependencies = [
  "derive_more 1.0.0",
  "futures",
  "generic-array",
+ "gloo-utils",
  "hex",
  "itertools 0.14.0",
  "linera-base",
@@ -5245,8 +5277,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.11.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5266,7 +5298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7136,6 +7168,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "trait-set"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7165,9 +7210,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsify"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
 dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -7360,46 +7405,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.43"
+name = "wasm-bindgen-backend"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
+ "log",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -7407,10 +7430,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.106"
+name = "wasm-bindgen-futures"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
@@ -7525,12 +7584,27 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-thread"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060cfc12637ebaf48b344331cea64fe6d13fed9a1381fb6cce10c3c7495778b4"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "thiserror 2.0.17",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -7551,6 +7625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c3f98861caac815f0aa966995e564b0b2db9abc259700ddee544fbdaf236b3"
 dependencies = [
  "cfg-if",
+ "web-thread",
  "web-thread-shim",
 ]
 
@@ -7602,7 +7677,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4286,12 +4286,12 @@ dependencies = [
 [[package]]
 name = "linera-wasmer"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "bytes",
  "cfg-if",
  "derivative",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "js-sys",
  "linera-wasmer-compiler",
  "linera-wasmer-compiler-cranelift",
@@ -4315,7 +4315,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4345,7 +4345,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler-cranelift"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler-singlepass"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -4381,7 +4381,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-vm"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "backtrace",
  "cc",
@@ -4392,7 +4392,7 @@ dependencies = [
  "derivative",
  "enum-iterator",
  "fnv",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "lazy_static",
  "libc",
  "mach2",
@@ -5726,7 +5726,6 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.12.3",
- "indexmap 1.9.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -7526,16 +7525,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb32f0d231b591e4c8a65e81d4647fa3180496d71a123d4948dba8551bba9c2"
+version = "4.4.0-linera.7"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
  "getrandom 0.2.15",
  "hex",
- "indexmap 1.9.3",
+ "indexmap 2.5.0",
  "more-asserts",
  "rkyv",
  "serde",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -20,17 +20,6 @@ reqwest = ["dep:reqwest"]
 revm = []
 opentelemetry = ["opentelemetry-otlp"]
 test = ["test-strategy", "proptest"]
-web = [
-    "clap",
-    "getrandom/js",
-    "linera-kywasmtime",
-    "rand/getrandom",
-    "rand/std",
-    "rand/std_rng",
-    "tracing-web",
-    "wasm-bindgen-futures",
-    "web-time",
-]
 
 [dependencies]
 allocative.workspace = true
@@ -46,11 +35,9 @@ custom_debug_derive.workspace = true
 derive_more = { workspace = true, features = ["display", "from_str"] }
 ed25519-dalek.workspace = true
 futures.workspace = true
-getrandom = { workspace = true, optional = true }
 hex.workspace = true
 is-terminal.workspace = true
 k256.workspace = true
-linera-kywasmtime = { workspace = true, optional = true }
 linera-witty = { workspace = true, features = ["macros"] }
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
@@ -71,13 +58,18 @@ trait-set.workspace = true
 trait-variant.workspace = true
 tsify.workspace = true
 wasm-bindgen.workspace = true
-wasm-bindgen-futures = { workspace = true, optional = true }
-web-time = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-clap = { optional = true, workspace = true }
 ruzstd.workspace = true
-tracing-web = { optional = true, workspace = true }
+
+[target.'cfg(target_os = "web")'.dependencies]
+clap.workspace = true
+getrandom = { workspace = true, features = ["js"] }
+linera-kywasmtime.workspace = true
+rand = { workspace = true, features = ["getrandom", "std", "std_rng"] }
+tracing-web.workspace = true
+wasm-bindgen-futures.workspace = true
+web-time.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono.workspace = true

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -62,7 +62,7 @@ wasm-bindgen.workspace = true
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 ruzstd.workspace = true
 
-[target.'cfg(target_os = "web")'.dependencies]
+[target.'cfg(target_env = "web")'.dependencies]
 clap.workspace = true
 getrandom = { workspace = true, features = ["js"] }
 linera-kywasmtime.workspace = true

--- a/linera-base/build.rs
+++ b/linera-base/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
         chain: { all(target_arch = "wasm32", not(web)) },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_reqwest: { feature = "reqwest" },

--- a/linera-base/build.rs
+++ b/linera-base/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { target_os = "web" },
+        web: { target_env = "web" },
         chain: { all(target_arch = "wasm32", not(web)) },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_reqwest: { feature = "reqwest" },

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -23,8 +23,6 @@ test = [
     "linera-base/test",
     "linera-execution/test",
 ]
-web = ["linera-base/web", "linera-views/web", "linera-execution/web"]
-
 [dependencies]
 allocative.workspace = true
 anyhow = { workspace = true, optional = true }

--- a/linera-chain/build.rs
+++ b/linera-chain/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { target_os = "web" },
+        web: { target_env = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_graphql: { not(web) },

--- a/linera-chain/build.rs
+++ b/linera-chain/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_graphql: { not(web) },

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -28,20 +28,8 @@ metrics = [
     "linera-rpc/metrics",
     "linera-views/metrics",
 ]
-web = [
-    "dep:web-sys",
-    "dep:wasm-bindgen-futures",
-    "linera-base/web",
-    "linera-execution/web",
-    "linera-chain/web",
-    "linera-client/web",
-    "linera-core/web",
-    "linera-rpc/web",
-    "linera-storage/web",
-    "linera-views/web",
-]
-indexed-db = ["web", "serde-wasm-bindgen", "gloo-utils"]
-web-default = ["web", "wasmer", "indexed-db"]
+indexed-db = ["serde-wasm-bindgen", "gloo-utils"]
+web-default = ["wasmer", "indexed-db"]
 
 [dependencies]
 anyhow.workspace = true
@@ -75,12 +63,12 @@ trait-variant.workspace = true
 tsify.workspace = true
 wasm-bindgen.workspace = true
 
-[target.wasm32-unknown-unknown.dependencies]
+[target.'cfg(target_os = "web")'.dependencies]
 flarch = { workspace = true, optional = true }
 gloo-utils = { workspace = true, optional = true }
 serde-wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { workspace = true, optional = true }
-web-sys = { workspace = true, optional = true }
+wasm-bindgen-futures.workspace = true
+web-sys.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 fs-err = { workspace = true, optional = true }

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -63,7 +63,7 @@ trait-variant.workspace = true
 tsify.workspace = true
 wasm-bindgen.workspace = true
 
-[target.'cfg(target_os = "web")'.dependencies]
+[target.'cfg(target_env = "web")'.dependencies]
 flarch = { workspace = true, optional = true }
 gloo-utils = { workspace = true, optional = true }
 serde-wasm-bindgen = { workspace = true, optional = true }

--- a/linera-client/build.rs
+++ b/linera-client/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { target_os = "web" },
+        web: { target_env = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
     };

--- a/linera-client/build.rs
+++ b/linera-client/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
     };

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -42,15 +42,6 @@ metrics = [
     "linera-storage/metrics",
     "linera-views/metrics",
 ]
-web = [
-    "linera-base/web",
-    "linera-chain/web",
-    "linera-execution/web",
-    "linera-storage/web",
-    "linera-views/web",
-    "wasm-bindgen-futures",
-]
-
 [dependencies]
 anyhow = { workspace = true, optional = true }
 async-graphql.workspace = true
@@ -82,8 +73,10 @@ tracing.workspace = true
 trait-set.workspace = true
 trait-variant.workspace = true
 wasm-bindgen.workspace = true
-wasm-bindgen-futures = { workspace = true, optional = true }
 web-thread-pool.workspace = true
+
+[target.'cfg(target_os = "web")'.dependencies]
+wasm-bindgen-futures.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 linera-storage-service = { workspace = true, optional = true }

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -75,7 +75,7 @@ trait-variant.workspace = true
 wasm-bindgen.workspace = true
 web-thread-pool.workspace = true
 
-[target.'cfg(target_os = "web")'.dependencies]
+[target.'cfg(target_env = "web")'.dependencies]
 wasm-bindgen-futures.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/linera-core/build.rs
+++ b/linera-core/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { target_os = "web" },
+        web: { target_env = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
 

--- a/linera-core/build.rs
+++ b/linera-core/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
 

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -101,7 +101,7 @@ wasmtime = { workspace = true, optional = true }
 web-thread-pool.workspace = true
 web-thread-select.workspace = true
 
-[target.'cfg(target_os = "web")'.dependencies]
+[target.'cfg(target_env = "web")'.dependencies]
 js-sys.workspace = true
 web-thread-select = { workspace = true, features = ["web"] }
 

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -35,8 +35,6 @@ fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
 wasmer = ["dep:wasmer", "wasmer/enable-serde", "linera-witty/wasmer"]
 wasmtime = ["dep:wasmtime", "linera-witty/wasmtime"]
-web = ["linera-base/web", "linera-views/web", "js-sys", "web-thread-select/web"]
-
 [dependencies]
 allocative.workspace = true
 alloy-primitives = { workspace = true, optional = true }
@@ -52,7 +50,6 @@ derive_more = { workspace = true, features = ["display"] }
 dyn-clone.workspace = true
 futures.workspace = true
 hex = { workspace = true, optional = true }
-js-sys = { workspace = true, optional = true }
 linera-base = { workspace = true, features = ["reqwest"] }
 linera-views.workspace = true
 linera-views-derive.workspace = true
@@ -103,6 +100,10 @@ wasm-instrument = { workspace = true, features = ["sign_ext", "bulk"] }
 wasmtime = { workspace = true, optional = true }
 web-thread-pool.workspace = true
 web-thread-select.workspace = true
+
+[target.'cfg(target_os = "web")'.dependencies]
+js-sys.workspace = true
+web-thread-select = { workspace = true, features = ["web"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/linera-execution/build.rs
+++ b/linera-execution/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
 
         with_fs: { all(not(target_arch = "wasm32"), feature = "fs") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },

--- a/linera-execution/build.rs
+++ b/linera-execution/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { target_os = "web" },
+        web: { target_env = "web" },
 
         with_fs: { all(not(target_arch = "wasm32"), feature = "fs") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },

--- a/linera-persistent/build.rs
+++ b/linera-persistent/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
         with_indexed_db: { all(web, feature = "indexed-db") },
     };
 }

--- a/linera-persistent/build.rs
+++ b/linera-persistent/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { target_os = "web" },
+        web: { target_env = "web" },
         with_indexed_db: { all(web, feature = "indexed-db") },
     };
 }

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -38,15 +38,6 @@ server = ["tokio-util", "tonic-health", "tonic-reflection"]
 simple-network = ["tokio-util/net"]
 transport = ["tonic-prost-build/transport"]
 
-web = [
-    "linera-base/web",
-    "linera-chain/web",
-    "linera-core/web",
-    "linera-execution/web",
-]
-
-web-default = ["web"]
-
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/linera-rpc/build.rs
+++ b/linera-rpc/build.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
-        web: { target_os = "web" },
+        web: { target_env = "web" },
         with_metrics: { all(not(web), feature = "metrics") },
         with_server: { all(not(web), feature = "server") },
         with_simple_network: { all(not(web), feature = "simple-network") },

--- a/linera-rpc/build.rs
+++ b/linera-rpc/build.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
-        web: { all(target_arch = "wasm32", target_os = "unknown") },
+        web: { target_os = "web" },
         with_metrics: { all(not(web), feature = "metrics") },
         with_server: { all(not(web), feature = "server") },
         with_simple_network: { all(not(web), feature = "simple-network") },

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -1663,6 +1663,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,7 +2100,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2152,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2231,9 +2243,11 @@ dependencies = [
  "derive_more 1.0.0",
  "ed25519-dalek",
  "futures",
+ "getrandom 0.2.17",
  "hex",
  "is-terminal",
  "k256",
+ "linera-kywasmtime",
  "linera-witty",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2257,10 +2271,13 @@ dependencies = [
  "tracing-chrome",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-web",
  "trait-set",
  "trait-variant",
  "tsify",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
  "zstd",
 ]
 
@@ -2326,6 +2343,7 @@ dependencies = [
  "trait-set",
  "trait-variant",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-thread-pool",
 ]
 
@@ -2345,6 +2363,7 @@ dependencies = [
  "derive_more 1.0.0",
  "dyn-clone",
  "futures",
+ "js-sys",
  "linera-base",
  "linera-views",
  "linera-views-derive",
@@ -2368,6 +2387,17 @@ dependencies = [
  "url",
  "web-thread-pool",
  "web-thread-select",
+]
+
+[[package]]
+name = "linera-kywasmtime"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01150702de5ca202f8800452d13560ab93e7c63e46819182202de6f0781668dc"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2492,6 +2522,7 @@ dependencies = [
  "derive_more 1.0.0",
  "futures",
  "generic-array",
+ "gloo-utils",
  "hex",
  "itertools",
  "linera-base",
@@ -2535,12 +2566,12 @@ dependencies = [
 [[package]]
 name = "linera-wasmer"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "bytes",
  "cfg-if",
  "derivative",
- "indexmap 1.9.3",
+ "indexmap 2.13.0",
  "js-sys",
  "linera-wasmer-compiler",
  "linera-wasmer-compiler-cranelift",
@@ -2564,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2594,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler-cranelift"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2612,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-compiler-singlepass"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -2630,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "linera-wasmer-vm"
 version = "4.4.0-linera.7"
-source = "git+https://github.com/linera-io/wasmer?branch=fix-rust-probestack#4cd177617a7b1c3079370db27afa6f3d957f2571"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "backtrace",
  "cc",
@@ -2641,7 +2672,7 @@ dependencies = [
  "derivative",
  "enum-iterator",
  "fnv",
- "indexmap 1.9.3",
+ "indexmap 2.13.0",
  "lazy_static",
  "libc",
  "mach2",
@@ -3603,7 +3634,6 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.12.3",
- "indexmap 1.9.3",
  "ptr_meta",
  "rend",
  "rkyv_derive",
@@ -4773,6 +4803,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "track-instantiation"
 version = "0.1.0"
 dependencies = [
@@ -4812,9 +4855,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tsify"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
+checksum = "b2ec91b85e6c6592ed28636cb1dd1fac377ecbbeb170ff1d79f97aac5e38926d"
 dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -4969,25 +5012,37 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
- "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4996,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5006,22 +5061,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
@@ -5100,16 +5155,15 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb32f0d231b591e4c8a65e81d4647fa3180496d71a123d4948dba8551bba9c2"
+version = "4.4.0-linera.7"
+source = "git+https://github.com/linera-io/wasmer?branch=wasmer-types-indexmap2#7e3d9eba53439ecde8754a3d2e5b1c14e329b1a7"
 dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
  "getrandom 0.2.17",
  "hex",
- "indexmap 1.9.3",
+ "indexmap 2.13.0",
  "more-asserts",
  "rkyv",
  "serde",
@@ -5156,12 +5210,27 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-thread"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060cfc12637ebaf48b344331cea64fe6d13fed9a1381fb6cce10c3c7495778b4"
+dependencies = [
+ "futures",
+ "pin-project-lite",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "thiserror 2.0.18",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5182,6 +5251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c3f98861caac815f0aa966995e564b0b2db9abc259700ddee544fbdaf236b3"
 dependencies = [
  "cfg-if",
+ "web-thread",
  "web-thread-shim",
 ]
 

--- a/linera-service/template/wasm32-unknown-js-web.json
+++ b/linera-service/template/wasm32-unknown-js-web.json
@@ -1,0 +1,59 @@
+{
+  "arch": "wasm32",
+  "binary-format": "wasm",
+  "crt-objects-fallback": "true",
+  "data-layout": "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20",
+  "dll-prefix": "",
+  "dll-suffix": ".wasm",
+  "dynamic-linking": false,
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "exe-suffix": ".wasm",
+  "generate-arange-section": false,
+  "has-thread-local": true,
+  "is-like-wasm": true,
+  "linker": "rust-lld",
+  "linker-flavor": "wasm-lld",
+  "linker-is-gnu": false,
+  "lld-flavor": "wasm",
+  "llvm-target": "wasm32-unknown-unknown",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "WebAssembly target for Linera web browser clients",
+    "host_tools": false,
+    "std": true,
+    "tier": 2
+  },
+  "only-cdylib": true,
+  "os": "web",
+  "panic-strategy": "abort",
+  "pre-link-args": {
+    "wasm-lld": [
+      "--shared-memory",
+      "--max-memory=1073741824",
+      "--import-memory",
+      "--export=__wasm_init_tls",
+      "--export=__tls_size",
+      "--export=__tls_align",
+      "--export=__tls_base"
+    ],
+    "wasm-lld-cc": [
+      "--target=wasm32-unknown-unknown",
+      "-Wl,--shared-memory",
+      "-Wl,--max-memory=1073741824",
+      "-Wl,--import-memory",
+      "-Wl,--export=__wasm_init_tls",
+      "-Wl,--export=__tls_size",
+      "-Wl,--export=__tls_align",
+      "-Wl,--export=__tls_base"
+    ]
+  },
+  "relocation-model": "static",
+  "singlethread": false,
+  "target-family": [
+    "wasm"
+  ],
+  "target-pointer-width": 32,
+  "tls-model": "local-exec",
+  "features": "+atomics,+bulk-memory,+mutable-globals,+reference-types"
+}

--- a/linera-service/template/wasm32-web-unknown.json
+++ b/linera-service/template/wasm32-web-unknown.json
@@ -25,7 +25,8 @@
     "tier": 2
   },
   "only-cdylib": true,
-  "os": "web",
+  "env": "web",
+  "os": "unknown",
   "panic-strategy": "abort",
   "pre-link-args": {
     "wasm-lld": [

--- a/linera-service/template/wasm32-web-unknown.json
+++ b/linera-service/template/wasm32-web-unknown.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20",
   "dll-prefix": "",
   "dll-suffix": ".wasm",
-  "dynamic-linking": false,
+  "dynamic-linking": true,
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
   "exe-suffix": ".wasm",

--- a/linera-service/wasm32-unknown-js-web.json
+++ b/linera-service/wasm32-unknown-js-web.json
@@ -1,0 +1,59 @@
+{
+  "arch": "wasm32",
+  "binary-format": "wasm",
+  "crt-objects-fallback": "true",
+  "data-layout": "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20",
+  "dll-prefix": "",
+  "dll-suffix": ".wasm",
+  "dynamic-linking": false,
+  "eh-frame-header": false,
+  "emit-debug-gdb-scripts": false,
+  "exe-suffix": ".wasm",
+  "generate-arange-section": false,
+  "has-thread-local": true,
+  "is-like-wasm": true,
+  "linker": "rust-lld",
+  "linker-flavor": "wasm-lld",
+  "linker-is-gnu": false,
+  "lld-flavor": "wasm",
+  "llvm-target": "wasm32-unknown-unknown",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "WebAssembly target for Linera web browser clients",
+    "host_tools": false,
+    "std": true,
+    "tier": 2
+  },
+  "only-cdylib": true,
+  "os": "web",
+  "panic-strategy": "abort",
+  "pre-link-args": {
+    "wasm-lld": [
+      "--shared-memory",
+      "--max-memory=1073741824",
+      "--import-memory",
+      "--export=__wasm_init_tls",
+      "--export=__tls_size",
+      "--export=__tls_align",
+      "--export=__tls_base"
+    ],
+    "wasm-lld-cc": [
+      "--target=wasm32-unknown-unknown",
+      "-Wl,--shared-memory",
+      "-Wl,--max-memory=1073741824",
+      "-Wl,--import-memory",
+      "-Wl,--export=__wasm_init_tls",
+      "-Wl,--export=__tls_size",
+      "-Wl,--export=__tls_align",
+      "-Wl,--export=__tls_base"
+    ]
+  },
+  "relocation-model": "static",
+  "singlethread": false,
+  "target-family": [
+    "wasm"
+  ],
+  "target-pointer-width": 32,
+  "tls-model": "local-exec",
+  "features": "+atomics,+bulk-memory,+mutable-globals,+reference-types"
+}

--- a/linera-service/wasm32-web-unknown.json
+++ b/linera-service/wasm32-web-unknown.json
@@ -30,6 +30,12 @@
   "panic-strategy": "abort",
   "pre-link-args": {
     "wasm-lld": [
+      "-z",
+      "stack-size=1048576",
+      "--stack-first",
+      "--allow-undefined",
+      "--no-demangle",
+      "--no-entry",
       "--shared-memory",
       "--max-memory=1073741824",
       "--import-memory",
@@ -39,7 +45,13 @@
       "--export=__tls_base"
     ],
     "wasm-lld-cc": [
+      "-Wl,-z",
+      "-Wl,stack-size=1048576",
+      "-Wl,--stack-first",
+      "-Wl,--allow-undefined",
+      "-Wl,--no-demangle",
       "--target=wasm32-unknown-unknown",
+      "-Wl,--no-entry",
       "-Wl,--shared-memory",
       "-Wl,--max-memory=1073741824",
       "-Wl,--import-memory",

--- a/linera-service/wasm32-web-unknown.json
+++ b/linera-service/wasm32-web-unknown.json
@@ -25,7 +25,8 @@
     "tier": 2
   },
   "only-cdylib": true,
-  "os": "web",
+  "env": "web",
+  "os": "unknown",
   "panic-strategy": "abort",
   "pre-link-args": {
     "wasm-lld": [

--- a/linera-service/wasm32-web-unknown.json
+++ b/linera-service/wasm32-web-unknown.json
@@ -5,7 +5,7 @@
   "data-layout": "e-m:e-p:32:32-p10:8:8-p20:8:8-i64:64-i128:128-n32:64-S128-ni:1:10:20",
   "dll-prefix": "",
   "dll-suffix": ".wasm",
-  "dynamic-linking": false,
+  "dynamic-linking": true,
   "eh-frame-header": false,
   "emit-debug-gdb-scripts": false,
   "exe-suffix": ".wasm",

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -27,13 +27,6 @@ metrics = [
     "linera-execution/metrics",
     "linera-views/metrics",
 ]
-web = [
-    "linera-base/web",
-    "linera-chain/web",
-    "linera-execution/web",
-    "linera-views/web",
-]
-
 [dependencies]
 async-trait.workspace = true
 bcs.workspace = true

--- a/linera-storage/build.rs
+++ b/linera-storage/build.rs
@@ -5,12 +5,12 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
-        with_wasmer: { all(any(target_os = "web", not(target_arch = "wasm32")), feature = "wasmer") },
+        with_wasmer: { all(any(target_env = "web", not(target_arch = "wasm32")), feature = "wasmer") },
         with_wasmtime: { all(not(target_arch = "wasm32"), feature = "wasmtime") },
         with_wasm_runtime: { any(with_wasmer, with_wasmtime) },
         with_rocksdb: { all(not(target_arch = "wasm32"), feature = "rocksdb") },
         with_scylladb: { all(not(target_arch = "wasm32"), feature = "scylladb") },
         with_revm: { feature = "revm" },
-        web: { target_os = "web" },
+        web: { target_env = "web" },
     };
 }

--- a/linera-storage/build.rs
+++ b/linera-storage/build.rs
@@ -5,12 +5,12 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
-        with_wasmer: { all(any(feature = "web", not(target_arch = "wasm32")), feature = "wasmer") },
+        with_wasmer: { all(any(target_os = "web", not(target_arch = "wasm32")), feature = "wasmer") },
         with_wasmtime: { all(not(target_arch = "wasm32"), feature = "wasmtime") },
         with_wasm_runtime: { any(with_wasmer, with_wasmtime) },
         with_rocksdb: { all(not(target_arch = "wasm32"), feature = "rocksdb") },
         with_scylladb: { all(not(target_arch = "wasm32"), feature = "scylladb") },
         with_revm: { feature = "revm" },
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
     };
 }

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -24,9 +24,8 @@ targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 [features]
 metrics = ["dep:hex", "linera-base/metrics", "linera-views-derive/metrics"]
 test = ["tokio/macros"]
-web = ["linera-base/web", "gloo-utils"]
 indexeddb = ["indexed-db", "wasm-bindgen"]
-web-default = ["web", "indexeddb"]
+web-default = ["indexeddb"]
 
 dynamodb = ["aws-config", "aws-sdk-dynamodb", "aws-smithy-types"]
 scylladb = ["scylla"]
@@ -65,13 +64,13 @@ tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
 trait-variant.workspace = true
 
-[target.wasm32-unknown-unknown.dependencies]
-gloo-utils = { workspace = true, optional = true }
+[target.'cfg(target_os = "web")'.dependencies]
+gloo-utils.workspace = true
 indexed-db = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 web-sys = { workspace = true, features = ["console"] }
 
-[target.wasm32-unknown-unknown.dev-dependencies]
+[target.'cfg(target_os = "web")'.dev-dependencies]
 wasm-bindgen-test.workspace = true
 
 [dev-dependencies]

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -64,13 +64,13 @@ tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
 trait-variant.workspace = true
 
-[target.'cfg(target_os = "web")'.dependencies]
+[target.'cfg(target_env = "web")'.dependencies]
 gloo-utils.workspace = true
 indexed-db = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 web-sys = { workspace = true, features = ["console"] }
 
-[target.'cfg(target_os = "web")'.dev-dependencies]
+[target.'cfg(target_env = "web")'.dev-dependencies]
 wasm-bindgen-test.workspace = true
 
 [dev-dependencies]

--- a/linera-views/build.rs
+++ b/linera-views/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { target_os = "web" },
+        web: { target_env = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_dynamodb: { all(not(target_arch = "wasm32"), feature = "dynamodb") },

--- a/linera-views/build.rs
+++ b/linera-views/build.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
-        web: { all(target_arch = "wasm32", feature = "web") },
+        web: { target_os = "web" },
         with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_dynamodb: { all(not(target_arch = "wasm32"), feature = "dynamodb") },

--- a/toolchains/nightly/rust-toolchain.toml
+++ b/toolchains/nightly/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
 channel = "nightly-2026-03-01"
 components = [ "clippy", "rustfmt", "rust-src" ]
-targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"

--- a/web/.cargo/config.toml
+++ b/web/.cargo/config.toml
@@ -2,8 +2,9 @@
 RUST_TARGET_PATH = { value = "../linera-service", relative = true }
 
 [build]
-target = "wasm32-unknown-js-web"
-rustflags = ["--cfg=web_sys_unstable_apis"]
+target = "wasm32-web-unknown"
+# -Zunstable-options is required for rustc to accept the custom target spec.
+rustflags = ["-Zunstable-options", "--cfg=web_sys_unstable_apis"]
 
 [unstable]
 build-std = ["panic_abort", "std"]

--- a/web/.cargo/config.toml
+++ b/web/.cargo/config.toml
@@ -1,17 +1,10 @@
-[target.wasm32-unknown-unknown]
-rustflags = [
-    # support threading; +bulk-memory is required for --shared-memory and must
-    # be re-enabled here since the root config disables it for contracts.
-    "-C", "target-feature=+atomics,+bulk-memory,+mutable-globals,+reference-types",
-    # Since Rust 1.92, atomics no longer auto-enables shared memory.
-    # These link args are needed for wasm threading support.
-    "-C", "link-args=--shared-memory --max-memory=1073741824 --import-memory --export=__wasm_init_tls --export=__tls_size --export=__tls_align --export=__tls_base",
-    # allow linking C code (for `rust_secp256k1`)
-    "--cfg=web_sys_unstable_apis",
-]
+[env]
+RUST_TARGET_PATH = { value = "../linera-service", relative = true }
+
+[build]
+target = "wasm32-unknown-js-web"
+rustflags = ["--cfg=web_sys_unstable_apis"]
 
 [unstable]
 build-std = ["panic_abort", "std"]
-
-[build]
-target = "wasm32-unknown-unknown"
+json-target-spec = true

--- a/web/@linera/client/Cargo.toml
+++ b/web/@linera/client/Cargo.toml
@@ -36,35 +36,33 @@ features = ["ansi", "fmt", "std"]
 workspace = true
 
 [dependencies.linera-base]
-features = ["web"]
 workspace = true
 
 [dependencies.linera-client]
 default-features = false
-features = ["web", "wasmer", "indexed-db"]
+features = ["wasmer", "indexed-db"]
 workspace = true
 
 [dependencies.linera-core]
-features = ["web", "wasmer"]
+features = ["wasmer"]
 workspace = true
 
 [dependencies.linera-execution]
-features = ["web", "wasmer"]
+features = ["wasmer"]
 workspace = true
 
 [dependencies.linera-faucet-client]
 workspace = true
 
 [dependencies.linera-rpc]
-features = ["web"]
 workspace = true
 
 [dependencies.linera-storage]
-features = ["web", "wasmer"]
+features = ["wasmer"]
 workspace = true
 
 [dependencies.linera-views]
-features = ["web", "indexeddb"]
+features = ["indexeddb"]
 workspace = true
 
 [dependencies.web-sys]

--- a/web/@linera/client/README.md
+++ b/web/@linera/client/README.md
@@ -13,6 +13,49 @@ policies, including in-memory keys and signing using an existing MetaMask wallet
 
 <!-- cargo-rdme end -->
 
+## Cross-Origin Isolation
+
+This package uses `SharedArrayBuffer` for WebAssembly threading support.
+Browsers require [cross-origin isolation](https://web.dev/articles/cross-origin-isolation-guide)
+to enable `SharedArrayBuffer`, which means the page serving the wasm module
+must include these HTTP headers:
+
+```
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+```
+
+Without these headers, the wasm module will fail at runtime when the async
+executor attempts to use `Atomics.waitAsync` on non-shared memory.
+
+Example server configurations:
+
+**Nginx:**
+```nginx
+add_header Cross-Origin-Opener-Policy same-origin;
+add_header Cross-Origin-Embedder-Policy require-corp;
+```
+
+**Caddy:**
+```
+header Cross-Origin-Opener-Policy same-origin
+header Cross-Origin-Embedder-Policy require-corp
+```
+
+**Express:**
+```js
+app.use((req, res, next) => {
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+  next();
+});
+```
+
+**Note:** `Cross-Origin-Embedder-Policy: require-corp` means all
+subresources (images, scripts, fonts) must be same-origin or served with
+a `Cross-Origin-Resource-Policy` header. This may require adjustments
+when loading third-party assets.
+
 ## Building
 
 Make sure your `cargo` invokes a nightly `rustc`. Then, you can build

--- a/web/@linera/client/build.bash
+++ b/web/@linera/client/build.bash
@@ -26,10 +26,10 @@ else
     profile_dir=debug
 fi
 
-cargo build --lib --target wasm32-unknown-unknown $profile_flag
+cargo build --lib $profile_flag
 
 wasm-bindgen \
-    "$target_dir"/wasm32-unknown-unknown/$profile_dir/linera_web.wasm \
+    "$target_dir"/wasm32-unknown-js-web/$profile_dir/linera_web.wasm \
     --out-dir src/wasm \
     --out-name index \
     --typescript \

--- a/web/@linera/client/build.bash
+++ b/web/@linera/client/build.bash
@@ -29,7 +29,7 @@ fi
 cargo build --lib $profile_flag
 
 wasm-bindgen \
-    "$target_dir"/wasm32-unknown-js-web/$profile_dir/linera_web.wasm \
+    "$target_dir"/wasm32-web-unknown/$profile_dir/linera_web.wasm \
     --out-dir src/wasm \
     --out-name index \
     --typescript \

--- a/web/@linera/client/vitest.config.ts
+++ b/web/@linera/client/vitest.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from 'vitest/config'
 export default defineConfig({
   envPrefix: ['LINERA_'],
+  // Required for SharedArrayBuffer support in the browser, which the
+  // wasm32-web-unknown target needs for shared memory and atomics.
+  server: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
   test: {
     browser: {
       provider: 'playwright',


### PR DESCRIPTION
## Motivation

  Replace the `web` Cargo feature flag with a custom wasm target (`wasm32-web-unknown`)
  that uses `target_env = "web"` for cfg detection. This eliminates the need to pass
  `features = ["web"]` through the entire dependency tree and makes web-specific code
  selection automatic based on the compilation target.

  ## Proposal

  - Introduce a custom target spec `wasm32-web-unknown.json` that extends
    `wasm32-unknown-unknown` with `"env": "web"`, threading support (`+atomics`,
    `--shared-memory`), and TLS exports.
  - Replace all `cfg(feature = "web")` checks with `cfg(target_env = "web")` via
    `cfg_aliases` in each crate's `build.rs`.
  - Remove the `web` feature from all Cargo.toml files.
  - Use a forked `wasmer-types` with indexmap 2 to resolve a `build-std` dependency
    conflict with custom targets.
  - Add the default `wasm32-unknown-unknown` linker flags (`-z stack-size=1048576`,
    `--stack-first`, `--allow-undefined`, `--no-entry`) to the custom target spec,
    which are not inherited when defining a custom target from scratch.
  - Add COOP/COEP headers to the vitest config for `SharedArrayBuffer` support
    required by the atomics-enabled wasm build.

  **Note on target naming:** The target is named `wasm32-web-unknown` (with `web` in
  the vendor position) as a workaround for `target-lexicon` (used by `wasmer-types`)
  not being able to parse custom OS values. The semantically correct name would be
  `wasm32-unknown-js-web` (arch-vendor-os-env); an upstream Rust PR
  (rust-lang/rust#153686) has been filed to enable this.

  ## Test Plan

  - `cd web && pnpm -r run ci` passes all 5 tests (2 signer + 3 client integration),
    lint, clippy, and typedoc generation.
  - CI web workflow should pass with the existing faucet + validator setup.

  ## Release Plan

  - Nothing to do / These changes follow the usual release cycle.

  ## Links

  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
  - Upstream Rust PR for proper target naming: rust-lang/rust#153686
  - Wasmer fork with indexmap 2: https://github.com/linera-io/wasmer/tree/wasmer-types-indexmap2