### PR TITLE
Revert to usage of nc (instead of wget)

### DIFF
--- a/docker/docker-compose.bridge-test.yml
+++ b/docker/docker-compose.bridge-test.yml
@@ -259,7 +259,7 @@ services:
       bridge-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:9091/health || exit 1"]
+      test: ["CMD-SHELL", "nc -z localhost ${BLOCK_EXPORTER_PORT:-8882}"]
       interval: 5s
       timeout: 3s
       retries: 10


### PR DESCRIPTION
## Motivation

Docker compose up fails b/c wget is missing

## Proposal

Revert back to `nc`

## Test Plan

CI and manual

## Release Plan

None for now

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
