### PR TITLE
Update e2e tests after removal of nextExpectedHeight

### DIFF
--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -176,7 +176,6 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
              --constructor-args \
              {light_client} \
              {chain_id_bytes32} \
-             0 \
              {zero_bytes32} \
              {erc20_addr}"
         ),

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -214,7 +214,6 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
              --constructor-args \
              {light_client} \
              {chain_a_bytes32} \
-             0 \
              {app_id_bytes32} \
              {erc20_addr}"
         ),


### PR DESCRIPTION
## Motivation

Bridge e2e tests are failing again.

## Proposal

Update docker compose to not pass the nextExpectedHeight which was removed in #5763 

## Test Plan

CI

## Release Plan

None

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
