### PR TITLE
Pin more versions in the template.

### DIFF
--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -11,6 +11,12 @@ futures = {{ version = "0.3 "}}
 serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = {{ version = "1.0" }}
 
+# TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
+darling = {{ version = ">=0.20, <0.23" }}
+serde_with = {{ version = ">=3, <3.18" }}
+time = {{ version = ">=0.3, <0.3.47" }}
+time-core = {{ version = ">=0.1, <0.1.8" }}
+
 [dev-dependencies]
 {linera_sdk_dev_dep}
 tokio = {{ version = "1.40", features = ["rt", "sync"] }}


### PR DESCRIPTION
## Motivation

CI is failing because some dependencies require Rust > 1.86.0 now.

## Proposal

Pin the versions of these dependencies in `Cargo.toml.template`.

## Test Plan

CI should be green now.

## Release Plan

- Backport to `testnet_conway`.

## Links


- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
