### PR TITLE
Introduce the `save_and_drop` for `RootView`.

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -312,8 +312,11 @@ impl Contract for AmmContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/controller/src/contract.rs
+++ b/examples/controller/src/contract.rs
@@ -327,8 +327,11 @@ impl Contract for ControllerContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/counter-no-graphql/src/contract.rs
+++ b/examples/counter-no-graphql/src/contract.rs
@@ -57,8 +57,11 @@ impl Contract for CounterContract {
         panic!("Counter application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -56,8 +56,11 @@ impl Contract for CounterContract {
         panic!("Counter application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -80,8 +80,11 @@ impl Contract for CrowdFundingContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/ethereum-tracker/src/contract.rs
+++ b/examples/ethereum-tracker/src/contract.rs
@@ -70,8 +70,11 @@ impl Contract for EthereumTrackerContract {
         panic!("Messages not supported");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -152,8 +152,11 @@ impl Contract for FungibleTokenContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/gen-nft/src/contract.rs
+++ b/examples/gen-nft/src/contract.rs
@@ -124,8 +124,11 @@ impl Contract for GenNftContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -97,8 +97,11 @@ impl Contract for HexContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -110,8 +110,11 @@ impl Contract for MatchingEngineContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -128,8 +128,11 @@ impl Contract for NonFungibleTokenContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -309,8 +309,11 @@ impl Contract for RfqContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -103,8 +103,11 @@ impl Contract for SocialContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/task-processor/src/contract.rs
+++ b/examples/task-processor/src/contract.rs
@@ -78,7 +78,10 @@ impl Contract for TaskProcessorContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/linera-sdk/tests/fixtures/cost-tracking/src/contract.rs
+++ b/linera-sdk/tests/fixtures/cost-tracking/src/contract.rs
@@ -351,7 +351,10 @@ impl Contract for CostTrackingContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/linera-sdk/tests/fixtures/create-and-call/src/contract.rs
+++ b/linera-sdk/tests/fixtures/create-and-call/src/contract.rs
@@ -88,7 +88,10 @@ impl Contract for CreateAndCallContract {
         panic!("Create and call application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/linera-sdk/tests/fixtures/time-expiry/src/contract.rs
+++ b/linera-sdk/tests/fixtures/time-expiry/src/contract.rs
@@ -59,7 +59,10 @@ impl Contract for TimeExpiryContract {
         panic!("TimeExpiry application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/linera-sdk/tests/fixtures/track-instantiation/src/contract.rs
+++ b/linera-sdk/tests/fixtures/track-instantiation/src/contract.rs
@@ -59,7 +59,10 @@ impl Contract for TrackInstantiationContract {
         *count += 1;
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -52,8 +52,11 @@ impl Contract for {project_name}Contract {{
 
     async fn execute_message(&mut self, _message: Self::Message) {{}}
 
-    async fn store(mut self) {{
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {{
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }}
 }}
 

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -297,6 +297,15 @@ fn generate_root_view_code(input: &ItemStruct) -> TokenStream2 {
                 self.post_save();
                 Ok(())
             }
+
+            async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+                use linera_views::{context::Context as _, batch::Batch, store::WritableKeyValueStore as _, views::View as _};
+                #metrics_code
+                let mut batch = Batch::new();
+                self.pre_save(&mut batch)?;
+                #write_batch_with_metrics
+                Ok(())
+            }
         }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -176,6 +176,9 @@ impl Hasher for sha3::Sha3_256 {
 pub trait RootView: View {
     /// Saves the root view to the database context
     async fn save(&mut self) -> Result<(), ViewError>;
+
+    /// Saves the root view to the database context and then drops it without calling `post_save`.
+    async fn save_and_drop(self) -> Result<(), ViewError>;
 }
 
 /// A [`View`] that also supports crypto hash


### PR DESCRIPTION
## Motivation

The `write_batch` of `fn save()` derive implementation of the `RootView` trait is followed by a `post_save`.
This does not make sense for the smart contract which takes `mut self` as input.

Fixes #4976 

## Proposal

Introduce a `fn save_and_drop(self)` function to the trait and implement it.
It turns out that there is no other use case than the smart contract where we consume a view and write it.

## Test Plan

CI

## Release Plan

It could definitely be backported to `testnet_conway` as it lead to a small gas reduction.

## Links

None.