### PR TITLE
[testnet] Introduce the `save_and_drop`

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -313,8 +313,11 @@ impl Contract for AmmContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/controller/src/contract.rs
+++ b/examples/controller/src/contract.rs
@@ -149,8 +149,11 @@ impl Contract for ControllerContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/counter-no-graphql/src/contract.rs
+++ b/examples/counter-no-graphql/src/contract.rs
@@ -57,8 +57,11 @@ impl Contract for CounterContract {
         panic!("Counter application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -66,8 +66,11 @@ impl Contract for CounterContract {
     }
 
     // ANCHOR: store
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
     // ANCHOR_END: store
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -80,8 +80,11 @@ impl Contract for CrowdFundingContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/ethereum-tracker/src/contract.rs
+++ b/examples/ethereum-tracker/src/contract.rs
@@ -70,8 +70,11 @@ impl Contract for EthereumTrackerContract {
         panic!("Messages not supported");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/evm-bridge/src/contract.rs
+++ b/examples/evm-bridge/src/contract.rs
@@ -73,8 +73,11 @@ impl Contract for EvmBridgeContract {
 
     async fn execute_message(&mut self, _message: ()) {}
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -152,8 +152,11 @@ impl Contract for FungibleTokenContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/game-of-life-challenge/src/contract.rs
+++ b/examples/game-of-life-challenge/src/contract.rs
@@ -73,8 +73,11 @@ impl Contract for GolChallengeContract {
         unreachable!();
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/gen-nft/src/contract.rs
+++ b/examples/gen-nft/src/contract.rs
@@ -125,8 +125,11 @@ impl Contract for GenNftContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -96,8 +96,11 @@ impl Contract for HexContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -129,8 +129,11 @@ impl Contract for MatchingEngineContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -129,8 +129,11 @@ impl Contract for NonFungibleTokenContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -309,8 +309,11 @@ impl Contract for RfqContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -102,8 +102,11 @@ impl Contract for SocialContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/examples/task-processor/src/contract.rs
+++ b/examples/task-processor/src/contract.rs
@@ -63,7 +63,10 @@ impl Contract for TaskProcessorContract {
         panic!("Task processor application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/examples/time-expiry/src/contract.rs
+++ b/examples/time-expiry/src/contract.rs
@@ -59,7 +59,10 @@ impl Contract for TimeExpiryContract {
         panic!("TimeExpiry application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/examples/wrapped-fungible/src/contract.rs
+++ b/examples/wrapped-fungible/src/contract.rs
@@ -153,8 +153,11 @@ impl Contract for WrappedFungibleTokenContract {
         }
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }
 

--- a/linera-sdk/tests/fixtures/create-and-call/src/contract.rs
+++ b/linera-sdk/tests/fixtures/create-and-call/src/contract.rs
@@ -88,7 +88,10 @@ impl Contract for CreateAndCallContract {
         panic!("Create and call application doesn't support any cross-chain messages");
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/linera-sdk/tests/fixtures/track-instantiation/src/contract.rs
+++ b/linera-sdk/tests/fixtures/track-instantiation/src/contract.rs
@@ -59,7 +59,10 @@ impl Contract for TrackInstantiationContract {
         *count += 1;
     }
 
-    async fn store(mut self) {
-        self.state.save().await.expect("Failed to save state");
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
     }
 }

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -254,6 +254,15 @@ fn generate_root_view_code(input: ItemStruct) -> TokenStream2 {
                 self.post_save();
                 Ok(())
             }
+
+            async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+                use linera_views::{context::Context as _, batch::Batch, store::WritableKeyValueStore as _, views::View as _};
+                #metrics_code
+                let mut batch = Batch::new();
+                self.pre_save(&mut batch)?;
+                #write_batch_with_metrics
+                Ok(())
+            }
         }
     }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_C_with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_CustomContext_with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T_.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__GenericContext_T__with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType.snap
@@ -19,4 +19,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_custom__path__to__ContextType_with_where.snap
@@ -20,4 +20,16 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            self.context().store().write_batch(batch).await?;
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_C_with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_CustomContext_with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T_.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType.snap
@@ -34,4 +34,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_root_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -35,4 +35,31 @@ where
         self.post_save();
         Ok(())
     }
+    async fn save_and_drop(self) -> Result<(), linera_views::ViewError> {
+        use linera_views::{
+            context::Context as _, batch::Batch, store::WritableKeyValueStore as _,
+            views::View as _,
+        };
+        #[cfg(not(target_arch = "wasm32"))]
+        linera_views::metrics::increment_counter(
+            &linera_views::metrics::SAVE_VIEW_COUNTER,
+            stringify!(TestView),
+            &self.context().base_key().bytes,
+        );
+        let mut batch = Batch::new();
+        self.pre_save(&mut batch)?;
+        if !batch.is_empty() {
+            #[cfg(not(target_arch = "wasm32"))]
+            let start = std::time::Instant::now();
+            self.context().store().write_batch(batch).await?;
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+                linera_views::metrics::SAVE_VIEW_LATENCY
+                    .with_label_values(&[stringify!(TestView)])
+                    .observe(latency_ms);
+            }
+        }
+        Ok(())
+    }
 }

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -176,6 +176,9 @@ impl Hasher for sha3::Sha3_256 {
 pub trait RootView: View {
     /// Saves the root view to the database context
     async fn save(&mut self) -> Result<(), ViewError>;
+
+    /// Saves the root view to the database context and drops it without calling `post_save`.
+    async fn save_and_drop(self) -> Result<(), ViewError>;
 }
 
 /// A [`View`] that also supports crypto hash


### PR DESCRIPTION
## Motivation

The `fn save()` is calling the `post_save` which is useless when the view is consumed which is the case for the finalize function of the smart contract.

## Proposal

This occurrence of consuming a view that is being saved occurred only for the smart contract.

## Test Plan

CI

## Release Plan

This is for `testnet_conway`.

## Links

None.