### PR TITLE
fix(helm): respect null otel_endpoint when alloy is enabled

### DIFF
--- a/kubernetes/linera-validator/values-local.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-local.yaml.gotmpl
@@ -10,12 +10,17 @@ logLevel: "debug"
 {{- $observabilityAlloyEnabled := eq (env "LINERA_HELMFILE_SET_ENABLE_OBSERVABILITY_ALLOY" | default "false") "true" }}
 {{- $tempoEnabled := eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
 {{- $explicitEndpoint := env "LINERA_HELMFILE_SET_OTLP_EXPORTER_ENDPOINT" }}
+{{- if $explicitEndpoint }}
 {{- if and $observabilityAlloyEnabled $tempoEnabled }}
-# Observability-alloy is enabled with traces - route through Alloy for dual forwarding (local + central)
-otlpExporterEndpoint: {{ $explicitEndpoint | default "http://observability-alloy.monitoring.svc.cluster.local:4317" }}
+# Observability-alloy is enabled with traces - route through Alloy for k8sattributes enrichment
+otlpExporterEndpoint: "http://observability-alloy.monitoring.svc.cluster.local:4317"
 {{- else }}
-# Direct endpoint (local Tempo or disabled)
-otlpExporterEndpoint: {{ $explicitEndpoint | default "" }}
+# Direct endpoint
+otlpExporterEndpoint: {{ $explicitEndpoint }}
+{{- end }}
+{{- else }}
+# No otel_endpoint configured - tracing disabled
+otlpExporterEndpoint: ""
 {{- end }}
 proxyPort: 19100
 metricsPort: 21100


### PR DESCRIPTION
## Summary

- Fix `values-local.yaml.gotmpl` defaulting to the Alloy OTLP URL even when `otel_endpoint` is null in network properties
- The `| default` fallback bypassed the Rust-side guard (`otel_endpoint.is_some()`) by filling in the Alloy endpoint when the env var was unset
- Now gates the entire OTLP endpoint block on `$explicitEndpoint` being set — when unset, always emits empty string to disable tracing

## Test plan

Ran `lineractl sync` with `otel_endpoint: null` in network properties and confirmed the diff no longer sets `LINERA_OTLP_EXPORTER_ENDPOINT` to the Alloy URL.