### PR TITLE
Consolidate `stage_block_execution` variants into a single function

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{Blob, BlockHeight, Epoch, Event, OracleResponse, Timestamp},
     hashed::Hashed,
-    identifiers::{AccountOwner, BlobId, BlobType, ChainId, StreamId},
+    identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
 };
 use linera_execution::{BlobState, Operation, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
@@ -616,6 +616,12 @@ impl Block {
             .iter()
             .flatten()
             .map(|blob| (blob.id(), blob.clone()))
+    }
+
+    /// Returns the IDs of all events in this block.
+    pub fn event_ids(&self) -> impl Iterator<Item = EventId> + '_ {
+        let to_id = |event: &Event| event.id(self.header.chain_id);
+        self.body.events.iter().flatten().map(to_id)
     }
 }
 

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -122,18 +122,10 @@ where
         callback: oneshot::Sender<Result<ApplicationDescription, WorkerError>>,
     },
 
-    /// Execute a block but discard any changes to the chain state.
+    /// Execute a block with a policy for handling bundle failures, but discard any changes
+    /// to the chain state. The block may be modified (bundles rejected or removed) based
+    /// on the policy.
     StageBlockExecution {
-        block: ProposedBlock,
-        round: Option<u32>,
-        published_blobs: Vec<Blob>,
-        #[debug(skip)]
-        callback: oneshot::Sender<Result<(Block, ChainInfoResponse, ResourceTracker), WorkerError>>,
-    },
-
-    /// Execute a block with a policy for handling bundle failures.
-    /// The block may be modified (bundles rejected or removed) based on the policy.
-    StageBlockExecutionWithPolicy {
         block: ProposedBlock,
         round: Option<u32>,
         published_blobs: Vec<Blob>,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -161,28 +161,11 @@ where
                 block,
                 round,
                 published_blobs,
-                callback,
-            } => callback
-                .send(
-                    self.stage_block_execution_with_policy(
-                        block,
-                        round,
-                        &published_blobs,
-                        BundleExecutionPolicy::committed(),
-                    )
-                    .await
-                    .map(|(_, block, response, tracker)| (block, response, tracker)),
-                )
-                .is_ok(),
-            ChainWorkerRequest::StageBlockExecutionWithPolicy {
-                block,
-                round,
-                published_blobs,
                 policy,
                 callback,
             } => {
                 let result = self
-                    .stage_block_execution_with_policy(block, round, &published_blobs, policy)
+                    .stage_block_execution(block, round, &published_blobs, policy)
                     .await;
                 callback.send(result).is_ok()
             }
@@ -1487,7 +1470,7 @@ where
         chain_id = %self.chain_id(),
         block_height = %block.height
     ))]
-    async fn stage_block_execution_with_policy(
+    async fn stage_block_execution(
         &mut self,
         block: ProposedBlock,
         round: Option<u32>,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -675,9 +675,19 @@ impl<Env: Environment> Client<Env> {
     ) -> Result<(), ChainClientError> {
         let validators = self.validator_nodes().await?;
         let info = Box::pin(self.fetch_chain_info(chain_id, &validators)).await?;
+        let mut missing_events = HashSet::new();
+        for event_id in event_ids {
+            if !self
+                .storage_client()
+                .contains_event(event_id.clone())
+                .await?
+            {
+                missing_events.insert(event_id.clone());
+            }
+        }
         let mut next_height = info.next_block_height;
         // Download one certificate at a time so we never overshoot the chain length.
-        loop {
+        while !missing_events.is_empty() {
             let result = self
                 .requests_scheduler
                 .download_certificates_from_validators(
@@ -692,6 +702,12 @@ impl<Env: Environment> Client<Env> {
                 Ok(certificates) => certificates,
                 Err(_) => break, // No validator has a certificate at this height.
             };
+            for event_id in certificates
+                .iter()
+                .flat_map(|cert| cert.block().event_ids())
+            {
+                missing_events.remove(&event_id);
+            }
             let Some(batch_info) = self
                 .process_certificates_using_all(&validators, certificates)
                 .await?
@@ -700,25 +716,8 @@ impl<Env: Environment> Client<Env> {
             };
             assert!(batch_info.next_block_height > next_height);
             next_height = batch_info.next_block_height;
-            if self.has_all_events(event_ids).await? {
-                return Ok(());
-            }
         }
         Ok(())
-    }
-
-    /// Returns `true` if all the given events exist in local storage.
-    async fn has_all_events(&self, event_ids: &[EventId]) -> Result<bool, ChainClientError> {
-        for event_id in event_ids {
-            if !self
-                .storage_client()
-                .contains_event(event_id.clone())
-                .await?
-            {
-                return Ok(false);
-            }
-        }
-        Ok(true)
     }
 
     /// Tries to process all the certificates, requesting any missing blobs from the given node.
@@ -1837,7 +1836,7 @@ impl<Env: Environment> Client<Env> {
     /// Returns the modified block (bundles may be rejected/removed based on the policy)
     /// and the execution result.
     #[instrument(level = "trace", skip(self, block))]
-    async fn stage_block_execution_with_policy(
+    async fn stage_block_execution(
         &self,
         block: ProposedBlock,
         round: Option<u32>,
@@ -1848,12 +1847,7 @@ impl<Env: Environment> Client<Env> {
         loop {
             let result = self
                 .local_node
-                .stage_block_execution_with_policy(
-                    block.clone(),
-                    round,
-                    published_blobs.clone(),
-                    policy,
-                )
+                .stage_block_execution(block.clone(), round, published_blobs.clone(), policy)
                 .await;
             if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
                 let validators = self.validator_nodes().await?;
@@ -1862,11 +1856,11 @@ impl<Env: Environment> Client<Env> {
                 continue; // We found the missing blob: retry.
             }
             if let Err(LocalNodeError::EventsNotFound(event_ids)) = &result {
-                let new_events: Vec<_> = event_ids
+                let new_events = event_ids
                     .iter()
                     .filter(|id| !downloaded_events.contains(id))
                     .cloned()
-                    .collect();
+                    .collect::<Vec<_>>();
                 if !new_events.is_empty() {
                     self.download_publisher_chains_for_events(&new_events)
                         .await?;
@@ -1888,57 +1882,6 @@ impl<Env: Environment> Client<Env> {
             }
             let (_modified_block, executed_block, response, _resource_tracker) = result?;
             return Ok((executed_block, response));
-        }
-    }
-
-    /// Attempts to execute the block locally. If any attempt to read a blob or event fails,
-    /// the missing data is downloaded and execution is retried.
-    #[instrument(level = "trace", skip(self, block))]
-    async fn stage_block_execution(
-        &self,
-        block: ProposedBlock,
-        round: Option<u32>,
-        published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse), ChainClientError> {
-        let mut downloaded_events = HashSet::<EventId>::new();
-        loop {
-            let result = self
-                .local_node
-                .stage_block_execution(block.clone(), round, published_blobs.clone())
-                .await;
-            if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
-                let validators = self.validator_nodes().await?;
-                self.update_local_node_with_blobs_from(blob_ids.clone(), &validators)
-                    .await?;
-                continue; // We found the missing blob: retry.
-            }
-            if let Err(LocalNodeError::EventsNotFound(event_ids)) = &result {
-                let new_events: Vec<_> = event_ids
-                    .iter()
-                    .filter(|id| !downloaded_events.contains(id))
-                    .cloned()
-                    .collect();
-                if !new_events.is_empty() {
-                    self.download_publisher_chains_for_events(&new_events)
-                        .await?;
-                    downloaded_events.extend(new_events);
-                    continue; // We downloaded new publisher chain data: retry.
-                }
-                // All reported events were already downloaded; don't loop forever.
-            }
-            if let Ok((block, _, _)) = &result {
-                let hash = CryptoHash::new(block);
-                let notification = Notification {
-                    chain_id: block.header.chain_id,
-                    reason: Reason::BlockExecuted {
-                        height: block.header.height,
-                        hash,
-                    },
-                };
-                self.notifier.notify(&[notification]);
-            }
-            let (block, response, _resource_tracker) = result?;
-            return Ok((block, response));
         }
     }
 }
@@ -2696,12 +2639,12 @@ impl<Env: Environment> ChainClient<Env> {
             .local_node
             .get_event_subscriptions(self.chain_id)
             .await?;
-        let chain_ids: BTreeSet<_> = subscriptions
+        let chain_ids = subscriptions
             .iter()
             .map(|((chain_id, _), _)| *chain_id)
             .chain(iter::once(self.client.admin_chain_id))
             .filter(|chain_id| *chain_id != self.chain_id)
-            .collect();
+            .collect::<BTreeSet<_>>();
         stream::iter(
             chain_ids
                 .into_iter()
@@ -3269,7 +3212,7 @@ impl<Env: Environment> ChainClient<Env> {
         let round = self.round_for_oracle(&info, &identity).await?;
         // Make sure every incoming message succeeds and otherwise remove them.
         // Also, compute the final certified hash while we're at it.
-        let (block, _) = Box::pin(self.client.stage_block_execution_with_policy(
+        let (block, _) = Box::pin(self.client.stage_block_execution(
             proposed_block,
             round,
             blobs.clone(),
@@ -3448,7 +3391,7 @@ impl<Env: Environment> ChainClient<Env> {
             },
             timestamp,
         };
-        match Box::pin(self.client.stage_block_execution_with_policy(
+        match Box::pin(self.client.stage_block_execution(
             block,
             None,
             Vec::new(),
@@ -3636,7 +3579,12 @@ impl<Env: Environment> ChainClient<Env> {
                         })?;
                     let block = self
                         .client
-                        .stage_block_execution(proposed_block, None, blobs.clone())
+                        .stage_block_execution(
+                            proposed_block,
+                            None,
+                            blobs.clone(),
+                            BundleExecutionPolicy::committed(),
+                        )
                         .await?
                         .0;
                     debug!("Retrying locking block from fast round.");
@@ -3649,7 +3597,12 @@ impl<Env: Environment> ChainClient<Env> {
             let round = self.round_for_oracle(&info, &owner).await?;
             let (block, _) = self
                 .client
-                .stage_block_execution(proposed_block, round, pending_proposal.blobs.clone())
+                .stage_block_execution(
+                    proposed_block,
+                    round,
+                    pending_proposal.blobs.clone(),
+                    BundleExecutionPolicy::committed(),
+                )
                 .await?;
             debug!("Proposing the local pending block.");
             (block, pending_proposal.blobs)
@@ -4474,10 +4427,10 @@ impl<Env: Environment> ChainClient<Env> {
         notification: Notification,
     ) -> Result<(), ChainClientError> {
         let mode = self.client.chain_mode(notification.chain_id);
-        let dominated = mode
+        let is_relevant = mode
             .as_ref()
-            .is_none_or(|mode| !mode.is_relevant(&notification.reason));
-        if dominated {
+            .is_some_and(|mode| mode.is_relevant(&notification.reason));
+        if !is_relevant {
             debug!(
                 chain_id = %notification.chain_id,
                 reason = ?notification.reason,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -137,26 +137,12 @@ where
         self.node.state.storage_client().clone()
     }
 
-    #[instrument(level = "trace", skip_all)]
-    pub async fn stage_block_execution(
-        &self,
-        block: ProposedBlock,
-        round: Option<u32>,
-        published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse, ResourceTracker), LocalNodeError> {
-        Ok(self
-            .node
-            .state
-            .stage_block_execution(block, round, published_blobs)
-            .await?)
-    }
-
     /// Executes a block with a policy for handling bundle failures.
     ///
     /// Returns the modified block (bundles may be rejected/removed based on the policy),
     /// the executed block, chain info response, and resource tracker.
     #[instrument(level = "trace", skip_all)]
-    pub async fn stage_block_execution_with_policy(
+    pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
         round: Option<u32>,
@@ -166,7 +152,7 @@ where
         Ok(self
             .node
             .state
-            .stage_block_execution_with_policy(block, round, published_blobs, policy)
+            .stage_block_execution(block, round, published_blobs, policy)
             .await?)
     }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -396,9 +396,14 @@ where
         .with_timestamp(1)
         .with_operation(publish_counter_op)
         .with_operation(publish_meta_op);
-    let (publish_executed, _, _) = env
+    let (_, publish_executed, _, _) = env
         .worker()
-        .stage_block_execution(publish_block, None, all_blobs.to_vec())
+        .stage_block_execution(
+            publish_block,
+            None,
+            all_blobs.to_vec(),
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let publish_cert = env.make_certificate(ConfirmedBlock::new(publish_executed));
     env.worker()
@@ -426,9 +431,14 @@ where
     let create_counter_block = make_child_block(&publish_cert.into_value())
         .with_timestamp(2)
         .with_operation(create_counter_op);
-    let (create_counter_executed, _, _) = env
+    let (_, create_counter_executed, _, _) = env
         .worker()
-        .stage_block_execution(create_counter_block, None, vec![])
+        .stage_block_execution(
+            create_counter_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let create_counter_cert = env.make_certificate(ConfirmedBlock::new(create_counter_executed));
     env.worker()
@@ -456,9 +466,14 @@ where
     let create_meta_block = make_child_block(&create_counter_cert.into_value())
         .with_timestamp(3)
         .with_operation(create_meta_op);
-    let (create_meta_executed, _, _) = env
+    let (_, create_meta_executed, _, _) = env
         .worker()
-        .stage_block_execution(create_meta_block, None, vec![])
+        .stage_block_execution(
+            create_meta_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let create_meta_cert = env.make_certificate(ConfirmedBlock::new(create_meta_executed));
     env.worker()
@@ -474,9 +489,14 @@ where
             application_id: meta_app_id,
             bytes: fail_op_bytes,
         });
-    let (send_fail_executed, _, _) = env
+    let (_, send_fail_executed, _, _) = env
         .worker()
-        .stage_block_execution(send_fail_block, None, vec![])
+        .stage_block_execution(
+            send_fail_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let send_fail_cert = env.make_certificate(ConfirmedBlock::new(send_fail_executed));
     env.worker()
@@ -516,7 +536,7 @@ where
     // This should handle the failing message by rejecting the bundle.
     let (modified_block, auto_retry_executed, _, _) = env
         .worker()
-        .stage_block_execution_with_policy(
+        .stage_block_execution(
             proposed_block.clone(),
             None,
             vec![],
@@ -545,7 +565,7 @@ where
     // and produce the same outcome.
     let (_, abort_executed, _, _) = env
         .worker()
-        .stage_block_execution_with_policy(
+        .stage_block_execution(
             modified_block.clone(),
             None,
             vec![],

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -26,9 +26,9 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        BlockExecutionOutcome, BlockProposal, ChainAndHeight, IncomingBundle, LiteValue, LiteVote,
-        MessageAction, MessageBundle, OperationResult, PostedMessage, SignatureAggregator,
-        Transaction,
+        BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, ChainAndHeight,
+        IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
+        PostedMessage, SignatureAggregator, Transaction,
     },
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -779,9 +779,14 @@ where
         .await
         .unwrap();
     // Stage execution to get the block for certificate creation.
-    let (block, _, _) = env
+    let (_, block, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block, None, vec![])
+        .stage_block_execution(
+            proposed_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     // Past timestamp should be handled immediately (and succeed).
     let result = env.worker().handle_block_proposal(block_proposal).await;
@@ -803,9 +808,14 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    let (block, _, _) = env
+    let (_, block, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block, None, vec![])
+        .stage_block_execution(
+            proposed_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let result = env.worker().handle_block_proposal(block_proposal).await;
     assert!(result.is_ok(), "Current timestamp should be accepted");
@@ -826,9 +836,14 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    let (block, _, _) = env
+    let (_, block, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block, None, vec![])
+        .stage_block_execution(
+            proposed_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
 
     // Spawn the proposal handling. It should not complete immediately.
@@ -3472,9 +3487,14 @@ where
             timeout_config: TimeoutConfig::default(),
         })
         .with_authenticated_signer(Some(owner0));
-    let (block0, _, _) = env
+    let (_, block0, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block0, None, vec![])
+        .stage_block_execution(
+            proposed_block0,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value0 = ConfirmedBlock::new(block0);
     let certificate0 = env.make_certificate(value0.clone());
@@ -3534,9 +3554,14 @@ where
 
     // Now owner 0 can propose a block, but owner 1 can't.
     let proposed_block1 = make_child_block(&value0).with_simple_transfer(chain_1, small_transfer);
-    let (block1, _, _) = env
+    let (_, block1, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block1.clone(), None, vec![])
+        .stage_block_execution(
+            proposed_block1.clone(),
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let proposal1_wrong_owner = proposed_block1
         .clone()
@@ -3584,9 +3609,14 @@ where
     // Create block2, also at height 1, but different from block 1.
     let amount = Amount::from_tokens(1);
     let proposed_block2 = make_child_block(&value0.clone()).with_simple_transfer(chain_1, amount);
-    let (block2, _, _) = env
+    let (_, block2, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block2.clone(), None, vec![])
+        .stage_block_execution(
+            proposed_block2.clone(),
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
 
     // Since round 3 is already over, the validator won't vote for a validated block from round 3.
@@ -3723,9 +3753,14 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _, _) = env
+    let (_, block0, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block0, None, vec![])
+        .stage_block_execution(
+            proposed_block0,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value0 = ConfirmedBlock::new(block0);
     let certificate0 = env.make_certificate(value0.clone());
@@ -3835,9 +3870,14 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (block0, _, _) = env
+    let (_, block0, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block0, None, vec![])
+        .stage_block_execution(
+            proposed_block0,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value0 = ConfirmedBlock::new(block0);
     let certificate0 = env.make_certificate(value0.clone());
@@ -3863,9 +3903,14 @@ where
         .into_proposal_with_round(owner0, &signer, Round::Fast)
         .await
         .unwrap();
-    let (block1, _, _) = env
+    let (_, block1, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block1.clone(), None, vec![])
+        .stage_block_execution(
+            proposed_block1.clone(),
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value1 = ConfirmedBlock::new(block1);
     let (response, _) = env
@@ -3920,9 +3965,14 @@ where
     env.worker().handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
-    let (block2, _, _) = env
+    let (_, block2, _, _) = env
         .worker()
-        .stage_block_execution(proposed_block2.clone(), None, vec![])
+        .stage_block_execution(
+            proposed_block2.clone(),
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value2 = ValidatedBlock::new(block2.clone());
     let certificate2 = env.make_certificate_with_round(value2.clone(), Round::MultiLeader(0));
@@ -4288,7 +4338,7 @@ where
     // Test stage_block_execution directly - this should fail with IncorrectMessageOrder.
     assert_matches!(
         env.worker()
-            .stage_block_execution(bad_proposed_block.clone(), None, vec![])
+            .stage_block_execution(bad_proposed_block.clone(), None, vec![], BundleExecutionPolicy::committed())
             .await,
         Err(WorkerError::ChainError(chain_error))
             if matches!(*chain_error, ChainError::IncorrectMessageOrder { .. })

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -759,31 +759,12 @@ where
         .await
     }
 
-    /// Tries to execute a block proposal without any verification other than block execution.
-    #[instrument(level = "trace", skip(self, block))]
-    pub async fn stage_block_execution(
-        &self,
-        block: ProposedBlock,
-        round: Option<u32>,
-        published_blobs: Vec<Blob>,
-    ) -> Result<(Block, ChainInfoResponse, ResourceTracker), WorkerError> {
-        self.query_chain_worker(block.chain_id, move |callback| {
-            ChainWorkerRequest::StageBlockExecution {
-                block,
-                round,
-                published_blobs,
-                callback,
-            }
-        })
-        .await
-    }
-
     /// Tries to execute a block proposal with a policy for handling bundle failures.
     ///
     /// Returns the modified block (bundles may be rejected/removed), the executed block,
     /// chain info response, and resource tracker.
     #[instrument(level = "trace", skip(self, block))]
-    pub async fn stage_block_execution_with_policy(
+    pub async fn stage_block_execution(
         &self,
         block: ProposedBlock,
         round: Option<u32>,
@@ -791,7 +772,7 @@ where
         policy: BundleExecutionPolicy,
     ) -> Result<(ProposedBlock, Block, ChainInfoResponse, ResourceTracker), WorkerError> {
         self.query_chain_worker(block.chain_id, move |callback| {
-            ChainWorkerRequest::StageBlockExecutionWithPolicy {
+            ChainWorkerRequest::StageBlockExecution {
                 block,
                 round,
                 published_blobs,

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -13,8 +13,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        IncomingBundle, LiteValue, LiteVote, MessageAction, ProposedBlock, SignatureAggregator,
-        Transaction,
+        BundleExecutionPolicy, IncomingBundle, LiteValue, LiteVote, MessageAction, ProposedBlock,
+        SignatureAggregator, Transaction,
     },
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
@@ -244,10 +244,15 @@ impl BlockBuilder {
                     .clone()
             })
             .collect();
-        let (block, _, resource_tracker) = self
+        let (_, block, _, resource_tracker) = self
             .validator
             .worker()
-            .stage_block_execution(self.block, None, published_blobs)
+            .stage_block_execution(
+                self.block,
+                None,
+                published_blobs,
+                BundleExecutionPolicy::committed(),
+            )
             .await?;
 
         let value = ConfirmedBlock::new(block);


### PR DESCRIPTION
## Motivation

#5638 was merged yesterday, but I still wanted to make some minor cleanups.

## Proposal

Merge `stage_block_execution` and `stage_block_execution_with_policy` into one `stage_block_execution` that always takes a `BundleExecutionPolicy`. Also remove the redundant `has_all_events` helper by inlining the check as a `missing_events` set, and add `Block::event_ids()` for iterating over event IDs in a block.

## Test Plan

CI

## Release Plan

- Should be ported to `main` where appropriate.

## Links

- Follow-up to #5638 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
