### PR TITLE
Fix linera-bridge compilation with --all-features

### DIFF
--- a/linera-bridge/src/lib.rs
+++ b/linera-bridge/src/lib.rs
@@ -9,23 +9,23 @@ pub mod proof;
 // -- Off-chain only (requires `not(chain)` / default features) --
 
 /// EVM contract ABIs, relay clients, and Solidity sources.
-#[cfg(not(feature = "chain"))]
+#[cfg(feature = "offchain")]
 pub mod evm;
 
 /// Relay server: HTTP proof endpoint + Linera chain inbox processing + EVM block forwarding.
-#[cfg(all(feature = "relay", not(feature = "chain")))]
+#[cfg(feature = "relay")]
 pub mod relay;
 
 // -- Test-only modules --
 
 /// Tests for the FungibleBridge EVM contract.
-#[cfg(all(test, not(feature = "chain")))]
+#[cfg(all(test, feature = "offchain"))]
 mod fungible_bridge;
 
 /// Gas usage measurements for LightClient and Microchain operations.
-#[cfg(all(test, not(feature = "chain")))]
+#[cfg(all(test, feature = "offchain"))]
 mod gas;
 
 /// Shared test helpers for EVM contract deployment and interaction.
-#[cfg(all(test, not(feature = "chain")))]
+#[cfg(all(test, feature = "offchain"))]
 pub(crate) mod test_helpers;

--- a/linera-bridge/src/proof/mod.rs
+++ b/linera-bridge/src/proof/mod.rs
@@ -67,7 +67,7 @@
 //! via an HTTP oracle before accepting a deposit.
 
 /// Off-chain deposit proof generation via EVM JSON-RPC.
-#[cfg(not(feature = "chain"))]
+#[cfg(feature = "offchain")]
 pub mod gen;
 
 use alloy_primitives::{keccak256, Address, Bytes, B256, U256};


### PR DESCRIPTION
## Motivation

We're failing merge queue due to the clippy test with `--all-features`

## Proposal

Gate off-chain modules on `feature = "offchain"` instead of `not(feature = "chain")` so that `--all-features` (which enables both `chain` and `offchain` simultaneously) no longer hides the evm, relay, and proof::gen modules


## Test Plan

CI

## Release Plan

None

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
