### PR TITLE
[testnet] Improve the access to the contracts

### DIFF
--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -96,7 +96,6 @@ impl WasmContractModule {
         contract_bytecode: Bytecode,
         runtime: WasmRuntime,
     ) -> Result<Self, WasmExecutionError> {
-        let contract_bytecode = add_metering(contract_bytecode)?;
         match runtime {
             #[cfg(with_wasmer)]
             WasmRuntime::Wasmer => Self::from_wasmer(contract_bytecode).await,

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -212,4 +212,3 @@ impl From<wasmer::RuntimeError> for ExecutionError {
             })
     }
 }
-

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -14,6 +14,7 @@ use tokio::sync::Mutex;
 use tracing::instrument;
 
 use super::{
+    add_metering,
     module_cache::ModuleCache,
     runtime_api::{BaseRuntimeApi, ContractRuntimeApi, RuntimeApiData, ServiceRuntimeApi},
     ContractEntrypoints, ServiceEntrypoints, WasmExecutionError,
@@ -36,9 +37,24 @@ static SERVICE_ENGINE: LazyLock<wasmer::Engine> = LazyLock::new(|| {
     }
 });
 
-/// A cache of compiled contract modules, with their respective [`wasmer::Engine`] instances.
-static CONTRACT_CACHE: LazyLock<Mutex<ModuleCache<CachedContractModule>>> =
-    LazyLock::new(Mutex::default);
+/// An [`Engine`] instance configured to run application contracts.
+static CONTRACT_ENGINE: LazyLock<wasmer::Engine> = LazyLock::new(|| {
+    #[cfg(not(web))]
+    {
+        let mut compiler_config = wasmer_compiler_singlepass::Singlepass::default();
+        compiler_config.canonicalize_nans(true);
+
+        wasmer::sys::EngineBuilder::new(compiler_config).into()
+    }
+
+    #[cfg(web)]
+    {
+        wasmer::Engine::default()
+    }
+});
+
+/// A cache of compiled contract modules.
+static CONTRACT_CACHE: LazyLock<Mutex<ModuleCache<wasmer::Module>>> = LazyLock::new(Mutex::default);
 
 /// A cache of compiled service modules.
 static SERVICE_CACHE: LazyLock<Mutex<ModuleCache<wasmer::Module>>> = LazyLock::new(Mutex::default);
@@ -59,12 +75,17 @@ impl WasmContractModule {
     /// Creates a new [`WasmContractModule`] using Wasmer with the provided bytecode files.
     pub async fn from_wasmer(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
-        let (engine, module) = contract_cache
-            .get_or_insert_with(contract_bytecode, "contract", CachedContractModule::new)
-            .map_err(WasmExecutionError::LoadContractModule)?
-            .create_execution_instance()
+        let module = contract_cache
+            .get_or_insert_with(contract_bytecode, "contract", |bytecode| {
+                let metered_bytecode = add_metering(bytecode)?;
+                wasmer::Module::new(&*CONTRACT_ENGINE, metered_bytecode)
+                    .map_err(anyhow::Error::from)
+            })
             .map_err(WasmExecutionError::LoadContractModule)?;
-        Ok(WasmContractModule::Wasmer { engine, module })
+        Ok(WasmContractModule::Wasmer {
+            engine: CONTRACT_ENGINE.clone(),
+            module,
+        })
     }
 }
 
@@ -192,48 +213,3 @@ impl From<wasmer::RuntimeError> for ExecutionError {
     }
 }
 
-/// Serialized bytes of a compiled contract bytecode.
-// Cloning `Module`s is cheap.
-#[derive(Clone)]
-pub struct CachedContractModule(wasmer::Module);
-
-impl CachedContractModule {
-    /// Creates a new [`CachedContractModule`] by compiling a `contract_bytecode`.
-    pub fn new(contract_bytecode: Bytecode) -> Result<Self, anyhow::Error> {
-        let module = wasmer::Module::new(&Self::create_compilation_engine(), contract_bytecode)?;
-        Ok(CachedContractModule(module))
-    }
-
-    /// Creates a new [`Engine`] to compile a contract bytecode.
-    fn create_compilation_engine() -> wasmer::Engine {
-        #[cfg(not(web))]
-        {
-            let mut compiler_config = wasmer_compiler_singlepass::Singlepass::default();
-            compiler_config.canonicalize_nans(true);
-
-            wasmer::sys::EngineBuilder::new(compiler_config).into()
-        }
-
-        #[cfg(web)]
-        wasmer::Engine::default()
-    }
-
-    /// Creates a [`Module`] from a compiled contract using a headless [`Engine`].
-    pub fn create_execution_instance(
-        &self,
-    ) -> Result<(wasmer::Engine, wasmer::Module), anyhow::Error> {
-        #[cfg(web)]
-        {
-            Ok((wasmer::Engine::default(), self.0.clone()))
-        }
-
-        #[cfg(not(web))]
-        {
-            let engine = wasmer::Engine::default();
-            let store = wasmer::Store::new(engine.clone());
-            let bytes = self.0.serialize()?;
-            let module = unsafe { wasmer::Module::deserialize(&store, bytes) }?;
-            Ok((engine, module))
-        }
-    }
-}

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -12,6 +12,7 @@ use tracing::instrument;
 use wasmtime::{Config, Engine, Linker, Module, Store};
 
 use super::{
+    add_metering,
     module_cache::ModuleCache,
     runtime_api::{BaseRuntimeApi, ContractRuntimeApi, RuntimeApiData, ServiceRuntimeApi},
     ContractEntrypoints, ServiceEntrypoints, WasmExecutionError,
@@ -62,7 +63,8 @@ impl WasmContractModule {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
         let module = contract_cache
             .get_or_insert_with(contract_bytecode, "contract", |bytecode| {
-                Module::new(&CONTRACT_ENGINE, bytecode)
+                let metered_bytecode = add_metering(bytecode)?;
+                Module::new(&CONTRACT_ENGINE, metered_bytecode)
             })
             .map_err(WasmExecutionError::LoadContractModule)?;
         Ok(WasmContractModule::Wasmtime { module })


### PR DESCRIPTION
## Motivation

We are computing the `add_metering` even when they are not needed.
Plus, for wasmer, we are serializing and then deserializing, which is inefficient.

## Proposal

Implement the same changes as in #5726 

## Test Plan

The CI.

## Release Plan

This is the release to `testnet_conway`.

## Links

None