### PR TITLE
Circuit breaker for validator notification streams

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -156,6 +156,12 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-backoff-ms <MAX_BACKOFF>` — Maximum backoff delay for retrying to connect to a validator
 
   Default value: `30000`
+* `--notification-circuit-breaker-initial-probe-interval-ms <NOTIFICATION_CIRCUIT_BREAKER_INITIAL_PROBE_INTERVAL>` — Initial probe interval (ms) for the notification circuit breaker. When a validator's notification stream exhausts retries, the circuit breaker waits this long before probing again. Doubles on each failed probe
+
+  Default value: `300000`
+* `--notification-circuit-breaker-max-probe-interval-ms <NOTIFICATION_CIRCUIT_BREAKER_MAX_PROBE_INTERVAL>` — Maximum probe interval (ms) for the notification circuit breaker. The probe interval doubles on each failure but is capped at this value
+
+  Default value: `3600000`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
 * `--allow-fast-blocks` — Whether to allow creating blocks in the fast round. Fast blocks have lower latency but must be used carefully so that there are never any conflicting fast block proposals
 * `--long-lived-services` — (EXPERIMENTAL) Whether application services can persist in some cases between queries

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -115,6 +115,25 @@ pub struct Options {
     )]
     pub max_backoff: Duration,
 
+    /// Initial probe interval (ms) for the notification circuit breaker. When a validator's
+    /// notification stream exhausts retries, the circuit breaker waits this long before
+    /// probing again. Doubles on each failed probe.
+    #[arg(
+        long = "notification-circuit-breaker-initial-probe-interval-ms",
+        default_value = "300000",
+        value_parser = util::parse_millis
+    )]
+    pub notification_circuit_breaker_initial_probe_interval: Duration,
+
+    /// Maximum probe interval (ms) for the notification circuit breaker. The probe interval
+    /// doubles on each failure but is capped at this value.
+    #[arg(
+        long = "notification-circuit-breaker-max-probe-interval-ms",
+        default_value = "3600000",
+        value_parser = util::parse_millis
+    )]
+    pub notification_circuit_breaker_max_probe_interval: Duration,
+
     /// Whether to wait until a quorum of validators has confirmed that all sent cross-chain
     /// messages have been delivered.
     #[arg(long)]
@@ -301,6 +320,10 @@ impl Options {
             sender_certificate_download_batch_size: self.sender_certificate_download_batch_size,
             max_joined_tasks: self.max_joined_tasks,
             allow_fast_blocks: self.allow_fast_blocks,
+            notification_circuit_breaker_initial_probe_interval: self
+                .notification_circuit_breaker_initial_probe_interval,
+            notification_circuit_breaker_max_probe_interval: self
+                .notification_circuit_breaker_max_probe_interval,
         }
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1908,6 +1908,18 @@ pub struct ChainClientOptions {
     /// Whether to allow creating blocks in the fast round. Fast blocks have lower latency but
     /// must be used carefully so that there are never any conflicting fast block proposals.
     pub allow_fast_blocks: bool,
+    /// Initial probe interval for the notification circuit breaker. When a validator's
+    /// notification stream exhausts retries, the circuit breaker waits this long before
+    /// probing again. Doubles on each failed probe.
+    pub notification_circuit_breaker_initial_probe_interval: Duration,
+    /// Maximum probe interval for the notification circuit breaker. The probe interval
+    /// doubles on each failure but is capped at this value.
+    pub notification_circuit_breaker_max_probe_interval: Duration,
+}
+
+struct CircuitBreakerState {
+    next_probe_at: Instant,
+    probe_interval: Duration,
 }
 
 pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
@@ -1932,6 +1944,8 @@ impl ChainClientOptions {
             sender_certificate_download_batch_size: DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
             max_joined_tasks: 100,
             allow_fast_blocks: false,
+            notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
+            notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
         }
     }
 }
@@ -4593,7 +4607,8 @@ impl<Env: Environment> ChainClient<Env> {
             }
         }
 
-        let mut senders = HashMap::new(); // Senders to cancel notification streams.
+        let mut senders = HashMap::new();
+        let mut circuit_breakers: HashMap<ValidatorPublicKey, CircuitBreakerState> = HashMap::new();
         let notifications = self.subscribe()?;
         let (abortable_notifications, abort) = stream::abortable(self.subscribe()?);
 
@@ -4605,7 +4620,10 @@ impl<Env: Environment> ChainClient<Env> {
 
         let mut process_notifications = FuturesUnordered::new();
 
-        match self.update_notification_streams(&mut senders).await {
+        match self
+            .update_notification_streams(&mut senders, &mut circuit_breakers)
+            .await
+        {
             Ok(handler) => process_notifications.push(handler),
             Err(error) => error!("Failed to update committee: {error}"),
         };
@@ -4627,7 +4645,8 @@ impl<Env: Environment> ChainClient<Env> {
                         .is_some_and(|m| matches!(m, ListeningMode::EventsOnly(_)));
                     if !is_events_only {
                         match Box::pin(await_while_polling(
-                            this.update_notification_streams(&mut senders).fuse(),
+                            this.update_notification_streams(&mut senders, &mut circuit_breakers)
+                                .fuse(),
                             &mut process_notifications,
                         ))
                         .await
@@ -4650,11 +4669,17 @@ impl<Env: Environment> ChainClient<Env> {
         Ok((update_streams, AbortOnDrop(abort), notifications))
     }
 
-    #[instrument(level = "trace", skip(senders))]
+    #[instrument(level = "trace", skip(senders, circuit_breakers))]
     async fn update_notification_streams(
         &self,
         senders: &mut HashMap<ValidatorPublicKey, AbortHandle>,
+        circuit_breakers: &mut HashMap<ValidatorPublicKey, CircuitBreakerState>,
     ) -> Result<impl Future<Output = ()>, ChainClientError> {
+        let initial_probe_interval = self
+            .options
+            .notification_circuit_breaker_initial_probe_interval;
+        let max_probe_interval = self.options.notification_circuit_breaker_max_probe_interval;
+
         let events_only = self
             .listening_mode()
             .is_some_and(|m| matches!(m, ListeningMode::EventsOnly(_)));
@@ -4675,20 +4700,74 @@ impl<Env: Environment> ChainClient<Env> {
                 .collect();
             (nodes, self.client.local_node.clone())
         };
-        // Drop removed validators.
+
+        // Detect circuit breaker state transitions before cleaning up senders.
+        for (validator, abort) in senders.iter() {
+            if abort.is_aborted() && nodes.contains_key(validator) {
+                if let Some(state) = circuit_breakers.get_mut(validator) {
+                    // Was probing → probe failed → escalate interval.
+                    state.probe_interval = (state.probe_interval * 2).min(max_probe_interval);
+                    state.next_probe_at = Instant::now() + state.probe_interval;
+                    warn!(
+                        %validator,
+                        chain_id = %self.chain_id,
+                        next_probe_in = ?state.probe_interval,
+                        "Validator still unhealthy after probe; increasing probe interval"
+                    );
+                } else {
+                    // First failure → enter circuit breaker.
+                    circuit_breakers.insert(
+                        *validator,
+                        CircuitBreakerState {
+                            next_probe_at: Instant::now() + initial_probe_interval,
+                            probe_interval: initial_probe_interval,
+                        },
+                    );
+                    error!(
+                        %validator,
+                        chain_id = %self.chain_id,
+                        next_probe_in = ?initial_probe_interval,
+                        "Validator notification stream ended; entering circuit breaker"
+                    );
+                }
+            } else if !abort.is_aborted() && circuit_breakers.contains_key(validator) {
+                // Stream alive while in circuit breaker → probe succeeded → recovered.
+                info!(
+                    %validator,
+                    chain_id = %self.chain_id,
+                    "Validator recovered from circuit breaker"
+                );
+                circuit_breakers.remove(validator);
+            }
+        }
+
         senders.retain(|validator, abort| {
             if !nodes.contains_key(validator) {
                 abort.abort();
             }
             !abort.is_aborted()
         });
-        // Add tasks for new validators.
+        circuit_breakers.retain(|validator, _| nodes.contains_key(validator));
+
         let validator_tasks = FuturesUnordered::new();
         for (public_key, node) in nodes {
-            let address = node.address();
             let hash_map::Entry::Vacant(entry) = senders.entry(public_key) else {
                 continue;
             };
+
+            // Circuit breaker: skip if not time to probe yet.
+            if let Some(state) = circuit_breakers.get(&public_key) {
+                if Instant::now() < state.next_probe_at {
+                    continue;
+                }
+                debug!(
+                    validator = %public_key,
+                    chain_id = %self.chain_id,
+                    "Probing unhealthy validator"
+                );
+            }
+
+            let address = node.address();
             let this = self.clone();
             let stream = stream::once({
                 let node = node.clone();
@@ -4720,8 +4799,8 @@ impl<Env: Environment> ChainClient<Env> {
             })
             .flatten();
             let (stream, abort) = stream::abortable(stream);
-            let mut stream = Box::pin(stream);
             let abort_on_exit = abort.clone();
+            let mut stream = Box::pin(stream);
             let this = self.clone();
             let local_node = local_node.clone();
             let remote_node = RemoteNode { public_key, node };
@@ -4747,7 +4826,7 @@ impl<Env: Environment> ChainClient<Env> {
                 warn!(
                     chain_id = %this.chain_id,
                     address = remote_node.address(),
-                    "Validator notification stream ended; will reconnect on next update"
+                    "Validator notification stream ended"
                 );
                 abort_on_exit.abort();
             });


### PR DESCRIPTION
## Motivation

Closes #5699.

PR #5619 fixed zombie `AbortHandle` entries by calling `abort()` when a notification
stream
ends naturally, but this creates an infinite re-queue cycle: retries exhaust (~1-2 min
of gRPC
backoff) → abort → entry removed → fresh subscription → retries exhaust → repeat
forever, each
cycle producing a burst of retry logs ("wall of logs").

## Proposal

Implement a per-validator [circuit
breaker](https://martinfowler.com/bliki/CircuitBreaker.html)
in `update_notification_streams`. The pattern follows the classic Closed → Open →
Half-Open
state machine originated by Michael Nygard (_Release It!_, 2007) and documented by
[Martin Fowler](https://martinfowler.com/bliki/CircuitBreaker.html),
[AWS](https://docs.aws.amazon.com/prescriptive-guidance/latest/cloud-design-patterns/cir
cuit-breaker.html),
and [Microsoft
Azure](https://learn.microsoft.com/en-us/azure/architecture/patterns/circuit-breaker).

The probe interval escalates with exponential backoff on repeated failures, matching the
`resetTimeout × exponentialBackoffFactor` refinement used by libraries like
[Arrow's CircuitBreaker](https://arrow-kt.io/learn/resilience/circuitbreaker/).

**Behavior:**

| State | Condition | Action |
| --- | --- | --- |
| Closed | Stream healthy | Normal notification processing |
| → Open | Stream ends (retries exhausted) | One error log; no further subscription attempts until probe time |
| Open | Probe time not reached | Validator skipped entirely (no work, no logs) |
| → Half-Open | Probe time reached | Single subscription attempt |
| Half-Open → Closed | Probe succeeds (stream stays alive) | Info log; normal operation resumes |
| Half-Open → Open | Probe fails (stream ends again) | Warn log; probe interval doubles (5m → 10m → 20m → ... → 1h cap) |

**New CLI arguments** (with sensible defaults):

- `--notification-circuit-breaker-initial-probe-interval-ms` (default: 300000 = 5 min)
- `--notificatiterval-ms` (default: 3600000 = 1 hour)

## Test Plan

CI