### PR TITLE
Reduce retry noise when validators are unhealthy

### DIFF
--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -25,14 +25,14 @@ use crate::simple::SimpleClient;
 
 #[derive(Clone)]
 pub enum Client {
-    Grpc(GrpcClient),
+    Grpc(Box<GrpcClient>),
     #[cfg(with_simple_network)]
     Simple(SimpleClient),
 }
 
 impl From<GrpcClient> for Client {
     fn from(client: GrpcClient) -> Self {
-        Self::Grpc(client)
+        Self::Grpc(Box::new(client))
     }
 }
 

--- a/linera-rpc/src/cross_chain_message_queue.rs
+++ b/linera-rpc/src/cross_chain_message_queue.rs
@@ -19,7 +19,7 @@ use linera_core::data_types::CrossChainRequest;
 use rand::Rng as _;
 use tracing::{trace, warn};
 
-use crate::{config::ShardId, full_jitter_delay};
+use crate::config::ShardId;
 
 #[cfg(with_metrics)]
 mod metrics {
@@ -105,11 +105,9 @@ pub(crate) async fn forward_cross_chain_queries<F, G>(
                 }
 
                 Action::Retry => {
-                    let delay = full_jitter_delay(
-                        cross_chain_retry_delay,
-                        state.retries,
-                        cross_chain_max_backoff,
-                    );
+                    let delay = cross_chain_retry_delay
+                        .saturating_mul(state.retries)
+                        .min(cross_chain_max_backoff);
                     linera_base::time::timer::sleep(delay).await;
                     Action::Proceed { id: state.id }
                 }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -18,7 +18,7 @@ use linera_base::{
     data_types::{BlobContent, BlockHeight, NetworkDescription},
     ensure,
     identifiers::{BlobId, ChainId, StreamId},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use linera_chain::{
     data_types::{self},
@@ -50,7 +50,7 @@ use linera_core::{
 };
 use linera_version::VersionInfo;
 use tonic::{Code, IntoRequest, Request, Status};
-use tracing::{debug, instrument, trace, warn, Level};
+use tracing::{debug, instrument, trace, Level};
 
 use super::{
     api::{self, validator_node_client::ValidatorNodeClient, SubscriptionRequest},
@@ -63,8 +63,8 @@ pub(crate) const MAX_STREAM_IDS_PER_REQUEST: usize = 10_000;
 #[cfg(feature = "opentelemetry")]
 use crate::propagation::{get_context_with_traffic_type, inject_context};
 use crate::{
-    full_jitter_delay, grpc::api::RawCertificate, HandleConfirmedCertificateRequest,
-    HandleLiteCertRequest, HandleTimeoutCertificateRequest, HandleValidatedCertificateRequest,
+    grpc::api::RawCertificate, HandleConfirmedCertificateRequest, HandleLiteCertRequest,
+    HandleTimeoutCertificateRequest, HandleValidatedCertificateRequest,
 };
 
 #[derive(Clone)]
@@ -74,6 +74,10 @@ pub struct GrpcClient {
     retry_delay: Duration,
     max_retries: u32,
     max_backoff: Duration,
+    /// Shared across all `GrpcClient` instances created by the same `GrpcNodeProvider`.
+    /// Tracks when each validator address last had a subscription failure, so that
+    /// other chains don't independently retry the same dead validator.
+    subscription_cooldowns: papaya::HashMap<String, Instant>,
 }
 
 impl GrpcClient {
@@ -83,6 +87,7 @@ impl GrpcClient {
         retry_delay: Duration,
         max_retries: u32,
         max_backoff: Duration,
+        subscription_cooldowns: papaya::HashMap<String, Instant>,
     ) -> Self {
         let client = ValidatorNodeClient::new(channel)
             .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
@@ -93,6 +98,7 @@ impl GrpcClient {
             retry_delay,
             max_retries,
             max_backoff,
+            subscription_cooldowns,
         }
     }
 
@@ -169,7 +175,11 @@ impl GrpcClient {
             inject_context(&get_context_with_traffic_type(), request.metadata_mut());
             match f(self.client.clone(), request).await {
                 Err(s) if Self::is_retryable(&s) && retry_count < self.max_retries => {
-                    let delay = full_jitter_delay(self.retry_delay, retry_count, self.max_backoff);
+                    let delay = crate::jittered_backoff_delay(
+                        self.retry_delay,
+                        retry_count,
+                        self.max_backoff,
+                    );
                     retry_count += 1;
                     linera_base::time::timer::sleep(delay).await;
                     continue;
@@ -329,6 +339,24 @@ impl ValidatorNode for GrpcClient {
         let max_retries = self.max_retries;
         let max_backoff = self.max_backoff;
         let address = self.address.clone();
+        let subscription_cooldowns = self.subscription_cooldowns.clone();
+
+        // Fast-fail if another subscription to this address recently failed.
+        // Prevents N chains from independently retrying the same dead validator.
+        {
+            let pinned = subscription_cooldowns.pin();
+            if let Some(&last_failure) = pinned.get(&address) {
+                if last_failure.elapsed() < max_backoff {
+                    return Err(NodeError::SubscriptionFailed {
+                        status: format!(
+                            "validator {} on cooldown after recent subscription failure",
+                            address
+                        ),
+                    });
+                }
+            }
+        }
+
         // Use shared atomic counter so unfold can reset it on successful reconnection.
         let retry_count = Arc::new(AtomicU32::new(0));
         let subscription_request = SubscriptionRequest {
@@ -341,8 +369,13 @@ impl ValidatorNode for GrpcClient {
             client
                 .subscribe(subscription_request.clone())
                 .await
-                .map_err(|status| NodeError::SubscriptionFailed {
-                    status: status.to_string(),
+                .map_err(|status| {
+                    subscription_cooldowns
+                        .pin()
+                        .insert(address.clone(), Instant::now());
+                    NodeError::SubscriptionFailed {
+                        status: status.to_string(),
+                    }
                 })?
                 .into_inner(),
         );
@@ -350,11 +383,15 @@ impl ValidatorNode for GrpcClient {
         // A stream of `Result<grpc::Notification, tonic::Status>` that keeps calling
         // `client.subscribe(request)` endlessly and without delay.
         let retry_count_for_unfold = retry_count.clone();
+        let cooldowns_for_unfold = subscription_cooldowns.clone();
+        let address_for_unfold = address.clone();
         let endlessly_retrying_notification_stream = stream::unfold((), move |()| {
             let mut client = client.clone();
             let subscription_request = subscription_request.clone();
             let mut stream = stream.take();
             let retry_count = retry_count_for_unfold.clone();
+            let cooldowns = cooldowns_for_unfold.clone();
+            let cooldown_address = address_for_unfold.clone();
             async move {
                 let stream = if let Some(stream) = stream.take() {
                     future::Either::Right(stream)
@@ -364,6 +401,7 @@ impl ValidatorNode for GrpcClient {
                         Ok(response) => {
                             // Reset retry count on successful reconnection.
                             retry_count.store(0, Ordering::Relaxed);
+                            cooldowns.pin().remove(&cooldown_address);
                             trace!("Successfully reconnected subscription stream");
                             future::Either::Right(response.into_inner())
                         }
@@ -377,6 +415,8 @@ impl ValidatorNode for GrpcClient {
         let span = tracing::info_span!("notification stream");
         #[cfg(with_metrics)]
         let address_for_metrics = address.clone();
+        let cooldowns_for_take_while = subscription_cooldowns;
+        let address_for_take_while = address.clone();
         // The stream of `Notification`s that inserts increasing delays after retriable errors, and
         // terminates after unexpected or fatal errors.
         let notification_stream = endlessly_retrying_notification_stream
@@ -401,9 +441,13 @@ impl ValidatorNode for GrpcClient {
                 if !span.in_scope(|| Self::is_retryable(status))
                     || current_retry_count >= max_retries
                 {
+                    cooldowns_for_take_while
+                        .pin()
+                        .insert(address_for_take_while.clone(), Instant::now());
                     return future::Either::Left(future::ready(false));
                 }
-                let delay = full_jitter_delay(retry_delay, current_retry_count, max_backoff);
+                let delay =
+                    crate::jittered_backoff_delay(retry_delay, current_retry_count, max_backoff);
                 retry_count.fetch_add(1, Ordering::Relaxed);
                 future::Either::Right(async move {
                     linera_base::time::timer::sleep(delay).await;
@@ -415,7 +459,7 @@ impl ValidatorNode for GrpcClient {
                     Ok(notification @ Some(_)) => notification,
                     Ok(None) => None,
                     Err(err) => {
-                        warn!(%address, "{}", err);
+                        debug!(%address, "{}", err);
                         None
                     }
                 })

--- a/linera-rpc/src/grpc/node_provider.rs
+++ b/linera-rpc/src/grpc/node_provider.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr as _;
 
-use linera_base::time::Duration;
+use linera_base::time::{Duration, Instant};
 use linera_core::node::{NodeError, ValidatorNodeProvider};
 
 use super::GrpcClient;
@@ -19,6 +19,10 @@ pub struct GrpcNodeProvider {
     retry_delay: Duration,
     max_retries: u32,
     max_backoff: Duration,
+    /// Shared across all `GrpcClient` instances. When a subscription to a validator
+    /// fails, the failure time is recorded here so that other chains (which share the
+    /// same provider) skip retrying the same dead validator.
+    subscription_cooldowns: papaya::HashMap<String, Instant>,
 }
 
 impl GrpcNodeProvider {
@@ -33,6 +37,7 @@ impl GrpcNodeProvider {
             retry_delay,
             max_retries,
             max_backoff,
+            subscription_cooldowns: papaya::HashMap::new(),
         }
     }
 }
@@ -60,6 +65,7 @@ impl ValidatorNodeProvider for GrpcNodeProvider {
             self.retry_delay,
             self.max_retries,
             self.max_backoff,
+            self.subscription_cooldowns.clone(),
         ))
     }
 }

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -58,11 +58,14 @@ pub const CERT_PEM: &str = include_str!(concat!(env!("OUT_DIR"), "/self_signed_c
 #[cfg(not(target_arch = "wasm32"))]
 pub const KEY_PEM: &str = include_str!(concat!(env!("OUT_DIR"), "/private_key.pem"));
 
-/// Computes a Full Jitter delay for exponential backoff.
+/// Computes a jittered exponential backoff delay.
 ///
-/// Uses the AWS-recommended formula: `sleep = random(0, min(cap, base * 2^attempt))`.
-/// Reference: <https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/>
-pub(crate) fn full_jitter_delay(
+/// Uses the gRPC-recommended approach: compute `min(cap, base * 2^attempt)`,
+/// then apply ±20% jitter. This guarantees a minimum delay of 80% of the
+/// computed backoff, preventing instant retries.
+///
+/// Reference: <https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md>
+pub(crate) fn jittered_backoff_delay(
     base_delay: std::time::Duration,
     attempt: u32,
     max_backoff: std::time::Duration,
@@ -70,8 +73,8 @@ pub(crate) fn full_jitter_delay(
     use rand::Rng as _;
     let exponential_delay =
         base_delay.saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX));
-    let capped_delay = exponential_delay.min(max_backoff);
-    std::time::Duration::from_millis(
-        rand::thread_rng().gen_range(0..=capped_delay.as_millis() as u64),
-    )
+    let capped_delay_ms = exponential_delay.min(max_backoff).as_millis() as u64;
+    let min_delay_ms = capped_delay_ms * 4 / 5; // 80%
+    let max_delay_ms = capped_delay_ms * 6 / 5; // 120%
+    std::time::Duration::from_millis(rand::thread_rng().gen_range(min_delay_ms..=max_delay_ms))
 }

--- a/linera-rpc/src/node_provider.rs
+++ b/linera-rpc/src/node_provider.rs
@@ -39,7 +39,7 @@ impl ValidatorNodeProvider for NodeProvider {
         }
 
         if address.starts_with("grpc") {
-            return Ok(Client::Grpc(self.grpc.make_node(&address)?));
+            return Ok(Client::Grpc(Box::new(self.grpc.make_node(&address)?)));
         }
 
         Err(NodeError::CannotResolveValidatorAddress { address })

--- a/linera-rpc/tests/transport.rs
+++ b/linera-rpc/tests/transport.rs
@@ -30,6 +30,7 @@ async fn client() {
         retry_delay,
         max_retries,
         linera_rpc::node_provider::DEFAULT_MAX_BACKOFF,
+        papaya::HashMap::new(),
     )
     .get_version_info()
     .await


### PR DESCRIPTION
## Motivation

When a validator is unhealthy (e.g. during pod restarts), clients produce a wall of
warn-level logs because:

1. Every chain independently retries subscriptions to the same dead validator (N chains
× retries).
2. The old `full_jitter_delay` could return 0ms (uniform random from `[0, cap]`),
allowing instant retries.
3. Per-retry errors were logged at `warn` level, flooding production logs at `info`
threshold.

Ref: #5699

## Proposal

**Jittered exponential backoff with guaranteed minimum delay**
(`linera-base/src/time.rs`):
- New `jittered_backoff_delay` function using the gRPC-recommended ±20% jitter,
guaranteeing at least 80% of the computed backoff. Replaces the old `full_jitter_delay`
which could return 0.

**Shared subscription cooldown** (`linera-rpc/src/grpc/client.rs`, `node_provider.rs`):
- A `papaya::HashMap<String, Instant>` shared across all `GrpcClient` instances from the
same `GrpcNodeProvider` tracks when each validator address last had a subscription
failure.
- Before connecting, `subscribe()` checks the cooldown — if the validator failed
recently (within `max_backoff`, default 30s), it fast-fails instead of opening another
connection.
- On successful reconnection the cooldown is cleared; on failure (initial connect or
retries exhausted) the cooldown is set.
- This reduces the burst from N×retries connections to ~1×retries when a validator goes
down.

**Log level downgrade** (`linera-rpc/src/grpc/client.rs`):
- Per-retry subscription errors downgraded from `warn` to `debug`. The circuit breaker
at the `ChainClient` level already logs meaningful state transitions at higher levels.

**Cross-chain message retry** (`cross_chain_message_queue.rs`):
- Replaced `full_jitter_delay` (exponential with full jitter) with linear backoff capped
at `max_backoff`. Linear backoff is more appropriate for server-to-server cross-chain
messages where thundering herd is not a concern and lower latency matters.

**Clean`linera-rpc/src/lib.rs`):
- Removed the now-unused `full_jitter_delay` function.

## Test Plan

CI

