### PR TITLE
Remove sequential block height requirement from Microchain contract

### DIFF
--- a/linera-bridge/README.md
+++ b/linera-bridge/README.md
@@ -99,25 +99,25 @@ The constructor takes `(address[], uint64[], bytes32, uint32)` — the genesis c
 
 ### Microchain (abstract)
 
-#### `constructor(address _lightClient, bytes32 _chainId, uint64 _latestHeight)`
+#### `constructor(address _lightClient, bytes32 _chainId)`
 
-Binds the contract to a specific `LightClient` instance, a Linera chain ID (a 32-byte `CryptoHash`), and an initial block height.
+Binds the contract to a specific `LightClient` instance and a Linera chain ID (a 32-byte `CryptoHash`).
 
 #### `addBlock(bytes calldata data)`
 
 Verifies a certificate via `lightClient.verifyBlock(data)`, then enforces:
+- **No duplicate blocks**: rejects certificates already processed via the `verifiedBlocks` mapping.
 - **Chain ID match**: the block's `header.chain_id` must equal this contract's `chainId`.
-- **Sequential heights**: the block's height must equal `nextExpectedHeight`.
 
-On success, calls the virtual `_onBlock(BridgeTypes.Block)` hook. Subcontracts override this to extract and store application-specific data from the verified block.
+Blocks can be submitted in any order; sequential height enforcement is not required because BFT-finalized certificates guarantee canonicality. On success, calls the virtual `_onBlock(BridgeTypes.Block)` hook. Subcontracts override this to extract and store application-specific data from the verified block.
 
 ### FungibleBridge (concrete Microchain)
 
 A `Microchain` subcontract that bridges ERC-20 tokens from Linera to Ethereum. When a fungible `Credit` message targeting an Ethereum address (`Address20`) is received, the contract transfers tokens from its own balance to the recipient.
 
-#### `constructor(address _lightClient, bytes32 _chainId, uint64 _latestHeight, bytes32 _applicationId, address _token)`
+#### `constructor(address _lightClient, bytes32 _chainId, bytes32 _applicationId, address _token)`
 
-Binds to a specific `LightClient`, chain, initial block height, Linera application ID, and ERC-20 token contract. Only messages targeting this `applicationId` are processed; all others are silently skipped.
+Binds to a specific `LightClient`, chain, Linera application ID, and ERC-20 token contract. Only messages targeting this `applicationId` are processed; all others are silently skipped.
 
 #### `_onBlock(BridgeTypes.Block)`
 
@@ -140,7 +140,7 @@ let calldata: Vec<u8> = call.abi_encode();
 
 // Available call types:
 // light_client: addCommitteeCall, verifyBlockCall, currentEpochCall
-// microchain:   addBlockCall, nextExpectedHeightCall, lightClientCall, chainIdCall
+// microchain:   addBlockCall, lightClientCall, chainIdCall
 
 // Solidity sources (for compilation or deployment tooling):
 // BRIDGE_TYPES_SOURCE, WRAPPED_FUNGIBLE_TYPES_SOURCE, FUNGIBLE_BRIDGE_SOURCE

--- a/linera-bridge/src/evm/microchain.rs
+++ b/linera-bridge/src/evm/microchain.rs
@@ -9,8 +9,6 @@ pub const SOURCE: &str = include_str!("../solidity/Microchain.sol");
 sol! {
     function addBlock(bytes calldata data) external;
 
-    function nextExpectedHeight() external view returns (uint64);
-
     function lightClient() external view returns (address);
 
     function chainId() external view returns (bytes32);
@@ -28,7 +26,7 @@ mod tests {
         primitives::Address,
     };
 
-    use super::{addBlockCall, chainIdCall, lightClientCall, nextExpectedHeightCall};
+    use super::{addBlockCall, chainIdCall, lightClientCall};
     use crate::test_helpers::*;
 
     sol! {
@@ -67,11 +65,6 @@ mod tests {
         microchain.add_block(BlockHeight(1));
 
         assert_eq!(microchain.query_block_count(), 1, "block count should be 1");
-        assert_eq!(
-            microchain.query_next_expected_height(),
-            2,
-            "next expected height should be 2"
-        );
     }
 
     #[test]
@@ -102,13 +95,18 @@ mod tests {
     }
 
     #[test]
-    fn test_microchain_rejects_non_sequential_height() {
+    fn test_microchain_accepts_non_sequential_height() {
         let mut t = TestMicrochain::new();
 
-        assert!(
-            t.try_add_block(t.chain_id, BlockHeight(5)).is_err(),
-            "should reject non-sequential block height"
-        );
+        // Blocks can be submitted at any height, not just sequentially.
+        t.add_block(BlockHeight(5));
+        assert_eq!(t.query_block_count(), 1, "block count should be 1");
+
+        t.add_block(BlockHeight(2));
+        assert_eq!(t.query_block_count(), 2, "block count should be 2");
+
+        t.add_block(BlockHeight(100));
+        assert_eq!(t.query_block_count(), 3, "block count should be 3");
     }
 
     /// Common test state for Microchain tests.
@@ -131,7 +129,7 @@ mod tests {
             let chain_id = CryptoHash::new(&TestString::new("test_chain"));
             let light_client =
                 deploy_light_client(&mut db, deployer, &[addr], &[1], test_admin_chain_id(), 0);
-            let contract = deploy_microchain(&mut db, deployer, light_client, chain_id, 1);
+            let contract = deploy_microchain(&mut db, deployer, light_client, chain_id);
 
             Self {
                 db,
@@ -188,16 +186,6 @@ mod tests {
                 blockCountCall {},
             );
             count
-        }
-
-        fn query_next_expected_height(&mut self) -> u64 {
-            let (height, _, _) = call_contract(
-                &mut self.db,
-                self.deployer,
-                self.contract,
-                nextExpectedHeightCall {},
-            );
-            height
         }
     }
 }

--- a/linera-bridge/src/fungible_bridge.rs
+++ b/linera-bridge/src/fungible_bridge.rs
@@ -96,7 +96,7 @@ mod tests {
             let chain_id = CryptoHash::new(&TestString::new("test_chain"));
             let app_id = CryptoHash::new(&TestString::new("fungible_app"));
             let bridge =
-                deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, 1, app_id, token);
+                deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, app_id, token);
 
             // Fund the bridge with the full token supply
             call_contract(
@@ -132,7 +132,7 @@ mod tests {
             self.submit_block(vec![txn])
         }
 
-        /// Submits a block with the given transactions at the next sequential height.
+        /// Submits a block with the given transactions.
         fn submit_block(
             &mut self,
             transactions: Vec<Transaction>,
@@ -311,7 +311,7 @@ mod tests {
         let chain_id = CryptoHash::new(&TestString::new("test_chain"));
         let app_id = CryptoHash::new(&TestString::new("fungible_app"));
         let bridge =
-            deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, 1, app_id, token);
+            deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, app_id, token);
 
         // Give depositor tokens (instead of funding the bridge)
         call_contract(

--- a/linera-bridge/src/gas.rs
+++ b/linera-bridge/src/gas.rs
@@ -67,7 +67,7 @@ mod tests {
         let mut db = CacheDB::default();
         let light_client =
             deploy_light_client(&mut db, deployer, &[addr], &[1], test_admin_chain_id(), 0);
-        let microchain = deploy_microchain(&mut db, deployer, light_client, chain_id, 1);
+        let microchain = deploy_microchain(&mut db, deployer, light_client, chain_id);
 
         let cert = create_signed_certificate_for_chain(&secret, &public, chain_id, BlockHeight(1));
         let bcs_bytes = bcs::to_bytes(&cert).expect("BCS serialization failed");

--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -644,8 +644,6 @@ async fn serve_loop<E: linera_core::environment::Environment>(
                         }
                     };
 
-                    // Forward the deposit block to EVM so the Microchain
-                    // height stays sequential.
                     forward_cert_to_evm(&cert, bridge_addr, &provider).await;
 
                     Ok::<(), anyhow::Error>(())

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -36,11 +36,10 @@ contract FungibleBridge is Microchain {
     constructor(
         address _lightClient,
         bytes32 _chainId,
-        uint64 _nextExpectedHeight,
         bytes32 _applicationId,
         address _token
     )
-        Microchain(_lightClient, _chainId, _nextExpectedHeight)
+        Microchain(_lightClient, _chainId)
     {
         applicationId = _applicationId;
         token = IERC20(_token);

--- a/linera-bridge/src/solidity/Microchain.sol
+++ b/linera-bridge/src/solidity/Microchain.sol
@@ -7,32 +7,27 @@ import "LightClient.sol";
 abstract contract Microchain {
     LightClient public immutable lightClient;
     bytes32 public immutable chainId;
-    uint64 public nextExpectedHeight;
     mapping(bytes32 => bool) public verifiedBlocks;
 
-    constructor(address _lightClient, bytes32 _chainId, uint64 _nextExpectedHeight) {
+    constructor(address _lightClient, bytes32 _chainId) {
         lightClient = LightClient(_lightClient);
         chainId = _chainId;
-        nextExpectedHeight = _nextExpectedHeight;
     }
 
-    /// Verifies a certificate and accepts the block if it matches this chain and
-    /// the next expected height.
+    /// Verifies a certificate and accepts the block if it matches this chain.
     ///
-    /// Note: this contract does NOT check `previous_block_hash` to link blocks
-    /// into a hash chain. This is safe because `ConfirmedBlockCertificate`
+    /// Note: this contract does NOT check `previous_block_hash` or enforce
+    /// sequential block heights. This is safe because `ConfirmedBlockCertificate`
     /// implies BFT-finalized canonicality — a quorum of validators signed this
     /// specific block at this height, so no conflicting block can exist.
-    /// If this assumption ever changes at the protocol layer, a
-    /// `previous_block_hash` check should be added here.
+    /// Blocks can be submitted in any order; the `verifiedBlocks` mapping
+    /// prevents duplicate processing.
     function addBlock(bytes calldata data) external {
         (BridgeTypes.Block memory blockValue, bytes32 signedHash) = lightClient.verifyBlock(data);
 
         require(!verifiedBlocks[signedHash], "block already verified");
         require(blockValue.header.chain_id.value.value == chainId, "chain id mismatch");
-        require(blockValue.header.height.value == nextExpectedHeight, "block height must be sequential");
 
-        nextExpectedHeight = blockValue.header.height.value + 1;
         verifiedBlocks[signedHash] = true;
         _onBlock(blockValue);
     }

--- a/linera-bridge/src/test_helpers.rs
+++ b/linera-bridge/src/test_helpers.rs
@@ -124,17 +124,12 @@ pub fn deploy_microchain(
     deployer: Address,
     light_client: Address,
     chain_id: CryptoHash,
-    next_expected_height: u64,
 ) -> Address {
     let test_source = std::fs::read_to_string("tests/solidity/MicrochainTest.sol")
         .expect("MicrochainTest.sol not found");
     let bytecode = compile_contract(&test_source, "MicrochainTest.sol", "MicrochainTest");
-    let constructor_args = (
-        light_client,
-        <[u8; 32]>::from(*chain_id.as_bytes()),
-        next_expected_height,
-    )
-        .abi_encode_params();
+    let constructor_args =
+        (light_client, <[u8; 32]>::from(*chain_id.as_bytes())).abi_encode_params();
     let mut deploy_data = bytecode;
     deploy_data.extend_from_slice(&constructor_args);
     deploy_contract(db, deployer, deploy_data)
@@ -145,7 +140,6 @@ pub fn deploy_fungible_bridge(
     deployer: Address,
     light_client: Address,
     chain_id: CryptoHash,
-    next_expected_height: u64,
     application_id: CryptoHash,
     token: Address,
 ) -> Address {
@@ -157,7 +151,6 @@ pub fn deploy_fungible_bridge(
     let constructor_args = (
         light_client,
         <[u8; 32]>::from(*chain_id.as_bytes()),
-        next_expected_height,
         <[u8; 32]>::from(*application_id.as_bytes()),
         token,
     )

--- a/linera-bridge/tests/anvil_deposit_proof.rs
+++ b/linera-bridge/tests/anvil_deposit_proof.rs
@@ -189,7 +189,6 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
     let bridge_constructor = (
         deployer,                                // light_client (unused by deposit)
         <[u8; 32]>::from(target_chain_id),       // chainId
-        0u64,                                    // nextExpectedHeight
         <[u8; 32]>::from(target_application_id), // applicationId
         token_address,                           // token
     )

--- a/linera-bridge/tests/solidity/MicrochainTest.sol
+++ b/linera-bridge/tests/solidity/MicrochainTest.sol
@@ -6,8 +6,8 @@ import "Microchain.sol";
 contract MicrochainTest is Microchain {
     uint64 public blockCount;
 
-    constructor(address _lightClient, bytes32 _chainId, uint64 _nextExpectedHeight)
-        Microchain(_lightClient, _chainId, _nextExpectedHeight)
+    constructor(address _lightClient, bytes32 _chainId)
+        Microchain(_lightClient, _chainId)
     {}
 
     function _onBlock(BridgeTypes.Block memory) internal override {


### PR DESCRIPTION
## Motivation

With the monotonic increase of `nextBlockHeight` in `Microchain.sol` it's more complicated to keep the messages relayed in a correct order.

## Proposal

BFT-finalized certificates already guarantee block canonicality — a quorum of validators cannot sign two conflicting blocks at the same height. The sequential height check added no security value while forcing the relayer to submit every block (including irrelevant ones) in strict order, wasting gas and adding fragility.

The verifiedBlocks mapping continues to prevent duplicate processing.

## Test Plan

CI

## Release Plan

None

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
