### PR TITLE
fix(tests): increase reqwest timeout from 30s to 60s

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -67,7 +67,7 @@ const CLIENT_SERVICE_ENV: &str = "LINERA_CLIENT_SERVICE_PARAMS";
 
 fn reqwest_client() -> reqwest::Client {
     reqwest::ClientBuilder::new()
-        .timeout(Duration::from_secs(30))
+        .timeout(Duration::from_secs(60))
         .build()
         .unwrap()
 }


### PR DESCRIPTION
## Motivation

`test_evm_erc20_shared` sends 500 EVM operations in a single request. On CI this can exceed the 30-second HTTP timeout, causing a retry that fails with a block conflict because the first request actually succeeded server-side.

## Proposal

Increase the timeout.

## Test Plan

CI: Let's see if it's still flaky.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
