### PR TITLE
fix(alloy): Remove invalid River ternary syntax and fix env var mapping

### DIFF
--- a/docker/alloy-config.river
+++ b/docker/alloy-config.river
@@ -11,9 +11,7 @@ prometheus.scrape "proxy_metrics" {
     instance    = env("HOSTNAME"),
   }]
 
-  // Conditionally forward to OTLP converter if Prometheus export is enabled
-  // Otherwise, just collect metrics without exporting
-  forward_to = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.receiver.prometheus.default.receiver] : []
+  forward_to = [otelcol.receiver.prometheus.default.receiver]
 
   scrape_interval = "15s"
   scrape_timeout  = "10s"
@@ -48,8 +46,7 @@ prometheus.scrape "shard_metrics" {
     },
   ]
 
-  // Conditional forwarding - only export if PROMETHEUS_ENABLED is set to "true"
-  forward_to = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.receiver.prometheus.default.receiver] : []
+  forward_to = [otelcol.receiver.prometheus.default.receiver]
 
   scrape_interval = "15s"
   scrape_timeout  = "10s"
@@ -60,17 +57,14 @@ prometheus.exporter.self "alloy" {}
 
 prometheus.scrape "alloy_metrics" {
   targets    = prometheus.exporter.self.alloy.targets
-  // Conditionally forward to OTLP converter if Prometheus export is enabled
-  forward_to = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.receiver.prometheus.default.receiver] : []
+  forward_to = [otelcol.receiver.prometheus.default.receiver]
 }
 
-// ==================== Prometheus Metrics Export (Optional) ====================
+// ==================== Prometheus Metrics Export ====================
 
 // Convert Prometheus metrics to OTLP and send to external Prometheus
-// Enabled via PROMETHEUS_ENABLED environment variable
 // Requires: PROMETHEUS_OTLP_URL, PROMETHEUS_OTLP_USER, PROMETHEUS_OTLP_PASS
 
-// Export Prometheus metrics as OTLP (only if enabled)
 otelcol.exporter.otlphttp "prometheus" {
   client {
     endpoint = env("PROMETHEUS_OTLP_URL")
@@ -80,19 +74,26 @@ otelcol.exporter.otlphttp "prometheus" {
     tls {
       insecure_skip_verify = false
     }
+
+    compression = "gzip"
+
+    headers = {
+      "Content-Type" = "application/x-protobuf",
+    }
   }
+
+  encoding = "proto"
 }
 
-// Basic auth for Prometheus OTLP
 otelcol.auth.basic "prometheus_credentials" {
   username = env("PROMETHEUS_OTLP_USER")
   password = env("PROMETHEUS_OTLP_PASS")
 }
 
-// Convert Prometheus metrics to OTLP format (only if enabled)
+// Convert Prometheus metrics to OTLP format
 otelcol.receiver.prometheus "default" {
   output {
-    metrics = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.exporter.otlphttp.prometheus.input] : []
+    metrics = [otelcol.exporter.otlphttp.prometheus.input]
   }
 }
 
@@ -106,17 +107,17 @@ discovery.docker "containers" {
 // Relabel discovered containers
 discovery.relabel "docker_logs" {
   targets = discovery.docker.containers.targets
-  
+
   rule {
     source_labels = ["__meta_docker_container_name"]
     target_label  = "container"
   }
-  
+
   rule {
     source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
     target_label  = "service"
   }
-  
+
   rule {
     source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
     target_label  = "project"
@@ -127,12 +128,10 @@ discovery.relabel "docker_logs" {
 loki.source.docker "containers" {
   host       = "unix:///var/run/docker.sock"
   targets    = discovery.relabel.docker_logs.output
-  // Conditionally forward to Loki if export is enabled
-  forward_to = env("LOKI_ENABLED") == "true" ? [loki.write.central.receiver] : []
+  forward_to = [loki.write.central.receiver]
 }
 
-// Write logs to external Loki (only if enabled)
-// Enabled via LOKI_ENABLED environment variable
+// Write logs to external Loki
 // Requires: LOKI_PUSH_URL, LOKI_PUSH_USER, LOKI_PUSH_PASS
 loki.write "central" {
   endpoint {
@@ -167,13 +166,11 @@ otelcol.receiver.otlp "default" {
   }
 
   output {
-    // Conditionally forward to Tempo if export is enabled
-    traces  = env("TEMPO_ENABLED") == "true" ? [otelcol.exporter.otlphttp.central.input] : []
+    traces = [otelcol.exporter.otlphttp.central.input]
   }
 }
 
-// Export traces to external Tempo (only if enabled)
-// Enabled via TEMPO_ENABLED environment variable
+// Export traces to external Tempo
 // Requires: TEMPO_OTLP_URL, TEMPO_OTLP_USER, TEMPO_OTLP_PASS
 otelcol.exporter.otlphttp "central" {
   client {
@@ -187,14 +184,7 @@ otelcol.exporter.otlphttp "central" {
   }
 }
 
-// Basic auth for OTLP
 otelcol.auth.basic "credentials" {
   username = env("TEMPO_OTLP_USER")
   password = env("TEMPO_OTLP_PASS")
 }
-
-// ==================== Metrics Exposition ====================
-
-// Expose Prometheus-compatible metrics endpoint for central Prometheus to scrape
-// This runs on port 12345 and exposes all collected metrics
-// Note: Alloy's own metrics are already exposed via prometheus.exporter.self

--- a/docker/docker-compose.alloy.yml
+++ b/docker/docker-compose.alloy.yml
@@ -5,19 +5,16 @@
 #
 # Documentation: See MONITORING.md for complete setup and configuration guide
 #
-# Required environment variables for remote push:
-#   ALLOY_PROMETHEUS_ENABLED: true|false (enable Prometheus metrics export)
-#   ALLOY_PROMETHEUS_URL: https://your-prometheus-endpoint/otlp
-#   ALLOY_PROMETHEUS_USER: your-username
-#   ALLOY_PROMETHEUS_PASS: your-password
-#   ALLOY_LOKI_ENABLED: true|false (enable Loki logs export)
-#   ALLOY_LOKI_URL: https://your-loki-endpoint/loki/api/v1/push
-#   ALLOY_LOKI_USER: your-username
-#   ALLOY_LOKI_PASS: your-password
-#   ALLOY_TEMPO_ENABLED: true|false (enable Tempo traces export)
-#   ALLOY_TEMPO_URL: https://your-tempo-endpoint/tempo/otlp
-#   ALLOY_TEMPO_USER: your-username
-#   ALLOY_TEMPO_PASS: your-password
+# Required environment variables for remote push (set in .env):
+#   PROMETHEUS_OTLP_URL: https://your-prometheus-endpoint/otlp
+#   PROMETHEUS_OTLP_USER: your-username
+#   PROMETHEUS_OTLP_PASS: your-password
+#   LOKI_PUSH_URL: https://your-loki-endpoint/loki/api/v1/push
+#   LOKI_PUSH_USER: your-username
+#   LOKI_PUSH_PASS: your-password
+#   TEMPO_OTLP_URL: https://your-tempo-endpoint/tempo/otlp
+#   TEMPO_OTLP_USER: your-username
+#   TEMPO_OTLP_PASS: your-password
 
 services:
   alloy:
@@ -36,18 +33,15 @@ services:
       - "/etc/alloy/config.river"
     environment:
       - HOSTNAME=${HOSTNAME:-validator}
-      - PROMETHEUS_ENABLED=${ALLOY_PROMETHEUS_ENABLED:-false}
-      - PROMETHEUS_OTLP_URL=${ALLOY_PROMETHEUS_URL:-}
-      - PROMETHEUS_OTLP_USER=${ALLOY_PROMETHEUS_USER:-}
-      - PROMETHEUS_OTLP_PASS=${ALLOY_PROMETHEUS_PASS:-}
-      - LOKI_ENABLED=${ALLOY_LOKI_ENABLED:-false}
-      - LOKI_PUSH_URL=${ALLOY_LOKI_URL:-}
-      - LOKI_PUSH_USER=${ALLOY_LOKI_USER:-}
-      - LOKI_PUSH_PASS=${ALLOY_LOKI_PASS:-}
-      - TEMPO_ENABLED=${ALLOY_TEMPO_ENABLED:-false}
-      - TEMPO_OTLP_URL=${ALLOY_TEMPO_URL:-}
-      - TEMPO_OTLP_USER=${ALLOY_TEMPO_USER:-}
-      - TEMPO_OTLP_PASS=${ALLOY_TEMPO_PASS:-}
+      - PROMETHEUS_OTLP_URL=${PROMETHEUS_OTLP_URL:-http://localhost:4318}
+      - PROMETHEUS_OTLP_USER=${PROMETHEUS_OTLP_USER:-}
+      - PROMETHEUS_OTLP_PASS=${PROMETHEUS_OTLP_PASS:-}
+      - LOKI_PUSH_URL=${LOKI_PUSH_URL:-http://localhost:3100}
+      - LOKI_PUSH_USER=${LOKI_PUSH_USER:-}
+      - LOKI_PUSH_PASS=${LOKI_PUSH_PASS:-}
+      - TEMPO_OTLP_URL=${TEMPO_OTLP_URL:-http://localhost:4318}
+      - TEMPO_OTLP_USER=${TEMPO_OTLP_USER:-}
+      - TEMPO_OTLP_PASS=${TEMPO_OTLP_PASS:-}
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     depends_on:

--- a/kubernetes/linera-validator/alloy-config.river.tpl
+++ b/kubernetes/linera-validator/alloy-config.river.tpl
@@ -61,9 +61,7 @@ discovery.relabel "linera_metrics" {
 prometheus.scrape "linera_metrics" {
   targets = discovery.relabel.linera_metrics.output
 
-  // Conditionally forward to OTLP converter if Prometheus export is enabled
-  // Otherwise, just collect metrics without exporting
-  forward_to = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.receiver.prometheus.default.receiver] : []
+  forward_to = [otelcol.receiver.prometheus.default.receiver]
 
   scrape_interval = "15s"
   scrape_timeout  = "10s"
@@ -74,17 +72,14 @@ prometheus.exporter.self "alloy" {}
 
 prometheus.scrape "alloy_metrics" {
   targets    = prometheus.exporter.self.alloy.targets
-  // Conditionally forward to OTLP converter if Prometheus export is enabled
-  forward_to = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.receiver.prometheus.default.receiver] : []
+  forward_to = [otelcol.receiver.prometheus.default.receiver]
 }
 
-// ==================== Prometheus Metrics Export (Optional) ====================
+// ==================== Prometheus Metrics Export ====================
 
 // Convert Prometheus metrics to OTLP and send to external Prometheus
-// Enabled via PROMETHEUS_ENABLED environment variable
 // Requires: PROMETHEUS_OTLP_URL, PROMETHEUS_OTLP_USER, PROMETHEUS_OTLP_PASS
 
-// Export Prometheus metrics as OTLP (only if enabled)
 otelcol.exporter.otlphttp "prometheus" {
   client {
     endpoint = env("PROMETHEUS_OTLP_URL")
@@ -94,19 +89,26 @@ otelcol.exporter.otlphttp "prometheus" {
     tls {
       insecure_skip_verify = false
     }
+
+    compression = "gzip"
+
+    headers = {
+      "Content-Type" = "application/x-protobuf",
+    }
   }
+
+  encoding = "proto"
 }
 
-// Basic auth for Prometheus OTLP
 otelcol.auth.basic "prometheus_credentials" {
   username = env("PROMETHEUS_OTLP_USER")
   password = env("PROMETHEUS_OTLP_PASS")
 }
 
-// Convert Prometheus metrics to OTLP format (only if enabled)
+// Convert Prometheus metrics to OTLP format
 otelcol.receiver.prometheus "default" {
   output {
-    metrics = env("PROMETHEUS_ENABLED") == "true" ? [otelcol.exporter.otlphttp.prometheus.input] : []
+    metrics = [otelcol.exporter.otlphttp.prometheus.input]
   }
 }
 
@@ -154,12 +156,10 @@ discovery.relabel "pod_logs" {
 // Read pod logs
 loki.source.kubernetes "pods" {
   targets    = discovery.relabel.pod_logs.output
-  // Conditionally forward to Loki if export is enabled
-  forward_to = env("LOKI_ENABLED") == "true" ? [loki.write.central.receiver] : []
+  forward_to = [loki.write.central.receiver]
 }
 
-// Write logs to external Loki (only if enabled)
-// Enabled via LOKI_ENABLED environment variable
+// Write logs to external Loki
 // Requires: LOKI_PUSH_URL, LOKI_PUSH_USER, LOKI_PUSH_PASS
 loki.write "central" {
   endpoint {
@@ -194,13 +194,11 @@ otelcol.receiver.otlp "default" {
   }
 
   output {
-    // Conditionally forward to Tempo if export is enabled
-    traces  = env("TEMPO_ENABLED") == "true" ? [otelcol.exporter.otlphttp.central.input] : []
+    traces = [otelcol.exporter.otlphttp.central.input]
   }
 }
 
-// Export traces to external Tempo (only if enabled)
-// Enabled via TEMPO_ENABLED environment variable
+// Export traces to external Tempo
 // Requires: TEMPO_OTLP_URL, TEMPO_OTLP_USER, TEMPO_OTLP_PASS
 otelcol.exporter.otlphttp "central" {
   client {
@@ -214,14 +212,7 @@ otelcol.exporter.otlphttp "central" {
   }
 }
 
-// Basic auth for OTLP
 otelcol.auth.basic "credentials" {
   username = env("TEMPO_OTLP_USER")
   password = env("TEMPO_OTLP_PASS")
 }
-
-// ==================== Metrics Exposition ====================
-
-// Expose Prometheus-compatible metrics endpoint for central Prometheus to scrape
-// This runs on port 12345 and exposes all collected metrics
-// Note: Alloy's own metrics are already exposed via prometheus.exporter.self


### PR DESCRIPTION
## Summary

- Remove invalid River ternary operators (`? :`) from all `alloy-config.river` files — River doesn't support this syntax, causing Alloy to crash at startup with `illegal character U+003A ':'`
- Fix `docker-compose.alloy.yml` env var mapping: was expecting `ALLOY_*` prefixed vars but `.env` provides direct names (`PROMETHEUS_OTLP_URL`, `LOKI_PUSH_URL`, etc.), causing all values to arrive as empty strings
- Add `encoding = "proto"`, `compression = "gzip"`, and protobuf Content-Type header to the Prometheus OTLP exporter, preventing request timeouts from oversized JSON payloads

## Test plan

- Deployed fixed config to Docker Compose validator on `15.204.31.226.sslip.io`
- Verified Alloy starts cleanly with no errors
- Confirmed metrics flow to `push.infra.linera.net` without timeouts

Related: linera-io/linera-infra#763
