### PR TITLE
Increase cache sizes and improve cache dashboard visibility

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
@@ -1375,7 +1375,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Ratio of cache hits to total cache accesses for value cache",
+      "description": "Ratio of cache hits to total cache accesses for value cache, broken down by value type",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1461,14 +1461,115 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[1m]))\n/\n(\n  sum (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[1m]))\n+ (\n    sum (rate(linera_value_cache_miss{validator=~\"$validator\", job=\"linera-linera-server\"}[1m]))\n    or on (validator) vector(0)\n  )\n)",
+          "expr": "sum by (value_type) (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[5m]))\n/\n(\n  sum by (value_type) (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[5m]))\n  + sum by (value_type) (rate(linera_value_cache_miss{validator=~\"$validator\", job=\"linera-linera-server\"}[5m]))\n)",
           "instant": false,
-          "legendFormat": "Cache Hit Ratio",
+          "legendFormat": "{{value_type}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Value Cache Hit Ratio",
+      "title": "Value Cache Hit Ratio by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of value cache operations (hits + misses) per second, broken down by value type. Helps distinguish 0% hit ratio due to zero traffic vs actual misses.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 69,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (value_type) (\n  rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[5m])\n  + rate(linera_value_cache_miss{validator=~\"$validator\", job=\"linera-linera-server\"}[5m])\n)",
+          "instant": false,
+          "legendFormat": "{{value_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Value Cache Operations Rate by Type",
       "type": "timeseries"
     },
     {

--- a/kubernetes/linera-validator/grafana-dashboards/linera/views.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/views.json
@@ -685,8 +685,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_cache_fault{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_cache_fault{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -799,8 +799,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_read_value_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_read_value_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -900,8 +900,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_contains_key_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_contains_key_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -1001,8 +1001,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_find_keys_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_find_keys_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -1102,8 +1102,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_find_key_values_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_find_key_values_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -45,9 +45,9 @@ storageReplicationFactor: 1
 # These settings control memory usage for caching storage queries
 storageCacheConfig:
   # Maximum total cache size in bytes
-  maxCacheSize: 200000000
+  maxCacheSize: 1000000000
   # Maximum number of entries in the cache
-  maxCacheEntries: 200000
+  maxCacheEntries: 500000
   # Maximum size of a single value entry in bytes
   maxValueEntrySize: 1000000
   # Maximum size of a single find-keys entry in bytes
@@ -55,9 +55,9 @@ storageCacheConfig:
   # Maximum size of a single find-key-values entry in bytes
   maxFindKeyValuesEntrySize: 1000000
   # Maximum total size of value entries in bytes
-  maxCacheValueSize: 200000000
+  maxCacheValueSize: 500000000
   # Maximum total size of find-keys entries in bytes
-  maxCacheFindKeysSize: 40000000
+  maxCacheFindKeysSize: 200000000
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
@@ -68,7 +68,7 @@ storageCacheSizes:
   confirmedBlockCacheSize: 10000
   liteCertificateCacheSize: 5000
   certificateRawCacheSize: 50000
-  eventCacheSize: 5000
+  eventCacheSize: 20000
 
 # Block cache size (number of entries)
 blockCacheSize: 20000


### PR DESCRIPTION
## Motivation

ScyllaDB read latency p99 spikes (2-4.6s every ~25-30 min) on Conway validators are
caused by a cache miss cascade: PM worker market bursts → app-level cache miss →
ScyllaDB row cache miss → disk read during compaction → latency spike. Increasing
application-level cache sizes will absorb bursts at layer 1, reducing pressure on
ScyllaDB. Dashboard panels also needed better granularity to diagnose cache behavior per
type.

## Proposal

**Cache size increases** (`values.yaml`):

| Setting | Old | New | Rationale |
|---------|-----|-----|-----------|
| `maxCacheSize` | 200MB | 1GB | Global ceiling to accommodate increased sub-budgets |
| `maxCacheEntries` | 200K | 500K | Entry count aligned with ~1GB at ~2KB avg entry |
| `maxCacheValueSize` | 200MB | 500MB | read_value + contains_key hit ratio drops during
PM bursts |
| `maxCacheFindKeysSize` | 40MB | 200MB | 72% miss rate across all validators |
| `eventCacheSize` | 5K | 20K | Event cache (Vec\<u62.8% hit ratio with 30
ops/sec — poor retention |

Memory impact: ~2-4GB additional across all shards (LRU prefix cache growth under real
workload) + ~120MB (event cache). Validators have 37-42GB free.

**Execution dashboard** (`execution.json`):
- Replaced aggregate "Value Cache Hit Ratio" panel with per-`value_type` breakdown (7
lines: Hashed\<Block\>, Blob, Vec\<u8\>, etc.)
- Added "Value Cache Operations Rate by Type" panel alongside, so 0% hit ratio can be
distinguished from zero traffic vs actual misses

**Views dashboard** (`views.json`):
- Removed `by (instance)` from Cache Hit Ratio and all 4 LRU cache hit% panels —
aggregate across shards instead of one noisy line per shard

## Test Plan

CI. Live Grafana dashboards already updated and rendering data — verify panels after
deployment shows cache hit ratios improving.
