### PR TITLE
Use MSRV-aware resolver in project template to fix CI

### DIFF
--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -49,6 +49,9 @@ impl Project {
         debug!("Writing Cargo.toml");
         Self::create_cargo_toml(&root, name, linera_root)?;
 
+        debug!("Writing .cargo/config.toml");
+        Self::create_cargo_config(&root)?;
+
         debug!("Writing rust-toolchain.toml");
         Self::create_rust_toolchain(&root)?;
 
@@ -163,6 +166,15 @@ impl Project {
             linera_sdk_dev_dep = linera_sdk_dev_dep,
         );
         Self::write_string_to_file(&toml_path, &toml_contents)
+    }
+
+    fn create_cargo_config(project_root: &Path) -> Result<()> {
+        let cargo_dir = project_root.join(".cargo");
+        fs_err::create_dir_all(&cargo_dir)?;
+        Self::write_string_to_file(
+            &cargo_dir.join("config.toml"),
+            "[resolver]\nincompatible-rust-versions = \"fallback\"\n",
+        )
     }
 
     fn create_rust_toolchain(project_root: &Path) -> Result<()> {

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -2,6 +2,7 @@
 name = "{project_name}"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.86.0"
 
 [dependencies]
 async-graphql = {{ version = "=7.0.17", default-features = false }}


### PR DESCRIPTION
## Motivation

The `test_project_new` and `test_project_publish` integration tests are failing because
newly
published crates require rustc 1.88+, while the scaffolded template projects use rustc
1\.86.0.

No change in linera-protocol caused this — it was triggered by
[`serde_with 3.18.0`](https://crates.io/crates/serde_with/3.18.0) being published on
[crates.io](http://crates.io)
on March 13, 2026, which declares `rust-version = "1.88"` and pulls in
[`darling 0.23.0`](https://crates.io/crates/darling/0.23.0) (also `rust-version =   "1.88"`).

The template generates standalone projects without a `Cargo.lock`, so Cargo resolves
dependencies
fresh from the registry on every run. The transitive dependency chain is:
template project → linera-sdk → linera-base → serde_with "3" → darling.

## Proposal

Add `rust-version = "1.86.0"` to the template's `Cargo.toml` and generate a
`.cargo/config.toml` with `[resolver] incompatible-rust-versions = "fallback"` in
scaffolded
projects. This enables Cargo's MSRV-aware dependency resolution, which prefers crate
versions
compatible with the declared `rust-version`. Since both `serde_with` and `darling`
declare their
MSRV in their crate metadata, the resolver will automatically select older compatible
versions.

This only affects newly scaffolded projects (via `linera project new`), not the
linera-protocol
workspace itself.

## Test Plan

CI — the previously failing `test_project_new` and `test_project_publish` tests should
now pass.