### PR TITLE
Address the `test_wasm_end_to_end_social_event_streams` errors.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2342,7 +2342,9 @@ async fn test_wasm_end_to_end_social_event_streams(config: impl LineraNetConfig)
             ]
         }
     });
-    notifications2.wait_for_block(height2.try_add_one()?).await?;
+    notifications2
+        .wait_for_block(height2.try_add_one()?)
+        .await?;
     assert_eq!(app2.query(query).await?, expected_response1);
 
     let tip_after_first_post = node_service2.chain_tip(chain1).await?;
@@ -2381,8 +2383,10 @@ async fn test_wasm_end_to_end_social_event_streams(config: impl LineraNetConfig)
         if response == expected_response2 {
             break;
         }
-        assert_eq!(response, expected_response1,
-            "unexpected intermediate state: expected either both posts or only the first post");
+        assert_eq!(
+            response, expected_response1,
+            "unexpected intermediate state: expected either both posts or only the first post"
+        );
     }
 
     let tip_after_second_post = node_service2.chain_tip(chain1).await?;


### PR DESCRIPTION
## Motivation

The test `test_wasm_end_to_end_social_event_streams` is regularly failing in CI. We propose here a solution to the problem.

Fixes #5761 

## Proposal

In the test, `app1` emits a post that should be received by `app1`. Just after that, a transfer is being done.
The call to `app1` leads to the creation of a stream entry to chain2. But the transfer also leads to another message.

I do not think we have guarantees about the order in which the calls are being processed. Therefore, we can have the next block that has the transfers and the one after that the new post. Or the reverse. So, the test has to be changed.

## Test Plan

CI is the goal.

## Release Plan

Can be backported to `testnet_conway`.

## Links

None