### PR TITLE
Fix benchmark formatting crash and fork PR comment posting

### DIFF
--- a/.github/scripts/format-bench-results.sh
+++ b/.github/scripts/format-bench-results.sh
@@ -172,7 +172,8 @@ fi
 
 # Check for instruction-count regressions (>1% increase)
 if $HAS_CMP; then
-  declare -a REGRESSED_NAMES REGRESSED_PCTS
+  REGRESSED_NAMES=()
+  REGRESSED_PCTS=()
   for ((j = 0; j < COUNT; j++)); do
     pct="${B_IP[j]}"
     if [[ -n "$pct" ]] && awk "BEGIN { exit !($pct > 1) }"; then

--- a/.github/workflows/instruction-count-benchmarks.yml
+++ b/.github/workflows/instruction-count-benchmarks.yml
@@ -1,3 +1,5 @@
+# NOTE: post-benchmark-comment.yml references this workflow by name.
+# If you rename it, update the workflow_run trigger there too.
 name: Instruction Count Benchmarks
 
 on:
@@ -24,7 +26,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
   actions: read
 
 jobs:
@@ -133,20 +134,17 @@ jobs:
       env:
         BASELINE_SHA: ${{ steps.download-baseline.outputs.baseline_sha }}
         CACHE_INFO: ${{ steps.cache-info.outputs.cache_info }}
-    - name: Post PR comment
+    - name: Save PR number
       if: github.event_name == 'pull_request' && always()
-      run: |
-        COMMENT=$(cat /tmp/bench-comment.md)
-
-        PR=${{ github.event.pull_request.number }}
-        EXISTING=$(gh api "repos/${{ github.repository }}/issues/${PR}/comments" \
-          --jq '[.[] | select(.body | startswith("## Instruction Count Benchmark Results")) | .id] | last // empty')
-
-        if [ -n "$EXISTING" ]; then
-          gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" \
-            -X PATCH -f body="${COMMENT}"
-        else
-          gh pr comment "${PR}" --body "${COMMENT}"
-        fi
+      run: echo "$PR_NUMBER" > /tmp/pr-number.txt
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+    - name: Upload benchmark comment
+      if: github.event_name == 'pull_request' && always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: bench-comment
+        path: |
+          /tmp/bench-comment.md
+          /tmp/pr-number.txt
+        retention-days: 1

--- a/.github/workflows/post-benchmark-comment.yml
+++ b/.github/workflows/post-benchmark-comment.yml
@@ -1,0 +1,59 @@
+name: Post Benchmark Comment
+
+# Runs after "Instruction Count Benchmarks" completes. Using workflow_run gives
+# this job write permissions even when the triggering workflow was a fork PR
+# (where GITHUB_TOKEN is read-only).
+#
+# The workflow name below must match the `name:` in instruction-count-benchmarks.yml.
+# If that name changes, update it here too or comment posting will silently stop.
+
+on:
+  workflow_run:
+    workflows: ["Instruction Count Benchmarks"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  post-comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - name: Download benchmark comment artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: bench-comment
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: /tmp/bench-artifacts
+
+    - name: Post or update PR comment
+      run: |
+        PR=$(cat /tmp/bench-artifacts/pr-number.txt)
+        COMMENT=$(cat /tmp/bench-artifacts/bench-comment.md)
+
+        if [ -z "$COMMENT" ]; then
+          echo "No benchmark comment to post"
+          exit 0
+        fi
+
+        EXISTING=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+          --jq '[.[] | select(.body | startswith("## Instruction Count Benchmark Results")) | .id] | last // empty')
+
+        if [ -n "$EXISTING" ]; then
+          gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" \
+            -X PATCH -f body="${COMMENT}"
+          echo "Updated existing comment $EXISTING on PR #$PR"
+        else
+          gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+            -f body="${COMMENT}"
+          echo "Posted new comment on PR #$PR"
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

The "Instruction Count Benchmarks" workflow fails on every PR that has zero
instruction-count regressions and a baseline to compare against. Additionally, fork PRs
can't post benchmark comments because `GITHUB_TOKEN` is read-only for forks.

Both issues were introduced by #5487 but were masked because that PR had no baseline to
compare against (it was the first run of the workflow).

## Proposal

Two fixes:

1. **Bash empty array bug**: `declare -a REGRESSED_NAMES` doesn't actually initialize
the array. With `set -u`, checking `${#REGRESSED_NAMES[@]}` on an empty
declared-but-uninitialized array triggers "unbound variable". Fixed by using
`REGRESSED_NAMES=()` instead.

2. **Fork PR comment permissions**: Moved comment posting from the main workflow to a
separate `workflow_run`-triggered workflow (`post-benchmark-comment.yml`). The main
workflow now saves the formatted comment as an artifact. The new workflow downloads it
and posts it with write permissions, since `workflow_run` always runs in the context of
the base repository.

## Test Plan

CI
