### PR TITLE
Expose storage cache CLI flags in the Helm chart

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -101,6 +101,12 @@ spec:
                 --storage-replication-factor {{ .Values.storageReplicationFactor | quote }} \
                 --storage-max-cache-size {{ .Values.storageCacheConfig.maxCacheSize | int }} \
                 --storage-max-cache-entries {{ .Values.storageCacheConfig.maxCacheEntries | int }} \
+                --storage-max-value-entry-size {{ .Values.storageCacheConfig.maxValueEntrySize | int }} \
+                --storage-max-find-keys-entry-size {{ .Values.storageCacheConfig.maxFindKeysEntrySize | int }} \
+                --storage-max-find-key-values-entry-size {{ .Values.storageCacheConfig.maxFindKeyValuesEntrySize | int }} \
+                --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
+                --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
+                --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
                 --id "$ORDINAL" \
                 /config/server.json
           env:

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -105,6 +105,12 @@ spec:
                 --storage-replication-factor {{ .Values.storageReplicationFactor | quote }} \
                 --storage-max-cache-size {{ .Values.storageCacheConfig.maxCacheSize | int }} \
                 --storage-max-cache-entries {{ .Values.storageCacheConfig.maxCacheEntries | int }} \
+                --storage-max-value-entry-size {{ .Values.storageCacheConfig.maxValueEntrySize | int }} \
+                --storage-max-find-keys-entry-size {{ .Values.storageCacheConfig.maxFindKeysEntrySize | int }} \
+                --storage-max-find-key-values-entry-size {{ .Values.storageCacheConfig.maxFindKeyValuesEntrySize | int }} \
+                --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
+                --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
+                --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -44,10 +44,22 @@ storageReplicationFactor: 1
 # LRU cache configuration for storage operations
 # These settings control memory usage for caching storage queries
 storageCacheConfig:
-  # Maximum total cache size in bytes (default: 10MB)
-  maxCacheSize: 10000000
-  # Maximum number of entries in the cache (default: 1000)
-  maxCacheEntries: 1000
+  # Maximum total cache size in bytes
+  maxCacheSize: 50000000
+  # Maximum number of entries in the cache
+  maxCacheEntries: 50000
+  # Maximum size of a single value entry in bytes
+  maxValueEntrySize: 1000000
+  # Maximum size of a single find-keys entry in bytes
+  maxFindKeysEntrySize: 1000000
+  # Maximum size of a single find-key-values entry in bytes
+  maxFindKeyValuesEntrySize: 1000000
+  # Maximum total size of value entries in bytes
+  maxCacheValueSize: 50000000
+  # Maximum total size of find-keys entries in bytes
+  maxCacheFindKeysSize: 10000000
+  # Maximum total size of find-key-values entries in bytes
+  maxCacheFindKeyValuesSize: 10000000
 
 # Dual storage mode (RocksDB + ScyllaDB)
 dualStore: false


### PR DESCRIPTION
## Motivation

The storage cache has per-entry and per-category size limits (`max_value_entry_size`,
`max_find_keys_entry_size`, `max_find_key_values_entry_size`, `max_cache_value_size`,
`max_cache_find_keys_size`, `max_cache_find_key_values_size`) that are already supported
by `CommonStorageOptions` but weren't being passed through the Helm chart. This means
deployed validators couldn't tune these limits without code changes.

Additionally, the existing `maxCacheSize` and `maxCacheEntries` defaults were too low
for
Conway's workload.

## Proposal

- Add 6 new fields to `storageCacheConfig` in `values.yaml` corresponding to the
existing
CLI flags
- Pass them as `--storage-*` flags in both `shards.yaml` and `proxy.yaml` templates
- Bump overall cache defaults: `maxCacheSize` 10MB → 50MB, `maxCacheEntries` 1K → 50K,
`maxCacheValueSize` 10MB → 50MB

Per-entry limits and find-keys/find-key-values cache sizes stay at the Rust defaults.

## Test Plan

CI

