### PR TITLE
Further inbox call simplification.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -466,26 +466,6 @@ where
         Ok(())
     }
 
-    /// Returns the next block height to receive and the last anticipated block height
-    /// for the given origin, loading the inbox read-only.
-    pub async fn inbox_cursors(
-        &self,
-        origin: &ChainId,
-    ) -> Result<(BlockHeight, Option<BlockHeight>), ChainError> {
-        let inbox = self.inboxes.try_load_entry(origin).await?;
-        match inbox {
-            Some(inbox) => {
-                let next_height = inbox.next_block_height_to_receive()?;
-                let last_anticipated = match inbox.removed_bundles.back().await? {
-                    Some(bundle) => Some(bundle.height),
-                    None => None,
-                };
-                Ok((next_height, last_anticipated))
-            }
-            None => Ok((BlockHeight::ZERO, None)),
-        }
-    }
-
     /// Returns the height of the highest block we have, plus one. Includes preprocessed blocks.
     ///
     /// The "+ 1" is so that it can be used in the same places as `next_block_height`.
@@ -507,8 +487,9 @@ where
         origin = %origin,
         bundle_height = %bundle.height
     ))]
-    pub async fn receive_message_bundle(
+    pub async fn receive_message_bundle_with_inbox(
         &mut self,
+        inbox: &mut InboxStateView<C>,
         origin: &ChainId,
         bundle: MessageBundle,
         local_time: Timestamp,
@@ -540,7 +521,6 @@ where
         }
 
         // Process the inbox bundle and update the inbox state.
-        let mut inbox = self.inboxes.try_load_entry_mut(origin).await?;
         let newly_added = inbox
             .add_bundle(bundle)
             .await

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -913,8 +913,12 @@ where
         bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
         // Only process certificates with relevant heights and epochs.
-        let (next_height_to_receive, last_anticipated_block_height) =
-            self.chain.inbox_cursors(&origin).await?;
+        let mut inbox = self.chain.inboxes.try_load_entry_mut(&origin).await?;
+        let next_height_to_receive = inbox.next_block_height_to_receive()?;
+        let last_anticipated_block_height = match inbox.removed_bundles.back().await? {
+            Some(bundle) => Some(bundle.height),
+            None => None,
+        };
         let helper = CrossChainUpdateHelper::new(&self.config, &self.chain);
         let recipient = self.chain_id();
         let bundles = helper.select_message_bundles(
@@ -935,9 +939,16 @@ where
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
             self.chain
-                .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
+                .receive_message_bundle_with_inbox(
+                    &mut inbox,
+                    &origin,
+                    bundle,
+                    local_time,
+                    add_to_received_log,
+                )
                 .await?;
         }
+        drop(inbox);
         if !self.config.allow_inactive_chains && !self.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by
             // now. Accordingly, do not send a confirmation, so that the


### PR DESCRIPTION
## Motivation

The `inbox` entry is accessed many times

## Proposal

We access the mutable inbox and then drop it after use.
Also remove useless code.

## Test Plan

CI

## Release Plan

Could be backported to `testnet_conway`.

## Links

None.