### PR TITLE
Make block cache and execution state cache sizes configurable via CLI

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -263,6 +263,12 @@ Client implementation and command-line tool for the Linera blockchain
 * `--blob-cache-size <BLOB_CACHE_SIZE>` — The maximal number of entries in the blob cache
 
   Default value: `1000`
+* `--block-cache-size <BLOCK_CACHE_SIZE>` — The number of entries in the block cache
+
+  Default value: `5000`
+* `--execution-state-cache-size <EXECUTION_STATE_CACHE_SIZE>` — The number of entries in the execution state cache
+
+  Default value: `10000`
 * `--storage-replication-factor <STORAGE_REPLICATION_FACTOR>` — The replication factor for the keyspace
 
   Default value: `1`

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -111,6 +111,8 @@ spec:
                 --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
                 --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
+                --block-cache-size {{ .Values.blockCacheSize | int }} \
+                --execution-state-cache-size {{ .Values.executionStateCacheSize | int }} \
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -61,6 +61,12 @@ storageCacheConfig:
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
+# Block cache size (number of entries)
+blockCacheSize: 20000
+
+# Execution state cache size (number of entries)
+executionStateCacheSize: 20000
+
 # Dual storage mode (RocksDB + ScyllaDB)
 dualStore: false
 

--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -373,6 +373,8 @@ pub async fn run(
         &Default::default(),
         None,
         genesis_config,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -121,6 +121,8 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &Default::default(),
         None,
         genesis_config,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -87,6 +87,8 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &Default::default(),
         None,
         genesis_config,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
     )
     .await?;
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -278,6 +278,8 @@ where
         options: &Options,
         default_chain: Option<ChainId>,
         genesis_config: GenesisConfig,
+        block_cache_size: usize,
+        execution_state_cache_size: usize,
     ) -> Result<Self, Error> {
         #[cfg(not(web))]
         let timing_config = options.to_timing_config();
@@ -320,6 +322,8 @@ where
             options.prioritize_bundles_from.clone().unwrap_or_default(),
             options.to_chain_client_options(),
             options.to_requests_scheduler_config(),
+            block_cache_size,
+            execution_state_cache_size,
         );
 
         #[cfg(not(web))]

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -18,7 +18,7 @@ use linera_core::{
         ClientOutcomeResultExt as _, MemoryStorageBuilder, StorageBuilder as _, TestBuilder,
     },
     wallet,
-    worker::Reason,
+    worker::{Reason, DEFAULT_BLOCK_CACHE_SIZE, DEFAULT_EXECUTION_STATE_CACHE_SIZE},
     Environment,
 };
 use linera_execution::{wasm_test, Operation, ResourceControlPolicy, WasmRuntime};
@@ -125,6 +125,8 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )),
     };
     context
@@ -237,6 +239,8 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
             HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )),
     };
 
@@ -385,6 +389,8 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
             HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )),
     };
     let context = Arc::new(Mutex::new(context));
@@ -461,6 +467,8 @@ async fn test_chain_listener_listen_command_adds_chains_to_wallet() -> anyhow::R
             HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )),
     };
 
@@ -577,6 +585,8 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
             HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )),
     };
 
@@ -777,6 +787,8 @@ async fn test_chain_listener_sparse_event_download() -> anyhow::Result<()> {
             HashSet::new(),
             ChainClientOptions::test_default(),
             linera_core::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )),
     };
     context.wallet().insert(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -280,12 +280,16 @@ impl<Env: Environment> Client<Env> {
         priority_bundle_origins: HashSet<ChainId>,
         options: ChainClientOptions,
         requests_scheduler_config: requests_scheduler::RequestsSchedulerConfig,
+        block_cache_size: usize,
+        execution_state_cache_size: usize,
     ) -> Self {
         let chain_modes = Arc::new(RwLock::new(chain_modes.into_iter().collect()));
         let state = WorkerState::new_for_client(
             name.into(),
             environment.storage().clone(),
             chain_modes.clone(),
+            block_cache_size,
+            execution_state_cache_size,
         )
         .with_long_lived_services(long_lived_services)
         .with_allow_inactive_chains(true)

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -56,7 +56,10 @@ use crate::{
         ValidatorNodeProvider,
     },
     notifier::ChannelNotifier,
-    worker::{Notification, ProcessableCertificate, WorkerState},
+    worker::{
+        Notification, ProcessableCertificate, WorkerState, DEFAULT_BLOCK_CACHE_SIZE,
+        DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+    },
 };
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -892,6 +895,8 @@ where
                 format!("Node {}", i),
                 Some(validator_keypair.secret_key),
                 storage.clone(),
+                DEFAULT_BLOCK_CACHE_SIZE,
+                DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             )
             .with_allow_inactive_chains(false)
             .with_allow_messages_from_deprecated_epochs(false);
@@ -1094,6 +1099,8 @@ where
             HashSet::new(),
             options,
             crate::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         ));
         Ok(client.create_chain_client(chain_id, block_hash, block_height, None, owner, None))
     }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -147,6 +147,8 @@ where
             "Single validator node".to_string(),
             Some(validator_keypair.secret_key),
             storage,
+            super::DEFAULT_BLOCK_CACHE_SIZE,
+            super::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )
         .with_allow_inactive_chains(is_client)
         .with_allow_messages_from_deprecated_epochs(is_client)

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -56,8 +56,8 @@ use crate::{
     CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
-const BLOCK_CACHE_SIZE: usize = 5_000;
-const EXECUTION_STATE_CACHE_SIZE: usize = 10_000;
+pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 5_000;
+pub const DEFAULT_EXECUTION_STATE_CACHE_SIZE: usize = 10_000;
 
 #[cfg(test)]
 #[path = "unit_tests/worker_tests.rs"]
@@ -540,13 +540,15 @@ where
         nickname: String,
         key_pair: Option<ValidatorSecretKey>,
         storage: StorageClient,
+        block_cache_size: usize,
+        execution_state_cache_size: usize,
     ) -> Self {
         WorkerState {
             nickname,
             storage,
             chain_worker_config: ChainWorkerConfig::default().with_key_pair(key_pair),
-            block_cache: Arc::new(ValueCache::new(BLOCK_CACHE_SIZE)),
-            execution_state_cache: Arc::new(UniqueValueCache::new(EXECUTION_STATE_CACHE_SIZE)),
+            block_cache: Arc::new(ValueCache::new(block_cache_size)),
+            execution_state_cache: Arc::new(UniqueValueCache::new(execution_state_cache_size)),
             chain_modes: None,
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
@@ -559,13 +561,15 @@ where
         nickname: String,
         storage: StorageClient,
         chain_modes: Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>,
+        block_cache_size: usize,
+        execution_state_cache_size: usize,
     ) -> Self {
         WorkerState {
             nickname,
             storage,
             chain_worker_config: ChainWorkerConfig::default(),
-            block_cache: Arc::new(ValueCache::new(BLOCK_CACHE_SIZE)),
-            execution_state_cache: Arc::new(UniqueValueCache::new(EXECUTION_STATE_CACHE_SIZE)),
+            block_cache: Arc::new(ValueCache::new(block_cache_size)),
+            execution_state_cache: Arc::new(UniqueValueCache::new(execution_state_cache_size)),
             chain_modes: Some(chain_modes),
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -21,7 +21,9 @@ use linera_base::{
     identifiers::{AccountOwner, ApplicationId, ChainId, ModuleId},
     ownership::ChainOwnership,
 };
-use linera_core::worker::WorkerState;
+use linera_core::worker::{
+    WorkerState, DEFAULT_BLOCK_CACHE_SIZE, DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+};
 use linera_execution::{
     committee::Committee,
     system::{AdminOperation, OpenChainConfig, SystemOperation},
@@ -92,6 +94,8 @@ impl TestValidator {
             "Single validator node".to_string(),
             Some(validator_keypair.secret_key.copy()),
             storage.clone(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         );
 
         // Create an admin chain.

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -74,6 +74,10 @@ impl Options {
             &self.client_options,
             default_chain,
             genesis_config,
+            self.common.common_storage_options.block_cache_size,
+            self.common
+                .common_storage_options
+                .execution_state_cache_size,
         )
         .await?)
     }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -71,6 +71,8 @@ struct ServerContext {
     block_time_grace_period: Duration,
     chain_worker_ttl: Duration,
     chain_info_max_received_log_entries: usize,
+    block_cache_size: usize,
+    execution_state_cache_size: usize,
 }
 
 impl ServerContext {
@@ -93,6 +95,8 @@ impl ServerContext {
             format!("Shard {} @ {}:{}", shard_id, local_ip_addr, shard.port),
             Some(self.server_config.validator_secret.copy()),
             storage,
+            self.block_cache_size,
+            self.execution_state_cache_size,
         )
         .with_allow_inactive_chains(false)
         .with_allow_messages_from_deprecated_epochs(false)
@@ -538,6 +542,8 @@ async fn run(options: ServerOptions) {
                 block_time_grace_period,
                 chain_worker_ttl,
                 chain_info_max_received_log_entries,
+                block_cache_size: common_storage_options.block_cache_size,
+                execution_state_cache_size: common_storage_options.execution_state_cache_size,
             };
             let wasm_runtime = wasm_runtime.with_wasm_default();
             let store_config = storage_config

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -86,6 +86,14 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "1000", global = true)]
     pub blob_cache_size: usize,
 
+    /// The number of entries in the block cache.
+    #[arg(long, default_value = "5000", global = true)]
+    pub block_cache_size: usize,
+
+    /// The number of entries in the execution state cache.
+    #[arg(long, default_value = "10000", global = true)]
+    pub execution_state_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1", global = true)]
     pub storage_replication_factor: u32,

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -14,6 +14,7 @@ use linera_core::{
     join_set_ext::JoinSet,
     test_utils::{MemoryStorageBuilder, StorageBuilder, TestBuilder},
     wallet,
+    worker::{DEFAULT_BLOCK_CACHE_SIZE, DEFAULT_EXECUTION_STATE_CACHE_SIZE},
 };
 use linera_rpc::{NodeOptions, NodeProvider};
 use linera_service::Wallet;
@@ -70,6 +71,8 @@ pub async fn new_test_client_context(
                 ..ChainClientOptions::test_default()
             },
             linera_core::client::RequestsSchedulerConfig::default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )
         .into(),
         genesis_config,

--- a/web/@linera/client/src/client.rs
+++ b/web/@linera/client/src/client.rs
@@ -73,6 +73,8 @@ impl Client {
             &options,
             default,
             genesis_config,
+            linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+            linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
         )
         .await?;
         // The `Arc` here is useless, but it is required by the `ChainListener` API.


### PR DESCRIPTION
## Motivation

On testnet-conway, hot shards have 59.4% block cache hit rate (vs 99.6%+ on other
validators), generating ~2,900 extra ScyllaDB reads/s. The block cache size is hardcoded
at 5,000 entries and the execution state cache at 10,000 entries. Making them
configurable lets operators increase them for validators with concentrated hot chains.

## Proposal

- Rename `BLOCK_CACHE_SIZE` and `EXECUTION_STATE_CACHE_SIZE` to
`DEFAULT_BLOCK_CACHE_SIZE` / `DEFAULT_EXECUTION_STATE_CACHE_SIZE` and make them `pub`
for use in tests.
- Add `--block-cache-size` and `--execution-state-cache-size` CLI flags to both
`linera-server` (via `CommonStorageOptions`) and the client (via `Options`).
- Thread the values through `ServerContext` → `WorkerState::new()` for the server path,
and through `Client::new()` → `WorkerState::new_for_client()` for the client path.
- Update the Helm chart to pass both flags to shards with a default of 20,000 entries
(4x the CLI default, appropriate forway's working set).

## Test Plan

CI
