### PR TITLE
Aggregate save view latency histograms before computing percentiles

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/views.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/views.json
@@ -207,7 +207,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Time to save a view to storage. p50 is median, p90 is most users' experience, p99 captures tail latency. Broken down by view type.",
+      "description": "Time to save a view to storage. p50 is median, p90 is most users' experience, p99 captures tail latency.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -263,8 +263,8 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byRegexp",
-              "options": ".*p50.*"
+              "id": "byName",
+              "options": "p50"
             },
             "properties": [
               {
@@ -278,8 +278,8 @@
           },
           {
             "matcher": {
-              "id": "byRegexp",
-              "options": ".*p90.*"
+              "id": "byName",
+              "options": "p90"
             },
             "properties": [
               {
@@ -293,8 +293,8 @@
           },
           {
             "matcher": {
-              "id": "byRegexp",
-              "options": ".*p99.*"
+              "id": "byName",
+              "options": "p99"
             },
             "properties": [
               {
@@ -338,8 +338,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(linera:save_view_latency:rate1m{validator=~\"$validator\"}) by (le, type))",
-          "legendFormat": "{{type}} p50",
+          "expr": "histogram_quantile(0.50, sum(linera:save_view_latency:rate1m{validator=~\"$validator\"}) by (le))",
+          "legendFormat": "p50",
           "range": true,
           "refId": "A"
         },
@@ -349,8 +349,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(linera:save_view_latency:rate1m{validator=~\"$validator\"}) by (le, type))",
-          "legendFormat": "{{type}} p90",
+          "expr": "histogram_quantile(0.90, sum(linera:save_view_latency:rate1m{validator=~\"$validator\"}) by (le))",
+          "legendFormat": "p90",
           "range": true,
           "refId": "B"
         },
@@ -360,8 +360,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(linera:save_view_latency:rate1m{validator=~\"$validator\"}) by (le, type))",
-          "legendFormat": "{{type}} p99",
+          "expr": "histogram_quantile(0.99, sum(linera:save_view_latency:rate1m{validator=~\"$validator\"}) by (le))",
+          "legendFormat": "p99",
           "range": true,
           "refId": "C"
         }


### PR DESCRIPTION
## Motivation

The Save View Latency panel on the Views Grafana dashboard shows duplicate
p50/p90/p99 lines with no distinguishing labels. The `histogram_quantile`
call groups by `(le, type)`, which produces a separate percentile set per
view type — currently just `ChainStateView`, but the `byRegexp` color
overrides and `{{type}} pXX` legend format make the panel inconsistent with
every other latency panel in the dashboards.

## Proposal

Aggregate by `(le)` only (dropping the `type` dimension), matching the
pattern used by Load View Latency, Block Execution Latency, and all other
latency panels. Also switch the color overrides from `byRegexp` to exact
`byName` matching.

The live central monitoring dashboard has already been updated to match.

## Test Plan

CI. Verified on central monitoring that the panel now shows exactly 3 clean
lines (p50/p90/p99) with correct green/yellow/red coloring.
