### PR TITLE
feat(helm): use HTTP health probes for block-exporter

### DIFF
--- a/kubernetes/linera-validator/templates/block-exporter.yaml
+++ b/kubernetes/linera-validator/templates/block-exporter.yaml
@@ -183,18 +183,18 @@ spec:
           startupProbe:
             httpGet:
               path: /health
-              port: {{ .Values.blockExporter.port }}
+              port: {{ .Values.blockExporter.metricsPort }}
             failureThreshold: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.blockExporter.port }}
+              port: {{ .Values.blockExporter.metricsPort }}
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /health
-              port: {{ .Values.blockExporter.port }}
+              port: {{ .Values.blockExporter.metricsPort }}
             periodSeconds: 5
       volumes:
         - name: configmap


### PR DESCRIPTION
## Summary

- Replace `tcpSocket` probes with `httpGet` on `/health` endpoint for the block-exporter StatefulSet
- Add `startupProbe` (30 x 10s = 300s budget) to handle slow startup without liveness probe killing the pod
- Remove `initialDelaySeconds` from liveness/readiness (startup probe handles this now)

## Motivation

The `/health` endpoint (added in 1aafb0ed66) returns 200 when healthy and 500 when unhealthy. Using HTTP probes provides actual application-level health checking instead of just verifying port availability via TCP.

Closes https://github.com/linera-io/linera-infra/issues/678

## Test plan

- Deploy to testnet_conway via `helmfile apply`
- Verify block-exporter pods start and pass all three probes
- Verify unhealthy exporters are detected and restarted