### PR TITLE
Measure state hash computation latency in microseconds

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -63,8 +63,7 @@ pub(crate) mod metrics {
     use std::sync::LazyLock;
 
     use linera_base::prometheus_util::{
-        exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
-        register_int_counter_vec,
+        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
     };
     use linera_execution::ResourceTracker;
     use prometheus::{HistogramVec, IntCounterVec};
@@ -149,9 +148,9 @@ pub(crate) mod metrics {
     pub static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
             "state_hash_computation_latency",
-            "Time to recompute the state hash",
+            "Time to recompute the state hash, in microseconds",
             &[],
-            exponential_bucket_latencies(2000.0),
+            exponential_bucket_interval(1.0, 2_000_000.0),
         )
     });
 
@@ -952,7 +951,7 @@ where
 
         let state_hash = {
             #[cfg(with_metrics)]
-            let _hash_latency = metrics::STATE_HASH_COMPUTATION_LATENCY.measure_latency();
+            let _hash_latency = metrics::STATE_HASH_COMPUTATION_LATENCY.measure_latency_us();
             chain.crypto_hash_mut().await?
         };
 


### PR DESCRIPTION
## Motivation

The `state_hash_computation_latency` metric is currently recorded in milliseconds, but
the operation is fast enough that microsecond resolution gives more useful data.

## Proposal

- Switch the histogram from `exponential_bucket_latencies(2000.0)` (ms buckets up to 2s)
to `exponential_bucket_interval(1.0, 2_000_000.0)` (μs buckets from 1μs to 2s)
- Use `measure_latency_us()` instead of `measure_latency()` so values are recorded in
microseconds
- Update the metric description to reflect the new unit

## Test Plan

CI
