### PR TITLE
Add missing README.md for linera-cache to fix documentation CI

### DIFF
--- a/linera-cache/README.md
+++ b/linera-cache/README.md
@@ -1,0 +1,13 @@
+<!-- cargo-rdme start -->
+
+Caching utilities for the Linera protocol.
+
+<!-- cargo-rdme end -->
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of the [Apache 2.0 license](../LICENSE).


### PR DESCRIPTION
## Motivation

The `documentation` CI job (`test-crates-and-docrs`) is failing on
`testnet_conway` because `cargo package` for `linera-cache` requires a
`README.md` file (declared in `Cargo.toml` with `readme = "README.md"`) but
the file was never created when the crate was introduced in #5714.

## Proposal

Add `linera-cache/README.md` following the same pattern used by all other
crates in the workspace.

## Test Plan

CI — the `test-crates-and-docrs` job should pass with this fix.
