### PR TITLE
Improve the performance of the access to storage.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5476,6 +5476,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-graphql",
+ "async-lock",
  "async-trait",
  "bcs",
  "cfg-if",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3752,6 +3752,7 @@ dependencies = [
  "allocative",
  "anyhow",
  "async-graphql",
+ "async-lock",
  "async-trait",
  "bcs",
  "cfg-if",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -43,6 +43,7 @@ alloy-primitives = { workspace = true, optional = true }
 alloy-sol-types = { workspace = true, optional = true }
 anyhow.workspace = true
 async-graphql.workspace = true
+async-lock.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 cfg-if.workspace = true

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -320,9 +320,6 @@ where
         let thread_pool = self.context().extra().thread_pool().clone();
         let mut actor = ExecutionStateActor::new(self, &mut txn_tracker, &mut resource_controller);
 
-        // Pre-warm the main application's view into the cache.
-        actor.pre_warm_user_state(&application_id).await?;
-
         let (codes, descriptions) = actor.service_and_dependencies(application_id).await?;
 
         let service_runtime_task = thread_pool

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -320,6 +320,9 @@ where
         let thread_pool = self.context().extra().thread_pool().clone();
         let mut actor = ExecutionStateActor::new(self, &mut txn_tracker, &mut resource_controller);
 
+        // Pre-warm the main application's view into the cache.
+        actor.pre_warm_user_state(&application_id).await?;
+
         let (codes, descriptions) = actor.service_and_dependencies(application_id).await?;
 
         let service_runtime_task = thread_pool

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -143,6 +143,19 @@ where
         Ok((code, description))
     }
 
+    /// Pre-warms the user state view for the given application into the cache,
+    /// so that subsequent storage operations don't need to reload from storage.
+    pub(crate) async fn pre_warm_user_state(
+        &mut self,
+        application_id: &ApplicationId,
+    ) -> Result<(), ExecutionError> {
+        self.state
+            .users
+            .try_load_entry_mut(application_id)
+            .await?;
+        Ok(())
+    }
+
     // TODO(#1416): Support concurrent I/O.
     #[instrument(
         skip_all,
@@ -335,38 +348,26 @@ where
             }
 
             ContainsKey { id, key, callback } => {
-                let view = self.state.users.try_load_entry(&id).await?;
-                let result = match view {
-                    Some(view) => view.contains_key(&key).await?,
-                    None => false,
-                };
+                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let result = view.contains_key(&key).await?;
                 callback.respond(result);
             }
 
             ContainsKeys { id, keys, callback } => {
-                let view = self.state.users.try_load_entry(&id).await?;
-                let result = match view {
-                    Some(view) => view.contains_keys(&keys).await?,
-                    None => vec![false; keys.len()],
-                };
+                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let result = view.contains_keys(&keys).await?;
                 callback.respond(result);
             }
 
             ReadMultiValuesBytes { id, keys, callback } => {
-                let view = self.state.users.try_load_entry(&id).await?;
-                let values = match view {
-                    Some(view) => view.multi_get(&keys).await?,
-                    None => vec![None; keys.len()],
-                };
+                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let values = view.multi_get(&keys).await?;
                 callback.respond(values);
             }
 
             ReadValueBytes { id, key, callback } => {
-                let view = self.state.users.try_load_entry(&id).await?;
-                let result = match view {
-                    Some(view) => view.get(&key).await?,
-                    None => None,
-                };
+                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let result = view.get(&key).await?;
                 callback.respond(result);
             }
 
@@ -375,11 +376,8 @@ where
                 key_prefix,
                 callback,
             } => {
-                let view = self.state.users.try_load_entry(&id).await?;
-                let result = match view {
-                    Some(view) => view.find_keys_by_prefix(&key_prefix).await?,
-                    None => Vec::new(),
-                };
+                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let result = view.find_keys_by_prefix(&key_prefix).await?;
                 callback.respond(result);
             }
 
@@ -388,11 +386,8 @@ where
                 key_prefix,
                 callback,
             } => {
-                let view = self.state.users.try_load_entry(&id).await?;
-                let result = match view {
-                    Some(view) => view.find_key_values_by_prefix(&key_prefix).await?,
-                    None => Vec::new(),
-                };
+                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let result = view.find_key_values_by_prefix(&key_prefix).await?;
                 callback.respond(result);
             }
 
@@ -796,14 +791,9 @@ where
                 application,
                 callback,
             } => {
-                let view = self.state.users.try_load_entry(&application).await?;
-                let result = match view {
-                    Some(view) => {
-                        let total_size = view.total_size();
-                        (total_size.key, total_size.value)
-                    }
-                    None => (0, 0),
-                };
+                let view = self.state.users.try_load_entry_mut(&application).await?;
+                let total_size = view.total_size();
+                let result = (total_size.key, total_size.value);
                 callback.respond(result);
             }
 
@@ -976,6 +966,10 @@ where
             .is_free_app(&application_id);
         controller.is_free = is_free;
         self.resource_controller.is_free = is_free;
+        // Pre-warm the main application's view into the cache so that subsequent
+        // storage operations don't need to reload it from storage each time.
+        self.pre_warm_user_state(&application_id).await?;
+
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -21,7 +21,14 @@ use linera_base::{
     ownership::ChainOwnership,
     time::Instant,
 };
-use linera_views::{batch::Batch, context::Context, views::View};
+use linera_views::{
+    batch::Batch,
+    context::Context,
+    key_value_store_view::KeyValueStoreView,
+    views::View,
+};
+use std::sync::Arc;
+use async_lock::RwLock;
 use oneshot::Sender;
 use reqwest::{header::HeaderMap, Client, Url};
 use tracing::{info_span, instrument, Instrument as _};
@@ -38,10 +45,12 @@ use crate::{
 };
 
 /// Actor for handling requests to the execution state.
-pub struct ExecutionStateActor<'a, C> {
+pub struct ExecutionStateActor<'a, C: Context> {
     state: &'a mut ExecutionStateView<C>,
     txn_tracker: &'a mut TransactionTracker,
     resource_controller: &'a mut ResourceController<Option<AccountOwner>>,
+    /// Cached key-value store views for fast access during execution.
+    key_value_stores: BTreeMap<ApplicationId, Arc<RwLock<KeyValueStoreView<C>>>>,
 }
 
 #[cfg(with_metrics)]
@@ -89,6 +98,7 @@ where
             state,
             txn_tracker,
             resource_controller,
+            key_value_stores: BTreeMap::new(),
         }
     }
 
@@ -143,17 +153,22 @@ where
         Ok((code, description))
     }
 
-    /// Pre-warms the user state view for the given application into the cache,
-    /// so that subsequent storage operations don't need to reload from storage.
-    pub(crate) async fn pre_warm_user_state(
+    /// Returns the cached key-value store view for the given application,
+    /// loading it from storage if necessary.
+    async fn get_or_load_key_value_store(
         &mut self,
         application_id: &ApplicationId,
-    ) -> Result<(), ExecutionError> {
-        self.state
+    ) -> Result<Arc<RwLock<KeyValueStoreView<C>>>, ExecutionError> {
+        if let Some(arc) = self.key_value_stores.get(application_id) {
+            return Ok(arc.clone());
+        }
+        let arc = self
+            .state
             .users
-            .try_load_entry_mut(application_id)
+            .try_load_view_arc(application_id)
             .await?;
-        Ok(())
+        self.key_value_stores.insert(*application_id, arc.clone());
+        Ok(arc)
     }
 
     // TODO(#1416): Support concurrent I/O.
@@ -348,25 +363,29 @@ where
             }
 
             ContainsKey { id, key, callback } => {
-                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let store = self.get_or_load_key_value_store(&id).await?;
+                let view = store.read().await;
                 let result = view.contains_key(&key).await?;
                 callback.respond(result);
             }
 
             ContainsKeys { id, keys, callback } => {
-                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let store = self.get_or_load_key_value_store(&id).await?;
+                let view = store.read().await;
                 let result = view.contains_keys(&keys).await?;
                 callback.respond(result);
             }
 
             ReadMultiValuesBytes { id, keys, callback } => {
-                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let store = self.get_or_load_key_value_store(&id).await?;
+                let view = store.read().await;
                 let values = view.multi_get(&keys).await?;
                 callback.respond(values);
             }
 
             ReadValueBytes { id, key, callback } => {
-                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let store = self.get_or_load_key_value_store(&id).await?;
+                let view = store.read().await;
                 let result = view.get(&key).await?;
                 callback.respond(result);
             }
@@ -376,7 +395,8 @@ where
                 key_prefix,
                 callback,
             } => {
-                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let store = self.get_or_load_key_value_store(&id).await?;
+                let view = store.read().await;
                 let result = view.find_keys_by_prefix(&key_prefix).await?;
                 callback.respond(result);
             }
@@ -386,7 +406,8 @@ where
                 key_prefix,
                 callback,
             } => {
-                let view = self.state.users.try_load_entry_mut(&id).await?;
+                let store = self.get_or_load_key_value_store(&id).await?;
+                let view = store.read().await;
                 let result = view.find_key_values_by_prefix(&key_prefix).await?;
                 callback.respond(result);
             }
@@ -396,7 +417,8 @@ where
                 batch,
                 callback,
             } => {
-                let mut view = self.state.users.try_load_entry_mut(&id).await?;
+                let store = self.get_or_load_key_value_store(&id).await?;
+                let mut view = store.write().await;
                 view.write_batch(batch).await?;
                 callback.respond(());
             }
@@ -791,7 +813,8 @@ where
                 application,
                 callback,
             } => {
-                let view = self.state.users.try_load_entry_mut(&application).await?;
+                let store = self.get_or_load_key_value_store(&application).await?;
+                let view = store.read().await;
                 let total_size = view.total_size();
                 let result = (total_size.key, total_size.value);
                 callback.respond(result);
@@ -966,10 +989,6 @@ where
             .is_free_app(&application_id);
         controller.is_free = is_free;
         self.resource_controller.is_free = is_free;
-        // Pre-warm the main application's view into the cache so that subsequent
-        // storage operations don't need to reload it from storage each time.
-        self.pre_warm_user_state(&application_id).await?;
-
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -3,8 +3,12 @@
 
 //! Handle requests from the synchronous execution thread of user applications.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
+use async_lock::RwLock;
 use custom_debug_derive::Debug;
 use futures::{channel::mpsc, StreamExt as _};
 #[cfg(with_metrics)]
@@ -22,13 +26,8 @@ use linera_base::{
     time::Instant,
 };
 use linera_views::{
-    batch::Batch,
-    context::Context,
-    key_value_store_view::KeyValueStoreView,
-    views::View,
+    batch::Batch, context::Context, key_value_store_view::KeyValueStoreView, views::View,
 };
-use std::sync::Arc;
-use async_lock::RwLock;
 use oneshot::Sender;
 use reqwest::{header::HeaderMap, Client, Url};
 use tracing::{info_span, instrument, Instrument as _};
@@ -162,11 +161,7 @@ where
         if let Some(arc) = self.key_value_stores.get(application_id) {
             return Ok(arc.clone());
         }
-        let arc = self
-            .state
-            .users
-            .try_load_view_arc(application_id)
-            .await?;
+        let arc = self.state.users.try_load_view_arc(application_id).await?;
         self.key_value_stores.insert(*application_id, arc.clone());
         Ok(arc)
     }

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2300,6 +2300,7 @@ dependencies = [
  "allocative",
  "anyhow",
  "async-graphql",
+ "async-lock",
  "async-trait",
  "bcs",
  "cfg-if",

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -199,9 +199,12 @@ impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
                     let view = view
                         .try_read()
                         .ok_or_else(|| ViewError::TryLockError(index.clone()))?;
+                    let batch_len_before = batch.operations.len();
                     view.pre_save(batch)?;
-                    self.add_index(batch, index);
-                    delete_view = false;
+                    if batch.operations.len() > batch_len_before {
+                        self.add_index(batch, index);
+                        delete_view = false;
+                    }
                 }
             }
         } else {
@@ -211,8 +214,11 @@ impl<W: View> View for ReentrantByteCollectionView<W::Context, W> {
                         let view = view
                             .try_read()
                             .ok_or_else(|| ViewError::TryLockError(index.clone()))?;
+                        let batch_len_before = batch.operations.len();
                         view.pre_save(batch)?;
-                        self.add_index(batch, index);
+                        if batch.operations.len() > batch_len_before {
+                            self.add_index(batch, index);
+                        }
                     }
                     Update::Removed => {
                         let key_subview = self.get_subview_key(index);
@@ -382,6 +388,16 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
                 .try_write_arc()
                 .ok_or_else(|| ViewError::TryLockError(short_key.to_vec()))?,
         ))
+    }
+
+    /// Loads a subview for the data at the given index in the collection and returns
+    /// the `Arc<RwLock<W>>` directly. If an entry is absent then a default entry is added
+    /// to the collection. This is useful for caching the Arc outside the collection.
+    pub async fn try_load_view_arc(
+        &mut self,
+        short_key: &[u8],
+    ) -> Result<Arc<RwLock<W>>, ViewError> {
+        self.try_load_view_mut(short_key).await
     }
 
     /// Loads a subview at the given index in the collection and gives read-only access to the data.
@@ -1237,6 +1253,20 @@ where
     {
         let short_key = BaseKey::derive_short_key(index)?;
         self.collection.try_load_entry_mut(&short_key).await
+    }
+
+    /// Loads a subview for the data at the given index and returns the `Arc<RwLock<W>>`
+    /// directly. If an entry is absent then a default entry is added to the collection.
+    pub async fn try_load_view_arc<Q>(
+        &mut self,
+        index: &Q,
+    ) -> Result<Arc<RwLock<W>>, ViewError>
+    where
+        I: Borrow<Q>,
+        Q: Serialize + ?Sized,
+    {
+        let short_key = BaseKey::derive_short_key(index)?;
+        self.collection.try_load_view_arc(&short_key).await
     }
 
     /// Loads a subview at the given index in the collection and gives read-only access to the data.

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -1257,10 +1257,7 @@ where
 
     /// Loads a subview for the data at the given index and returns the `Arc<RwLock<W>>`
     /// directly. If an entry is absent then a default entry is added to the collection.
-    pub async fn try_load_view_arc<Q>(
-        &mut self,
-        index: &Q,
-    ) -> Result<Arc<RwLock<W>>, ViewError>
+    pub async fn try_load_view_arc<Q>(&mut self, index: &Q) -> Result<Arc<RwLock<W>>, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + ?Sized,


### PR DESCRIPTION
## Motivation

Access to storage is done in the `execution_chain_actor`. It always goes in two
steps of accessing first to the view and then loading doing the operation.
This is repetitive operation, already with the serialization. This is hitting us
quite hard because a contract would have a lot of read operations.

We used to have a cache of views in `ReentrantCollectionView`. But we removed it
because it is not great to put the cache in the views.

## Proposal

Put it in the `ExecutionStateActor`. We unfortunately cannot access by an index because
of long lived services. So, for any query, we have to access via a `BTreeMap<_,_>`.

The views are accessed via `Arc<RwLock<KeyValueStoreView<C>>>`. So, we expose
some of the internals of the `ReentrantCollectionView` to the user. That is a little
unfortunate.

Other approaches:
* Put the `Arc<RwLock<KeyValueStoreView<C>>>` in the `SyncRuntimeContract`. But it is a major change and for a start we do not even have a `Context` in `SyncRuntimeContract`. So `block_on` would be needed to use.
* Other idea is to store the `KeyValueStoreView` as a single `BTreeMap<Vec<u8>,Vec<u8>>` stored as a `RegisterView`. This is a somewhat orthogonal approach but still something to consider.

## Test Plan

CI.

## Release Plan

It can be put in `testnet_conway`.

## Links

None