### PR TITLE
Access to keys with pagination

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -24,7 +24,7 @@ use linera_base::{
     ownership::ChainOwnership,
     time::Instant,
 };
-use linera_views::{batch::Batch, context::Context, views::View};
+use linera_views::{batch::Batch, context::Context, store::KeyInterval, views::View};
 use oneshot::Sender;
 use reqwest::{header::HeaderMap, Client, Url};
 use tracing::{info_span, instrument, Instrument as _};
@@ -35,9 +35,10 @@ use crate::{
     system::{CreateApplicationResult, OpenChainConfig},
     util::{OracleResponseExt as _, RespondExt as _},
     ApplicationDescription, ApplicationId, ExecutionError, ExecutionRuntimeContext,
-    ExecutionStateView, JsVec, Message, MessageContext, MessageKind, ModuleId, Operation,
-    OperationContext, OutgoingMessage, ProcessStreamsContext, QueryContext, QueryOutcome,
-    ResourceController, SystemMessage, TransactionTracker, UserContractCode, UserServiceCode,
+    ExecutionStateView, IntervalKeyValues, IntervalKeys, JsVec, Message, MessageContext,
+    MessageKind, ModuleId, Operation, OperationContext, OutgoingMessage, ProcessStreamsContext,
+    QueryContext, QueryOutcome, ResourceController, SystemMessage, TransactionTracker,
+    UserContractCode, UserServiceCode,
 };
 
 /// Actor for handling requests to the execution state.
@@ -401,6 +402,32 @@ where
                 let result = match view {
                     Some(view) => view.find_key_values_by_prefix(&key_prefix).await?,
                     None => Vec::new(),
+                };
+                callback.respond(result);
+            }
+
+            FindKeysInInterval {
+                id,
+                key_interval,
+                callback,
+            } => {
+                let view = self.state.users.try_load_entry(&id).await?;
+                let result = match view {
+                    Some(view) => view.find_keys_in_interval(key_interval).await?,
+                    None => (Vec::new(), true),
+                };
+                callback.respond(result);
+            }
+
+            FindKeyValuesInInterval {
+                id,
+                key_interval,
+                callback,
+            } => {
+                let view = self.state.users.try_load_entry(&id).await?;
+                let result = match view {
+                    Some(view) => view.find_key_values_in_interval(key_interval).await?,
+                    None => (Vec::new(), true),
                 };
                 callback.respond(result);
             }
@@ -1398,6 +1425,20 @@ pub enum ExecutionRequest {
         key_prefix: Vec<u8>,
         #[debug(skip)]
         callback: Sender<Vec<(Vec<u8>, Vec<u8>)>>,
+    },
+
+    FindKeysInInterval {
+        id: ApplicationId,
+        key_interval: KeyInterval,
+        #[debug(skip)]
+        callback: Sender<IntervalKeys>,
+    },
+
+    FindKeyValuesInInterval {
+        id: ApplicationId,
+        key_interval: KeyInterval,
+        #[debug(skip)]
+        callback: Sender<IntervalKeyValues>,
     },
 
     WriteBatch {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -45,9 +45,12 @@ use linera_base::{
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
-use linera_views::{batch::Batch, ViewError};
+use linera_views::{batch::Batch, store::KeyInterval, ViewError};
 use serde::{Deserialize, Serialize};
 use system::AdminOperation;
+
+pub type IntervalKeys = (Vec<Vec<u8>>, bool);
+pub type IntervalKeyValues = (Vec<(Vec<u8>, Vec<u8>)>, bool);
 use thiserror::Error;
 pub use web_thread_pool::Pool as ThreadPool;
 use web_thread_select as web_thread;
@@ -724,6 +727,8 @@ pub trait BaseRuntime {
     type ReadValueBytes: fmt::Debug + Send + Sync;
     type FindKeysByPrefix: fmt::Debug + Send + Sync;
     type FindKeyValuesByPrefix: fmt::Debug + Send + Sync;
+    type FindKeysInInterval: fmt::Debug + Send + Sync;
+    type FindKeyValuesInInterval: fmt::Debug + Send + Sync;
 
     /// The current chain ID.
     fn chain_id(&mut self) -> Result<ChainId, ExecutionError>;
@@ -864,6 +869,18 @@ pub trait BaseRuntime {
         promise: &Self::FindKeysByPrefix,
     ) -> Result<Vec<Vec<u8>>, ExecutionError>;
 
+    /// Creates the promise to access keys in a specific interval.
+    fn find_keys_in_interval_new(
+        &mut self,
+        key_interval: KeyInterval,
+    ) -> Result<Self::FindKeysInInterval, ExecutionError>;
+
+    /// Resolves the promise to access keys in a specific interval.
+    fn find_keys_in_interval_wait(
+        &mut self,
+        promise: &Self::FindKeysInInterval,
+    ) -> Result<IntervalKeys, ExecutionError>;
+
     /// Reads the data from the key/values having a specific prefix.
     #[cfg(feature = "test")]
     #[expect(clippy::type_complexity)]
@@ -887,6 +904,18 @@ pub trait BaseRuntime {
         &mut self,
         promise: &Self::FindKeyValuesByPrefix,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError>;
+
+    /// Creates the promise to access key/values in a specific interval.
+    fn find_key_values_in_interval_new(
+        &mut self,
+        key_interval: KeyInterval,
+    ) -> Result<Self::FindKeyValuesInInterval, ExecutionError>;
+
+    /// Resolves the promise to access key/values in a specific interval.
+    fn find_key_values_in_interval_wait(
+        &mut self,
+        promise: &Self::FindKeyValuesInInterval,
+    ) -> Result<IntervalKeyValues, ExecutionError>;
 
     /// Makes an HTTP request to the given URL and returns the answer, if any.
     fn perform_http_request(

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -22,7 +22,7 @@ use linera_base::{
     time::Instant,
     vm::VmRuntime,
 };
-use linera_views::batch::Batch;
+use linera_views::{batch::Batch, store::KeyInterval};
 use oneshot::Receiver;
 use tracing::instrument;
 
@@ -251,6 +251,8 @@ impl<T> QueryManager<T> {
 type Keys = Vec<Vec<u8>>;
 type Value = Vec<u8>;
 type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+type IntervalKeys = (Vec<Vec<u8>>, bool);
+type IntervalKeyValues = (Vec<(Vec<u8>, Vec<u8>)>, bool);
 
 #[derive(Debug, Default)]
 struct ViewUserState {
@@ -266,6 +268,10 @@ struct ViewUserState {
     find_keys_queries: QueryManager<Keys>,
     /// The find-key-values queries in progress.
     find_key_values_queries: QueryManager<KeyValues>,
+    /// The find-keys-in-interval queries in progress.
+    find_keys_in_interval_queries: QueryManager<IntervalKeys>,
+    /// The find-key-values-in-interval queries in progress.
+    find_key_values_in_interval_queries: QueryManager<IntervalKeyValues>,
 }
 
 impl ViewUserState {
@@ -276,6 +282,8 @@ impl ViewUserState {
         self.read_multi_values_queries.force_all()?;
         self.find_keys_queries.force_all()?;
         self.find_key_values_queries.force_all()?;
+        self.find_keys_in_interval_queries.force_all()?;
+        self.find_key_values_in_interval_queries.force_all()?;
         Ok(())
     }
 }
@@ -599,6 +607,8 @@ where
     type ReadMultiValuesBytes = u32;
     type FindKeysByPrefix = u32;
     type FindKeyValuesByPrefix = u32;
+    type FindKeysInInterval = u32;
+    type FindKeyValuesInInterval = u32;
 
     fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
         let mut this = self.inner();
@@ -928,6 +938,77 @@ where
         this.resource_controller
             .track_bytes_read(read_size as u64)?;
         Ok(key_values)
+    }
+
+    fn find_keys_in_interval_new(
+        &mut self,
+        key_interval: KeyInterval,
+    ) -> Result<Self::FindKeysInInterval, ExecutionError> {
+        let mut this = self.inner();
+        let id = this.current_application().id;
+        this.resource_controller.track_read_operation()?;
+        let receiver = this.execution_state_sender.send_request(move |callback| {
+            ExecutionRequest::FindKeysInInterval {
+                id,
+                key_interval,
+                callback,
+            }
+        })?;
+        let state = this.view_user_states.entry(id).or_default();
+        state.find_keys_in_interval_queries.register(receiver)
+    }
+
+    fn find_keys_in_interval_wait(
+        &mut self,
+        promise: &Self::FindKeysInInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), ExecutionError> {
+        let mut this = self.inner();
+        let id = this.current_application().id;
+        let (keys, is_finished) = {
+            let state = this.view_user_states.entry(id).or_default();
+            state.find_keys_in_interval_queries.wait(*promise)?
+        };
+        let read_size = keys.iter().map(Vec::len).sum::<usize>();
+        this.resource_controller
+            .track_bytes_read(read_size as u64)?;
+        Ok((keys, is_finished))
+    }
+
+    fn find_key_values_in_interval_new(
+        &mut self,
+        key_interval: KeyInterval,
+    ) -> Result<Self::FindKeyValuesInInterval, ExecutionError> {
+        let mut this = self.inner();
+        let id = this.current_application().id;
+        this.resource_controller.track_read_operation()?;
+        let receiver = this.execution_state_sender.send_request(move |callback| {
+            ExecutionRequest::FindKeyValuesInInterval {
+                id,
+                key_interval,
+                callback,
+            }
+        })?;
+        let state = this.view_user_states.entry(id).or_default();
+        state.find_key_values_in_interval_queries.register(receiver)
+    }
+
+    fn find_key_values_in_interval_wait(
+        &mut self,
+        promise: &Self::FindKeyValuesInInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ExecutionError> {
+        let mut this = self.inner();
+        let id = this.current_application().id;
+        let (key_values, is_finished) = {
+            let state = this.view_user_states.entry(id).or_default();
+            state.find_key_values_in_interval_queries.wait(*promise)?
+        };
+        let read_size = key_values
+            .iter()
+            .map(|(key, value)| key.len() + value.len())
+            .sum::<usize>();
+        this.resource_controller
+            .track_bytes_read(read_size as u64)?;
+        Ok((key_values, is_finished))
     }
 
     fn perform_http_request(

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -13,8 +13,11 @@ use linera_base::{
     ownership::{ChainOwnership, ManageChainError},
     vm::VmRuntime,
 };
-use linera_views::batch::{Batch, WriteOperation};
-use linera_witty::{wit_export, Instance, RuntimeError};
+use linera_views::{
+    batch::{Batch, WriteOperation},
+    store::{KeyInterval, KeyIntervalStart},
+};
+use linera_witty::{wit_export, Instance, RuntimeError, WitLoad, WitStore, WitType};
 use tracing::log;
 
 use super::WasmExecutionError;
@@ -25,6 +28,27 @@ pub struct RuntimeApiData<Runtime> {
     runtime: Runtime,
     active_promises: HashMap<u32, Box<dyn Any + Send + Sync>>,
     promise_counter: u32,
+}
+
+#[derive(Clone, Debug, WitLoad, WitStore, WitType)]
+pub struct KeyIntervalQuery {
+    start: Vec<u8>,
+    start_inclusive: bool,
+    end: Option<Vec<u8>>,
+    end_inclusive: bool,
+    limit: Option<u32>,
+}
+
+#[derive(Clone, Debug, WitLoad, WitStore, WitType)]
+pub struct KeyListQueryResult {
+    keys: Vec<Vec<u8>>,
+    is_finished: bool,
+}
+
+#[derive(Clone, Debug, WitLoad, WitStore, WitType)]
+pub struct KeyValueListQueryResult {
+    key_values: Vec<(Vec<u8>, Vec<u8>)>,
+    is_finished: bool,
 }
 
 impl<Runtime> RuntimeApiData<Runtime> {
@@ -425,6 +449,46 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Creates a new promise to search for keys in the `key_interval`.
+    fn find_keys_in_interval_new(
+        caller: &mut Caller,
+        query: KeyIntervalQuery,
+    ) -> Result<u32, RuntimeError> {
+        let mut data = caller.user_data_mut();
+        let promise = data
+            .runtime
+            .find_keys_in_interval_new(KeyInterval {
+                start: if query.start_inclusive {
+                    KeyIntervalStart::Included(query.start)
+                } else {
+                    KeyIntervalStart::Excluded(query.start)
+                },
+                end: match query.end {
+                    Some(end) if query.end_inclusive => std::ops::Bound::Included(end),
+                    Some(end) => std::ops::Bound::Excluded(end),
+                    None => std::ops::Bound::Unbounded,
+                },
+                limit: query.limit.map(|limit| limit as usize),
+            })
+            .map_err(|error| RuntimeError::Custom(error.into()))?;
+
+        Ok(data.register_promise(promise))
+    }
+
+    /// Waits for the promise to search for keys in the `key_interval`.
+    fn find_keys_in_interval_wait(
+        caller: &mut Caller,
+        promise_id: u32,
+    ) -> Result<KeyListQueryResult, RuntimeError> {
+        let mut data = caller.user_data_mut();
+        let promise = data.take_promise(promise_id)?;
+        let (keys, is_finished) = data
+            .runtime
+            .find_keys_in_interval_wait(&promise)
+            .map_err(|error| RuntimeError::Custom(error.into()))?;
+        Ok(KeyListQueryResult { keys, is_finished })
+    }
+
     /// Creates a new promise to search for entries whose keys that start with the `key_prefix`.
     fn find_key_values_new(caller: &mut Caller, key_prefix: Vec<u8>) -> Result<u32, RuntimeError> {
         let mut data = caller.user_data_mut();
@@ -448,6 +512,49 @@ where
         data.runtime
             .find_key_values_by_prefix_wait(&promise)
             .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Creates a new promise to search for entries in the `key_interval`.
+    fn find_key_values_in_interval_new(
+        caller: &mut Caller,
+        query: KeyIntervalQuery,
+    ) -> Result<u32, RuntimeError> {
+        let mut data = caller.user_data_mut();
+        let promise = data
+            .runtime
+            .find_key_values_in_interval_new(KeyInterval {
+                start: if query.start_inclusive {
+                    KeyIntervalStart::Included(query.start)
+                } else {
+                    KeyIntervalStart::Excluded(query.start)
+                },
+                end: match query.end {
+                    Some(end) if query.end_inclusive => std::ops::Bound::Included(end),
+                    Some(end) => std::ops::Bound::Excluded(end),
+                    None => std::ops::Bound::Unbounded,
+                },
+                limit: query.limit.map(|limit| limit as usize),
+            })
+            .map_err(|error| RuntimeError::Custom(error.into()))?;
+
+        Ok(data.register_promise(promise))
+    }
+
+    /// Waits for the promise to search for entries in the `key_interval`.
+    fn find_key_values_in_interval_wait(
+        caller: &mut Caller,
+        promise_id: u32,
+    ) -> Result<KeyValueListQueryResult, RuntimeError> {
+        let mut data = caller.user_data_mut();
+        let promise = data.take_promise(promise_id)?;
+        let (key_values, is_finished) = data
+            .runtime
+            .find_key_values_in_interval_wait(&promise)
+            .map_err(|error| RuntimeError::Custom(error.into()))?;
+        Ok(KeyValueListQueryResult {
+            key_values,
+            is_finished,
+        })
     }
 }
 

--- a/linera-exporter/src/main.rs
+++ b/linera-exporter/src/main.rs
@@ -319,8 +319,7 @@ impl DestinationsCommand {
         };
 
         let cache_sizes = options.common_storage_options.storage_cache_config();
-        store_config
-            .run_with_storage(None, false, cache_sizes, context)
+        Box::pin(store_config.run_with_storage(None, false, cache_sizes, context))
             .await?
             .map_err(Into::into)
     }

--- a/linera-sdk/src/views/mock_key_value_store.rs
+++ b/linera-sdk/src/views/mock_key_value_store.rs
@@ -15,8 +15,11 @@ use futures::FutureExt as _;
 use linera_views::{
     batch::Batch,
     memory::MemoryStore,
-    store::{ReadableKeyValueStore, WritableKeyValueStore},
+    store::{KeyInterval, ReadableKeyValueStore, WritableKeyValueStore},
 };
+
+type IntervalKeys = (Vec<Vec<u8>>, bool);
+type IntervalKeyValues = (Vec<(Vec<u8>, Vec<u8>)>, bool);
 
 /// A mock [`KeyValueStore`] implementation using a [`MemoryStore`].
 pub(super) struct MockKeyValueStore {
@@ -25,8 +28,8 @@ pub(super) struct MockKeyValueStore {
     contains_keys_promises: PromiseRegistry<Vec<bool>>,
     read_multi_promises: PromiseRegistry<Vec<Option<Vec<u8>>>>,
     read_single_promises: PromiseRegistry<Option<Vec<u8>>>,
-    find_keys_promises: PromiseRegistry<Vec<Vec<u8>>>,
-    find_key_values_promises: PromiseRegistry<Vec<(Vec<u8>, Vec<u8>)>>,
+    find_keys_in_interval_promises: PromiseRegistry<IntervalKeys>,
+    find_key_values_in_interval_promises: PromiseRegistry<IntervalKeyValues>,
 }
 
 impl Default for MockKeyValueStore {
@@ -37,8 +40,8 @@ impl Default for MockKeyValueStore {
             contains_keys_promises: PromiseRegistry::default(),
             read_multi_promises: PromiseRegistry::default(),
             read_single_promises: PromiseRegistry::default(),
-            find_keys_promises: PromiseRegistry::default(),
-            find_key_values_promises: PromiseRegistry::default(),
+            find_keys_in_interval_promises: PromiseRegistry::default(),
+            find_key_values_in_interval_promises: PromiseRegistry::default(),
         }
     }
 }
@@ -141,39 +144,39 @@ impl MockKeyValueStore {
         self.read_single_promises.take(promise)
     }
 
-    /// Finds keys in the storage that start with `key_prefix`, returning a promise to
-    /// retrieve the final value.
-    pub(crate) fn find_keys_new(&self, key_prefix: &[u8]) -> u32 {
-        self.find_keys_promises.register(
+    /// Finds keys in the storage matching `key_interval`, returning a promise to retrieve the
+    /// final value.
+    pub(crate) fn find_keys_in_interval_new(&self, key_interval: KeyInterval) -> u32 {
+        self.find_keys_in_interval_promises.register(
             self.store
-                .find_keys_by_prefix(key_prefix)
+                .find_keys_in_interval(key_interval)
                 .now_or_never()
                 .expect("Memory store should never wait for anything")
                 .expect("Memory store should never fail"),
         )
     }
 
-    /// Returns the keys found in storage by the respective [`find_keys_new`] call.
-    pub(crate) fn find_keys_wait(&self, promise: u32) -> Vec<Vec<u8>> {
-        self.find_keys_promises.take(promise)
+    /// Returns the keys found in storage by the respective [`find_keys_in_interval_new`] call.
+    pub(crate) fn find_keys_in_interval_wait(&self, promise: u32) -> IntervalKeys {
+        self.find_keys_in_interval_promises.take(promise)
     }
 
-    /// Finds key-value pairs in the storage in which the key starts with `key_prefix`,
-    /// returning a promise to retrieve the final value.
-    pub(crate) fn find_key_values_new(&self, key_prefix: &[u8]) -> u32 {
-        self.find_key_values_promises.register(
+    /// Finds key-value pairs matching `key_interval`, returning a promise to retrieve the final
+    /// value.
+    pub(crate) fn find_key_values_in_interval_new(&self, key_interval: KeyInterval) -> u32 {
+        self.find_key_values_in_interval_promises.register(
             self.store
-                .find_key_values_by_prefix(key_prefix)
+                .find_key_values_in_interval(key_interval)
                 .now_or_never()
                 .expect("Memory store should never wait for anything")
                 .expect("Memory store should never fail"),
         )
     }
 
-    /// Returns the key-value pairs found in storage by the respective [`find_key_values_new`]
-    /// call.
-    pub(crate) fn find_key_values_wait(&self, promise: u32) -> Vec<(Vec<u8>, Vec<u8>)> {
-        self.find_key_values_promises.take(promise)
+    /// Returns the key-value pairs found in storage by the respective
+    /// [`find_key_values_in_interval_new`] call.
+    pub(crate) fn find_key_values_in_interval_wait(&self, promise: u32) -> IntervalKeyValues {
+        self.find_key_values_in_interval_promises.take(promise)
     }
 
     /// Writes a `batch` of operations to storage.

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 use linera_base::ensure;
 use linera_views::{
     batch::Batch,
-    store::{ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyInterval, KeyIntervalStart, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+    },
 };
 use thiserror::Error;
 
@@ -22,6 +24,9 @@ use crate::{
     },
     service::wit::base_runtime_api as service_wit,
 };
+
+type IntervalKeys = (Vec<Vec<u8>>, bool);
+type IntervalKeyValues = (Vec<(Vec<u8>, Vec<u8>)>, bool);
 
 /// We need to have a maximum key size that handles all possible underlying
 /// sizes. The constraint so far is DynamoDB which has a key length of 1024.
@@ -157,28 +162,38 @@ impl ReadableKeyValueStore for KeyValueStore {
         Ok(self.wit_api.read_value_bytes_wait(promise))
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, KeyValueStoreError> {
-        ensure!(
-            key_prefix.len() <= Self::MAX_KEY_SIZE,
-            KeyValueStoreError::KeyTooLong
-        );
-        let promise = self.wit_api.find_keys_new(key_prefix);
-        Ok(self.wit_api.find_keys_wait(promise))
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), KeyValueStoreError> {
+        for key in [key_interval.start_bound(), key_interval.end_bound()] {
+            match key {
+                std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => ensure!(
+                    key.len() <= Self::MAX_KEY_SIZE,
+                    KeyValueStoreError::KeyTooLong
+                ),
+                std::ops::Bound::Unbounded => {}
+            }
+        }
+        let promise = self.wit_api.find_keys_in_interval_new(&key_interval);
+        Ok(self.wit_api.find_keys_in_interval_wait(promise))
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, KeyValueStoreError> {
-        ensure!(
-            key_prefix.len() <= Self::MAX_KEY_SIZE,
-            KeyValueStoreError::KeyTooLong
-        );
-        let promise = self.wit_api.find_key_values_new(key_prefix);
-        Ok(self.wit_api.find_key_values_wait(promise))
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), KeyValueStoreError> {
+        for key in [key_interval.start_bound(), key_interval.end_bound()] {
+            match key {
+                std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => ensure!(
+                    key.len() <= Self::MAX_KEY_SIZE,
+                    KeyValueStoreError::KeyTooLong
+                ),
+                std::ops::Bound::Unbounded => {}
+            }
+        }
+        let promise = self.wit_api.find_key_values_in_interval_new(&key_interval);
+        Ok(self.wit_api.find_key_values_in_interval_wait(promise))
     }
 }
 
@@ -212,6 +227,44 @@ enum WitInterface {
 }
 
 impl WitInterface {
+    fn contract_key_interval_query(key_interval: &KeyInterval) -> contract_wit::KeyIntervalQuery {
+        contract_wit::KeyIntervalQuery {
+            start: match &key_interval.start {
+                KeyIntervalStart::Included(key) | KeyIntervalStart::Excluded(key) => key.clone(),
+            },
+            start_inclusive: matches!(&key_interval.start, KeyIntervalStart::Included(_)),
+            end: match &key_interval.end {
+                std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => {
+                    Some(key.clone())
+                }
+                std::ops::Bound::Unbounded => None,
+            },
+            end_inclusive: matches!(&key_interval.end, std::ops::Bound::Included(_)),
+            limit: key_interval
+                .limit
+                .and_then(|limit| u32::try_from(limit).ok()),
+        }
+    }
+
+    fn service_key_interval_query(key_interval: &KeyInterval) -> service_wit::KeyIntervalQuery {
+        service_wit::KeyIntervalQuery {
+            start: match &key_interval.start {
+                KeyIntervalStart::Included(key) | KeyIntervalStart::Excluded(key) => key.clone(),
+            },
+            start_inclusive: matches!(&key_interval.start, KeyIntervalStart::Included(_)),
+            end: match &key_interval.end {
+                std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => {
+                    Some(key.clone())
+                }
+                std::ops::Bound::Unbounded => None,
+            },
+            end_inclusive: matches!(&key_interval.end, std::ops::Bound::Included(_)),
+            limit: key_interval
+                .limit
+                .and_then(|limit| u32::try_from(limit).ok()),
+        }
+    }
+
     /// Creates a promise for testing if a key exist in the key-value store
     fn contains_key_new(&self, key: &[u8]) -> u32 {
         match self {
@@ -292,43 +345,67 @@ impl WitInterface {
         }
     }
 
-    /// Creates a promise for finding keys having a specified prefix in the key-value store
-    fn find_keys_new(&self, key_prefix: &[u8]) -> u32 {
+    /// Creates a promise for finding keys in an interval in the key-value store.
+    fn find_keys_in_interval_new(&self, key_interval: &KeyInterval) -> u32 {
         match self {
-            WitInterface::Contract => contract_wit::find_keys_new(key_prefix),
-            WitInterface::Service => service_wit::find_keys_new(key_prefix),
+            WitInterface::Contract => contract_wit::find_keys_in_interval_new(
+                &Self::contract_key_interval_query(key_interval),
+            ),
+            WitInterface::Service => service_wit::find_keys_in_interval_new(
+                &Self::service_key_interval_query(key_interval),
+            ),
             #[cfg(with_testing)]
-            WitInterface::Mock { store, .. } => store.find_keys_new(key_prefix),
+            WitInterface::Mock { store, .. } => {
+                store.find_keys_in_interval_new(key_interval.clone())
+            }
         }
     }
 
-    /// Resolves a promise for finding keys having a specified prefix in the key-value store
-    fn find_keys_wait(&self, promise: u32) -> Vec<Vec<u8>> {
+    /// Resolves a promise for finding keys in an interval in the key-value store.
+    fn find_keys_in_interval_wait(&self, promise: u32) -> IntervalKeys {
         match self {
-            WitInterface::Contract => contract_wit::find_keys_wait(promise),
-            WitInterface::Service => service_wit::find_keys_wait(promise),
+            WitInterface::Contract => {
+                let result = contract_wit::find_keys_in_interval_wait(promise);
+                (result.keys, result.is_finished)
+            }
+            WitInterface::Service => {
+                let result = service_wit::find_keys_in_interval_wait(promise);
+                (result.keys, result.is_finished)
+            }
             #[cfg(with_testing)]
-            WitInterface::Mock { store, .. } => store.find_keys_wait(promise),
+            WitInterface::Mock { store, .. } => store.find_keys_in_interval_wait(promise),
         }
     }
 
-    /// Creates a promise for finding the key/values having a specified prefix in the key-value store
-    fn find_key_values_new(&self, key_prefix: &[u8]) -> u32 {
+    /// Creates a promise for finding key-values in an interval in the key-value store.
+    fn find_key_values_in_interval_new(&self, key_interval: &KeyInterval) -> u32 {
         match self {
-            WitInterface::Contract => contract_wit::find_key_values_new(key_prefix),
-            WitInterface::Service => service_wit::find_key_values_new(key_prefix),
+            WitInterface::Contract => contract_wit::find_key_values_in_interval_new(
+                &Self::contract_key_interval_query(key_interval),
+            ),
+            WitInterface::Service => service_wit::find_key_values_in_interval_new(
+                &Self::service_key_interval_query(key_interval),
+            ),
             #[cfg(with_testing)]
-            WitInterface::Mock { store, .. } => store.find_key_values_new(key_prefix),
+            WitInterface::Mock { store, .. } => {
+                store.find_key_values_in_interval_new(key_interval.clone())
+            }
         }
     }
 
-    /// Resolves a promise for finding the key/values having a specified prefix in the key-value store
-    fn find_key_values_wait(&self, promise: u32) -> Vec<(Vec<u8>, Vec<u8>)> {
+    /// Resolves a promise for finding key-values in an interval in the key-value store.
+    fn find_key_values_in_interval_wait(&self, promise: u32) -> IntervalKeyValues {
         match self {
-            WitInterface::Contract => contract_wit::find_key_values_wait(promise),
-            WitInterface::Service => service_wit::find_key_values_wait(promise),
+            WitInterface::Contract => {
+                let result = contract_wit::find_key_values_in_interval_wait(promise);
+                (result.key_values, result.is_finished)
+            }
+            WitInterface::Service => {
+                let result = service_wit::find_key_values_in_interval_wait(promise);
+                (result.key_values, result.is_finished)
+            }
             #[cfg(with_testing)]
-            WitInterface::Mock { store, .. } => store.find_key_values_wait(promise),
+            WitInterface::Mock { store, .. } => store.find_key_values_in_interval_wait(promise),
         }
     }
 

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -242,7 +242,7 @@ impl WitInterface {
             end_inclusive: matches!(&key_interval.end, std::ops::Bound::Included(_)),
             limit: key_interval
                 .limit
-                .and_then(|limit| u32::try_from(limit).ok()),
+                .map(|limit| u32::try_from(limit).unwrap_or(u32::MAX)),
         }
     }
 
@@ -261,7 +261,7 @@ impl WitInterface {
             end_inclusive: matches!(&key_interval.end, std::ops::Bound::Included(_)),
             limit: key_interval
                 .limit
-                .and_then(|limit| u32::try_from(limit).ok()),
+                .map(|limit| u32::try_from(limit).unwrap_or(u32::MAX)),
         }
     }
 

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -31,8 +31,12 @@ interface base-runtime-api {
     read-value-bytes-wait: func(promise-id: u32) -> option<list<u8>>;
     find-keys-new: func(key-prefix: list<u8>) -> u32;
     find-keys-wait: func(promise-id: u32) -> list<list<u8>>;
+    find-keys-in-interval-new: func(query: key-interval-query) -> u32;
+    find-keys-in-interval-wait: func(promise-id: u32) -> key-list-query-result;
     find-key-values-new: func(key-prefix: list<u8>) -> u32;
     find-key-values-wait: func(promise-id: u32) -> list<tuple<list<u8>, list<u8>>>;
+    find-key-values-in-interval-new: func(query: key-interval-query) -> u32;
+    find-key-values-in-interval-wait: func(promise-id: u32) -> key-value-list-query-result;
 
     variant account-owner {
         reserved(u8),
@@ -127,6 +131,24 @@ interface base-runtime-api {
         status: u16,
         headers: list<http-header>,
         body: list<u8>,
+    }
+
+    record key-interval-query {
+        start: list<u8>,
+        start-inclusive: bool,
+        end: option<list<u8>>,
+        end-inclusive: bool,
+        limit: option<u32>,
+    }
+
+    record key-list-query-result {
+        keys: list<list<u8>>,
+        is-finished: bool,
+    }
+
+    record key-value-list-query-result {
+        key-values: list<tuple<list<u8>, list<u8>>>,
+        is-finished: bool,
     }
 
     enum log-level {

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -72,10 +72,19 @@ message RequestFindKeysByPrefix {
   bytes key_prefix = 1;
 }
 
+message RequestFindKeysInInterval {
+  optional bytes start = 1;
+  bool start_inclusive = 2;
+  optional bytes end = 3;
+  bool end_inclusive = 4;
+  optional uint32 limit = 5;
+}
+
 message ReplyFindKeysByPrefix {
   repeated bytes keys = 1;
   int64 message_index = 2;
   int32 num_chunks = 3;
+  bool is_finished = 4;
 }
 
 
@@ -83,10 +92,19 @@ message RequestFindKeyValuesByPrefix {
   bytes key_prefix = 1;
 }
 
+message RequestFindKeyValuesInInterval {
+  optional bytes start = 1;
+  bool start_inclusive = 2;
+  optional bytes end = 3;
+  bool end_inclusive = 4;
+  optional uint32 limit = 5;
+}
+
 message ReplyFindKeyValuesByPrefix {
   repeated KeyValue key_values = 1;
   int64 message_index = 2;
   int32 num_chunks = 3;
+  bool is_finished = 4;
 }
 
 
@@ -143,7 +161,9 @@ service StorageService {
   rpc ProcessContainsKey (RequestContainsKey) returns (ReplyContainsKey) {}
   rpc ProcessContainsKeys (RequestContainsKeys) returns (ReplyContainsKeys) {}
   rpc ProcessReadMultiValues (RequestReadMultiValues) returns (ReplyReadMultiValues) {}
+  rpc ProcessFindKeysInInterval (RequestFindKeysInInterval) returns (ReplyFindKeysByPrefix) {}
   rpc ProcessFindKeysByPrefix (RequestFindKeysByPrefix) returns (ReplyFindKeysByPrefix) {}
+  rpc ProcessFindKeyValuesInInterval (RequestFindKeyValuesInInterval) returns (ReplyFindKeyValuesByPrefix) {}
   rpc ProcessFindKeyValuesByPrefix (RequestFindKeyValuesByPrefix) returns (ReplyFindKeyValuesByPrefix) {}
   rpc ProcessWriteBatchExtended (RequestWriteBatchExtended) returns (google.protobuf.Empty) {}
   rpc ProcessSpecificChunk (RequestSpecificChunk) returns (ReplySpecificChunk) {}

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -3,6 +3,7 @@
 
 use std::{
     mem,
+    ops::Bound::{Excluded, Included, Unbounded},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -19,7 +20,10 @@ use linera_views::store::TestKeyValueDatabase;
 use linera_views::{
     batch::{Batch, WriteOperation},
     lru_caching::LruCachingDatabase,
-    store::{KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyInterval, KeyIntervalStart, KeyValueDatabase, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore,
+    },
 };
 use serde::de::DeserializeOwned;
 use tonic::transport::{Channel, Endpoint};
@@ -36,7 +40,7 @@ use crate::{
         ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix, ReplyListAll, ReplyListRootKeys,
         ReplyReadMultiValues, ReplyReadValue, ReplySpecificChunk, RequestContainsKey,
         RequestContainsKeys, RequestCreateNamespace, RequestDeleteNamespace,
-        RequestExistsNamespace, RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix,
+        RequestExistsNamespace, RequestFindKeyValuesInInterval, RequestFindKeysInInterval,
         RequestListRootKeys, RequestReadMultiValues, RequestReadValue, RequestSpecificChunk,
         RequestWriteBatchExtended, Statement,
     },
@@ -44,6 +48,19 @@ use crate::{
 
 // The maximum key size is set to 1M rather arbitrarily.
 const MAX_KEY_SIZE: usize = 1000000;
+
+/// Computes the exclusive upper bound for a prefix scan.
+/// Returns `None` if the prefix is all 0xFF bytes (no upper bound exists).
+fn upper_bound_of_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
+    for i in (0..prefix.len()).rev() {
+        if prefix[i] < u8::MAX {
+            let mut upper_bound = prefix[0..=i].to_vec();
+            upper_bound[i] += 1;
+            return Some(upper_bound);
+        }
+    }
+    None
+}
 
 // The shared store client.
 // * Interior mutability is required for the client because
@@ -208,25 +225,48 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
         }
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, StorageServiceStoreError> {
-        ensure!(
-            key_prefix.len() <= MAX_KEY_SIZE,
-            StorageServiceStoreError::KeyTooLong
-        );
-        let mut full_key_prefix = self.start_key.clone();
-        full_key_prefix.extend(key_prefix);
-        let query = RequestFindKeysByPrefix {
-            key_prefix: full_key_prefix,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), StorageServiceStoreError> {
+        let start = match &key_interval.start {
+            KeyIntervalStart::Included(key) | KeyIntervalStart::Excluded(key) => {
+                ensure!(
+                    key.len() <= MAX_KEY_SIZE,
+                    StorageServiceStoreError::KeyTooLong
+                );
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                Some(full_key)
+            }
+        };
+        let (end, end_inclusive) = match &key_interval.end {
+            Included(key) | Excluded(key) => {
+                ensure!(
+                    key.len() <= MAX_KEY_SIZE,
+                    StorageServiceStoreError::KeyTooLong
+                );
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                (Some(full_key), matches!(&key_interval.end, Included(_)))
+            }
+            Unbounded => (upper_bound_of_prefix(&self.start_key), false),
+        };
+        let query = RequestFindKeysInInterval {
+            start,
+            start_inclusive: matches!(&key_interval.start, KeyIntervalStart::Included(_)),
+            end,
+            end_inclusive,
+            limit: key_interval
+                .limit
+                .and_then(|limit| u32::try_from(limit).ok()),
         };
         let request = tonic::Request::new(query);
         let channel = self.channel.clone();
         let mut client = StorageServiceClient::new(channel);
         let _guard = self.acquire().await;
         let response = client
-            .process_find_keys_by_prefix(request)
+            .process_find_keys_in_interval(request)
             .make_sync()
             .await?;
         let response = response.into_inner();
@@ -234,33 +274,67 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
             keys,
             message_index,
             num_chunks,
+            is_finished,
         } = response;
+        let prefix_len = self.start_key.len();
         if num_chunks == 0 {
-            Ok(keys)
+            let keys = keys
+                .into_iter()
+                .map(|key| key[prefix_len..].to_vec())
+                .collect();
+            Ok((keys, is_finished))
         } else {
-            self.read_entries(message_index, num_chunks).await
+            let keys: Vec<Vec<u8>> = self.read_entries(message_index, num_chunks).await?;
+            let keys = keys
+                .into_iter()
+                .map(|key| key[prefix_len..].to_vec())
+                .collect();
+            Ok((keys, is_finished))
         }
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, StorageServiceStoreError> {
-        ensure!(
-            key_prefix.len() <= MAX_KEY_SIZE,
-            StorageServiceStoreError::KeyTooLong
-        );
-        let mut full_key_prefix = self.start_key.clone();
-        full_key_prefix.extend(key_prefix);
-        let query = RequestFindKeyValuesByPrefix {
-            key_prefix: full_key_prefix,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), StorageServiceStoreError> {
+        let start = match &key_interval.start {
+            KeyIntervalStart::Included(key) | KeyIntervalStart::Excluded(key) => {
+                ensure!(
+                    key.len() <= MAX_KEY_SIZE,
+                    StorageServiceStoreError::KeyTooLong
+                );
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                Some(full_key)
+            }
+        };
+        let (end, end_inclusive) = match &key_interval.end {
+            Included(key) | Excluded(key) => {
+                ensure!(
+                    key.len() <= MAX_KEY_SIZE,
+                    StorageServiceStoreError::KeyTooLong
+                );
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                (Some(full_key), matches!(&key_interval.end, Included(_)))
+            }
+            Unbounded => (upper_bound_of_prefix(&self.start_key), false),
+        };
+        let query = RequestFindKeyValuesInInterval {
+            start,
+            start_inclusive: matches!(&key_interval.start, KeyIntervalStart::Included(_)),
+            end,
+            end_inclusive,
+            limit: key_interval
+                .limit
+                .and_then(|limit| u32::try_from(limit).ok()),
         };
         let request = tonic::Request::new(query);
         let channel = self.channel.clone();
         let mut client = StorageServiceClient::new(channel);
         let _guard = self.acquire().await;
         let response = client
-            .process_find_key_values_by_prefix(request)
+            .process_find_key_values_in_interval(request)
             .make_sync()
             .await?;
         let response = response.into_inner();
@@ -268,15 +342,23 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
             key_values,
             message_index,
             num_chunks,
+            is_finished,
         } = response;
+        let prefix_len = self.start_key.len();
         if num_chunks == 0 {
             let key_values = key_values
                 .into_iter()
-                .map(|x| (x.key, x.value))
+                .map(|x| (x.key[prefix_len..].to_vec(), x.value))
                 .collect::<Vec<_>>();
-            Ok(key_values)
+            Ok((key_values, is_finished))
         } else {
-            self.read_entries(message_index, num_chunks).await
+            let key_values: Vec<(Vec<u8>, Vec<u8>)> =
+                self.read_entries(message_index, num_chunks).await?;
+            let key_values = key_values
+                .into_iter()
+                .map(|(key, value)| (key[prefix_len..].to_vec(), value))
+                .collect();
+            Ok((key_values, is_finished))
         }
     }
 }

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -265,20 +265,22 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
             is_finished,
         } = response;
         let prefix_len = self.start_key.len();
-        if num_chunks == 0 {
-            let keys = keys
-                .into_iter()
-                .map(|key| key[prefix_len..].to_vec())
-                .collect();
-            Ok((keys, is_finished))
+        let keys = if num_chunks == 0 {
+            keys
         } else {
-            let keys: Vec<Vec<u8>> = self.read_entries(message_index, num_chunks).await?;
-            let keys = keys
-                .into_iter()
-                .map(|key| key[prefix_len..].to_vec())
-                .collect();
-            Ok((keys, is_finished))
-        }
+            self.read_entries(message_index, num_chunks).await?
+        };
+        let keys = keys
+            .into_iter()
+            .map(|key| {
+                ensure!(
+                    key.starts_with(&self.start_key),
+                    StorageServiceStoreError::KeyOutsidePartition
+                );
+                Ok::<_, StorageServiceStoreError>(key[prefix_len..].to_vec())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok((keys, is_finished))
     }
 
     async fn find_key_values_in_interval(
@@ -333,21 +335,22 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
             is_finished,
         } = response;
         let prefix_len = self.start_key.len();
-        if num_chunks == 0 {
-            let key_values = key_values
-                .into_iter()
-                .map(|x| (x.key[prefix_len..].to_vec(), x.value))
-                .collect::<Vec<_>>();
-            Ok((key_values, is_finished))
+        let key_values: Vec<(Vec<u8>, Vec<u8>)> = if num_chunks == 0 {
+            key_values.into_iter().map(|x| (x.key, x.value)).collect()
         } else {
-            let key_values: Vec<(Vec<u8>, Vec<u8>)> =
-                self.read_entries(message_index, num_chunks).await?;
-            let key_values = key_values
-                .into_iter()
-                .map(|(key, value)| (key[prefix_len..].to_vec(), value))
-                .collect();
-            Ok((key_values, is_finished))
-        }
+            self.read_entries(message_index, num_chunks).await?
+        };
+        let key_values = key_values
+            .into_iter()
+            .map(|(key, value)| {
+                ensure!(
+                    key.starts_with(&self.start_key),
+                    StorageServiceStoreError::KeyOutsidePartition
+                );
+                Ok::<_, StorageServiceStoreError>((key[prefix_len..].to_vec(), value))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok((key_values, is_finished))
     }
 }
 

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -19,6 +19,7 @@ use linera_views::metering::MeteredDatabase;
 use linera_views::store::TestKeyValueDatabase;
 use linera_views::{
     batch::{Batch, WriteOperation},
+    common::get_upper_bound_option,
     lru_caching::LruCachingDatabase,
     store::{
         KeyInterval, KeyIntervalStart, KeyValueDatabase, ReadableKeyValueStore, WithError,
@@ -48,19 +49,6 @@ use crate::{
 
 // The maximum key size is set to 1M rather arbitrarily.
 const MAX_KEY_SIZE: usize = 1000000;
-
-/// Computes the exclusive upper bound for a prefix scan.
-/// Returns `None` if the prefix is all 0xFF bytes (no upper bound exists).
-fn upper_bound_of_prefix(prefix: &[u8]) -> Option<Vec<u8>> {
-    for i in (0..prefix.len()).rev() {
-        if prefix[i] < u8::MAX {
-            let mut upper_bound = prefix[0..=i].to_vec();
-            upper_bound[i] += 1;
-            return Some(upper_bound);
-        }
-    }
-    None
-}
 
 // The shared store client.
 // * Interior mutability is required for the client because
@@ -250,7 +238,7 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
                 full_key.extend(key);
                 (Some(full_key), matches!(&key_interval.end, Included(_)))
             }
-            Unbounded => (upper_bound_of_prefix(&self.start_key), false),
+            Unbounded => (get_upper_bound_option(&self.start_key), false),
         };
         let query = RequestFindKeysInInterval {
             start,
@@ -259,7 +247,7 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
             end_inclusive,
             limit: key_interval
                 .limit
-                .and_then(|limit| u32::try_from(limit).ok()),
+                .map(|limit| u32::try_from(limit).unwrap_or(u32::MAX)),
         };
         let request = tonic::Request::new(query);
         let channel = self.channel.clone();
@@ -318,7 +306,7 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
                 full_key.extend(key);
                 (Some(full_key), matches!(&key_interval.end, Included(_)))
             }
-            Unbounded => (upper_bound_of_prefix(&self.start_key), false),
+            Unbounded => (get_upper_bound_option(&self.start_key), false),
         };
         let query = RequestFindKeyValuesInInterval {
             start,
@@ -327,7 +315,7 @@ impl ReadableKeyValueStore for StorageServiceStoreInternal {
             end_inclusive,
             limit: key_interval
                 .limit
-                .and_then(|limit| u32::try_from(limit).ok()),
+                .map(|limit| u32::try_from(limit).unwrap_or(u32::MAX)),
         };
         let request = tonic::Request::new(query);
         let channel = self.channel.clone();

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -51,6 +51,13 @@ pub enum StorageServiceStoreError {
     #[error("The key size must be at most 1 MB")]
     KeyTooLong,
 
+    /// The server returned a key that does not lie within the requesting
+    /// client's partition. This indicates either a malformed request (e.g. an
+    /// `Unbounded` end with an all-`0xFF` `start_key`, which leaves the
+    /// underlying scan unbounded) or a server-side bug.
+    #[error("server returned a key outside this client's partition")]
+    KeyOutsidePartition,
+
     /// Transport error
     #[error(transparent)]
     TransportError(#[from] tonic::transport::Error),

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -1,14 +1,21 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    ops::Bound::{Excluded, Included, Unbounded},
+    sync::Arc,
+};
 
 use async_lock::RwLock;
 use linera_storage_service::common::{KeyPrefix, MAX_PAYLOAD_SIZE};
 use linera_views::{
     batch::Batch,
     memory::{MemoryDatabase, MemoryStoreConfig},
-    store::{KeyValueDatabase, ReadableKeyValueStore, WritableKeyValueStore},
+    store::{
+        KeyInterval, KeyIntervalStart, KeyValueDatabase, ReadableKeyValueStore,
+        WritableKeyValueStore,
+    },
 };
 #[cfg(with_rocksdb)]
 use linera_views::{
@@ -30,8 +37,9 @@ use crate::key_value_store::{
     ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix, ReplyListAll, ReplyListRootKeys,
     ReplyReadMultiValues, ReplyReadValue, ReplySpecificChunk, RequestContainsKey,
     RequestContainsKeys, RequestCreateNamespace, RequestDeleteNamespace, RequestExistsNamespace,
-    RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix, RequestListRootKeys,
-    RequestReadMultiValues, RequestReadValue, RequestSpecificChunk, RequestWriteBatchExtended,
+    RequestFindKeyValuesByPrefix, RequestFindKeyValuesInInterval, RequestFindKeysByPrefix,
+    RequestFindKeysInInterval, RequestListRootKeys, RequestReadMultiValues, RequestReadValue,
+    RequestSpecificChunk, RequestWriteBatchExtended,
 };
 
 pub mod key_value_store {
@@ -61,6 +69,30 @@ struct StorageServer {
     store: LocalStore,
     pending_big_puts: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
     pending_big_reads: Arc<RwLock<PendingBigReads>>,
+}
+
+fn request_to_interval(
+    start: Option<Vec<u8>>,
+    start_inclusive: bool,
+    end: Option<Vec<u8>>,
+    end_inclusive: bool,
+    limit: Option<u32>,
+) -> KeyInterval {
+    let start = match start {
+        Some(key) if start_inclusive => KeyIntervalStart::Included(key),
+        Some(key) => KeyIntervalStart::Excluded(key),
+        None => KeyIntervalStart::Included(Vec::new()),
+    };
+    let end = match end {
+        Some(key) if end_inclusive => Included(key),
+        Some(key) => Excluded(key),
+        None => Unbounded,
+    };
+    KeyInterval {
+        start,
+        end,
+        limit: limit.map(|limit| limit as usize),
+    }
 }
 
 impl StorageServer {
@@ -121,40 +153,43 @@ impl StorageServer {
         }
     }
 
-    pub async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Status> {
+    pub async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), Status> {
         match &self.store {
             LocalStore::Memory(store) => store
-                .find_keys_by_prefix(key_prefix)
+                .find_keys_in_interval(key_interval)
                 .await
-                .map_err(|e| Status::unknown(format!("Memory error {e:?} at find_keys_by_prefix"))),
+                .map_err(|e| {
+                    Status::unknown(format!("Memory error {e:?} at find_keys_in_interval"))
+                }),
             #[cfg(with_rocksdb)]
             LocalStore::RocksDb(store) => {
-                store.find_keys_by_prefix(key_prefix).await.map_err(|e| {
-                    Status::unknown(format!("RocksDB error {e:?} at find_keys_by_prefix"))
+                store.find_keys_in_interval(key_interval).await.map_err(|e| {
+                    Status::unknown(format!("RocksDB error {e:?} at find_keys_in_interval"))
                 })
             }
         }
     }
 
-    pub async fn find_key_values_by_prefix(
+    pub async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Status> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Status> {
         match &self.store {
-            LocalStore::Memory(store) => {
-                store
-                    .find_key_values_by_prefix(key_prefix)
-                    .await
-                    .map_err(|e| {
-                        Status::unknown(format!("Memory error {e:?} at find_key_values_by_prefix"))
-                    })
-            }
-            #[cfg(with_rocksdb)]
-            LocalStore::RocksDb(store) => store
-                .find_key_values_by_prefix(key_prefix)
+            LocalStore::Memory(store) => store
+                .find_key_values_in_interval(key_interval)
                 .await
                 .map_err(|e| {
-                    Status::unknown(format!("RocksDB error {e:?} at find_key_values_by_prefix"))
+                    Status::unknown(format!("Memory error {e:?} at find_key_values_in_interval"))
+                }),
+            #[cfg(with_rocksdb)]
+            LocalStore::RocksDb(store) => store
+                .find_key_values_in_interval(key_interval)
+                .await
+                .map_err(|e| {
+                    Status::unknown(format!("RocksDB error {e:?} at find_key_values_in_interval"))
                 }),
         }
     }
@@ -174,17 +209,27 @@ impl StorageServer {
     }
 
     pub async fn list_all(&self) -> Result<Vec<Vec<u8>>, Status> {
-        self.find_keys_by_prefix(&[KeyPrefix::Namespace as u8])
-            .await
+        let prefix = vec![KeyPrefix::Namespace as u8];
+        let (keys, _) = self
+            .find_keys_in_interval(KeyInterval::for_prefix(&prefix))
+            .await?;
+        let keys = keys
+            .into_iter()
+            .map(|key| key[prefix.len()..].to_vec())
+            .collect();
+        Ok(keys)
     }
 
     pub async fn list_root_keys(&self, namespace: &[u8]) -> Result<Vec<Vec<u8>>, Status> {
         let mut full_key = vec![KeyPrefix::RootKey as u8];
         full_key.extend(namespace);
-        let bcs_root_keys = self.find_keys_by_prefix(&full_key).await?;
+        let prefix_len = full_key.len();
+        let (bcs_root_keys, _) = self
+            .find_keys_in_interval(KeyInterval::for_prefix(&full_key))
+            .await?;
         let mut root_keys = Vec::new();
         for bcs_root_key in bcs_root_keys {
-            let root_key = bcs::from_bytes::<Vec<u8>>(&bcs_root_key)
+            let root_key = bcs::from_bytes::<Vec<u8>>(&bcs_root_key[prefix_len..])
                 .map_err(|e| Status::unknown(format!("Bcs error {e:?} at list_root_keys")))?;
             root_keys.push(root_key);
         }
@@ -406,13 +451,16 @@ impl StorageService for StorageServer {
     ) -> Result<Response<ReplyFindKeysByPrefix>, Status> {
         let request = request.into_inner();
         let RequestFindKeysByPrefix { key_prefix } = request;
-        let keys = self.find_keys_by_prefix(&key_prefix).await?;
+        let (keys, is_finished) = self
+            .find_keys_in_interval(KeyInterval::for_prefix(&key_prefix))
+            .await?;
         let size = keys.iter().map(|x| x.len()).sum::<usize>();
         let response = if size < MAX_PAYLOAD_SIZE {
             ReplyFindKeysByPrefix {
                 keys,
                 message_index: 0,
                 num_chunks: 0,
+                is_finished,
             }
         } else {
             let (message_index, num_chunks) = self.insert_pending_read(keys).await;
@@ -420,6 +468,41 @@ impl StorageService for StorageServer {
                 keys: Vec::default(),
                 message_index,
                 num_chunks,
+                is_finished,
+            }
+        };
+        Ok(Response::new(response))
+    }
+
+    #[instrument(target = "store_server", skip_all, err)]
+    async fn process_find_keys_in_interval(
+        &self,
+        request: Request<RequestFindKeysInInterval>,
+    ) -> Result<Response<ReplyFindKeysByPrefix>, Status> {
+        let request = request.into_inner();
+        let key_interval = request_to_interval(
+            request.start,
+            request.start_inclusive,
+            request.end,
+            request.end_inclusive,
+            request.limit,
+        );
+        let (keys, is_finished) = self.find_keys_in_interval(key_interval).await?;
+        let size = keys.iter().map(|x| x.len()).sum::<usize>();
+        let response = if size < MAX_PAYLOAD_SIZE {
+            ReplyFindKeysByPrefix {
+                keys,
+                message_index: 0,
+                num_chunks: 0,
+                is_finished,
+            }
+        } else {
+            let (message_index, num_chunks) = self.insert_pending_read(keys).await;
+            ReplyFindKeysByPrefix {
+                keys: Vec::default(),
+                message_index,
+                num_chunks,
+                is_finished,
             }
         };
         Ok(Response::new(response))
@@ -432,7 +515,9 @@ impl StorageService for StorageServer {
     ) -> Result<Response<ReplyFindKeyValuesByPrefix>, Status> {
         let request = request.into_inner();
         let RequestFindKeyValuesByPrefix { key_prefix } = request;
-        let key_values = self.find_key_values_by_prefix(&key_prefix).await?;
+        let (key_values, is_finished) = self
+            .find_key_values_in_interval(KeyInterval::for_prefix(&key_prefix))
+            .await?;
         let size = key_values
             .iter()
             .map(|x| x.0.len() + x.1.len())
@@ -449,6 +534,7 @@ impl StorageService for StorageServer {
                 key_values,
                 message_index: 0,
                 num_chunks: 0,
+                is_finished,
             }
         } else {
             let (message_index, num_chunks) = self.insert_pending_read(key_values).await;
@@ -456,6 +542,51 @@ impl StorageService for StorageServer {
                 key_values: Vec::default(),
                 message_index,
                 num_chunks,
+                is_finished,
+            }
+        };
+        Ok(Response::new(response))
+    }
+
+    #[instrument(target = "store_server", skip_all, err)]
+    async fn process_find_key_values_in_interval(
+        &self,
+        request: Request<RequestFindKeyValuesInInterval>,
+    ) -> Result<Response<ReplyFindKeyValuesByPrefix>, Status> {
+        let request = request.into_inner();
+        let key_interval = request_to_interval(
+            request.start,
+            request.start_inclusive,
+            request.end,
+            request.end_inclusive,
+            request.limit,
+        );
+        let (key_values, is_finished) = self.find_key_values_in_interval(key_interval).await?;
+        let size = key_values
+            .iter()
+            .map(|x| x.0.len() + x.1.len())
+            .sum::<usize>();
+        let response = if size < MAX_PAYLOAD_SIZE {
+            let key_values = key_values
+                .into_iter()
+                .map(|x| KeyValue {
+                    key: x.0,
+                    value: x.1,
+                })
+                .collect::<Vec<_>>();
+            ReplyFindKeyValuesByPrefix {
+                key_values,
+                message_index: 0,
+                num_chunks: 0,
+                is_finished,
+            }
+        } else {
+            let (message_index, num_chunks) = self.insert_pending_read(key_values).await;
+            ReplyFindKeyValuesByPrefix {
+                key_values: Vec::default(),
+                message_index,
+                num_chunks,
+                is_finished,
             }
         };
         Ok(Response::new(response))

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -158,17 +158,22 @@ impl StorageServer {
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), Status> {
         match &self.store {
-            LocalStore::Memory(store) => store
-                .find_keys_in_interval(key_interval)
-                .await
-                .map_err(|e| {
-                    Status::unknown(format!("Memory error {e:?} at find_keys_in_interval"))
-                }),
+            LocalStore::Memory(store) => {
+                store
+                    .find_keys_in_interval(key_interval)
+                    .await
+                    .map_err(|e| {
+                        Status::unknown(format!("Memory error {e:?} at find_keys_in_interval"))
+                    })
+            }
             #[cfg(with_rocksdb)]
             LocalStore::RocksDb(store) => {
-                store.find_keys_in_interval(key_interval).await.map_err(|e| {
-                    Status::unknown(format!("RocksDB error {e:?} at find_keys_in_interval"))
-                })
+                store
+                    .find_keys_in_interval(key_interval)
+                    .await
+                    .map_err(|e| {
+                        Status::unknown(format!("RocksDB error {e:?} at find_keys_in_interval"))
+                    })
             }
         }
     }
@@ -189,7 +194,9 @@ impl StorageServer {
                 .find_key_values_in_interval(key_interval)
                 .await
                 .map_err(|e| {
-                    Status::unknown(format!("RocksDB error {e:?} at find_key_values_in_interval"))
+                    Status::unknown(format!(
+                        "RocksDB error {e:?} at find_key_values_in_interval"
+                    ))
                 }),
         }
     }

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -125,7 +125,7 @@ fn bench_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance_queue_view::<ScyllaDbDatabase>(iterations).await
+                Box::pin(performance_queue_view::<ScyllaDbDatabase>(iterations)).await
             })
     });
 }
@@ -207,7 +207,10 @@ fn bench_bucket_queue_view(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance_bucket_queue_view::<ScyllaDbDatabase>(iterations).await
+                Box::pin(performance_bucket_queue_view::<ScyllaDbDatabase>(
+                    iterations,
+                ))
+                .await
             })
     });
 }

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -43,7 +43,10 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::contains_key::<ScyllaDbDatabase, _>(iterations, black_box).await
+                Box::pin(performance::contains_key::<ScyllaDbDatabase, _>(
+                    iterations, black_box,
+                ))
+                .await
             })
     });
 }
@@ -80,7 +83,10 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::contains_keys::<ScyllaDbDatabase, _>(iterations, black_box).await
+                Box::pin(performance::contains_keys::<ScyllaDbDatabase, _>(
+                    iterations, black_box,
+                ))
+                .await
             })
     });
 }
@@ -117,7 +123,10 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_keys_by_prefix::<ScyllaDbDatabase, _>(iterations, black_box).await
+                Box::pin(performance::find_keys_by_prefix::<ScyllaDbDatabase, _>(
+                    iterations, black_box,
+                ))
+                .await
             })
     });
 }
@@ -157,8 +166,12 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::find_key_values_by_prefix::<ScyllaDbDatabase, _>(iterations, black_box)
-                    .await
+                Box::pin(
+                    performance::find_key_values_by_prefix::<ScyllaDbDatabase, _>(
+                        iterations, black_box,
+                    ),
+                )
+                .await
             })
     });
 }
@@ -195,7 +208,10 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_value_bytes::<ScyllaDbDatabase, _>(iterations, black_box).await
+                Box::pin(performance::read_value_bytes::<ScyllaDbDatabase, _>(
+                    iterations, black_box,
+                ))
+                .await
             })
     });
 }
@@ -235,8 +251,10 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::read_multi_values_bytes::<ScyllaDbDatabase, _>(iterations, black_box)
-                    .await
+                Box::pin(performance::read_multi_values_bytes::<ScyllaDbDatabase, _>(
+                    iterations, black_box,
+                ))
+                .await
             })
     });
 }
@@ -273,7 +291,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                performance::write_batch::<ScyllaDbDatabase>(iterations).await
+                Box::pin(performance::write_batch::<ScyllaDbDatabase>(iterations)).await
             })
     });
 }

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -11,7 +11,7 @@ use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::Batch,
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        KeyInterval, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
 };
@@ -161,31 +161,34 @@ where
         Ok(result)
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
+    async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
         let result = match self {
             Self::First(store) => store
-                .find_keys_by_prefix(key_prefix)
+                .find_keys_in_interval(key_interval.clone())
                 .await
                 .map_err(DualStoreError::First)?,
             Self::Second(store) => store
-                .find_keys_by_prefix(key_prefix)
+                .find_keys_in_interval(key_interval)
                 .await
                 .map_err(DualStoreError::Second)?,
         };
         Ok(result)
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
         let result = match self {
             Self::First(store) => store
-                .find_key_values_by_prefix(key_prefix)
+                .find_key_values_in_interval(key_interval.clone())
                 .await
                 .map_err(DualStoreError::First)?,
             Self::Second(store) => store
-                .find_key_values_by_prefix(key_prefix)
+                .find_key_values_in_interval(key_interval)
                 .await
                 .map_err(DualStoreError::Second)?,
         };

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -43,12 +43,12 @@ use crate::metering::MeteredDatabase;
 use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::SimpleUnorderedBatch,
-    common::get_uleb128_size,
+    common::{get_uleb128_size, key_matches_interval},
     journaling::JournalingKeyValueDatabase,
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError,
+        DirectWritableKeyValueStore, KeyInterval, KeyValueDatabase, KeyValueStoreError,
+        ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
@@ -873,30 +873,51 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
         Ok(results.into_iter().flatten().collect())
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, DynamoDbStoreInternalError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), DynamoDbStoreInternalError> {
         let result_queries = self
-            .get_list_responses(KEY_ATTRIBUTE, &self.start_key, key_prefix)
+            .get_list_responses(KEY_ATTRIBUTE, &self.start_key, &[])
             .await?;
-        result_queries
-            .keys()
-            .map(|key| key.map(|k| k.to_vec()))
-            .collect()
+        let mut keys = Vec::new();
+        for key in result_queries.keys() {
+            let key = key?;
+            if key_matches_interval(key, key_interval.start_bound(), key_interval.end_bound()) {
+                keys.push(key.to_vec());
+                if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
+                    break;
+                }
+            }
+        }
+        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        Ok((keys, is_finished))
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, DynamoDbStoreInternalError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), DynamoDbStoreInternalError> {
         let result_queries = self
-            .get_list_responses(KEY_VALUE_ATTRIBUTE, &self.start_key, key_prefix)
+            .get_list_responses(KEY_VALUE_ATTRIBUTE, &self.start_key, &[])
             .await?;
-        result_queries
-            .key_values()
-            .map(|entry| entry.map(|(key, value)| (key.to_vec(), value.to_vec())))
-            .collect()
+        let mut key_values = Vec::new();
+        for entry in result_queries.key_values() {
+            let (key, value) = entry?;
+            if key_matches_interval(key, key_interval.start_bound(), key_interval.end_bound()) {
+                key_values.push((key.to_vec(), value.to_vec()));
+                if key_interval
+                    .limit
+                    .is_some_and(|limit| key_values.len() >= limit)
+                {
+                    break;
+                }
+            }
+        }
+        let is_finished = key_interval
+            .limit
+            .is_none_or(|limit| key_values.len() < limit);
+        Ok((key_values, is_finished))
     }
 }
 

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -6,6 +6,7 @@
 use std::{
     collections::HashMap,
     env,
+    ops::Bound,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -21,7 +22,7 @@ use aws_sdk_dynamodb::{
         delete_table::DeleteTableError,
         get_item::GetItemError,
         list_tables::ListTablesError,
-        query::{QueryError, QueryOutput},
+        query::QueryError,
         transact_write_items::TransactWriteItemsError,
     },
     primitives::Blob,
@@ -43,12 +44,12 @@ use crate::metering::MeteredDatabase;
 use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::SimpleUnorderedBatch,
-    common::{get_uleb128_size, key_matches_interval},
+    common::get_uleb128_size,
     journaling::JournalingKeyValueDatabase,
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        DirectWritableKeyValueStore, KeyInterval, KeyValueDatabase, KeyValueStoreError,
-        ReadableKeyValueStore, WithError,
+        DirectWritableKeyValueStore, KeyInterval, KeyIntervalStart, KeyValueDatabase,
+        KeyValueStoreError, ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
@@ -602,35 +603,128 @@ impl DynamoDbStoreInternal {
         }
     }
 
-    async fn get_query_output(
+    /// Builds the inclusive lower bound (in DynamoDB sort-key space) for an
+    /// interval scan. Items in the partition have sort key `[1] || user_key`,
+    /// and `Excluded(k)` is rewritten to `Included(k || [0x00])` (the smallest
+    /// sort key strictly greater than `[1] || k`).
+    fn lower_sort_bound(start: &KeyIntervalStart<Vec<u8>>) -> Vec<u8> {
+        let mut bound = vec![1];
+        match start {
+            KeyIntervalStart::Included(k) => bound.extend(k),
+            KeyIntervalStart::Excluded(k) => {
+                bound.extend(k);
+                bound.push(0);
+            }
+        }
+        bound
+    }
+
+    /// Builds the inclusive upper bound (in DynamoDB sort-key space). Returns
+    /// `None` for `Unbounded`. When the user requested `Excluded(end)` the
+    /// caller drops the (at most one) returned item whose sort key matches
+    /// this bound.
+    fn upper_sort_bound(end: &Bound<Vec<u8>>) -> Option<Vec<u8>> {
+        match end {
+            Bound::Included(k) | Bound::Excluded(k) => {
+                let mut bound = vec![1];
+                bound.extend(k);
+                Some(bound)
+            }
+            Bound::Unbounded => None,
+        }
+    }
+
+    /// Runs a DynamoDB Query with the user-supplied interval and limit pushed
+    /// down to the database. Pages until the limit is reached, the exclusive
+    /// upper bound is hit, or the partition is exhausted.
+    async fn run_interval_query(
         &self,
         attribute_str: &str,
-        start_key: &[u8],
-        key_prefix: &[u8],
-        start_key_map: Option<HashMap<String, AttributeValue>>,
-    ) -> Result<QueryOutput, DynamoDbStoreInternalError> {
-        let _guard = self.acquire().await;
-        let start_key = start_key.to_vec();
-        let mut prefixed_key_prefix = vec![1];
-        prefixed_key_prefix.extend(key_prefix);
-        let response = self
-            .client
-            .query()
-            .table_name(&self.namespace)
-            .projection_expression(attribute_str)
-            .key_condition_expression(format!(
-                "{PARTITION_ATTRIBUTE} = :partition and begins_with({KEY_ATTRIBUTE}, :prefix)"
-            ))
-            .expression_attribute_values(":partition", AttributeValue::B(Blob::new(start_key)))
-            .expression_attribute_values(
-                ":prefix",
-                AttributeValue::B(Blob::new(prefixed_key_prefix)),
-            )
-            .set_exclusive_start_key(start_key_map)
-            .send()
-            .boxed_sync()
-            .await?;
-        Ok(response)
+        key_interval: &KeyInterval,
+    ) -> Result<(Vec<HashMap<String, AttributeValue>>, bool), DynamoDbStoreInternalError> {
+        match &key_interval.start {
+            KeyIntervalStart::Included(k) | KeyIntervalStart::Excluded(k) => check_key_size(k)?,
+        }
+        if let Bound::Included(k) | Bound::Excluded(k) = &key_interval.end {
+            check_key_size(k)?;
+        }
+
+        // DynamoDB's BETWEEN rejects requests where lower > upper, which the
+        // pagination loop in callers can produce for degenerate intervals
+        // (e.g. `Excluded(K), Included(K)`).
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
+        }
+
+        let lower = Self::lower_sort_bound(&key_interval.start);
+        let upper = Self::upper_sort_bound(&key_interval.end);
+        let drop_upper = matches!(key_interval.end, Bound::Excluded(_));
+        let user_limit = key_interval.limit;
+
+        let mut items: Vec<HashMap<String, AttributeValue>> = Vec::new();
+        let mut start_key_map: Option<HashMap<String, AttributeValue>> = None;
+
+        loop {
+            let _guard = self.acquire().await;
+            let mut query = self
+                .client
+                .query()
+                .table_name(&self.namespace)
+                .projection_expression(attribute_str)
+                .expression_attribute_values(
+                    ":partition",
+                    AttributeValue::B(Blob::new(self.start_key.to_vec())),
+                )
+                .expression_attribute_values(
+                    ":lo",
+                    AttributeValue::B(Blob::new(lower.clone())),
+                )
+                .set_exclusive_start_key(start_key_map.take());
+            query = match &upper {
+                Some(hi) => query
+                    .key_condition_expression(format!(
+                        "{PARTITION_ATTRIBUTE} = :partition AND \
+                         {KEY_ATTRIBUTE} BETWEEN :lo AND :hi"
+                    ))
+                    .expression_attribute_values(":hi", AttributeValue::B(Blob::new(hi.clone()))),
+                None => query.key_condition_expression(format!(
+                    "{PARTITION_ATTRIBUTE} = :partition AND {KEY_ATTRIBUTE} >= :lo"
+                )),
+            };
+            if let Some(limit) = user_limit {
+                let remaining = limit - items.len();
+                query = query.limit(i32::try_from(remaining).unwrap_or(i32::MAX));
+            }
+
+            let response = query.send().boxed_sync().await?;
+            let last_evaluated_key = response.last_evaluated_key;
+            let response_items = response.items.unwrap_or_default();
+
+            for item in response_items {
+                if drop_upper {
+                    if let Some(upper_bytes) = &upper {
+                        if let Some(AttributeValue::B(blob)) = item.get(KEY_ATTRIBUTE) {
+                            if blob.as_ref() == upper_bytes.as_slice() {
+                                // Excluded upper bound reached. BETWEEN's
+                                // upper is inclusive, so this is the only
+                                // item we ever need to drop, and no items
+                                // strictly less than the bound remain.
+                                return Ok((items, true));
+                            }
+                        }
+                    }
+                }
+                items.push(item);
+                if user_limit.is_some_and(|limit| items.len() >= limit) {
+                    return Ok((items, false));
+                }
+            }
+
+            match last_evaluated_key {
+                None => return Ok((items, true)),
+                Some(next) => start_key_map = Some(next),
+            }
+        }
     }
 
     async fn read_value_bytes_general(
@@ -672,36 +766,6 @@ impl DynamoDbStoreInternal {
             .await?;
 
         Ok(response.item.is_some())
-    }
-
-    async fn get_list_responses(
-        &self,
-        attribute: &str,
-        start_key: &[u8],
-        key_prefix: &[u8],
-    ) -> Result<QueryResponses, DynamoDbStoreInternalError> {
-        check_key_size(key_prefix)?;
-        let mut responses = Vec::new();
-        let mut start_key_map = None;
-        loop {
-            let response = self
-                .get_query_output(attribute, start_key, key_prefix, start_key_map)
-                .await?;
-            let last_evaluated = response.last_evaluated_key.clone();
-            responses.push(response);
-            match last_evaluated {
-                None => {
-                    break;
-                }
-                Some(value) => {
-                    start_key_map = Some(value);
-                }
-            }
-        }
-        Ok(QueryResponses {
-            prefix_len: key_prefix.len(),
-            responses,
-        })
     }
 
     async fn read_batch_values_bytes(
@@ -784,29 +848,6 @@ impl DynamoDbStoreInternal {
     }
 }
 
-struct QueryResponses {
-    prefix_len: usize,
-    responses: Vec<QueryOutput>,
-}
-
-impl QueryResponses {
-    fn keys(&self) -> impl Iterator<Item = Result<&[u8], DynamoDbStoreInternalError>> {
-        self.responses
-            .iter()
-            .flat_map(|response| response.items.iter().flatten())
-            .map(|item| extract_key(self.prefix_len, item))
-    }
-
-    fn key_values(
-        &self,
-    ) -> impl Iterator<Item = Result<(&[u8], &[u8]), DynamoDbStoreInternalError>> {
-        self.responses
-            .iter()
-            .flat_map(|response| response.items.iter().flatten())
-            .map(|item| extract_key_value(self.prefix_len, item))
-    }
-}
-
 impl WithError for DynamoDbStoreInternal {
     type Error = DynamoDbStoreInternalError;
 }
@@ -877,20 +918,13 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), DynamoDbStoreInternalError> {
-        let result_queries = self
-            .get_list_responses(KEY_ATTRIBUTE, &self.start_key, &[])
+        let (items, is_finished) = self
+            .run_interval_query(KEY_ATTRIBUTE, &key_interval)
             .await?;
-        let mut keys = Vec::new();
-        for key in result_queries.keys() {
-            let key = key?;
-            if key_matches_interval(key, key_interval.start_bound(), key_interval.end_bound()) {
-                keys.push(key.to_vec());
-                if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
-                    break;
-                }
-            }
+        let mut keys = Vec::with_capacity(items.len());
+        for item in &items {
+            keys.push(extract_key(0, item)?.to_vec());
         }
-        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
         Ok((keys, is_finished))
     }
 
@@ -898,25 +932,14 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), DynamoDbStoreInternalError> {
-        let result_queries = self
-            .get_list_responses(KEY_VALUE_ATTRIBUTE, &self.start_key, &[])
+        let (items, is_finished) = self
+            .run_interval_query(KEY_VALUE_ATTRIBUTE, &key_interval)
             .await?;
-        let mut key_values = Vec::new();
-        for entry in result_queries.key_values() {
-            let (key, value) = entry?;
-            if key_matches_interval(key, key_interval.start_bound(), key_interval.end_bound()) {
-                key_values.push((key.to_vec(), value.to_vec()));
-                if key_interval
-                    .limit
-                    .is_some_and(|limit| key_values.len() >= limit)
-                {
-                    break;
-                }
-            }
+        let mut key_values = Vec::with_capacity(items.len());
+        for item in &items {
+            let (key, value) = extract_key_value(0, item)?;
+            key_values.push((key.to_vec(), value.to_vec()));
         }
-        let is_finished = key_interval
-            .limit
-            .is_none_or(|limit| key_values.len() < limit);
         Ok((key_values, is_finished))
     }
 }

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -692,14 +692,20 @@ impl DynamoDbStoreInternal {
                 )),
             };
             if let Some(limit) = user_limit {
+                // Ask DynamoDB for one row past the user's remaining quota
+                // so we can tell whether more matches exist without an extra
+                // round-trip. `last_evaluated_key` alone is unreliable —
+                // DynamoDB can set it even when the scan range is exhausted.
                 let remaining = limit - items.len();
-                query = query.limit(i32::try_from(remaining).unwrap_or(i32::MAX));
+                let request_limit = remaining.saturating_add(1);
+                query = query.limit(i32::try_from(request_limit).unwrap_or(i32::MAX));
             }
 
             let response = query.send().boxed_sync().await?;
             let last_evaluated_key = response.last_evaluated_key;
             let response_items = response.items.unwrap_or_default();
 
+            let mut hit_extra = false;
             for item in response_items {
                 if drop_upper {
                     if let Some(upper_bytes) = &upper {
@@ -714,10 +720,17 @@ impl DynamoDbStoreInternal {
                         }
                     }
                 }
-                items.push(item);
                 if user_limit.is_some_and(|limit| items.len() >= limit) {
-                    return Ok((items, false));
+                    // We already have the user-requested count; this is the
+                    // extra item, which proves more matches exist.
+                    hit_extra = true;
+                    break;
                 }
+                items.push(item);
+            }
+
+            if hit_extra {
+                return Ok((items, false));
             }
 
             match last_evaluated_key {

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -17,13 +17,9 @@ use async_lock::{Semaphore, SemaphoreGuard};
 use aws_sdk_dynamodb::{
     error::SdkError,
     operation::{
-        batch_get_item::BatchGetItemError,
-        create_table::CreateTableError,
-        delete_table::DeleteTableError,
-        get_item::GetItemError,
-        list_tables::ListTablesError,
-        query::QueryError,
-        transact_write_items::TransactWriteItemsError,
+        batch_get_item::BatchGetItemError, create_table::CreateTableError,
+        delete_table::DeleteTableError, get_item::GetItemError, list_tables::ListTablesError,
+        query::QueryError, transact_write_items::TransactWriteItemsError,
     },
     primitives::Blob,
     types::{
@@ -675,10 +671,7 @@ impl DynamoDbStoreInternal {
                     ":partition",
                     AttributeValue::B(Blob::new(self.start_key.to_vec())),
                 )
-                .expression_attribute_values(
-                    ":lo",
-                    AttributeValue::B(Blob::new(lower.clone())),
-                )
+                .expression_attribute_values(":lo", AttributeValue::B(Blob::new(lower.clone())))
                 .set_exclusive_start_key(start_key_map.take());
             query = match &upper {
                 Some(hi) => query

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -14,8 +14,8 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::get_upper_bound_option,
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
-        WritableKeyValueStore,
+        KeyInterval, KeyIntervalStart, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
+        WithError, WritableKeyValueStore,
     },
 };
 
@@ -97,6 +97,44 @@ fn prefix_to_range(prefix: &[u8]) -> (Bound<JsValue>, Bound<JsValue>) {
     (lower, upper)
 }
 
+fn interval_to_range(
+    start_key: &[u8],
+    key_interval: &KeyInterval,
+) -> (Bound<JsValue>, Bound<JsValue>) {
+    let lower = match &key_interval.start {
+        KeyIntervalStart::Included(key) => {
+            let key = [start_key, key.as_slice()].concat();
+            Bound::Included(js_sys::Uint8Array::from(key.as_slice()).into())
+        }
+        KeyIntervalStart::Excluded(key) => {
+            let key = [start_key, key.as_slice()].concat();
+            Bound::Excluded(js_sys::Uint8Array::from(key.as_slice()).into())
+        }
+    };
+    let upper = match &key_interval.end {
+        Bound::Included(key) => {
+            let key = [start_key, key.as_slice()].concat();
+            if let Some(upper) = get_upper_bound_option(&key) {
+                Bound::Excluded(js_sys::Uint8Array::from(upper.as_slice()).into())
+            } else {
+                Bound::Unbounded
+            }
+        }
+        Bound::Excluded(key) => {
+            let key = [start_key, key.as_slice()].concat();
+            Bound::Excluded(js_sys::Uint8Array::from(key.as_slice()).into())
+        }
+        Bound::Unbounded => {
+            if let Some(upper) = get_upper_bound_option(start_key) {
+                Bound::Excluded(js_sys::Uint8Array::from(upper.as_slice()).into())
+            } else {
+                Bound::Unbounded
+            }
+        }
+    };
+    (lower, upper)
+}
+
 impl WithError for IndexedDbStore {
     type Error = IndexedDbStoreError;
 }
@@ -149,47 +187,65 @@ impl ReadableKeyValueStore for IndexedDbStore {
         .await
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>> {
-        let key_prefix = self.full_key(key_prefix);
-        let range = prefix_to_range(&key_prefix);
-        Ok(self
-            .with_object_store(|o| o.get_all_keys_in(range, None))
+    async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool)> {
+        let range = interval_to_range(&self.start_key, &key_interval);
+        let keys = self
+            .with_object_store(move |o| {
+                o.get_all_keys_in(range, key_interval.limit.map(|limit| limit as u32))
+            })
             .await??
             .into_iter()
             .map(|key| {
                 let key = js_sys::Uint8Array::new(&key);
-                key.subarray(key_prefix.len() as u32, key.length()).to_vec()
+                key.subarray(self.start_key.len() as u32, key.length())
+                    .to_vec()
             })
-            .collect())
+            .collect::<Vec<_>>();
+        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        Ok((keys, is_finished))
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
-        let key_prefix = self.full_key(key_prefix);
-        let range = prefix_to_range(&key_prefix);
-        self.with_object_store(|object_store| async move {
-            let mut key_values = vec![];
-            let mut cursor = object_store.cursor().range(range)?.open().await?;
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool)> {
+        let range = interval_to_range(&self.start_key, &key_interval);
+        let prefix_len = self.start_key.len() as u32;
+        let key_values = self
+            .with_object_store(move |object_store| async move {
+                let mut key_values = vec![];
+                let mut cursor = object_store.cursor().range(range)?.open().await?;
 
-            while let Some(key) = cursor.primary_key() {
-                let key = js_sys::Uint8Array::new(&key);
-                key_values.push((
-                    key.subarray(key_prefix.len() as u32, key.length()).to_vec(),
-                    js_sys::Uint8Array::new(
-                        &cursor
-                            .value()
-                            .expect("we should have a value because we have a key"),
-                    )
-                    .to_vec(),
-                ));
-                cursor.advance(1).await?;
-            }
+                while let Some(key) = cursor.primary_key() {
+                    let key = js_sys::Uint8Array::new(&key);
+                    key_values.push((
+                        key.subarray(prefix_len, key.length()).to_vec(),
+                        js_sys::Uint8Array::new(
+                            &cursor
+                                .value()
+                                .expect("we should have a value because we have a key"),
+                        )
+                        .to_vec(),
+                    ));
+                    if key_interval
+                        .limit
+                        .is_some_and(|limit| key_values.len() >= limit)
+                    {
+                        break;
+                    }
+                    cursor.advance(1).await?;
+                }
 
-            Ok(key_values)
-        })
-        .await?
+                Ok::<_, IndexedDbStoreError>(key_values)
+            })
+            .await??;
+        let is_finished = key_interval
+            .limit
+            .is_none_or(|limit| key_values.len() < limit);
+        Ok((key_values, is_finished))
     }
 }
 

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -113,12 +113,12 @@ fn interval_to_range(
     };
     let upper = match &key_interval.end {
         Bound::Included(key) => {
-            let key = [start_key, key.as_slice()].concat();
-            if let Some(upper) = get_upper_bound_option(&key) {
-                Bound::Excluded(js_sys::Uint8Array::from(upper.as_slice()).into())
-            } else {
-                Bound::Unbounded
-            }
+            // The cursor's upper bound is exclusive. The smallest key strictly
+            // greater than `start_key + key` is obtained by appending `0`,
+            // which correctly excludes any key that lex-extends `key`.
+            let mut full_key = [start_key, key.as_slice()].concat();
+            full_key.push(0);
+            Bound::Excluded(js_sys::Uint8Array::from(full_key.as_slice()).into())
         }
         Bound::Excluded(key) => {
             let key = [start_key, key.as_slice()].concat();

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -191,6 +191,9 @@ impl ReadableKeyValueStore for IndexedDbStore {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool)> {
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
+        }
         let range = interval_to_range(&self.start_key, &key_interval);
         // Ask for one extra key past the user limit so we can decide
         // `is_finished` precisely without an extra round-trip.
@@ -226,6 +229,9 @@ impl ReadableKeyValueStore for IndexedDbStore {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool)> {
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
+        }
         let range = interval_to_range(&self.start_key, &key_interval);
         let prefix_len = self.start_key.len() as u32;
         let user_limit = key_interval.limit;

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -192,10 +192,14 @@ impl ReadableKeyValueStore for IndexedDbStore {
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool)> {
         let range = interval_to_range(&self.start_key, &key_interval);
-        let keys = self
-            .with_object_store(move |o| {
-                o.get_all_keys_in(range, key_interval.limit.map(|limit| limit as u32))
-            })
+        // Ask for one extra key past the user limit so we can decide
+        // `is_finished` precisely without an extra round-trip.
+        let user_limit = key_interval.limit;
+        let fetch_limit = user_limit.map(|limit| {
+            u32::try_from(limit.saturating_add(1).min(u32::MAX as usize)).unwrap_or(u32::MAX)
+        });
+        let mut keys = self
+            .with_object_store(move |o| o.get_all_keys_in(range, fetch_limit))
             .await??
             .into_iter()
             .map(|key| {
@@ -204,7 +208,17 @@ impl ReadableKeyValueStore for IndexedDbStore {
                     .to_vec()
             })
             .collect::<Vec<_>>();
-        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        let is_finished = match user_limit {
+            Some(limit) => {
+                if keys.len() > limit {
+                    keys.truncate(limit);
+                    false
+                } else {
+                    true
+                }
+            }
+            None => true,
+        };
         Ok((keys, is_finished))
     }
 
@@ -214,7 +228,12 @@ impl ReadableKeyValueStore for IndexedDbStore {
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool)> {
         let range = interval_to_range(&self.start_key, &key_interval);
         let prefix_len = self.start_key.len() as u32;
-        let key_values = self
+        let user_limit = key_interval.limit;
+        // Walk one cursor step past the user limit so we know whether the
+        // database has more matches — the cursor advance is the only extra
+        // cost.
+        let fetch_target = user_limit.map(|limit| limit.saturating_add(1));
+        let mut key_values = self
             .with_object_store(move |object_store| async move {
                 let mut key_values = vec![];
                 let mut cursor = object_store.cursor().range(range)?.open().await?;
@@ -230,10 +249,7 @@ impl ReadableKeyValueStore for IndexedDbStore {
                         )
                         .to_vec(),
                     ));
-                    if key_interval
-                        .limit
-                        .is_some_and(|limit| key_values.len() >= limit)
-                    {
+                    if fetch_target.is_some_and(|target| key_values.len() >= target) {
                         break;
                     }
                     cursor.advance(1).await?;
@@ -242,9 +258,17 @@ impl ReadableKeyValueStore for IndexedDbStore {
                 Ok::<_, IndexedDbStoreError>(key_values)
             })
             .await??;
-        let is_finished = key_interval
-            .limit
-            .is_none_or(|limit| key_values.len() < limit);
+        let is_finished = match user_limit {
+            Some(limit) => {
+                if key_values.len() > limit {
+                    key_values.truncate(limit);
+                    false
+                } else {
+                    true
+                }
+            }
+            None => true,
+        };
         Ok((key_values, is_finished))
     }
 }

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -26,8 +26,8 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, BatchValueWriter, DeletePrefixExpander, SimplifiedBatch},
     store::{
-        DirectKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError, WritableKeyValueStore,
+        DirectKeyValueStore, KeyInterval, KeyValueDatabase, KeyValueStoreError,
+        ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     views::MIN_VIEW_TAG,
 };
@@ -192,15 +192,18 @@ where
         Ok(self.store.read_multi_values_bytes(keys).await?)
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
-        Ok(self.store.find_keys_by_prefix(key_prefix).await?)
+    async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
+        Ok(self.store.find_keys_in_interval(key_interval).await?)
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
-        Ok(self.store.find_key_values_by_prefix(key_prefix).await?)
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
+        Ok(self.store.find_key_values_in_interval(key_interval).await?)
     }
 }
 

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -14,7 +14,9 @@ use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::{Batch, WriteOperation},
     lru_prefix_cache::{LruPrefixCache, StorageCacheConfig},
-    store::{KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyInterval, KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+    },
 };
 
 #[cfg(with_metrics)]
@@ -293,6 +295,13 @@ where
         Ok(result)
     }
 
+    async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
+        self.store.find_keys_in_interval(key_interval).await
+    }
+
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
         let Some(cache) = self.get_exclusive_cache() else {
             return self.store.find_keys_by_prefix(key_prefix).await;
@@ -315,6 +324,13 @@ where
         let mut cache = cache.lock().unwrap();
         cache.insert_find_keys(key_prefix.to_vec(), &keys);
         Ok(keys)
+    }
+
+    async fn find_key_values_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
+        self.store.find_key_values_in_interval(key_interval).await
     }
 
     async fn find_key_values_by_prefix(

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -14,7 +14,9 @@ use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::{Batch, WriteOperation},
     lru_prefix_cache::{LruPrefixCache, StorageCacheConfig},
-    store::{KeyInterval, KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyInterval, KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+    },
 };
 
 #[cfg(with_metrics)]
@@ -370,10 +372,7 @@ where
             if !key_interval.contains(&full) {
                 continue;
             }
-            if key_interval
-                .limit
-                .is_some_and(|limit| keys.len() >= limit)
-            {
+            if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
                 more_after_limit = true;
                 break;
             }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -123,6 +123,46 @@ mod metrics {
                 &[],
             )
         });
+
+    /// The total number of find_keys_in_interval cache misses.
+    pub static FIND_KEYS_IN_INTERVAL_CACHE_MISS_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "num_find_keys_in_interval_cache_miss",
+                "Number of find keys in interval cache misses",
+                &[],
+            )
+        });
+
+    /// The total number of find_keys_in_interval cache hits.
+    pub static FIND_KEYS_IN_INTERVAL_CACHE_HIT_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "num_find_keys_in_interval_cache_hit",
+                "Number of find keys in interval cache hits",
+                &[],
+            )
+        });
+
+    /// The total number of find_key_values_in_interval cache misses.
+    pub static FIND_KEY_VALUES_IN_INTERVAL_CACHE_MISS_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "num_find_key_values_in_interval_cache_miss",
+                "Number of find key values in interval cache misses",
+                &[],
+            )
+        });
+
+    /// The total number of find_key_values_in_interval cache hits.
+    pub static FIND_KEY_VALUES_IN_INTERVAL_CACHE_HIT_COUNT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "num_find_key_values_in_interval_cache_hit",
+                "Number of find key values in interval cache hits",
+                &[],
+            )
+        });
 }
 
 /// The maximum number of entries in the cache.
@@ -335,13 +375,13 @@ where
         };
         let Some(stripped) = cached else {
             #[cfg(with_metrics)]
-            metrics::FIND_KEYS_BY_PREFIX_CACHE_MISS_COUNT
+            metrics::FIND_KEYS_IN_INTERVAL_CACHE_MISS_COUNT
                 .with_label_values(&[])
                 .inc();
             return self.store.find_keys_in_interval(key_interval).await;
         };
         #[cfg(with_metrics)]
-        metrics::FIND_KEYS_BY_PREFIX_CACHE_HIT_COUNT
+        metrics::FIND_KEYS_IN_INTERVAL_CACHE_HIT_COUNT
             .with_label_values(&[])
             .inc();
         // The cached prefix family is complete, so we can compute
@@ -405,13 +445,13 @@ where
         };
         let Some(stripped) = cached else {
             #[cfg(with_metrics)]
-            metrics::FIND_KEY_VALUES_BY_PREFIX_CACHE_MISS_COUNT
+            metrics::FIND_KEY_VALUES_IN_INTERVAL_CACHE_MISS_COUNT
                 .with_label_values(&[])
                 .inc();
             return self.store.find_key_values_in_interval(key_interval).await;
         };
         #[cfg(with_metrics)]
-        metrics::FIND_KEY_VALUES_BY_PREFIX_CACHE_HIT_COUNT
+        metrics::FIND_KEY_VALUES_IN_INTERVAL_CACHE_HIT_COUNT
             .with_label_values(&[])
             .inc();
         let mut key_values = Vec::new();

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -11,36 +11,11 @@ use serde::{Deserialize, Serialize};
 use crate::memory::MemoryDatabase;
 #[cfg(with_testing)]
 use crate::store::TestKeyValueDatabase;
-use std::ops::Bound;
-
 use crate::{
     batch::{Batch, WriteOperation},
     lru_prefix_cache::{LruPrefixCache, StorageCacheConfig},
-    store::{
-        KeyInterval, KeyIntervalStart, KeyValueDatabase, ReadableKeyValueStore, WithError,
-        WritableKeyValueStore,
-    },
+    store::{KeyInterval, KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
 };
-
-/// Returns the longest common byte prefix shared by `start` and `end`. Any key
-/// inside `[start, end]` (any inclusivity) must start with this prefix. For
-/// `Unbounded` ends the LCP is empty (only an empty-prefix cache entry could
-/// cover the request).
-fn lcp_of_interval(key_interval: &KeyInterval) -> Vec<u8> {
-    let start = match &key_interval.start {
-        KeyIntervalStart::Included(k) | KeyIntervalStart::Excluded(k) => k.as_slice(),
-    };
-    let end = match &key_interval.end {
-        Bound::Included(k) | Bound::Excluded(k) => k.as_slice(),
-        Bound::Unbounded => return Vec::new(),
-    };
-    let n = start
-        .iter()
-        .zip(end.iter())
-        .take_while(|(a, b)| a == b)
-        .count();
-    start[..n].to_vec()
-}
 
 #[cfg(with_metrics)]
 mod metrics {
@@ -368,7 +343,7 @@ where
         // Any key in the user interval starts with `lcp(start, end)`. The
         // prefix cache walks back from this prefix to any shorter cached
         // prefix that covers it, so a single probe is sufficient.
-        let lcp = lcp_of_interval(&key_interval);
+        let lcp = key_interval.common_prefix();
         let cached = {
             let mut cache = cache.lock().unwrap();
             cache.query_find_keys(&lcp)
@@ -438,7 +413,7 @@ where
         let Some(cache) = self.get_exclusive_cache() else {
             return self.store.find_key_values_in_interval(key_interval).await;
         };
-        let lcp = lcp_of_interval(&key_interval);
+        let lcp = key_interval.common_prefix();
         let cached = {
             let mut cache = cache.lock().unwrap();
             cache.query_find_key_values(&lcp)

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -11,13 +11,36 @@ use serde::{Deserialize, Serialize};
 use crate::memory::MemoryDatabase;
 #[cfg(with_testing)]
 use crate::store::TestKeyValueDatabase;
+use std::ops::Bound;
+
 use crate::{
     batch::{Batch, WriteOperation},
     lru_prefix_cache::{LruPrefixCache, StorageCacheConfig},
     store::{
-        KeyInterval, KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        KeyInterval, KeyIntervalStart, KeyValueDatabase, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore,
     },
 };
+
+/// Returns the longest common byte prefix shared by `start` and `end`. Any key
+/// inside `[start, end]` (any inclusivity) must start with this prefix. For
+/// `Unbounded` ends the LCP is empty (only an empty-prefix cache entry could
+/// cover the request).
+fn lcp_of_interval(key_interval: &KeyInterval) -> Vec<u8> {
+    let start = match &key_interval.start {
+        KeyIntervalStart::Included(k) | KeyIntervalStart::Excluded(k) => k.as_slice(),
+    };
+    let end = match &key_interval.end {
+        Bound::Included(k) | Bound::Excluded(k) => k.as_slice(),
+        Bound::Unbounded => return Vec::new(),
+    };
+    let n = start
+        .iter()
+        .zip(end.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    start[..n].to_vec()
+}
 
 #[cfg(with_metrics)]
 mod metrics {
@@ -299,7 +322,49 @@ where
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
-        self.store.find_keys_in_interval(key_interval).await
+        let Some(cache) = self.get_exclusive_cache() else {
+            return self.store.find_keys_in_interval(key_interval).await;
+        };
+        // Any key in the user interval starts with `lcp(start, end)`. The
+        // prefix cache walks back from this prefix to any shorter cached
+        // prefix that covers it, so a single probe is sufficient.
+        let lcp = lcp_of_interval(&key_interval);
+        let cached = {
+            let mut cache = cache.lock().unwrap();
+            cache.query_find_keys(&lcp)
+        };
+        let Some(stripped) = cached else {
+            #[cfg(with_metrics)]
+            metrics::FIND_KEYS_BY_PREFIX_CACHE_MISS_COUNT
+                .with_label_values(&[])
+                .inc();
+            return self.store.find_keys_in_interval(key_interval).await;
+        };
+        #[cfg(with_metrics)]
+        metrics::FIND_KEYS_BY_PREFIX_CACHE_HIT_COUNT
+            .with_label_values(&[])
+            .inc();
+        // The cached prefix family is complete, so we can compute
+        // `is_finished` exactly: the answer is unfinished iff we stopped
+        // because of `limit` while a further matching key remained.
+        let mut keys = Vec::new();
+        let mut more_after_limit = false;
+        for sk in &stripped {
+            let mut full = lcp.clone();
+            full.extend(sk);
+            if !key_interval.contains(&full) {
+                continue;
+            }
+            if key_interval
+                .limit
+                .is_some_and(|limit| keys.len() >= limit)
+            {
+                more_after_limit = true;
+                break;
+            }
+            keys.push(full);
+        }
+        Ok((keys, !more_after_limit))
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
@@ -330,7 +395,43 @@ where
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
-        self.store.find_key_values_in_interval(key_interval).await
+        let Some(cache) = self.get_exclusive_cache() else {
+            return self.store.find_key_values_in_interval(key_interval).await;
+        };
+        let lcp = lcp_of_interval(&key_interval);
+        let cached = {
+            let mut cache = cache.lock().unwrap();
+            cache.query_find_key_values(&lcp)
+        };
+        let Some(stripped) = cached else {
+            #[cfg(with_metrics)]
+            metrics::FIND_KEY_VALUES_BY_PREFIX_CACHE_MISS_COUNT
+                .with_label_values(&[])
+                .inc();
+            return self.store.find_key_values_in_interval(key_interval).await;
+        };
+        #[cfg(with_metrics)]
+        metrics::FIND_KEY_VALUES_BY_PREFIX_CACHE_HIT_COUNT
+            .with_label_values(&[])
+            .inc();
+        let mut key_values = Vec::new();
+        let mut more_after_limit = false;
+        for (sk, value) in &stripped {
+            let mut full = lcp.clone();
+            full.extend(sk);
+            if !key_interval.contains(&full) {
+                continue;
+            }
+            if key_interval
+                .limit
+                .is_some_and(|limit| key_values.len() >= limit)
+            {
+                more_after_limit = true;
+                break;
+            }
+            key_values.push((full, value.clone()));
+        }
+        Ok((key_values, !more_after_limit))
     }
 
     async fn find_key_values_by_prefix(

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -15,9 +15,9 @@ use thiserror::Error;
 use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::{Batch, WriteOperation},
-    common::get_key_range_for_prefix,
+    common::{get_interval_range, get_key_range_for_prefix},
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        KeyInterval, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
 };
@@ -179,37 +179,51 @@ impl ReadableKeyValueStore for MemoryStore {
         Ok(result)
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, MemoryStoreError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), MemoryStoreError> {
         let map = self
             .map
             .read()
             .expect("MemoryStore lock should not be poisoned");
         let mut values = Vec::new();
-        let len = key_prefix.len();
-        for (key, _value) in map.range(get_key_range_for_prefix(key_prefix.to_vec())) {
-            values.push(key[len..].to_vec())
+        for (key, _value) in map.range(get_interval_range(key_interval.start, key_interval.end)) {
+            values.push(key.to_vec());
+            if key_interval
+                .limit
+                .is_some_and(|limit| values.len() >= limit)
+            {
+                break;
+            }
         }
-        Ok(values)
+        let is_finished = key_interval.limit.is_none_or(|limit| values.len() < limit);
+        Ok((values, is_finished))
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, MemoryStoreError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), MemoryStoreError> {
         let map = self
             .map
             .read()
             .expect("MemoryStore lock should not be poisoned");
         let mut key_values = Vec::new();
-        let len = key_prefix.len();
-        for (key, value) in map.range(get_key_range_for_prefix(key_prefix.to_vec())) {
-            let key_value = (key[len..].to_vec(), value.to_vec());
+        for (key, value) in map.range(get_interval_range(key_interval.start, key_interval.end)) {
+            let key_value = (key.to_vec(), value.to_vec());
             key_values.push(key_value);
+            if key_interval
+                .limit
+                .is_some_and(|limit| key_values.len() >= limit)
+            {
+                break;
+            }
         }
-        Ok(key_values)
+        let is_finished = key_interval
+            .limit
+            .is_none_or(|limit| key_values.len() < limit);
+        Ok((key_values, is_finished))
     }
 }
 

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -183,6 +183,9 @@ impl ReadableKeyValueStore for MemoryStore {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), MemoryStoreError> {
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
+        }
         let map = self
             .map
             .read()
@@ -205,6 +208,9 @@ impl ReadableKeyValueStore for MemoryStore {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), MemoryStoreError> {
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
+        }
         let map = self
             .map
             .read()

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -193,7 +193,7 @@ impl ReadableKeyValueStore for MemoryStore {
         let mut iter = map.range(get_interval_range(key_interval.start, key_interval.end));
         let mut values = Vec::new();
         let mut hit_limit = false;
-        while let Some((key, _value)) = iter.next() {
+        for (key, _value) in iter.by_ref() {
             values.push(key.to_vec());
             if key_interval
                 .limit
@@ -227,7 +227,7 @@ impl ReadableKeyValueStore for MemoryStore {
         let mut iter = map.range(get_interval_range(key_interval.start, key_interval.end));
         let mut key_values = Vec::new();
         let mut hit_limit = false;
-        while let Some((key, value)) = iter.next() {
+        for (key, value) in iter.by_ref() {
             key_values.push((key.to_vec(), value.to_vec()));
             if key_interval
                 .limit

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -190,17 +190,26 @@ impl ReadableKeyValueStore for MemoryStore {
             .map
             .read()
             .expect("MemoryStore lock should not be poisoned");
+        let mut iter = map.range(get_interval_range(key_interval.start, key_interval.end));
         let mut values = Vec::new();
-        for (key, _value) in map.range(get_interval_range(key_interval.start, key_interval.end)) {
+        let mut hit_limit = false;
+        while let Some((key, _value)) = iter.next() {
             values.push(key.to_vec());
             if key_interval
                 .limit
                 .is_some_and(|limit| values.len() >= limit)
             {
+                hit_limit = true;
                 break;
             }
         }
-        let is_finished = key_interval.limit.is_none_or(|limit| values.len() < limit);
+        // Precise `is_finished`: when we stopped at the limit, peek one
+        // BTreeMap step ahead — `next()` is the only extra cost.
+        let is_finished = if hit_limit {
+            iter.next().is_none()
+        } else {
+            true
+        };
         Ok((values, is_finished))
     }
 
@@ -215,20 +224,24 @@ impl ReadableKeyValueStore for MemoryStore {
             .map
             .read()
             .expect("MemoryStore lock should not be poisoned");
+        let mut iter = map.range(get_interval_range(key_interval.start, key_interval.end));
         let mut key_values = Vec::new();
-        for (key, value) in map.range(get_interval_range(key_interval.start, key_interval.end)) {
-            let key_value = (key.to_vec(), value.to_vec());
-            key_values.push(key_value);
+        let mut hit_limit = false;
+        while let Some((key, value)) = iter.next() {
+            key_values.push((key.to_vec(), value.to_vec()));
             if key_interval
                 .limit
                 .is_some_and(|limit| key_values.len() >= limit)
             {
+                hit_limit = true;
                 break;
             }
         }
-        let is_finished = key_interval
-            .limit
-            .is_none_or(|limit| key_values.len() < limit);
+        let is_finished = if hit_limit {
+            iter.next().is_none()
+        } else {
+            true
+        };
         Ok((key_values, is_finished))
     }
 }

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -19,7 +19,9 @@ use prometheus::{exponential_buckets, HistogramVec, IntCounterVec};
 use crate::store::TestKeyValueDatabase;
 use crate::{
     batch::Batch,
-    store::{KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        KeyInterval, KeyValueDatabase, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+    },
 };
 
 #[derive(Clone)]
@@ -416,14 +418,21 @@ where
         self.store.read_multi_values_bytes(keys).await
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
+    async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
         let _latency = self.counter.find_keys_by_prefix_latency.measure_latency();
+        let prefix_size = match key_interval.start_bound() {
+            std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => key.len(),
+            std::ops::Bound::Unbounded => unreachable!("KeyInterval start is always bounded"),
+        };
         self.counter
             .find_keys_by_prefix_prefix_size
             .with_label_values(&[])
-            .observe(key_prefix.len() as f64);
-        let result = self.store.find_keys_by_prefix(key_prefix).await?;
-        let (num_keys, keys_size) = result
+            .observe(prefix_size as f64);
+        let (keys, is_finished) = self.store.find_keys_in_interval(key_interval).await?;
+        let (num_keys, keys_size) = keys
             .iter()
             .map(|key| key.len())
             .fold((0, 0), |(count, size), len| (count + 1, size + len));
@@ -435,23 +444,28 @@ where
             .find_keys_by_prefix_keys_size
             .with_label_values(&[])
             .observe(keys_size as f64);
-        Ok(result)
+        Ok((keys, is_finished))
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
         let _latency = self
             .counter
             .find_key_values_by_prefix_latency
             .measure_latency();
+        let prefix_size = match key_interval.start_bound() {
+            std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => key.len(),
+            std::ops::Bound::Unbounded => unreachable!("KeyInterval start is always bounded"),
+        };
         self.counter
             .find_key_values_by_prefix_prefix_size
             .with_label_values(&[])
-            .observe(key_prefix.len() as f64);
-        let result = self.store.find_key_values_by_prefix(key_prefix).await?;
-        let (num_keys, key_values_size) = result
+            .observe(prefix_size as f64);
+        let (key_values, is_finished) =
+            self.store.find_key_values_in_interval(key_interval).await?;
+        let (num_keys, key_values_size) = key_values
             .iter()
             .map(|(key, value)| key.len() + value.len())
             .fold((0, 0), |(count, size), len| (count + 1, size + len));
@@ -463,7 +477,7 @@ where
             .find_key_values_by_prefix_key_values_size
             .with_label_values(&[])
             .observe(key_values_size as f64);
-        Ok(result)
+        Ok((key_values, is_finished))
     }
 }
 

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -31,8 +31,8 @@ pub struct KeyValueStoreMetrics {
     contains_key_latency: HistogramVec,
     contains_keys_latency: HistogramVec,
     read_multi_values_bytes_latency: HistogramVec,
-    find_keys_by_prefix_latency: HistogramVec,
-    find_key_values_by_prefix_latency: HistogramVec,
+    find_keys_in_interval_latency: HistogramVec,
+    find_key_values_in_interval_latency: HistogramVec,
     write_batch_latency: HistogramVec,
     clear_journal_latency: HistogramVec,
     connect_latency: HistogramVec,
@@ -52,12 +52,12 @@ pub struct KeyValueStoreMetrics {
     contains_keys_num_entries: HistogramVec,
     contains_keys_key_sizes: HistogramVec,
     contains_key_key_size: HistogramVec,
-    find_keys_by_prefix_prefix_size: HistogramVec,
-    find_keys_by_prefix_num_keys: HistogramVec,
-    find_keys_by_prefix_keys_size: HistogramVec,
-    find_key_values_by_prefix_prefix_size: HistogramVec,
-    find_key_values_by_prefix_num_keys: HistogramVec,
-    find_key_values_by_prefix_key_values_size: HistogramVec,
+    find_keys_in_interval_start_size: HistogramVec,
+    find_keys_in_interval_num_keys: HistogramVec,
+    find_keys_in_interval_keys_size: HistogramVec,
+    find_key_values_in_interval_start_size: HistogramVec,
+    find_key_values_in_interval_num_keys: HistogramVec,
+    find_key_values_in_interval_key_values_size: HistogramVec,
     write_batch_size: HistogramVec,
     list_all_sizes: HistogramVec,
     exists_true_cases: IntCounterVec,
@@ -125,14 +125,14 @@ impl KeyValueStoreMetrics {
         let read_multi_values_bytes_latency =
             register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_keys_by_prefix_latency");
-        let entry2 = format!("{title_name} find keys by prefix latency");
-        let find_keys_by_prefix_latency =
+        let entry1 = format!("{var_name}_find_keys_in_interval_latency");
+        let entry2 = format!("{title_name} find keys in interval latency");
+        let find_keys_in_interval_latency =
             register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_key_values_by_prefix_latency");
-        let entry2 = format!("{title_name} find key values by prefix latency");
-        let find_key_values_by_prefix_latency =
+        let entry1 = format!("{var_name}_find_key_values_in_interval_latency");
+        let entry2 = format!("{title_name} find key values in interval latency");
+        let find_key_values_in_interval_latency =
             register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
 
         let entry1 = format!("{var_name}_write_batch_latency");
@@ -226,34 +226,34 @@ impl KeyValueStoreMetrics {
         let contains_key_key_size =
             register_histogram_vec(&entry1, &entry2, &[], size_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_keys_by_prefix_prefix_size");
-        let entry2 = format!("{title_name} find keys by prefix prefix size");
-        let find_keys_by_prefix_prefix_size =
+        let entry1 = format!("{var_name}_find_keys_in_interval_start_size");
+        let entry2 = format!("{title_name} find keys in interval start size");
+        let find_keys_in_interval_start_size =
             register_histogram_vec(&entry1, &entry2, &[], size_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_keys_by_prefix_num_keys");
-        let entry2 = format!("{title_name} find keys by prefix num keys");
-        let find_keys_by_prefix_num_keys =
+        let entry1 = format!("{var_name}_find_keys_in_interval_num_keys");
+        let entry2 = format!("{title_name} find keys in interval num keys");
+        let find_keys_in_interval_num_keys =
             register_histogram_vec(&entry1, &entry2, &[], count_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_keys_by_prefix_keys_size");
-        let entry2 = format!("{title_name} find keys by prefix keys size");
-        let find_keys_by_prefix_keys_size =
+        let entry1 = format!("{var_name}_find_keys_in_interval_keys_size");
+        let entry2 = format!("{title_name} find keys in interval keys size");
+        let find_keys_in_interval_keys_size =
             register_histogram_vec(&entry1, &entry2, &[], size_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_key_values_by_prefix_prefix_size");
-        let entry2 = format!("{title_name} find key values by prefix prefix size");
-        let find_key_values_by_prefix_prefix_size =
+        let entry1 = format!("{var_name}_find_key_values_in_interval_start_size");
+        let entry2 = format!("{title_name} find key values in interval start size");
+        let find_key_values_in_interval_start_size =
             register_histogram_vec(&entry1, &entry2, &[], size_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_key_values_by_prefix_num_keys");
-        let entry2 = format!("{title_name} find key values by prefix num keys");
-        let find_key_values_by_prefix_num_keys =
+        let entry1 = format!("{var_name}_find_key_values_in_interval_num_keys");
+        let entry2 = format!("{title_name} find key values in interval num keys");
+        let find_key_values_in_interval_num_keys =
             register_histogram_vec(&entry1, &entry2, &[], count_buckets.clone());
 
-        let entry1 = format!("{var_name}_find_key_values_by_prefix_key_values_size");
-        let entry2 = format!("{title_name} find key values by prefix key values size");
-        let find_key_values_by_prefix_key_values_size =
+        let entry1 = format!("{var_name}_find_key_values_in_interval_key_values_size");
+        let entry2 = format!("{title_name} find key values in interval key values size");
+        let find_key_values_in_interval_key_values_size =
             register_histogram_vec(&entry1, &entry2, &[], size_buckets.clone());
 
         let entry1 = format!("{var_name}_write_batch_size");
@@ -273,8 +273,8 @@ impl KeyValueStoreMetrics {
             contains_key_latency,
             contains_keys_latency,
             read_multi_values_bytes_latency,
-            find_keys_by_prefix_latency,
-            find_key_values_by_prefix_latency,
+            find_keys_in_interval_latency,
+            find_key_values_in_interval_latency,
             write_batch_latency,
             clear_journal_latency,
             connect_latency,
@@ -294,12 +294,12 @@ impl KeyValueStoreMetrics {
             contains_keys_num_entries,
             contains_keys_key_sizes,
             contains_key_key_size,
-            find_keys_by_prefix_prefix_size,
-            find_keys_by_prefix_num_keys,
-            find_keys_by_prefix_keys_size,
-            find_key_values_by_prefix_prefix_size,
-            find_key_values_by_prefix_num_keys,
-            find_key_values_by_prefix_key_values_size,
+            find_keys_in_interval_start_size,
+            find_keys_in_interval_num_keys,
+            find_keys_in_interval_keys_size,
+            find_key_values_in_interval_start_size,
+            find_key_values_in_interval_num_keys,
+            find_key_values_in_interval_key_values_size,
             write_batch_size,
             list_all_sizes,
             exists_true_cases,
@@ -422,13 +422,13 @@ where
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
-        let _latency = self.counter.find_keys_by_prefix_latency.measure_latency();
+        let _latency = self.counter.find_keys_in_interval_latency.measure_latency();
         let prefix_size = match key_interval.start_bound() {
             std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => key.len(),
             std::ops::Bound::Unbounded => unreachable!("KeyInterval start is always bounded"),
         };
         self.counter
-            .find_keys_by_prefix_prefix_size
+            .find_keys_in_interval_start_size
             .with_label_values(&[])
             .observe(prefix_size as f64);
         let (keys, is_finished) = self.store.find_keys_in_interval(key_interval).await?;
@@ -437,11 +437,11 @@ where
             .map(|key| key.len())
             .fold((0, 0), |(count, size), len| (count + 1, size + len));
         self.counter
-            .find_keys_by_prefix_num_keys
+            .find_keys_in_interval_num_keys
             .with_label_values(&[])
             .observe(num_keys as f64);
         self.counter
-            .find_keys_by_prefix_keys_size
+            .find_keys_in_interval_keys_size
             .with_label_values(&[])
             .observe(keys_size as f64);
         Ok((keys, is_finished))
@@ -453,14 +453,14 @@ where
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
         let _latency = self
             .counter
-            .find_key_values_by_prefix_latency
+            .find_key_values_in_interval_latency
             .measure_latency();
         let prefix_size = match key_interval.start_bound() {
             std::ops::Bound::Included(key) | std::ops::Bound::Excluded(key) => key.len(),
             std::ops::Bound::Unbounded => unreachable!("KeyInterval start is always bounded"),
         };
         self.counter
-            .find_key_values_by_prefix_prefix_size
+            .find_key_values_in_interval_start_size
             .with_label_values(&[])
             .observe(prefix_size as f64);
         let (key_values, is_finished) =
@@ -470,11 +470,11 @@ where
             .map(|(key, value)| key.len() + value.len())
             .fold((0, 0), |(count, size), len| (count + 1, size + len));
         self.counter
-            .find_key_values_by_prefix_num_keys
+            .find_key_values_in_interval_num_keys
             .with_label_values(&[])
             .observe(num_keys as f64);
         self.counter
-            .find_key_values_by_prefix_key_values_size
+            .find_key_values_in_interval_key_values_size
             .with_label_values(&[])
             .observe(key_values_size as f64);
         Ok((key_values, is_finished))

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -273,14 +273,23 @@ impl RocksDbStoreExecutor {
         let len = self.start_key.len();
         let mut iter = self.get_interval_iterator(&start, &end);
         let mut keys = Vec::new();
+        let mut hit_limit = false;
         while let Some(key) = iter.key() {
             keys.push(key[len..].to_vec());
             if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
+                hit_limit = true;
                 break;
             }
             iter.next();
         }
-        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        // Precise `is_finished`: when we stopped at the limit, advance the
+        // iterator once more and check whether anything remains.
+        let is_finished = if hit_limit {
+            iter.next();
+            iter.key().is_none()
+        } else {
+            true
+        };
         Ok((keys, is_finished))
     }
 
@@ -293,20 +302,24 @@ impl RocksDbStoreExecutor {
         let len = self.start_key.len();
         let mut iter = self.get_interval_iterator(&start, &end);
         let mut key_values = Vec::new();
+        let mut hit_limit = false;
         while let Some((key, value)) = iter.item() {
-            let key_value = (key[len..].to_vec(), value.to_vec());
-            key_values.push(key_value);
+            key_values.push((key[len..].to_vec(), value.to_vec()));
             if key_interval
                 .limit
                 .is_some_and(|limit| key_values.len() >= limit)
             {
+                hit_limit = true;
                 break;
             }
             iter.next();
         }
-        let is_finished = key_interval
-            .limit
-            .is_none_or(|limit| key_values.len() < limit);
+        let is_finished = if hit_limit {
+            iter.next();
+            iter.item().is_none()
+        } else {
+            true
+        };
         Ok((key_values, is_finished))
     }
 

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -6,6 +6,7 @@
 use std::{
     ffi::OsString,
     fmt::Display,
+    ops::Bound::{self, Excluded, Included, Unbounded},
     path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -29,8 +30,8 @@ use crate::{
     common::get_upper_bound_option,
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
-        WritableKeyValueStore,
+        KeyInterval, KeyIntervalStart, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
+        WithError, WritableKeyValueStore,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
@@ -178,63 +179,128 @@ impl RocksDbStoreExecutor {
         Ok(entries.into_iter().collect::<Result<_, _>>()?)
     }
 
-    fn get_find_prefix_iterator(
+    fn get_interval_iterator(
         &self,
-        prefix: &[u8],
+        start: &std::ops::Bound<Vec<u8>>,
+        end: &std::ops::Bound<Vec<u8>>,
     ) -> rocksdb::DBRawIteratorWithThreadMode<'_, DB> {
         // Configure ReadOptions optimized for SSDs and iterator performance
         let mut read_opts = rocksdb::ReadOptions::default();
         // Enable async I/O for better concurrency
         read_opts.set_async_io(true);
+        // Use total order seek to avoid prefix bloom filter mismatches
+        // when the seek key prefix differs from stored key prefixes.
+        read_opts.set_total_order_seek(true);
 
-        // Set precise upper bound to minimize key traversal
-        let upper_bound = get_upper_bound_option(prefix);
+        let upper_bound = match end {
+            Included(bound) => get_upper_bound_option(bound),
+            Excluded(bound) => Some(bound.clone()),
+            Unbounded => None,
+        };
         if let Some(upper_bound) = upper_bound {
             read_opts.set_iterate_upper_bound(upper_bound);
         }
 
         let mut iter = self.db.raw_iterator_opt(read_opts);
-        iter.seek(prefix);
+        match start {
+            Included(bound) | Excluded(bound) => iter.seek(bound),
+            Unbounded => iter.seek_to_first(),
+        }
+        if let Excluded(bound) = start {
+            if iter.key().is_some_and(|key| key == bound.as_slice()) {
+                iter.next();
+            }
+        }
         iter
     }
 
-    fn find_keys_by_prefix_internal(
+    #[expect(clippy::type_complexity)]
+    fn get_full_interval(
         &self,
-        key_prefix: Vec<u8>,
-    ) -> Result<Vec<Vec<u8>>, RocksDbStoreInternalError> {
-        check_key_size(&key_prefix)?;
+        key_interval: &KeyInterval,
+    ) -> Result<(Bound<Vec<u8>>, Bound<Vec<u8>>), RocksDbStoreInternalError> {
+        let start = match &key_interval.start {
+            KeyIntervalStart::Included(key) => {
+                check_key_size(key)?;
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                Included(full_key)
+            }
+            KeyIntervalStart::Excluded(key) => {
+                check_key_size(key)?;
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                Excluded(full_key)
+            }
+        };
+        let end = match &key_interval.end {
+            Included(key) => {
+                check_key_size(key)?;
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                Included(full_key)
+            }
+            Excluded(key) => {
+                check_key_size(key)?;
+                let mut full_key = self.start_key.clone();
+                full_key.extend(key);
+                Excluded(full_key)
+            }
+            Unbounded => {
+                let full_key = self.start_key.clone();
+                if let Some(next_prefix) = get_upper_bound_option(&full_key) {
+                    Excluded(next_prefix)
+                } else {
+                    Unbounded
+                }
+            }
+        };
+        Ok((start, end))
+    }
 
-        let mut prefix = self.start_key.clone();
-        prefix.extend(key_prefix);
-        let len = prefix.len();
-
-        let mut iter = self.get_find_prefix_iterator(&prefix);
+    fn find_keys_in_interval_internal(
+        &self,
+        key_interval: &KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), RocksDbStoreInternalError> {
+        let (start, end) = self.get_full_interval(key_interval)?;
+        let len = self.start_key.len();
+        let mut iter = self.get_interval_iterator(&start, &end);
         let mut keys = Vec::new();
         while let Some(key) = iter.key() {
             keys.push(key[len..].to_vec());
+            if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
+                break;
+            }
             iter.next();
         }
-        Ok(keys)
+        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        Ok((keys, is_finished))
     }
 
     #[expect(clippy::type_complexity)]
-    fn find_key_values_by_prefix_internal(
+    fn find_key_values_in_interval_internal(
         &self,
-        key_prefix: Vec<u8>,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, RocksDbStoreInternalError> {
-        check_key_size(&key_prefix)?;
-        let mut prefix = self.start_key.clone();
-        prefix.extend(key_prefix);
-        let len = prefix.len();
-
-        let mut iter = self.get_find_prefix_iterator(&prefix);
+        key_interval: &KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), RocksDbStoreInternalError> {
+        let (start, end) = self.get_full_interval(key_interval)?;
+        let len = self.start_key.len();
+        let mut iter = self.get_interval_iterator(&start, &end);
         let mut key_values = Vec::new();
         while let Some((key, value)) = iter.item() {
             let key_value = (key[len..].to_vec(), value.to_vec());
             key_values.push(key_value);
+            if key_interval
+                .limit
+                .is_some_and(|limit| key_values.len() >= limit)
+            {
+                break;
+            }
             iter.next();
         }
-        Ok(key_values)
+        let is_finished = key_interval
+            .limit
+            .is_none_or(|limit| key_values.len() < limit);
+        Ok((key_values, is_finished))
     }
 
     fn write_batch_internal(
@@ -512,30 +578,28 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
             .await
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, RocksDbStoreInternalError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), RocksDbStoreInternalError> {
         let executor = self.executor.clone();
-        let key_prefix = key_prefix.to_vec();
         self.spawn_mode
             .spawn(
-                move |x| executor.find_keys_by_prefix_internal(x),
-                key_prefix,
+                move |x| executor.find_keys_in_interval_internal(&x),
+                key_interval,
             )
             .await
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, RocksDbStoreInternalError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), RocksDbStoreInternalError> {
         let executor = self.executor.clone();
-        let key_prefix = key_prefix.to_vec();
         self.spawn_mode
             .spawn(
-                move |x| executor.find_key_values_by_prefix_internal(x),
-                key_prefix,
+                move |x| executor.find_key_values_in_interval_internal(&x),
+                key_interval,
             )
             .await
     }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -193,7 +193,14 @@ impl RocksDbStoreExecutor {
         read_opts.set_total_order_seek(true);
 
         let upper_bound = match end {
-            Included(bound) => get_upper_bound_option(bound),
+            Included(bound) => {
+                // RocksDB's iterate_upper_bound is exclusive. The smallest key
+                // strictly greater than `bound` is `bound + [0]`, which
+                // correctly excludes any key that lex-extends `bound`.
+                let mut upper = bound.clone();
+                upper.push(0);
+                Some(upper)
+            }
             Excluded(bound) => Some(bound.clone()),
             Unbounded => None,
         };

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -9,7 +9,10 @@
 
 use std::{
     collections::{BTreeSet, HashMap},
-    ops::Deref,
+    ops::{
+        Bound::{Excluded, Included, Unbounded},
+        Deref,
+    },
     sync::Arc,
 };
 
@@ -47,8 +50,8 @@ use crate::{
     journaling::{JournalingError, JournalingKeyValueDatabase},
     lru_caching::{LruCachingConfig, LruCachingDatabase},
     store::{
-        DirectWritableKeyValueStore, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
-        WithError,
+        DirectWritableKeyValueStore, KeyInterval, KeyIntervalStart, KeyValueDatabase,
+        KeyValueStoreError, ReadableKeyValueStore, WithError,
     },
     value_splitting::{ValueSplittingDatabase, ValueSplittingError},
 };
@@ -109,10 +112,30 @@ struct ScyllaDbClient {
     write_batch_delete_prefix_bounded: PreparedStatement,
     write_batch_deletion: PreparedStatement,
     write_batch_insertion: PreparedStatement,
-    find_keys_by_prefix_unbounded: PreparedStatement,
-    find_keys_by_prefix_bounded: PreparedStatement,
-    find_key_values_by_prefix_unbounded: PreparedStatement,
-    find_key_values_by_prefix_bounded: PreparedStatement,
+    find_keys_interval_inclusive_inclusive: PreparedStatement,
+    find_keys_interval_inclusive_inclusive_limited: PreparedStatement,
+    find_keys_interval_inclusive_exclusive: PreparedStatement,
+    find_keys_interval_inclusive_exclusive_limited: PreparedStatement,
+    find_keys_interval_inclusive_unbounded: PreparedStatement,
+    find_keys_interval_inclusive_unbounded_limited: PreparedStatement,
+    find_keys_interval_exclusive_inclusive: PreparedStatement,
+    find_keys_interval_exclusive_inclusive_limited: PreparedStatement,
+    find_keys_interval_exclusive_exclusive: PreparedStatement,
+    find_keys_interval_exclusive_exclusive_limited: PreparedStatement,
+    find_keys_interval_exclusive_unbounded: PreparedStatement,
+    find_keys_interval_exclusive_unbounded_limited: PreparedStatement,
+    find_key_values_interval_inclusive_inclusive: PreparedStatement,
+    find_key_values_interval_inclusive_inclusive_limited: PreparedStatement,
+    find_key_values_interval_inclusive_exclusive: PreparedStatement,
+    find_key_values_interval_inclusive_exclusive_limited: PreparedStatement,
+    find_key_values_interval_inclusive_unbounded: PreparedStatement,
+    find_key_values_interval_inclusive_unbounded_limited: PreparedStatement,
+    find_key_values_interval_exclusive_inclusive: PreparedStatement,
+    find_key_values_interval_exclusive_inclusive_limited: PreparedStatement,
+    find_key_values_interval_exclusive_exclusive: PreparedStatement,
+    find_key_values_interval_exclusive_exclusive_limited: PreparedStatement,
+    find_key_values_interval_exclusive_unbounded: PreparedStatement,
+    find_key_values_interval_exclusive_unbounded_limited: PreparedStatement,
     multi_key_values: papaya::HashMap<usize, PreparedStatement>,
     multi_keys: papaya::HashMap<usize, PreparedStatement>,
 }
@@ -156,27 +179,135 @@ impl ScyllaDbClient {
             ))
             .await?;
 
-        let find_keys_by_prefix_unbounded = session
+        let find_keys_interval_inclusive_inclusive = session
             .prepare(format!(
-                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ?"
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k <= ?"
+            ))
+            .await?;
+        let find_keys_interval_inclusive_inclusive_limited = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k <= ? LIMIT ?"
             ))
             .await?;
 
-        let find_keys_by_prefix_bounded = session
+        let find_keys_interval_inclusive_exclusive = session
             .prepare(format!(
                 "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k < ?"
             ))
             .await?;
+        let find_keys_interval_inclusive_exclusive_limited = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k < ? LIMIT ?"
+            ))
+            .await?;
 
-        let find_key_values_by_prefix_unbounded = session
+        let find_keys_interval_inclusive_unbounded = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ?"
+            ))
+            .await?;
+        let find_keys_interval_inclusive_unbounded_limited = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_keys_interval_exclusive_inclusive = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k <= ?"
+            ))
+            .await?;
+        let find_keys_interval_exclusive_inclusive_limited = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k <= ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_keys_interval_exclusive_exclusive = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k < ?"
+            ))
+            .await?;
+        let find_keys_interval_exclusive_exclusive_limited = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k < ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_keys_interval_exclusive_unbounded = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ?"
+            ))
+            .await?;
+        let find_keys_interval_exclusive_unbounded_limited = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_key_values_interval_inclusive_inclusive = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k <= ?"
+            ))
+            .await?;
+        let find_key_values_interval_inclusive_inclusive_limited = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k <= ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_key_values_interval_inclusive_exclusive = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k < ?"
+            ))
+            .await?;
+        let find_key_values_interval_inclusive_exclusive_limited = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k < ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_key_values_interval_inclusive_unbounded = session
             .prepare(format!(
                 "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ?"
             ))
             .await?;
-
-        let find_key_values_by_prefix_bounded = session
+        let find_key_values_interval_inclusive_unbounded_limited = session
             .prepare(format!(
-                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? AND k < ?"
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k >= ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_key_values_interval_exclusive_inclusive = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k <= ?"
+            ))
+            .await?;
+        let find_key_values_interval_exclusive_inclusive_limited = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k <= ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_key_values_interval_exclusive_exclusive = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k < ?"
+            ))
+            .await?;
+        let find_key_values_interval_exclusive_exclusive_limited = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? AND k < ? LIMIT ?"
+            ))
+            .await?;
+
+        let find_key_values_interval_exclusive_unbounded = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ?"
+            ))
+            .await?;
+        let find_key_values_interval_exclusive_unbounded_limited = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k > ? LIMIT ?"
             ))
             .await?;
 
@@ -189,10 +320,30 @@ impl ScyllaDbClient {
             write_batch_delete_prefix_bounded,
             write_batch_deletion,
             write_batch_insertion,
-            find_keys_by_prefix_unbounded,
-            find_keys_by_prefix_bounded,
-            find_key_values_by_prefix_unbounded,
-            find_key_values_by_prefix_bounded,
+            find_keys_interval_inclusive_inclusive,
+            find_keys_interval_inclusive_inclusive_limited,
+            find_keys_interval_inclusive_exclusive,
+            find_keys_interval_inclusive_exclusive_limited,
+            find_keys_interval_inclusive_unbounded,
+            find_keys_interval_inclusive_unbounded_limited,
+            find_keys_interval_exclusive_inclusive,
+            find_keys_interval_exclusive_inclusive_limited,
+            find_keys_interval_exclusive_exclusive,
+            find_keys_interval_exclusive_exclusive_limited,
+            find_keys_interval_exclusive_unbounded,
+            find_keys_interval_exclusive_unbounded_limited,
+            find_key_values_interval_inclusive_inclusive,
+            find_key_values_interval_inclusive_inclusive_limited,
+            find_key_values_interval_inclusive_exclusive,
+            find_key_values_interval_inclusive_exclusive_limited,
+            find_key_values_interval_inclusive_unbounded,
+            find_key_values_interval_inclusive_unbounded_limited,
+            find_key_values_interval_exclusive_inclusive,
+            find_key_values_interval_exclusive_inclusive_limited,
+            find_key_values_interval_exclusive_exclusive,
+            find_key_values_interval_exclusive_exclusive_limited,
+            find_key_values_interval_exclusive_unbounded,
+            find_key_values_interval_exclusive_unbounded_limited,
             multi_key_values: papaya::HashMap::new(),
             multi_keys: papaya::HashMap::new(),
         })
@@ -442,66 +593,326 @@ impl ScyllaDbClient {
         Ok(())
     }
 
-    async fn find_keys_by_prefix_internal(
+    async fn find_keys_in_interval_internal(
         &self,
         root_key: &[u8],
-        key_prefix: Vec<u8>,
-    ) -> Result<Vec<Vec<u8>>, ScyllaDbStoreInternalError> {
-        Self::check_key_size(&key_prefix)?;
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), ScyllaDbStoreInternalError> {
         let session = &self.session;
-        // Read the value of a key
-        let len = key_prefix.len();
-        let query_unbounded = &self.find_keys_by_prefix_unbounded;
-        let query_bounded = &self.find_keys_by_prefix_bounded;
-        let rows = match get_upper_bound_option(&key_prefix) {
-            None => {
-                let values = (root_key.to_vec(), key_prefix.clone());
-                Box::pin(session.execute_iter(query_unbounded.clone(), values)).await?
+        let limit = key_interval
+            .limit
+            .map(|limit| limit.min(i32::MAX as usize) as i32);
+        let rows = match (key_interval.start, key_interval.end) {
+            (KeyIntervalStart::Included(start), Included(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_inclusive_inclusive_limited.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_inclusive_inclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
             }
-            Some(upper_bound) => {
-                let values = (root_key.to_vec(), key_prefix.clone(), upper_bound);
-                Box::pin(session.execute_iter(query_bounded.clone(), values)).await?
+            (KeyIntervalStart::Included(start), Excluded(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_inclusive_exclusive_limited.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_inclusive_exclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Included(start), Unbounded) => {
+                Self::check_key_size(&start)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, limit);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_inclusive_unbounded_limited.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_inclusive_unbounded.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Excluded(start), Included(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_exclusive_inclusive_limited.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_exclusive_inclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Excluded(start), Excluded(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_exclusive_exclusive_limited.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_exclusive_exclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Excluded(start), Unbounded) => {
+                Self::check_key_size(&start)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, limit);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_exclusive_unbounded_limited.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start);
+                        Box::pin(session.execute_iter(
+                            self.find_keys_interval_exclusive_unbounded.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
             }
         };
         let mut rows = rows.rows_stream::<(Vec<u8>,)>()?;
         let mut keys = Vec::new();
         while let Some(row) = rows.next().await {
             let (key,) = row?;
-            let short_key = key[len..].to_vec();
-            keys.push(short_key);
+            keys.push(key);
         }
-        Ok(keys)
+        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        Ok((keys, is_finished))
     }
 
-    async fn find_key_values_by_prefix_internal(
+    async fn find_key_values_in_interval_internal(
         &self,
         root_key: &[u8],
-        key_prefix: Vec<u8>,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ScyllaDbStoreInternalError> {
-        Self::check_key_size(&key_prefix)?;
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ScyllaDbStoreInternalError> {
         let session = &self.session;
-        // Read the value of a key
-        let len = key_prefix.len();
-        let query_unbounded = &self.find_key_values_by_prefix_unbounded;
-        let query_bounded = &self.find_key_values_by_prefix_bounded;
-        let rows = match get_upper_bound_option(&key_prefix) {
-            None => {
-                let values = (root_key.to_vec(), key_prefix.clone());
-                Box::pin(session.execute_iter(query_unbounded.clone(), values)).await?
+        let limit = key_interval
+            .limit
+            .map(|limit| limit.min(i32::MAX as usize) as i32);
+        let rows = match (key_interval.start, key_interval.end) {
+            (KeyIntervalStart::Included(start), Included(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(
+                            session.execute_iter(
+                                self.find_key_values_interval_inclusive_inclusive_limited
+                                    .clone(),
+                                values,
+                            ),
+                        )
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_key_values_interval_inclusive_inclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
             }
-            Some(upper_bound) => {
-                let values = (root_key.to_vec(), key_prefix.clone(), upper_bound);
-                Box::pin(session.execute_iter(query_bounded.clone(), values)).await?
+            (KeyIntervalStart::Included(start), Excluded(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(
+                            session.execute_iter(
+                                self.find_key_values_interval_inclusive_exclusive_limited
+                                    .clone(),
+                                values,
+                            ),
+                        )
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_key_values_interval_inclusive_exclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Included(start), Unbounded) => {
+                Self::check_key_size(&start)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, limit);
+                        Box::pin(
+                            session.execute_iter(
+                                self.find_key_values_interval_inclusive_unbounded_limited
+                                    .clone(),
+                                values,
+                            ),
+                        )
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start);
+                        Box::pin(session.execute_iter(
+                            self.find_key_values_interval_inclusive_unbounded.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Excluded(start), Included(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(
+                            session.execute_iter(
+                                self.find_key_values_interval_exclusive_inclusive_limited
+                                    .clone(),
+                                values,
+                            ),
+                        )
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_key_values_interval_exclusive_inclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Excluded(start), Excluded(end)) => {
+                Self::check_key_size(&start)?;
+                Self::check_key_size(&end)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, end, limit);
+                        Box::pin(
+                            session.execute_iter(
+                                self.find_key_values_interval_exclusive_exclusive_limited
+                                    .clone(),
+                                values,
+                            ),
+                        )
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start, end);
+                        Box::pin(session.execute_iter(
+                            self.find_key_values_interval_exclusive_exclusive.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
+            }
+            (KeyIntervalStart::Excluded(start), Unbounded) => {
+                Self::check_key_size(&start)?;
+                match limit {
+                    Some(limit) => {
+                        let values = (root_key.to_vec(), start, limit);
+                        Box::pin(
+                            session.execute_iter(
+                                self.find_key_values_interval_exclusive_unbounded_limited
+                                    .clone(),
+                                values,
+                            ),
+                        )
+                        .await?
+                    }
+                    None => {
+                        let values = (root_key.to_vec(), start);
+                        Box::pin(session.execute_iter(
+                            self.find_key_values_interval_exclusive_unbounded.clone(),
+                            values,
+                        ))
+                        .await?
+                    }
+                }
             }
         };
         let mut rows = rows.rows_stream::<(Vec<u8>, Vec<u8>)>()?;
         let mut key_values = Vec::new();
         while let Some(row) = rows.next().await {
             let (key, value) = row?;
-            let short_key = key[len..].to_vec();
-            key_values.push((short_key, value));
+            key_values.push((key, value));
         }
-        Ok(key_values)
+        let is_finished = key_interval
+            .limit
+            .is_none_or(|limit| key_values.len() < limit);
+        Ok((key_values, is_finished))
     }
 }
 
@@ -658,23 +1069,22 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         Ok(results.into_iter().flatten().collect())
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, ScyllaDbStoreInternalError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), ScyllaDbStoreInternalError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
-        Box::pin(store.find_keys_by_prefix_internal(&self.root_key, key_prefix.to_vec())).await
+        Box::pin(store.find_keys_in_interval_internal(&self.root_key, key_interval)).await
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ScyllaDbStoreInternalError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ScyllaDbStoreInternalError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
-        Box::pin(store.find_key_values_by_prefix_internal(&self.root_key, key_prefix.to_vec()))
-            .await
+        Box::pin(store.find_key_values_in_interval_internal(&self.root_key, key_interval)).await
     }
 }
 

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -599,9 +599,10 @@ impl ScyllaDbClient {
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), ScyllaDbStoreInternalError> {
         let session = &self.session;
-        let limit = key_interval
-            .limit
-            .map(|limit| limit.min(i32::MAX as usize) as i32);
+        // Ask for one row past the user-requested limit so we can tell
+        // whether the database has more matches without an extra round-trip.
+        let user_limit = key_interval.limit;
+        let limit = user_limit.map(|limit| limit.saturating_add(1).min(i32::MAX as usize) as i32);
         let rows = match (key_interval.start, key_interval.end) {
             (KeyIntervalStart::Included(start), Included(end)) => {
                 Self::check_key_size(&start)?;
@@ -740,7 +741,19 @@ impl ScyllaDbClient {
             let (key,) = row?;
             keys.push(key);
         }
-        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        // We asked for one extra row above. If we got it, drop it and report
+        // unfinished; otherwise the scan is exhausted within the user limit.
+        let is_finished = match user_limit {
+            Some(limit) => {
+                if keys.len() > limit {
+                    keys.truncate(limit);
+                    false
+                } else {
+                    true
+                }
+            }
+            None => true,
+        };
         Ok((keys, is_finished))
     }
 
@@ -750,9 +763,8 @@ impl ScyllaDbClient {
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ScyllaDbStoreInternalError> {
         let session = &self.session;
-        let limit = key_interval
-            .limit
-            .map(|limit| limit.min(i32::MAX as usize) as i32);
+        let user_limit = key_interval.limit;
+        let limit = user_limit.map(|limit| limit.saturating_add(1).min(i32::MAX as usize) as i32);
         let rows = match (key_interval.start, key_interval.end) {
             (KeyIntervalStart::Included(start), Included(end)) => {
                 Self::check_key_size(&start)?;
@@ -909,9 +921,17 @@ impl ScyllaDbClient {
             let (key, value) = row?;
             key_values.push((key, value));
         }
-        let is_finished = key_interval
-            .limit
-            .is_none_or(|limit| key_values.len() < limit);
+        let is_finished = match user_limit {
+            Some(limit) => {
+                if key_values.len() > limit {
+                    key_values.truncate(limit);
+                    false
+                } else {
+                    true
+                }
+            }
+            None => true,
+        };
         Ok((key_values, is_finished))
     }
 }

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -9,8 +9,8 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     store::{
-        KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore, WithError,
-        WritableKeyValueStore,
+        KeyInterval, KeyIntervalStart, KeyValueDatabase, KeyValueStoreError, ReadableKeyValueStore,
+        WithError, WritableKeyValueStore,
     },
 };
 #[cfg(with_testing)]
@@ -206,23 +206,55 @@ where
         Ok(big_values)
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
+    async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
+        let big_interval = Self::get_big_key_interval(&key_interval);
         let mut keys = Vec::new();
-        for big_key in self.store.find_keys_by_prefix(key_prefix).await? {
-            let len = big_key.len();
-            if Self::read_index_from_key(&big_key)? == 0 {
-                let key = big_key[0..len - 4].to_vec();
-                keys.push(key);
+        let mut next_start = big_interval.start;
+        loop {
+            let remaining_limit = key_interval.limit.map(|limit| limit - keys.len());
+            if remaining_limit == Some(0) {
+                return Ok((keys, false));
             }
+            let (big_keys, is_big_finished) = self
+                .store
+                .find_keys_in_interval(KeyInterval {
+                    start: next_start.clone(),
+                    end: big_interval.end.clone(),
+                    limit: remaining_limit,
+                })
+                .await?;
+            let mut last_big_key = None;
+            for big_key in big_keys {
+                let len = big_key.len();
+                last_big_key = Some(big_key.clone());
+                if Self::read_index_from_key(&big_key)? == 0 {
+                    let key = big_key[0..len - 4].to_vec();
+                    keys.push(key);
+                    if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
+                        return Ok((keys, false));
+                    }
+                }
+            }
+            if is_big_finished {
+                return Ok((keys, true));
+            }
+            let Some(last_big_key) = last_big_key else {
+                return Ok((keys, false));
+            };
+            next_start = KeyIntervalStart::Excluded(last_big_key);
         }
-        Ok(keys)
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
-        let small_key_values = self.store.find_key_values_by_prefix(key_prefix).await?;
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
+        let big_interval = Self::get_big_key_interval(&key_interval);
+        let (small_key_values, is_big_finished) =
+            self.store.find_key_values_in_interval(big_interval).await?;
         let mut small_kv_iterator = small_key_values.into_iter();
         let mut key_values = Vec::new();
         while let Some((mut big_key, value)) = small_kv_iterator.next() {
@@ -234,9 +266,12 @@ where
             let count = Self::read_count_from_value(&value)?;
             let mut big_value = value[4..].to_vec();
             for idx in 1..count {
-                let (big_key, value) = small_kv_iterator
-                    .next()
-                    .ok_or(ValueSplittingError::MissingSegment)?;
+                let Some((big_key, value)) = small_kv_iterator.next() else {
+                    if is_big_finished {
+                        return Err(ValueSplittingError::MissingSegment);
+                    }
+                    return Ok((key_values, false));
+                };
                 ensure!(
                     Self::read_index_from_key(&big_key)? == idx
                         && big_key.starts_with(&key)
@@ -246,8 +281,18 @@ where
                 big_value.extend(value);
             }
             key_values.push((key, big_value));
+            if key_interval
+                .limit
+                .is_some_and(|limit| key_values.len() >= limit)
+            {
+                break;
+            }
         }
-        Ok(key_values)
+        let is_finished = match key_interval.limit {
+            Some(limit) => key_values.len() < limit,
+            None => is_big_finished,
+        };
+        Ok((key_values, is_finished))
     }
 }
 
@@ -293,6 +338,36 @@ where
 
     async fn clear_journal(&self) -> Result<(), Self::Error> {
         Ok(self.store.clear_journal().await?)
+    }
+}
+
+impl<S> ValueSplittingStore<S>
+where
+    S: ReadableKeyValueStore,
+{
+    fn get_big_key_interval(key_interval: &KeyInterval) -> KeyInterval {
+        let start = match &key_interval.start {
+            KeyIntervalStart::Included(key) => {
+                KeyIntervalStart::Included([key.as_slice(), &[0, 0, 0, 0]].concat())
+            }
+            KeyIntervalStart::Excluded(key) => {
+                KeyIntervalStart::Excluded([key.as_slice(), &[0, 0, 0, 0]].concat())
+            }
+        };
+        let end = match &key_interval.end {
+            std::ops::Bound::Included(key) => {
+                std::ops::Bound::Included([key.as_slice(), &[u8::MAX; 4]].concat())
+            }
+            std::ops::Bound::Excluded(key) => {
+                std::ops::Bound::Excluded([key.as_slice(), &[0, 0, 0, 0]].concat())
+            }
+            std::ops::Bound::Unbounded => std::ops::Bound::Unbounded,
+        };
+        KeyInterval {
+            start,
+            end,
+            limit: key_interval.limit,
+        }
     }
 }
 
@@ -459,18 +534,18 @@ impl ReadableKeyValueStore for LimitedTestMemoryStore {
         self.inner.read_multi_values_bytes(keys).await
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, MemoryStoreError> {
-        self.inner.find_keys_by_prefix(key_prefix).await
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), MemoryStoreError> {
+        self.inner.find_keys_in_interval(key_interval).await
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, MemoryStoreError> {
-        self.inner.find_key_values_by_prefix(key_prefix).await
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), MemoryStoreError> {
+        self.inner.find_key_values_in_interval(key_interval).await
     }
 }
 

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -210,6 +210,9 @@ where
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
+        }
         let big_interval = Self::get_big_key_interval(&key_interval);
         let mut keys = Vec::new();
         let mut next_start = big_interval.start;
@@ -230,12 +233,20 @@ where
             for big_key in big_keys {
                 let len = big_key.len();
                 last_big_key = Some(big_key.clone());
-                if Self::read_index_from_key(&big_key)? == 0 {
-                    let key = big_key[0..len - 4].to_vec();
-                    keys.push(key);
-                    if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
-                        return Ok((keys, false));
-                    }
+                if Self::read_index_from_key(&big_key)? != 0 {
+                    continue;
+                }
+                let key = big_key[0..len - 4].to_vec();
+                // The big-key interval is a loose superset of the user
+                // interval (variable-length user keys cause prefix-extending
+                // user keys to land between `K || [0;4]` and `K || [255;4]`),
+                // so we re-check each reconstructed user key.
+                if !key_interval.contains(&key) {
+                    continue;
+                }
+                keys.push(key);
+                if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
+                    return Ok((keys, false));
                 }
             }
             if is_big_finished {
@@ -252,47 +263,97 @@ where
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
-        let big_interval = Self::get_big_key_interval(&key_interval);
-        let (small_key_values, is_big_finished) =
-            self.store.find_key_values_in_interval(big_interval).await?;
-        let mut small_kv_iterator = small_key_values.into_iter();
-        let mut key_values = Vec::new();
-        while let Some((mut big_key, value)) = small_kv_iterator.next() {
-            if Self::read_index_from_key(&big_key)? != 0 {
-                continue; // Leftover segment from an earlier value.
-            }
-            big_key.truncate(big_key.len() - 4);
-            let key = big_key;
-            let count = Self::read_count_from_value(&value)?;
-            let mut big_value = value[4..].to_vec();
-            for idx in 1..count {
-                let Some((big_key, value)) = small_kv_iterator.next() else {
-                    if is_big_finished {
-                        return Err(ValueSplittingError::MissingSegment);
-                    }
-                    return Ok((key_values, false));
-                };
-                ensure!(
-                    Self::read_index_from_key(&big_key)? == idx
-                        && big_key.starts_with(&key)
-                        && big_key.len() == key.len() + 4,
-                    ValueSplittingError::MissingSegment
-                );
-                big_value.extend(value);
-            }
-            key_values.push((key, big_value));
-            if key_interval
-                .limit
-                .is_some_and(|limit| key_values.len() >= limit)
-            {
-                break;
-            }
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
         }
-        let is_finished = match key_interval.limit {
-            Some(limit) => key_values.len() < limit,
-            None => is_big_finished,
-        };
-        Ok((key_values, is_finished))
+        let big_interval = Self::get_big_key_interval(&key_interval);
+        let mut key_values: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+        let mut next_start = big_interval.start;
+        loop {
+            let remaining_limit = key_interval.limit.map(|limit| limit - key_values.len());
+            if remaining_limit == Some(0) {
+                return Ok((key_values, false));
+            }
+            let (small_kvs, is_big_finished) = self
+                .store
+                .find_key_values_in_interval(KeyInterval {
+                    start: next_start.clone(),
+                    end: big_interval.end.clone(),
+                    limit: remaining_limit,
+                })
+                .await?;
+            if small_kvs.is_empty() {
+                return Ok((key_values, is_big_finished));
+            }
+            let mut iter = small_kvs.into_iter();
+            let mut last_big_key: Option<Vec<u8>> = None;
+            let mut limit_reached = false;
+            while let Some((big_key, value)) = iter.next() {
+                last_big_key = Some(big_key.clone());
+                if Self::read_index_from_key(&big_key)? != 0 {
+                    // Tail segment of an earlier user key (only possible at
+                    // the start of a batch when an `Excluded(start)` lands
+                    // inside a segmented value).
+                    continue;
+                }
+                let mut user_key = big_key;
+                user_key.truncate(user_key.len() - 4);
+                let count = Self::read_count_from_value(&value)?;
+                let mut full_value = value[4..].to_vec();
+                let mut consumed_idx = 0u32;
+                while consumed_idx + 1 < count {
+                    let Some((seg_key, seg_value)) = iter.next() else {
+                        break;
+                    };
+                    ensure!(
+                        Self::read_index_from_key(&seg_key)? == consumed_idx + 1
+                            && seg_key.starts_with(&user_key)
+                            && seg_key.len() == user_key.len() + 4,
+                        ValueSplittingError::MissingSegment
+                    );
+                    last_big_key = Some(seg_key);
+                    full_value.extend(seg_value);
+                    consumed_idx += 1;
+                }
+                if consumed_idx + 1 < count {
+                    // The current batch ran out before we could read all
+                    // segments of this value. Fall back to point reads for
+                    // the remaining ones rather than refetching the whole
+                    // tail by scan (which would risk the same truncation).
+                    let missing_keys: Vec<Vec<u8>> = (consumed_idx + 1..count)
+                        .map(|i| Self::get_segment_key(&user_key, i))
+                        .collect::<Result<_, _>>()?;
+                    let missing_values =
+                        self.store.read_multi_values_bytes(&missing_keys).await?;
+                    for (i, value_opt) in missing_values.into_iter().enumerate() {
+                        let value = value_opt.ok_or(ValueSplittingError::MissingSegment)?;
+                        full_value.extend(value);
+                        last_big_key = Some(missing_keys[i].clone());
+                    }
+                }
+                if !key_interval.contains(&user_key) {
+                    continue;
+                }
+                key_values.push((user_key, full_value));
+                if key_interval
+                    .limit
+                    .is_some_and(|limit| key_values.len() >= limit)
+                {
+                    limit_reached = true;
+                    break;
+                }
+            }
+            if limit_reached {
+                return Ok((key_values, false));
+            }
+            if is_big_finished {
+                return Ok((key_values, true));
+            }
+            let Some(last) = last_big_key else {
+                return Ok((key_values, false));
+            };
+            next_start = KeyIntervalStart::Excluded(last);
+        }
     }
 }
 

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -328,8 +328,7 @@ where
                     let missing_keys: Vec<Vec<u8>> = (consumed_idx + 1..count)
                         .map(|i| Self::get_segment_key(&user_key, i))
                         .collect::<Result<_, _>>()?;
-                    let missing_values =
-                        self.store.read_multi_values_bytes(&missing_keys).await?;
+                    let missing_values = self.store.read_multi_values_bytes(&missing_keys).await?;
                     for (i, value_opt) in missing_values.into_iter().enumerate() {
                         let value = value_opt.ok_or(ValueSplittingError::MissingSegment)?;
                         full_value.extend(value);

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -230,7 +230,8 @@ where
                 })
                 .await?;
             let mut last_big_key = None;
-            for big_key in big_keys {
+            let n_big_keys = big_keys.len();
+            for (i, big_key) in big_keys.into_iter().enumerate() {
                 let len = big_key.len();
                 last_big_key = Some(big_key.clone());
                 if Self::read_index_from_key(&big_key)? != 0 {
@@ -246,7 +247,11 @@ where
                 }
                 keys.push(key);
                 if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
-                    return Ok((keys, false));
+                    // Precise `is_finished`: if we just consumed the last
+                    // big-key of the batch and the inner store reports it is
+                    // exhausted, no more matches are possible.
+                    let is_finished = i + 1 == n_big_keys && is_big_finished;
+                    return Ok((keys, is_finished));
                 }
             }
             if is_big_finished {
@@ -344,7 +349,14 @@ where
                 }
             }
             if limit_reached {
-                return Ok((key_values, false));
+                // Precise `is_finished`: if the batch iterator has no more
+                // items (the tail segments of the current user key were all
+                // consumed in the inner while-loop, so the next item would
+                // be segment 0 of a fresh user key) and the inner store is
+                // exhausted, no more matches are possible.
+                let batch_exhausted = iter.next().is_none();
+                let is_finished = batch_exhausted && is_big_finished;
+                return Ok((key_values, is_finished));
             }
             if is_big_finished {
                 return Ok((key_values, true));

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -16,7 +16,7 @@ use allocative::Allocative;
 use itertools::Either;
 use serde::de::DeserializeOwned;
 
-use crate::ViewError;
+use crate::{store::KeyIntervalStart, ViewError};
 
 type HasherOutputSize = <sha3::Sha3_256 as sha3::digest::OutputSizeUser>::OutputSize;
 #[doc(hidden)]
@@ -104,6 +104,32 @@ pub(crate) fn get_upper_bound(key_prefix: &[u8]) -> Bound<Vec<u8>> {
 pub(crate) fn get_key_range_for_prefix(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
     let upper_bound = get_upper_bound(&key_prefix);
     (Included(key_prefix), upper_bound)
+}
+
+#[allow(dead_code)]
+pub(crate) fn key_matches_interval(key: &[u8], start: Bound<&[u8]>, end: Bound<&[u8]>) -> bool {
+    let start_matches = match start {
+        Included(bound) => key >= bound,
+        Excluded(bound) => key > bound,
+        Unbounded => true,
+    };
+    let end_matches = match end {
+        Included(bound) => key <= bound,
+        Excluded(bound) => key < bound,
+        Unbounded => true,
+    };
+    start_matches && end_matches
+}
+
+pub(crate) fn get_interval_range(
+    start: KeyIntervalStart<Vec<u8>>,
+    end: Bound<Vec<u8>>,
+) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+    let start = match start {
+        KeyIntervalStart::Included(key) => Included(key),
+        KeyIntervalStart::Excluded(key) => Excluded(key),
+    };
+    (start, end)
 }
 
 /// Deserializes an optional vector of `u8`

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -77,7 +77,7 @@ impl DeletionSet {
 /// is possible with the way the comparison operators for vectors are built.
 ///
 /// The statement is that `p` is a prefix of `v` if and only if `p <= v < upper_bound(p)`.
-pub(crate) fn get_upper_bound_option(key_prefix: &[u8]) -> Option<Vec<u8>> {
+pub fn get_upper_bound_option(key_prefix: &[u8]) -> Option<Vec<u8>> {
     let len = key_prefix.len();
     for i in (0..len).rev() {
         if key_prefix[i] < u8::MAX {

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -3,7 +3,11 @@
 
 //! This provides the trait definitions for the stores.
 
-use std::{fmt::Debug, future::Future};
+use std::{
+    fmt::Debug,
+    future::Future,
+    ops::Bound::{self, Excluded, Included, Unbounded},
+};
 
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -11,9 +15,73 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::random::generate_test_namespace;
 use crate::{
     batch::{Batch, SimplifiedBatch},
-    common::from_bytes_option,
+    common::{from_bytes_option, get_upper_bound_option},
     ViewError,
 };
+
+/// The lower bound of a key interval.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum KeyIntervalStart<T> {
+    /// Inclusive lower bound.
+    Included(T),
+    /// Exclusive lower bound.
+    Excluded(T),
+}
+
+/// A key interval for scan operations.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyInterval {
+    /// The lower bound of the interval.
+    pub start: KeyIntervalStart<Vec<u8>>,
+    /// The upper bound of the interval.
+    pub end: Bound<Vec<u8>>,
+    /// The maximal number of entries to return.
+    pub limit: Option<usize>,
+}
+
+impl KeyInterval {
+    /// Creates a new interval.
+    pub fn new(start: KeyIntervalStart<Vec<u8>>, end: Bound<Vec<u8>>) -> Self {
+        Self {
+            start,
+            end,
+            limit: None,
+        }
+    }
+
+    /// Creates a prefix interval `[prefix, upper_bound(prefix))`.
+    pub fn for_prefix(key_prefix: &[u8]) -> Self {
+        let start = KeyIntervalStart::Included(key_prefix.to_vec());
+        let end = match get_upper_bound_option(key_prefix) {
+            Some(upper_bound) => Excluded(upper_bound),
+            None => Unbounded,
+        };
+        Self::new(start, end)
+    }
+
+    /// Sets the maximal number of entries to return.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
+
+    /// Returns the interval start if it is bounded.
+    pub fn start_bound(&self) -> Bound<&[u8]> {
+        match &self.start {
+            KeyIntervalStart::Included(key) => Included(key.as_slice()),
+            KeyIntervalStart::Excluded(key) => Excluded(key.as_slice()),
+        }
+    }
+
+    /// Returns the interval end if it is bounded.
+    pub fn end_bound(&self) -> Bound<&[u8]> {
+        match &self.end {
+            Included(key) => Included(key.as_slice()),
+            Excluded(key) => Excluded(key.as_slice()),
+            Unbounded => Unbounded,
+        }
+    }
+}
 
 /// The error type for the key-value stores.
 pub trait KeyValueStoreError:
@@ -47,6 +115,7 @@ pub trait WithError {
 }
 
 /// Asynchronous read key-value operations.
+#[expect(clippy::type_complexity)]
 #[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait ReadableKeyValueStore: WithError {
     /// The maximal size of keys that can be stored.
@@ -73,14 +142,49 @@ pub trait ReadableKeyValueStore: WithError {
         keys: &[Vec<u8>],
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
 
-    /// Finds the `key` matching the prefix. The prefix is not included in the returned keys.
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
+    /// Finds the `key`s matching the interval.
+    async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), Self::Error>;
 
-    /// Finds the `(key,value)` pairs matching the prefix. The prefix is not included in the returned keys.
-    async fn find_key_values_by_prefix(
+    /// Finds the `(key, value)` pairs matching the interval.
+    async fn find_key_values_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error>;
+
+    /// Finds the `key` matching the prefix. The prefix is not included in the returned keys.
+    fn find_keys_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error>;
+    ) -> impl Future<Output = Result<Vec<Vec<u8>>, Self::Error>> {
+        async move {
+            let prefix_len = key_prefix.len();
+            let key_interval = KeyInterval::for_prefix(key_prefix);
+            let (keys, _) = Box::pin(self.find_keys_in_interval(key_interval)).await?;
+            Ok(keys
+                .into_iter()
+                .map(|key| key[prefix_len..].to_vec())
+                .collect())
+        }
+    }
+
+    /// Finds the `(key,value)` pairs matching the prefix. The prefix is not included in the returned keys.
+    fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> impl Future<Output = Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error>> {
+        async move {
+            let prefix_len = key_prefix.len();
+            let key_interval = KeyInterval::for_prefix(key_prefix);
+            let (key_values, _) = Box::pin(self.find_key_values_in_interval(key_interval)).await?;
+            Ok(key_values
+                .into_iter()
+                .map(|(key, value)| (key[prefix_len..].to_vec(), value))
+                .collect())
+        }
+    }
 
     // We can't use `async fn` here in the below implementations due to
     // https://github.com/rust-lang/impl-trait-utils/issues/17, but once that bug is fixed
@@ -327,18 +431,18 @@ pub mod inactive_store {
             panic!("attempt to read from an inactive store!")
         }
 
-        async fn find_keys_by_prefix(
+        async fn find_keys_in_interval(
             &self,
-            _key_prefix: &[u8],
-        ) -> Result<Vec<Vec<u8>>, Self::Error> {
+            _key_interval: KeyInterval,
+        ) -> Result<(Vec<Vec<u8>>, bool), Self::Error> {
             panic!("attempt to read from an inactive store!")
         }
 
-        /// Finds the `(key,value)` pairs matching the prefix. The prefix is not included in the returned keys.
-        async fn find_key_values_by_prefix(
+        /// Finds the `(key,value)` pairs matching the interval.
+        async fn find_key_values_in_interval(
             &self,
-            _key_prefix: &[u8],
-        ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
+            _key_interval: KeyInterval,
+        ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), Self::Error> {
             panic!("attempt to read from an inactive store!")
         }
     }

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -82,6 +82,26 @@ impl KeyInterval {
         }
     }
 
+    /// Returns the longest common byte prefix shared by the start and end
+    /// keys of this interval. Any key inside the interval (any inclusivity)
+    /// must start with this prefix. Returns the empty vector when the end
+    /// is `Unbounded` (only an empty-prefix scan can cover such a request).
+    pub fn common_prefix(&self) -> Vec<u8> {
+        let start = match &self.start {
+            KeyIntervalStart::Included(k) | KeyIntervalStart::Excluded(k) => k.as_slice(),
+        };
+        let end = match &self.end {
+            Included(k) | Excluded(k) => k.as_slice(),
+            Unbounded => return Vec::new(),
+        };
+        let n = start
+            .iter()
+            .zip(end.iter())
+            .take_while(|(a, b)| a == b)
+            .count();
+        start[..n].to_vec()
+    }
+
     /// Returns `true` if `key` falls within this interval's bounds. The
     /// `limit` field is ignored.
     pub fn contains(&self, key: &[u8]) -> bool {

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -82,6 +82,21 @@ impl KeyInterval {
         }
     }
 
+    /// Returns `true` if `key` falls within this interval's bounds. The
+    /// `limit` field is ignored.
+    pub fn contains(&self, key: &[u8]) -> bool {
+        let lo_ok = match &self.start {
+            KeyIntervalStart::Included(bound) => key >= bound.as_slice(),
+            KeyIntervalStart::Excluded(bound) => key > bound.as_slice(),
+        };
+        let hi_ok = match &self.end {
+            Included(bound) => key <= bound.as_slice(),
+            Excluded(bound) => key < bound.as_slice(),
+            Unbounded => true,
+        };
+        lo_ok && hi_ok
+    }
+
     /// Returns `true` if the bounds make this interval provably empty
     /// (i.e. `start` is past `end`). Backends that delegate to a range
     /// primitive which panics on degenerate input (`BTreeMap::range`

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -81,6 +81,24 @@ impl KeyInterval {
             Unbounded => Unbounded,
         }
     }
+
+    /// Returns `true` if the bounds make this interval provably empty
+    /// (i.e. `start` is past `end`). Backends that delegate to a range
+    /// primitive which panics on degenerate input (`BTreeMap::range`
+    /// rejects equal-and-excluded; DynamoDB rejects `BETWEEN lo > hi`)
+    /// must short-circuit on this case.
+    pub fn is_empty(&self) -> bool {
+        let (start_key, start_inclusive) = match &self.start {
+            KeyIntervalStart::Included(key) => (key.as_slice(), true),
+            KeyIntervalStart::Excluded(key) => (key.as_slice(), false),
+        };
+        match &self.end {
+            Included(end) if start_inclusive => start_key > end.as_slice(),
+            Included(end) => start_key >= end.as_slice(),
+            Excluded(end) => start_key >= end.as_slice(),
+            Unbounded => false,
+        }
+    }
 }
 
 /// The error type for the key-value stores.

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -18,8 +18,8 @@ use crate::{
     },
     random::{generate_test_namespace, make_deterministic_rng, make_nondeterministic_rng},
     store::{
-        KeyValueDatabase, KeyValueStore, ReadableKeyValueStore, TestKeyValueDatabase,
-        WritableKeyValueStore,
+        KeyInterval, KeyIntervalStart, KeyValueDatabase, KeyValueStore, ReadableKeyValueStore,
+        TestKeyValueDatabase, WritableKeyValueStore,
     },
 };
 
@@ -203,6 +203,104 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
         }
         assert_eq!(set_key_value1, set_key_value2);
     }
+
+    let mut sorted_key_values = key_values.clone();
+    sorted_key_values.sort();
+    if let [first, middle @ .., last] = sorted_key_values.as_slice() {
+        let start = first.0.clone();
+        let end = last.0.clone();
+        let inclusive = store
+            .find_key_values_in_interval(KeyInterval::new(
+                KeyIntervalStart::Included(start.clone()),
+                std::ops::Bound::Included(end.clone()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(inclusive, (sorted_key_values.clone(), true));
+
+        let exclusive = store
+            .find_key_values_in_interval(KeyInterval::new(
+                KeyIntervalStart::Excluded(start.clone()),
+                std::ops::Bound::Excluded(end.clone()),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(exclusive, (middle.to_vec(), true));
+
+        let unbounded_inclusive = store
+            .find_keys_in_interval(KeyInterval::new(
+                KeyIntervalStart::Included(start.clone()),
+                std::ops::Bound::Unbounded,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            unbounded_inclusive,
+            (
+                sorted_key_values
+                    .iter()
+                    .map(|(key, _)| key.clone())
+                    .collect::<Vec<_>>(),
+                true,
+            )
+        );
+
+        let unbounded_exclusive = store
+            .find_key_values_in_interval(KeyInterval::new(
+                KeyIntervalStart::Excluded(start.clone()),
+                std::ops::Bound::Unbounded,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(
+            unbounded_exclusive,
+            (middle.iter().chain([last]).cloned().collect(), true)
+        );
+
+        let expected_keys = sorted_key_values
+            .iter()
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        let mut paged_keys = Vec::new();
+        let mut next_start = KeyIntervalStart::Included(start.clone());
+        loop {
+            let (page, is_finished) = store
+                .find_keys_in_interval(
+                    KeyInterval::new(next_start, std::ops::Bound::Included(end.clone()))
+                        .with_limit(2),
+                )
+                .await
+                .unwrap();
+            if page.is_empty() {
+                assert!(is_finished);
+                break;
+            }
+            assert!(page.len() <= 2);
+            paged_keys.extend(page.clone());
+            if is_finished {
+                break;
+            }
+            next_start = KeyIntervalStart::Excluded(page.last().unwrap().clone());
+        }
+        assert_eq!(paged_keys, expected_keys);
+
+        let (limited_key_values, _) = store
+            .find_key_values_in_interval(
+                KeyInterval::new(
+                    KeyIntervalStart::Included(start),
+                    std::ops::Bound::Included(end.clone()),
+                )
+                .with_limit(2),
+            )
+            .await
+            .unwrap();
+        assert!(limited_key_values.len() <= 2);
+        assert_eq!(
+            limited_key_values,
+            sorted_key_values[0..limited_key_values.len()].to_vec()
+        );
+    }
+
     // Now checking the read_multi_values_bytes
     let mut rng = make_deterministic_rng();
     for _ in 0..3 {

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -339,6 +339,67 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
         assert_eq!(values_read_stat, test_exists);
         assert_eq!(values_read_stat, test_exists_direct);
     }
+
+    // Regression test for `Included(end)` translation in interval scans.
+    //
+    // Some backends translate `Included(end)` into an exclusive upper bound
+    // computed by `get_upper_bound_option(end)` (e.g. `[1, 2, 3]` becomes
+    // `[1, 2, 4]`). That bound still admits any key that lex-extends `end`,
+    // such as `[1, 2, 3, 0]`, even though those keys are strictly greater
+    // than `end` and must be excluded. We seed a partition under the
+    // unused `0xfe` byte (random test data uses prefix `[0]`, so it cannot
+    // collide) with several prefix-extending keys, then verify that every
+    // `Included(cutoff)` query returns exactly the keys `<= cutoff`.
+    let bug_test_prefix: Vec<u8> = vec![0xfe];
+    let bug_test_keys: Vec<Vec<u8>> = vec![
+        vec![0xfe, 1],
+        vec![0xfe, 1, 0],
+        vec![0xfe, 1, 0, 0],
+        vec![0xfe, 2],
+        vec![0xfe, 2, 0xff],
+    ];
+    let mut bug_test_batch = Batch::new();
+    for key in &bug_test_keys {
+        bug_test_batch.put_key_value_bytes(key.clone(), b"v".to_vec());
+    }
+    store.write_batch(bug_test_batch).await.unwrap();
+    for cutoff in &bug_test_keys {
+        let (keys, is_finished) = store
+            .find_keys_in_interval(KeyInterval::new(
+                KeyIntervalStart::Included(bug_test_prefix.clone()),
+                std::ops::Bound::Included(cutoff.clone()),
+            ))
+            .await
+            .unwrap();
+        assert!(is_finished);
+        let expected: Vec<Vec<u8>> = bug_test_keys
+            .iter()
+            .filter(|k| k.as_slice() <= cutoff.as_slice())
+            .cloned()
+            .collect();
+        assert_eq!(
+            keys, expected,
+            "find_keys_in_interval Included({cutoff:?}) returned wrong keys",
+        );
+
+        let (key_values, is_finished) = store
+            .find_key_values_in_interval(KeyInterval::new(
+                KeyIntervalStart::Included(bug_test_prefix.clone()),
+                std::ops::Bound::Included(cutoff.clone()),
+            ))
+            .await
+            .unwrap();
+        assert!(is_finished);
+        let expected: Vec<(Vec<u8>, Vec<u8>)> = bug_test_keys
+            .iter()
+            .filter(|k| k.as_slice() <= cutoff.as_slice())
+            .map(|k| (k.clone(), b"v".to_vec()))
+            .collect();
+        assert_eq!(
+            key_values, expected,
+            "find_key_values_in_interval Included({cutoff:?}) returned wrong entries",
+        );
+    }
 }
 
 /// Generates a list of random key-values with no duplicates

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -465,16 +465,23 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
                          end={end_key:?} (incl={end_inclusive}) limit={limit:?} \
                          returned wrong keys",
                     );
-                    if expected_keys.len() < full_match.len() {
-                        assert!(!is_finished, "expected !is_finished for partial result");
+                    // `is_finished` is checked one-sided: when the result is
+                    // a strict subset of the matches, it MUST be false.
+                    // When the result is the full match, backends may report
+                    // either `true` (precise leaf or cache) or `false`
+                    // (conservative wrapper such as value-splitting that
+                    // can't cheaply distinguish unmatched extras from
+                    // unfinished pagination).
+                    let is_full_result = expected_keys.len() == full_match.len();
+                    if !is_full_result {
+                        assert!(
+                            !is_finished,
+                            "find_keys_in_interval claimed is_finished but the \
+                             result is partial; start={start_key:?} \
+                             (incl={start_inclusive}) end={end_key:?} \
+                             (incl={end_inclusive}) limit={limit:?}",
+                        );
                     }
-                    if limit.is_none() {
-                        assert!(is_finished, "expected is_finished when no limit");
-                    }
-                    // `is_finished` is checked one-sided: backends may
-                    // conservatively report `false` when the limit happens to
-                    // equal the full-match length, so we only assert the
-                    // direction that must hold.
 
                     let (key_values, is_finished_kv) = store
                         .find_key_values_in_interval(interval.clone())
@@ -490,11 +497,8 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
                          (incl={start_inclusive}) end={end_key:?} \
                          (incl={end_inclusive}) limit={limit:?} returned wrong entries",
                     );
-                    if expected_keys.len() < full_match.len() {
+                    if !is_full_result {
                         assert!(!is_finished_kv);
-                    }
-                    if limit.is_none() {
-                        assert!(is_finished_kv);
                     }
                 }
             }
@@ -538,11 +542,9 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
                     "Unbounded-end start={start_key:?} (incl={start_inclusive}) limit={limit:?} \
                      returned wrong keys",
                 );
-                if expected_keys.len() < full_match.len() {
+                let is_full_result = expected_keys.len() == full_match.len();
+                if !is_full_result {
                     assert!(!is_finished);
-                }
-                if limit.is_none() {
-                    assert!(is_finished);
                 }
             }
         }

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -400,6 +400,153 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
             "find_key_values_in_interval Included({cutoff:?}) returned wrong entries",
         );
     }
+
+    // Exhaustive coverage of the 4 boundary combinations (II, IE, EI, EE) for
+    // every (start, end) pair drawn from `bug_test_keys`, both with and
+    // without a small `limit`. This exercises:
+    //   - the DynamoDB `BETWEEN` pushdown for inclusive-inclusive intervals,
+    //   - the `BETWEEN`-plus-end-drop path for exclusive-end intervals,
+    //   - the `Excluded(start) -> Included(start || [0])` translation for
+    //     exclusive-start intervals,
+    //   - DynamoDB's `Limit` pushdown with paginated continuation,
+    //   - and the degenerate empty cases (e.g. `Excluded(K), Included(K)`)
+    //     that DynamoDB would reject without a guard.
+    let bound_kinds: &[(bool, bool)] =
+        &[(true, true), (true, false), (false, true), (false, false)];
+    let limits: &[Option<usize>] = &[None, Some(1), Some(2)];
+    for start_key in &bug_test_keys {
+        for end_key in &bug_test_keys {
+            for &(start_inclusive, end_inclusive) in bound_kinds {
+                for &limit in limits {
+                    let start_bound = if start_inclusive {
+                        KeyIntervalStart::Included(start_key.clone())
+                    } else {
+                        KeyIntervalStart::Excluded(start_key.clone())
+                    };
+                    let end_bound = if end_inclusive {
+                        std::ops::Bound::Included(end_key.clone())
+                    } else {
+                        std::ops::Bound::Excluded(end_key.clone())
+                    };
+                    let mut interval = KeyInterval::new(start_bound, end_bound);
+                    if let Some(l) = limit {
+                        interval = interval.with_limit(l);
+                    }
+
+                    let lo_passes = move |k: &Vec<u8>| {
+                        if start_inclusive {
+                            k.as_slice() >= start_key.as_slice()
+                        } else {
+                            k.as_slice() > start_key.as_slice()
+                        }
+                    };
+                    let hi_passes = move |k: &Vec<u8>| {
+                        if end_inclusive {
+                            k.as_slice() <= end_key.as_slice()
+                        } else {
+                            k.as_slice() < end_key.as_slice()
+                        }
+                    };
+                    let full_match: Vec<Vec<u8>> = bug_test_keys
+                        .iter()
+                        .filter(|k| lo_passes(k) && hi_passes(k))
+                        .cloned()
+                        .collect();
+                    let expected_keys: Vec<Vec<u8>> = match limit {
+                        None => full_match.clone(),
+                        Some(l) => full_match.iter().take(l).cloned().collect(),
+                    };
+
+                    let (keys, is_finished) =
+                        store.find_keys_in_interval(interval.clone()).await.unwrap();
+                    assert_eq!(
+                        keys, expected_keys,
+                        "find_keys_in_interval start={start_key:?} (incl={start_inclusive}) \
+                         end={end_key:?} (incl={end_inclusive}) limit={limit:?} \
+                         returned wrong keys",
+                    );
+                    if expected_keys.len() < full_match.len() {
+                        assert!(!is_finished, "expected !is_finished for partial result");
+                    }
+                    if limit.is_none() {
+                        assert!(is_finished, "expected is_finished when no limit");
+                    }
+                    // `is_finished` is checked one-sided: backends may
+                    // conservatively report `false` when the limit happens to
+                    // equal the full-match length, so we only assert the
+                    // direction that must hold.
+
+                    let (key_values, is_finished_kv) = store
+                        .find_key_values_in_interval(interval.clone())
+                        .await
+                        .unwrap();
+                    let expected_kv: Vec<(Vec<u8>, Vec<u8>)> = expected_keys
+                        .iter()
+                        .map(|k| (k.clone(), b"v".to_vec()))
+                        .collect();
+                    assert_eq!(
+                        key_values, expected_kv,
+                        "find_key_values_in_interval start={start_key:?} \
+                         (incl={start_inclusive}) end={end_key:?} \
+                         (incl={end_inclusive}) limit={limit:?} returned wrong entries",
+                    );
+                    if expected_keys.len() < full_match.len() {
+                        assert!(!is_finished_kv);
+                    }
+                    if limit.is_none() {
+                        assert!(is_finished_kv);
+                    }
+                }
+            }
+        }
+    }
+
+    // Unbounded-end variants, with and without a limit, and with both start
+    // boundary kinds.
+    for start_key in &bug_test_keys {
+        for &start_inclusive in &[true, false] {
+            for &limit in limits {
+                let start_bound = if start_inclusive {
+                    KeyIntervalStart::Included(start_key.clone())
+                } else {
+                    KeyIntervalStart::Excluded(start_key.clone())
+                };
+                let mut interval = KeyInterval::new(start_bound, std::ops::Bound::Unbounded);
+                if let Some(l) = limit {
+                    interval = interval.with_limit(l);
+                }
+                let lo_passes = |k: &Vec<u8>| {
+                    if start_inclusive {
+                        k.as_slice() >= start_key.as_slice()
+                    } else {
+                        k.as_slice() > start_key.as_slice()
+                    }
+                };
+                let full_match: Vec<Vec<u8>> = bug_test_keys
+                    .iter()
+                    .filter(|k| lo_passes(k))
+                    .cloned()
+                    .collect();
+                let expected_keys: Vec<Vec<u8>> = match limit {
+                    None => full_match.clone(),
+                    Some(l) => full_match.iter().take(l).cloned().collect(),
+                };
+                let (keys, is_finished) =
+                    store.find_keys_in_interval(interval.clone()).await.unwrap();
+                assert_eq!(
+                    keys, expected_keys,
+                    "Unbounded-end start={start_key:?} (incl={start_inclusive}) limit={limit:?} \
+                     returned wrong keys",
+                );
+                if expected_keys.len() < full_match.len() {
+                    assert!(!is_finished);
+                }
+                if limit.is_none() {
+                    assert!(is_finished);
+                }
+            }
+        }
+    }
 }
 
 /// Generates a list of random key-values with no duplicates

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -25,13 +25,13 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::{
         from_bytes_option, from_bytes_option_or_default, get_key_range_for_prefix, get_upper_bound,
-        DeletionSet, HasherOutput, SuffixClosedSetIterator, Update,
+        key_matches_interval, DeletionSet, HasherOutput, SuffixClosedSetIterator, Update,
     },
     context::Context,
     hashable_wrapper::WrappedHashableContainerView,
     historical_hash_wrapper::HistoricallyHashableView,
     map_view::ByteMapView,
-    store::ReadableKeyValueStore,
+    store::{KeyInterval, ReadableKeyValueStore},
     views::{ClonableView, HashableView, Hasher, ReplaceContext, View, ViewError, MIN_VIEW_TAG},
 };
 
@@ -1007,6 +1007,49 @@ impl<C: Context> KeyValueStoreView<C> {
         self.write_batch(batch).await
     }
 
+    /// Iterates over all keys matching the given interval.
+    pub async fn find_keys_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), ViewError> {
+        let key_values = self.find_key_values_by_prefix(&[]).await?;
+        let mut keys = Vec::new();
+        for (key, _value) in key_values {
+            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
+                keys.push(key);
+                if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
+                    break;
+                }
+            }
+        }
+        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        Ok((keys, is_finished))
+    }
+
+    /// Iterates over all key-value pairs matching the given interval.
+    pub async fn find_key_values_in_interval(
+        &self,
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ViewError> {
+        let entries = self.find_key_values_by_prefix(&[]).await?;
+        let mut key_values = Vec::new();
+        for (key, value) in entries {
+            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
+                key_values.push((key, value));
+                if key_interval
+                    .limit
+                    .is_some_and(|limit| key_values.len() >= limit)
+                {
+                    break;
+                }
+            }
+        }
+        let is_finished = key_interval
+            .limit
+            .is_none_or(|limit| key_values.len() < limit);
+        Ok((key_values, is_finished))
+    }
+
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -1283,20 +1326,47 @@ impl<C: Context> ReadableKeyValueStore for ViewContainer<C> {
         Ok(view.multi_get(keys).await?)
     }
 
-    async fn find_keys_by_prefix(
+    async fn find_keys_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<Vec<u8>>, ViewContainerError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<Vec<u8>>, bool), ViewContainerError> {
         let view = self.view.read().await;
-        Ok(view.find_keys_by_prefix(key_prefix).await?)
+        let key_values = view.find_key_values_by_prefix(&[]).await?;
+        let mut keys = Vec::new();
+        for (key, _value) in key_values {
+            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
+                keys.push(key);
+                if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
+                    break;
+                }
+            }
+        }
+        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
+        Ok((keys, is_finished))
     }
 
-    async fn find_key_values_by_prefix(
+    async fn find_key_values_in_interval(
         &self,
-        key_prefix: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewContainerError> {
+        key_interval: KeyInterval,
+    ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ViewContainerError> {
         let view = self.view.read().await;
-        Ok(view.find_key_values_by_prefix(key_prefix).await?)
+        let entries = view.find_key_values_by_prefix(&[]).await?;
+        let mut key_values = Vec::new();
+        for (key, value) in entries {
+            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
+                key_values.push((key, value));
+                if key_interval
+                    .limit
+                    .is_some_and(|limit| key_values.len() >= limit)
+                {
+                    break;
+                }
+            }
+        }
+        let is_finished = key_interval
+            .limit
+            .is_none_or(|limit| key_values.len() < limit);
+        Ok((key_values, is_finished))
     }
 }
 

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -25,7 +25,7 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::{
         from_bytes_option, from_bytes_option_or_default, get_key_range_for_prefix, get_upper_bound,
-        key_matches_interval, DeletionSet, HasherOutput, SuffixClosedSetIterator, Update,
+        DeletionSet, HasherOutput, SuffixClosedSetIterator, Update,
     },
     context::Context,
     hashable_wrapper::WrappedHashableContainerView,
@@ -1012,18 +1012,33 @@ impl<C: Context> KeyValueStoreView<C> {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), ViewError> {
-        let key_values = self.find_key_values_by_prefix(&[]).await?;
-        let mut keys = Vec::new();
-        for (key, _value) in key_values {
-            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
-                keys.push(key);
-                if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
-                    break;
-                }
-            }
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
         }
-        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
-        Ok((keys, is_finished))
+        // Any key in the interval starts with the longest common prefix of
+        // its bounds, so the prefix-scan path (which already merges in-memory
+        // updates with the underlying store and respects the deletion set)
+        // is a sufficient superset. We then trim it to the interval and limit.
+        let prefix = key_interval.common_prefix();
+        let prefix_keys = self.find_keys_by_prefix(&prefix).await?;
+        let mut keys = Vec::new();
+        let mut more_after_limit = false;
+        for stripped in prefix_keys {
+            let mut full = prefix.clone();
+            full.extend(&stripped);
+            if !key_interval.contains(&full) {
+                continue;
+            }
+            if key_interval
+                .limit
+                .is_some_and(|limit| keys.len() >= limit)
+            {
+                more_after_limit = true;
+                break;
+            }
+            keys.push(full);
+        }
+        Ok((keys, !more_after_limit))
     }
 
     /// Iterates over all key-value pairs matching the given interval.
@@ -1031,23 +1046,29 @@ impl<C: Context> KeyValueStoreView<C> {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ViewError> {
-        let entries = self.find_key_values_by_prefix(&[]).await?;
-        let mut key_values = Vec::new();
-        for (key, value) in entries {
-            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
-                key_values.push((key, value));
-                if key_interval
-                    .limit
-                    .is_some_and(|limit| key_values.len() >= limit)
-                {
-                    break;
-                }
-            }
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
         }
-        let is_finished = key_interval
-            .limit
-            .is_none_or(|limit| key_values.len() < limit);
-        Ok((key_values, is_finished))
+        let prefix = key_interval.common_prefix();
+        let prefix_entries = self.find_key_values_by_prefix(&prefix).await?;
+        let mut key_values = Vec::new();
+        let mut more_after_limit = false;
+        for (stripped, value) in prefix_entries {
+            let mut full = prefix.clone();
+            full.extend(&stripped);
+            if !key_interval.contains(&full) {
+                continue;
+            }
+            if key_interval
+                .limit
+                .is_some_and(|limit| key_values.len() >= limit)
+            {
+                more_after_limit = true;
+                break;
+            }
+            key_values.push((full, value));
+        }
+        Ok((key_values, !more_after_limit))
     }
 
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
@@ -1330,43 +1351,60 @@ impl<C: Context> ReadableKeyValueStore for ViewContainer<C> {
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<Vec<u8>>, bool), ViewContainerError> {
-        let view = self.view.read().await;
-        let key_values = view.find_key_values_by_prefix(&[]).await?;
-        let mut keys = Vec::new();
-        for (key, _value) in key_values {
-            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
-                keys.push(key);
-                if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
-                    break;
-                }
-            }
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
         }
-        let is_finished = key_interval.limit.is_none_or(|limit| keys.len() < limit);
-        Ok((keys, is_finished))
+        let view = self.view.read().await;
+        let prefix = key_interval.common_prefix();
+        let prefix_keys = view.find_keys_by_prefix(&prefix).await?;
+        let mut keys = Vec::new();
+        let mut more_after_limit = false;
+        for stripped in prefix_keys {
+            let mut full = prefix.clone();
+            full.extend(&stripped);
+            if !key_interval.contains(&full) {
+                continue;
+            }
+            if key_interval
+                .limit
+                .is_some_and(|limit| keys.len() >= limit)
+            {
+                more_after_limit = true;
+                break;
+            }
+            keys.push(full);
+        }
+        Ok((keys, !more_after_limit))
     }
 
     async fn find_key_values_in_interval(
         &self,
         key_interval: KeyInterval,
     ) -> Result<(Vec<(Vec<u8>, Vec<u8>)>, bool), ViewContainerError> {
-        let view = self.view.read().await;
-        let entries = view.find_key_values_by_prefix(&[]).await?;
-        let mut key_values = Vec::new();
-        for (key, value) in entries {
-            if key_matches_interval(&key, key_interval.start_bound(), key_interval.end_bound()) {
-                key_values.push((key, value));
-                if key_interval
-                    .limit
-                    .is_some_and(|limit| key_values.len() >= limit)
-                {
-                    break;
-                }
-            }
+        if key_interval.is_empty() {
+            return Ok((Vec::new(), true));
         }
-        let is_finished = key_interval
-            .limit
-            .is_none_or(|limit| key_values.len() < limit);
-        Ok((key_values, is_finished))
+        let view = self.view.read().await;
+        let prefix = key_interval.common_prefix();
+        let prefix_entries = view.find_key_values_by_prefix(&prefix).await?;
+        let mut key_values = Vec::new();
+        let mut more_after_limit = false;
+        for (stripped, value) in prefix_entries {
+            let mut full = prefix.clone();
+            full.extend(&stripped);
+            if !key_interval.contains(&full) {
+                continue;
+            }
+            if key_interval
+                .limit
+                .is_some_and(|limit| key_values.len() >= limit)
+            {
+                more_after_limit = true;
+                break;
+            }
+            key_values.push((full, value));
+        }
+        Ok((key_values, !more_after_limit))
     }
 }
 

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -1029,10 +1029,7 @@ impl<C: Context> KeyValueStoreView<C> {
             if !key_interval.contains(&full) {
                 continue;
             }
-            if key_interval
-                .limit
-                .is_some_and(|limit| keys.len() >= limit)
-            {
+            if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
                 more_after_limit = true;
                 break;
             }
@@ -1365,10 +1362,7 @@ impl<C: Context> ReadableKeyValueStore for ViewContainer<C> {
             if !key_interval.contains(&full) {
                 continue;
             }
-            if key_interval
-                .limit
-                .is_some_and(|limit| keys.len() >= limit)
-            {
+            if key_interval.limit.is_some_and(|limit| keys.len() >= limit) {
                 more_after_limit = true;
                 break;
             }

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -51,7 +51,7 @@ async fn test_queue_operations_with_dynamo_db_context() -> Result<(), anyhow::Er
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_queue_operations_with_scylla_db_context() -> Result<(), anyhow::Error> {
-    run_test_queue_operations_test_cases(ScyllaDbContextFactory).await
+    Box::pin(run_test_queue_operations_test_cases(ScyllaDbContextFactory)).await
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -45,7 +45,10 @@ async fn test_read_multi_values_dynamo_db() {
 async fn test_read_multi_values_scylla_db() {
     use linera_views::scylla_db::ScyllaDbDatabase;
     let config = ScyllaDbDatabase::new_test_config().await.unwrap();
-    big_read_multi_values::<ScyllaDbDatabase>(config, 22200000, 200).await;
+    Box::pin(big_read_multi_values::<ScyllaDbDatabase>(
+        config, 22200000, 200,
+    ))
+    .await;
 }
 
 #[tokio::test]
@@ -342,7 +345,7 @@ async fn test_scylla_db_writes_from_state() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylladb_access() {
-    access_admin_test::<linera_views::scylla_db::ScyllaDbDatabase>().await
+    Box::pin(access_admin_test::<linera_views::scylla_db::ScyllaDbDatabase>()).await
 }
 
 #[cfg(with_dynamodb)]

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -92,6 +92,24 @@ async fn test_reads_dynamo_db() {
     }
 }
 
+#[cfg(with_dynamodb)]
+#[tokio::test]
+async fn test_reads_dynamo_db_internal() {
+    use linera_views::{
+        dynamo_db::DynamoDbDatabaseInternal, journaling::JournalingKeyValueDatabase,
+        store::KeyValueDatabase as _,
+    };
+
+    for scenario in get_random_test_scenarios() {
+        let database =
+            JournalingKeyValueDatabase::<DynamoDbDatabaseInternal>::connect_test_namespace()
+                .await
+                .unwrap();
+        let store = database.open_exclusive(&[]).unwrap();
+        run_reads(store, scenario).await;
+    }
+}
+
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_reads_scylla_db() {

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -742,7 +742,7 @@ async fn test_views_in_scylla_db_param(config: &TestConfig) -> Result<()> {
 #[tokio::test]
 async fn test_views_in_scylla_db() -> Result<()> {
     for config in TestConfig::samples() {
-        test_views_in_scylla_db_param(&config).await?;
+        Box::pin(test_views_in_scylla_db_param(&config)).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Accessing key-values in `MapView` is an expensive operation that blocks the system.
It would be better to be able to do pagination.

## Proposal

When doing a `find_{keys,key_values}_by_prefix` in ScyllaDB, RocksDB and others, we are accessing the keys with a start and end with the start and end specifically defined. So, there is a very clear way to generalize the code. We also have a very clear way to limit the size of the request. In ScyllaDB, this is done via the " LIMIT X" appended, and for RocksDB, we can stop in the middle.

Now, if we ask for 200 keys and we get 190 then we know that we do not need to continue. If we get exactly 200, then the number of keys may be 200 or 201. But we do not that. So, we report `is_finished=false` in that case. The number of keys being returned may in the end be much less than 200 because the value_splitting forces to split some keys in several smaller keys.

This opens the possibility of reading the key-values of a `MapView` with pagination. This has not been done in this PR.


## Test Plan

CI.
The tests have been expanded.


## Release Plan

This can be backported to `testnet_conway`.

## Links

None.