### PR TITLE
Don't add --http-request-allow-list if not set

### DIFF
--- a/docker/docker-compose.bridge-test.yml
+++ b/docker/docker-compose.bridge-test.yml
@@ -70,23 +70,27 @@ services:
       - "13001:13001"
       - "9090:9090"
       - "${RELAY_PORT:-3001}:${RELAY_PORT:-3001}"
-    command: >
-      sh -c "mkdir -p ${LINERA_NET_PATH:-/tmp/wallet} &&
-      ./linera net
-      --storage scylladb:tcp:scylla:9042:table_default
-      up
-      --path ${LINERA_NET_PATH:-/tmp/wallet}
-      --with-faucet
-      --faucet-port ${FAUCET_PORT:-8080}
-      --with-block-exporter
-      --exporter-address linera-block-exporter
-      --exporter-port ${BLOCK_EXPORTER_PORT:-8882}
-      --http-request-allow-list ${HTTP_REQUEST_ALLOW_LIST:-anvil}"
+    command:
+      - sh
+      - -c
+      - |
+        mkdir -p ${LINERA_NET_PATH:-/tmp/wallet} &&
+        ./linera net \
+          --storage scylladb:tcp:scylla:9042:table_default \
+          up \
+          --path ${LINERA_NET_PATH:-/tmp/wallet} \
+          --with-faucet \
+          --faucet-port ${FAUCET_PORT:-8080} \
+          --with-block-exporter \
+          --exporter-address linera-block-exporter \
+          --exporter-port ${BLOCK_EXPORTER_PORT:-8882} \
+          $${HTTP_REQUEST_ALLOW_LIST:+--http-request-allow-list $$HTTP_REQUEST_ALLOW_LIST}
     environment:
       - RUST_LOG=linera=info
       - FAUCET_PORT=${FAUCET_PORT:-8080}
       - BLOCK_EXPORTER_PORT=${BLOCK_EXPORTER_PORT:-8882}
       - LINERA_NET_PATH=${LINERA_NET_PATH:-/tmp/wallet}
+      - HTTP_REQUEST_ALLOW_LIST=${HTTP_REQUEST_ALLOW_LIST:-}
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'cat < /dev/null > /dev/tcp/localhost/'${FAUCET_PORT:-8080}"]
       interval: 5s


### PR DESCRIPTION
## Motivation

Bridge e2e task is currently failing - fix it.

## Proposal

Don't add `--http-request-allow-list` in docker compose of the bridge test if it's not set.

Should make the CI green and unblock docker image publishing.

## Test Plan

CI

## Release Plan

None.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
