### PR TITLE
[testnet] Fix dropped notifications in `retry_pending_cross_chain_requests` (#5680)

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -453,7 +453,6 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         if !new_ids.is_empty() {
             context_guard
                 .client()
-                .local_node
                 .retry_pending_cross_chain_requests(parent_chain_id)
                 .await?;
         }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -339,6 +339,16 @@ impl<Env: Environment> Client<Env> {
         self.environment.network()
     }
 
+    /// Handles any pending local cross-chain requests, notifying subscribers.
+    pub async fn retry_pending_cross_chain_requests(
+        &self,
+        sender_chain: ChainId,
+    ) -> Result<(), LocalNodeError> {
+        self.local_node
+            .retry_pending_cross_chain_requests(sender_chain, &self.notifier)
+            .await
+    }
+
     /// Returns a reference to the client's [`Signer`][crate::environment::Signer].
     #[instrument(level = "trace", skip(self))]
     pub fn signer(&self) -> &Env::Signer {
@@ -1374,8 +1384,7 @@ impl<Env: Environment> Client<Env> {
         }
 
         if certificates.is_empty() {
-            self.local_node
-                .retry_pending_cross_chain_requests(sender_chain_id)
+            self.retry_pending_cross_chain_requests(sender_chain_id)
                 .await?;
         }
 
@@ -2834,7 +2843,7 @@ impl<Env: Environment> ChainClient<Env> {
         // Certificates for these chains were omitted from `certificates` because they were
         // already processed locally. If they were processed in a concurrent task, it is not
         // guaranteed that their cross-chain messages were already handled.
-        self.retry_pending_cross_chain_requests(nodes, other_sender_chains)
+        self.retry_pending_cross_chain_requests_from_sender_chains(nodes, other_sender_chains)
             .await;
 
         debug!("receive_sender_certificates: finished processing other_sender_chains");
@@ -2843,16 +2852,17 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     /// Retries cross chain requests on the chains which may have been processed on
-    /// another task without the messages being correctly handled.
-    async fn retry_pending_cross_chain_requests(
+    /// another task without the messages being correctly handled. Fetches missing blobs from
+    /// the given nodes if necessary.
+    async fn retry_pending_cross_chain_requests_from_sender_chains(
         &self,
         nodes: &[RemoteNode<Env::ValidatorNode>],
         other_sender_chains: Vec<ChainId>,
     ) {
-        let stream = FuturesUnordered::from_iter(other_sender_chains.into_iter().map(|chain_id| {
-            let local_node = self.client.local_node.clone();
-            async move {
-                if let Err(error) = match local_node
+        let stream = FuturesUnordered::from_iter(other_sender_chains.into_iter().map(
+            |chain_id| async move {
+                if let Err(error) = match self
+                    .client
                     .retry_pending_cross_chain_requests(chain_id)
                     .await
                 {
@@ -2870,7 +2880,7 @@ impl<Env: Environment> ChainClient<Env> {
                                 messages"
                             );
                         }
-                        local_node
+                        self.client
                             .retry_pending_cross_chain_requests(chain_id)
                             .await
                     }
@@ -2882,8 +2892,8 @@ impl<Env: Environment> ChainClient<Env> {
                         "Failed to retry outgoing messages from chain"
                     );
                 }
-            }
-        }));
+            },
+        ));
         stream.for_each(future::ready).await;
     }
 
@@ -4005,7 +4015,6 @@ impl<Env: Environment> ChainClient<Env> {
             }
         }
         self.client
-            .local_node
             .retry_pending_cross_chain_requests(self.chain_id)
             .await?;
         Ok(ClientOutcome::Committed((description, certificate)))
@@ -4381,7 +4390,6 @@ impl<Env: Environment> ChainClient<Env> {
     #[instrument(level = "trace")]
     pub async fn retry_pending_outgoing_messages(&self) -> Result<(), ChainClientError> {
         self.client
-            .local_node
             .retry_pending_cross_chain_requests(self.chain_id)
             .await?;
         Ok(())

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -261,10 +261,11 @@ where
     }
 
     /// Handles any pending local cross-chain requests.
-    #[instrument(level = "trace", skip(self))]
+    #[instrument(level = "trace", skip(self, notifier))]
     pub async fn retry_pending_cross_chain_requests(
         &self,
         sender_chain: ChainId,
+        notifier: &impl Notifier,
     ) -> Result<(), LocalNodeError> {
         let (_response, actions) = self
             .node
@@ -274,6 +275,7 @@ where
         let mut requests = VecDeque::from_iter(actions.cross_chain_requests);
         while let Some(request) = requests.pop_front() {
             let new_actions = self.node.state.handle_cross_chain_request(request).await?;
+            notifier.notify(&new_actions.notifications);
             requests.extend(new_actions.cross_chain_requests);
         }
         Ok(())


### PR DESCRIPTION
Backport of #5680.

## Motivation

`retry_pending_cross_chain_requests` was silently dropping `NewIncomingBundle` notifications returned by `handle_cross_chain_request`. This could potentially cause dropped notifications when concurrent paths (e.g. validator notification streams) triggered cross-chain delivery through this method.

## Proposal

Don't drop these.

## Test Plan

CI

It's unclear if this was actually a problem, and related to some of the flaky tests we're seeing.

## Release Plan

- Nothing to do.

## Links

- `main` version: #5680.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)