### PR TITLE
fix(ci): skip Bridge E2E on fork PRs due to missing OIDC tokens

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -27,6 +27,11 @@ permissions:
 
 jobs:
   bridge-e2e:
+    # Skip on fork PRs: GCP Workload Identity Federation requires OIDC tokens
+    # that GitHub does not inject for pull_request events from forks.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 60
 


### PR DESCRIPTION
## Summary

- Skip the `bridge-e2e` job on fork PRs since GitHub Actions does not inject OIDC tokens (`$ACTIONS_ID_TOKEN_REQUEST_TOKEN`) for `pull_request` events from forks, causing `google-github-actions/auth@v2` to fail
- Same-repo PRs, push events, merge_group, and workflow_dispatch continue to run the job normally
- The workflow has **never** worked for fork PRs — every fork PR run in history has failed with this error

## Context

The `bridge-e2e.yml` workflow uses GCP Workload Identity Federation which requires `id-token: write` permission. GitHub restricts this for fork PRs as a security measure to prevent secrets exfiltration.

Investigation confirmed the pattern: all `fork=True` runs failed, all `fork=False` runs succeeded.

## Test Plan

- Verified via Prometheus API that all historical fork PR runs of this workflow failed with the same OIDC error
- The `if` condition `github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` correctly evaluates to:
  - `true` for push, merge_group, workflow_dispatch (non-PR events)
  - `true` for same-repo PRs
  - `false` for fork PRs only

Closes #5751