### PR TITLE
Add linera-cache to packages.txt

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -11,6 +11,7 @@ linera-views
 linera-execution
 linera-chain
 linera-storage-service
+linera-cache
 linera-storage
 linera-core
 linera-ethereum


### PR DESCRIPTION
## Motivation

The `documentation` CI job (`test-crates-and-docrs`) is failing on
`testnet_conway` because `cargo package` can't find `linera-cache` in the
local registry when packaging `linera-core`.

PR #5714 introduced the `linera-cache` crate but didn't add it to
`packages.txt`, which defines the order crates are packaged for the publish
simulation.

## Proposal

Add `linera-cache` to `packages.txt` between `linera-storage-service` and
`linera-storage`. This placement respects the dependency order: `linera-cache`
depends on `linera-base` (packaged earlier), and both `linera-storage` and
`linera-core` depend on it (packaged later).

## Test Plan

CI — the `test-crates-and-docrs` job should pass with this fix.
