### PR TITLE
[testnet][web] Add connection timeout to IndexedDB

### DIFF
--- a/web/@linera/client/src/client.rs
+++ b/web/@linera/client/src/client.rs
@@ -49,7 +49,6 @@ impl Client {
     /// On transport or protocol error, if persistent storage is
     /// unavailable, or if `options` is incorrectly structured.
     #[wasm_bindgen(constructor)]
-    #[tracing::instrument(skip_all)]
     pub async fn new(
         mut wallet: Wallet,
         signer: Signer,


### PR DESCRIPTION
## Motivation

Debug and partially solve bricked client connect in production

## Proposal

Failure to cleanup IndexedDB may create stale connections causing future attempts to never return.

Let's use a timer to fail and return an error instead

## Test Plan

CI + tested in pm-app