### PR TITLE
Add global blob cache to DbStorage

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -260,6 +260,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--storage-max-cache-find-key-values-size <STORAGE_MAX_CACHE_FIND_KEY_VALUES_SIZE>` — The maximal memory used in the find_key_values_by_prefix cache
 
   Default value: `10000000`
+* `--blob-cache-size <BLOB_CACHE_SIZE>` — The maximal number of entries in the blob cache
+
+  Default value: `1000`
 * `--storage-replication-factor <STORAGE_REPLICATION_FACTOR>` — The replication factor for the keyspace
 
   Default value: `1`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6155,6 +6155,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-storage",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4155,6 +4155,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-views",

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -82,6 +82,10 @@ struct ServeOptions {
     /// Port to listen on for HTTP requests
     #[arg(long, default_value = "3001")]
     port: u16,
+
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000")]
+    blob_cache_size: usize,
 }
 
 fn main() -> Result<()> {
@@ -109,6 +113,7 @@ impl ServeOptions {
             &self.fungible_app_id_file,
             &self.evm_private_key,
             self.port,
+            self.blob_cache_size,
         )
         .await
     }

--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -318,6 +318,7 @@ pub async fn run(
     fungible_app_id_file: &str,
     evm_private_key: &str,
     port: u16,
+    blob_cache_size: usize,
 ) -> Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -344,6 +345,7 @@ pub async fn run(
         &config,
         "bridge-relay",
         Some(WasmRuntime::default()),
+        blob_cache_size,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -106,6 +106,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &config,
         "e2l-bridge-e2e-test",
         Some(WasmRuntime::default()),
+        1000,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -72,6 +72,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &config,
         "bridge-e2e-test",
         Some(WasmRuntime::default()),
+        1000,
     )
     .await?;
 

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -68,6 +68,10 @@ pub struct RocksDbConfig {
     /// The maximal memory used in the find_key_values_by_prefix cache in bytes.
     #[arg(long, default_value = "10000000")]
     pub max_cache_find_key_values_size: usize,
+
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000")]
+    pub blob_cache_size: usize,
 }
 
 pub type RocksDbRunner = Runner<RocksDbDatabase, RocksDbConfig>;
@@ -106,7 +110,7 @@ impl RocksDbRunner {
         };
         store_config
             .clone()
-            .run_with_store(StorageMigration)
+            .run_with_store(config.client.blob_cache_size, StorageMigration)
             .await
             .expect("Failure to migrate the database");
         let database =

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -63,6 +63,10 @@ pub struct ScyllaDbConfig {
     #[arg(long, default_value = "10000000")]
     pub max_cache_find_key_values_size: usize,
 
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000")]
+    pub blob_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1")]
     pub replication_factor: u32,
@@ -100,7 +104,7 @@ impl ScyllaDbRunner {
         };
         store_config
             .clone()
-            .run_with_store(StorageMigration)
+            .run_with_store(config.client.blob_cache_size, StorageMigration)
             .await
             .expect("ScyllaDb migration failed");
         let database = ScyllaDbDatabase::connect(&scylladb_store_config, &namespace).await?;

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2423,6 +2423,7 @@ dependencies = [
  "futures",
  "itertools",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-views",

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1806,6 +1806,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -1846,8 +1847,13 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                 genesis_config_path,
             } => {
                 let genesis_config: GenesisConfig = util::read_json(genesis_config_path)?;
-                let mut storage =
-                    DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None).await?;
+                let mut storage = DbStorage::<D, _>::maybe_create_and_connect(
+                    &config,
+                    &namespace,
+                    None,
+                    blob_cache_size,
+                )
+                .await?;
                 genesis_config.initialize_storage(&mut storage).await?;
                 info!(
                     "Namespace {namespace} was initialized in {} ms",

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -83,9 +83,11 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
+        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
         let output = Box::pin(store_config.run_with_storage(
             self.common.wasm_runtime.with_wasm_default(),
             self.common.application_logs,
+            blob_cache_size,
             job,
         ))
         .await?;
@@ -102,19 +104,20 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
+        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
         if assert_storage_v1 {
             store_config
                 .clone()
-                .run_with_store(crate::AssertStorageV1)
+                .run_with_store(blob_cache_size, crate::AssertStorageV1)
                 .await?;
         }
         if need_migration {
             store_config
                 .clone()
-                .run_with_store(crate::StorageMigration)
+                .run_with_store(blob_cache_size, crate::StorageMigration)
                 .await?;
         }
-        let output = Box::pin(store_config.run_with_store(job)).await?;
+        let output = Box::pin(store_config.run_with_store(blob_cache_size, job)).await?;
         Ok(output)
     }
 
@@ -124,7 +127,10 @@ impl Options {
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
         let wallet = self.wallet()?;
-        store_config.initialize(wallet.genesis_config()).await?;
+        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        store_config
+            .initialize(blob_cache_size, wallet.genesis_config())
+            .await?;
         Ok(())
     }
 

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -302,14 +302,15 @@ impl RunOptions {
                 .storage_config
                 .add_common_storage_options(&self.common_storage_options)
                 .unwrap();
+            let blob_cache_size = self.common_storage_options.blob_cache_size;
             store_config
                 .clone()
-                .run_with_store(StorageMigration)
+                .run_with_store(blob_cache_size, StorageMigration)
                 .await?;
             // Exporters are part of validator infrastructure and should not output contract logs.
             let allow_application_logs = false;
             store_config
-                .run_with_storage(None, allow_application_logs, context)
+                .run_with_storage(None, allow_application_logs, blob_cache_size, context)
                 .boxed()
                 .await
         };
@@ -349,8 +350,9 @@ impl DestinationsCommand {
             action,
         };
 
+        let blob_cache_size = options.common_storage_options.blob_cache_size;
         store_config
-            .run_with_storage(None, false, context)
+            .run_with_storage(None, false, blob_cache_size, context)
             .await?
             .map_err(Into::into)
     }

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -498,13 +498,18 @@ impl ProxyOptions {
         let store_config = self
             .storage_config
             .add_common_storage_options(&self.common_storage_options)?;
-        store_config.clone().run_with_store(AssertStorageV1).await?;
+        let blob_cache_size = self.common_storage_options.blob_cache_size;
+        store_config
+            .clone()
+            .run_with_store(blob_cache_size, AssertStorageV1)
+            .await?;
         // Proxies are part of validator infrastructure and should not output contract logs.
         let allow_application_logs = false;
         store_config
             .run_with_storage(
                 None,
                 allow_application_logs,
+                blob_cache_size,
                 ProxyContext::from_options(self)?,
             )
             .boxed()

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -545,13 +545,14 @@ async fn run(options: ServerOptions) {
                 .unwrap();
             // Validators should not output contract logs.
             let allow_application_logs = false;
+            let blob_cache_size = common_storage_options.blob_cache_size;
             store_config
                 .clone()
-                .run_with_store(AssertStorageV1)
+                .run_with_store(blob_cache_size, AssertStorageV1)
                 .await
                 .unwrap();
             store_config
-                .run_with_storage(wasm_runtime, allow_application_logs, job)
+                .run_with_storage(wasm_runtime, allow_application_logs, blob_cache_size, job)
                 .boxed()
                 .await
                 .unwrap()

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -82,6 +82,10 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "10000000", global = true)]
     pub storage_max_cache_find_key_values_size: usize,
 
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub blob_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1", global = true)]
     pub storage_replication_factor: u32,
@@ -618,6 +622,7 @@ pub trait RunnableWithStore {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -630,6 +635,7 @@ impl StoreConfig {
         self,
         wasm_runtime: Option<WasmRuntime>,
         allow_application_logs: bool,
+        blob_cache_size: usize,
         job: Job,
     ) -> Result<Job::Output, anyhow::Error>
     where
@@ -645,6 +651,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
+                    blob_cache_size,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -659,6 +666,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
+                    blob_cache_size,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -666,26 +674,38 @@ impl StoreConfig {
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb { config, namespace } => {
-                let storage =
-                    DbStorage::<RocksDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?
-                        .with_allow_application_logs(allow_application_logs);
+                let storage = DbStorage::<RocksDbDatabase, _>::connect(
+                    &config,
+                    &namespace,
+                    wasm_runtime,
+                    blob_cache_size,
+                )
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb { config, namespace } => {
-                let storage =
-                    DbStorage::<DynamoDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?
-                        .with_allow_application_logs(allow_application_logs);
+                let storage = DbStorage::<DynamoDbDatabase, _>::connect(
+                    &config,
+                    &namespace,
+                    wasm_runtime,
+                    blob_cache_size,
+                )
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb { config, namespace } => {
-                let storage =
-                    DbStorage::<ScyllaDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?
-                        .with_allow_application_logs(allow_application_logs);
+                let storage = DbStorage::<ScyllaDbDatabase, _>::connect(
+                    &config,
+                    &namespace,
+                    wasm_runtime,
+                    blob_cache_size,
+                )
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
@@ -693,7 +713,9 @@ impl StoreConfig {
                 let storage = DbStorage::<
                     DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>,
                     _,
-                >::connect(&config, &namespace, wasm_runtime)
+                >::connect(
+                    &config, &namespace, wasm_runtime, blob_cache_size
+                )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
@@ -702,7 +724,11 @@ impl StoreConfig {
     }
 
     #[allow(unused_variables)]
-    pub async fn run_with_store<Job>(self, job: Job) -> Result<Job::Output, anyhow::Error>
+    pub async fn run_with_store<Job>(
+        self,
+        blob_cache_size: usize,
+        job: Job,
+    ) -> Result<Job::Output, anyhow::Error>
     where
         Job: RunnableWithStore,
     {
@@ -711,33 +737,42 @@ impl StoreConfig {
                 Err(anyhow!("Cannot run admin operations on the memory store"))
             }
             #[cfg(feature = "storage-service")]
-            StoreConfig::StorageService { config, namespace } => {
-                Ok(job.run::<StorageServiceDatabase>(config, namespace).await?)
-            }
+            StoreConfig::StorageService { config, namespace } => Ok(job
+                .run::<StorageServiceDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(feature = "rocksdb")]
-            StoreConfig::RocksDb { config, namespace } => {
-                Ok(job.run::<RocksDbDatabase>(config, namespace).await?)
-            }
+            StoreConfig::RocksDb { config, namespace } => Ok(job
+                .run::<RocksDbDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(feature = "dynamodb")]
-            StoreConfig::DynamoDb { config, namespace } => {
-                Ok(job.run::<DynamoDbDatabase>(config, namespace).await?)
-            }
+            StoreConfig::DynamoDb { config, namespace } => Ok(job
+                .run::<DynamoDbDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(feature = "scylladb")]
-            StoreConfig::ScyllaDb { config, namespace } => {
-                Ok(job.run::<ScyllaDbDatabase>(config, namespace).await?)
-            }
+            StoreConfig::ScyllaDb { config, namespace } => Ok(job
+                .run::<ScyllaDbDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
             StoreConfig::DualRocksDbScyllaDb { config, namespace } => Ok(job
                 .run::<DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>>(
-                    config, namespace,
+                    config,
+                    namespace,
+                    blob_cache_size,
                 )
                 .await?),
         }
     }
 
-    pub async fn initialize(self, config: &GenesisConfig) -> Result<(), anyhow::Error> {
-        self.clone().run_with_store(StorageMigration).await?;
-        self.run_with_store(InitializeStorageJob(config)).await
+    pub async fn initialize(
+        self,
+        blob_cache_size: usize,
+        config: &GenesisConfig,
+    ) -> Result<(), anyhow::Error> {
+        self.clone()
+            .run_with_store(blob_cache_size, StorageMigration)
+            .await?;
+        self.run_with_store(blob_cache_size, InitializeStorageJob(config))
+            .await
     }
 }
 
@@ -751,6 +786,7 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -758,7 +794,8 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         D::Error: Send + Sync,
     {
         let mut storage =
-            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None).await?;
+            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None, blob_cache_size)
+                .await?;
         self.0.initialize_storage(&mut storage).await?;
         Ok(())
     }
@@ -774,6 +811,7 @@ impl RunnableWithStore for StorageMigration {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -782,8 +820,13 @@ impl RunnableWithStore for StorageMigration {
     {
         if D::exists(&config, &namespace).await? {
             let wasm_runtime = None;
-            let storage =
-                DbStorage::<D, WallClock>::connect(&config, &namespace, wasm_runtime).await?;
+            let storage = DbStorage::<D, WallClock>::connect(
+                &config,
+                &namespace,
+                wasm_runtime,
+                blob_cache_size,
+            )
+            .await?;
             storage.migrate_if_needed().await?;
         }
         Ok(())
@@ -800,6 +843,7 @@ impl RunnableWithStore for AssertStorageV1 {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -808,8 +852,13 @@ impl RunnableWithStore for AssertStorageV1 {
     {
         if D::exists(&config, &namespace).await? {
             let wasm_runtime = None;
-            let storage =
-                DbStorage::<D, WallClock>::connect(&config, &namespace, wasm_runtime).await?;
+            let storage = DbStorage::<D, WallClock>::connect(
+                &config,
+                &namespace,
+                wasm_runtime,
+                blob_cache_size,
+            )
+            .await?;
             storage.assert_is_migrated_storage().await?;
         }
         Ok(())

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -25,6 +25,7 @@ metrics = [
     "linera-base/metrics",
     "linera-chain/metrics",
     "linera-execution/metrics",
+    "linera-cache/metrics",
     "linera-views/metrics",
 ]
 web = [
@@ -41,6 +42,7 @@ cfg-if.workspace = true
 futures.workspace = true
 itertools.workspace = true
 linera-base.workspace = true
+linera-cache.workspace = true
 linera-chain.workspace = true
 linera-execution.workspace = true
 linera-views.workspace = true

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -11,6 +11,7 @@ use linera_base::{
     data_types::{Blob, BlockHeight, NetworkDescription, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
 };
+use linera_cache::ValueCache;
 use linera_chain::{
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     ChainStateView,
@@ -369,6 +370,7 @@ pub struct DbStorage<Database, Clock = WallClock> {
     wasm_runtime: Option<WasmRuntime>,
     user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
+    blob_cache: Arc<ValueCache<BlobId, Blob>>,
     execution_runtime_config: ExecutionRuntimeConfig,
 }
 
@@ -1251,12 +1253,20 @@ where
 
     #[instrument(skip_all, fields(%blob_id))]
     async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError> {
+        if let Some(blob) = self.blob_cache.get(&blob_id) {
+            return Ok(Some(blob));
+        }
         let root_key = RootKey::Blob(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
         let maybe_blob_bytes = store.read_value_bytes(BLOB_KEY).await?;
         #[cfg(with_metrics)]
         metrics::READ_BLOB_COUNTER.with_label_values(&[]).inc();
-        Ok(maybe_blob_bytes.map(|blob_bytes| Blob::new_with_id_unchecked(blob_id, blob_bytes)))
+        let result =
+            maybe_blob_bytes.map(|blob_bytes| Blob::new_with_id_unchecked(blob_id, blob_bytes));
+        if let Some(ref blob) = result {
+            self.blob_cache.insert(&blob_id, blob.clone());
+        }
+        Ok(result)
     }
 
     #[instrument(skip_all, fields(blob_ids_len = %blob_ids.len()))]
@@ -1764,7 +1774,12 @@ where
     Database::Store: KeyValueStore + Clone + 'static,
     C: Clock + Clone + Send + Sync + 'static,
 {
-    pub(crate) fn new(database: Database, wasm_runtime: Option<WasmRuntime>, clock: C) -> Self {
+    pub(crate) fn new(
+        database: Database,
+        wasm_runtime: Option<WasmRuntime>,
+        blob_cache_size: usize,
+        clock: C,
+    ) -> Self {
         Self {
             database: Arc::new(database),
             clock,
@@ -1774,6 +1789,7 @@ where
             wasm_runtime,
             user_contracts: Arc::new(papaya::HashMap::new()),
             user_services: Arc::new(papaya::HashMap::new()),
+            blob_cache: Arc::new(ValueCache::new(blob_cache_size)),
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }
     }
@@ -1795,9 +1811,10 @@ where
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
+        blob_cache_size: usize,
     ) -> Result<Self, ViewError> {
         let database = Database::maybe_create_and_connect(config, namespace).await?;
-        let storage = Self::new(database, wasm_runtime, WallClock);
+        let storage = Self::new(database, wasm_runtime, blob_cache_size, WallClock);
         Ok(storage)
     }
 
@@ -1805,9 +1822,10 @@ where
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
+        blob_cache_size: usize,
     ) -> Result<Self, ViewError> {
         let database = Database::connect(config, namespace).await?;
-        let storage = Self::new(database, wasm_runtime, WallClock);
+        let storage = Self::new(database, wasm_runtime, blob_cache_size, WallClock);
         Ok(storage)
     }
 
@@ -1881,7 +1899,7 @@ where
         clock: TestClock,
     ) -> Result<Self, ViewError> {
         let database = Database::recreate_and_connect(&config, namespace).await?;
-        let storage = Self::new(database, wasm_runtime, clock);
+        let storage = Self::new(database, wasm_runtime, 1000, clock);
         storage.assert_is_migrated_storage().await?;
         Ok(storage)
     }

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -575,7 +575,7 @@ mod tests {
         let mut storage_state = get_storage_state();
         write_storage_state_old_schema(&database, storage_state.clone()).await?;
         // Creating a storage and migrate to the new database schema.
-        let storage = DbStorage::<D, WallClock>::new(database, None, WallClock);
+        let storage = DbStorage::<D, WallClock>::new(database, None, 1000, WallClock);
         storage.migrate_if_needed().await?;
         // read the storage state and compare it.
         let read_storage_state = read_storage_state_new_schema(storage.database.deref()).await?;

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -17,6 +17,7 @@ pub async fn get_storage(namespace: &str) -> Result<Storage, linera_views::ViewE
         },
         namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
+        1000,
     )
     .await?
     .with_allow_application_logs(true))


### PR DESCRIPTION
## Motivation

`load_contract` → `describe_application` → `read_blob` hits the database on every call.
For steady-state workloads with a single app, the same ~3 blobs (description, contract
bytecode, service bytecode) are re-read thousands of times per block. Blobs are
content-addressed and immutable — ideal for caching.

Stacked on #5714.

## Proposal

- Add a `blob_cache: Arc<ValueCache<BlobId, Blob>>` field to `DbStorage`, using the
`ValueCache` from `linera-cache` (PR #5714).
- Intercept `read_blob()` to check the cache before hitting the database, and populate
on miss.
- Add `--blob-cache-size` CLI argument (default 1000) to `CommonStorageOptions`,
threaded through `run_with_storage`, `run_with_store`, and the `RunnableWithStore` trait
so every code path receives the configured value consistently.
- `Blob` clone is cheap (`Arc<Box<[u8]>>` refcount bump), `BlobId` is `Copy` — no
overhead concern.

## Test Plan

- CI

This change seems to make us be able to keep the inboxes empty MUCH better.
On the same network, benchmark with the same exact TPS without this PR and then with this PR (on both the workers and validator), for around the same amount of time, this is how the inbox size looked:

Before:
<img width="1270" height="301" alt="Screenshot 2026-03-18 at 02 13 50" src="https://github.com/user-attachments/assets/e087e482-2b8f-4709-9554-5542f11a151a" />

After:
<img width="1268" height="302" alt="Screenshot 2026-03-18 at 02 13 20" src="https://github.com/user-attachments/assets/6d5f9983-ea7e-49ab-926a-bf56d0728790" />

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
