### PR TITLE
Separate owners from super-owners in their access.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -10,6 +10,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
 * [`linera show-ownership`↴](#linera-show-ownership)
 * [`linera change-ownership`↴](#linera-change-ownership)
+* [`linera change-super-ownership`↴](#linera-change-super-ownership)
 * [`linera set-preferred-owner`↴](#linera-set-preferred-owner)
 * [`linera change-application-permissions`↴](#linera-change-application-permissions)
 * [`linera close-chain`↴](#linera-close-chain)
@@ -89,7 +90,8 @@ Client implementation and command-line tool for the Linera blockchain
 * `open-chain` — Open (i.e. activate) a new chain deriving the UID from an existing one
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `show-ownership` — Display who owns the chain, and how the owners work together proposing blocks
-* `change-ownership` — Change who owns the chain, and how the owners work together proposing blocks
+* `change-ownership` — Change the regular owners of the chain
+* `change-super-ownership` — Change the super owners of the chain
 * `set-preferred-owner` — Change the preferred owner of a chain
 * `change-application-permissions` — Changes the application permissions configuration
 * `close-chain` — Close an existing chain
@@ -382,24 +384,38 @@ Display who owns the chain, and how the owners work together proposing blocks
 
 ## `linera change-ownership`
 
-Change who owns the chain, and how the owners work together proposing blocks.
+Change the regular owners of the chain.
 
-Specify the complete set of new owners, by public key. Existing owners that are not included will be removed.
+Any owner can use this command. Specify the complete set of new regular owners, by public key. Existing regular owners that are not included will be removed.
 
 **Usage:** `linera change-ownership [OPTIONS]`
 
 ###### **Options:**
 
 * `--chain-id <CHAIN_ID>` — The ID of the chain whose owners will be changed
-* `--super-owners <SUPER_OWNERS>` — A JSON list of the new super owners. Absence of the option leaves the current set of super owners unchanged
 * `--owners <OWNERS>` — A JSON map of the new owners to their weights. Absence of the option leaves the current set of owners unchanged
 * `--first-leader <FIRST_LEADER>` — The leader of the first single-leader round. If set to null, this is random like other rounds. Absence of the option leaves the current setting unchanged
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks. "null" is equivalent to 2^32 - 1. Absence of the option leaves the current setting unchanged
 * `--open-multi-leader-rounds` — Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners. This should only be `true` on chains with restrictive application permissions and an application-based mechanism to select block proposers
-* `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds. "null" means the fast round will not time out. Absence of the option leaves the current setting unchanged
 * `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds. Absence of the option leaves the current setting unchanged
 * `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round. Absence of the option leaves the current setting unchanged
 * `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds. Absence of the option leaves the current setting unchanged
+
+
+
+## `linera change-super-ownership`
+
+Change the super owners of the chain.
+
+Only a super owner can use this command. Specify the complete set of new super owners, by public key. Existing super owners that are not included will be removed.
+
+**Usage:** `linera change-super-ownership [OPTIONS]`
+
+###### **Options:**
+
+* `--chain-id <CHAIN_ID>` — The ID of the chain whose super owners will be changed
+* `--super-owners <SUPER_OWNERS>` — A JSON list of the new super owners
+* `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds. "null" means the fast round will not time out. Absence of the option leaves the current setting unchanged
 
 
 

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -73,7 +73,7 @@ async fn single_transaction() {
     let owner_a = AccountOwner::from(user_chain_a.public_key());
     let mut user_chain_b = validator.new_chain().await;
     let owner_b = AccountOwner::from(user_chain_b.public_key());
-    let mut matching_chain = validator.new_chain().await;
+    let mut matching_chain = validator.new_super_owner_chain().await;
     let admin_account = AccountOwner::from(matching_chain.public_key());
 
     let fungible_module_id = user_chain_a

--- a/linera-bridge/src/solidity/BridgeTypes.sol
+++ b/linera-bridge/src/solidity/BridgeTypes.sol
@@ -2661,25 +2661,27 @@ library BridgeTypes {
         // choice=2 corresponds to OpenChain
         OpenChainConfig open_chain;
         // choice=3 corresponds to CloseChain
-        // choice=4 corresponds to ChangeOwnership
-        SystemOperation_ChangeOwnership change_ownership;
-        // choice=5 corresponds to ChangeApplicationPermissions
+        // choice=4 corresponds to ChangeOwners
+        SystemOperation_ChangeOwners change_owners;
+        // choice=5 corresponds to ChangeSuperOwners
+        SystemOperation_ChangeSuperOwners change_super_owners;
+        // choice=6 corresponds to ChangeApplicationPermissions
         ApplicationPermissions change_application_permissions;
-        // choice=6 corresponds to PublishModule
+        // choice=7 corresponds to PublishModule
         SystemOperation_PublishModule publish_module;
-        // choice=7 corresponds to PublishDataBlob
+        // choice=8 corresponds to PublishDataBlob
         SystemOperation_PublishDataBlob publish_data_blob;
-        // choice=8 corresponds to VerifyBlob
+        // choice=9 corresponds to VerifyBlob
         SystemOperation_VerifyBlob verify_blob;
-        // choice=9 corresponds to CreateApplication
+        // choice=10 corresponds to CreateApplication
         SystemOperation_CreateApplication create_application;
-        // choice=10 corresponds to Admin
+        // choice=11 corresponds to Admin
         AdminOperation admin;
-        // choice=11 corresponds to ProcessNewEpoch
+        // choice=12 corresponds to ProcessNewEpoch
         Epoch process_new_epoch;
-        // choice=12 corresponds to ProcessRemovedEpoch
+        // choice=13 corresponds to ProcessRemovedEpoch
         Epoch process_removed_epoch;
-        // choice=13 corresponds to UpdateStreams
+        // choice=14 corresponds to UpdateStreams
         tuple_ChainId_StreamId_uint32[] update_streams;
     }
 
@@ -2690,7 +2692,8 @@ library BridgeTypes {
     {
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2700,7 +2703,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(0), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(0), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_claim(SystemOperation_Claim memory claim)
@@ -2710,7 +2713,8 @@ library BridgeTypes {
     {
         SystemOperation_Transfer memory transfer_;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2720,7 +2724,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(1), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(1), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_open_chain(OpenChainConfig memory open_chain)
@@ -2730,7 +2734,8 @@ library BridgeTypes {
     {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2740,7 +2745,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(2), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(2), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_close_chain()
@@ -2751,7 +2756,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2761,10 +2767,10 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(3), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(3), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
-    function SystemOperation_case_change_ownership(SystemOperation_ChangeOwnership memory change_ownership)
+    function SystemOperation_case_change_owners(SystemOperation_ChangeOwners memory change_owners)
         internal
         pure
         returns (SystemOperation memory)
@@ -2772,6 +2778,7 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2781,7 +2788,28 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(4), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(4), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+    }
+
+    function SystemOperation_case_change_super_owners(SystemOperation_ChangeSuperOwners memory change_super_owners)
+        internal
+        pure
+        returns (SystemOperation memory)
+    {
+        SystemOperation_Transfer memory transfer_;
+        SystemOperation_Claim memory claim;
+        OpenChainConfig memory open_chain;
+        SystemOperation_ChangeOwners memory change_owners;
+        ApplicationPermissions memory change_application_permissions;
+        SystemOperation_PublishModule memory publish_module;
+        SystemOperation_PublishDataBlob memory publish_data_blob;
+        SystemOperation_VerifyBlob memory verify_blob;
+        SystemOperation_CreateApplication memory create_application;
+        AdminOperation memory admin;
+        Epoch memory process_new_epoch;
+        Epoch memory process_removed_epoch;
+        tuple_ChainId_StreamId_uint32[] memory update_streams;
+        return SystemOperation(uint8(5), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_change_application_permissions(ApplicationPermissions memory change_application_permissions)
@@ -2792,7 +2820,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
         SystemOperation_VerifyBlob memory verify_blob;
@@ -2801,7 +2830,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(5), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(6), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_publish_module(SystemOperation_PublishModule memory publish_module)
@@ -2812,7 +2841,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishDataBlob memory publish_data_blob;
         SystemOperation_VerifyBlob memory verify_blob;
@@ -2821,7 +2851,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(6), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(7), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_publish_data_blob(SystemOperation_PublishDataBlob memory publish_data_blob)
@@ -2832,7 +2862,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_VerifyBlob memory verify_blob;
@@ -2841,7 +2872,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(7), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(8), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_verify_blob(SystemOperation_VerifyBlob memory verify_blob)
@@ -2852,7 +2883,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2861,7 +2893,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(8), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(9), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_create_application(SystemOperation_CreateApplication memory create_application)
@@ -2872,7 +2904,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2881,7 +2914,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(9), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(10), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_admin(AdminOperation memory admin)
@@ -2892,7 +2925,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2901,7 +2935,7 @@ library BridgeTypes {
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(10), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(11), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_process_new_epoch(Epoch memory process_new_epoch)
@@ -2912,7 +2946,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2921,7 +2956,7 @@ library BridgeTypes {
         AdminOperation memory admin;
         Epoch memory process_removed_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(11), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(12), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_process_removed_epoch(Epoch memory process_removed_epoch)
@@ -2932,7 +2967,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2941,7 +2977,7 @@ library BridgeTypes {
         AdminOperation memory admin;
         Epoch memory process_new_epoch;
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        return SystemOperation(uint8(12), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(13), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function SystemOperation_case_update_streams(tuple_ChainId_StreamId_uint32[] memory update_streams)
@@ -2952,7 +2988,8 @@ library BridgeTypes {
         SystemOperation_Transfer memory transfer_;
         SystemOperation_Claim memory claim;
         OpenChainConfig memory open_chain;
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
         ApplicationPermissions memory change_application_permissions;
         SystemOperation_PublishModule memory publish_module;
         SystemOperation_PublishDataBlob memory publish_data_blob;
@@ -2961,7 +2998,7 @@ library BridgeTypes {
         AdminOperation memory admin;
         Epoch memory process_new_epoch;
         Epoch memory process_removed_epoch;
-        return SystemOperation(uint8(13), transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
+        return SystemOperation(uint8(14), transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams);
     }
 
     function bcs_serialize_SystemOperation(SystemOperation memory input)
@@ -2979,33 +3016,36 @@ library BridgeTypes {
             return abi.encodePacked(input.choice, bcs_serialize_OpenChainConfig(input.open_chain));
         }
         if (input.choice == 4) {
-            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_ChangeOwnership(input.change_ownership));
+            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_ChangeOwners(input.change_owners));
         }
         if (input.choice == 5) {
-            return abi.encodePacked(input.choice, bcs_serialize_ApplicationPermissions(input.change_application_permissions));
+            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_ChangeSuperOwners(input.change_super_owners));
         }
         if (input.choice == 6) {
-            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_PublishModule(input.publish_module));
+            return abi.encodePacked(input.choice, bcs_serialize_ApplicationPermissions(input.change_application_permissions));
         }
         if (input.choice == 7) {
-            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_PublishDataBlob(input.publish_data_blob));
+            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_PublishModule(input.publish_module));
         }
         if (input.choice == 8) {
-            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_VerifyBlob(input.verify_blob));
+            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_PublishDataBlob(input.publish_data_blob));
         }
         if (input.choice == 9) {
-            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_CreateApplication(input.create_application));
+            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_VerifyBlob(input.verify_blob));
         }
         if (input.choice == 10) {
-            return abi.encodePacked(input.choice, bcs_serialize_AdminOperation(input.admin));
+            return abi.encodePacked(input.choice, bcs_serialize_SystemOperation_CreateApplication(input.create_application));
         }
         if (input.choice == 11) {
-            return abi.encodePacked(input.choice, bcs_serialize_Epoch(input.process_new_epoch));
+            return abi.encodePacked(input.choice, bcs_serialize_AdminOperation(input.admin));
         }
         if (input.choice == 12) {
-            return abi.encodePacked(input.choice, bcs_serialize_Epoch(input.process_removed_epoch));
+            return abi.encodePacked(input.choice, bcs_serialize_Epoch(input.process_new_epoch));
         }
         if (input.choice == 13) {
+            return abi.encodePacked(input.choice, bcs_serialize_Epoch(input.process_removed_epoch));
+        }
+        if (input.choice == 14) {
             return abi.encodePacked(input.choice, bcs_serialize_seq_tuple_ChainId_StreamId_uint32(input.update_streams));
         }
         return abi.encodePacked(input.choice);
@@ -3031,48 +3071,52 @@ library BridgeTypes {
         if (choice == 2) {
             (new_pos, open_chain) = bcs_deserialize_offset_OpenChainConfig(new_pos, input);
         }
-        SystemOperation_ChangeOwnership memory change_ownership;
+        SystemOperation_ChangeOwners memory change_owners;
         if (choice == 4) {
-            (new_pos, change_ownership) = bcs_deserialize_offset_SystemOperation_ChangeOwnership(new_pos, input);
+            (new_pos, change_owners) = bcs_deserialize_offset_SystemOperation_ChangeOwners(new_pos, input);
+        }
+        SystemOperation_ChangeSuperOwners memory change_super_owners;
+        if (choice == 5) {
+            (new_pos, change_super_owners) = bcs_deserialize_offset_SystemOperation_ChangeSuperOwners(new_pos, input);
         }
         ApplicationPermissions memory change_application_permissions;
-        if (choice == 5) {
+        if (choice == 6) {
             (new_pos, change_application_permissions) = bcs_deserialize_offset_ApplicationPermissions(new_pos, input);
         }
         SystemOperation_PublishModule memory publish_module;
-        if (choice == 6) {
+        if (choice == 7) {
             (new_pos, publish_module) = bcs_deserialize_offset_SystemOperation_PublishModule(new_pos, input);
         }
         SystemOperation_PublishDataBlob memory publish_data_blob;
-        if (choice == 7) {
+        if (choice == 8) {
             (new_pos, publish_data_blob) = bcs_deserialize_offset_SystemOperation_PublishDataBlob(new_pos, input);
         }
         SystemOperation_VerifyBlob memory verify_blob;
-        if (choice == 8) {
+        if (choice == 9) {
             (new_pos, verify_blob) = bcs_deserialize_offset_SystemOperation_VerifyBlob(new_pos, input);
         }
         SystemOperation_CreateApplication memory create_application;
-        if (choice == 9) {
+        if (choice == 10) {
             (new_pos, create_application) = bcs_deserialize_offset_SystemOperation_CreateApplication(new_pos, input);
         }
         AdminOperation memory admin;
-        if (choice == 10) {
+        if (choice == 11) {
             (new_pos, admin) = bcs_deserialize_offset_AdminOperation(new_pos, input);
         }
         Epoch memory process_new_epoch;
-        if (choice == 11) {
+        if (choice == 12) {
             (new_pos, process_new_epoch) = bcs_deserialize_offset_Epoch(new_pos, input);
         }
         Epoch memory process_removed_epoch;
-        if (choice == 12) {
+        if (choice == 13) {
             (new_pos, process_removed_epoch) = bcs_deserialize_offset_Epoch(new_pos, input);
         }
         tuple_ChainId_StreamId_uint32[] memory update_streams;
-        if (choice == 13) {
+        if (choice == 14) {
             (new_pos, update_streams) = bcs_deserialize_offset_seq_tuple_ChainId_StreamId_uint32(new_pos, input);
         }
-        require(choice < 14);
-        return (new_pos, SystemOperation(choice, transfer_, claim, open_chain, change_ownership, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams));
+        require(choice < 15);
+        return (new_pos, SystemOperation(choice, transfer_, claim, open_chain, change_owners, change_super_owners, change_application_permissions, publish_module, publish_data_blob, verify_blob, create_application, admin, process_new_epoch, process_removed_epoch, update_streams));
     }
 
     function bcs_deserialize_SystemOperation(bytes memory input)
@@ -3087,57 +3131,100 @@ library BridgeTypes {
         return value;
     }
 
-    struct SystemOperation_ChangeOwnership {
-        AccountOwner[] super_owners;
+    struct SystemOperation_ChangeOwners {
         tuple_AccountOwner_uint64[] owners;
         opt_AccountOwner first_leader;
         uint32 multi_leader_rounds;
         bool open_multi_leader_rounds;
-        TimeoutConfig timeout_config;
+        TimeDelta base_timeout;
+        TimeDelta timeout_increment;
+        TimeDelta fallback_duration;
     }
 
-    function bcs_serialize_SystemOperation_ChangeOwnership(SystemOperation_ChangeOwnership memory input)
+    function bcs_serialize_SystemOperation_ChangeOwners(SystemOperation_ChangeOwners memory input)
         internal
         pure
         returns (bytes memory)
     {
-        bytes memory result = bcs_serialize_seq_AccountOwner(input.super_owners);
-        result = abi.encodePacked(result, bcs_serialize_seq_tuple_AccountOwner_uint64(input.owners));
+        bytes memory result = bcs_serialize_seq_tuple_AccountOwner_uint64(input.owners);
         result = abi.encodePacked(result, bcs_serialize_opt_AccountOwner(input.first_leader));
         result = abi.encodePacked(result, bcs_serialize_uint32(input.multi_leader_rounds));
         result = abi.encodePacked(result, bcs_serialize_bool(input.open_multi_leader_rounds));
-        return abi.encodePacked(result, bcs_serialize_TimeoutConfig(input.timeout_config));
+        result = abi.encodePacked(result, bcs_serialize_TimeDelta(input.base_timeout));
+        result = abi.encodePacked(result, bcs_serialize_TimeDelta(input.timeout_increment));
+        return abi.encodePacked(result, bcs_serialize_TimeDelta(input.fallback_duration));
     }
 
-    function bcs_deserialize_offset_SystemOperation_ChangeOwnership(uint256 pos, bytes memory input)
+    function bcs_deserialize_offset_SystemOperation_ChangeOwners(uint256 pos, bytes memory input)
         internal
         pure
-        returns (uint256, SystemOperation_ChangeOwnership memory)
+        returns (uint256, SystemOperation_ChangeOwners memory)
     {
         uint256 new_pos;
-        AccountOwner[] memory super_owners;
-        (new_pos, super_owners) = bcs_deserialize_offset_seq_AccountOwner(pos, input);
         tuple_AccountOwner_uint64[] memory owners;
-        (new_pos, owners) = bcs_deserialize_offset_seq_tuple_AccountOwner_uint64(new_pos, input);
+        (new_pos, owners) = bcs_deserialize_offset_seq_tuple_AccountOwner_uint64(pos, input);
         opt_AccountOwner memory first_leader;
         (new_pos, first_leader) = bcs_deserialize_offset_opt_AccountOwner(new_pos, input);
         uint32 multi_leader_rounds;
         (new_pos, multi_leader_rounds) = bcs_deserialize_offset_uint32(new_pos, input);
         bool open_multi_leader_rounds;
         (new_pos, open_multi_leader_rounds) = bcs_deserialize_offset_bool(new_pos, input);
-        TimeoutConfig memory timeout_config;
-        (new_pos, timeout_config) = bcs_deserialize_offset_TimeoutConfig(new_pos, input);
-        return (new_pos, SystemOperation_ChangeOwnership(super_owners, owners, first_leader, multi_leader_rounds, open_multi_leader_rounds, timeout_config));
+        TimeDelta memory base_timeout;
+        (new_pos, base_timeout) = bcs_deserialize_offset_TimeDelta(new_pos, input);
+        TimeDelta memory timeout_increment;
+        (new_pos, timeout_increment) = bcs_deserialize_offset_TimeDelta(new_pos, input);
+        TimeDelta memory fallback_duration;
+        (new_pos, fallback_duration) = bcs_deserialize_offset_TimeDelta(new_pos, input);
+        return (new_pos, SystemOperation_ChangeOwners(owners, first_leader, multi_leader_rounds, open_multi_leader_rounds, base_timeout, timeout_increment, fallback_duration));
     }
 
-    function bcs_deserialize_SystemOperation_ChangeOwnership(bytes memory input)
+    function bcs_deserialize_SystemOperation_ChangeOwners(bytes memory input)
         internal
         pure
-        returns (SystemOperation_ChangeOwnership memory)
+        returns (SystemOperation_ChangeOwners memory)
     {
         uint256 new_pos;
-        SystemOperation_ChangeOwnership memory value;
-        (new_pos, value) = bcs_deserialize_offset_SystemOperation_ChangeOwnership(0, input);
+        SystemOperation_ChangeOwners memory value;
+        (new_pos, value) = bcs_deserialize_offset_SystemOperation_ChangeOwners(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct SystemOperation_ChangeSuperOwners {
+        AccountOwner[] super_owners;
+        opt_TimeDelta fast_round_duration;
+    }
+
+    function bcs_serialize_SystemOperation_ChangeSuperOwners(SystemOperation_ChangeSuperOwners memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes memory result = bcs_serialize_seq_AccountOwner(input.super_owners);
+        return abi.encodePacked(result, bcs_serialize_opt_TimeDelta(input.fast_round_duration));
+    }
+
+    function bcs_deserialize_offset_SystemOperation_ChangeSuperOwners(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, SystemOperation_ChangeSuperOwners memory)
+    {
+        uint256 new_pos;
+        AccountOwner[] memory super_owners;
+        (new_pos, super_owners) = bcs_deserialize_offset_seq_AccountOwner(pos, input);
+        opt_TimeDelta memory fast_round_duration;
+        (new_pos, fast_round_duration) = bcs_deserialize_offset_opt_TimeDelta(new_pos, input);
+        return (new_pos, SystemOperation_ChangeSuperOwners(super_owners, fast_round_duration));
+    }
+
+    function bcs_deserialize_SystemOperation_ChangeSuperOwners(bytes memory input)
+        internal
+        pure
+        returns (SystemOperation_ChangeSuperOwners memory)
+    {
+        uint256 new_pos;
+        SystemOperation_ChangeSuperOwners memory value;
+        (new_pos, value) = bcs_deserialize_offset_SystemOperation_ChangeSuperOwners(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-bridge/src/solidity/LightClient.sol
+++ b/linera-bridge/src/solidity/LightClient.sol
@@ -45,8 +45,8 @@ contract LightClient {
             // choice=0 is System
             if (op.choice != 0) continue;
             BridgeTypes.SystemOperation memory sysOp = op.system;
-            // choice=10 is Admin
-            if (sysOp.choice != 10) continue;
+            // choice=11 is Admin
+            if (sysOp.choice != 11) continue;
             BridgeTypes.AdminOperation memory adminOp = sysOp.admin;
             // choice=1 is CreateCommittee
             if (adminOp.choice != 1) continue;

--- a/linera-bridge/tests/snapshots/format__format.yaml.snap
+++ b/linera-bridge/tests/snapshots/format__format.yaml.snap
@@ -466,11 +466,8 @@ SystemOperation:
     3:
       CloseChain: UNIT
     4:
-      ChangeOwnership:
+      ChangeOwners:
         STRUCT:
-          - super_owners:
-              SEQ:
-                TYPENAME: AccountOwner
           - owners:
               SEQ:
                 TUPLE:
@@ -481,28 +478,41 @@ SystemOperation:
                 TYPENAME: AccountOwner
           - multi_leader_rounds: U32
           - open_multi_leader_rounds: BOOL
-          - timeout_config:
-              TYPENAME: TimeoutConfig
+          - base_timeout:
+              TYPENAME: TimeDelta
+          - timeout_increment:
+              TYPENAME: TimeDelta
+          - fallback_duration:
+              TYPENAME: TimeDelta
     5:
+      ChangeSuperOwners:
+        STRUCT:
+          - super_owners:
+              SEQ:
+                TYPENAME: AccountOwner
+          - fast_round_duration:
+              OPTION:
+                TYPENAME: TimeDelta
+    6:
       ChangeApplicationPermissions:
         NEWTYPE:
           TYPENAME: ApplicationPermissions
-    6:
+    7:
       PublishModule:
         STRUCT:
           - module_id:
               TYPENAME: ModuleId
-    7:
+    8:
       PublishDataBlob:
         STRUCT:
           - blob_hash:
               TYPENAME: CryptoHash
-    8:
+    9:
       VerifyBlob:
         STRUCT:
           - blob_id:
               TYPENAME: BlobId
-    9:
+    10:
       CreateApplication:
         STRUCT:
           - module_id:
@@ -512,19 +522,19 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: ApplicationId
-    10:
+    11:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation
-    11:
+    12:
       ProcessNewEpoch:
         NEWTYPE:
           TYPENAME: Epoch
-    12:
+    13:
       ProcessRemovedEpoch:
         NEWTYPE:
           TYPENAME: Epoch
-    13:
+    14:
       UpdateStreams:
         NEWTYPE:
           SEQ:

--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -88,8 +88,10 @@ pub struct SystemOperationMetadata {
     pub claim: Option<ClaimOperationMetadata>,
     /// Open chain operation details
     pub open_chain: Option<OpenChainOperationMetadata>,
-    /// Change ownership operation details
-    pub change_ownership: Option<ChangeOwnershipOperationMetadata>,
+    /// Change owners operation details
+    pub change_owners: Option<ChangeOwnersOperationMetadata>,
+    /// Change super owners operation details
+    pub change_super_owners: Option<ChangeSuperOwnersOperationMetadata>,
     /// Change application permissions operation details
     pub change_application_permissions: Option<ChangeApplicationPermissionsMetadata>,
     /// Admin operation details
@@ -116,7 +118,8 @@ impl SystemOperationMetadata {
             transfer: None,
             claim: None,
             open_chain: None,
-            change_ownership: None,
+            change_owners: None,
+            change_super_owners: None,
             change_application_permissions: None,
             admin: None,
             create_application: None,
@@ -154,15 +157,23 @@ pub struct OpenChainOperationMetadata {
     pub application_permissions: ApplicationPermissionsMetadata,
 }
 
-/// Change ownership operation metadata.
+/// Change owners operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-pub struct ChangeOwnershipOperationMetadata {
-    pub super_owners: Vec<AccountOwner>,
+pub struct ChangeOwnersOperationMetadata {
     pub owners: Vec<OwnerWithWeight>,
     pub first_leader: Option<AccountOwner>,
     pub multi_leader_rounds: i32,
     pub open_multi_leader_rounds: bool,
-    pub timeout_config: TimeoutConfigMetadata,
+    pub base_timeout_ms: String,
+    pub timeout_increment_ms: String,
+    pub fallback_duration_ms: String,
+}
+
+/// Change super owners operation metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+pub struct ChangeSuperOwnersOperationMetadata {
+    pub super_owners: Vec<AccountOwner>,
+    pub fast_round_ms: Option<String>,
 }
 
 /// Owner with weight metadata.
@@ -301,16 +312,16 @@ impl From<&SystemOperation> for SystemOperationMetadata {
                 ..SystemOperationMetadata::new("OpenChain")
             },
             SystemOperation::CloseChain => SystemOperationMetadata::new("CloseChain"),
-            SystemOperation::ChangeOwnership {
-                super_owners,
+            SystemOperation::ChangeOwners {
                 owners,
                 first_leader,
                 multi_leader_rounds,
                 open_multi_leader_rounds,
-                timeout_config,
+                base_timeout,
+                timeout_increment,
+                fallback_duration,
             } => SystemOperationMetadata {
-                change_ownership: Some(ChangeOwnershipOperationMetadata {
-                    super_owners: super_owners.clone(),
+                change_owners: Some(ChangeOwnersOperationMetadata {
                     owners: owners
                         .iter()
                         .map(|(owner, weight)| OwnerWithWeight {
@@ -321,9 +332,21 @@ impl From<&SystemOperation> for SystemOperationMetadata {
                     first_leader: *first_leader,
                     multi_leader_rounds: *multi_leader_rounds as i32,
                     open_multi_leader_rounds: *open_multi_leader_rounds,
-                    timeout_config: TimeoutConfigMetadata::from(timeout_config),
+                    base_timeout_ms: (base_timeout.as_micros() / 1000).to_string(),
+                    timeout_increment_ms: (timeout_increment.as_micros() / 1000).to_string(),
+                    fallback_duration_ms: (fallback_duration.as_micros() / 1000).to_string(),
                 }),
-                ..SystemOperationMetadata::new("ChangeOwnership")
+                ..SystemOperationMetadata::new("ChangeOwners")
+            },
+            SystemOperation::ChangeSuperOwners {
+                super_owners,
+                fast_round_duration,
+            } => SystemOperationMetadata {
+                change_super_owners: Some(ChangeSuperOwnersOperationMetadata {
+                    super_owners: super_owners.clone(),
+                    fast_round_ms: fast_round_duration.map(|d| (d.as_micros() / 1000).to_string()),
+                }),
+                ..SystemOperationMetadata::new("ChangeSuperOwners")
             },
             SystemOperation::ChangeApplicationPermissions(permissions) => SystemOperationMetadata {
                 change_application_permissions: Some(ChangeApplicationPermissionsMetadata {

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -59,7 +59,7 @@ use {
 
 use crate::{
     chain_listener::{self, ClientContext as _},
-    client_options::{ChainOwnershipConfig, Options},
+    client_options::{ChangeOwnershipConfig, ChangeSuperOwnershipConfig, Options},
     config::GenesisConfig,
     error, util, Error,
 };
@@ -617,10 +617,11 @@ impl<Env: Environment> ClientContext<Env> {
         Ok(info.manager.ownership)
     }
 
+    /// Changes the regular owners of a chain. Any owner can call this.
     pub async fn change_ownership(
         &mut self,
         chain_id: Option<ChainId>,
-        ownership_config: ChainOwnershipConfig,
+        ownership_config: ChangeOwnershipConfig,
     ) -> Result<(), Error> {
         let chain_id = chain_id.unwrap_or_else(|| self.default_chain());
         let chain_client = self.make_chain_client(chain_id).await?;
@@ -630,7 +631,7 @@ impl<Env: Environment> ClientContext<Env> {
         );
         let time_start = Instant::now();
         let mut ownership = chain_client.query_chain_ownership().await?;
-        ownership_config.update(&mut ownership)?;
+        ownership_config.update(&mut ownership);
 
         if ownership.super_owners.is_empty() && ownership.owners.is_empty() {
             tracing::error!("At least one owner or super owner of the chain has to be set.");
@@ -642,11 +643,59 @@ impl<Env: Environment> ClientContext<Env> {
                 let ownership = ownership.clone();
                 let chain_client = chain_client.clone();
                 async move {
+                    let tc = &ownership.timeout_config;
                     chain_client
-                        .change_ownership(ownership)
+                        .execute_operation(linera_execution::SystemOperation::ChangeOwners {
+                            owners: ownership.owners.into_iter().collect(),
+                            first_leader: ownership.first_leader,
+                            multi_leader_rounds: ownership.multi_leader_rounds,
+                            open_multi_leader_rounds: ownership.open_multi_leader_rounds,
+                            base_timeout: tc.base_timeout,
+                            timeout_increment: tc.timeout_increment,
+                            fallback_duration: tc.fallback_duration,
+                        })
                         .await
                         .map_err(Error::from)
                         .context("Failed to change ownership")
+                }
+            })
+            .await?;
+        let time_total = time_start.elapsed();
+        info!("Operation confirmed after {} ms", time_total.as_millis());
+        debug!("{:?}", certificate);
+        Ok(())
+    }
+
+    /// Changes the super owners of a chain. Only a super owner can call this.
+    pub async fn change_super_ownership(
+        &mut self,
+        chain_id: Option<ChainId>,
+        ownership_config: ChangeSuperOwnershipConfig,
+    ) -> Result<(), Error> {
+        let chain_id = chain_id.unwrap_or_else(|| self.default_chain());
+        let chain_client = self.make_chain_client(chain_id).await?;
+        info!(
+            ?ownership_config, %chain_id, preferred_owner=?chain_client.preferred_owner(),
+            "Changing super ownership of a chain"
+        );
+        let time_start = Instant::now();
+        let mut ownership = chain_client.query_chain_ownership().await?;
+        ownership_config.update(&mut ownership);
+
+        let certificate = self
+            .apply_client_command(&chain_client, |chain_client| {
+                let ownership = ownership.clone();
+                let chain_client = chain_client.clone();
+                async move {
+                    let tc = &ownership.timeout_config;
+                    chain_client
+                        .execute_operation(linera_execution::SystemOperation::ChangeSuperOwners {
+                            super_owners: ownership.super_owners.into_iter().collect(),
+                            fast_round_duration: tc.fast_round_duration,
+                        })
+                        .await
+                        .map_err(Error::from)
+                        .context("Failed to change super ownership")
                 }
             })
             .await?;

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -492,6 +492,105 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
     }
 }
 
+/// CLI config for changing regular owners (accessible by any owner).
+#[derive(Debug, Clone, clap::Args)]
+pub struct ChangeOwnershipConfig {
+    /// A JSON map of the new owners to their weights. Absence of the option leaves the current
+    /// set of owners unchanged.
+    #[arg(long, value_parser = util::parse_json::<BTreeMap<AccountOwner, u64>>)]
+    pub owners: Option<BTreeMap<AccountOwner, u64>>,
+
+    /// The leader of the first single-leader round. If set to null, this is random like other
+    /// rounds. Absence of the option leaves the current setting unchanged.
+    #[arg(long, value_parser = util::parse_json::<Option<AccountOwner>>)]
+    pub first_leader: Option<Option<AccountOwner>>,
+
+    /// The number of rounds in which every owner can propose blocks, i.e. the first round
+    /// number in which only a single designated leader is allowed to propose blocks. "null" is
+    /// equivalent to 2^32 - 1. Absence of the option leaves the current setting unchanged.
+    #[arg(long, value_parser = util::parse_json::<Option<u32>>)]
+    pub multi_leader_rounds: Option<Option<u32>>,
+
+    /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
+    /// This should only be `true` on chains with restrictive application permissions and an
+    /// application-based mechanism to select block proposers.
+    #[arg(long)]
+    pub open_multi_leader_rounds: bool,
+
+    /// The duration of the first single-leader and all multi-leader rounds. Absence of
+    /// the option leaves the current setting unchanged.
+    #[arg(
+        long = "base-timeout-ms",
+        value_parser = util::parse_millis_delta
+    )]
+    pub base_timeout: Option<TimeDelta>,
+
+    /// The number of milliseconds by which the timeout increases after each
+    /// single-leader round. Absence of the option leaves the current setting unchanged.
+    #[arg(
+        long = "timeout-increment-ms",
+        value_parser = util::parse_millis_delta
+    )]
+    pub timeout_increment: Option<TimeDelta>,
+
+    /// The age of an incoming tracked or protected message after which the validators start
+    /// transitioning the chain to fallback mode, in milliseconds. Absence of the option
+    /// leaves the current setting unchanged.
+    #[arg(
+        long = "fallback-duration-ms",
+        value_parser = util::parse_millis_delta
+    )]
+    pub fallback_duration: Option<TimeDelta>,
+}
+
+impl ChangeOwnershipConfig {
+    pub fn update(self, chain_ownership: &mut ChainOwnership) {
+        if let Some(owners) = self.owners {
+            chain_ownership.owners = owners;
+        }
+        if let Some(first_leader) = self.first_leader {
+            chain_ownership.first_leader = first_leader;
+        }
+        if let Some(multi_leader_rounds) = self.multi_leader_rounds {
+            chain_ownership.multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
+        }
+        chain_ownership.open_multi_leader_rounds = self.open_multi_leader_rounds;
+        if let Some(base_timeout) = self.base_timeout {
+            chain_ownership.timeout_config.base_timeout = base_timeout;
+        }
+        if let Some(timeout_increment) = self.timeout_increment {
+            chain_ownership.timeout_config.timeout_increment = timeout_increment;
+        }
+        if let Some(fallback_duration) = self.fallback_duration {
+            chain_ownership.timeout_config.fallback_duration = fallback_duration;
+        }
+    }
+}
+
+/// CLI config for changing super owners (requires super owner privileges).
+#[derive(Debug, Clone, clap::Args)]
+pub struct ChangeSuperOwnershipConfig {
+    /// A JSON list of the new super owners.
+    #[arg(long, value_parser = util::parse_json::<Vec<AccountOwner>>)]
+    pub super_owners: Option<Vec<AccountOwner>>,
+
+    /// The duration of the fast round, in milliseconds. "null" means the fast round will
+    /// not time out. Absence of the option leaves the current setting unchanged.
+    #[arg(long = "fast-round-ms", value_parser = util::parse_json_optional_millis_delta)]
+    pub fast_round_duration: Option<Option<TimeDelta>>,
+}
+
+impl ChangeSuperOwnershipConfig {
+    pub fn update(self, chain_ownership: &mut ChainOwnership) {
+        if let Some(super_owners) = self.super_owners {
+            chain_ownership.super_owners = super_owners.into_iter().collect();
+        }
+        if let Some(fast_round_duration) = self.fast_round_duration {
+            chain_ownership.timeout_config.fast_round_duration = fast_round_duration;
+        }
+    }
+}
+
 #[derive(Debug, Clone, clap::Args)]
 pub struct ApplicationPermissionsConfig {
     /// A JSON list of applications allowed to execute operations on this chain. If set to null, all

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -87,7 +87,7 @@ impl chain_listener::ClientContext for ClientContext {
 /// timeout certificates until it becomes the leader and can process the inbox.
 #[test_log::test(tokio::test)]
 async fn test_chain_listener() -> anyhow::Result<()> {
-    // Create two chains.
+    // Create three chains: admin (regular), chain under test (super owner), sender (regular).
     let mut signer = InMemorySigner::new(Some(42));
     let key_pair = signer.generate_new();
     let owner: AccountOwner = key_pair.into();
@@ -95,15 +95,18 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let storage_builder = MemoryStorageBuilder::default();
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer.clone()).await?;
-    let client0 = builder.add_root_chain(0, Amount::ONE).await?;
-    let chain_id0 = client0.chain_id();
-    let client1 = builder.add_root_chain(1, Amount::ONE).await?;
-    // Start a chain listener for chain 0 with a new key.
+    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let mut client1 = builder
+        .add_root_super_owner_chain(1, Amount::ONE)
+        .await?;
+    let chain_id1 = client1.chain_id();
+    let client2 = builder.add_root_chain(2, Amount::ONE).await?;
+    // Start a chain listener for chain 1 with a new key.
     let genesis_config = GenesisConfig::new_testing(&builder);
     let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
-    let epoch0 = client0.chain_info().await?.epoch;
     let epoch1 = client1.chain_info().await?.epoch;
+    let epoch2 = client2.chain_info().await?.epoch;
 
     let mut context = ClientContext {
         client: Arc::new(Client::new(
@@ -115,8 +118,8 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             },
             admin_chain_id,
             false,
-            [(chain_id0, ListeningMode::FullChain)],
-            format!("Client node for {:.8}", chain_id0),
+            [(chain_id1, ListeningMode::FullChain)],
+            format!("Client node for {:.8}", chain_id1),
             Some(Duration::from_secs(30)),
             Some(Duration::from_secs(1)),
             HashSet::new(),
@@ -127,18 +130,18 @@ async fn test_chain_listener() -> anyhow::Result<()> {
         )),
     };
     context
-        .update_wallet_for_new_chain(chain_id0, Some(owner), clock.current_time(), epoch0)
+        .update_wallet_for_new_chain(chain_id1, Some(owner), clock.current_time(), epoch1)
         .await?;
     context
         .update_wallet_for_new_chain(
-            client1.chain_id(),
-            client1.preferred_owner(),
+            client2.chain_id(),
+            client2.preferred_owner(),
             clock.current_time(),
-            epoch1,
+            epoch2,
         )
         .await?;
 
-    // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
+    // Transfer ownership of chain 1 to the chain listener and some other key. The listener will
     // be leader in ~10% of the rounds.
     let owners = [(owner, 1), (AccountPublicKey::test_key(1).into(), 9)];
     let timeout_config = TimeoutConfig {
@@ -146,7 +149,9 @@ async fn test_chain_listener() -> anyhow::Result<()> {
         timeout_increment: TimeDelta::ZERO,
         ..TimeoutConfig::default()
     };
-    client0
+    // Enable fast blocks so the super owner can propose the ownership change.
+    client1.options_mut().allow_fast_blocks = true;
+    client1
         .change_ownership(ChainOwnership::multiple(owners, 0, timeout_config))
         .await?;
 
@@ -166,15 +171,15 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     .unwrap();
 
     let handle = linera_base::Task::spawn(async move { chain_listener.await.unwrap() });
-    // Transfer one token to chain 0. The listener should eventually become leader and receive
+    // Transfer one token to chain 1. The listener should eventually become leader and receive
     // the message.
-    let recipient0 = Account::chain(chain_id0);
-    client1
-        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient0)
+    let recipient1 = Account::chain(chain_id1);
+    client2
+        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient1)
         .await?;
     for i in 0.. {
-        client0.synchronize_from_validators().boxed().await?;
-        let balance = client0.local_balance().await?;
+        client1.synchronize_from_validators().boxed().await?;
+        let balance = client1.local_balance().await?;
         if balance == Amount::from_tokens(2) {
             break;
         }
@@ -544,11 +549,15 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer.clone()).await?;
 
-    // Chain 0: the chain under test (owned by both autosigner and dynamic).
-    let client0 = builder.add_root_chain(0, Amount::ONE).await?;
-    let chain_id0 = client0.chain_id();
-    // Chain 1: sender of incoming messages.
-    let client1 = builder.add_root_chain(1, Amount::ONE).await?;
+    // Chain 0: admin chain (regular owner).
+    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    // Chain 1: the chain under test (super owner, will change ownership).
+    let mut client1 = builder
+        .add_root_super_owner_chain(1, Amount::ONE)
+        .await?;
+    let chain_id1 = client1.chain_id();
+    // Chain 2: sender of incoming messages.
+    let client2 = builder.add_root_chain(2, Amount::ONE).await?;
 
     // Transfer ownership to both the autosigner and dynamic owners.
     // Use multi_leader_rounds > 0 so both owners can propose without waiting for leadership.
@@ -557,7 +566,9 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
         timeout_increment: TimeDelta::ZERO,
         ..TimeoutConfig::default()
     };
-    client0
+    // Enable fast blocks so the super owner can propose the ownership change.
+    client1.options_mut().allow_fast_blocks = true;
+    client1
         .change_ownership(ChainOwnership::multiple(
             [(autosigner_owner, 1), (dynamic_owner, 1)],
             100,
@@ -579,8 +590,8 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
             },
             admin_chain_id,
             false,
-            [(chain_id0, ListeningMode::FullChain)],
-            format!("Client node for {:.8}", chain_id0),
+            [(chain_id1, ListeningMode::FullChain)],
+            format!("Client node for {:.8}", chain_id1),
             Some(Duration::from_secs(30)),
             Some(Duration::from_secs(1)),
             HashSet::new(),
@@ -592,22 +603,22 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
     };
 
     // Set wallet owner to the autosigner (as wallet.setOwner() would in the web client).
-    let chain0_info = client0.chain_info().await?;
+    let chain1_info = client1.chain_info().await?;
     context.wallet().insert(
-        chain_id0,
+        chain_id1,
         wallet::Chain {
             owner: Some(autosigner_owner),
-            block_hash: chain0_info.block_hash,
-            next_block_height: chain0_info.next_block_height,
+            block_hash: chain1_info.block_hash,
+            next_block_height: chain1_info.next_block_height,
             timestamp: clock.current_time(),
             pending_proposal: None,
-            epoch: Some(chain0_info.epoch),
+            epoch: Some(chain1_info.epoch),
         },
     );
     context
         .update_wallet_for_new_chain(
-            client1.chain_id(),
-            client1.preferred_owner(),
+            client2.chain_id(),
+            client2.preferred_owner(),
             clock.current_time(),
             Epoch::ZERO,
         )
@@ -616,7 +627,7 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
     // Simulate the web client's client.chain({owner: dynamicAddress}) followed by an
     // operation (e.g. addOwner). This calls update_wallet, which with the bug overwrites
     // the wallet owner with the ChainClient's preferred_owner.
-    let mut chain_client = context.make_chain_client(chain_id0).await?;
+    let mut chain_client = context.make_chain_client(chain_id1).await?;
     chain_client.set_preferred_owner(dynamic_owner);
     context.update_wallet(&chain_client).await?;
 
@@ -639,17 +650,17 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
 
     let handle = linera_base::Task::spawn(async move { chain_listener.await.unwrap() });
 
-    // Send a message from chain 1 to chain 0. The listener should process the inbox.
-    let recipient0 = Account::chain(chain_id0);
-    client1
-        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient0)
+    // Send a message from chain 2 to chain 1. The listener should process the inbox.
+    let recipient1 = Account::chain(chain_id1);
+    client2
+        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient1)
         .await?;
 
     // Wait for the listener to process the inbox (creating a block after the
     // change_ownership block).
     for i in 0.. {
-        client0.synchronize_from_validators().boxed().await?;
-        let balance = client0.local_balance().await?;
+        client1.synchronize_from_validators().boxed().await?;
+        let balance = client1.local_balance().await?;
         if balance == Amount::from_tokens(2) {
             break;
         }
@@ -667,7 +678,7 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
     // The inbox-processing block is at height 1 (created by the listener).
     // Verify the listener's block was signed by the autosigner, not the dynamic signer.
     let certs = storage
-        .read_certificates_by_heights(chain_id0, &[BlockHeight::from(1)])
+        .read_certificates_by_heights(chain_id1, &[BlockHeight::from(1)])
         .await?;
     let inbox_cert = certs[0]
         .as_ref()
@@ -685,12 +696,12 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
         .transfer(
             AccountOwner::CHAIN,
             Amount::ONE,
-            Account::chain(client1.chain_id()),
+            Account::chain(client2.chain_id()),
         )
         .await?;
 
     let certs = storage
-        .read_certificates_by_heights(chain_id0, &[BlockHeight::from(2)])
+        .read_certificates_by_heights(chain_id1, &[BlockHeight::from(2)])
         .await?;
     let user_cert = certs[0]
         .as_ref()

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -96,9 +96,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer.clone()).await?;
     let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
-    let mut client1 = builder
-        .add_root_super_owner_chain(1, Amount::ONE)
-        .await?;
+    let mut client1 = builder.add_root_super_owner_chain(1, Amount::ONE).await?;
     let chain_id1 = client1.chain_id();
     let client2 = builder.add_root_chain(2, Amount::ONE).await?;
     // Start a chain listener for chain 1 with a new key.
@@ -552,9 +550,7 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
     // Chain 0: admin chain (regular owner).
     let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
     // Chain 1: the chain under test (super owner, will change ownership).
-    let mut client1 = builder
-        .add_root_super_owner_chain(1, Amount::ONE)
-        .await?;
+    let mut client1 = builder.add_root_super_owner_chain(1, Amount::ONE).await?;
     let chain_id1 = client1.chain_id();
     // Chain 2: sender of incoming messages.
     let client2 = builder.add_root_chain(2, Amount::ONE).await?;

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -21,7 +21,7 @@ use linera_base::{
     crypto::{signer, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
-        ChainDescription, Epoch, MessagePolicy, Round, Timestamp,
+        ChainDescription, Epoch, MessagePolicy, Round, TimeDelta, Timestamp,
     },
     ensure,
     identifiers::{
@@ -2119,34 +2119,62 @@ impl<Env: Environment> ChainClient<Env> {
 
     /// Rotates the key of the chain.
     ///
-    /// Replaces current owners of the chain with the new key pair.
+    /// Replaces the current regular owner of the chain with the new key pair.
     #[cfg(with_testing)]
     #[instrument(level = "trace")]
     pub async fn rotate_key_pair(
         &self,
         public_key: linera_base::crypto::AccountPublicKey,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
-        self.transfer_ownership(public_key.into()).await
+        self.change_owner(public_key.into()).await
     }
 
-    /// Transfers ownership of the chain to a single super owner.
+    /// Sets the chain to have a single regular owner.
     #[instrument(level = "trace")]
-    pub async fn transfer_ownership(
+    pub async fn change_owner(
         &self,
         new_owner: AccountOwner,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
-        self.execute_operation(SystemOperation::ChangeOwnership {
-            super_owners: vec![new_owner],
-            owners: Vec::new(),
+        let tc = TimeoutConfig::default();
+        self.execute_operation(SystemOperation::ChangeOwners {
+            owners: vec![(new_owner, 100)],
             first_leader: None,
             multi_leader_rounds: 2,
             open_multi_leader_rounds: false,
-            timeout_config: TimeoutConfig::default(),
+            base_timeout: tc.base_timeout,
+            timeout_increment: tc.timeout_increment,
+            fallback_duration: tc.fallback_duration,
         })
         .await
     }
 
-    /// Adds another owner to the chain, and turns existing super owners into regular owners.
+    /// Transfers super ownership of the chain to a single super owner.
+    /// The caller must be a current super owner.
+    #[instrument(level = "trace")]
+    pub async fn transfer_super_ownership(
+        &self,
+        new_super_owner: AccountOwner,
+    ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
+        let tc = TimeoutConfig::default();
+        let operations = vec![
+            Operation::system(SystemOperation::ChangeSuperOwners {
+                super_owners: vec![new_super_owner],
+                fast_round_duration: tc.fast_round_duration,
+            }),
+            Operation::system(SystemOperation::ChangeOwners {
+                owners: Vec::new(),
+                first_leader: None,
+                multi_leader_rounds: 2,
+                open_multi_leader_rounds: false,
+                base_timeout: tc.base_timeout,
+                timeout_increment: tc.timeout_increment,
+                fallback_duration: tc.fallback_duration,
+            }),
+        ];
+        self.execute_block(operations, vec![]).await
+    }
+
+    /// Adds another regular owner to the chain.
     #[instrument(level = "trace")]
     pub async fn share_ownership(
         &self,
@@ -2159,17 +2187,18 @@ impl<Env: Environment> ChainClient<Env> {
             ChainError::InactiveChain(self.chain_id)
         );
         let mut owners = ownership.owners.into_iter().collect::<Vec<_>>();
-        owners.extend(ownership.super_owners.into_iter().zip(iter::repeat(100)));
         owners.push((new_owner, new_weight));
-        let operations = vec![Operation::system(SystemOperation::ChangeOwnership {
-            super_owners: Vec::new(),
+        let tc = &ownership.timeout_config;
+        self.execute_operation(SystemOperation::ChangeOwners {
             owners,
             first_leader: ownership.first_leader,
             multi_leader_rounds: ownership.multi_leader_rounds,
             open_multi_leader_rounds: ownership.open_multi_leader_rounds,
-            timeout_config: ownership.timeout_config,
-        })];
-        self.execute_block(operations, vec![]).await
+            base_timeout: tc.base_timeout,
+            timeout_increment: tc.timeout_increment,
+            fallback_duration: tc.fallback_duration,
+        })
+        .await
     }
 
     /// Returns the current ownership settings on this chain.
@@ -2188,20 +2217,35 @@ impl<Env: Environment> ChainClient<Env> {
             .clone())
     }
 
-    /// Changes the ownership of this chain. Fails if it would remove existing owners, unless
-    /// `remove_owners` is `true`.
+    /// Changes the regular owners and timeout configuration of this chain.
     #[instrument(level = "trace")]
     pub async fn change_ownership(
         &self,
         ownership: ChainOwnership,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
-        self.execute_operation(SystemOperation::ChangeOwnership {
-            super_owners: ownership.super_owners.into_iter().collect(),
+        let tc = &ownership.timeout_config;
+        self.execute_operation(SystemOperation::ChangeOwners {
             owners: ownership.owners.into_iter().collect(),
             first_leader: ownership.first_leader,
             multi_leader_rounds: ownership.multi_leader_rounds,
             open_multi_leader_rounds: ownership.open_multi_leader_rounds,
-            timeout_config: ownership.timeout_config.clone(),
+            base_timeout: tc.base_timeout,
+            timeout_increment: tc.timeout_increment,
+            fallback_duration: tc.fallback_duration,
+        })
+        .await
+    }
+
+    /// Changes the super owners and fast round duration. Only a super owner can do this.
+    #[instrument(level = "trace")]
+    pub async fn change_super_ownership(
+        &self,
+        super_owners: Vec<AccountOwner>,
+        fast_round_duration: Option<TimeDelta>,
+    ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
+        self.execute_operation(SystemOperation::ChangeSuperOwners {
+            super_owners,
+            fast_round_duration,
         })
         .await
     }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -5,7 +5,6 @@ mod state;
 use std::{
     collections::{hash_map, BTreeMap, BTreeSet, HashMap},
     convert::Infallible,
-    iter,
     sync::Arc,
 };
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2125,7 +2125,13 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         public_key: linera_base::crypto::AccountPublicKey,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
-        self.change_owner(public_key.into()).await
+        let new_owner = public_key.into();
+        let ownership = self.prepare_chain().await?.manager.ownership;
+        if ownership.super_owners.is_empty() {
+            self.change_owner(new_owner).await
+        } else {
+            self.transfer_super_ownership(new_owner).await
+        }
     }
 
     /// Sets the chain to have a single regular owner.
@@ -2155,11 +2161,9 @@ impl<Env: Environment> ChainClient<Env> {
         new_super_owner: AccountOwner,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
         let tc = TimeoutConfig::default();
+        // `ChangeOwners` must run before `ChangeSuperOwners`: both require super-owner
+        // authorization, and `ChangeSuperOwners` removes the caller from the super-owner set.
         let operations = vec![
-            Operation::system(SystemOperation::ChangeSuperOwners {
-                super_owners: vec![new_super_owner],
-                fast_round_duration: tc.fast_round_duration,
-            }),
             Operation::system(SystemOperation::ChangeOwners {
                 owners: Vec::new(),
                 first_leader: None,
@@ -2168,6 +2172,10 @@ impl<Env: Environment> ChainClient<Env> {
                 base_timeout: tc.base_timeout,
                 timeout_increment: tc.timeout_increment,
                 fallback_duration: tc.fallback_duration,
+            }),
+            Operation::system(SystemOperation::ChangeSuperOwners {
+                super_owners: vec![new_super_owner],
+                fast_round_duration: tc.fast_round_duration,
             }),
         ];
         self.execute_block(operations, vec![]).await
@@ -2186,9 +2194,15 @@ impl<Env: Environment> ChainClient<Env> {
             ChainError::InactiveChain(self.chain_id)
         );
         let mut owners = ownership.owners.into_iter().collect::<Vec<_>>();
+        // When converting from super-owner-only, include super owners as regular owners.
+        for super_owner in &ownership.super_owners {
+            if !owners.iter().any(|(o, _)| o == super_owner) {
+                owners.push((*super_owner, new_weight));
+            }
+        }
         owners.push((new_owner, new_weight));
         let tc = &ownership.timeout_config;
-        self.execute_operation(SystemOperation::ChangeOwners {
+        let mut operations = vec![Operation::system(SystemOperation::ChangeOwners {
             owners,
             first_leader: ownership.first_leader,
             multi_leader_rounds: ownership.multi_leader_rounds,
@@ -2196,8 +2210,16 @@ impl<Env: Environment> ChainClient<Env> {
             base_timeout: tc.base_timeout,
             timeout_increment: tc.timeout_increment,
             fallback_duration: tc.fallback_duration,
-        })
-        .await
+        })];
+        // Also clear super owners so that the chain leaves Fast round and
+        // all regular owners can propose blocks.
+        if !ownership.super_owners.is_empty() {
+            operations.push(Operation::system(SystemOperation::ChangeSuperOwners {
+                super_owners: Vec::new(),
+                fast_round_duration: tc.fast_round_duration,
+            }));
+        }
+        self.execute_block(operations, vec![]).await
     }
 
     /// Returns the current ownership settings on this chain.
@@ -2223,16 +2245,22 @@ impl<Env: Environment> ChainClient<Env> {
         ownership: ChainOwnership,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
         let tc = &ownership.timeout_config;
-        self.execute_operation(SystemOperation::ChangeOwners {
-            owners: ownership.owners.into_iter().collect(),
-            first_leader: ownership.first_leader,
-            multi_leader_rounds: ownership.multi_leader_rounds,
-            open_multi_leader_rounds: ownership.open_multi_leader_rounds,
-            base_timeout: tc.base_timeout,
-            timeout_increment: tc.timeout_increment,
-            fallback_duration: tc.fallback_duration,
-        })
-        .await
+        let operations = vec![
+            Operation::system(SystemOperation::ChangeOwners {
+                owners: ownership.owners.into_iter().collect(),
+                first_leader: ownership.first_leader,
+                multi_leader_rounds: ownership.multi_leader_rounds,
+                open_multi_leader_rounds: ownership.open_multi_leader_rounds,
+                base_timeout: tc.base_timeout,
+                timeout_increment: tc.timeout_increment,
+                fallback_duration: tc.fallback_duration,
+            }),
+            Operation::system(SystemOperation::ChangeSuperOwners {
+                super_owners: ownership.super_owners.into_iter().collect(),
+                fast_round_duration: tc.fast_round_duration,
+            }),
+        ];
+        self.execute_block(operations, vec![]).await
     }
 
     /// Changes the super owners and fast round duration. Only a super owner can do this.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -307,7 +307,9 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer)
         .await?
         .with_policy(ResourceControlPolicy::only_fuel());
-    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let mut sender = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
     let certificate = sender
         .rotate_key_pair(new_public_key)
         .await
@@ -352,10 +354,16 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer)
         .await?
         .with_policy(ResourceControlPolicy::only_fuel());
-    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let sender = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
 
     let new_owner: AccountOwner = builder.signer.generate_new().into();
-    let certificate = sender.change_owner(new_owner).await.unwrap().unwrap();
+    let certificate = sender
+        .transfer_super_ownership(new_owner)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         sender.chain_info().await?.next_block_height,
         BlockHeight::from(1)
@@ -399,7 +407,9 @@ where
     let mut signer = InMemorySigner::new(None);
     let new_owner = signer.generate_new().into();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let sender = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
     let certificate = sender
         .share_ownership(new_owner, 100)
         .await
@@ -573,7 +583,7 @@ where
     // Open the new chain.
     let (new_description, _certificate) = sender
         .open_chain(
-            ChainOwnership::single(new_public_key.into()),
+            ChainOwnership::single_super(new_public_key.into()),
             ApplicationPermissions::default(),
             Amount::ZERO,
         )
@@ -790,7 +800,9 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
-    let client1 = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let client1 = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
     let client2 = builder.add_root_chain(2, Amount::from_tokens(4)).await?;
 
     let certificate = client1.close_chain().await.unwrap().unwrap().unwrap();
@@ -1231,7 +1243,9 @@ where
             ..ResourceControlPolicy::default()
         });
     let admin = builder.add_root_chain(0, initial_balance).await?;
-    let user = builder.add_root_chain(1, Amount::ZERO).await?;
+    let user = builder
+        .add_root_super_owner_chain(1, Amount::ZERO)
+        .await?;
     let validators = builder.initial_committee.validators().clone();
 
     let committee = Committee::new(validators.clone(), ResourceControlPolicy::only_fuel())?;
@@ -1528,7 +1542,7 @@ where
 {
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let client_1a = builder.add_root_chain(1, Amount::ZERO).await?;
+    let client_1a = builder.add_root_super_owner_chain(1, Amount::ZERO).await?;
     let owner_1a = client_1a.identity().await.unwrap();
     let chain_1 = client_1a.chain_id();
     let pk_1b = builder.signer.generate_new();
@@ -1546,7 +1560,9 @@ where
         )
         .await?;
 
-    let client_2a = builder.add_root_chain(2, Amount::from_tokens(10)).await?;
+    let client_2a = builder
+        .add_root_super_owner_chain(2, Amount::from_tokens(10))
+        .await?;
     let owner_2a = client_2a.identity().await.unwrap();
     let chain_2 = client_2a.chain_id();
     let pk_2b = builder.signer.generate_new();
@@ -1705,27 +1721,18 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
 
     let client1 = builder.add_root_chain(1, Amount::ZERO).await?;
-    let client2_a = builder.add_root_chain(2, Amount::from_tokens(10)).await?;
+    let client2_a = builder
+        .add_root_super_owner_chain(2, Amount::from_tokens(10))
+        .await?;
 
     let chain_id2 = client2_a.chain_id();
 
     let owner2_a = client2_a.identity().await.unwrap();
     let owner2_b = builder.signer.generate_new().into();
 
-    let tc = TimeoutConfig::default();
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwners {
-        owners: vec![(owner2_a, 50), (owner2_b, 50)],
-        first_leader: None,
-        multi_leader_rounds: 10,
-        open_multi_leader_rounds: false,
-        base_timeout: tc.base_timeout,
-        timeout_increment: tc.timeout_increment,
-        fallback_duration: tc.fallback_duration,
-    });
-    client2_a
-        .execute_operation(owner_change_op.clone())
-        .await
-        .unwrap();
+    let owners = [(owner2_a, 50), (owner2_b, 50)];
+    let ownership = ChainOwnership::multiple(owners, 10, TimeoutConfig::default());
+    client2_a.change_ownership(ownership).await.unwrap();
 
     let mut client2_b = builder
         .make_client(
@@ -1813,12 +1820,12 @@ where
             amount: Amount::from_tokens(1),
         })));
 
-    // Previous should be the `ChangeOwnership` operation, as the blob operations shouldn't be executed here.
+    // Previous should be the `ChangeOwnership` block, as the blob operations shouldn't be executed here.
     assert!(certificate_values[1]
         .block()
         .body
         .operations()
-        .any(|op| *op == owner_change_op));
+        .any(|op| matches!(op, Operation::System(op) if matches!(**op, SystemOperation::ChangeOwners { .. }))));
     Ok(())
 }
 
@@ -1835,23 +1842,13 @@ where
     let mut signer = InMemorySigner::new(None);
     let owner2 = signer.generate_new().into();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let client1 = builder.add_root_chain(1, Amount::ONE).await?;
+    let client1 = builder.add_root_super_owner_chain(1, Amount::ONE).await?;
     let chain_id = client1.chain_id();
     let owner1 = client1.identity().await?;
-    let tc = TimeoutConfig::default();
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwners {
-        owners: vec![(owner1, 50), (owner2, 50)],
-        first_leader: None,
-        multi_leader_rounds: 10,
-        open_multi_leader_rounds: false,
-        base_timeout: tc.base_timeout,
-        timeout_increment: tc.timeout_increment,
-        fallback_duration: tc.fallback_duration,
-    });
-    client1
-        .execute_operation(owner_change_op.clone())
-        .await
-        .unwrap();
+
+    let owners = [(owner1, 50), (owner2, 50)];
+    let ownership = ChainOwnership::multiple(owners, 10, TimeoutConfig::default());
+    client1.change_ownership(ownership).await.unwrap();
     let mut client2 = builder
         .make_client(
             chain_id,
@@ -1923,7 +1920,9 @@ where
 
     let client1 = builder.add_root_chain(1, Amount::ZERO).await?;
     let client2 = builder.add_root_chain(2, Amount::ZERO).await?;
-    let client3_a = builder.add_root_chain(3, Amount::from_tokens(10)).await?;
+    let client3_a = builder
+        .add_root_super_owner_chain(3, Amount::from_tokens(10))
+        .await?;
 
     let chain_id3 = client3_a.chain_id();
 
@@ -1931,21 +1930,9 @@ where
     let owner3_b = builder.signer.generate_new().into();
     let owner3_c = builder.signer.generate_new().into();
 
-    let tc = TimeoutConfig::default();
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwners {
-        owners: vec![(owner3_a, 50), (owner3_b, 50), (owner3_c, 50)],
-        first_leader: None,
-        multi_leader_rounds: 10,
-        open_multi_leader_rounds: false,
-        base_timeout: tc.base_timeout,
-        timeout_increment: tc.timeout_increment,
-        fallback_duration: tc.fallback_duration,
-    });
-
-    client3_a
-        .execute_operation(owner_change_op.clone())
-        .await
-        .unwrap();
+    let owners = [(owner3_a, 50), (owner3_b, 50), (owner3_c, 50)];
+    let ownership = ChainOwnership::multiple(owners, 10, TimeoutConfig::default());
+    client3_a.change_ownership(ownership).await.unwrap();
 
     let block_hash = client3_a.chain_info().await?.block_hash;
     let mut client3_b = builder
@@ -2150,7 +2137,9 @@ where
     let signer = InMemorySigner::new(None);
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
-    let client = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let client = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(3))
+        .await?;
     let observer = builder.add_root_chain(2, Amount::ZERO).await?;
     let chain_id = client.chain_id();
     let observer_id = observer.chain_id();
@@ -2284,17 +2273,25 @@ where
     let signer = InMemorySigner::new(None);
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
-    let client = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let mut client = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(3))
+        .await?;
     let observer = builder.add_root_chain(2, Amount::ZERO).await?;
     let chain_id = client.chain_id();
     let observer_id = observer.chain_id();
     let owner0 = client.identity().await.unwrap();
     let owner1 = AccountSecretKey::generate().public().into();
 
+    // Enable fast blocks so the super owner can propose in the Fast round.
+    client.options_mut().allow_fast_blocks = true;
+
     // Set up multi-owner chain.
     let owners = [(owner0, 100), (owner1, 100)];
     let ownership = ChainOwnership::multiple(owners, 0, TimeoutConfig::default());
     client.change_ownership(ownership.clone()).await.unwrap();
+
+    // Disable fast blocks again; the chain no longer has super owners.
+    client.options_mut().allow_fast_blocks = false;
 
     // Advance to a round where owner1 is the leader (so owner0 is not).
     let round_where_owner0_not_leader = loop {
@@ -2316,8 +2313,13 @@ where
         .make_client(chain_id, None, BlockHeight::ZERO)
         .await?;
 
-    // Sync client2 to get the current state.
+    // Sync client2 to get the current state. We need an explicit
+    // `synchronize_chain_state` because `prepare_chain` (called by
+    // `synchronize_from_validators`) skips the network sync when the preferred
+    // owner is a super owner with no regular owners—but the ownership was already
+    // changed by `client` from a different client instance.
     client2.synchronize_from_validators().await?;
+    client2.synchronize_chain_state(chain_id).await?;
 
     // Advance validators one more round using client2.
     let timeout = client2
@@ -2394,7 +2396,9 @@ where
     let mut signer = InMemorySigner::new(None);
     let owner1 = signer.generate_new().into();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
-    let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let client0 = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(10))
+        .await?;
     let chain_id = client0.chain_id();
     let owner0 = client0.preferred_owner().unwrap();
 
@@ -2538,7 +2542,9 @@ where
     // Configure a chain with two regular and no super owners.
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let client0 = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(10))
+        .await?;
     let chain_id = client0.chain_id();
     let owner0 = client0.identity().await.unwrap();
     let owner1 = builder.signer.generate_new().into();
@@ -3598,7 +3604,9 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
 
     // Create a chain and get its owner.
-    let client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let client = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
     let owner = client.identity().await?;
     let chain_id = client.chain_id();
 
@@ -3796,12 +3804,13 @@ where
         .await?;
     let super_owner = sender.identity().await?;
 
-    // Add a regular owner.
+    // Add a regular owner. This clears super owners and converts them to regular owners.
     sender.share_ownership(regular_owner, 100).await.unwrap();
 
-    // Query ownership to verify super owner is still there.
+    // Query ownership to verify super owner was converted to regular owner.
     let ownership = sender.query_chain_ownership().await?;
-    assert!(ownership.super_owners.contains(&super_owner));
+    assert!(ownership.super_owners.is_empty());
+    assert!(ownership.owners.contains_key(&super_owner));
     assert!(ownership.owners.contains_key(&regular_owner));
 
     Ok(())

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -6,8 +6,6 @@ mod test_helpers;
 #[path = "./wasm_client_tests.rs"]
 mod wasm;
 
-use std::collections::{BTreeMap, BTreeSet};
-
 use assert_matches::assert_matches;
 use futures::StreamExt;
 use linera_base::{
@@ -357,7 +355,7 @@ where
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
 
     let new_owner: AccountOwner = builder.signer.generate_new().into();
-    let certificate = sender.transfer_ownership(new_owner).await.unwrap().unwrap();
+    let certificate = sender.change_owner(new_owner).await.unwrap().unwrap();
     assert_eq!(
         sender.chain_info().await?.next_block_height,
         BlockHeight::from(1)
@@ -517,19 +515,29 @@ where
     let mut signer = InMemorySigner::new(None);
     let regular_owner = signer.generate_new().into();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let mut sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let mut sender = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
     let super_owner = sender.identity().await?;
 
     // Configure chain with one super owner and one regular owner, no multi-leader rounds.
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
-        super_owners: vec![super_owner],
-        owners: vec![(regular_owner, 100)],
-        first_leader: None,
-        multi_leader_rounds: 0,
-        open_multi_leader_rounds: false,
-        timeout_config: TimeoutConfig::default(),
-    });
-    sender.execute_operation(owner_change_op).await.unwrap();
+    let tc = TimeoutConfig::default();
+    let ops = vec![
+        Operation::system(SystemOperation::ChangeSuperOwners {
+            super_owners: vec![super_owner],
+            fast_round_duration: tc.fast_round_duration,
+        }),
+        Operation::system(SystemOperation::ChangeOwners {
+            owners: vec![(regular_owner, 100)],
+            first_leader: None,
+            multi_leader_rounds: 0,
+            open_multi_leader_rounds: false,
+            base_timeout: tc.base_timeout,
+            timeout_increment: tc.timeout_increment,
+            fallback_duration: tc.fallback_duration,
+        }),
+    ];
+    sender.execute_operations(ops, vec![]).await.unwrap();
 
     // Enable fast blocks so the super owner can propose in the Fast round.
     sender.options_mut().allow_fast_blocks = true;
@@ -1704,13 +1712,15 @@ where
     let owner2_a = client2_a.identity().await.unwrap();
     let owner2_b = builder.signer.generate_new().into();
 
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
-        super_owners: Vec::new(),
+    let tc = TimeoutConfig::default();
+    let owner_change_op = Operation::system(SystemOperation::ChangeOwners {
         owners: vec![(owner2_a, 50), (owner2_b, 50)],
         first_leader: None,
         multi_leader_rounds: 10,
         open_multi_leader_rounds: false,
-        timeout_config: TimeoutConfig::default(),
+        base_timeout: tc.base_timeout,
+        timeout_increment: tc.timeout_increment,
+        fallback_duration: tc.fallback_duration,
     });
     client2_a
         .execute_operation(owner_change_op.clone())
@@ -1828,13 +1838,15 @@ where
     let client1 = builder.add_root_chain(1, Amount::ONE).await?;
     let chain_id = client1.chain_id();
     let owner1 = client1.identity().await?;
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
-        super_owners: Vec::new(),
+    let tc = TimeoutConfig::default();
+    let owner_change_op = Operation::system(SystemOperation::ChangeOwners {
         owners: vec![(owner1, 50), (owner2, 50)],
         first_leader: None,
         multi_leader_rounds: 10,
         open_multi_leader_rounds: false,
-        timeout_config: TimeoutConfig::default(),
+        base_timeout: tc.base_timeout,
+        timeout_increment: tc.timeout_increment,
+        fallback_duration: tc.fallback_duration,
     });
     client1
         .execute_operation(owner_change_op.clone())
@@ -1919,13 +1931,15 @@ where
     let owner3_b = builder.signer.generate_new().into();
     let owner3_c = builder.signer.generate_new().into();
 
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
-        super_owners: Vec::new(),
+    let tc = TimeoutConfig::default();
+    let owner_change_op = Operation::system(SystemOperation::ChangeOwners {
         owners: vec![(owner3_a, 50), (owner3_b, 50), (owner3_c, 50)],
         first_leader: None,
         multi_leader_rounds: 10,
         open_multi_leader_rounds: false,
-        timeout_config: TimeoutConfig::default(),
+        base_timeout: tc.base_timeout,
+        timeout_increment: tc.timeout_increment,
+        fallback_duration: tc.fallback_duration,
     });
 
     client3_a
@@ -2637,26 +2651,33 @@ where
     let signer = InMemorySigner::new(None);
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let mut client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let mut client0 = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(10))
+        .await?;
     // Enable fast blocks for this test that specifically tests fast block behavior.
     client0.options_mut().allow_fast_blocks = true;
     let chain_id = client0.chain_id();
     let owner0 = client0.identity().await.unwrap();
     let owner1 = builder.signer.generate_new().into();
 
-    let timeout_config = TimeoutConfig {
-        fast_round_duration: Some(TimeDelta::from_secs(5)),
-        ..TimeoutConfig::default()
-    };
-    let ownership = ChainOwnership {
-        super_owners: BTreeSet::from_iter([owner0]),
-        owners: BTreeMap::from_iter([(owner1, 100)]),
-        first_leader: None,
-        multi_leader_rounds: 10,
-        open_multi_leader_rounds: false,
-        timeout_config,
-    };
-    client0.change_ownership(ownership).await.unwrap();
+    let tc = TimeoutConfig::default();
+    // Set fast round duration and add a regular owner in a single block.
+    let ops = vec![
+        Operation::system(SystemOperation::ChangeSuperOwners {
+            super_owners: vec![owner0],
+            fast_round_duration: Some(TimeDelta::from_secs(5)),
+        }),
+        Operation::system(SystemOperation::ChangeOwners {
+            owners: vec![(owner1, 100)],
+            first_leader: None,
+            multi_leader_rounds: 10,
+            open_multi_leader_rounds: false,
+            base_timeout: tc.base_timeout,
+            timeout_increment: tc.timeout_increment,
+            fallback_duration: tc.fallback_duration,
+        }),
+    ];
+    client0.execute_operations(ops, vec![]).await.unwrap();
     let mut client1 = builder
         .make_client(
             chain_id,
@@ -2874,17 +2895,14 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer)
         .await?
         .with_policy(policy.clone());
-    let mut client1 = builder.add_root_chain(1, Amount::ONE).await?;
-    let mut client2 = builder.add_root_chain(2, Amount::ONE).await?;
-    let mut client3 = builder.add_root_chain(3, Amount::ONE).await?;
+    let mut client1 = builder.add_root_super_owner_chain(1, Amount::ONE).await?;
+    let mut client2 = builder.add_root_super_owner_chain(2, Amount::ONE).await?;
+    let mut client3 = builder.add_root_super_owner_chain(3, Amount::ONE).await?;
     let chain_id3 = client3.chain_id();
 
-    // Configure the clients as super owners with fast blocks enabled.
+    // Enable fast blocks for all clients.
     for client in [&mut client1, &mut client2, &mut client3] {
         client.options_mut().allow_fast_blocks = true;
-        let owner = client.identity().await?;
-        let ownership = ChainOwnership::single_super(owner);
-        client.change_ownership(ownership).await.unwrap();
     }
 
     // Take one validator down
@@ -2923,7 +2941,8 @@ where
     assert_eq!(certificate.round, Round::MultiLeader(0));
     let block = certificate.block();
     assert_eq!(block.body.incoming_bundles().count(), 1);
-    assert_eq!(block.required_blob_ids().len(), 1);
+    // The data blob plus the committee blob (this is the first block on chain 3).
+    assert_eq!(block.required_blob_ids().len(), 2);
 
     // This will go way over the limit, because of the different overheads.
     let blob_bytes = (0..100)
@@ -3464,20 +3483,10 @@ where
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
 
-    // Create a chain and get its owner.
-    let mut client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
-    let super_owner = client.identity().await?;
-
-    // Change ownership to make the owner a super owner.
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
-        super_owners: vec![super_owner],
-        owners: vec![],
-        first_leader: None,
-        multi_leader_rounds: 10,
-        open_multi_leader_rounds: false,
-        timeout_config: TimeoutConfig::default(),
-    });
-    client.execute_operation(owner_change_op).await.unwrap();
+    // Create a chain with a super owner.
+    let mut client = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
 
     // With fast blocks enabled, the super owner creates a block in the Fast round.
     client.options_mut().allow_fast_blocks = true;
@@ -3594,13 +3603,15 @@ where
     let chain_id = client.chain_id();
 
     // Configure open multi-leader rounds.
-    let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
-        super_owners: vec![],
+    let tc = TimeoutConfig::default();
+    let owner_change_op = Operation::system(SystemOperation::ChangeOwners {
         owners: vec![(owner, 100)],
         first_leader: None,
         multi_leader_rounds: 10,
         open_multi_leader_rounds: true,
-        timeout_config: TimeoutConfig::default(),
+        base_timeout: tc.base_timeout,
+        timeout_increment: tc.timeout_increment,
+        fallback_duration: tc.fallback_duration,
     });
     client.execute_operation(owner_change_op).await.unwrap();
     let info = client.chain_info().await?;
@@ -3701,6 +3712,97 @@ where
         Amount::from_tokens(10),
         "Receiver should have received all three transfers"
     );
+
+    Ok(())
+}
+
+/// A regular owner cannot change super owners via the client API.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_regular_owner_cannot_change_super_owners<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    // Chain with only a regular owner (no super owners).
+    let client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+
+    // Trying to add super owners should fail because the chain has none.
+    let result = client
+        .change_super_ownership(vec![client.identity().await?], None)
+        .await;
+    assert_matches!(result, Err(_));
+
+    Ok(())
+}
+
+/// A super owner can transfer super ownership.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_super_owner_can_transfer_super_ownership<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let new_super_owner_key = signer.generate_new();
+    let new_super_owner = AccountOwner::from(new_super_owner_key);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
+    let old_super_owner = sender.identity().await?;
+
+    // Transfer super ownership to another key.
+    sender
+        .transfer_super_ownership(new_super_owner)
+        .await
+        .unwrap();
+
+    // Verify the new super owner is set and old one is gone.
+    let ownership = sender.query_chain_ownership().await?;
+    assert!(ownership.super_owners.contains(&new_super_owner));
+    assert!(!ownership.super_owners.contains(&old_super_owner));
+    // transfer_super_ownership also clears regular owners.
+    assert!(ownership.owners.is_empty());
+
+    Ok(())
+}
+
+/// ChangeOwners does not affect super owners.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_change_owners_preserves_super_owners<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let regular_owner = AccountOwner::from(signer.generate_new());
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder
+        .add_root_super_owner_chain(1, Amount::from_tokens(4))
+        .await?;
+    let super_owner = sender.identity().await?;
+
+    // Add a regular owner.
+    sender.share_ownership(regular_owner, 100).await.unwrap();
+
+    // Query ownership to verify super owner is still there.
+    let ownership = sender.query_chain_ownership().await?;
+    assert!(ownership.super_owners.contains(&super_owner));
+    assert!(ownership.owners.contains_key(&regular_owner));
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1243,9 +1243,7 @@ where
             ..ResourceControlPolicy::default()
         });
     let admin = builder.add_root_chain(0, initial_balance).await?;
-    let user = builder
-        .add_root_super_owner_chain(1, Amount::ZERO)
-        .await?;
+    let user = builder.add_root_super_owner_chain(1, Amount::ZERO).await?;
     let validators = builder.initial_committee.validators().clone();
 
     let committee = Committee::new(validators.clone(), ResourceControlPolicy::only_fuel())?;

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1029,6 +1029,65 @@ where
         self.make_client(chain_id, None, BlockHeight::ZERO).await
     }
 
+    pub async fn add_root_super_owner_chain(
+        &mut self,
+        index: u32,
+        balance: Amount,
+    ) -> anyhow::Result<ChainClient<B::Storage>> {
+        // Make sure the admin chain is initialized.
+        if self.admin_description.is_none() && index != 0 {
+            Box::pin(self.add_root_chain(0, Amount::ZERO)).await?;
+        }
+        let origin = ChainOrigin::Root(index);
+        let public_key = self.signer.generate_new();
+        let open_chain_config = InitialChainConfig {
+            ownership: ChainOwnership::single_super(public_key.into()),
+            epoch: Epoch(0),
+            min_active_epoch: Epoch(0),
+            max_active_epoch: Epoch(0),
+            balance,
+            application_permissions: ApplicationPermissions::default(),
+        };
+        let description = ChainDescription::new(origin, open_chain_config, Timestamp::from(0));
+        let committee_blob = Blob::new_committee(bcs::to_bytes(&self.initial_committee).unwrap());
+        if index == 0 {
+            self.admin_description = Some(description.clone());
+            self.network_description = Some(NetworkDescription {
+                admin_chain_id: description.id(),
+                genesis_config_hash: CryptoHash::test_hash("genesis config"),
+                genesis_timestamp: Timestamp::from(0),
+                genesis_committee_blob_hash: committee_blob.id().hash,
+                name: "test network".to_string(),
+            });
+        }
+        self.genesis_storage_builder
+            .add(description.clone(), public_key);
+
+        let network_description = self.network_description.as_ref().unwrap();
+
+        for validator in self.node_provider.all_nodes() {
+            let storage = self
+                .validator_storages
+                .get_mut(&validator.public_key)
+                .unwrap();
+            storage
+                .write_network_description(network_description)
+                .await
+                .expect("writing the NetworkDescription should succeed");
+            storage
+                .write_blob(&committee_blob)
+                .await
+                .expect("writing a blob should succeed");
+            storage.create_chain(description.clone()).await.unwrap();
+        }
+        for storage in &mut self.chain_client_storages {
+            storage.create_chain(description.clone()).await.unwrap();
+        }
+        let chain_id = description.id();
+        self.chain_owners.insert(chain_id, public_key.into());
+        self.make_client(chain_id, None, BlockHeight::ZERO).await
+    }
+
     pub fn genesis_chains(&self) -> Vec<(AccountPublicKey, Amount)> {
         let mut result = Vec::new();
         for (i, genesis_account) in self.genesis_storage_builder.accounts.iter().enumerate() {

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -296,10 +296,11 @@ where
         .with_policy(ResourceControlPolicy::all_categories());
     // Will publish the module.
     let publisher = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
-    // Will create the apps and use them to send a message.
-    let creator = builder.add_root_chain(1, Amount::ONE).await?;
-    // Will receive the message.
-    let receiver = builder.add_root_chain(2, Amount::ONE).await?;
+    // Will create the apps and use them to send a message. Needs super-owner status to call
+    // `change_ownership`.
+    let creator = builder.add_root_super_owner_chain(1, Amount::ONE).await?;
+    // Will receive the message. Also needs super-owner status to call `change_ownership`.
+    let receiver = builder.add_root_super_owner_chain(2, Amount::ONE).await?;
     let receiver_id = receiver.chain_id();
 
     // Handling the message causes an oracle request to the counter service, so no fast blocks

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3464,13 +3464,14 @@ where
     // Add another owner and use the leader-based protocol in all rounds.
     // Set owner0 as the first leader to test the first_leader configuration.
     let proposed_block0 = make_first_block(chain_1)
-        .with_operation(SystemOperation::ChangeOwnership {
-            super_owners: Vec::new(),
+        .with_operation(SystemOperation::ChangeOwners {
             owners: vec![(owner0, 100), (owner1, 100)],
             first_leader: Some(owner0),
             multi_leader_rounds: 0,
             open_multi_leader_rounds: false,
-            timeout_config: TimeoutConfig::default(),
+            base_timeout: TimeoutConfig::default().base_timeout,
+            timeout_increment: TimeoutConfig::default().timeout_increment,
+            fallback_duration: TimeoutConfig::default().fallback_duration,
         })
         .with_authenticated_owner(Some(owner0));
     let (_, block0, _, _) = env
@@ -3741,22 +3742,32 @@ where
     let owner1 = AccountOwner::from(key_pairs[1]);
     let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
     let clock = storage_builder.clock();
-    let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
+    let chain_1_desc = env
+        .add_root_chain_with_ownership(
+            1,
+            Amount::from_tokens(2),
+            ChainOwnership::single_super(owner0),
+        )
+        .await;
     let small_transfer = Amount::from_micros(1);
     let chain_id = chain_1_desc.id();
 
     // Add another owner and configure two multi-leader rounds.
-    let proposed_block0 =
-        make_first_block(chain_id).with_operation(SystemOperation::ChangeOwnership {
+    let tc = TimeoutConfig::default();
+    let proposed_block0 = make_first_block(chain_id)
+        .with_authenticated_owner(Some(owner0))
+        .with_operation(SystemOperation::ChangeSuperOwners {
             super_owners: vec![owner0],
+            fast_round_duration: Some(TimeDelta::from_secs(5)),
+        })
+        .with_operation(SystemOperation::ChangeOwners {
             owners: vec![(owner0, 100), (owner1, 100)],
             first_leader: None,
             multi_leader_rounds: 2,
             open_multi_leader_rounds: false,
-            timeout_config: TimeoutConfig {
-                fast_round_duration: Some(TimeDelta::from_secs(5)),
-                ..TimeoutConfig::default()
-            },
+            base_timeout: tc.base_timeout,
+            timeout_increment: tc.timeout_increment,
+            fallback_duration: tc.fallback_duration,
         });
     let (_, block0, _, _) = env
         .executing_worker()
@@ -3780,6 +3791,7 @@ where
 
     // So owner 1 cannot propose a block in this round. And the next round hasn't started yet.
     let proposal = make_child_block(&value0)
+        .with_authenticated_owner(None)
         .with_simple_transfer(chain_id, small_transfer)
         .into_proposal_with_round(owner1, &signer, Round::Fast)
         .await
@@ -3787,6 +3799,7 @@ where
     let result = env.executing_worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal = make_child_block(&value0)
+        .with_authenticated_owner(None)
         .into_proposal_with_round(owner1, &signer, Round::MultiLeader(0))
         .await
         .unwrap();
@@ -3865,7 +3878,13 @@ where
     let owner1 = AccountOwner::from(key_pairs[1]);
     let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
     let clock = storage_builder.clock();
-    let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
+    let chain_1_desc = env
+        .add_root_chain_with_ownership(
+            1,
+            Amount::from_tokens(2),
+            ChainOwnership::single_super(owner0),
+        )
+        .await;
     let chain_id = chain_1_desc.id();
 
     // Add another owner and configure two multi-leader rounds.
@@ -3876,16 +3895,18 @@ where
             Amount::from_tokens(1),
         )
         .with_authenticated_owner(Some(owner0))
-        .with_operation(SystemOperation::ChangeOwnership {
+        .with_operation(SystemOperation::ChangeSuperOwners {
             super_owners: vec![owner0],
+            fast_round_duration: Some(TimeDelta::from_millis(5)),
+        })
+        .with_operation(SystemOperation::ChangeOwners {
             owners: vec![(owner0, 100), (owner1, 100)],
             first_leader: None,
             multi_leader_rounds: 3,
             open_multi_leader_rounds: false,
-            timeout_config: TimeoutConfig {
-                fast_round_duration: Some(TimeDelta::from_millis(5)),
-                ..TimeoutConfig::default()
-            },
+            base_timeout: TimeoutConfig::default().base_timeout,
+            timeout_increment: TimeoutConfig::default().timeout_increment,
+            fallback_duration: TimeoutConfig::default().fallback_duration,
         });
     let (_, block0, _, _) = env
         .executing_worker()
@@ -4531,6 +4552,7 @@ where
     Ok(())
 }
 
+/// A regular owner on a chain with super owners cannot add or change super owners.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
@@ -4609,6 +4631,80 @@ where
     assert_eq!(
         bundles[1].origin, chain_1,
         "Non-priority chain bundle should be second"
+    );
+
+    Ok(())
+}
+
+/// A regular owner on a chain with super owners cannot add or change super owners.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_regular_owner_cannot_change_super_owners<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let key_pairs = generate_key_pairs(&mut signer, 2);
+    let super_owner = AccountOwner::from(key_pairs[0]);
+    let regular_owner = AccountOwner::from(key_pairs[1]);
+    let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
+
+    // Create a chain with a super owner.
+    let chain_desc = env
+        .add_root_chain_with_ownership(
+            1,
+            Amount::from_tokens(2),
+            ChainOwnership::single_super(super_owner),
+        )
+        .await;
+    let chain_id = chain_desc.id();
+
+    // Add a regular owner (done by super owner).
+    let tc = TimeoutConfig::default();
+    let block0 = make_first_block(chain_id)
+        .with_authenticated_owner(Some(super_owner))
+        .with_operation(SystemOperation::ChangeOwners {
+            owners: vec![(regular_owner, 100)],
+            first_leader: None,
+            multi_leader_rounds: 2,
+            open_multi_leader_rounds: false,
+            base_timeout: tc.base_timeout,
+            timeout_increment: tc.timeout_increment,
+            fallback_duration: tc.fallback_duration,
+        });
+    let (executed0, _, _) = env
+        .executing_worker()
+        .stage_block_execution(block0, None, vec![])
+        .await?;
+    let value0 = ConfirmedBlock::new(executed0);
+    let cert0 = env.make_certificate(value0.clone());
+    env.executing_worker()
+        .fully_handle_certificate_with_notifications(cert0, &())
+        .await?;
+
+    // Now the regular owner tries to change super owners — should fail at execution.
+    let block1 = make_child_block(&value0)
+        .with_authenticated_owner(Some(regular_owner))
+        .with_operation(SystemOperation::ChangeSuperOwners {
+            super_owners: vec![regular_owner],
+            fast_round_duration: None,
+        });
+    let result = env
+        .executing_worker()
+        .stage_block_execution(block1, None, vec![])
+        .await;
+    assert_matches!(
+        result,
+        Err(WorkerError::ChainError(ref error))
+            if matches!(&**error, ChainError::ExecutionError(
+                err,
+                ChainExecutionContext::Operation(_),
+            ) if matches!(**err, ExecutionError::UnauthorizedChangeSuperOwners))
     );
 
     Ok(())
@@ -4837,6 +4933,53 @@ where
         inbox.next_block_height_to_receive()?,
         BlockHeight::from(1),
         "Only height 0 should have been received before gap detection"
+    );
+
+    Ok(())
+}
+
+/// A chain without super owners cannot gain super owners.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_chain_without_super_owners_cannot_add_super_owners<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let key_pairs = generate_key_pairs(&mut signer, 1);
+    let owner = AccountOwner::from(key_pairs[0]);
+    let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
+
+    // Create a chain with only a regular owner (no super owners).
+    let chain_desc = env
+        .add_root_chain_with_ownership(1, Amount::from_tokens(2), ChainOwnership::single(owner))
+        .await;
+    let chain_id = chain_desc.id();
+
+    // The regular owner tries to add a super owner — should fail at execution.
+    let block0 = make_first_block(chain_id)
+        .with_authenticated_owner(Some(owner))
+        .with_operation(SystemOperation::ChangeSuperOwners {
+            super_owners: vec![owner],
+            fast_round_duration: None,
+        });
+    let proposal = block0
+        .into_proposal_with_round(owner, &signer, Round::MultiLeader(0))
+        .await
+        .unwrap();
+    let result = env.executing_worker().handle_block_proposal(proposal).await;
+    assert_matches!(
+        result,
+        Err(WorkerError::ChainError(ref error))
+            if matches!(&**error, ChainError::ExecutionError(
+                err,
+                ChainExecutionContext::Operation(_),
+            ) if matches!(**err, ExecutionError::UnauthorizedChangeSuperOwners))
     );
 
     Ok(())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -264,6 +264,16 @@ where
             .await
     }
 
+    async fn add_root_super_owner_chain(
+        &mut self,
+        index: u32,
+        owner: AccountOwner,
+        balance: Amount,
+    ) -> ChainDescription {
+        self.add_root_chain_with_ownership(index, balance, ChainOwnership::single_super(owner))
+            .await
+    }
+
     async fn add_root_chain_with_ownership(
         &mut self,
         index: u32,
@@ -3457,11 +3467,14 @@ where
     let owner1 = AccountOwner::from(key_pairs[1]);
     let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
     let clock = storage_builder.clock();
-    let chain_1_desc = env.add_root_chain(1, owner0, Amount::from_tokens(2)).await;
+    let chain_1_desc = env
+        .add_root_super_owner_chain(1, owner0, Amount::from_tokens(2))
+        .await;
     let small_transfer = Amount::from_micros(1);
     let chain_1 = chain_1_desc.id();
 
-    // Add another owner and use the leader-based protocol in all rounds.
+    // Add another owner and use the leader-based protocol in all rounds. Also drop the
+    // super-owner set so the chain leaves the Fast round and enters the single-leader rounds.
     // Set owner0 as the first leader to test the first_leader configuration.
     let proposed_block0 = make_first_block(chain_1)
         .with_operation(SystemOperation::ChangeOwners {
@@ -3472,6 +3485,10 @@ where
             base_timeout: TimeoutConfig::default().base_timeout,
             timeout_increment: TimeoutConfig::default().timeout_increment,
             fallback_duration: TimeoutConfig::default().fallback_duration,
+        })
+        .with_operation(SystemOperation::ChangeSuperOwners {
+            super_owners: Vec::new(),
+            fast_round_duration: TimeoutConfig::default().fast_round_duration,
         })
         .with_authenticated_owner(Some(owner0));
     let (_, block0, _, _) = env

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4677,11 +4677,11 @@ where
             timeout_increment: tc.timeout_increment,
             fallback_duration: tc.fallback_duration,
         });
-    let (executed0, _, _) = env
+    let (_, block0, _, _) = env
         .executing_worker()
-        .stage_block_execution(block0, None, vec![])
+        .stage_block_execution(block0, None, vec![], BundleExecutionPolicy::committed())
         .await?;
-    let value0 = ConfirmedBlock::new(executed0);
+    let value0 = ConfirmedBlock::new(block0);
     let cert0 = env.make_certificate(value0.clone());
     env.executing_worker()
         .fully_handle_certificate_with_notifications(cert0, &())
@@ -4696,7 +4696,7 @@ where
         });
     let result = env
         .executing_worker()
-        .stage_block_execution(block1, None, vec![])
+        .stage_block_execution(block1, None, vec![], BundleExecutionPolicy::committed())
         .await;
     assert_matches!(
         result,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -450,7 +450,7 @@ where
                 }
             }
 
-            ChangeOwnership {
+            ChangeOwners {
                 application_id,
                 ownership,
                 callback,
@@ -459,7 +459,18 @@ where
                 if !app_permissions.can_manage_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
-                    self.state.system.ownership.set(ownership);
+                    // Applications can change regular owners but not super owners.
+                    let mut current = self.state.system.ownership.get().await?.clone();
+                    current.owners = ownership.owners;
+                    current.first_leader = ownership.first_leader;
+                    current.multi_leader_rounds = ownership.multi_leader_rounds;
+                    current.open_multi_leader_rounds = ownership.open_multi_leader_rounds;
+                    current.timeout_config.base_timeout = ownership.timeout_config.base_timeout;
+                    current.timeout_config.timeout_increment =
+                        ownership.timeout_config.timeout_increment;
+                    current.timeout_config.fallback_duration =
+                        ownership.timeout_config.fallback_duration;
+                    self.state.system.ownership.set(current);
                     callback.respond(Ok(()));
                 }
             }
@@ -1419,7 +1430,7 @@ pub enum ExecutionRequest {
         callback: Sender<Result<(), ExecutionError>>,
     },
 
-    ChangeOwnership {
+    ChangeOwners {
         application_id: ApplicationId,
         ownership: ChainOwnership,
         #[debug(skip)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -286,6 +286,10 @@ pub enum ExecutionError {
     UnauthorizedChangeSuperOwners,
     #[error("Only a super owner can change the set of owners")]
     UnauthorizedChangeOwners,
+    #[error("Only a super owner can close the chain")]
+    UnauthorizedCloseChain,
+    #[error("Only a super owner can change the application permissions")]
+    UnauthorizedChangeApplicationPermissions,
     #[error("Failed to make network reqwest: {0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("Encountered I/O error: {0}")]
@@ -395,6 +399,8 @@ impl ExecutionError {
             | ExecutionError::UnauthorizedApplication(_)
             | ExecutionError::UnauthorizedChangeSuperOwners
             | ExecutionError::UnauthorizedChangeOwners
+            | ExecutionError::UnauthorizedCloseChain
+            | ExecutionError::UnauthorizedChangeApplicationPermissions
             | ExecutionError::UnexpectedOracleResponse
             | ExecutionError::JsonError(_)
             | ExecutionError::BcsError(_)

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -282,6 +282,8 @@ pub enum ExecutionError {
     MissingRuntimeResponse,
     #[error("Application is not authorized to perform system operations on this chain: {0:}")]
     UnauthorizedApplication(ApplicationId),
+    #[error("Only a super owner can change super owners, and only if the chain already has super owners")]
+    UnauthorizedChangeSuperOwners,
     #[error("Failed to make network reqwest: {0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("Encountered I/O error: {0}")]
@@ -389,6 +391,7 @@ impl ExecutionError {
             | ExecutionError::BlockTooLarge
             | ExecutionError::HttpResponseSizeLimitExceeded { .. }
             | ExecutionError::UnauthorizedApplication(_)
+            | ExecutionError::UnauthorizedChangeSuperOwners
             | ExecutionError::UnexpectedOracleResponse
             | ExecutionError::JsonError(_)
             | ExecutionError::BcsError(_)

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -284,6 +284,8 @@ pub enum ExecutionError {
     UnauthorizedApplication(ApplicationId),
     #[error("Only a super owner can change super owners, and only if the chain already has super owners")]
     UnauthorizedChangeSuperOwners,
+    #[error("Only a super owner can change the set of owners")]
+    UnauthorizedChangeOwners,
     #[error("Failed to make network reqwest: {0}")]
     ReqwestError(#[from] reqwest::Error),
     #[error("Encountered I/O error: {0}")]
@@ -392,6 +394,7 @@ impl ExecutionError {
             | ExecutionError::HttpResponseSizeLimitExceeded { .. }
             | ExecutionError::UnauthorizedApplication(_)
             | ExecutionError::UnauthorizedChangeSuperOwners
+            | ExecutionError::UnauthorizedChangeOwners
             | ExecutionError::UnexpectedOracleResponse
             | ExecutionError::JsonError(_)
             | ExecutionError::BcsError(_)

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1598,7 +1598,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let this = self.inner();
         let application_id = this.current_application().id;
         this.execution_state_sender
-            .send_request(|callback| ExecutionRequest::ChangeOwnership {
+            .send_request(|callback| ExecutionRequest::ChangeOwners {
                 application_id,
                 ownership,
                 callback,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -205,7 +205,7 @@ pub enum SystemOperation {
     /// Closes the chain.
     CloseChain,
     /// Changes the regular owners and non-fast-round settings of the chain.
-    /// Any owner can execute this operation.
+    /// Only a super owner can execute this operation.
     ChangeOwners {
         /// The regular owners, with their weights that determine how often they are round leader.
         #[debug(skip_if = Vec::is_empty)]
@@ -382,7 +382,12 @@ where
                 timeout_increment,
                 fallback_duration,
             } => {
-                let mut ownership = self.ownership.get().await?.clone();
+                let current_ownership = self.ownership.get().await?;
+                match context.authenticated_owner {
+                    Some(owner) if current_ownership.super_owners.contains(&owner) => {}
+                    _ => return Err(ExecutionError::UnauthorizedChangeOwners),
+                }
+                let mut ownership = current_ownership.clone();
                 ownership.owners = owners.into_iter().collect();
                 ownership.first_leader = first_leader;
                 ownership.multi_leader_rounds = multi_leader_rounds;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -416,7 +416,7 @@ where
                 self.ownership.set(ownership);
             }
             ChangeApplicationPermissions(application_permissions) => {
-                let current_ownership = self.ownership.get();
+                let current_ownership = self.ownership.get().await?;
                 match context.authenticated_owner {
                     Some(owner) if current_ownership.super_owners.contains(&owner) => {}
                     _ => return Err(ExecutionError::UnauthorizedChangeApplicationPermissions),
@@ -424,7 +424,7 @@ where
                 self.application_permissions.set(application_permissions);
             }
             CloseChain => {
-                let current_ownership = self.ownership.get();
+                let current_ownership = self.ownership.get().await?;
                 match context.authenticated_owner {
                     Some(owner) if current_ownership.super_owners.contains(&owner) => {}
                     _ => return Err(ExecutionError::UnauthorizedCloseChain),

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -202,7 +202,7 @@ pub enum SystemOperation {
     /// Creates (or activates) a new chain.
     /// This will automatically subscribe to the future committees created by `admin_chain_id`.
     OpenChain(OpenChainConfig),
-    /// Closes the chain.
+    /// Closes the chain. Only a super owner can execute this operation.
     CloseChain,
     /// Changes the regular owners and non-fast-round settings of the chain.
     /// Only a super owner can execute this operation.
@@ -237,6 +237,7 @@ pub enum SystemOperation {
         fast_round_duration: Option<TimeDelta>,
     },
     /// Changes the application permissions configuration on this chain.
+    /// Only a super owner can execute this operation.
     ChangeApplicationPermissions(ApplicationPermissions),
     /// Publishes a new application module.
     PublishModule { module_id: ModuleId },
@@ -415,9 +416,21 @@ where
                 self.ownership.set(ownership);
             }
             ChangeApplicationPermissions(application_permissions) => {
+                let current_ownership = self.ownership.get();
+                match context.authenticated_owner {
+                    Some(owner) if current_ownership.super_owners.contains(&owner) => {}
+                    _ => return Err(ExecutionError::UnauthorizedChangeApplicationPermissions),
+                }
                 self.application_permissions.set(application_permissions);
             }
-            CloseChain => self.close_chain(),
+            CloseChain => {
+                let current_ownership = self.ownership.get();
+                match context.authenticated_owner {
+                    Some(owner) if current_ownership.super_owners.contains(&owner) => {}
+                    _ => return Err(ExecutionError::UnauthorizedCloseChain),
+                }
+                self.close_chain()
+            }
             Transfer {
                 owner,
                 amount,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -17,13 +17,14 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
-        ChainDescription, ChainOrigin, Epoch, InitialChainConfig, OracleResponse, Timestamp,
+        ChainDescription, ChainOrigin, Epoch, InitialChainConfig, OracleResponse, TimeDelta,
+        Timestamp,
     },
     ensure, hex_debug,
     identifiers::{
         Account, AccountOwner, BlobId, BlobType, ChainId, EventId, ModuleId, OwnerSpender, StreamId,
     },
-    ownership::{ChainOwnership, TimeoutConfig},
+    ownership::ChainOwnership,
 };
 use linera_views::{
     context::Context,
@@ -203,11 +204,9 @@ pub enum SystemOperation {
     OpenChain(OpenChainConfig),
     /// Closes the chain.
     CloseChain,
-    /// Changes the ownership of the chain.
-    ChangeOwnership {
-        /// Super owners can propose fast blocks in the first round, and regular blocks in any round.
-        #[debug(skip_if = Vec::is_empty)]
-        super_owners: Vec<AccountOwner>,
+    /// Changes the regular owners and non-fast-round settings of the chain.
+    /// Any owner can execute this operation.
+    ChangeOwners {
         /// The regular owners, with their weights that determine how often they are round leader.
         #[debug(skip_if = Vec::is_empty)]
         owners: Vec<(AccountOwner, u64)>,
@@ -220,8 +219,22 @@ pub enum SystemOperation {
         /// This should only be `true` on chains with restrictive application permissions and an
         /// application-based mechanism to select block proposers.
         open_multi_leader_rounds: bool,
-        /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
-        timeout_config: TimeoutConfig,
+        /// The timeout configuration (excluding fast round duration): how long multi-leader and
+        /// single-leader rounds last.
+        base_timeout: TimeDelta,
+        /// The duration by which the timeout increases after each single-leader round.
+        timeout_increment: TimeDelta,
+        /// The age of an incoming tracked or protected message after which the validators start
+        /// transitioning the chain to fallback mode.
+        fallback_duration: TimeDelta,
+    },
+    /// Changes the super owners and fast round duration of the chain.
+    /// Only a super owner can execute this operation. Rejected if the chain has no super owners.
+    ChangeSuperOwners {
+        /// Super owners can propose fast blocks in the first round, and regular blocks in any round.
+        super_owners: Vec<AccountOwner>,
+        /// The duration of the fast round.
+        fast_round_duration: Option<TimeDelta>,
     },
     /// Changes the application permissions configuration on this chain.
     ChangeApplicationPermissions(ApplicationPermissions),
@@ -360,22 +373,41 @@ where
                 #[cfg(with_metrics)]
                 metrics::OPEN_CHAIN_COUNT.with_label_values(&[]).inc();
             }
-            ChangeOwnership {
-                super_owners,
+            ChangeOwners {
                 owners,
                 first_leader,
                 multi_leader_rounds,
                 open_multi_leader_rounds,
-                timeout_config,
+                base_timeout,
+                timeout_increment,
+                fallback_duration,
             } => {
-                self.ownership.set(ChainOwnership {
-                    super_owners: super_owners.into_iter().collect(),
-                    owners: owners.into_iter().collect(),
-                    first_leader,
-                    multi_leader_rounds,
-                    open_multi_leader_rounds,
-                    timeout_config,
-                });
+                let mut ownership = self.ownership.get().await?.clone();
+                ownership.owners = owners.into_iter().collect();
+                ownership.first_leader = first_leader;
+                ownership.multi_leader_rounds = multi_leader_rounds;
+                ownership.open_multi_leader_rounds = open_multi_leader_rounds;
+                ownership.timeout_config.base_timeout = base_timeout;
+                ownership.timeout_config.timeout_increment = timeout_increment;
+                ownership.timeout_config.fallback_duration = fallback_duration;
+                self.ownership.set(ownership);
+            }
+            ChangeSuperOwners {
+                super_owners,
+                fast_round_duration,
+            } => {
+                let current_ownership = self.ownership.get().await?;
+                if current_ownership.super_owners.is_empty() {
+                    return Err(ExecutionError::UnauthorizedChangeSuperOwners);
+                }
+                match context.authenticated_owner {
+                    Some(owner) if current_ownership.super_owners.contains(&owner) => {}
+                    _ => return Err(ExecutionError::UnauthorizedChangeSuperOwners),
+                }
+                let mut ownership = current_ownership.clone();
+                ownership.super_owners = super_owners.into_iter().collect();
+                ownership.timeout_config.fast_round_duration = fast_round_duration;
+                self.ownership.set(ownership);
             }
             ChangeApplicationPermissions(application_permissions) => {
                 self.application_permissions.set(application_permissions);

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -1100,8 +1100,9 @@ async fn test_change_ownership_system_api() -> anyhow::Result<()> {
 
     let (application_id, application, blobs) = view.register_mock_application(0).await?;
 
+    // Applications can only change regular owners, not super owners.
     let new_ownership = ChainOwnership {
-        super_owners: BTreeSet::from([AccountOwner::from(AccountPublicKey::test_key(1))]),
+        owners: BTreeMap::from([(AccountOwner::from(AccountPublicKey::test_key(1)), 100)]),
         ..ChainOwnership::default()
     };
 
@@ -1135,7 +1136,7 @@ async fn test_change_ownership_system_api() -> anyhow::Result<()> {
         )
         .await?;
 
-    // Verify the ownership was changed.
+    // Verify the ownership was changed (only regular owners, not super owners).
     assert_eq!(*view.system.ownership.get().await?, new_ownership);
 
     Ok(())
@@ -1150,7 +1151,7 @@ async fn test_unauthorized_change_ownership_system_api() -> anyhow::Result<()> {
     let (application_id, application, blobs) = view.register_mock_application(0).await?;
 
     let new_ownership = ChainOwnership {
-        super_owners: BTreeSet::from([AccountOwner::from(AccountPublicKey::test_key(1))]),
+        owners: BTreeMap::from([(AccountOwner::from(AccountPublicKey::test_key(1)), 100)]),
         ..ChainOwnership::default()
     };
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1266,7 +1266,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
 /// Tests the system API call `close_chain`.
 #[tokio::test]
 async fn test_close_chain() -> anyhow::Result<()> {
-    let ownership = ChainOwnership::single(AccountPublicKey::test_key(1).into());
+    let ownership = ChainOwnership::single_super(AccountPublicKey::test_key(1).into());
     let description = dummy_chain_description_with_ownership_and_balance(
         0,
         ownership.clone(),
@@ -1302,11 +1302,16 @@ async fn test_close_chain() -> anyhow::Result<()> {
     assert!(!view.system.closed.get());
 
     // Now we authorize the application and it can close the chain.
+    // ChangeApplicationPermissions requires super-owner authentication.
+    let super_owner_context = OperationContext {
+        authenticated_owner: Some(AccountPublicKey::test_key(1).into()),
+        ..context
+    };
     let permissions = ApplicationPermissions::new_single(application_id);
     let operation = SystemOperation::ChangeApplicationPermissions(permissions);
     let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
     ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
-        .execute_operation(context, operation.into())
+        .execute_operation(super_owner_context, operation.into())
         .await?;
 
     application.expect_call(ExpectedCall::execute_operation(

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::AccountSecretKey,
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
     identifiers::{Account, AccountOwner},
     ownership::ChainOwnership,
 };
@@ -14,9 +14,9 @@ use linera_execution::{
         dummy_chain_description, dummy_chain_description_with_ownership_and_balance,
         SystemExecutionState,
     },
-    ExecutionStateActor, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
-    QueryOutcome, QueryResponse, ResourceController, SystemMessage, SystemOperation, SystemQuery,
-    SystemResponse, TransactionTracker,
+    ExecutionError, ExecutionStateActor, Message, MessageContext, Operation, OperationContext,
+    Query, QueryContext, QueryOutcome, QueryResponse, ResourceController, SystemMessage,
+    SystemOperation, SystemQuery, SystemResponse, TransactionTracker,
 };
 
 #[tokio::test]
@@ -123,5 +123,234 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         })
     );
     assert!(operations.is_empty());
+    Ok(())
+}
+
+/// A super owner can change super owners.
+#[tokio::test]
+async fn test_change_super_owners_by_super_owner() -> anyhow::Result<()> {
+    let super_owner_key = AccountSecretKey::generate();
+    let super_owner = AccountOwner::from(super_owner_key.public());
+    let new_super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let operation = SystemOperation::ChangeSuperOwners {
+        super_owners: vec![new_super_owner],
+        fast_round_duration: Some(TimeDelta::from_secs(5)),
+    };
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(super_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await?;
+    let new_ownership = view.system.ownership.get();
+    assert!(new_ownership.super_owners.contains(&new_super_owner));
+    assert!(!new_ownership.super_owners.contains(&super_owner));
+    assert_eq!(
+        new_ownership.timeout_config.fast_round_duration,
+        Some(TimeDelta::from_secs(5))
+    );
+    Ok(())
+}
+
+/// A regular owner cannot change super owners.
+#[tokio::test]
+async fn test_change_super_owners_by_regular_owner_fails() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let regular_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        owners: [(regular_owner, 100)].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let operation = SystemOperation::ChangeSuperOwners {
+        super_owners: vec![regular_owner],
+        fast_round_duration: None,
+    };
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(regular_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedChangeSuperOwners)
+    ));
+    Ok(())
+}
+
+/// A chain without super owners cannot gain super owners.
+#[tokio::test]
+async fn test_change_super_owners_on_chain_without_super_owners_fails() -> anyhow::Result<()> {
+    let regular_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        owners: [(regular_owner, 100)].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let new_super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let operation = SystemOperation::ChangeSuperOwners {
+        super_owners: vec![new_super_owner],
+        fast_round_duration: None,
+    };
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(regular_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedChangeSuperOwners)
+    ));
+    Ok(())
+}
+
+/// ChangeSuperOwners fails without an authenticated owner.
+#[tokio::test]
+async fn test_change_super_owners_without_authenticated_owner_fails() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let operation = SystemOperation::ChangeSuperOwners {
+        super_owners: vec![super_owner],
+        fast_round_duration: None,
+    };
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: None,
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedChangeSuperOwners)
+    ));
+    Ok(())
+}
+
+/// A regular owner can change regular owners via ChangeOwners.
+#[tokio::test]
+async fn test_change_owners_preserves_super_owners() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let regular_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let new_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        owners: [(regular_owner, 100)].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let tc = linera_base::ownership::TimeoutConfig::default();
+    let operation = SystemOperation::ChangeOwners {
+        owners: vec![(new_owner, 100)],
+        first_leader: None,
+        multi_leader_rounds: 2,
+        open_multi_leader_rounds: false,
+        base_timeout: tc.base_timeout,
+        timeout_increment: tc.timeout_increment,
+        fallback_duration: tc.fallback_duration,
+    };
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(regular_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await?;
+    let new_ownership = view.system.ownership.get();
+    // Super owners are preserved by ChangeOwners.
+    assert!(new_ownership.super_owners.contains(&super_owner));
+    // Regular owners were changed.
+    assert!(new_ownership.owners.contains_key(&new_owner));
+    assert!(!new_ownership.owners.contains_key(&regular_owner));
     Ok(())
 }

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::AccountSecretKey,
-    data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
+    data_types::{Amount, ApplicationPermissions, BlockHeight, TimeDelta, Timestamp},
     identifiers::{Account, AccountOwner},
     ownership::ChainOwnership,
 };
@@ -401,6 +401,254 @@ async fn test_change_owners_by_regular_owner_fails() -> anyhow::Result<()> {
     assert!(matches!(
         result,
         Err(ExecutionError::UnauthorizedChangeOwners)
+    ));
+    Ok(())
+}
+
+/// A super owner can close the chain.
+#[tokio::test]
+async fn test_close_chain_by_super_owner() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(super_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(SystemOperation::CloseChain))
+        .await?;
+    assert!(*view.system.closed.get());
+    Ok(())
+}
+
+/// A regular owner cannot close the chain.
+#[tokio::test]
+async fn test_close_chain_by_regular_owner_fails() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let regular_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        owners: [(regular_owner, 100)].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(regular_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(SystemOperation::CloseChain))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedCloseChain)
+    ));
+    assert!(!*view.system.closed.get());
+    Ok(())
+}
+
+/// CloseChain fails without an authenticated owner.
+#[tokio::test]
+async fn test_close_chain_without_authenticated_owner_fails() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: None,
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(SystemOperation::CloseChain))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedCloseChain)
+    ));
+    Ok(())
+}
+
+/// A super owner can change application permissions.
+#[tokio::test]
+async fn test_change_application_permissions_by_super_owner() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let new_permissions = ApplicationPermissions {
+        execute_operations: Some(Vec::new()),
+        ..ApplicationPermissions::default()
+    };
+    let operation = SystemOperation::ChangeApplicationPermissions(new_permissions.clone());
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(super_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await?;
+    assert_eq!(view.system.application_permissions.get(), &new_permissions);
+    Ok(())
+}
+
+/// A regular owner cannot change application permissions.
+#[tokio::test]
+async fn test_change_application_permissions_by_regular_owner_fails() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let regular_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        owners: [(regular_owner, 100)].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let initial_permissions = ApplicationPermissions::default();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        application_permissions: initial_permissions.clone(),
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let new_permissions = ApplicationPermissions {
+        execute_operations: Some(Vec::new()),
+        ..ApplicationPermissions::default()
+    };
+    let operation = SystemOperation::ChangeApplicationPermissions(new_permissions);
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(regular_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedChangeApplicationPermissions)
+    ));
+    // Permissions should be unchanged.
+    assert_eq!(
+        view.system.application_permissions.get(),
+        &initial_permissions
+    );
+    Ok(())
+}
+
+/// ChangeApplicationPermissions fails on a chain without super owners.
+#[tokio::test]
+async fn test_change_application_permissions_without_super_owners_fails() -> anyhow::Result<()> {
+    let regular_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        owners: [(regular_owner, 100)].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let operation = SystemOperation::ChangeApplicationPermissions(ApplicationPermissions {
+        execute_operations: Some(Vec::new()),
+        ..ApplicationPermissions::default()
+    });
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(regular_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedChangeApplicationPermissions)
     ));
     Ok(())
 }

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -302,7 +302,7 @@ async fn test_change_super_owners_without_authenticated_owner_fails() -> anyhow:
     Ok(())
 }
 
-/// A regular owner can change regular owners via ChangeOwners.
+/// A super owner can change regular owners via ChangeOwners and super owners are preserved.
 #[tokio::test]
 async fn test_change_owners_preserves_super_owners() -> anyhow::Result<()> {
     let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
@@ -338,7 +338,7 @@ async fn test_change_owners_preserves_super_owners() -> anyhow::Result<()> {
         chain_id,
         height: BlockHeight(0),
         round: Some(0),
-        authenticated_owner: Some(regular_owner),
+        authenticated_owner: Some(super_owner),
         timestamp: Default::default(),
     };
     let mut controller = ResourceController::default();
@@ -352,5 +352,55 @@ async fn test_change_owners_preserves_super_owners() -> anyhow::Result<()> {
     // Regular owners were changed.
     assert!(new_ownership.owners.contains_key(&new_owner));
     assert!(!new_ownership.owners.contains_key(&regular_owner));
+    Ok(())
+}
+
+/// A regular owner cannot change owners via ChangeOwners.
+#[tokio::test]
+async fn test_change_owners_by_regular_owner_fails() -> anyhow::Result<()> {
+    let super_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let regular_owner = AccountOwner::from(AccountSecretKey::generate().public());
+    let ownership = ChainOwnership {
+        super_owners: [super_owner].into_iter().collect(),
+        owners: [(regular_owner, 100)].into_iter().collect(),
+        ..ChainOwnership::default()
+    };
+    let balance = Amount::from_tokens(4);
+    let description =
+        dummy_chain_description_with_ownership_and_balance(0, ownership.clone(), balance);
+    let chain_id = description.id();
+    let state = SystemExecutionState {
+        description: Some(description),
+        balance,
+        ownership,
+        ..SystemExecutionState::default()
+    };
+    let mut view = state.into_view().await;
+    let tc = linera_base::ownership::TimeoutConfig::default();
+    let operation = SystemOperation::ChangeOwners {
+        owners: vec![(regular_owner, 100)],
+        first_leader: None,
+        multi_leader_rounds: 2,
+        open_multi_leader_rounds: false,
+        base_timeout: tc.base_timeout,
+        timeout_increment: tc.timeout_increment,
+        fallback_duration: tc.fallback_duration,
+    };
+    let context = OperationContext {
+        chain_id,
+        height: BlockHeight(0),
+        round: Some(0),
+        authenticated_owner: Some(regular_owner),
+        timestamp: Default::default(),
+    };
+    let mut controller = ResourceController::default();
+    let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
+    let result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
+        .execute_operation(context, Operation::system(operation))
+        .await;
+    assert!(matches!(
+        result,
+        Err(ExecutionError::UnauthorizedChangeOwners)
+    ));
     Ok(())
 }

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -163,7 +163,7 @@ async fn test_change_super_owners_by_super_owner() -> anyhow::Result<()> {
     ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
         .execute_operation(context, Operation::system(operation))
         .await?;
-    let new_ownership = view.system.ownership.get();
+    let new_ownership = view.system.ownership.get().await?;
     assert!(new_ownership.super_owners.contains(&new_super_owner));
     assert!(!new_ownership.super_owners.contains(&super_owner));
     assert_eq!(
@@ -346,7 +346,7 @@ async fn test_change_owners_preserves_super_owners() -> anyhow::Result<()> {
     ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
         .execute_operation(context, Operation::system(operation))
         .await?;
-    let new_ownership = view.system.ownership.get();
+    let new_ownership = view.system.ownership.get().await?;
     // Super owners are preserved by ChangeOwners.
     assert!(new_ownership.super_owners.contains(&super_owner));
     // Regular owners were changed.
@@ -555,7 +555,10 @@ async fn test_change_application_permissions_by_super_owner() -> anyhow::Result<
     ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
         .execute_operation(context, Operation::system(operation))
         .await?;
-    assert_eq!(view.system.application_permissions.get(), &new_permissions);
+    assert_eq!(
+        view.system.application_permissions.get().await?,
+        &new_permissions
+    );
     Ok(())
 }
 
@@ -605,7 +608,7 @@ async fn test_change_application_permissions_by_regular_owner_fails() -> anyhow:
     ));
     // Permissions should be unchanged.
     assert_eq!(
-        view.system.application_permissions.get(),
+        view.system.application_permissions.get().await?,
         &initial_permissions
     );
     Ok(())

--- a/linera-indexer/lib/src/db/postgres/mod.rs
+++ b/linera-indexer/lib/src/db/postgres/mod.rs
@@ -280,7 +280,8 @@ impl PostgresDatabase {
                     SystemOperation::ProcessNewEpoch(_) => "ProcessNewEpoch",
                     SystemOperation::ProcessRemovedEpoch(_) => "ProcessRemovedEpoch",
                     SystemOperation::UpdateStreams(_) => "UpdateStreams",
-                    SystemOperation::ChangeOwnership { .. } => "ChangeOwnership",
+                    SystemOperation::ChangeOwners { .. } => "ChangeOwners",
+                    SystemOperation::ChangeSuperOwners { .. } => "ChangeSuperOwners",
                     SystemOperation::VerifyBlob { .. } => "VerifyBlob",
                 };
                 ("System", None, Some(sys_op_type))

--- a/linera-indexer/lib/src/db/sqlite/mod.rs
+++ b/linera-indexer/lib/src/db/sqlite/mod.rs
@@ -285,7 +285,8 @@ impl SqliteDatabase {
                     SystemOperation::ProcessNewEpoch(_) => "ProcessNewEpoch",
                     SystemOperation::ProcessRemovedEpoch(_) => "ProcessRemovedEpoch",
                     SystemOperation::UpdateStreams(_) => "UpdateStreams",
-                    SystemOperation::ChangeOwnership { .. } => "ChangeOwnership",
+                    SystemOperation::ChangeOwners { .. } => "ChangeOwners",
+                    SystemOperation::ChangeSuperOwners { .. } => "ChangeSuperOwners",
                     SystemOperation::VerifyBlob { .. } => "VerifyBlob",
                 };
                 ("System", None, Some(sys_op_type))

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1314,11 +1314,8 @@ SystemOperation:
     3:
       CloseChain: UNIT
     4:
-      ChangeOwnership:
+      ChangeOwners:
         STRUCT:
-          - super_owners:
-              SEQ:
-                TYPENAME: AccountOwner
           - owners:
               SEQ:
                 TUPLE:
@@ -1329,28 +1326,41 @@ SystemOperation:
                 TYPENAME: AccountOwner
           - multi_leader_rounds: U32
           - open_multi_leader_rounds: BOOL
-          - timeout_config:
-              TYPENAME: TimeoutConfig
+          - base_timeout:
+              TYPENAME: TimeDelta
+          - timeout_increment:
+              TYPENAME: TimeDelta
+          - fallback_duration:
+              TYPENAME: TimeDelta
     5:
+      ChangeSuperOwners:
+        STRUCT:
+          - super_owners:
+              SEQ:
+                TYPENAME: AccountOwner
+          - fast_round_duration:
+              OPTION:
+                TYPENAME: TimeDelta
+    6:
       ChangeApplicationPermissions:
         NEWTYPE:
           TYPENAME: ApplicationPermissions
-    6:
+    7:
       PublishModule:
         STRUCT:
           - module_id:
               TYPENAME: ModuleId
-    7:
+    8:
       PublishDataBlob:
         STRUCT:
           - blob_hash:
               TYPENAME: CryptoHash
-    8:
+    9:
       VerifyBlob:
         STRUCT:
           - blob_id:
               TYPENAME: BlobId
-    9:
+    10:
       CreateApplication:
         STRUCT:
           - module_id:
@@ -1360,19 +1370,19 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: ApplicationId
-    10:
+    11:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation
-    11:
+    12:
       ProcessNewEpoch:
         NEWTYPE:
           TYPENAME: Epoch
-    12:
+    13:
       ProcessRemovedEpoch:
         NEWTYPE:
           TYPENAME: Epoch
-    13:
+    14:
       UpdateStreams:
         NEWTYPE:
           SEQ:

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -7,7 +7,7 @@
 
 use linera_base::{
     abi::ContractAbi,
-    data_types::{Amount, ApplicationPermissions, Blob, Epoch, Round, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Blob, Epoch, Round, TimeDelta, Timestamp},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
     ownership::TimeoutConfig,
 };
@@ -119,20 +119,32 @@ impl BlockBuilder {
     /// Adds an operation to change this chain's ownership.
     pub fn with_owner_change(
         &mut self,
-        super_owners: Vec<AccountOwner>,
         owners: Vec<(AccountOwner, u64)>,
         first_leader: Option<AccountOwner>,
         multi_leader_rounds: u32,
         open_multi_leader_rounds: bool,
         timeout_config: TimeoutConfig,
     ) -> &mut Self {
-        self.with_system_operation(SystemOperation::ChangeOwnership {
-            super_owners,
+        self.with_system_operation(SystemOperation::ChangeOwners {
             owners,
             first_leader,
             multi_leader_rounds,
             open_multi_leader_rounds,
-            timeout_config,
+            base_timeout: timeout_config.base_timeout,
+            timeout_increment: timeout_config.timeout_increment,
+            fallback_duration: timeout_config.fallback_duration,
+        })
+    }
+
+    /// Adds a super owner change to this block. Only a super owner can execute this.
+    pub fn with_super_owner_change(
+        &mut self,
+        super_owners: Vec<AccountOwner>,
+        fast_round_duration: Option<TimeDelta>,
+    ) -> &mut Self {
+        self.with_system_operation(SystemOperation::ChangeSuperOwners {
+            super_owners,
+            fast_round_duration,
         })
     }
 

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -123,7 +123,7 @@ impl BlockBuilder {
         first_leader: Option<AccountOwner>,
         multi_leader_rounds: u32,
         open_multi_leader_rounds: bool,
-        timeout_config: TimeoutConfig,
+        timeout_config: &TimeoutConfig,
     ) -> &mut Self {
         self.with_system_operation(SystemOperation::ChangeOwners {
             owners,

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -304,6 +304,23 @@ impl TestValidator {
         Box::pin(self.new_chain_with_keypair(key_pair)).await
     }
 
+    /// Creates a new microchain whose owner is a super owner, and returns the [`ActiveChain`]
+    /// that can be used to add blocks to it.
+    pub async fn new_super_owner_chain(&self) -> ActiveChain {
+        let key_pair = AccountSecretKey::generate();
+        let description = Box::pin(self.request_new_chain_from_admin_chain_with_ownership(
+            ChainOwnership::single_super(key_pair.public().into()),
+        ))
+        .await;
+        let chain = ActiveChain::new(key_pair, description.clone(), self.clone());
+
+        Box::pin(chain.handle_received_messages()).await;
+
+        self.chains.pin().insert(description.id(), chain.clone());
+
+        chain
+    }
+
     /// Adds an existing [`ActiveChain`].
     pub fn add_chain(&self, chain: ActiveChain) {
         self.chains.pin().insert(chain.id(), chain);
@@ -313,6 +330,17 @@ impl TestValidator {
     ///
     /// Returns the [`ChainDescription`] of the new chain.
     async fn request_new_chain_from_admin_chain(&self, owner: AccountOwner) -> ChainDescription {
+        self.request_new_chain_from_admin_chain_with_ownership(ChainOwnership::single(owner))
+            .await
+    }
+
+    /// Adds a block to the admin chain to create a new chain with the given ownership.
+    ///
+    /// Returns the [`ChainDescription`] of the new chain.
+    async fn request_new_chain_from_admin_chain_with_ownership(
+        &self,
+        ownership: ChainOwnership,
+    ) -> ChainDescription {
         let admin_chain_id = self.admin_chain_id;
         let pinned = self.chains.pin();
         let admin_chain = pinned
@@ -320,7 +348,7 @@ impl TestValidator {
             .expect("Admin chain should be created when the `TestValidator` is constructed");
 
         let open_chain_config = OpenChainConfig {
-            ownership: ChainOwnership::single(owner),
+            ownership,
             balance: Amount::from_tokens(10),
             application_permissions: ApplicationPermissions::default(),
         };

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -99,7 +99,7 @@ impl TestValidator {
         let key_pair = AccountSecretKey::generate();
 
         let new_chain_config = InitialChainConfig {
-            ownership: ChainOwnership::single(key_pair.public().into()),
+            ownership: ChainOwnership::single_super(key_pair.public().into()),
             min_active_epoch: epoch,
             max_active_epoch: epoch,
             epoch,

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -405,8 +405,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
                   permissionsJson
                 }
               }
-              changeOwnership {
-                superOwners
+              changeOwners {
                 owners {
                   owner
                   weight
@@ -414,12 +413,13 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
                 firstLeader
                 multiLeaderRounds
                 openMultiLeaderRounds
-                timeoutConfig {
-                  fastRoundMs
-                  baseTimeoutMs
-                  timeoutIncrementMs
-                  fallbackDurationMs
-                }
+                baseTimeoutMs
+                timeoutIncrementMs
+                fallbackDurationMs
+              }
+              changeSuperOwners {
+                superOwners
+                fastRoundMs
               }
               changeApplicationPermissions {
                 permissions {
@@ -583,8 +583,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
                   permissionsJson
                 }
               }
-              changeOwnership {
-                superOwners
+              changeOwners {
                 owners {
                   owner
                   weight
@@ -592,12 +591,13 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
                 firstLeader
                 multiLeaderRounds
                 openMultiLeaderRounds
-                timeoutConfig {
-                  fastRoundMs
-                  baseTimeoutMs
-                  timeoutIncrementMs
-                  fallbackDurationMs
-                }
+                baseTimeoutMs
+                timeoutIncrementMs
+                fallbackDurationMs
+              }
+              changeSuperOwners {
+                superOwners
+                fastRoundMs
               }
               changeApplicationPermissions {
                 permissions {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -438,15 +438,24 @@ type ChangeApplicationPermissionsMetadata {
 }
 
 """
-Change ownership operation metadata.
+Change owners operation metadata.
 """
-type ChangeOwnershipOperationMetadata {
-	superOwners: [AccountOwner!]!
+type ChangeOwnersOperationMetadata {
 	owners: [OwnerWithWeight!]!
 	firstLeader: AccountOwner
 	multiLeaderRounds: Int!
 	openMultiLeaderRounds: Boolean!
-	timeoutConfig: TimeoutConfigMetadata!
+	baseTimeoutMs: String!
+	timeoutIncrementMs: String!
+	fallbackDurationMs: String!
+}
+
+"""
+Change super owners operation metadata.
+"""
+type ChangeSuperOwnersOperationMetadata {
+	superOwners: [AccountOwner!]!
+	fastRoundMs: String
 }
 
 """
@@ -1001,7 +1010,7 @@ type MutationRoot {
 		chainId: ChainId!
 	): CryptoHash
 	"""
-	Changes the chain to a single-owner chain
+	Changes the chain to a single regular owner.
 	"""
 	changeOwner(
 		"""
@@ -1014,7 +1023,20 @@ type MutationRoot {
 		newOwner: AccountOwner!
 	): CryptoHash!
 	"""
-	Changes the ownership of the chain
+	Changes the chain to a single super owner. The caller must be a current super owner.
+	"""
+	changeSuperOwner(
+		"""
+		The chain whose super ownership changes
+		"""
+		chainId: ChainId!,
+		"""
+		The new single super owner of the chain
+		"""
+		newSuperOwner: AccountOwner!
+	): CryptoHash!
+	"""
+	Changes the regular owners of the chain
 	"""
 	changeMultipleOwners(
 		"""
@@ -1041,10 +1063,6 @@ type MutationRoot {
 		The leader of the first single-leader round. If not set, this is random like other rounds.
 		"""
 		firstLeader: AccountOwner,
-		"""
-		The duration of the fast round, in milliseconds; default: no timeout
-		"""
-		fastRoundMs: Int,
 		"""
 		The duration of the first single-leader and all multi-leader rounds
 		"""
@@ -1496,9 +1514,13 @@ type SystemOperationMetadata {
 	"""
 	openChain: OpenChainOperationMetadata
 	"""
-	Change ownership operation details
+	Change owners operation details
 	"""
-	changeOwnership: ChangeOwnershipOperationMetadata
+	changeOwners: ChangeOwnersOperationMetadata
+	"""
+	Change super owners operation details
+	"""
+	changeSuperOwners: ChangeSuperOwnersOperationMetadata
 	"""
 	Change application permissions operation details
 	"""
@@ -1531,29 +1553,6 @@ type SystemOperationMetadata {
 	`UpdateStreams` operation details
 	"""
 	updateStreams: [UpdateStreamMetadata!]
-}
-
-"""
-Timeout configuration metadata for GraphQL.
-"""
-type TimeoutConfigMetadata {
-	"""
-	The duration of the fast round in milliseconds.
-	"""
-	fastRoundMs: String
-	"""
-	The duration of the first single-leader and all multi-leader rounds in milliseconds.
-	"""
-	baseTimeoutMs: String!
-	"""
-	The duration by which the timeout increases after each single-leader round in milliseconds.
-	"""
-	timeoutIncrementMs: String!
-	"""
-	The age of an incoming tracked or protected message after which validators start
-	transitioning to fallback mode, in milliseconds.
-	"""
-	fallbackDurationMs: String!
 }
 
 """

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -141,7 +141,7 @@ mod from {
     use linera_base::{
         data_types::{ApplicationPermissions, Event, TimeDelta},
         identifiers::{Account, ApplicationId as RealApplicationId, ModuleId, StreamId},
-        ownership::{ChainOwnership, TimeoutConfig},
+        ownership::ChainOwnership,
     };
     use linera_chain::{
         block::{Block, BlockBody, BlockHeader},
@@ -212,69 +212,15 @@ mod from {
                 }))
             }
             "CloseChain" => Ok(SystemOperation::CloseChain),
-            "ChangeOwnership" => {
-                let change_ownership = system_op.change_ownership.ok_or_else(|| {
+            "ChangeOwners" => {
+                let change_owners = system_op.change_owners.ok_or_else(|| {
                     ConversionError::UnexpectedCertificateType(
-                        "Missing change_ownership metadata for ChangeOwnership operation"
-                            .to_string(),
+                        "Missing change_owners metadata for ChangeOwners operation".to_string(),
                     )
                 })?;
 
-                let timeout_config = TimeoutConfig {
-                    fast_round_duration: change_ownership
-                        .timeout_config
-                        .fast_round_ms
-                        .as_ref()
-                        .map(|s| {
-                            s.parse::<u64>().map_err(|_| {
-                                ConversionError::UnexpectedCertificateType(
-                                    "Invalid fast_round_ms value".to_string(),
-                                )
-                            })
-                        })
-                        .transpose()?
-                        .map(|ms| TimeDelta::from_micros(ms * 1000)),
-                    base_timeout: TimeDelta::from_micros(
-                        change_ownership
-                            .timeout_config
-                            .base_timeout_ms
-                            .parse::<u64>()
-                            .map_err(|_| {
-                                ConversionError::UnexpectedCertificateType(
-                                    "Invalid base_timeout_ms value".to_string(),
-                                )
-                            })?
-                            * 1000,
-                    ),
-                    timeout_increment: TimeDelta::from_micros(
-                        change_ownership
-                            .timeout_config
-                            .timeout_increment_ms
-                            .parse::<u64>()
-                            .map_err(|_| {
-                                ConversionError::UnexpectedCertificateType(
-                                    "Invalid timeout_increment_ms value".to_string(),
-                                )
-                            })?
-                            * 1000,
-                    ),
-                    fallback_duration: TimeDelta::from_micros(
-                        change_ownership
-                            .timeout_config
-                            .fallback_duration_ms
-                            .parse::<u64>()
-                            .map_err(|_| {
-                                ConversionError::UnexpectedCertificateType(
-                                    "Invalid fallback_duration_ms value".to_string(),
-                                )
-                            })?
-                            * 1000,
-                    ),
-                };
-
-                Ok(SystemOperation::ChangeOwnership {
-                    super_owners: change_ownership.super_owners,
-                    owners: change_ownership
+                Ok(SystemOperation::ChangeOwners {
+                    owners: change_owners
                         .owners
                         .into_iter()
                         .map(|ow| {
@@ -286,10 +232,62 @@ mod from {
                             Ok((ow.owner, weight))
                         })
                         .collect::<Result<Vec<_>, ConversionError>>()?,
-                    first_leader: change_ownership.first_leader,
-                    multi_leader_rounds: change_ownership.multi_leader_rounds as u32,
-                    open_multi_leader_rounds: change_ownership.open_multi_leader_rounds,
-                    timeout_config,
+                    first_leader: change_owners.first_leader,
+                    multi_leader_rounds: change_owners.multi_leader_rounds as u32,
+                    open_multi_leader_rounds: change_owners.open_multi_leader_rounds,
+                    base_timeout: TimeDelta::from_micros(
+                        change_owners.base_timeout_ms.parse::<u64>().map_err(|_| {
+                            ConversionError::UnexpectedCertificateType(
+                                "Invalid base_timeout_ms value".to_string(),
+                            )
+                        })? * 1000,
+                    ),
+                    timeout_increment: TimeDelta::from_micros(
+                        change_owners
+                            .timeout_increment_ms
+                            .parse::<u64>()
+                            .map_err(|_| {
+                                ConversionError::UnexpectedCertificateType(
+                                    "Invalid timeout_increment_ms value".to_string(),
+                                )
+                            })?
+                            * 1000,
+                    ),
+                    fallback_duration: TimeDelta::from_micros(
+                        change_owners
+                            .fallback_duration_ms
+                            .parse::<u64>()
+                            .map_err(|_| {
+                                ConversionError::UnexpectedCertificateType(
+                                    "Invalid fallback_duration_ms value".to_string(),
+                                )
+                            })?
+                            * 1000,
+                    ),
+                })
+            }
+            "ChangeSuperOwners" => {
+                let change_super_owners = system_op.change_super_owners.ok_or_else(|| {
+                    ConversionError::UnexpectedCertificateType(
+                        "Missing change_super_owners metadata for ChangeSuperOwners operation"
+                            .to_string(),
+                    )
+                })?;
+
+                Ok(SystemOperation::ChangeSuperOwners {
+                    super_owners: change_super_owners.super_owners,
+                    fast_round_duration: change_super_owners
+                        .fast_round_ms
+                        .as_ref()
+                        .map(|s| {
+                            s.parse::<u64>().map_err(|_| {
+                                ConversionError::UnexpectedCertificateType(
+                                    "Invalid fast_round_ms value".to_string(),
+                                )
+                            })
+                        })
+                        .transpose()?
+                        .map(|ms| TimeDelta::from_micros(ms * 1000)),
                 })
             }
             "ChangeApplicationPermissions" => {

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -14,7 +14,8 @@ use linera_base::{
 use linera_client::{
     chain_listener::ChainListenerConfig,
     client_options::{
-        ApplicationPermissionsConfig, ChainOwnershipConfig, ResourceControlPolicyConfig,
+        ApplicationPermissionsConfig, ChainOwnershipConfig, ChangeOwnershipConfig,
+        ChangeSuperOwnershipConfig, ResourceControlPolicyConfig,
     },
     util,
 };
@@ -266,17 +267,30 @@ pub enum ClientCommand {
         chain_id: Option<ChainId>,
     },
 
-    /// Change who owns the chain, and how the owners work together proposing blocks.
+    /// Change the regular owners of the chain.
     ///
-    /// Specify the complete set of new owners, by public key. Existing owners that are
-    /// not included will be removed.
+    /// Any owner can use this command. Specify the complete set of new regular owners,
+    /// by public key. Existing regular owners that are not included will be removed.
     ChangeOwnership {
         /// The ID of the chain whose owners will be changed.
         #[clap(long)]
         chain_id: Option<ChainId>,
 
         #[clap(flatten)]
-        ownership_config: ChainOwnershipConfig,
+        ownership_config: ChangeOwnershipConfig,
+    },
+
+    /// Change the super owners of the chain.
+    ///
+    /// Only a super owner can use this command. Specify the complete set of new super
+    /// owners, by public key. Existing super owners that are not included will be removed.
+    ChangeSuperOwnership {
+        /// The ID of the chain whose super owners will be changed.
+        #[clap(long)]
+        chain_id: Option<ChainId>,
+
+        #[clap(flatten)]
+        ownership_config: ChangeSuperOwnershipConfig,
     },
 
     /// Change the preferred owner of a chain.
@@ -1059,6 +1073,7 @@ impl ClientCommand {
             | ClientCommand::OpenMultiOwnerChain { .. }
             | ClientCommand::ShowOwnership { .. }
             | ClientCommand::ChangeOwnership { .. }
+            | ClientCommand::ChangeSuperOwnership { .. }
             | ClientCommand::SetPreferredOwner { .. }
             | ClientCommand::ChangeApplicationPermissions { .. }
             | ClientCommand::CloseChain { .. }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -323,7 +323,7 @@ impl Runnable for Job {
                 ownership_config,
             } => {
                 let mut context = options
-                    .create_client_context(storage, wallet, signer.into_value())
+                    .create_client_context(storage, wallet, keystore)
                     .await?;
                 context
                     .change_super_ownership(chain_id, ownership_config)

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -318,6 +318,18 @@ impl Runnable for Job {
                 context.change_ownership(chain_id, ownership_config).await?
             }
 
+            ChangeSuperOwnership {
+                chain_id,
+                ownership_config,
+            } => {
+                let mut context = options
+                    .create_client_context(storage, wallet, signer.into_value())
+                    .await?;
+                context
+                    .change_super_ownership(chain_id, ownership_config)
+                    .await?
+            }
+
             SetPreferredOwner { chain_id, owner } => {
                 let mut context = options
                     .create_client_context(storage, wallet, keystore)

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1019,22 +1019,34 @@ impl ClientWrapper {
     pub async fn change_ownership(
         &self,
         chain_id: ChainId,
-        super_owners: Vec<AccountOwner>,
         owners: Vec<AccountOwner>,
     ) -> Result<()> {
         let mut command = self.command().await?;
         command
             .arg("change-ownership")
             .args(["--chain-id", &chain_id.to_string()]);
-        command
-            .arg("--super-owners")
-            .arg(serde_json::to_string(&super_owners)?);
         command.arg("--owners").arg(serde_json::to_string(
             &owners
                 .into_iter()
                 .zip(std::iter::repeat(100u64))
                 .collect::<BTreeMap<_, _>>(),
         )?);
+        command.spawn_and_wait_for_stdout().await?;
+        Ok(())
+    }
+
+    pub async fn change_super_ownership(
+        &self,
+        chain_id: ChainId,
+        super_owners: Vec<AccountOwner>,
+    ) -> Result<()> {
+        let mut command = self.command().await?;
+        command
+            .arg("change-super-ownership")
+            .args(["--chain-id", &chain_id.to_string()]);
+        command
+            .arg("--super-owners")
+            .arg(serde_json::to_string(&super_owners)?);
         command.spawn_and_wait_for_stdout().await?;
         Ok(())
     }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -998,6 +998,26 @@ impl ClientWrapper {
         balance: Amount,
         base_timeout_ms: u64,
     ) -> Result<ChainId> {
+        self.open_multi_owner_chain_with_manage_chain(
+            from,
+            owners,
+            multi_leader_rounds,
+            balance,
+            base_timeout_ms,
+            vec![],
+        )
+        .await
+    }
+
+    pub async fn open_multi_owner_chain_with_manage_chain(
+        &self,
+        from: ChainId,
+        owners: BTreeMap<AccountOwner, u64>,
+        multi_leader_rounds: u32,
+        balance: Amount,
+        base_timeout_ms: u64,
+        manage_chain: Vec<ApplicationId>,
+    ) -> Result<ChainId> {
         let mut command = self.command().await?;
         command
             .arg("open-multi-owner-chain")
@@ -1008,6 +1028,11 @@ impl ClientWrapper {
         command
             .args(["--multi-leader-rounds", &multi_leader_rounds.to_string()])
             .args(["--initial-balance", &balance.to_string()]);
+        if !manage_chain.is_empty() {
+            command
+                .arg("--manage-chain")
+                .arg(serde_json::to_string(&manage_chain)?);
+        }
 
         let stdout = command.spawn_and_wait_for_stdout().await?;
         let mut split = stdout.split('\n');

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -231,12 +231,24 @@ where
         system_operation: SystemOperation,
         chain_id: ChainId,
     ) -> Result<CryptoHash, Error> {
+        self.execute_system_operations(vec![system_operation], chain_id)
+            .await
+    }
+
+    async fn execute_system_operations(
+        &self,
+        system_operations: Vec<SystemOperation>,
+        chain_id: ChainId,
+    ) -> Result<CryptoHash, Error> {
         let certificate = self
             .apply_client_command(&chain_id, move |client| {
-                let operation = Operation::system(system_operation.clone());
+                let operations: Vec<_> = system_operations
+                    .iter()
+                    .map(|op| Operation::system(op.clone()))
+                    .collect();
                 async move {
                     let result = client
-                        .execute_operation(operation)
+                        .execute_operations(operations, vec![])
                         .await
                         .map_err(Error::from);
                     (result, client)
@@ -533,24 +545,40 @@ where
         Ok(maybe_cert.as_ref().map(GenericCertificate::hash))
     }
 
-    /// Changes the chain to a single-owner chain
+    /// Changes the chain to a single regular owner.
     async fn change_owner(
         &self,
         #[graphql(desc = "The chain whose ownership changes")] chain_id: ChainId,
         #[graphql(desc = "The new single owner of the chain")] new_owner: AccountOwner,
     ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::ChangeOwnership {
-            super_owners: vec![new_owner],
-            owners: Vec::new(),
-            first_leader: None,
-            multi_leader_rounds: 2,
-            open_multi_leader_rounds: false,
-            timeout_config: TimeoutConfig::default(),
-        };
-        self.execute_system_operation(operation, chain_id).await
+        let certificate = self
+            .apply_client_command(&chain_id, move |client| async move {
+                let result = client.change_owner(new_owner).await.map_err(Error::from);
+                (result, client)
+            })
+            .await?;
+        Ok(certificate.hash())
     }
 
-    /// Changes the ownership of the chain
+    /// Changes the chain to a single super owner. The caller must be a current super owner.
+    async fn change_super_owner(
+        &self,
+        #[graphql(desc = "The chain whose super ownership changes")] chain_id: ChainId,
+        #[graphql(desc = "The new single super owner of the chain")] new_super_owner: AccountOwner,
+    ) -> Result<CryptoHash, Error> {
+        let certificate = self
+            .apply_client_command(&chain_id, move |client| async move {
+                let result = client
+                    .transfer_super_ownership(new_super_owner)
+                    .await
+                    .map_err(Error::from);
+                (result, client)
+            })
+            .await?;
+        Ok(certificate.hash())
+    }
+
+    /// Changes the regular owners of the chain
     #[expect(clippy::too_many_arguments)]
     async fn change_multiple_owners(
         &self,
@@ -565,8 +593,6 @@ where
         #[graphql(desc = "The leader of the first single-leader round. \
                           If not set, this is random like other rounds.")]
         first_leader: Option<AccountOwner>,
-        #[graphql(desc = "The duration of the fast round, in milliseconds; default: no timeout")]
-        fast_round_ms: Option<u64>,
         #[graphql(
             desc = "The duration of the first single-leader and all multi-leader rounds",
             default = 10_000
@@ -585,18 +611,14 @@ where
         )]
         fallback_duration_ms: u64,
     ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::ChangeOwnership {
-            super_owners: Vec::new(),
+        let operation = SystemOperation::ChangeOwners {
             owners: new_owners.into_iter().zip(new_weights).collect(),
             first_leader,
             multi_leader_rounds,
             open_multi_leader_rounds,
-            timeout_config: TimeoutConfig {
-                fast_round_duration: fast_round_ms.map(TimeDelta::from_millis),
-                base_timeout: TimeDelta::from_millis(base_timeout_ms),
-                timeout_increment: TimeDelta::from_millis(timeout_increment_ms),
-                fallback_duration: TimeDelta::from_millis(fallback_duration_ms),
-            },
+            base_timeout: TimeDelta::from_millis(base_timeout_ms),
+            timeout_increment: TimeDelta::from_millis(timeout_increment_ms),
+            fallback_duration: TimeDelta::from_millis(fallback_duration_ms),
         };
         self.execute_system_operation(operation, chain_id).await
     }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -4723,16 +4723,14 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
     // Generate an owner for which we don't have a secret key in the Signer.
     let owner2 = AccountPublicKey::test_key(2).into();
 
-    // Make both keys owners.
-    client
-        .change_ownership(chain, vec![], vec![owner1, owner2])
-        .await?;
+    // Make both keys regular owners.
+    client.change_ownership(chain, vec![owner1, owner2]).await?;
 
-    // Make owner2 the only (super) owner.
-    client.change_ownership(chain, vec![owner2], vec![]).await?;
+    // Make owner2 the only regular owner.
+    client.change_ownership(chain, vec![owner2]).await?;
     client.set_preferred_owner(chain, Some(owner2)).await?;
     // Now we're not the owner anymore.
-    let result = client.change_ownership(chain, vec![], vec![owner1]).await;
+    let result = client.change_ownership(chain, vec![owner1]).await;
     assert_matches::assert_matches!(result, Err(_));
 
     net.ensure_is_running().await?;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -25,7 +25,7 @@ use guard::INTEGRATION_TEST_GUARD;
 use linera_base::vm::{EvmInstantiation, EvmOperation, EvmQuery};
 use linera_base::{
     crypto::{CryptoHash, Secp256k1SecretKey},
-    data_types::{Amount, ApplicationPermissions},
+    data_types::Amount,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, OwnerSpender},
     time::{Duration, Instant},
     vm::VmRuntime,
@@ -5452,8 +5452,9 @@ async fn test_controller(config: impl LineraNetConfig) -> Result<()> {
     service_client.wallet_init(None).await?;
     let service_owner = service_client.keygen().await?;
     // We make it a multi-owner chain, so that worker1 can also propose.
+    // The controller application is allowed to manage the chain from the start.
     let service_chain = admin_client
-        .open_multi_owner_chain(
+        .open_multi_owner_chain_with_manage_chain(
             admin_chain,
             vec![
                 (service_owner, 100),
@@ -5469,20 +5470,10 @@ async fn test_controller(config: impl LineraNetConfig) -> Result<()> {
             u32::MAX,
             Amount::from_tokens(10),
             1000,
+            vec![controller_id.forget_abi()],
         )
         .await?;
     service_client.assign(service_owner, service_chain).await?;
-    // Service chain block 0: allow the controller application to change ownership
-    service_client
-        .change_application_permissions(
-            service_chain,
-            ApplicationPermissions {
-                manage_chain: vec![controller_id.forget_abi()],
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("changing application permissions should succeed");
 
     let admin_port = get_node_port().await;
     let mut admin_node_service = admin_client

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1163,15 +1163,8 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
     let (mut net, client) = config.instantiate().await?;
     let chain = client.load_wallet()?.default_chain().unwrap();
 
-    // Change the ownership so that the blocks inserted are not
-    // fast blocks. Fast blocks are not allowed for the oracles.
-    let owner1 = {
-        let wallet = client.load_wallet()?;
-        let user_chain = wallet.get(chain).unwrap();
-        *user_chain.owner.as_ref().unwrap()
-    };
-
-    client.change_ownership(chain, vec![owner1]).await?;
+    // Genesis chains use `ChainOwnership::single()` (regular owner, no super owner),
+    // so there are no fast blocks — oracles work without any ownership change.
     let (contract, service) = client.build_example("ethereum-tracker").await?;
 
     tracing::info!("Publishing Ethereum tracker contract");

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -1171,7 +1171,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
         *user_chain.owner.as_ref().unwrap()
     };
 
-    client.change_ownership(chain, vec![], vec![owner1]).await?;
+    client.change_ownership(chain, vec![owner1]).await?;
     let (contract, service) = client.build_example("ethereum-tracker").await?;
 
     tracing::info!("Publishing Ethereum tracker contract");


### PR DESCRIPTION
## Motivation

We have owners and super-owners. However, there is a privilege escalation mechanism that allows an owner to change the super-owners, and so do something the chain was not designed for.

Fixes #5269 

## Proposal

The owners can change the owners, but not the super-owners. They also cannot change the fast part of the creation of a block, only super owners can do that.

The changes then follow from that.

Of course, if a chain has no super-owners, it can never have any.

## Test Plan

CI and add some tests to check that 

## Release Plan

It is interesting to see whether we can backport it to `testnet_conway`.

## Links

None