### PR TITLE
Split blob_cache_size into individual cache size flags

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -263,6 +263,18 @@ Client implementation and command-line tool for the Linera blockchain
 * `--blob-cache-size <BLOB_CACHE_SIZE>` — The maximal number of entries in the blob cache
 
   Default value: `1000`
+* `--confirmed-block-cache-size <CONFIRMED_BLOCK_CACHE_SIZE>` — The maximal number of entries in the confirmed block cache
+
+  Default value: `1000`
+* `--lite-certificate-cache-size <LITE_CERTIFICATE_CACHE_SIZE>` — The maximal number of entries in the lite certificate cache
+
+  Default value: `1000`
+* `--certificate-raw-cache-size <CERTIFICATE_RAW_CACHE_SIZE>` — The maximal number of entries in the raw certificate cache
+
+  Default value: `1000`
+* `--event-cache-size <EVENT_CACHE_SIZE>` — The maximal number of entries in the event cache
+
+  Default value: `1000`
 * `--block-cache-size <BLOCK_CACHE_SIZE>` — The number of entries in the block cache
 
   Default value: `5000`

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -107,6 +107,11 @@ spec:
                 --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
                 --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
+                --blob-cache-size {{ .Values.storageCacheSizes.blobCacheSize | int }} \
+                --confirmed-block-cache-size {{ .Values.storageCacheSizes.confirmedBlockCacheSize | int }} \
+                --lite-certificate-cache-size {{ .Values.storageCacheSizes.liteCertificateCacheSize | int }} \
+                --certificate-raw-cache-size {{ .Values.storageCacheSizes.certificateRawCacheSize | int }} \
+                --event-cache-size {{ .Values.storageCacheSizes.eventCacheSize | int }} \
                 --id "$ORDINAL" \
                 /config/server.json
           env:

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -111,6 +111,11 @@ spec:
                 --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
                 --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
+                --blob-cache-size {{ .Values.storageCacheSizes.blobCacheSize | int }} \
+                --confirmed-block-cache-size {{ .Values.storageCacheSizes.confirmedBlockCacheSize | int }} \
+                --lite-certificate-cache-size {{ .Values.storageCacheSizes.liteCertificateCacheSize | int }} \
+                --certificate-raw-cache-size {{ .Values.storageCacheSizes.certificateRawCacheSize | int }} \
+                --event-cache-size {{ .Values.storageCacheSizes.eventCacheSize | int }} \
                 --block-cache-size {{ .Values.blockCacheSize | int }} \
                 --execution-state-cache-size {{ .Values.executionStateCacheSize | int }} \
           env:

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -61,6 +61,15 @@ storageCacheConfig:
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
+# Individual cache sizes for DbStorage ValueCaches
+# These control the number of entries in each in-memory LRU cache
+storageCacheSizes:
+  blobCacheSize: 1000
+  confirmedBlockCacheSize: 10000
+  liteCertificateCacheSize: 5000
+  certificateRawCacheSize: 5000
+  eventCacheSize: 5000
+
 # Block cache size (number of entries)
 blockCacheSize: 20000
 

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -97,6 +97,22 @@ struct ServeOptions {
     /// The maximal number of entries in the blob cache.
     #[arg(long, default_value = "1000")]
     blob_cache_size: usize,
+
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000")]
+    confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000")]
+    lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000")]
+    certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000")]
+    event_cache_size: usize,
 }
 
 fn main() -> Result<()> {
@@ -127,7 +143,13 @@ impl ServeOptions {
             &self.linera_fungible_address,
             &self.evm_private_key,
             self.port,
-            self.blob_cache_size,
+            linera_storage::StorageCacheSizes {
+                blob_cache_size: self.blob_cache_size,
+                confirmed_block_cache_size: self.confirmed_block_cache_size,
+                lite_certificate_cache_size: self.lite_certificate_cache_size,
+                certificate_raw_cache_size: self.certificate_raw_cache_size,
+                event_cache_size: self.event_cache_size,
+            },
         ))
         .await
     }

--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -258,7 +258,10 @@ async fn forward_cert_to_evm(
 
 type RocksDbStorage = DbStorage<RocksDbDatabase, linera_storage::WallClock>;
 
-async fn create_rocksdb_storage(path: &Path, blob_cache_size: usize) -> Result<RocksDbStorage> {
+async fn create_rocksdb_storage(
+    path: &Path,
+    cache_sizes: linera_storage::StorageCacheSizes,
+) -> Result<RocksDbStorage> {
     let config = LruCachingConfig {
         inner_config: RocksDbStoreInternalConfig {
             path_with_guard: PathWithGuard::new(path.to_path_buf()),
@@ -280,7 +283,7 @@ async fn create_rocksdb_storage(path: &Path, blob_cache_size: usize) -> Result<R
         &config,
         "bridge_relay",
         Some(WasmRuntime::default()),
-        blob_cache_size,
+        cache_sizes,
     )
     .await?;
     Ok(storage)
@@ -301,7 +304,7 @@ pub async fn run(
     linera_fungible_address: &str,
     evm_private_key: &str,
     port: u16,
-    blob_cache_size: usize,
+    cache_sizes: linera_storage::StorageCacheSizes,
 ) -> Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -348,7 +351,7 @@ pub async fn run(
     let db_path = storage_path
         .strip_prefix("rocksdb:")
         .context("storage config must start with 'rocksdb:'")?;
-    let mut storage = create_rocksdb_storage(Path::new(db_path), blob_cache_size).await?;
+    let mut storage = create_rocksdb_storage(Path::new(db_path), cache_sizes).await?;
 
     // ── Wallet: load existing or create fresh ──
     let wallet_exists = wallet_path.exists();

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -30,7 +30,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, Query, QueryResponse, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::DbStorage;
+use linera_storage::{DbStorage, StorageCacheSizes};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use serde::{Deserialize, Serialize};
 use wrapped_fungible::{InitialState, WrappedParameters};
@@ -106,7 +106,13 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &config,
         "e2l-bridge-e2e-test",
         Some(WasmRuntime::default()),
-        1000,
+        StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        },
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -33,7 +33,7 @@ use linera_faucet_client::Faucet;
 use wrapped_fungible::{
     Account, InitialState, WrappedFungibleOperation, WrappedFungibleTokenAbi, WrappedParameters,
 };
-use linera_storage::DbStorage;
+use linera_storage::{DbStorage, StorageCacheSizes};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -72,7 +72,13 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &config,
         "bridge-e2e-test",
         Some(WasmRuntime::default()),
-        1000,
+        StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        },
     )
     .await?;
 

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -4,7 +4,7 @@
 use std::path::PathBuf;
 
 use clap::Parser as _;
-use linera_service::storage::{StorageMigration, StoreConfig};
+use linera_service::storage::{StorageCacheSizes, StorageMigration, StoreConfig};
 use linera_views::{
     lru_prefix_cache::StorageCacheConfig,
     rocks_db::{
@@ -72,6 +72,22 @@ pub struct RocksDbConfig {
     /// The maximal number of entries in the blob cache.
     #[arg(long, default_value = "1000")]
     pub blob_cache_size: usize,
+
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000")]
+    pub confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000")]
+    pub event_cache_size: usize,
 }
 
 pub type RocksDbRunner = Runner<RocksDbDatabase, RocksDbConfig>;
@@ -110,7 +126,16 @@ impl RocksDbRunner {
         };
         store_config
             .clone()
-            .run_with_store(config.client.blob_cache_size, StorageMigration)
+            .run_with_store(
+                StorageCacheSizes {
+                    blob_cache_size: config.client.blob_cache_size,
+                    confirmed_block_cache_size: config.client.confirmed_block_cache_size,
+                    lite_certificate_cache_size: config.client.lite_certificate_cache_size,
+                    certificate_raw_cache_size: config.client.certificate_raw_cache_size,
+                    event_cache_size: config.client.event_cache_size,
+                },
+                StorageMigration,
+            )
             .await
             .expect("Failure to migrate the database");
         let database =

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_service::storage::{StorageMigration, StoreConfig};
+use linera_service::storage::{StorageCacheSizes, StorageMigration, StoreConfig};
 use linera_views::{
     lru_prefix_cache::StorageCacheConfig,
     scylla_db::{ScyllaDbDatabase, ScyllaDbStoreConfig, ScyllaDbStoreInternalConfig},
@@ -67,6 +67,22 @@ pub struct ScyllaDbConfig {
     #[arg(long, default_value = "1000")]
     pub blob_cache_size: usize,
 
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000")]
+    pub confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000")]
+    pub event_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1")]
     pub replication_factor: u32,
@@ -104,7 +120,16 @@ impl ScyllaDbRunner {
         };
         store_config
             .clone()
-            .run_with_store(config.client.blob_cache_size, StorageMigration)
+            .run_with_store(
+                StorageCacheSizes {
+                    blob_cache_size: config.client.blob_cache_size,
+                    confirmed_block_cache_size: config.client.confirmed_block_cache_size,
+                    lite_certificate_cache_size: config.client.lite_certificate_cache_size,
+                    certificate_raw_cache_size: config.client.certificate_raw_cache_size,
+                    event_cache_size: config.client.event_cache_size,
+                },
+                StorageMigration,
+            )
             .await
             .expect("ScyllaDb migration failed");
         let database = ScyllaDbDatabase::connect(&scylladb_store_config, &namespace).await?;

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -79,7 +79,7 @@ use linera_service::{
     controller::Controller,
     node_service::NodeService,
     project::{self, Project},
-    storage::{AssertStorageV1, Runnable, RunnableWithStore, StorageMigration},
+    storage::{AssertStorageV1, Runnable, RunnableWithStore, StorageCacheSizes, StorageMigration},
     task_processor::TaskProcessor,
     util,
     wallet::WalletExt as _,
@@ -1807,7 +1807,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -1852,7 +1852,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                     &config,
                     &namespace,
                     None,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?;
                 genesis_config.initialize_storage(&mut storage).await?;

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -87,11 +87,11 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
-        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        let cache_sizes = self.common.common_storage_options.storage_cache_sizes();
         let output = Box::pin(store_config.run_with_storage(
             self.common.wasm_runtime.with_wasm_default(),
             self.common.application_logs,
-            blob_cache_size,
+            cache_sizes,
             job,
         ))
         .await?;
@@ -108,20 +108,20 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
-        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        let cache_sizes = self.common.common_storage_options.storage_cache_sizes();
         if assert_storage_v1 {
             store_config
                 .clone()
-                .run_with_store(blob_cache_size, crate::AssertStorageV1)
+                .run_with_store(cache_sizes, crate::AssertStorageV1)
                 .await?;
         }
         if need_migration {
             store_config
                 .clone()
-                .run_with_store(blob_cache_size, crate::StorageMigration)
+                .run_with_store(cache_sizes, crate::StorageMigration)
                 .await?;
         }
-        let output = Box::pin(store_config.run_with_store(blob_cache_size, job)).await?;
+        let output = Box::pin(store_config.run_with_store(cache_sizes, job)).await?;
         Ok(output)
     }
 
@@ -131,9 +131,9 @@ impl Options {
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
         let wallet = self.wallet()?;
-        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        let cache_sizes = self.common.common_storage_options.storage_cache_sizes();
         store_config
-            .initialize(blob_cache_size, wallet.genesis_config())
+            .initialize(cache_sizes, wallet.genesis_config())
             .await?;
         Ok(())
     }

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -302,15 +302,15 @@ impl RunOptions {
                 .storage_config
                 .add_common_storage_options(&self.common_storage_options)
                 .unwrap();
-            let blob_cache_size = self.common_storage_options.blob_cache_size;
+            let cache_sizes = self.common_storage_options.storage_cache_sizes();
             store_config
                 .clone()
-                .run_with_store(blob_cache_size, StorageMigration)
+                .run_with_store(cache_sizes, StorageMigration)
                 .await?;
             // Exporters are part of validator infrastructure and should not output contract logs.
             let allow_application_logs = false;
             store_config
-                .run_with_storage(None, allow_application_logs, blob_cache_size, context)
+                .run_with_storage(None, allow_application_logs, cache_sizes, context)
                 .boxed()
                 .await
         };
@@ -350,9 +350,9 @@ impl DestinationsCommand {
             action,
         };
 
-        let blob_cache_size = options.common_storage_options.blob_cache_size;
+        let cache_sizes = options.common_storage_options.storage_cache_sizes();
         store_config
-            .run_with_storage(None, false, blob_cache_size, context)
+            .run_with_storage(None, false, cache_sizes, context)
             .await?
             .map_err(Into::into)
     }

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -498,10 +498,10 @@ impl ProxyOptions {
         let store_config = self
             .storage_config
             .add_common_storage_options(&self.common_storage_options)?;
-        let blob_cache_size = self.common_storage_options.blob_cache_size;
+        let cache_sizes = self.common_storage_options.storage_cache_sizes();
         store_config
             .clone()
-            .run_with_store(blob_cache_size, AssertStorageV1)
+            .run_with_store(cache_sizes, AssertStorageV1)
             .await?;
         // Proxies are part of validator infrastructure and should not output contract logs.
         let allow_application_logs = false;
@@ -509,7 +509,7 @@ impl ProxyOptions {
             .run_with_storage(
                 None,
                 allow_application_logs,
-                blob_cache_size,
+                cache_sizes,
                 ProxyContext::from_options(self)?,
             )
             .boxed()

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -551,14 +551,14 @@ async fn run(options: ServerOptions) {
                 .unwrap();
             // Validators should not output contract logs.
             let allow_application_logs = false;
-            let blob_cache_size = common_storage_options.blob_cache_size;
+            let cache_sizes = common_storage_options.storage_cache_sizes();
             store_config
                 .clone()
-                .run_with_store(blob_cache_size, AssertStorageV1)
+                .run_with_store(cache_sizes, AssertStorageV1)
                 .await
                 .unwrap();
             store_config
-                .run_with_storage(wasm_runtime, allow_application_logs, blob_cache_size, job)
+                .run_with_storage(wasm_runtime, allow_application_logs, cache_sizes, job)
                 .boxed()
                 .await
                 .unwrap()

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use linera_client::config::GenesisConfig;
 use linera_execution::WasmRuntime;
+pub use linera_storage::StorageCacheSizes;
 use linera_storage::{DbStorage, Storage, WallClock, DEFAULT_NAMESPACE};
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{
@@ -86,6 +87,22 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "1000", global = true)]
     pub blob_cache_size: usize,
 
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub event_cache_size: usize,
+
     /// The number of entries in the block cache.
     #[arg(long, default_value = "5000", global = true)]
     pub block_cache_size: usize,
@@ -100,6 +117,16 @@ pub struct CommonStorageOptions {
 }
 
 impl CommonStorageOptions {
+    pub fn storage_cache_sizes(&self) -> StorageCacheSizes {
+        StorageCacheSizes {
+            blob_cache_size: self.blob_cache_size,
+            confirmed_block_cache_size: self.confirmed_block_cache_size,
+            lite_certificate_cache_size: self.lite_certificate_cache_size,
+            certificate_raw_cache_size: self.certificate_raw_cache_size,
+            event_cache_size: self.event_cache_size,
+        }
+    }
+
     pub fn storage_cache_config(&self) -> StorageCacheConfig {
         StorageCacheConfig {
             max_cache_size: self.storage_max_cache_size,
@@ -630,7 +657,7 @@ pub trait RunnableWithStore {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -643,7 +670,7 @@ impl StoreConfig {
         self,
         wasm_runtime: Option<WasmRuntime>,
         allow_application_logs: bool,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         job: Job,
     ) -> Result<Job::Output, anyhow::Error>
     where
@@ -659,7 +686,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -674,7 +701,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -686,7 +713,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -698,7 +725,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -710,7 +737,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -718,14 +745,13 @@ impl StoreConfig {
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
             StoreConfig::DualRocksDbScyllaDb { config, namespace } => {
-                let storage = DbStorage::<
-                    DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>,
-                    _,
-                >::connect(
-                    &config, &namespace, wasm_runtime, blob_cache_size
-                )
-                .await?
-                .with_allow_application_logs(allow_application_logs);
+                let storage =
+                    DbStorage::<
+                        DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>,
+                        _,
+                    >::connect(&config, &namespace, wasm_runtime, cache_sizes)
+                    .await?
+                    .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
         }
@@ -734,7 +760,7 @@ impl StoreConfig {
     #[allow(unused_variables)]
     pub async fn run_with_store<Job>(
         self,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         job: Job,
     ) -> Result<Job::Output, anyhow::Error>
     where
@@ -746,26 +772,26 @@ impl StoreConfig {
             }
             #[cfg(feature = "storage-service")]
             StoreConfig::StorageService { config, namespace } => Ok(job
-                .run::<StorageServiceDatabase>(config, namespace, blob_cache_size)
+                .run::<StorageServiceDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb { config, namespace } => Ok(job
-                .run::<RocksDbDatabase>(config, namespace, blob_cache_size)
+                .run::<RocksDbDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb { config, namespace } => Ok(job
-                .run::<DynamoDbDatabase>(config, namespace, blob_cache_size)
+                .run::<DynamoDbDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb { config, namespace } => Ok(job
-                .run::<ScyllaDbDatabase>(config, namespace, blob_cache_size)
+                .run::<ScyllaDbDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
             StoreConfig::DualRocksDbScyllaDb { config, namespace } => Ok(job
                 .run::<DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>>(
                     config,
                     namespace,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?),
         }
@@ -773,13 +799,13 @@ impl StoreConfig {
 
     pub async fn initialize(
         self,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         config: &GenesisConfig,
     ) -> Result<(), anyhow::Error> {
         self.clone()
-            .run_with_store(blob_cache_size, StorageMigration)
+            .run_with_store(cache_sizes, StorageMigration)
             .await?;
-        self.run_with_store(blob_cache_size, InitializeStorageJob(config))
+        self.run_with_store(cache_sizes, InitializeStorageJob(config))
             .await
     }
 }
@@ -794,7 +820,7 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -802,7 +828,7 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         D::Error: Send + Sync,
     {
         let mut storage =
-            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None, blob_cache_size)
+            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None, cache_sizes)
                 .await?;
         self.0.initialize_storage(&mut storage).await?;
         Ok(())
@@ -819,7 +845,7 @@ impl RunnableWithStore for StorageMigration {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -828,13 +854,9 @@ impl RunnableWithStore for StorageMigration {
     {
         if D::exists(&config, &namespace).await? {
             let wasm_runtime = None;
-            let storage = DbStorage::<D, WallClock>::connect(
-                &config,
-                &namespace,
-                wasm_runtime,
-                blob_cache_size,
-            )
-            .await?;
+            let storage =
+                DbStorage::<D, WallClock>::connect(&config, &namespace, wasm_runtime, cache_sizes)
+                    .await?;
             storage.migrate_if_needed().await?;
         }
         Ok(())
@@ -851,7 +873,7 @@ impl RunnableWithStore for AssertStorageV1 {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -860,13 +882,9 @@ impl RunnableWithStore for AssertStorageV1 {
     {
         if D::exists(&config, &namespace).await? {
             let wasm_runtime = None;
-            let storage = DbStorage::<D, WallClock>::connect(
-                &config,
-                &namespace,
-                wasm_runtime,
-                blob_cache_size,
-            )
-            .await?;
+            let storage =
+                DbStorage::<D, WallClock>::connect(&config, &namespace, wasm_runtime, cache_sizes)
+                    .await?;
             storage.assert_is_migrated_storage().await?;
         }
         Ok(())

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -361,6 +361,16 @@ impl MultiPartitionBatch {
     }
 }
 
+/// Individual cache sizes for each `ValueCache` in `DbStorage`.
+#[derive(Clone, Copy, Debug)]
+pub struct StorageCacheSizes {
+    pub blob_cache_size: usize,
+    pub confirmed_block_cache_size: usize,
+    pub lite_certificate_cache_size: usize,
+    pub certificate_raw_cache_size: usize,
+    pub event_cache_size: usize,
+}
+
 /// Raw certificate bytes: (lite_certificate_bytes, confirmed_block_bytes).
 type RawCertificate = (Vec<u8>, Vec<u8>);
 
@@ -1845,7 +1855,7 @@ where
     pub(crate) fn new(
         database: Database,
         wasm_runtime: Option<WasmRuntime>,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         clock: C,
     ) -> Self {
         Self {
@@ -1857,11 +1867,17 @@ where
             wasm_runtime,
             user_contracts: Arc::new(papaya::HashMap::new()),
             user_services: Arc::new(papaya::HashMap::new()),
-            blob_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            confirmed_block_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            lite_certificate_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            certificate_raw_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            event_cache: Arc::new(ValueCache::new(blob_cache_size)),
+            blob_cache: Arc::new(ValueCache::new(cache_sizes.blob_cache_size)),
+            confirmed_block_cache: Arc::new(ValueCache::new(
+                cache_sizes.confirmed_block_cache_size,
+            )),
+            lite_certificate_cache: Arc::new(ValueCache::new(
+                cache_sizes.lite_certificate_cache_size,
+            )),
+            certificate_raw_cache: Arc::new(ValueCache::new(
+                cache_sizes.certificate_raw_cache_size,
+            )),
+            event_cache: Arc::new(ValueCache::new(cache_sizes.event_cache_size)),
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }
     }
@@ -1883,10 +1899,10 @@ where
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self, ViewError> {
         let database = Database::maybe_create_and_connect(config, namespace).await?;
-        let storage = Self::new(database, wasm_runtime, blob_cache_size, WallClock);
+        let storage = Self::new(database, wasm_runtime, cache_sizes, WallClock);
         Ok(storage)
     }
 
@@ -1894,10 +1910,10 @@ where
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self, ViewError> {
         let database = Database::connect(config, namespace).await?;
-        let storage = Self::new(database, wasm_runtime, blob_cache_size, WallClock);
+        let storage = Self::new(database, wasm_runtime, cache_sizes, WallClock);
         Ok(storage)
     }
 
@@ -1971,7 +1987,14 @@ where
         clock: TestClock,
     ) -> Result<Self, ViewError> {
         let database = Database::recreate_and_connect(&config, namespace).await?;
-        let storage = Self::new(database, wasm_runtime, 1000, clock);
+        let default_cache_sizes = StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        };
+        let storage = Self::new(database, wasm_runtime, default_cache_sizes, clock);
         storage.assert_is_migrated_storage().await?;
         Ok(storage)
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -40,7 +40,7 @@ use linera_views::{context::Context, views::RootView, ViewError};
 pub use crate::db_storage::metrics;
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
-pub use crate::db_storage::{ChainStatesFirstAssignment, DbStorage, WallClock};
+pub use crate::db_storage::{ChainStatesFirstAssignment, DbStorage, StorageCacheSizes, WallClock};
 
 /// The default namespace to be used when none is specified
 pub const DEFAULT_NAMESPACE: &str = "table_linera";

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -243,7 +243,7 @@ mod tests {
             BaseKey, RootKey, BLOB_KEY, BLOB_STATE_KEY, BLOCK_KEY, LITE_CERTIFICATE_KEY,
             NETWORK_DESCRIPTION_KEY,
         },
-        DbStorage, WallClock,
+        DbStorage, StorageCacheSizes, WallClock,
     };
 
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -575,7 +575,14 @@ mod tests {
         let mut storage_state = get_storage_state();
         write_storage_state_old_schema(&database, storage_state.clone()).await?;
         // Creating a storage and migrate to the new database schema.
-        let storage = DbStorage::<D, WallClock>::new(database, None, 1000, WallClock);
+        let cache_sizes = StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        };
+        let storage = DbStorage::<D, WallClock>::new(database, None, cache_sizes, WallClock);
         storage.migrate_if_needed().await?;
         // read the storage state and compare it.
         let read_storage_state = read_storage_state_new_schema(storage.database.deref()).await?;

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -17,7 +17,13 @@ pub async fn get_storage(namespace: &str) -> Result<Storage, linera_views::ViewE
         },
         namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
-        1000,
+        linera_storage::StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        },
     )
     .await?
     .with_allow_application_logs(true))


### PR DESCRIPTION
## Motivation

`DbStorage` has 5 `ValueCache` instances (blob, confirmed_block, lite_certificate,
certificate_raw, event) all initialized with the same `blob_cache_size` parameter. Hit
rates across Conway validators vary wildly (7% to 99%), so operators need to tune them
independently.

## Proposal

- Add a `StorageCacheSizes` struct in `linera-storage` that holds individual sizes for
each cache.
- Replace the single `--blob-cache-size` CLI flag with 5 independent flags:
`--blob-cache-size`, `--confirmed-block-cache-size`, `--lite-certificate-cache-size`,
`--certificate-raw-cache-size`, `--event-cache-size` (all default to 1000, preserving
existing behavior).
- Thread `StorageCacheSizes` through `DbStorage::new()`, `RunnableWithStore::run()`,
`StoreConfig::run_with_store()`, `StoreConfig::initialize()`, and all their callers.
- Update Helm chart `values.yaml` with a `storageCacheSizes` section (tuned defaults:
blob=1000, confirmed_block=10000, lite_certificate=5000, certificate_raw=5000,
event=5000) and pass the flags in `shards.yaml` and `proxy.yaml` templates.
- Indexer and bridge callers maintain backward compatibility by constructing
`StorageCacheSizes` with all fields set to the single existing `blob_cache_size`.

## Test Plan

CI
