### PR TITLE
[testnet] restructuration of inbox access

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -154,15 +154,6 @@ pub(crate) mod metrics {
         )
     });
 
-    pub static NUM_INBOXES: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
-            "num_inboxes",
-            "Number of inboxes",
-            &[],
-            exponential_bucket_interval(1.0, 10_000.0),
-        )
-    });
-
     pub static NUM_OUTBOXES: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
             "num_outboxes",
@@ -509,14 +500,23 @@ where
         Ok(())
     }
 
-    pub async fn next_block_height_to_receive(
+    /// Returns the next block height to receive and the last anticipated block height
+    /// for the given origin, loading the inbox read-only.
+    pub async fn inbox_cursors(
         &self,
         origin: &ChainId,
-    ) -> Result<BlockHeight, ChainError> {
+    ) -> Result<(BlockHeight, Option<BlockHeight>), ChainError> {
         let inbox = self.inboxes.try_load_entry(origin).await?;
         match inbox {
-            Some(inbox) => inbox.next_block_height_to_receive(),
-            None => Ok(BlockHeight::ZERO),
+            Some(inbox) => {
+                let next_height = inbox.next_block_height_to_receive()?;
+                let last_anticipated = match inbox.removed_bundles.back().await? {
+                    Some(bundle) => Some(bundle.height),
+                    None => None,
+                };
+                Ok((next_height, last_anticipated))
+            }
+            None => Ok((BlockHeight::ZERO, None)),
         }
     }
 
@@ -528,20 +528,6 @@ where
             return Ok(height.saturating_add(BlockHeight(1)));
         }
         Ok(self.tip_state.get().next_block_height)
-    }
-
-    pub async fn last_anticipated_block_height(
-        &self,
-        origin: &ChainId,
-    ) -> Result<Option<BlockHeight>, ChainError> {
-        let inbox = self.inboxes.try_load_entry(origin).await?;
-        match inbox {
-            Some(inbox) => match inbox.removed_bundles.back().await? {
-                Some(bundle) => Ok(Some(bundle.height)),
-                None => Ok(None),
-            },
-            None => Ok(None),
-        }
     }
 
     /// Attempts to process a new `bundle` of messages from the given `origin`. Returns an
@@ -589,10 +575,6 @@ where
 
         // Process the inbox bundle and update the inbox state.
         let mut inbox = self.inboxes.try_load_entry_mut(origin).await?;
-        #[cfg(with_metrics)]
-        metrics::NUM_INBOXES
-            .with_label_values(&[])
-            .observe(self.inboxes.count().await? as f64);
         inbox
             .add_bundle(bundle)
             .await
@@ -698,10 +680,6 @@ where
                 }
             }
         }
-        #[cfg(with_metrics)]
-        metrics::NUM_INBOXES
-            .with_label_values(&[])
-            .observe(self.inboxes.count().await? as f64);
         Ok(())
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -55,14 +55,26 @@ use crate::{
 mod metrics {
     use std::sync::LazyLock;
 
-    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram};
-    use prometheus::Histogram;
+    use linera_base::prometheus_util::{
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
+        register_histogram_vec,
+    };
+    use prometheus::{Histogram, HistogramVec};
 
     pub static CREATE_NETWORK_ACTIONS_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
         register_histogram(
             "create_network_actions_latency",
             "Time (ms) to create network actions",
             exponential_bucket_latencies(10_000.0),
+        )
+    });
+
+    pub static NUM_INBOXES: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "num_inboxes",
+            "Number of inboxes",
+            &[],
+            exponential_bucket_interval(1.0, 10_000.0),
         )
     });
 }
@@ -1064,9 +1076,8 @@ where
         bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
         // Only process certificates with relevant heights and epochs.
-        let next_height_to_receive = self.chain.next_block_height_to_receive(&origin).await?;
-        let last_anticipated_block_height =
-            self.chain.last_anticipated_block_height(&origin).await?;
+        let (next_height_to_receive, last_anticipated_block_height) =
+            self.chain.inbox_cursors(&origin).await?;
         let helper = CrossChainUpdateHelper::new(&self.config, &self.chain);
         let recipient = self.chain_id();
         let bundles = helper.select_message_bundles(
@@ -1738,6 +1749,10 @@ where
         if query.request_pending_message_bundles {
             let mut bundles = Vec::new();
             let pairs = chain.inboxes.try_load_all_entries().await?;
+            #[cfg(with_metrics)]
+            metrics::NUM_INBOXES
+                .with_label_values(&[])
+                .observe(pairs.len() as f64);
             let action = if *chain.execution_state.system.closed.get() {
                 MessageAction::Reject
             } else {


### PR DESCRIPTION
## Motivation

The inbox was read two times in a row which is inefficient.
The access to the `NUM_INBOXES` should not be in the critical path.

## Proposal

Backport the corrections of #5689 

## Test Plan

CI

## Release Plan

This is the backport.

## Links

None