### PR TITLE
Increase storage cache defaults for Conway

### DIFF
--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -45,9 +45,9 @@ storageReplicationFactor: 1
 # These settings control memory usage for caching storage queries
 storageCacheConfig:
   # Maximum total cache size in bytes
-  maxCacheSize: 50000000
+  maxCacheSize: 200000000
   # Maximum number of entries in the cache
-  maxCacheEntries: 50000
+  maxCacheEntries: 200000
   # Maximum size of a single value entry in bytes
   maxValueEntrySize: 1000000
   # Maximum size of a single find-keys entry in bytes
@@ -55,9 +55,9 @@ storageCacheConfig:
   # Maximum size of a single find-key-values entry in bytes
   maxFindKeyValuesEntrySize: 1000000
   # Maximum total size of value entries in bytes
-  maxCacheValueSize: 50000000
+  maxCacheValueSize: 200000000
   # Maximum total size of find-keys entries in bytes
-  maxCacheFindKeysSize: 10000000
+  maxCacheFindKeysSize: 40000000
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
@@ -67,7 +67,7 @@ storageCacheSizes:
   blobCacheSize: 1000
   confirmedBlockCacheSize: 10000
   liteCertificateCacheSize: 5000
-  certificateRawCacheSize: 5000
+  certificateRawCacheSize: 50000
   eventCacheSize: 5000
 
 # Block cache size (number of entries)


### PR DESCRIPTION
## Motivation

Two cache bottlenecks on Conway:

1. **Validator-1 shards-0/shards-4**: The per-chain storage LRU caches
(`read_value_cache`,
`contains_key_cache`) have 20-25% hit rates, causing ~3,400 ScyllaDB reads/sec (vs
5-9/sec on healthy shards). This creates chain worker queue contention (71s p95 wait
on
shards-0) and pegs V1's proxy p99 latency at the 2s histogram ceiling.

2. **All proxies on all validators**: The `certificate_raw_cache` (DbStorage ValueCache
for raw certificate bytes) has a 13.4% hit rate and accounts for 90% of all proxy
cache
traffic (~282 misses/sec). The proxy reads raw certificate bytes and forwards them
over
gRPC without deserializing — with only 1000 entries (current) or 5000 (PR #5769
default),
the cache is far too small for the working set.

## Proposal

**Per-chain LRU caches** (`storageCacheConfig`):
- `maxCacheSize`: 50MB → 200MB
- `maxCacheEntries`: 50K → 200K
- `maxCacheValueSize`: 50MB → 200MBxCacheFindKeysSize`: 10MB → 40MB

Memory impact: per-chain limits, only hot chains fill them. With ~5-10 hot chains per
shard, adds ~750MB-1.5GB per shard. Nodes have 64GB RAM with ~58GB free.

**DbStorage ValueCaches** (`storageCacheSizes`):
- `certificateRawCacheSize`: 5K → 50K

Memory impact: ~100-250MB per proxy/shard instance (50K entries × ~2-5KB per raw
certificate pair). Nodes have ample headroom.

## Test Plan

CI. Monitor cache hit rates and proxy p99 latency after deployment.
