### PR TITLE
Unify client mutex and proposal state. #5666

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -423,7 +423,7 @@ impl<Env: Environment> ClientContext<Env> {
             .and_then(|chain| chain.owner);
 
         let new_chain = wallet::Chain {
-            pending_proposal: client.pending_proposal().clone(),
+            pending_proposal: client.pending_proposal().await,
             owner: existing_owner,
             ..info.as_ref().into()
         };
@@ -971,7 +971,7 @@ impl<Env: Environment> ClientContext<Env> {
             for chain_client in chain_clients {
                 let info = chain_client.chain_info().await?;
                 let client_owner = chain_client.preferred_owner();
-                let pending_proposal = chain_client.pending_proposal().clone();
+                let pending_proposal = chain_client.pending_proposal().await;
                 self.wallet()
                     .insert(
                         info.chain_id,

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -69,7 +69,7 @@ impl chain_listener::ClientContext for ClientContext {
     ) -> Result<(), Error> {
         let info = client.chain_info().await?;
         let existing_owner = self.wallet().get(info.chain_id).and_then(|c| c.owner);
-        let pending_proposal = client.pending_proposal().clone();
+        let pending_proposal = client.pending_proposal().await;
         self.wallet().insert(
             info.chain_id,
             wallet::Chain {

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -323,43 +323,23 @@ impl<Env: Environment> ChainClient<Env> {
         self.client.is_chain_follow_only(self.chain_id)
     }
 
-    /// Gets the client mutex from the chain's state.
+    /// Returns the proposal mutex for this chain.
+    ///
+    /// The mutex serializes block proposals and holds the pending proposal (if any).
     #[instrument(level = "trace", skip(self))]
-    fn client_mutex(&self) -> Arc<tokio::sync::Mutex<()>> {
+    fn proposal_mutex(&self) -> Arc<tokio::sync::Mutex<Option<PendingProposal>>> {
         self.client
             .chains
             .pin()
             .get(&self.chain_id)
             .expect("Chain client constructed for invalid chain")
-            .client_mutex()
+            .proposal_mutex()
     }
 
-    /// Gets the next pending block.
+    /// Returns the pending proposal, if any.
     #[instrument(level = "trace", skip(self))]
-    pub fn pending_proposal(&self) -> Option<PendingProposal> {
-        self.client
-            .chains
-            .pin()
-            .get(&self.chain_id)
-            .expect("Chain client constructed for invalid chain")
-            .pending_proposal()
-            .clone()
-    }
-
-    /// Updates the chain's state using a closure.
-    #[instrument(level = "trace", skip(self, f))]
-    fn update_state<F>(&self, f: F)
-    where
-        F: Fn(&mut State),
-    {
-        let chains = self.client.chains.pin();
-        chains
-            .update(self.chain_id, |state| {
-                let mut state = state.clone_for_update_unchecked();
-                f(&mut state);
-                state
-            })
-            .expect("Chain client constructed for invalid chain");
+    pub async fn pending_proposal(&self) -> Option<PendingProposal> {
+        self.proposal_mutex().lock().await.clone()
     }
 
     /// Gets a reference to the client's signer instance.
@@ -488,7 +468,6 @@ impl<Env: Environment> ChainClient<Env> {
             .local_node
             .handle_chain_info_query(query)
             .await?;
-        self.client.update_from_info(&response.info);
         Ok(response.info)
     }
 
@@ -503,7 +482,6 @@ impl<Env: Environment> ChainClient<Env> {
             .local_node
             .handle_chain_info_query(query)
             .await?;
-        self.client.update_from_info(&response.info);
         Ok(response.info)
     }
 
@@ -744,7 +722,6 @@ impl<Env: Environment> ChainClient<Env> {
                 .await?;
         }
 
-        self.client.update_from_info(&info);
         Ok(info)
     }
 
@@ -1162,7 +1139,7 @@ impl<Env: Environment> ChainClient<Env> {
                 .communicate_chain_action(committee, action, value)
                 .await?,
         );
-        self.client.process_certificate(certificate.clone()).await?;
+        self.client.handle_certificate(*certificate.clone()).await?;
         // The block height didn't increase, but this will communicate the timeout as well.
         self.client
             .communicate_chain_updates(
@@ -1266,10 +1243,22 @@ impl<Env: Environment> ChainClient<Env> {
         #[cfg(with_metrics)]
         let _latency = super::metrics::EXECUTE_BLOCK_LATENCY.measure_latency();
 
-        let mutex = self.client_mutex();
-        let _guard = mutex.lock_owned().await;
+        let mutex = self.proposal_mutex();
+        let lock_start = linera_base::time::Instant::now();
+        let mut proposal_guard = mutex.lock_owned().await;
+        tracing::debug!(
+            lock_wait_ms = lock_start.elapsed().as_millis(),
+            "acquired proposal_mutex in execute_block"
+        );
         // TODO(#5092): We shouldn't need to call this explicitly.
-        match self.process_pending_block_without_prepare().await? {
+        // Process any leftover pending proposal from a previous interrupted call.
+        // Even if there is no pending proposal, this still calls
+        // `request_leader_timeout_if_needed` which ensures the local chain state
+        // is synchronized with the current consensus round.
+        match self
+            .process_pending_block_without_prepare(&mut proposal_guard)
+            .await?
+        {
             ClientOutcome::Committed(Some(certificate)) => {
                 return Ok(ClientOutcome::Conflict(Box::new(certificate)))
             }
@@ -1293,16 +1282,21 @@ impl<Env: Environment> ChainClient<Env> {
             )));
         }
 
-        let block = self.new_pending_block(transactions, blobs).await?;
+        let block = self
+            .new_pending_block(transactions, blobs, &mut proposal_guard)
+            .await?;
 
-        match self.process_pending_block_without_prepare().await? {
+        match self
+            .process_pending_block_without_prepare(&mut proposal_guard)
+            .await?
+        {
             ClientOutcome::Committed(Some(certificate)) if certificate.block() == &block => {
                 Ok(ClientOutcome::Committed(certificate))
             }
             ClientOutcome::Committed(Some(certificate)) => {
                 Ok(ClientOutcome::Conflict(Box::new(certificate)))
             }
-            // Should be unreachable: We did set a pending block.
+            // Unreachable: We just set the pending proposal in the guard.
             ClientOutcome::Committed(None) => {
                 Err(Error::BlockProposalError("Unexpected block proposal error"))
             }
@@ -1342,19 +1336,21 @@ impl<Env: Environment> ChainClient<Env> {
             .collect::<Vec<_>>())
     }
 
-    /// Creates a new pending block and handles the proposal in the local node.
-    /// Next time `process_pending_block_without_prepare` is called, this block will be proposed
-    /// to the validators.
-    #[instrument(level = "trace", skip(transactions, blobs))]
+    /// Creates a new pending block and stores it in `proposal_guard`.
+    ///
+    /// The caller must hold the proposal mutex. The pending proposal is written directly
+    /// into the guard so that it is always synchronized with the mutex.
+    #[instrument(level = "trace", skip(transactions, blobs, proposal_guard))]
     async fn new_pending_block(
         &self,
         transactions: Vec<Transaction>,
         blobs: Vec<Blob>,
+        proposal_guard: &mut Option<PendingProposal>,
     ) -> Result<Block, Error> {
         let identity = self.identity().await?;
 
         ensure!(
-            self.pending_proposal().is_none(),
+            proposal_guard.is_none(),
             Error::BlockProposalError(
                 "Client state already has a pending block; \
                 use the `linera retry-pending-block` command to commit that first"
@@ -1387,8 +1383,9 @@ impl<Env: Environment> ChainClient<Env> {
             )
             .await?;
         let (proposed_block, _) = block.clone().into_proposal();
-        self.update_state(|state| {
-            state.set_pending_proposal(proposed_block.clone(), blobs.clone())
+        *proposal_guard = Some(PendingProposal {
+            block: proposed_block,
+            blobs,
         });
         Ok(block)
     }
@@ -1688,21 +1685,41 @@ impl<Env: Environment> ChainClient<Env> {
         Ok(info)
     }
 
-    /// Processes the last pending block
+    /// Processes the last pending block.
     #[instrument(level = "trace")]
     pub async fn process_pending_block(
         &self,
     ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, Error> {
         self.prepare_chain().await?;
-        self.process_pending_block_without_prepare().await
+        let mutex = self.proposal_mutex();
+        let mut proposal_guard = mutex.lock_owned().await;
+        self.process_pending_block_without_prepare(&mut proposal_guard)
+            .await
     }
 
     /// Processes the last pending block. Assumes that the local chain is up to date.
-    #[instrument(level = "trace")]
+    ///
+    /// The caller must hold the proposal mutex via `proposal_guard`. The pending proposal
+    /// is read from and cleared through the guard, ensuring synchronization.
+    #[instrument(level = "trace", skip(proposal_guard))]
     async fn process_pending_block_without_prepare(
         &self,
+        proposal_guard: &mut Option<PendingProposal>,
     ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, Error> {
+        let process_start = linera_base::time::Instant::now();
+        tracing::debug!("process_pending_block_without_prepare started");
         let info = self.request_leader_timeout_if_needed().await?;
+
+        // Clear stale pending proposals whose height has already been committed.
+        if let Some(pending) = &*proposal_guard {
+            if pending.block.height < info.next_block_height {
+                tracing::debug!(
+                    "Clearing pending proposal: a block was committed at height {}",
+                    pending.block.height
+                );
+                *proposal_guard = None;
+            }
+        }
 
         // If there is a validated block in the current round, finalize it.
         if info.manager.has_locking_block_in_current_round()
@@ -1714,7 +1731,6 @@ impl<Env: Environment> ChainClient<Env> {
 
         let local_node = &self.client.local_node;
         // Otherwise we have to re-propose the highest validated block, if there is one.
-        let pending_proposal = self.pending_proposal();
         let (block, blobs) = if let Some(locking) = &info.manager.requested_locking {
             match &**locking {
                 LockingBlock::Regular(certificate) => {
@@ -1742,16 +1758,17 @@ impl<Env: Environment> ChainClient<Env> {
                     (block, blobs)
                 }
             }
-        } else if let Some(pending_proposal) = pending_proposal {
+        } else if let Some(pending) = proposal_guard.as_ref() {
             // Otherwise we are free to propose our own pending block.
-            let proposed_block = pending_proposal.block;
+            let proposed_block = pending.block.clone();
+            let blobs = pending.blobs.clone();
             let round = self.round_for_oracle(&info, &owner).await?;
             let (block, _) = self
                 .client
-                .stage_block_execution(proposed_block, round, pending_proposal.blobs.clone())
+                .stage_block_execution(proposed_block, round, blobs.clone())
                 .await?;
             debug!("Proposing the local pending block.");
-            (block, pending_proposal.blobs)
+            (block, blobs)
         } else {
             return Ok(ClientOutcome::Committed(None)); // Nothing to do.
         };
@@ -1823,9 +1840,15 @@ impl<Env: Environment> ChainClient<Env> {
             self.client.finalize_block(&committee, certificate).await?
         };
         self.send_timing(submit_block_proposal_start, TimingType::SubmitBlockProposal);
+        tracing::debug!(
+            total_process_ms = process_start.elapsed().as_millis(),
+            "process_pending_block_without_prepare completing"
+        );
         debug!(round = %certificate.round, "Sending confirmed block to validators");
         self.update_validators(Some(&committee), Some(certificate.clone()))
             .await?;
+        // Clear the pending proposal now that the block has been committed.
+        *proposal_guard = None;
         Ok(ClientOutcome::Committed(Some(certificate)))
     }
 
@@ -1959,8 +1982,8 @@ impl<Env: Environment> ChainClient<Env> {
     /// Clears the information on any operation that previously failed.
     #[cfg(with_testing)]
     #[instrument(level = "trace")]
-    pub fn clear_pending_proposal(&self) {
-        self.update_state(|state| state.clear_pending_proposal());
+    pub async fn clear_pending_proposal(&self) {
+        *self.proposal_mutex().lock().await = None;
     }
 
     /// Rotates the key of the chain.
@@ -2504,11 +2527,7 @@ impl<Env: Environment> ChainClient<Env> {
         local_node: &LocalNodeClient<Env::Storage>,
     ) -> Result<Option<Box<ChainInfo>>, Error> {
         match local_node.chain_info(chain_id).await {
-            Ok(info) => {
-                // Useful in case `chain_id` is the same as a local chain.
-                self.client.update_from_info(&info);
-                Ok(Some(info))
-            }
+            Ok(info) => Ok(Some(info)),
             Err(LocalNodeError::BlobsNotFound(_) | LocalNodeError::InactiveChain(_)) => Ok(None),
             Err(err) => Err(err.into()),
         }

--- a/linera-core/src/client/chain_client/state.rs
+++ b/linera-core/src/client/chain_client/state.rs
@@ -2,26 +2,23 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeSet, sync::Arc};
+use std::sync::Arc;
 
-use linera_base::data_types::Blob;
-use linera_chain::data_types::ProposedBlock;
 use tokio::sync::Mutex;
 
 use super::super::PendingProposal;
-use crate::data_types::ChainInfo;
 
-/// The state of our interaction with a particular chain: how far we have synchronized it and
-/// whether we are currently attempting to propose a new block.
+/// Per-chain state holding the proposal mutex.
+///
+/// The mutex serves two purposes:
+/// 1. It serializes block proposals so the client never makes conflicting proposals
+///    (which could brick the chain in the Fast consensus round).
+/// 2. Its locked value holds the pending proposal, ensuring that reads and writes
+///    to the pending proposal are always synchronized with the proposal flow.
 pub struct State {
-    /// The block we are currently trying to propose for the next height, if any.
-    ///
-    /// This is always at the same height as `next_block_height`.
-    pending_proposal: Option<PendingProposal>,
-
-    /// A mutex that is held whilst we are performing operations that should not be
-    /// attempted by multiple clients at the same time.
-    client_mutex: Arc<Mutex<()>>,
+    /// Mutex that serializes block proposals. The locked value is the pending proposal
+    /// (if any) that we are currently trying to commit.
+    proposal_mutex: Arc<Mutex<Option<PendingProposal>>>,
 
     /// If true, only download blocks for this chain without fetching manager values.
     /// Use this for chains we're interested in observing but don't intend to propose blocks for.
@@ -31,19 +28,8 @@ pub struct State {
 impl State {
     pub fn new(pending_proposal: Option<PendingProposal>, follow_only: bool) -> State {
         State {
-            pending_proposal,
-            client_mutex: Arc::default(),
+            proposal_mutex: Arc::new(Mutex::new(pending_proposal)),
             follow_only,
-        }
-    }
-
-    /// Clones the state. This must only be used to update the state, and one of the two clones
-    /// must be dropped.
-    pub(crate) fn clone_for_update_unchecked(&self) -> State {
-        State {
-            pending_proposal: self.pending_proposal.clone(),
-            client_mutex: Arc::clone(&self.client_mutex),
-            follow_only: self.follow_only,
         }
     }
 
@@ -52,51 +38,17 @@ impl State {
         self.follow_only
     }
 
-    /// Sets whether this chain is in follow-only mode.
-    pub fn set_follow_only(&mut self, follow_only: bool) {
-        self.follow_only = follow_only;
-    }
-
-    pub fn pending_proposal(&self) -> &Option<PendingProposal> {
-        &self.pending_proposal
-    }
-
-    pub(super) fn set_pending_proposal(&mut self, block: ProposedBlock, blobs: Vec<Blob>) {
-        if self
-            .pending_proposal
-            .as_ref()
-            .is_some_and(|pending| pending.block.height >= block.height)
-        {
-            tracing::error!(
-                "Not setting pending block at {}, because we already have a pending proposal.",
-                block.height
-            );
-            return;
-        }
-        assert_eq!(
-            block.published_blob_ids(),
-            BTreeSet::from_iter(blobs.iter().map(Blob::id))
-        );
-        self.pending_proposal = Some(PendingProposal { block, blobs });
-    }
-
-    pub(crate) fn update_from_info(&mut self, info: &ChainInfo) {
-        if let Some(pending) = &self.pending_proposal {
-            if pending.block.height < info.next_block_height {
-                tracing::debug!(
-                    "Clearing pending proposal: a block was committed at height {}",
-                    pending.block.height
-                );
-                self.clear_pending_proposal();
-            }
+    /// Returns a new `State` with the given `follow_only` value, sharing the same
+    /// proposal mutex.
+    pub(crate) fn with_follow_only(&self, follow_only: bool) -> State {
+        State {
+            proposal_mutex: Arc::clone(&self.proposal_mutex),
+            follow_only,
         }
     }
 
-    pub(super) fn clear_pending_proposal(&mut self) {
-        self.pending_proposal = None;
-    }
-
-    pub(super) fn client_mutex(&self) -> Arc<Mutex<()>> {
-        self.client_mutex.clone()
+    /// Returns the proposal mutex for this chain.
+    pub(super) fn proposal_mutex(&self) -> Arc<Mutex<Option<PendingProposal>>> {
+        Arc::clone(&self.proposal_mutex)
     }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -428,11 +428,9 @@ impl<Env: Environment> Client<Env> {
 
     /// Sets whether the given chain is in follow-only mode.
     pub fn set_chain_follow_only(&self, chain_id: ChainId, follow_only: bool) {
-        self.chains.pin().update(chain_id, |state| {
-            let mut state = state.clone_for_update_unchecked();
-            state.set_follow_only(follow_only);
-            state
-        });
+        self.chains
+            .pin()
+            .update(chain_id, |state| state.with_follow_only(follow_only));
     }
 
     /// Fetches the chain description blob if needed, and returns the chain info.
@@ -719,27 +717,6 @@ impl<Env: Environment> Client<Env> {
         Ok(bcs::from_bytes(blob.bytes())?)
     }
 
-    /// Updates the latest block and next block height and round information from the chain info.
-    #[instrument(level = "trace", skip_all, fields(chain_id = format!("{:.8}", info.chain_id)))]
-    fn update_from_info(&self, info: &ChainInfo) {
-        self.chains.pin().update(info.chain_id, |state| {
-            let mut state = state.clone_for_update_unchecked();
-            state.update_from_info(info);
-            state
-        });
-    }
-
-    /// Handles the certificate in the local node and the resulting notifications.
-    #[instrument(level = "trace", skip_all)]
-    async fn process_certificate<T: ProcessableCertificate>(
-        &self,
-        certificate: Box<GenericCertificate<T>>,
-    ) -> Result<(), LocalNodeError> {
-        let info = self.handle_certificate(*certificate).await?.info;
-        self.update_from_info(&info);
-        Ok(())
-    }
-
     /// Submits a validated block for finalization and returns the confirmed block certificate.
     #[instrument(level = "trace", skip_all)]
     pub(crate) async fn finalize_block(
@@ -829,8 +806,7 @@ impl<Env: Environment> Client<Env> {
 
         clock_skew_check_handle.await;
 
-        self.process_certificate(Box::new(certificate.clone()))
-            .await?;
+        self.handle_certificate(certificate.clone()).await?;
         Ok(certificate)
     }
 
@@ -930,20 +906,19 @@ impl<Env: Environment> Client<Env> {
         &self,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<(), chain_client::Error> {
-        let certificate = Box::new(certificate);
         let block = certificate.block();
         // Recover history from the network.
         self.download_certificates(block.header.chain_id, block.header.height)
             .await?;
         // Process the received operations. Download required hashed certificate values if
         // necessary.
-        if let Err(err) = self.process_certificate(certificate.clone()).await {
+        if let Err(err) = self.handle_certificate(certificate.clone()).await {
             match &err {
                 LocalNodeError::BlobsNotFound(blob_ids) => {
                     self.download_blobs(&self.validator_nodes().await?, blob_ids)
                         .await
                         .map_err(|_| err)?;
-                    self.process_certificate(certificate).await?;
+                    self.handle_certificate(certificate).await?;
                 }
                 _ => {
                     // The certificate is not as expected. Give up.
@@ -1613,8 +1588,7 @@ impl<Env: Environment> Client<Env> {
         certificate: GenericCertificate<ValidatedBlock>,
     ) -> Result<(), chain_client::Error> {
         let chain_id = certificate.inner().chain_id();
-        let certificate = Box::new(certificate);
-        match self.process_certificate(certificate.clone()).await {
+        match self.handle_certificate(certificate.clone()).await {
             Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
                 let mut blobs = Vec::new();
                 for blob_id in blob_ids {
@@ -1627,11 +1601,11 @@ impl<Env: Environment> Client<Env> {
                 self.local_node
                     .handle_pending_blobs(chain_id, blobs)
                     .await?;
-                self.process_certificate(certificate).await?;
+                self.handle_certificate(certificate).await?;
                 Ok(())
             }
             Err(err) => Err(err.into()),
-            Ok(()) => Ok(()),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -116,7 +116,7 @@ where
             sender.chain_info().await?.next_block_height,
             BlockHeight::from(1)
         );
-        assert!(sender.pending_proposal().is_none());
+        assert!(sender.pending_proposal().await.is_none());
         assert_eq!(
             sender.local_balance().await.unwrap(),
             Amount::from_millis(1000)
@@ -319,7 +319,7 @@ where
         sender.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(sender.pending_proposal().is_none());
+    assert!(sender.pending_proposal().await.is_none());
     assert_eq!(sender.identity().await?, new_owner);
     assert_eq!(
         builder
@@ -362,7 +362,7 @@ where
         sender.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(sender.pending_proposal().is_none());
+    assert!(sender.pending_proposal().await.is_none());
     assert_matches!(
         sender.identity().await,
         Err(chain_client::Error::NotAnOwner(_))
@@ -410,7 +410,7 @@ where
         sender.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(sender.pending_proposal().is_none());
+    assert!(sender.pending_proposal().await.is_none());
     assert_eq!(sender.identity().await?, sender.preferred_owner().unwrap());
     assert_eq!(
         builder
@@ -477,7 +477,7 @@ where
         client.local_balance().await.unwrap(),
         Amount::from_tokens(2)
     );
-    client.clear_pending_proposal();
+    client.clear_pending_proposal().await;
     client
         .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
@@ -489,7 +489,7 @@ where
     sender.process_inbox().await.unwrap();
     assert_eq!(client.chain_info().await?, sender.chain_info().await?);
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ONE);
-    sender.clear_pending_proposal();
+    sender.clear_pending_proposal().await;
     sender
         .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
@@ -577,7 +577,7 @@ where
         sender.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(sender.pending_proposal().is_none());
+    assert!(sender.pending_proposal().await.is_none());
     assert_eq!(sender.identity().await?, sender.preferred_owner().unwrap());
     // Make a client to try the new chain.
     let mut client = builder.make_client(new_id, None, BlockHeight::ZERO).await?;
@@ -659,7 +659,7 @@ where
         parent.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(sender.pending_proposal().is_none());
+    assert!(sender.pending_proposal().await.is_none());
     assert_eq!(sender.identity().await?, sender.preferred_owner().unwrap());
     assert_matches!(
         &certificate.block().body.transactions[0],
@@ -747,7 +747,7 @@ where
         sender.chain_info().await?.next_block_height,
         BlockHeight::from(2)
     );
-    assert!(sender.pending_proposal().is_none());
+    assert!(sender.pending_proposal().await.is_none());
     assert_eq!(sender.identity().await?, sender.preferred_owner().unwrap());
     // Make a client to try the new chain.
     let mut client = builder.make_client(new_id, None, BlockHeight::ZERO).await?;
@@ -800,7 +800,7 @@ where
         client1.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(client1.pending_proposal().is_none());
+    assert!(client1.pending_proposal().await.is_none());
     assert!(client1.identity().await.is_ok());
     assert_eq!(
         builder
@@ -908,7 +908,7 @@ where
         chain_1.chain_info().await?.next_block_height,
         BlockHeight::ZERO
     );
-    assert!(chain_1.pending_proposal().is_some());
+    assert!(chain_1.pending_proposal().await.is_some());
     assert_eq!(
         chain_1.local_balance().await.unwrap(),
         Amount::from_tokens(4)
@@ -957,7 +957,7 @@ where
         client1.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(client1.pending_proposal().is_none());
+    assert!(client1.pending_proposal().await.is_none());
     assert_eq!(client1.local_balance().await.unwrap(), Amount::ZERO);
     assert_eq!(
         client1.query_system_application(SystemQuery).await.unwrap(),
@@ -1015,7 +1015,7 @@ where
         client2.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(client2.pending_proposal().is_none());
+    assert!(client2.pending_proposal().await.is_none());
     assert_eq!(
         client2.local_balance().await.unwrap(),
         Amount::from_tokens(2)
@@ -1076,7 +1076,7 @@ where
         client1.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(client1.pending_proposal().is_none());
+    assert!(client1.pending_proposal().await.is_none());
     // The receiver doesn't know about the transfer.
     client2.process_inbox().await.unwrap();
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
@@ -1180,13 +1180,13 @@ where
         client1.chain_info().await?.next_block_height,
         BlockHeight::from(2)
     );
-    assert!(client1.pending_proposal().is_none());
+    assert!(client1.pending_proposal().await.is_none());
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
     assert_eq!(
         client2.chain_info().await?.next_block_height,
         BlockHeight::from(1)
     );
-    assert!(client2.pending_proposal().is_none());
+    assert!(client2.pending_proposal().await.is_none());
     // Last one was not confirmed remotely, hence a conservative balance.
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
     // Let the receiver confirm in last resort.
@@ -1243,7 +1243,7 @@ where
         admin.chain_info().await?.next_block_height,
         BlockHeight::from(5)
     );
-    assert!(admin.pending_proposal().is_none());
+    assert!(admin.pending_proposal().await.is_none());
     assert!(admin.identity().await.is_ok());
     assert_eq!(admin.chain_info().await?.epoch, Epoch::from(2));
 
@@ -1574,7 +1574,7 @@ where
         .await;
 
     assert!(b0_result.is_err());
-    assert!(client_2a.pending_proposal().is_some());
+    assert!(client_2a.pending_proposal().await.is_some());
 
     for i in 0..=2 {
         let info = builder
@@ -1713,7 +1713,7 @@ where
         .await;
 
     assert!(b0_result.is_err());
-    assert!(client2_a.pending_proposal().is_some());
+    assert!(client2_a.pending_proposal().await.is_some());
 
     for i in 0..=2 {
         let validator_manager = builder
@@ -1946,7 +1946,7 @@ where
         .await;
 
     assert!(b0_result.is_err());
-    assert!(client3_a.pending_proposal().is_some());
+    assert!(client3_a.pending_proposal().await.is_some());
 
     let manager = client3_a
         .chain_info_with_manager_values()
@@ -2170,7 +2170,7 @@ where
         ClientOutcome::Conflict(_) => panic!("Got conflict where we aren't the leader."),
         ClientOutcome::WaitForTimeout(timeout) => timeout,
     };
-    client.clear_pending_proposal();
+    client.clear_pending_proposal().await;
     assert!(client.request_leader_timeout().await.is_err());
     clock.set(timeout.timestamp);
     client.request_leader_timeout().await.unwrap();
@@ -2381,6 +2381,7 @@ where
     assert!(result.is_err());
     assert!(!client1
         .pending_proposal()
+        .await
         .as_ref()
         .unwrap()
         .blobs
@@ -2398,7 +2399,7 @@ where
         manager.requested_locking.unwrap().round(),
         Round::MultiLeader(1)
     );
-    assert!(client0.pending_proposal().is_some());
+    assert!(client0.pending_proposal().await.is_some());
 
     // Client 0 now only tries to transfer 1 token. But instead, they automatically finalize the
     // pending block, which publishes the blob.
@@ -2412,7 +2413,7 @@ where
         client0.local_balance().await.unwrap(),
         Amount::from_tokens(10)
     );
-    assert!(client0.pending_proposal().is_none());
+    assert!(client0.pending_proposal().await.is_none());
 
     // Transfer a token so Client 1 sees that the blob is already published
     client1.prepare_chain().await.unwrap();
@@ -2423,7 +2424,7 @@ where
         client1.local_balance().await.unwrap(),
         Amount::from_tokens(9)
     );
-    assert!(client1.pending_proposal().is_none());
+    assert!(client1.pending_proposal().await.is_none());
     Ok(())
 }
 
@@ -2560,7 +2561,7 @@ where
         Round::MultiLeader(0)
     );
     assert_eq!(manager.current_round, Round::MultiLeader(1));
-    assert!(client1.pending_proposal().is_some());
+    assert!(client1.pending_proposal().await.is_some());
     assert_matches!(
         client1
             .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
@@ -2672,7 +2673,7 @@ where
     // validated block in round 0, and re-proposes it when it tries to burn 4 tokens.
     builder.set_fault_type([0, 1, 2], FaultType::Honest);
     client1.synchronize_from_validators().await.unwrap();
-    assert!(client1.pending_proposal().is_some());
+    assert!(client1.pending_proposal().await.is_some());
     // This test involves timeouts and potential conflicts. Handle them appropriately.
     loop {
         match client1

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -629,7 +629,7 @@ where
         .execute_operation(Operation::user(application_id, &transfer)?)
         .await
         .is_err());
-    receiver.clear_pending_proposal();
+    receiver.clear_pending_proposal().await;
 
     // Try another transfer with the correct amount.
     let transfer = FungibleOperation::Transfer {
@@ -1513,7 +1513,7 @@ where
     );
 
     // Clear the pending proposal and try again with ExpireAfter(6 seconds).
-    creator.clear_pending_proposal();
+    creator.clear_pending_proposal().await;
     let op2 = time_expiry::TimeExpiryOperation::ExpireAfter(TimeDelta::from_secs(6));
     let result = creator
         .execute_operation(Operation::user(app_id, &op2)?)
@@ -1528,7 +1528,7 @@ where
     );
 
     // Clear the pending proposal and try once more with ExpireAfter(7 seconds).
-    creator.clear_pending_proposal();
+    creator.clear_pending_proposal().await;
     let op3 = time_expiry::TimeExpiryOperation::ExpireAfter(TimeDelta::from_secs(7));
     let result = creator
         .execute_operation(Operation::user(app_id, &op3)?)
@@ -1549,7 +1549,7 @@ where
     clock.add(TimeDelta::from_secs(10));
 
     // Clear pending and try to commit ExpireAfter(10 minutes) - should timeout.
-    creator.clear_pending_proposal();
+    creator.clear_pending_proposal().await;
     let op4 = time_expiry::TimeExpiryOperation::ExpireAfter(TimeDelta::from_secs(600));
     let result = creator
         .execute_operation(Operation::user(app_id, &op4)?)


### PR DESCRIPTION
Port of #5666.

## Motivation

`update_from_info` can clear the pending block proposal while `execute_block` is ongoing, because it doesn't lock the `client_mutex`.

## Proposal

Unify both into a single `Arc<Mutex<Option<PendingProposal>>>` per chain. The mutex now both serializes proposals and holds the pending proposal, ensuring all reads/writes are synchronized. Remove `update_from_info` (which only cleared stale proposals), `update_state`, `clone_for_update_unchecked`, and inline `process_certificate` into its call sites.

## Test Plan

CI

This should fix the (rare and hard to reproduce) race condition.

## Release Plan

- Nothing to do.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/5664.
- Testnet version: #5666 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
