### PR TITLE
Add Prometheus metrics to all caches and switch to allocative-based byte weights

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -260,25 +260,25 @@ Client implementation and command-line tool for the Linera blockchain
 * `--storage-max-cache-find-key-values-size <STORAGE_MAX_CACHE_FIND_KEY_VALUES_SIZE>` — The maximal memory used in the find_key_values_by_prefix cache
 
   Default value: `10000000`
-* `--blob-cache-size <BLOB_CACHE_SIZE>` — The maximal number of entries in the blob cache
+* `--blob-cache-size <BLOB_CACHE_SIZE>` — Maximum bytes in the blob cache
 
-  Default value: `1000`
-* `--confirmed-block-cache-size <CONFIRMED_BLOCK_CACHE_SIZE>` — The maximal number of entries in the confirmed block cache
+  Default value: `52428800`
+* `--confirmed-block-cache-size <CONFIRMED_BLOCK_CACHE_SIZE>` — Maximum bytes in the confirmed block cache
 
-  Default value: `1000`
-* `--lite-certificate-cache-size <LITE_CERTIFICATE_CACHE_SIZE>` — The maximal number of entries in the lite certificate cache
+  Default value: `52428800`
+* `--lite-certificate-cache-size <LITE_CERTIFICATE_CACHE_SIZE>` — Maximum bytes in the lite certificate cache
 
-  Default value: `1000`
-* `--certificate-raw-cache-size <CERTIFICATE_RAW_CACHE_SIZE>` — The maximal number of entries in the raw certificate cache
+  Default value: `52428800`
+* `--certificate-raw-cache-size <CERTIFICATE_RAW_CACHE_SIZE>` — Maximum bytes in the raw certificate cache
 
-  Default value: `1000`
-* `--event-cache-size <EVENT_CACHE_SIZE>` — The maximal number of entries in the event cache
+  Default value: `52428800`
+* `--event-cache-size <EVENT_CACHE_SIZE>` — Maximum bytes in the event cache
 
-  Default value: `1000`
-* `--block-cache-size <BLOCK_CACHE_SIZE>` — The number of entries in the block cache
+  Default value: `52428800`
+* `--block-cache-size <BLOCK_CACHE_SIZE>` — Maximum bytes in the block cache
 
-  Default value: `5000`
-* `--execution-state-cache-size <EXECUTION_STATE_CACHE_SIZE>` — The number of entries in the execution state cache
+  Default value: `52428800`
+* `--execution-state-cache-size <EXECUTION_STATE_CACHE_SIZE>` — Maximum entries in the execution state cache
 
   Default value: `10000`
 * `--storage-replication-factor <STORAGE_REPLICATION_FACTOR>` — The replication factor for the keyspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5463,6 +5463,7 @@ dependencies = [
 name = "linera-cache"
 version = "0.15.15"
 dependencies = [
+ "allocative",
  "cfg_aliases",
  "linera-base",
  "linera-cache",
@@ -6061,6 +6062,7 @@ dependencies = [
  "kube",
  "linera-base",
  "linera-bridge",
+ "linera-cache",
  "linera-chain",
  "linera-client",
  "linera-core",
@@ -6077,7 +6079,6 @@ dependencies = [
  "linera-storage-service",
  "linera-version",
  "linera-views",
- "lru 0.15.0",
  "matching-engine",
  "mini-moka",
  "native-fungible",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3966,6 +3966,7 @@ dependencies = [
 name = "linera-cache"
 version = "0.15.15"
 dependencies = [
+ "allocative",
  "cfg_aliases",
  "linera-base",
  "lru 0.15.0",

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -94,25 +94,25 @@ struct ServeOptions {
     #[arg(long, default_value = "3001")]
     port: u16,
 
-    /// The maximal number of entries in the blob cache.
-    #[arg(long, default_value = "1000")]
-    blob_cache_size: usize,
+    /// Maximum bytes in the blob cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    blob_cache_size: u64,
 
-    /// The maximal number of entries in the confirmed block cache.
-    #[arg(long, default_value = "1000")]
-    confirmed_block_cache_size: usize,
+    /// Maximum bytes in the confirmed block cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    confirmed_block_cache_size: u64,
 
-    /// The maximal number of entries in the lite certificate cache.
-    #[arg(long, default_value = "1000")]
-    lite_certificate_cache_size: usize,
+    /// Maximum bytes in the lite certificate cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    lite_certificate_cache_size: u64,
 
-    /// The maximal number of entries in the raw certificate cache.
-    #[arg(long, default_value = "1000")]
-    certificate_raw_cache_size: usize,
+    /// Maximum bytes in the raw certificate cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    certificate_raw_cache_size: u64,
 
-    /// The maximal number of entries in the event cache.
-    #[arg(long, default_value = "1000")]
-    event_cache_size: usize,
+    /// Maximum bytes in the event cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    event_cache_size: u64,
 }
 
 fn main() -> Result<()> {

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -3701,6 +3701,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linera-cache"
+version = "0.15.15"
+dependencies = [
+ "allocative",
+ "cfg_aliases",
+ "linera-base",
+ "lru 0.15.0",
+ "prometheus",
+ "quick_cache",
+]
+
+[[package]]
 name = "linera-chain"
 version = "0.15.15"
 dependencies = [
@@ -3774,12 +3786,12 @@ dependencies = [
  "custom_debug_derive",
  "futures",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-storage",
  "linera-version",
  "linera-views",
- "lru 0.15.0",
  "papaya",
  "prometheus",
  "rand 0.8.5",
@@ -3944,6 +3956,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-views",
@@ -4031,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer"
-version = "4.4.0-linera.7"
+version = "4.4.0-linera.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6652182476826343f0dd1e76a184ad34bcee57650a9c00c77574b993dd30529"
+checksum = "6453ccd433866100d587f3db5ffb6c2116ebbcb97891df4197c1038708a551ba"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -4061,9 +4074,9 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler"
-version = "4.4.0-linera.7"
+version = "4.4.0-linera.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4781ce9fc4a892c9a9727f51ec92d19e1c5b54259da21573671aa49211ae80f"
+checksum = "37d7e7b04c3cd3b94eccf13a1b57f631a5339dbf719e58618d03f30f52ff75e4"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4092,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler-cranelift"
-version = "4.4.0-linera.7"
+version = "4.4.0-linera.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8056c8bff8e1b5cafd21aac59b9009e93b30f35b7baab5592a6f4c7db120b490"
+checksum = "5e5bf79646e59839a83c10b4c48456a86909596c37cc380c49c94c2632a9126c"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -4111,9 +4124,9 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-compiler-singlepass"
-version = "4.4.0-linera.7"
+version = "4.4.0-linera.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3635a86dd98e2c2fd6dd603054f40b8e379f84365a2238cc177d47547a83eebc"
+checksum = "9d5ca769ec09d276da3b4580992ec5b96268f3b36b0d05a6fabc7dcb7cd3418a"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -4130,9 +4143,9 @@ dependencies = [
 
 [[package]]
 name = "linera-wasmer-vm"
-version = "4.4.0-linera.7"
+version = "4.4.0-linera.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27d020717572fdb6222324ec46b10eeb49f6f4a120ee63cf7145f4392f12fd8"
+checksum = "22ed6366c2d832e034052b6f037b5afe38efb1e9d8e9ef4b31b778751330e519"
 dependencies = [
  "backtrace",
  "cc",
@@ -5159,6 +5172,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick_cache"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5171,7 +5195,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5208,9 +5232,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -107,11 +107,11 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         "e2l-bridge-e2e-test",
         Some(WasmRuntime::default()),
         StorageCacheSizes {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            lite_certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
+            blob_cache_size: 1024 * 1024,
+            confirmed_block_cache_size: 1024 * 1024,
+            lite_certificate_cache_size: 1024 * 1024,
+            certificate_raw_cache_size: 1024 * 1024,
+            event_cache_size: 1024 * 1024,
         },
     )
     .await?;

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -73,11 +73,11 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         "bridge-e2e-test",
         Some(WasmRuntime::default()),
         StorageCacheSizes {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            lite_certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
+            blob_cache_size: 1024 * 1024,
+            confirmed_block_cache_size: 1024 * 1024,
+            lite_certificate_cache_size: 1024 * 1024,
+            certificate_raw_cache_size: 1024 * 1024,
+            event_cache_size: 1024 * 1024,
         },
     )
     .await?;

--- a/linera-cache/Cargo.toml
+++ b/linera-cache/Cargo.toml
@@ -18,6 +18,7 @@ metrics = ["prometheus", "linera-base/metrics"]
 test = ["linera-base/test"]
 
 [dependencies]
+allocative.workspace = true
 linera-base.workspace = true
 lru.workspace = true
 prometheus = { workspace = true, optional = true }

--- a/linera-cache/src/lib.rs
+++ b/linera-cache/src/lib.rs
@@ -8,3 +8,45 @@ mod value_cache;
 
 pub use unique_value_cache::UniqueValueCache;
 pub use value_cache::ValueCache;
+
+#[cfg(with_metrics)]
+pub(crate) mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{register_int_counter_vec, register_int_gauge_vec};
+    use prometheus::{IntCounterVec, IntGaugeVec};
+
+    pub static CACHE_HIT: LazyLock<IntCounterVec> =
+        LazyLock::new(|| register_int_counter_vec("cache_hit", "Cache hits", &["name", "type"]));
+
+    pub static CACHE_MISS: LazyLock<IntCounterVec> =
+        LazyLock::new(|| register_int_counter_vec("cache_miss", "Cache misses", &["name", "type"]));
+
+    pub static CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec("cache_entries", "Current entry count", &["name", "type"])
+    });
+
+    pub static CACHE_BYTES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "cache_bytes",
+            "Total weight (bytes) in cache",
+            &["name", "type"],
+        )
+    });
+
+    pub static CACHE_INVALIDATION: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "cache_invalidation",
+            "Full-cache invalidation count",
+            &["name", "type"],
+        )
+    });
+
+    pub static CACHE_EVICTION: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "cache_eviction",
+            "Entries evicted from cache",
+            &["name", "type"],
+        )
+    });
+}

--- a/linera-cache/src/unique_value_cache.rs
+++ b/linera-cache/src/unique_value_cache.rs
@@ -3,30 +3,55 @@
 
 //! A mutex-guarded LRU cache for move-in/move-out value patterns where `V` is not `Clone`.
 
-use std::{hash::Hash, num::NonZeroUsize, sync::Mutex};
+use std::{
+    hash::Hash,
+    num::NonZeroUsize,
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Mutex,
+    },
+};
 
+use allocative::Allocative;
 use lru::LruCache;
 
 /// A bounded cache for values that are inserted and then taken out (moved), not cloned.
 ///
 /// Uses `Mutex<LruCache>` internally. Suitable for caching values that don't implement
 /// `Clone`, where the access pattern is insert → remove rather than insert → get.
+///
+/// When built with the `metrics` feature, reports hit, miss, entry-count, byte-weight,
+/// and invalidation counters to Prometheus.
 pub struct UniqueValueCache<K, V>
 where
     K: Hash + Eq,
 {
     cache: Mutex<LruCache<K, V>>,
+    total_bytes: AtomicI64,
+    #[cfg(with_metrics)]
+    name: &'static str,
 }
 
 impl<K, V> UniqueValueCache<K, V>
 where
     K: Hash + Eq + Copy,
+    V: Allocative,
 {
-    /// Creates a new `UniqueValueCache` with the given capacity.
-    pub fn new(size: usize) -> Self {
-        let size = NonZeroUsize::try_from(size).expect("Cache size must be greater than zero");
+    /// Creates a new `UniqueValueCache`.
+    ///
+    /// * `name` – human-readable label for Prometheus metrics (e.g. `"execution_state"`).
+    /// * `capacity` – maximum number of entries (LRU eviction by item count).
+    ///
+    /// Byte weights are computed automatically via [`allocative::size_of_unique`].
+    #[cfg_attr(not(with_metrics), allow(unused_variables))]
+    pub fn new(name: &'static str, capacity: usize) -> Self {
+        let capacity =
+            NonZeroUsize::try_from(capacity).expect("Cache capacity must be greater than zero");
         UniqueValueCache {
-            cache: Mutex::new(LruCache::new(size)),
+            cache: Mutex::new(LruCache::new(capacity)),
+            total_bytes: AtomicI64::new(0),
+            #[cfg(with_metrics)]
+            name,
         }
     }
 
@@ -39,14 +64,68 @@ where
             cache.promote(key);
             false
         } else {
-            cache.push(*key, value);
+            let added_weight = allocative::size_of_unique(&value) as i64;
+            let evicted = cache.push(*key, value);
+            let mut delta = added_weight;
+            if let Some((_evicted_key, evicted_value)) = evicted {
+                delta -= allocative::size_of_unique(&evicted_value) as i64;
+                #[cfg(with_metrics)]
+                crate::metrics::CACHE_EVICTION
+                    .with_label_values(&[self.name, "unique"])
+                    .inc();
+            }
+            self.total_bytes.fetch_add(delta, Ordering::Relaxed);
+            #[cfg(with_metrics)]
+            self.update_gauges(&cache);
             true
         }
     }
 
     /// Removes a value from the cache and returns it, if present.
     pub fn remove(&self, key: &K) -> Option<V> {
-        self.cache.lock().unwrap().pop(key)
+        let mut cache = self.cache.lock().unwrap();
+        let result = cache.pop(key);
+        #[cfg(with_metrics)]
+        {
+            let metric = if result.is_some() {
+                &crate::metrics::CACHE_HIT
+            } else {
+                &crate::metrics::CACHE_MISS
+            };
+            metric.with_label_values(&[self.name, "unique"]).inc();
+        }
+        if let Some(ref value) = result {
+            let removed_weight = allocative::size_of_unique(value) as i64;
+            self.total_bytes
+                .fetch_sub(removed_weight, Ordering::Relaxed);
+            #[cfg(with_metrics)]
+            self.update_gauges(&cache);
+        }
+        result
+    }
+
+    /// Clears all entries and increments the invalidation counter.
+    pub fn invalidate(&self) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.clear();
+        self.total_bytes.store(0, Ordering::Relaxed);
+        #[cfg(with_metrics)]
+        {
+            crate::metrics::CACHE_INVALIDATION
+                .with_label_values(&[self.name, "unique"])
+                .inc();
+            self.update_gauges(&cache);
+        }
+    }
+
+    #[cfg(with_metrics)]
+    fn update_gauges(&self, cache: &LruCache<K, V>) {
+        crate::metrics::CACHE_ENTRIES
+            .with_label_values(&[self.name, "unique"])
+            .set(cache.len() as i64);
+        crate::metrics::CACHE_BYTES
+            .with_label_values(&[self.name, "unique"])
+            .set(self.total_bytes.load(Ordering::Relaxed));
     }
 }
 
@@ -56,15 +135,19 @@ mod tests {
 
     const TEST_CACHE_SIZE: usize = 10;
 
+    fn new_test_cache() -> UniqueValueCache<u64, String> {
+        UniqueValueCache::new("test", TEST_CACHE_SIZE)
+    }
+
     #[test]
     fn test_retrieve_missing_value() {
-        let cache = UniqueValueCache::<u64, String>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
         assert!(cache.remove(&42).is_none());
     }
 
     #[test]
     fn test_insert_and_remove() {
-        let cache = UniqueValueCache::<u64, String>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
 
         assert!(cache.insert(&1, "hello".to_string()));
         assert_eq!(cache.remove(&1), Some("hello".to_string()));
@@ -74,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_insert_duplicate_returns_false() {
-        let cache = UniqueValueCache::<u64, String>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
 
         assert!(cache.insert(&1, "first".to_string()));
         assert!(!cache.insert(&1, "second".to_string()));
@@ -85,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_insert_many_values() {
-        let cache = UniqueValueCache::<u64, String>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
 
         for i in 0..TEST_CACHE_SIZE as u64 {
             assert!(cache.insert(&i, format!("value-{i}")));
@@ -98,7 +181,7 @@ mod tests {
 
     #[test]
     fn test_lru_eviction() {
-        let cache = UniqueValueCache::<u64, String>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
 
         // Fill cache to capacity.
         for i in 0..TEST_CACHE_SIZE as u64 {
@@ -118,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_reinsertion_promotes_entry() {
-        let cache = UniqueValueCache::<u64, String>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
 
         // Fill cache.
         for i in 0..TEST_CACHE_SIZE as u64 {
@@ -139,5 +222,23 @@ mod tests {
             cache.remove(&1).is_none(),
             "entry after promoted one should be evicted"
         );
+    }
+
+    #[test]
+    fn test_invalidate_clears_all_entries() {
+        let cache = new_test_cache();
+
+        for i in 0..5u64 {
+            cache.insert(&i, format!("value-{i}"));
+        }
+
+        cache.invalidate();
+
+        for i in 0..5u64 {
+            assert!(
+                cache.remove(&i).is_none(),
+                "cache should be empty after invalidation"
+            );
+        }
     }
 }

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -1,32 +1,96 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! A concurrent cache with efficient eviction.
+//! A concurrent cache with efficient eviction and Prometheus metrics.
 
-#[cfg(with_metrics)]
-use std::any::type_name;
 use std::{borrow::Cow, hash::Hash};
 
+use allocative::Allocative;
 use linera_base::{crypto::CryptoHash, hashed::Hashed};
-use quick_cache::sync::Cache;
+use quick_cache::{sync::Cache, DefaultHashBuilder, Lifecycle, Weighter};
+
+/// A [`Weighter`] that uses [`allocative::size_of_unique`] to compute the byte weight
+/// of cached entries. This measures `mem::size_of::<T>()` plus all uniquely-owned heap
+/// allocations — correct for any type that derives or implements [`Allocative`].
+#[derive(Clone)]
+struct AllocativeWeighter;
+
+impl<K: Allocative, V: Allocative> Weighter<K, V> for AllocativeWeighter {
+    fn weight(&self, key: &K, val: &V) -> u64 {
+        (allocative::size_of_unique(key) + allocative::size_of_unique(val)) as u64
+    }
+}
+
+/// Lifecycle hook that increments the `cache_eviction` Prometheus counter on each eviction.
+#[derive(Clone)]
+struct EvictionTracker {
+    #[cfg(with_metrics)]
+    name: &'static str,
+}
+
+impl<K, V> Lifecycle<K, V> for EvictionTracker {
+    type RequestState = ();
+
+    fn begin_request(&self) -> Self::RequestState {}
+
+    #[cfg_attr(not(with_metrics), allow(unused_variables))]
+    fn on_evict(&self, _state: &mut Self::RequestState, _key: K, _val: V) {
+        #[cfg(with_metrics)]
+        crate::metrics::CACHE_EVICTION
+            .with_label_values(&[self.name, "value"])
+            .inc();
+    }
+}
 
 /// A concurrent cache with efficient eviction.
 ///
 /// Backed by `quick_cache` which uses sharded locks for concurrent reads
 /// and S3-FIFO eviction for better hit ratios than LRU.
+///
+/// When built with the `metrics` feature, every instance reports hit, miss,
+/// entry-count, byte-weight, and invalidation counters to Prometheus, labeled
+/// by the human-readable `name` provided at construction time.
 pub struct ValueCache<K, V> {
-    cache: Cache<K, V>,
+    cache: Cache<K, V, AllocativeWeighter, DefaultHashBuilder, EvictionTracker>,
+    #[cfg(with_metrics)]
+    name: &'static str,
 }
 
 impl<K, V> ValueCache<K, V>
 where
-    K: Hash + Eq + Clone + Send + Sync + 'static,
-    V: Clone + Send + Sync + 'static,
+    K: Hash + Eq + Clone + Allocative + Send + Sync + 'static,
+    V: Clone + Allocative + Send + Sync + 'static,
 {
-    /// Creates a new `ValueCache` with the given capacity.
-    pub fn new(size: usize) -> Self {
+    /// Creates a new weight-based `ValueCache`.
+    ///
+    /// * `name` – human-readable label for Prometheus metrics (e.g. `"block"`).
+    /// * `weight_capacity` – maximum total weight (bytes) before eviction kicks in.
+    ///
+    /// Entry weights are computed automatically via [`allocative::size_of_unique`],
+    /// which measures stack size plus all uniquely-owned heap allocations.
+    #[cfg_attr(not(with_metrics), allow(unused_variables))]
+    pub fn new(name: &'static str, weight_capacity: u64) -> Self {
+        // quick_cache REQUIRES estimated_items_capacity (no default — options.rs:134 errors).
+        // Controls: shard count (≥32 items/shard) and ghost entry space (50% of estimate).
+        // Docs say "within 1-2 orders of magnitude is often good enough" (options.rs:76-77).
+        //
+        // Heuristic: weight_capacity / 4096 (assume ~4 KiB average entry).
+        // Ghost overhead = estimated * 0.5 * ~16 bytes ≈ 0.2% of weight_capacity (negligible).
+        // Shard count on 16-core machine = 64 shards (determined by core count, not this).
+        let estimated_items = (weight_capacity / 4096).clamp(1024, 1_000_000) as usize;
         ValueCache {
-            cache: Cache::new(size),
+            cache: Cache::with(
+                estimated_items,
+                weight_capacity,
+                AllocativeWeighter,
+                DefaultHashBuilder::default(),
+                EvictionTracker {
+                    #[cfg(with_metrics)]
+                    name,
+                },
+            ),
+            #[cfg(with_metrics)]
+            name,
         }
     }
 
@@ -38,6 +102,7 @@ where
             false
         } else {
             self.cache.insert(key.clone(), value);
+            self.update_gauges();
             true
         }
     }
@@ -47,13 +112,14 @@ where
         let value = self.cache.peek(key);
         if value.is_some() {
             self.cache.remove(key);
+            self.update_gauges();
         }
-        Self::track_cache_usage(value)
+        value
     }
 
     /// Returns a clone of the value from the cache, if present.
     pub fn get(&self, key: &K) -> Option<V> {
-        Self::track_cache_usage(self.cache.get(key))
+        self.track_hit_miss(self.cache.get(key))
     }
 
     /// Returns `true` if the cache contains an entry for the given key.
@@ -61,24 +127,46 @@ where
         self.cache.peek(key).is_some()
     }
 
-    fn track_cache_usage(maybe_value: Option<V>) -> Option<V> {
+    /// Clears all entries and increments the invalidation counter.
+    pub fn invalidate(&self) {
+        self.cache.clear();
+        #[cfg(with_metrics)]
+        {
+            crate::metrics::CACHE_INVALIDATION
+                .with_label_values(&[self.name, "value"])
+                .inc();
+        }
+        self.update_gauges();
+    }
+
+    fn track_hit_miss(&self, maybe_value: Option<V>) -> Option<V> {
         #[cfg(with_metrics)]
         {
             let metric = if maybe_value.is_some() {
-                &metrics::CACHE_HIT_COUNT
+                &crate::metrics::CACHE_HIT
             } else {
-                &metrics::CACHE_MISS_COUNT
+                &crate::metrics::CACHE_MISS
             };
-
-            metric
-                .with_label_values(&[type_name::<K>(), type_name::<V>()])
-                .inc();
+            metric.with_label_values(&[self.name, "value"]).inc();
         }
         maybe_value
     }
+
+    #[cfg(with_metrics)]
+    fn update_gauges(&self) {
+        crate::metrics::CACHE_ENTRIES
+            .with_label_values(&[self.name, "value"])
+            .set(self.cache.len() as i64);
+        crate::metrics::CACHE_BYTES
+            .with_label_values(&[self.name, "value"])
+            .set(self.cache.weight() as i64);
+    }
+
+    #[cfg(not(with_metrics))]
+    fn update_gauges(&self) {}
 }
 
-impl<T: Clone + Send + Sync + 'static> ValueCache<CryptoHash, Hashed<T>> {
+impl<T: Clone + Allocative + Send + Sync + 'static> ValueCache<CryptoHash, Hashed<T>> {
     /// Inserts a [`Hashed<T>`] into the cache if its hash is not already present.
     ///
     /// The `value` is wrapped in a [`Cow`] so that it is only cloned if it needs to be
@@ -91,6 +179,7 @@ impl<T: Clone + Send + Sync + 'static> ValueCache<CryptoHash, Hashed<T>> {
             false
         } else {
             self.cache.insert(hash, value.into_owned());
+            self.update_gauges();
             true
         }
     }
@@ -107,47 +196,40 @@ impl<T: Clone + Send + Sync + 'static> ValueCache<CryptoHash, Hashed<T>> {
                 self.cache.insert(hash, value.into_owned());
             }
         }
+        self.update_gauges();
     }
-}
-
-#[cfg(with_metrics)]
-mod metrics {
-    use std::sync::LazyLock;
-
-    use linera_base::prometheus_util::register_int_counter_vec;
-    use prometheus::IntCounterVec;
-
-    pub static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "value_cache_hit",
-            "Cache hits in `ValueCache`",
-            &["key_type", "value_type"],
-        )
-    });
-
-    pub static CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "value_cache_miss",
-            "Cache misses in `ValueCache`",
-            &["key_type", "value_type"],
-        )
-    });
 }
 
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
 
+    use allocative::Allocative;
     use linera_base::{crypto::CryptoHash, hashed::Hashed};
     use serde::{Deserialize, Serialize};
 
     use super::ValueCache;
 
-    /// Test cache size for unit tests.
-    const TEST_CACHE_SIZE: usize = 10;
+    /// Weight capacity large enough to never trigger weight-based eviction in tests.
+    const TEST_WEIGHT_CAPACITY: u64 = 10_000_000;
+
+    /// Number of items used in multi-entry tests.
+    const TEST_ITEM_COUNT: usize = 10;
+
+    /// Small weight capacity for eviction tests.
+    /// Each `(CryptoHash, Hashed<TestValue>)` weighs ~72 bytes via allocative.
+    const SMALL_WEIGHT_CAPACITY: u64 = 5000;
+
+    fn new_test_cache() -> ValueCache<CryptoHash, Hashed<TestValue>> {
+        ValueCache::new("test", TEST_WEIGHT_CAPACITY)
+    }
+
+    fn new_small_cache() -> ValueCache<CryptoHash, Hashed<TestValue>> {
+        ValueCache::new("test_small", SMALL_WEIGHT_CAPACITY)
+    }
 
     /// A minimal hashable value for testing `ValueCache<CryptoHash, Hashed<T>>`.
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Allocative)]
     struct TestValue(u64);
 
     impl linera_base::crypto::BcsHashable<'_> for TestValue {}
@@ -162,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_retrieve_missing_value() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
         let hash = CryptoHash::test_hash("Missing value");
 
         assert!(cache.get(&hash).is_none());
@@ -171,7 +253,7 @@ mod tests {
 
     #[test]
     fn test_insert_single_value() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
+        let cache = new_test_cache();
         let value = create_test_value(0);
         let hash = value.hash();
 
@@ -182,8 +264,8 @@ mod tests {
 
     #[test]
     fn test_insert_many_values_individually() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
-        let values = create_test_values(0..TEST_CACHE_SIZE as u64);
+        let cache = new_test_cache();
+        let values = create_test_values(0..TEST_ITEM_COUNT as u64);
 
         for value in &values {
             assert!(cache.insert_hashed(Cow::Borrowed(value)));
@@ -197,8 +279,8 @@ mod tests {
 
     #[test]
     fn test_insert_many_values_together() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
-        let values = create_test_values(0..TEST_CACHE_SIZE as u64);
+        let cache = new_test_cache();
+        let values = create_test_values(0..TEST_ITEM_COUNT as u64);
 
         cache.insert_all_hashed(values.iter().map(Cow::Borrowed));
 
@@ -210,8 +292,8 @@ mod tests {
 
     #[test]
     fn test_reinsertion_of_values() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
-        let values = create_test_values(0..TEST_CACHE_SIZE as u64);
+        let cache = new_test_cache();
+        let values = create_test_values(0..TEST_ITEM_COUNT as u64);
 
         cache.insert_all_hashed(values.iter().map(Cow::Borrowed));
 
@@ -227,10 +309,10 @@ mod tests {
 
     #[test]
     fn test_eviction() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
-        // Insert 3x capacity to guarantee evictions (quick_cache capacity is approximate).
-        let total = TEST_CACHE_SIZE * 3;
-        let values = create_test_values(0..total as u64);
+        let cache = new_small_cache();
+        // Insert many more entries than the cache can hold (1000 bytes / ~72 bytes per entry ≈ 13).
+        let total = 50;
+        let values = create_test_values(0..total);
 
         for value in &values {
             cache.insert_hashed(Cow::Borrowed(value));
@@ -238,16 +320,15 @@ mod tests {
 
         let present_count = values.iter().filter(|v| cache.contains(&v.hash())).count();
         assert!(
-            present_count <= TEST_CACHE_SIZE + 1,
-            "cache should not hold significantly more than its capacity, \
-             but has {present_count} entries for capacity {TEST_CACHE_SIZE}"
+            present_count < total as usize,
+            "cache should have evicted some entries, but all {total} are still present"
         );
         assert!(present_count > 0, "cache should still hold some entries");
     }
 
     #[test]
     fn test_accessed_entry_survives_eviction() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
+        let cache = new_small_cache();
         let promoted = create_test_value(0);
         let promoted_hash = promoted.hash();
 
@@ -256,7 +337,7 @@ mod tests {
         cache.get(&promoted_hash);
 
         // Insert many more entries to force evictions.
-        let extras = create_test_values(1..=TEST_CACHE_SIZE as u64 * 2);
+        let extras = create_test_values(1..=TEST_ITEM_COUNT as u64 * 2);
         for value in &extras {
             cache.insert_hashed(Cow::Borrowed(value));
         }
@@ -269,7 +350,7 @@ mod tests {
 
     #[test]
     fn test_promotion_of_reinsertion() {
-        let cache = ValueCache::<CryptoHash, Hashed<TestValue>>::new(TEST_CACHE_SIZE);
+        let cache = new_small_cache();
         let promoted = create_test_value(0);
         let promoted_hash = promoted.hash();
 
@@ -278,7 +359,7 @@ mod tests {
         assert!(!cache.insert_hashed(Cow::Borrowed(&promoted)));
 
         // Insert many more entries to force evictions.
-        let extras = create_test_values(1..=TEST_CACHE_SIZE as u64 * 2);
+        let extras = create_test_values(1..=TEST_ITEM_COUNT as u64 * 2);
         for value in &extras {
             cache.insert_hashed(Cow::Borrowed(value));
         }
@@ -287,5 +368,24 @@ mod tests {
             cache.contains(&promoted_hash),
             "re-inserted entry should survive eviction"
         );
+    }
+
+    #[test]
+    fn test_invalidate_clears_all_entries() {
+        let cache = new_test_cache();
+        let values = create_test_values(0..5);
+
+        for value in &values {
+            cache.insert_hashed(Cow::Borrowed(value));
+        }
+
+        cache.invalidate();
+
+        for value in &values {
+            assert!(
+                !cache.contains(&value.hash()),
+                "cache should be empty after invalidation"
+            );
+        }
     }
 }

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -278,7 +278,7 @@ where
         options: &Options,
         default_chain: Option<ChainId>,
         genesis_config: GenesisConfig,
-        block_cache_size: usize,
+        block_cache_size: u64,
         execution_state_cache_size: usize,
     ) -> Result<Self, Error> {
         #[cfg(not(web))]

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -280,7 +280,7 @@ impl<Env: Environment> Client<Env> {
         priority_bundle_origins: HashSet<ChainId>,
         options: ChainClientOptions,
         requests_scheduler_config: requests_scheduler::RequestsSchedulerConfig,
-        block_cache_size: usize,
+        block_cache_size: u64,
         execution_state_cache_size: usize,
     ) -> Self {
         let chain_modes = Arc::new(RwLock::new(chain_modes.into_iter().collect()));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -56,7 +56,7 @@ use crate::{
     CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
-pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 5_000;
+pub const DEFAULT_BLOCK_CACHE_SIZE: u64 = 52_428_800;
 pub const DEFAULT_EXECUTION_STATE_CACHE_SIZE: usize = 10_000;
 
 #[cfg(test)]
@@ -540,15 +540,18 @@ where
         nickname: String,
         key_pair: Option<ValidatorSecretKey>,
         storage: StorageClient,
-        block_cache_size: usize,
+        block_cache_size: u64,
         execution_state_cache_size: usize,
     ) -> Self {
         WorkerState {
             nickname,
             storage,
             chain_worker_config: ChainWorkerConfig::default().with_key_pair(key_pair),
-            block_cache: Arc::new(ValueCache::new(block_cache_size)),
-            execution_state_cache: Arc::new(UniqueValueCache::new(execution_state_cache_size)),
+            block_cache: Arc::new(ValueCache::new("block", block_cache_size)),
+            execution_state_cache: Arc::new(UniqueValueCache::new(
+                "execution_state",
+                execution_state_cache_size,
+            )),
             chain_modes: None,
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
@@ -561,15 +564,18 @@ where
         nickname: String,
         storage: StorageClient,
         chain_modes: Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>,
-        block_cache_size: usize,
+        block_cache_size: u64,
         execution_state_cache_size: usize,
     ) -> Self {
         WorkerState {
             nickname,
             storage,
             chain_worker_config: ChainWorkerConfig::default(),
-            block_cache: Arc::new(ValueCache::new(block_cache_size)),
-            execution_state_cache: Arc::new(UniqueValueCache::new(execution_state_cache_size)),
+            block_cache: Arc::new(ValueCache::new("block", block_cache_size)),
+            execution_state_cache: Arc::new(UniqueValueCache::new(
+                "execution_state",
+                execution_state_cache_size,
+            )),
             chain_modes: Some(chain_modes),
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -69,25 +69,25 @@ pub struct RocksDbConfig {
     #[arg(long, default_value = "10000000")]
     pub max_cache_find_key_values_size: usize,
 
-    /// The maximal number of entries in the blob cache.
-    #[arg(long, default_value = "1000")]
-    pub blob_cache_size: usize,
+    /// Maximum bytes in the blob cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub blob_cache_size: u64,
 
-    /// The maximal number of entries in the confirmed block cache.
-    #[arg(long, default_value = "1000")]
-    pub confirmed_block_cache_size: usize,
+    /// Maximum bytes in the confirmed block cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub confirmed_block_cache_size: u64,
 
-    /// The maximal number of entries in the lite certificate cache.
-    #[arg(long, default_value = "1000")]
-    pub lite_certificate_cache_size: usize,
+    /// Maximum bytes in the lite certificate cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub lite_certificate_cache_size: u64,
 
-    /// The maximal number of entries in the raw certificate cache.
-    #[arg(long, default_value = "1000")]
-    pub certificate_raw_cache_size: usize,
+    /// Maximum bytes in the raw certificate cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub certificate_raw_cache_size: u64,
 
-    /// The maximal number of entries in the event cache.
-    #[arg(long, default_value = "1000")]
-    pub event_cache_size: usize,
+    /// Maximum bytes in the event cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub event_cache_size: u64,
 }
 
 pub type RocksDbRunner = Runner<RocksDbDatabase, RocksDbConfig>;

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -63,25 +63,25 @@ pub struct ScyllaDbConfig {
     #[arg(long, default_value = "10000000")]
     pub max_cache_find_key_values_size: usize,
 
-    /// The maximal number of entries in the blob cache.
-    #[arg(long, default_value = "1000")]
-    pub blob_cache_size: usize,
+    /// Maximum bytes in the blob cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub blob_cache_size: u64,
 
-    /// The maximal number of entries in the confirmed block cache.
-    #[arg(long, default_value = "1000")]
-    pub confirmed_block_cache_size: usize,
+    /// Maximum bytes in the confirmed block cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub confirmed_block_cache_size: u64,
 
-    /// The maximal number of entries in the lite certificate cache.
-    #[arg(long, default_value = "1000")]
-    pub lite_certificate_cache_size: usize,
+    /// Maximum bytes in the lite certificate cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub lite_certificate_cache_size: u64,
 
-    /// The maximal number of entries in the raw certificate cache.
-    #[arg(long, default_value = "1000")]
-    pub certificate_raw_cache_size: usize,
+    /// Maximum bytes in the raw certificate cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub certificate_raw_cache_size: u64,
 
-    /// The maximal number of entries in the event cache.
-    #[arg(long, default_value = "1000")]
-    pub event_cache_size: usize,
+    /// Maximum bytes in the event cache.
+    #[arg(long, default_value_t = 52_428_800)]
+    pub event_cache_size: u64,
 
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1")]

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2256,6 +2256,7 @@ dependencies = [
 name = "linera-cache"
 version = "0.15.15"
 dependencies = [
+ "allocative",
  "cfg_aliases",
  "linera-base",
  "lru",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -97,6 +97,7 @@ k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 linera-base.workspace = true
 linera-bridge.workspace = true
+linera-cache.workspace = true
 linera-chain.workspace = true
 linera-client = { workspace = true, features = ["fs"] }
 linera-core = { workspace = true, features = ["fs"] }
@@ -115,7 +116,6 @@ linera-storage.workspace = true
 linera-storage-service = { workspace = true, optional = true }
 linera-version.workspace = true
 linera-views.workspace = true
-lru.workspace = true
 mini-moka.workspace = true
 nonzero_lit.workspace = true
 papaya.workspace = true

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -33,6 +33,7 @@ use linera_base::{
     vm::VmRuntime,
     BcsHexParseError,
 };
+use linera_cache::ValueCache;
 use linera_chain::{
     types::{ConfirmedBlock, GenericCertificate},
     ChainStateView,
@@ -53,7 +54,6 @@ use linera_execution::{
 #[cfg(with_metrics)]
 use linera_metrics::monitoring_server;
 use linera_sdk::linera_base_types::BlobContent;
-use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tokio::sync::{mpsc::UnboundedReceiver, OwnedRwLockReadGuard};
@@ -988,45 +988,10 @@ where
     }
 }
 
-#[cfg(with_metrics)]
-mod query_cache_metrics {
-    use std::sync::LazyLock;
-
-    use linera_base::prometheus_util::{register_int_counter_vec, register_int_gauge};
-    use prometheus::{IntCounterVec, IntGauge};
-
-    pub static QUERY_CACHE_HIT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec("query_response_cache_hit", "Query response cache hits", &[])
-    });
-
-    pub static QUERY_CACHE_MISS: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "query_response_cache_miss",
-            "Query response cache misses",
-            &[],
-        )
-    });
-
-    pub static QUERY_CACHE_INVALIDATION: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "query_response_cache_invalidation",
-            "Query response cache invalidations (per chain)",
-            &[],
-        )
-    });
-
-    pub static QUERY_CACHE_ENTRIES: LazyLock<IntGauge> = LazyLock::new(|| {
-        register_int_gauge(
-            "query_response_cache_entries",
-            "Current number of cached query responses across all chains",
-        )
-    });
-}
-
-/// Per-chain cache state: an LRU map plus the `next_block_height` at the time the
+/// Per-chain cache state: a `ValueCache` plus the `next_block_height` at the time the
 /// cache was last invalidated. Both are behind the same mutex.
 struct PerChainCache {
-    lru: LruCache<(ApplicationId, Vec<u8>), Vec<u8>>,
+    cache: ValueCache<(ApplicationId, Vec<u8>), Vec<u8>>,
     next_block_height: BlockHeight,
 }
 
@@ -1044,17 +1009,17 @@ struct QueryResponseCache {
     subscribed: papaya::HashSet<ChainId>,
     /// Sender half of the notification channel, used to subscribe new chains lazily.
     notification_sender: StdMutex<Option<tokio::sync::mpsc::UnboundedSender<Notification>>>,
-    capacity_per_chain: std::num::NonZeroUsize,
+    weight_capacity_per_chain: u64,
 }
 
 impl QueryResponseCache {
-    fn new(capacity_per_chain: usize) -> Self {
+    fn new(weight_capacity_per_chain: u64) -> Self {
+        assert!(weight_capacity_per_chain > 0, "weight capacity must be > 0");
         Self {
             chains: papaya::HashMap::new(),
             subscribed: papaya::HashSet::new(),
             notification_sender: StdMutex::new(None),
-            capacity_per_chain: std::num::NonZeroUsize::new(capacity_per_chain)
-                .expect("capacity must be > 0"),
+            weight_capacity_per_chain,
         }
     }
 
@@ -1092,34 +1057,22 @@ impl QueryResponseCache {
         }
     }
 
+    fn new_per_chain_cache(&self, next_block_height: BlockHeight) -> StdMutex<PerChainCache> {
+        StdMutex::new(PerChainCache {
+            cache: ValueCache::new("query_response", self.weight_capacity_per_chain),
+            next_block_height,
+        })
+    }
+
     /// Looks up a cached response. Returns `Some(bytes)` on hit, `None` on miss
     /// (including when the chain has no cache entry yet).
     #[allow(clippy::question_mark)]
     fn get(&self, chain_id: ChainId, app_id: &ApplicationId, request: &[u8]) -> Option<Vec<u8>> {
         let pinned = self.chains.pin();
-        let Some(mutex) = pinned.get(&chain_id) else {
-            #[cfg(with_metrics)]
-            query_cache_metrics::QUERY_CACHE_MISS
-                .with_label_values(&[])
-                .inc();
-            return None;
-        };
-        let mut cache = mutex.lock().expect("LRU mutex poisoned");
+        let mutex = pinned.get(&chain_id)?;
+        let cache = mutex.lock().expect("cache mutex poisoned");
         let key = (*app_id, request.to_vec());
-        let result = cache.lru.get(&key).cloned();
-        #[cfg(with_metrics)]
-        {
-            if result.is_some() {
-                query_cache_metrics::QUERY_CACHE_HIT
-                    .with_label_values(&[])
-                    .inc();
-            } else {
-                query_cache_metrics::QUERY_CACHE_MISS
-                    .with_label_values(&[])
-                    .inc();
-            }
-        }
-        result
+        cache.cache.get(&key)
     }
 
     /// Inserts a response into the cache, unless the chain's `next_block_height` has
@@ -1134,66 +1087,33 @@ impl QueryResponseCache {
         next_block_height: BlockHeight,
     ) {
         let pinned = self.chains.pin();
-        let capacity = self.capacity_per_chain;
-        let mutex = pinned.get_or_insert_with(chain_id, || {
-            StdMutex::new(PerChainCache {
-                lru: LruCache::new(capacity),
-                next_block_height,
-            })
-        });
-        let mut cache = mutex.lock().expect("LRU mutex poisoned");
+        let mutex =
+            pinned.get_or_insert_with(chain_id, || self.new_per_chain_cache(next_block_height));
+        let mut cache = mutex.lock().expect("cache mutex poisoned");
         if next_block_height < cache.next_block_height {
             return; // A new block arrived since this query started; discard stale response.
         }
-        // If the chain has advanced since the last cache update, also clear stale entries.
-        // Note: This should not happen if notifications are timely. Also, this only
-        // works when we have a cache miss.
         if next_block_height > cache.next_block_height {
             debug!(
                 "Unexpected query cache invalidation for chain {chain_id}:\
                  {next_block_height} > {}",
                 cache.next_block_height
             );
-            #[cfg(with_metrics)]
-            {
-                query_cache_metrics::QUERY_CACHE_ENTRIES.sub(cache.lru.len() as i64);
-                query_cache_metrics::QUERY_CACHE_INVALIDATION
-                    .with_label_values(&[])
-                    .inc();
-            }
-            cache.lru.clear();
+            cache.cache.invalidate();
             cache.next_block_height = next_block_height;
         }
-        #[cfg(with_metrics)]
-        let prev_len = cache.lru.len();
-        cache.lru.put((app_id, request), response);
-        #[cfg(with_metrics)]
-        if cache.lru.len() != prev_len {
-            query_cache_metrics::QUERY_CACHE_ENTRIES.inc();
-        }
+        cache.cache.insert(&(app_id, request), response);
     }
 
     /// Called when a `NewBlock` notification arrives. Records the new
     /// `next_block_height` and clears all cached responses for the chain.
     fn invalidate_chain(&self, chain_id: &ChainId, next_block_height: BlockHeight) {
         let pinned = self.chains.pin();
-        let capacity = self.capacity_per_chain;
-        let mutex = pinned.get_or_insert_with(*chain_id, || {
-            StdMutex::new(PerChainCache {
-                lru: LruCache::new(capacity),
-                next_block_height,
-            })
-        });
-        let mut cache = mutex.lock().expect("LRU mutex poisoned");
+        let mutex =
+            pinned.get_or_insert_with(*chain_id, || self.new_per_chain_cache(next_block_height));
+        let mut cache = mutex.lock().expect("cache mutex poisoned");
         if next_block_height > cache.next_block_height {
-            #[cfg(with_metrics)]
-            {
-                query_cache_metrics::QUERY_CACHE_ENTRIES.sub(cache.lru.len() as i64);
-                query_cache_metrics::QUERY_CACHE_INVALIDATION
-                    .with_label_values(&[])
-                    .inc();
-            }
-            cache.lru.clear();
+            cache.cache.invalidate();
             cache.next_block_height = next_block_height;
         } else {
             debug!(
@@ -1266,7 +1186,12 @@ where
         query_subscriptions: Option<Arc<crate::query_subscription::QuerySubscriptionManager>>,
         cancellation_token: CancellationToken,
     ) -> Self {
-        let query_cache = query_cache_size.map(|size| Arc::new(QueryResponseCache::new(size)));
+        // Convert per-chain item capacity (from CLI) to a weight capacity.
+        // Assume ~4 KB average response size.
+        let query_cache = query_cache_size.map(|item_count| {
+            let weight_capacity = (item_count as u64).saturating_mul(4 * 1024);
+            Arc::new(QueryResponseCache::new(weight_capacity))
+        });
         Self {
             config,
             port,
@@ -1581,7 +1506,7 @@ mod tests {
 
     #[test]
     fn cache_hit_and_miss() {
-        let cache = QueryResponseCache::new(100);
+        let cache = QueryResponseCache::new(1_000_000);
         let chain = test_chain(0);
         let app = test_app(0);
         let request = b"query { balance }".to_vec();
@@ -1605,7 +1530,7 @@ mod tests {
 
     #[test]
     fn per_chain_isolation() {
-        let cache = QueryResponseCache::new(100);
+        let cache = QueryResponseCache::new(1_000_000);
         let chain_a = test_chain(0);
         let chain_b = test_chain(1);
         let app = test_app(0);
@@ -1627,7 +1552,7 @@ mod tests {
 
     #[test]
     fn invalidation_clears_all_entries() {
-        let cache = QueryResponseCache::new(100);
+        let cache = QueryResponseCache::new(1_000_000);
         let chain = test_chain(0);
         let app = test_app(0);
 
@@ -1640,24 +1565,32 @@ mod tests {
     }
 
     #[test]
-    fn lru_eviction() {
-        let cache = QueryResponseCache::new(2);
+    fn weight_based_eviction() {
+        // Each (ApplicationId, Vec<u8>) + Vec<u8> entry weighs ~230 bytes via allocative
+        // (32 for ApplicationId + Vec overhead + heap). A capacity of 600 fits ~2 entries,
+        // so inserting 3 must evict at least one.
+        let cache = QueryResponseCache::new(600);
         let chain = test_chain(0);
         let app = test_app(0);
+        let response = vec![0u8; 50];
 
-        cache.insert(chain, app, b"q1".to_vec(), b"r1".to_vec(), BlockHeight(1));
-        cache.insert(chain, app, b"q2".to_vec(), b"r2".to_vec(), BlockHeight(1));
-        // Third insert evicts q1 (least recently used).
-        cache.insert(chain, app, b"q3".to_vec(), b"r3".to_vec(), BlockHeight(1));
+        cache.insert(chain, app, b"q1".to_vec(), response.clone(), BlockHeight(1));
+        cache.insert(chain, app, b"q2".to_vec(), response.clone(), BlockHeight(1));
+        cache.insert(chain, app, b"q3".to_vec(), response, BlockHeight(1));
 
-        assert!(cache.get(chain, &app, b"q1").is_none());
-        assert!(cache.get(chain, &app, b"q2").is_some());
-        assert!(cache.get(chain, &app, b"q3").is_some());
+        let remaining = [b"q1", b"q2", b"q3"]
+            .iter()
+            .filter(|q| cache.get(chain, &app, q.as_slice()).is_some())
+            .count();
+        assert!(
+            remaining < 3,
+            "expected eviction to remove at least one entry, but all 3 are still present"
+        );
     }
 
     #[test]
     fn stale_insert_rejected_after_invalidation() {
-        let cache = QueryResponseCache::new(100);
+        let cache = QueryResponseCache::new(1_000_000);
         let chain = test_chain(0);
         let app = test_app(0);
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -71,7 +71,7 @@ struct ServerContext {
     block_time_grace_period: Duration,
     chain_worker_ttl: Duration,
     chain_info_max_received_log_entries: usize,
-    block_cache_size: usize,
+    block_cache_size: u64,
     execution_state_cache_size: usize,
 }
 

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -83,31 +83,31 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "10000000", global = true)]
     pub storage_max_cache_find_key_values_size: usize,
 
-    /// The maximal number of entries in the blob cache.
-    #[arg(long, default_value = "1000", global = true)]
-    pub blob_cache_size: usize,
+    /// Maximum bytes in the blob cache.
+    #[arg(long, default_value_t = 52_428_800, global = true)]
+    pub blob_cache_size: u64,
 
-    /// The maximal number of entries in the confirmed block cache.
-    #[arg(long, default_value = "1000", global = true)]
-    pub confirmed_block_cache_size: usize,
+    /// Maximum bytes in the confirmed block cache.
+    #[arg(long, default_value_t = 52_428_800, global = true)]
+    pub confirmed_block_cache_size: u64,
 
-    /// The maximal number of entries in the lite certificate cache.
-    #[arg(long, default_value = "1000", global = true)]
-    pub lite_certificate_cache_size: usize,
+    /// Maximum bytes in the lite certificate cache.
+    #[arg(long, default_value_t = 52_428_800, global = true)]
+    pub lite_certificate_cache_size: u64,
 
-    /// The maximal number of entries in the raw certificate cache.
-    #[arg(long, default_value = "1000", global = true)]
-    pub certificate_raw_cache_size: usize,
+    /// Maximum bytes in the raw certificate cache.
+    #[arg(long, default_value_t = 52_428_800, global = true)]
+    pub certificate_raw_cache_size: u64,
 
-    /// The maximal number of entries in the event cache.
-    #[arg(long, default_value = "1000", global = true)]
-    pub event_cache_size: usize,
+    /// Maximum bytes in the event cache.
+    #[arg(long, default_value_t = 52_428_800, global = true)]
+    pub event_cache_size: u64,
 
-    /// The number of entries in the block cache.
-    #[arg(long, default_value = "5000", global = true)]
-    pub block_cache_size: usize,
+    /// Maximum bytes in the block cache.
+    #[arg(long, default_value_t = 52_428_800, global = true)]
+    pub block_cache_size: u64,
 
-    /// The number of entries in the execution state cache.
+    /// Maximum entries in the execution state cache.
     #[arg(long, default_value = "10000", global = true)]
     pub execution_state_cache_size: usize,
 

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -23,7 +23,7 @@ pub async fn new_test_client_context(
     storage: impl linera_core::environment::Storage,
     wallet: Wallet,
     signer: impl linera_core::environment::Signer,
-    _block_cache_size: usize,
+    _block_cache_size: u64,
     _execution_state_cache_size: usize,
 ) -> anyhow::Result<ClientContext<impl linera_core::Environment>> {
     use linera_core::{client::ChainClientOptions, node::CrossChainMessageDelivery};

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -354,11 +354,11 @@ impl MultiPartitionBatch {
 /// Individual cache sizes for each `ValueCache` in `DbStorage`.
 #[derive(Clone, Copy, Debug)]
 pub struct StorageCacheSizes {
-    pub blob_cache_size: usize,
-    pub confirmed_block_cache_size: usize,
-    pub lite_certificate_cache_size: usize,
-    pub certificate_raw_cache_size: usize,
-    pub event_cache_size: usize,
+    pub blob_cache_size: u64,
+    pub confirmed_block_cache_size: u64,
+    pub lite_certificate_cache_size: u64,
+    pub certificate_raw_cache_size: u64,
+    pub event_cache_size: u64,
 }
 
 /// Raw certificate bytes: (lite_certificate_bytes, confirmed_block_bytes).
@@ -1937,17 +1937,20 @@ where
             wasm_runtime,
             user_contracts: Arc::new(papaya::HashMap::new()),
             user_services: Arc::new(papaya::HashMap::new()),
-            blob_cache: Arc::new(ValueCache::new(cache_sizes.blob_cache_size)),
+            blob_cache: Arc::new(ValueCache::new("blob", cache_sizes.blob_cache_size)),
             confirmed_block_cache: Arc::new(ValueCache::new(
+                "confirmed_block",
                 cache_sizes.confirmed_block_cache_size,
             )),
             lite_certificate_cache: Arc::new(ValueCache::new(
+                "lite_certificate",
                 cache_sizes.lite_certificate_cache_size,
             )),
             certificate_raw_cache: Arc::new(ValueCache::new(
+                "certificate_raw",
                 cache_sizes.certificate_raw_cache_size,
             )),
-            event_cache: Arc::new(ValueCache::new(cache_sizes.event_cache_size)),
+            event_cache: Arc::new(ValueCache::new("event", cache_sizes.event_cache_size)),
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }
     }
@@ -2058,11 +2061,11 @@ where
     ) -> Result<Self, ViewError> {
         let database = Database::recreate_and_connect(&config, namespace).await?;
         let default_cache_sizes = StorageCacheSizes {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            lite_certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
+            blob_cache_size: 1024 * 1024,
+            confirmed_block_cache_size: 1024 * 1024,
+            lite_certificate_cache_size: 1024 * 1024,
+            certificate_raw_cache_size: 1024 * 1024,
+            event_cache_size: 1024 * 1024,
         };
         let storage = Self::new(database, wasm_runtime, default_cache_sizes, clock);
         storage.assert_is_migrated_storage().await?;

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -576,11 +576,11 @@ mod tests {
         write_storage_state_old_schema(&database, storage_state.clone()).await?;
         // Creating a storage and migrate to the new database schema.
         let cache_sizes = StorageCacheSizes {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            lite_certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
+            blob_cache_size: 1024 * 1024,
+            confirmed_block_cache_size: 1024 * 1024,
+            lite_certificate_cache_size: 1024 * 1024,
+            certificate_raw_cache_size: 1024 * 1024,
+            event_cache_size: 1024 * 1024,
         };
         let storage = DbStorage::<D, WallClock>::new(database, None, cache_sizes, WallClock);
         storage.migrate_if_needed().await?;

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -18,11 +18,11 @@ pub async fn get_storage(namespace: &str) -> Result<Storage, linera_views::ViewE
         namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
         linera_storage::StorageCacheSizes {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            lite_certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
+            blob_cache_size: 1024 * 1024,
+            confirmed_block_cache_size: 1024 * 1024,
+            lite_certificate_cache_size: 1024 * 1024,
+            certificate_raw_cache_size: 1024 * 1024,
+            event_cache_size: 1024 * 1024,
         },
     )
     .await?


### PR DESCRIPTION
## Motivation

Our caches had two problems:

1. **No observability for most caches.** `ValueCache` only had type-name-based hit/miss
counters (`value_cache_hit{key_type, value_type}`). `UniqueValueCache` had zero metrics.
The query response cache in `node_service.rs` had its own bespoke metrics module. We
had no visibility into cache byte usage, eviction rates, entry counts, or invalidations
for any cache.

2. **Incorrect or expensive weight functions.** `ValueCache` used item-count eviction
(no weight awareness at all — just `Cache::new(size)`). When we eventually need
weight-based eviction, the existing approach required per-cache weight function closures
— some using `bcs::serialized_size` (full serde traversal cost) and others using
`std::mem::size_of` (wrong for heap-heavy types).

## Proposal

### Unified Prometheus metrics for all caches

Added a `metrics` module to `linera-cache` with six labeled metrics covering all cache
instances:

- `cache_hit{name, t` / `cache_miss{name, type}` — per-cache hit/miss counters
- `cache_entries{name, type}` / `cache_bytes{name, type}` — current entry count and byte
weight gauges
- `cache_eviction{name, type}` — eviction counter (via quick_cache `Lifecycle` hook for
`ValueCache`, manual tracking for `UniqueValueCache`)
- `cache_invalidation{name, type}` — full-cache clear counter

The `type` label is `"value"` or `"unique"`, and `name` is a human-readable label like
`"block"`, `"blob"`, `"execution_state"`, etc. This replaces the old type-name-based
labels (e.g., `key_type="linera_base::crypto::CryptoHash"`) and the bespoke
`query_response_cache_*` metrics in `node_service.rs`.

A global name registry (behind `#[cfg(with_metrics)]`) panics at startup if two caches
are created with the same name, preventing metric label collisions.

### `allocative`-based byte weights

Every cached type already derives `Allocative`. The new `AllocativeWeighter` uses
`allocative::size_of_unique()` which memem::size_of::<T>()` + all uniquely-owned
heap allocations. This replaces the need for per-cache weight function closures.

- `ValueCache::new(name, weight_capacity)` — down from `Cache::new(size)` (item-count)
to weight-based eviction with 2 parameters
- `UniqueValueCache::new(name, capacity)` — keeps item-count LRU eviction but now tracks
byte weight via allocative for the `cache_bytes` gauge

### Byte-based CLI options

All cache size CLI flags are now byte limits (`u64`) instead of entry counts (`usize`):

- `--blob-cache-size`, `--confirmed-block-cache-size`, `--lite-certificate-cache-size`,
`--certificate-raw-cache-size`, `--event-cache-size`, `--block-cache-size` — all default
to 50 MiB (conservative; production deployments tune via Helm)
- `--execution-state-cache-size` — unchanged, stays as item count (it uses
`UniqueValueCache` with LRU eviction)

### Query response cache consolidation

`node_service.rs` had its own `query_cache_metrics` module with 4 bespokeeus
metrics and an `LruCache`-based implementation. Replaced it with `ValueCache` from
`linera-cache`, getting all six standard cache metrics for free. Removed the `lru`
dependency from `linera-service`.

## Test Plan

CI
