### PR TITLE
Rename the `fn count` as `fn iterative_count`.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1233,7 +1233,7 @@ where
                     .check_blob_size(blob.content())
                     .with_execution_context(ChainExecutionContext::Block)?;
                 ensure!(
-                    u64::try_from(pending_blobs.pending_blobs.count().await?)
+                    u64::try_from(pending_blobs.pending_blobs.iterative_count().await?)
                         .is_ok_and(|count| count < policy.maximum_published_blobs),
                     WorkerError::TooManyPublishedBlobs(policy.maximum_published_blobs)
                 );

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -809,10 +809,10 @@ impl<W: View> ByteCollectionView<W::Context, W> {
     ///     ByteCollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&[0, 1]).await.unwrap();
     /// view.load_entry_mut(&[0, 2]).await.unwrap();
-    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// assert_eq!(view.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         let mut count = 0;
         self.for_each_key(|_key| {
             count += 1;
@@ -1224,11 +1224,11 @@ where
     ///     CollectionView::load(context).await.unwrap();
     /// view.load_entry_mut(&23).await.unwrap();
     /// view.load_entry_mut(&25).await.unwrap();
-    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// assert_eq!(view.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.collection.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.collection.iterative_count().await
     }
 }
 
@@ -1644,11 +1644,11 @@ impl<I: CustomSerialize + Send, W: View> CustomCollectionView<W::Context, I, W> 
     ///     .unwrap();
     /// view.load_entry_mut(&(23 as u128)).await.unwrap();
     /// view.load_entry_mut(&(25 as u128)).await.unwrap();
-    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// assert_eq!(view.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.collection.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.collection.iterative_count().await
     }
 }
 
@@ -1826,7 +1826,7 @@ mod graphql {
 
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count().await? as u32)
+            Ok(self.iterative_count().await? as u32)
         }
 
         async fn entry(
@@ -1891,7 +1891,7 @@ mod graphql {
 
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count().await? as u32)
+            Ok(self.iterative_count().await? as u32)
         }
 
         async fn entry(

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -645,10 +645,10 @@ where
     /// map.insert(vec![0, 1], String::from("Hello"));
     /// map.insert(vec![1, 2], String::from("Bonjour"));
     /// map.insert(vec![2, 2], String::from("Hallo"));
-    /// assert_eq!(map.count().await.unwrap(), 3);
+    /// assert_eq!(map.iterative_count().await.unwrap(), 3);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         let mut count = 0;
         let prefix = Vec::new();
         self.for_each_key(
@@ -1523,11 +1523,11 @@ where
     /// let mut map: MapView<_, String, _> = MapView::load(context).await.unwrap();
     /// map.insert("Italian", String::from("Ciao"));
     /// map.insert("French", String::from("Bonjour"));
-    /// assert_eq!(map.count().await.unwrap(), 2);
+    /// assert_eq!(map.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.map.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.map.iterative_count().await
     }
 }
 
@@ -2076,11 +2076,11 @@ where
     /// let mut map = CustomMapView::<_, u128, _>::load(context).await.unwrap();
     /// map.insert(&(24 as u128), String::from("Ciao"));
     /// map.insert(&(37 as u128), String::from("Bonjour"));
-    /// assert_eq!(map.count().await.unwrap(), 2);
+    /// assert_eq!(map.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.map.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.map.iterative_count().await
     }
 }
 
@@ -2279,7 +2279,7 @@ mod graphql {
 
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count().await? as u32)
+            Ok(self.iterative_count().await? as u32)
         }
 
         async fn entry(&self, key: I) -> Result<Entry<I, Option<V>>, async_graphql::Error> {

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -936,10 +936,10 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
     ///     ReentrantByteCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&[0, 1]).await.unwrap();
     /// view.try_load_entry_mut(&[0, 2]).await.unwrap();
-    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// assert_eq!(view.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         let mut count = 0;
         self.for_each_key(|_key| {
             count += 1;
@@ -1604,11 +1604,11 @@ where
     ///     ReentrantCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
     /// view.try_load_entry_mut(&25).await.unwrap();
-    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// assert_eq!(view.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.collection.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.collection.iterative_count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order
@@ -2167,11 +2167,11 @@ where
     ///     ReentrantCustomCollectionView::load(context).await.unwrap();
     /// view.try_load_entry_mut(&23).await.unwrap();
     /// view.try_load_entry_mut(&25).await.unwrap();
-    /// assert_eq!(view.count().await.unwrap(), 2);
+    /// assert_eq!(view.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.collection.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.collection.iterative_count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order
@@ -2348,7 +2348,7 @@ mod graphql {
 
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count().await? as u32)
+            Ok(self.iterative_count().await? as u32)
         }
 
         async fn entry(

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -248,7 +248,7 @@ impl<C: Context> ByteSetView<C> {
     /// assert_eq!(set.keys().await.unwrap(), vec![vec![0, 1], vec![0, 2]]);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         let mut count = 0;
         self.for_each_key(|_key| {
             count += 1;
@@ -562,11 +562,11 @@ impl<C: Context, I: Serialize + DeserializeOwned + Send> SetView<C, I> {
     /// # let context = MemoryContext::new_for_testing(());
     /// let mut set: SetView<_, u32> = SetView::load(context).await.unwrap();
     /// set.insert(&(34 as u32));
-    /// assert_eq!(set.count().await.unwrap(), 1);
+    /// assert_eq!(set.iterative_count().await.unwrap(), 1);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.set.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.set.iterative_count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order
@@ -846,11 +846,11 @@ where
     /// let mut set = CustomSetView::<_, u128>::load(context).await.unwrap();
     /// set.insert(&(34 as u128));
     /// set.insert(&(37 as u128));
-    /// assert_eq!(set.count().await.unwrap(), 2);
+    /// assert_eq!(set.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
-    pub async fn count(&self) -> Result<usize, ViewError> {
-        self.set.count().await
+    pub async fn iterative_count(&self) -> Result<usize, ViewError> {
+        self.set.iterative_count().await
     }
 
     /// Applies a function f on each index. Indices are visited in an order
@@ -999,7 +999,7 @@ mod graphql {
 
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count().await? as u32)
+            Ok(self.iterative_count().await? as u32)
         }
     }
 
@@ -1030,7 +1030,7 @@ mod graphql {
 
         #[graphql(derived(name = "count"))]
         async fn count_(&self) -> Result<u32, async_graphql::Error> {
-            Ok(self.count().await? as u32)
+            Ok(self.iterative_count().await? as u32)
         }
     }
 }
@@ -1066,7 +1066,7 @@ mod tests {
 
         // Check keys after flush
         assert_eq!(set.keys().await?, vec![vec![1, 2, 3], vec![4, 5, 6]]);
-        assert_eq!(set.count().await?, 2);
+        assert_eq!(set.iterative_count().await?, 2);
 
         // Now clear the set (this sets delete_storage_first = true)
         set.clear();
@@ -1572,8 +1572,8 @@ mod tests {
         // Initially no pending changes
         assert!(!set.has_pending_changes().await);
 
-        // Test line 557: self.set.count().await - SetView delegates to ByteSetView
-        assert_eq!(set.count().await?, 0);
+        // Test line 557: self.set.iterative_count().await - SetView delegates to ByteSetView
+        assert_eq!(set.iterative_count().await?, 0);
 
         // Add items and verify delegation works
         set.insert(&42)?;
@@ -1594,7 +1594,7 @@ mod tests {
         assert_eq!(set.indices().await?, vec![42, 84, 126]);
 
         // This calls line 557 which delegates to the underlying ByteSetView
-        assert_eq!(set.count().await?, 3);
+        assert_eq!(set.iterative_count().await?, 3);
 
         Ok(())
     }
@@ -1795,14 +1795,14 @@ mod tests {
     async fn test_custom_set_view_for_each_index_while_method_signature() -> Result<(), ViewError> {
         let context = MemoryContext::new_for_testing(());
         let mut set = CustomSetView::<_, u128>::load(context).await?;
-        assert_eq!(set.count().await?, 0);
+        assert_eq!(set.iterative_count().await?, 0);
 
         // Add some data to test the method
         set.insert(&100u128)?;
         set.insert(&200u128)?;
         set.insert(&300u128)?;
 
-        assert_eq!(set.count().await?, 3);
+        assert_eq!(set.iterative_count().await?, 3);
 
         let mut collected_indices = Vec::new();
 
@@ -1934,7 +1934,7 @@ mod tests {
             }
 
             async fn count(&self) -> Result<u32, async_graphql::Error> {
-                Ok(self.set.count().await? as u32)
+                Ok(self.set.iterative_count().await? as u32)
             }
         }
 

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -271,7 +271,7 @@ async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) -> Result<()> 
         let mut new_state_vec = state_vec.clone();
         for _ in 0..count_oper {
             let choice = rng.gen_range(0..7);
-            let count = view.map.count().await?;
+            let count = view.map.iterative_count().await?;
             if choice == 0 {
                 // inserting random stuff
                 let n_ins = rng.gen_range(0..10);


### PR DESCRIPTION
## Motivation

The function `fn count` of `ReentrantCollectionView`, `CollectionView`, `MapView`, and `SetView` has a misleading name that could imply that it is cheap. It is not since they all have a `find_keys_by_prefix` operation underlying them at a minimum.

## Proposal

Rename it to `iterative_count`

## Test Plan

CI

## Release Plan

Can be backported to `testnet_conway`.

## Links

None.