### PR TITLE
Add --prioritize-bundles-from flag for priority-based bundle selection

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -140,6 +140,7 @@ Client implementation and command-line tool for the Linera blockchain
 
   Default value: `10`
 * `--staging-bundles-time-budget-ms <STAGING_BUNDLES_TIME_BUDGET>` — Time budget for staging message bundles in milliseconds. When set, limits bundle execution by wall-clock time, in addition to the count limit from `max_pending_message_bundles`
+* `--prioritize-bundles-from <PRIORITIZE_BUNDLES_FROM>` — Comma-separated list of chain IDs whose incoming bundles should be processed first
 * `--chain-worker-ttl-ms <CHAIN_WORKER_TTL>` — The duration in milliseconds after which an idle chain worker will free its memory
 
   Default value: `30000`

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -315,6 +315,7 @@ where
             name,
             options.chain_worker_ttl,
             options.sender_chain_worker_ttl,
+            options.prioritize_bundles_from.clone().unwrap_or_default(),
             options.to_chain_client_options(),
             options.to_requests_scheduler_config(),
         );

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -72,6 +72,10 @@ pub struct Options {
     #[arg(long = "staging-bundles-time-budget-ms", value_parser = util::parse_millis)]
     pub staging_bundles_time_budget: Option<Duration>,
 
+    /// Comma-separated list of chain IDs whose incoming bundles should be processed first.
+    #[arg(long, value_parser = util::parse_chain_set)]
+    pub prioritize_bundles_from: Option<HashSet<ChainId>>,
+
     /// The duration in milliseconds after which an idle chain worker will free its memory.
     #[arg(
         long = "chain-worker-ttl-ms",

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use futures::{lock::Mutex, FutureExt as _};
 use linera_base::{
@@ -122,6 +122,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             format!("Client node for {:.8}", chain_id0),
             Duration::from_secs(30),
             Duration::from_secs(1),
+            HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
         )),
@@ -233,6 +234,7 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
             "Client node with follow-only and owned chains".to_string(),
             Duration::from_secs(30),
             Duration::from_secs(1),
+            HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
         )),
@@ -380,6 +382,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
             "Client node with no chains".to_string(),
             Duration::from_secs(30),
             Duration::from_secs(1),
+            HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
         )),
@@ -455,6 +458,7 @@ async fn test_chain_listener_listen_command_adds_chains_to_wallet() -> anyhow::R
             "Client node with no chains".to_string(),
             Duration::from_secs(30),
             Duration::from_secs(1),
+            HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
         )),
@@ -570,6 +574,7 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
             format!("Client node for {:.8}", chain_id0),
             Duration::from_secs(30),
             Duration::from_secs(1),
+            HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
         )),
@@ -769,6 +774,7 @@ async fn test_chain_listener_sparse_event_download() -> anyhow::Result<()> {
             format!("Client node for {:.8}", receiver_id),
             Duration::from_secs(30),
             Duration::from_secs(1),
+            HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
         )),

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -3,9 +3,9 @@
 
 //! Configuration parameters for the chain worker.
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
-use linera_base::{crypto::ValidatorSecretKey, time::Duration};
+use linera_base::{crypto::ValidatorSecretKey, identifiers::ChainId, time::Duration};
 
 use crate::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES;
 
@@ -31,6 +31,8 @@ pub struct ChainWorkerConfig {
     pub sender_chain_ttl: Duration,
     /// The size to truncate receive log entries in chain info responses.
     pub chain_info_max_received_log_entries: usize,
+    /// Chain IDs whose incoming bundles should be processed first.
+    pub priority_bundle_origins: HashSet<ChainId>,
 }
 
 impl ChainWorkerConfig {
@@ -57,6 +59,7 @@ impl Default for ChainWorkerConfig {
             ttl: Default::default(),
             sender_chain_ttl: Default::default(),
             chain_info_max_received_log_entries: CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+            priority_bundle_origins: HashSet::new(),
         }
     }
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1752,7 +1752,14 @@ where
                     });
                 }
             }
-            bundles.sort_by_key(|b| b.bundle.timestamp);
+            let priority_origins = &self.config.priority_bundle_origins;
+            bundles.sort_by(|a, b| {
+                let a_priority = priority_origins.contains(&a.origin);
+                let b_priority = priority_origins.contains(&b.origin);
+                b_priority
+                    .cmp(&a_priority)
+                    .then(a.bundle.timestamp.cmp(&b.bundle.timestamp))
+            });
             info.requested_pending_message_bundles = bundles;
         }
         let hashes = chain

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -277,6 +277,7 @@ impl<Env: Environment> Client<Env> {
         name: impl Into<String>,
         chain_worker_ttl: Duration,
         sender_chain_worker_ttl: Duration,
+        priority_bundle_origins: HashSet<ChainId>,
         options: ChainClientOptions,
         requests_scheduler_config: requests_scheduler::RequestsSchedulerConfig,
     ) -> Self {
@@ -290,7 +291,8 @@ impl<Env: Environment> Client<Env> {
         .with_allow_inactive_chains(true)
         .with_allow_messages_from_deprecated_epochs(true)
         .with_chain_worker_ttl(chain_worker_ttl)
-        .with_sender_chain_worker_ttl(sender_chain_worker_ttl);
+        .with_sender_chain_worker_ttl(sender_chain_worker_ttl)
+        .with_priority_bundle_origins(priority_bundle_origins);
         let local_node = LocalNodeClient::new(state);
         let requests_scheduler = RequestsScheduler::new(vec![], requests_scheduler_config);
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1091,6 +1091,7 @@ where
             format!("Client node for {:.8}", chain_id),
             Duration::from_secs(30),
             Duration::from_secs(1),
+            HashSet::new(),
             options,
             crate::client::RequestsSchedulerConfig::default(),
         ));

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -8,7 +8,7 @@
 mod wasm;
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     iter,
     sync::{Arc, Mutex},
     time::Duration,
@@ -171,6 +171,11 @@ where
 
     fn worker(&self) -> &WorkerState<S> {
         &self.worker
+    }
+
+    fn with_priority_bundle_origins(mut self, origins: HashSet<ChainId>) -> Self {
+        self.worker = self.worker.with_priority_bundle_origins(origins);
+        self
     }
 
     fn admin_public_key(&self) -> AccountPublicKey {
@@ -4354,6 +4359,85 @@ where
         env.worker().handle_block_proposal(bad_proposal).await,
         Err(WorkerError::ChainError(chain_error))
             if matches!(*chain_error, ChainError::IncorrectMessageOrder { .. })
+    );
+
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_pending_bundles_priority_ordering<B>(mut storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_1_key = AccountSecretKey::generate();
+    let sender_2_key = AccountSecretKey::generate();
+    let storage = storage_builder.build().await?;
+
+    // Source chain 1 (non-priority) has index 1, source chain 3 (priority) has index 3.
+    let chain_1_desc = dummy_chain_description(1);
+    let chain_1 = chain_1_desc.id();
+    let chain_3_desc = dummy_chain_description(3);
+    let chain_3 = chain_3_desc.id();
+
+    let mut env = TestEnvironment::new(storage, false, false)
+        .await
+        .with_priority_bundle_origins(HashSet::from([chain_3]));
+
+    // Target chain 2 receives messages from both sources.
+    let chain_2_desc = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ONE)
+        .await;
+    let chain_2 = chain_2_desc.id();
+
+    // Send from chain 1 (non-priority) first — it would normally appear first by timestamp.
+    let certificate_1 = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            sender_1_key.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::ZERO,
+            vec![],
+        )
+        .await;
+    env.worker()
+        .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate_1))
+        .await?;
+
+    // Send from chain 3 (priority) second — later timestamp but should appear first.
+    let certificate_3 = env
+        .make_simple_transfer_certificate(
+            chain_3_desc,
+            sender_2_key.public(),
+            chain_2,
+            Amount::from_tokens(3),
+            Vec::new(),
+            Amount::ZERO,
+            vec![],
+        )
+        .await;
+    env.worker()
+        .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate_3))
+        .await?;
+
+    // Query pending bundles and verify priority chain's bundle comes first.
+    let query = ChainInfoQuery::new(chain_2).with_pending_message_bundles();
+    let (response, _actions) = env.worker().handle_chain_info_query(query).await?;
+    let bundles = &response.info.requested_pending_message_bundles;
+
+    assert_eq!(bundles.len(), 2);
+    assert_eq!(
+        bundles[0].origin, chain_3,
+        "Priority chain bundle should be first"
+    );
+    assert_eq!(
+        bundles[1].origin, chain_1,
+        "Non-priority chain bundle should be second"
     );
 
     Ok(())

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
@@ -617,6 +617,14 @@ where
     #[instrument(level = "trace", skip(self))]
     pub fn with_sender_chain_worker_ttl(mut self, sender_chain_worker_ttl: Duration) -> Self {
         self.chain_worker_config.sender_chain_ttl = sender_chain_worker_ttl;
+        self
+    }
+
+    /// Returns an instance with the specified set of chain IDs whose incoming bundles
+    /// should be processed first.
+    #[instrument(level = "trace", skip(self, origins))]
+    pub fn with_priority_bundle_origins(mut self, origins: HashSet<ChainId>) -> Self {
+        self.chain_worker_config.priority_bundle_origins = origins;
         self
     }
 

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use linera_base::{
     crypto::InMemorySigner,
@@ -64,6 +64,7 @@ pub async fn new_test_client_context(
             name,
             chain_worker_ttl,
             sender_chain_worker_ttl,
+            HashSet::new(),
             ChainClientOptions {
                 cross_chain_message_delivery: CrossChainMessageDelivery::Blocking,
                 ..ChainClientOptions::test_default()


### PR DESCRIPTION
## Motivation

When one market chain receives heavy traffic, its messages dominate the inbox, delaying
oracle resolution messages that need to be snappy for good UX.

Closes #5673

## Proposal

Add a `--prioritize-bundles-from` CLI flag that accepts a comma-separated list of chain
IDs. Bundles from those chains are sorted to the front when the chain worker responds to
`pending_message_bundles` queries. Within each group (priority vs non-priority),
timestamp ordering is preserved.

The sort happens at the source — in `handle_chain_info_query` — so downstream consumers
(`pending_message_bundles()`, time budget, `max_pending_message_bundles` cap) all
naturally respect the priority ordering without any changes.

When the flag is not set (default), the `HashSet` is empty, `contains()` is always
false, and the sort falls through to pure timestamp comparison — identical to current
behavior.

## Test Plan

CI, plus a new integration test (`test_pending_bundles_priority_ordering`) that sends
cross-chain messages from two source chains to a target, marks one as priority, and
asserts the priority chain's bundle appears first in the pending bundles query response.

