### PR TITLE
Gate Tempo deployment on otel_endpoint being configured

### DIFF
--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -181,6 +181,7 @@ releases:
     namespace: tempo
     chart: grafana/tempo
     timeout: 900
+    installed: {{ ne (env "LINERA_HELMFILE_SET_OTLP_EXPORTER_ENDPOINT" | default "") "" }}
     values:
       - {{ env "LINERA_HELMFILE_VALUES_LINERA_CORE" | default "values-local.yaml.gotmpl" }}
   - name: observability-alloy


### PR DESCRIPTION
## Motivation

Tempo is unconditionally deployed via helmfile even when `otel_endpoint` is not
configured, wasting resources (pod + 100Gi PVC) on clusters that don't use
distributed tracing.

## Proposal

Add an `installed:` condition to the Tempo helmfile release that checks whether
`LINERA_HELMFILE_SET_OTLP_EXPORTER_ENDPOINT` is set. When `otel_endpoint` is
null in network properties, lineractl doesn't set this env var, so Tempo won't
be deployed.

## Test Plan

CI
