### PR TITLE
Switch ScyllaDB compaction to LCS and enable immediate tombstone GC

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -920,12 +920,8 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
                     PRIMARY KEY (root_key, k) \
                 ) \
                 WITH compaction = {{ \
-                    'class'            : 'SizeTieredCompactionStrategy', \
-                    'min_sstable_size' : 52428800, \
-                    'bucket_low'       : 0.5, \
-                    'bucket_high'      : 1.5, \
-                    'min_threshold'    : 4, \
-                    'max_threshold'    : 32 \
+                    'class'          : 'LeveledCompactionStrategy', \
+                    'sstable_size_in_mb' : 160 \
                 }} \
                 AND compression = {{ \
                     'sstable_compression': 'LZ4Compressor', \
@@ -933,7 +929,9 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
                 }} \
                 AND caching = {{ \
                     'enabled': 'true' \
-                }}",
+                }} \
+                AND gc_grace_seconds = 0 \
+                AND tombstone_gc = {{'mode': 'immediate'}}",
                 KEYSPACE, namespace
             ))
             .await?;


### PR DESCRIPTION
## Motivation

ScyllaDB read latencies spiked on testnet-conway due to tombstone accumulation and
SSTable count explosion. STCS compaction couldn't keep up with the write rate, SSTable
counts reached 165 (target: 4), and the default `gc_grace_seconds` of 10 days prevented
tombstone purging during compaction. Once the working set exceeded cache capacity, reads
fell to disk and had to scan through 100+ tombstone-heavy SSTables, saturating the
reader concurrency semaphore and causing p99 read latency to spike to seconds.

## Proposal

- Switch compaction strategy from `SizeTieredCompactionStrategy` to
`LeveledCompactionStrategy` with 160MB SSTable size. LCS keeps SSTable counts bounded
and reads only touch 1-2 SSTables per level, which matches our read-heavy workload (5:1
read:write ratio).
- Set `gc_grace_seconds = 0` since we run RF=1 with a single node per cluster, so
there's no need to wait for tombstone propagation to replicas.
- Set `tombstone_gc = immediate` so compaction can purge tombstones without waiting for
any grace period or repair cycle.

## Test Plan

CI. Already applied these settings manually via ALTER TABLE on all testnet-conway
validators and confirmed read latency recovered.
