### PR TITLE
restructuration of inbox access

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -26,7 +26,7 @@ use linera_views::{
     context::Context,
     log_view::LogView,
     map_view::MapView,
-    reentrant_collection_view::{ReadGuardedView, ReentrantCollectionView, WriteGuardedView},
+    reentrant_collection_view::{ReadGuardedView, ReentrantCollectionView},
     register_view::RegisterView,
     views::{ClonableView, RootView, View},
 };
@@ -464,25 +464,24 @@ where
         Ok(())
     }
 
-    /// Loads the inbox for the given origin mutably.
-    pub async fn load_inbox_mut(
-        &mut self,
-        origin: &ChainId,
-    ) -> Result<WriteGuardedView<InboxStateView<C>>, ChainError> {
-        Ok(self.inboxes.try_load_entry_mut(origin).await?)
-    }
-
     /// Returns the next block height to receive and the last anticipated block height
-    /// from an already-loaded inbox.
+    /// for the given origin, loading the inbox read-only.
     pub async fn inbox_cursors(
-        inbox: &InboxStateView<C>,
+        &self,
+        origin: &ChainId,
     ) -> Result<(BlockHeight, Option<BlockHeight>), ChainError> {
-        let next_height = inbox.next_block_height_to_receive()?;
-        let last_anticipated = match inbox.removed_bundles.back().await? {
-            Some(bundle) => Some(bundle.height),
-            None => None,
-        };
-        Ok((next_height, last_anticipated))
+        let inbox = self.inboxes.try_load_entry(origin).await?;
+        match inbox {
+            Some(inbox) => {
+                let next_height = inbox.next_block_height_to_receive()?;
+                let last_anticipated = match inbox.removed_bundles.back().await? {
+                    Some(bundle) => Some(bundle.height),
+                    None => None,
+                };
+                Ok((next_height, last_anticipated))
+            }
+            None => Ok((BlockHeight::ZERO, None)),
+        }
     }
 
     /// Returns the height of the highest block we have, plus one. Includes preprocessed blocks.
@@ -508,7 +507,6 @@ where
     ))]
     pub async fn receive_message_bundle(
         &mut self,
-        inbox: &mut WriteGuardedView<InboxStateView<C>>,
         origin: &ChainId,
         bundle: MessageBundle,
         local_time: Timestamp,
@@ -540,6 +538,7 @@ where
         }
 
         // Process the inbox bundle and update the inbox state.
+        let mut inbox = self.inboxes.try_load_entry_mut(origin).await?;
         inbox
             .add_bundle(bundle)
             .await

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -909,9 +909,8 @@ where
         bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
         // Only process certificates with relevant heights and epochs.
-        let mut inbox = self.chain.load_inbox_mut(&origin).await?;
         let (next_height_to_receive, last_anticipated_block_height) =
-            ChainStateView::inbox_cursors(&inbox).await?;
+            self.chain.inbox_cursors(&origin).await?;
         let helper = CrossChainUpdateHelper::new(&self.config, &self.chain);
         let recipient = self.chain_id();
         let bundles = helper.select_message_bundles(
@@ -932,13 +931,7 @@ where
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
             self.chain
-                .receive_message_bundle(
-                    &mut inbox,
-                    &origin,
-                    bundle,
-                    local_time,
-                    add_to_received_log,
-                )
+                .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
                 .await?;
         }
         if !self.config.allow_inactive_chains && !self.chain.is_active() {


### PR DESCRIPTION
## Motivation

The function `fn process_cross_chain_update` of `linera-core/src/chain_worker/state.rs` is reading rhe inbox of origin three times:
* In next_block_height_to_receive (1 time)
* In last_anticipated_block_height (1 time)
* In receive_message_bundle (as many times as the number of bundles)

Another issue is the `NUM_INBOXES` metric being called in the hot path. The does a `inboxes.count()` which is an expensive operation.

This is inefficient.

## Proposal

Access the inbox directly in `process_cross_chain_update` and pass it around. We could not do it for receive_message_bundle.
Put a single emission of `NUM_INBOXES` when we did a `try_load_all_entries`.

## Test Plan

CI

## Release Plan

Can be backported to `testnet_conway` since this is strictly a change to the ordering of operations.

## Links

None.