### PR TITLE
[Testnet conway] clean up async calls after simplification of key-value store view

### DIFF
--- a/linera-core/src/client/requests_scheduler/node_info.rs
+++ b/linera-core/src/client/requests_scheduler/node_info.rs
@@ -66,7 +66,7 @@ impl<Env: Environment> NodeInfo<Env> {
     /// - **Success score**: Directly proportional to EMA success rate
     ///
     /// Returns a score from 0.0 to 1.0, where higher values indicate better performance.
-    pub(super) async fn calculate_score(&self) -> f64 {
+    pub(super) fn calculate_score(&self) -> f64 {
         // 1. Normalize latency (lower is better, so we invert)
         let latency_score = 1.0
             - (self.ema_latency_ms.min(self.max_expected_latency_ms)

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -485,7 +485,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
         let mut result = BTreeMap::new();
 
         for (key, info) in nodes.iter() {
-            let score = info.calculate_score().await;
+            let score = info.calculate_score();
             result.insert(
                 *key,
                 (score, info.ema_success_rate(), info.total_requests()),
@@ -529,7 +529,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
             let mut nodes_guard = nodes.write().await;
             if let Some(info) = nodes_guard.get_mut(&public_key) {
                 info.update_metrics(is_success, response_time_ms);
-                let score = info.calculate_score().await;
+                let score = info.calculate_score();
                 tracing::trace!(
                     node = %public_key,
                     address = %info.node.node.address(),
@@ -877,7 +877,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
         // Filter nodes that can accept requests and calculate their scores
         let mut scored_nodes = Vec::new();
         for info in nodes.values() {
-            let score = info.calculate_score().await;
+            let score = info.calculate_score();
             scored_nodes.push((score, info.node.clone()));
         }
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -234,7 +234,7 @@ where
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match query {
             Query::System(query) => {
-                let outcome = self.system.handle_query(context, query).await?;
+                let outcome = self.system.handle_query(context, query)?;
                 Ok(outcome.into())
             }
             Query::User {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -332,7 +332,7 @@ where
                 callback,
             } => {
                 let mut view = self.state.users.try_load_entry_mut(&id).await?;
-                view.write_batch(batch).await?;
+                view.write_batch(batch)?;
                 callback.respond(());
             }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -366,7 +366,7 @@ where
                 if !app_permissions.can_close_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
-                    self.state.system.close_chain().await?;
+                    self.state.system.close_chain()?;
                     callback.respond(Ok(()));
                 }
             }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -381,7 +381,7 @@ where
             ChangeApplicationPermissions(application_permissions) => {
                 self.application_permissions.set(application_permissions);
             }
-            CloseChain => self.close_chain().await?,
+            CloseChain => self.close_chain()?,
             Transfer {
                 owner,
                 amount,
@@ -799,7 +799,7 @@ where
         Ok(false)
     }
 
-    pub async fn handle_query(
+    pub fn handle_query(
         &mut self,
         context: QueryContext,
         _query: SystemQuery,
@@ -853,7 +853,7 @@ where
         Ok(child_id)
     }
 
-    pub async fn close_chain(&mut self) -> Result<(), ExecutionError> {
+    pub fn close_chain(&mut self) -> Result<(), ExecutionError> {
         self.closed.set(true);
         Ok(())
     }

--- a/linera-views/src/views/historical_hash_wrapper.rs
+++ b/linera-views/src/views/historical_hash_wrapper.rs
@@ -207,7 +207,7 @@ where
 
 impl<W: View> HistoricallyHashableView<W::Context, W> {
     /// Obtains a hash of the history of the changes in the view.
-    pub async fn historical_hash(&mut self) -> Result<HasherOutput, ViewError> {
+    pub fn historical_hash(&mut self) -> Result<HasherOutput, ViewError> {
         if let Some(hash) = self.hash.get_mut().unwrap() {
             return Ok(*hash);
         }
@@ -287,7 +287,7 @@ mod tests {
         assert!(!view.has_pending_changes().await);
 
         // Initial hash should be the hash of an empty batch with default stored_hash
-        let hash = view.historical_hash().await?;
+        let hash = view.historical_hash()?;
         assert_eq!(hash, HasherOutput::default());
 
         Ok(())
@@ -301,14 +301,14 @@ mod tests {
             HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
 
         // Get initial hash
-        let hash0 = view.historical_hash().await?;
+        let hash0 = view.historical_hash()?;
 
         // Set a value
         view.set(42);
         assert!(view.has_pending_changes().await);
 
         // Hash should change after modification
-        let hash1 = view.historical_hash().await?;
+        let hash1 = view.historical_hash()?;
 
         // Calling `historical_hash` doesn't flush changes.
         assert!(view.has_pending_changes().await);
@@ -320,11 +320,11 @@ mod tests {
         context.store().write_batch(batch).await?;
         view.post_save();
         assert!(!view.has_pending_changes().await);
-        assert_eq!(hash1, view.historical_hash().await?);
+        assert_eq!(hash1, view.historical_hash()?);
 
         // Make another modification
         view.set(84);
-        let hash2 = view.historical_hash().await?;
+        let hash2 = view.historical_hash()?;
         assert_ne!(hash1, hash2);
 
         Ok(())
@@ -343,14 +343,14 @@ mod tests {
         context.store().write_batch(batch).await?;
         view.post_save();
 
-        let hash_after_flush = view.historical_hash().await?;
+        let hash_after_flush = view.historical_hash()?;
 
         // Reload the view
         let mut view2 =
             HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
 
         // Hash should be the same (loaded from storage)
-        let hash_reloaded = view2.historical_hash().await?;
+        let hash_reloaded = view2.historical_hash()?;
         assert_eq!(hash_after_flush, hash_reloaded);
 
         Ok(())
@@ -369,13 +369,13 @@ mod tests {
         context.store().write_batch(batch).await?;
         view.post_save();
 
-        let hash_before = view.historical_hash().await?;
+        let hash_before = view.historical_hash()?;
         assert!(!view.has_pending_changes().await);
 
         // Make a modification
         view.set(84);
         assert!(view.has_pending_changes().await);
-        let hash_modified = view.historical_hash().await?;
+        let hash_modified = view.historical_hash()?;
         assert_ne!(hash_before, hash_modified);
 
         // Rollback
@@ -383,7 +383,7 @@ mod tests {
         assert!(!view.has_pending_changes().await);
 
         // Hash should return to previous value
-        let hash_after_rollback = view.historical_hash().await?;
+        let hash_after_rollback = view.historical_hash()?;
         assert_eq!(hash_before, hash_after_rollback);
 
         Ok(())
@@ -402,7 +402,7 @@ mod tests {
         context.store().write_batch(batch).await?;
         view.post_save();
 
-        assert_ne!(view.historical_hash().await?, HasherOutput::default());
+        assert_ne!(view.historical_hash()?, HasherOutput::default());
 
         // Clear the view
         view.clear();
@@ -416,7 +416,7 @@ mod tests {
         view.post_save();
 
         // Verify the view is not reset to default
-        assert_ne!(view.historical_hash().await?, HasherOutput::default());
+        assert_ne!(view.historical_hash()?, HasherOutput::default());
 
         Ok(())
     }
@@ -434,22 +434,22 @@ mod tests {
         context.store().write_batch(batch).await?;
         view.post_save();
 
-        let original_hash = view.historical_hash().await?;
+        let original_hash = view.historical_hash()?;
 
         // Clone the view
         let mut cloned_view = view.clone_unchecked()?;
 
         // Verify the clone has the same hash initially
-        let cloned_hash = cloned_view.historical_hash().await?;
+        let cloned_hash = cloned_view.historical_hash()?;
         assert_eq!(original_hash, cloned_hash);
 
         // Modify the clone
         cloned_view.set(84);
-        let cloned_hash_after = cloned_view.historical_hash().await?;
+        let cloned_hash_after = cloned_view.historical_hash()?;
         assert_ne!(original_hash, cloned_hash_after);
 
         // Original should be unchanged
-        let original_hash_after = view.historical_hash().await?;
+        let original_hash_after = view.historical_hash()?;
         assert_eq!(original_hash, original_hash_after);
 
         Ok(())
@@ -468,7 +468,7 @@ mod tests {
         view.set(42);
         assert!(view.has_pending_changes().await);
 
-        let hash_before_flush = view.historical_hash().await?;
+        let hash_before_flush = view.historical_hash()?;
 
         // Flush - this should update stored_hash
         let mut batch = Batch::new();
@@ -481,7 +481,7 @@ mod tests {
 
         // Make another change
         view.set(84);
-        let hash_after_second_change = view.historical_hash().await?;
+        let hash_after_second_change = view.historical_hash()?;
 
         // The new hash should be based on the previous stored hash
         assert_ne!(hash_before_flush, hash_after_second_change);
@@ -513,7 +513,7 @@ mod tests {
             let mut view =
                 HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
 
-            let mut previous_hash = view.historical_hash().await?;
+            let mut previous_hash = view.historical_hash()?;
             for &value in values {
                 view.set(value);
                 if value % 2 == 0 {
@@ -523,7 +523,7 @@ mod tests {
                     context.store().write_batch(batch).await?;
                     view.post_save();
                 }
-                let current_hash = view.historical_hash().await?;
+                let current_hash = view.historical_hash()?;
                 assert_ne!(previous_hash, current_hash);
                 previous_hash = current_hash;
             }
@@ -551,7 +551,7 @@ mod tests {
         context.store().write_batch(batch).await?;
         view.post_save();
 
-        let hash_before = view.historical_hash().await?;
+        let hash_before = view.historical_hash()?;
 
         // Flush again without changes - no new hash should be stored
         let mut batch = Batch::new();
@@ -560,7 +560,7 @@ mod tests {
         context.store().write_batch(batch).await?;
         view.post_save();
 
-        let hash_after = view.historical_hash().await?;
+        let hash_after = view.historical_hash()?;
         assert_eq!(hash_before, hash_after);
 
         Ok(())

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -362,9 +362,9 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 2], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 3], vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![0]).unwrap();
+    /// view.insert(vec![0, 2], vec![0]).unwrap();
+    /// view.insert(vec![0, 3], vec![0]).unwrap();
     /// let mut count = 0;
     /// view.for_each_index_while(|_key| {
     ///     count += 1;
@@ -433,9 +433,9 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 2], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 3], vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![0]).unwrap();
+    /// view.insert(vec![0, 2], vec![0]).unwrap();
+    /// view.insert(vec![0, 3], vec![0]).unwrap();
     /// let mut count = 0;
     /// view.for_each_index(|_key| {
     ///     count += 1;
@@ -466,8 +466,8 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 2], vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![0]).unwrap();
+    /// view.insert(vec![0, 2], vec![0]).unwrap();
     /// let mut values = Vec::new();
     /// view.for_each_index_value_while(|_key, value| {
     ///     values.push(value.to_vec());
@@ -537,8 +537,8 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 2], vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![0]).unwrap();
+    /// view.insert(vec![0, 2], vec![0]).unwrap();
     /// let mut part_keys = Vec::new();
     /// view.for_each_index_while(|key| {
     ///     part_keys.push(key.to_vec());
@@ -568,8 +568,8 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 2], vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![0]).unwrap();
+    /// view.insert(vec![0, 2], vec![0]).unwrap();
     /// let indices = view.indices().await.unwrap();
     /// assert_eq!(indices, vec![vec![0, 1], vec![0, 2]]);
     /// # })
@@ -592,8 +592,8 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 2], vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![0]).unwrap();
+    /// view.insert(vec![0, 2], vec![0]).unwrap();
     /// let key_values = view.indices().await.unwrap();
     /// assert_eq!(key_values, vec![vec![0, 1], vec![0, 2]]);
     /// # })
@@ -640,7 +640,7 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![42]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![42]).unwrap();
     /// assert_eq!(view.get(&[0, 1]).await.unwrap(), Some(vec![42]));
     /// assert_eq!(view.get(&[0, 2]).await.unwrap(), None);
     /// # })
@@ -674,7 +674,7 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![42]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![42]).unwrap();
     /// assert!(view.contains_key(&[0, 1]).await.unwrap());
     /// assert!(!view.contains_key(&[0, 2]).await.unwrap());
     /// # })
@@ -708,7 +708,7 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![42]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![42]).unwrap();
     /// let keys = vec![vec![0, 1], vec![0, 2]];
     /// let results = view.contains_keys(&keys).await.unwrap();
     /// assert_eq!(results, vec![true, false]);
@@ -755,7 +755,7 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![42]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![42]).unwrap();
     /// assert_eq!(
     ///     view.multi_get(&[vec![0, 1], vec![0, 2]]).await.unwrap(),
     ///     vec![Some(vec![42]), None]
@@ -808,16 +808,16 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![34]).await.unwrap();
-    /// view.insert(vec![3, 4], vec![42]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![34]).unwrap();
+    /// view.insert(vec![3, 4], vec![42]).unwrap();
     /// let mut batch = Batch::new();
     /// batch.delete_key_prefix(vec![0]);
-    /// view.write_batch(batch).await.unwrap();
+    /// view.write_batch(batch).unwrap();
     /// let key_values = view.find_key_values_by_prefix(&[0]).await.unwrap();
     /// assert_eq!(key_values, vec![]);
     /// # })
     /// ```
-    pub async fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
+    pub fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY.measure_latency();
         *self.hash.get_mut().unwrap() = None;
@@ -862,14 +862,14 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![34]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![34]).unwrap();
     /// assert_eq!(view.get(&[0, 1]).await.unwrap(), Some(vec![34]));
     /// # })
     /// ```
-    pub async fn insert(&mut self, index: Vec<u8>, value: Vec<u8>) -> Result<(), ViewError> {
+    pub fn insert(&mut self, index: Vec<u8>, value: Vec<u8>) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.put_key_value_bytes(index, value);
-        self.write_batch(batch).await
+        self.write_batch(batch)
     }
 
     /// Removes a value. If absent then the action has no effect.
@@ -880,15 +880,15 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![34]).await.unwrap();
-    /// view.remove(vec![0, 1]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![34]).unwrap();
+    /// view.remove(vec![0, 1]).unwrap();
     /// assert_eq!(view.get(&[0, 1]).await.unwrap(), None);
     /// # })
     /// ```
-    pub async fn remove(&mut self, index: Vec<u8>) -> Result<(), ViewError> {
+    pub fn remove(&mut self, index: Vec<u8>) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.delete_key(index);
-        self.write_batch(batch).await
+        self.write_batch(batch)
     }
 
     /// Deletes a key prefix.
@@ -899,15 +899,15 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![34]).await.unwrap();
-    /// view.remove_by_prefix(vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![34]).unwrap();
+    /// view.remove_by_prefix(vec![0]).unwrap();
     /// assert_eq!(view.get(&[0, 1]).await.unwrap(), None);
     /// # })
     /// ```
-    pub async fn remove_by_prefix(&mut self, key_prefix: Vec<u8>) -> Result<(), ViewError> {
+    pub fn remove_by_prefix(&mut self, key_prefix: Vec<u8>) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.delete_key_prefix(key_prefix);
-        self.write_batch(batch).await
+        self.write_batch(batch)
     }
 
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
@@ -918,8 +918,8 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![34]).await.unwrap();
-    /// view.insert(vec![3, 4], vec![42]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![34]).unwrap();
+    /// view.insert(vec![3, 4], vec![42]).unwrap();
     /// let keys = view.find_keys_by_prefix(&[0]).await.unwrap();
     /// assert_eq!(keys, vec![vec![1]]);
     /// # })
@@ -995,8 +995,8 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![34]).await.unwrap();
-    /// view.insert(vec![3, 4], vec![42]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![34]).unwrap();
+    /// view.insert(vec![3, 4], vec![42]).unwrap();
     /// let key_values = view.find_key_values_by_prefix(&[0]).await.unwrap();
     /// assert_eq!(key_values, vec![(vec![1], vec![34])]);
     /// # })
@@ -1209,7 +1209,7 @@ impl<C: Context> WritableKeyValueStore for ViewContainer<C> {
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewContainerError> {
         let mut view = self.view.write().await;
-        view.write_batch(batch).await?;
+        view.write_batch(batch)?;
         let mut batch = Batch::new();
         view.pre_save(&mut batch)?;
         view.post_save();

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -616,8 +616,8 @@ impl<C: Context> KeyValueStoreView<C> {
     /// # use linera_views::views::View;
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0]).await.unwrap();
-    /// view.insert(vec![0, 2], vec![0]).await.unwrap();
+    /// view.insert(vec![0, 1], vec![0]).unwrap();
+    /// view.insert(vec![0, 2], vec![0]).unwrap();
     /// let count = view.count().await.unwrap();
     /// assert_eq!(count, 2);
     /// # })

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -171,7 +171,7 @@ async fn key_value_store_view_mutability() -> Result<()> {
                         .collect::<Vec<_>>();
                     all_keys.insert(key.clone());
                     let value = Vec::new();
-                    view.store.insert(key.clone(), value.clone()).await?;
+                    view.store.insert(key.clone(), value.clone())?;
                     new_state_map.insert(key, value);
 
                     new_state_vec = new_state_map.clone().into_iter().collect();
@@ -186,14 +186,14 @@ async fn key_value_store_view_mutability() -> Result<()> {
                     let pos = rng.gen_range(0..entry_count);
                     let (key, _) = new_state_vec[pos].clone();
                     new_state_map.remove(&key);
-                    view.store.remove(key).await?;
+                    view.store.remove(key)?;
                 }
             }
             if choice == 2 && entry_count > 0 {
                 // deleting a prefix
                 let val = rng.gen_range(0..5) as u8;
                 let key_prefix = vec![val];
-                view.store.remove_by_prefix(key_prefix.clone()).await?;
+                view.store.remove_by_prefix(key_prefix.clone())?;
                 remove_by_prefix(&mut new_state_map, key_prefix);
             }
             if choice == 3 {

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -932,7 +932,7 @@ where
         let key_str = format!("{:?}", &key);
         let value_usize = (*value.first().unwrap()) as usize;
         view.map.insert(&key_str, value_usize)?;
-        view.key_value_store.insert(key, value).await?;
+        view.key_value_store.insert(key, value)?;
         {
             let subview = view.collection.load_entry_mut(&key_str).await?;
             subview.push(value_usize as u32);
@@ -967,7 +967,7 @@ where
                 tmp += first_value_u64;
                 view.x1.set(tmp);
                 view.map.insert(&key_str, first_value_usize)?;
-                view.key_value_store.insert(key, value).await?;
+                view.key_value_store.insert(key, value)?;
                 {
                     let subview = view.collection.load_entry_mut(&key_str).await?;
                     subview.push(first_value as u32);
@@ -976,7 +976,7 @@ where
             Delete { key } => {
                 let key_str = format!("{:?}", &key);
                 view.map.remove(&key_str)?;
-                view.key_value_store.remove(key).await?;
+                view.key_value_store.remove(key)?;
             }
             DeletePrefix { key_prefix: _ } => {}
         }
@@ -1095,8 +1095,7 @@ where
                 view.map.insert(&str0, pair1_first_u8 as usize)?;
                 view.map.insert(&str1, pair0_first_u8 as usize)?;
                 view.key_value_store
-                    .insert(pair.0.clone(), pair.1.clone())
-                    .await?;
+                    .insert(pair.0.clone(), pair.1.clone())?;
                 if choice == 0 {
                     view.rollback();
                     let hash_new = view.hash().await?;


### PR DESCRIPTION
## Motivation

Following PR #5446 the `write_batch` function has become sync but we have kept its status as async.
This is incorrect,

## Proposal

Remove the async property of `write_batch`and of other functions that should are in fact sync.

## Test Plan

CI

## Release Plan

On testnet_conway is the point here.

## Links

None.