### PR TITLE
Backport #5601: Make jemalloc memory profiling opt-in via --enable-memory-profiling flag

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ ARG binaries=
 ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
-ARG build_features=scylladb,metrics,opentelemetry
+ARG build_features=scylladb,metrics,opentelemetry,jemalloc
 ARG rustflags="-C force-frame-pointers=yes"
 
 FROM rust:1.86-slim-bookworm AS builder

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -1106,6 +1106,7 @@ where
     pending_requests: Arc<Mutex<VecDeque<PendingRequest>>>,
     request_notifier: Arc<Notify>,
     max_batch_size: usize,
+    enable_memory_profiling: bool,
 }
 
 impl<C> Clone for FaucetService<C>
@@ -1133,6 +1134,7 @@ where
             pending_requests: Arc::clone(&self.pending_requests),
             request_notifier: Arc::clone(&self.request_notifier),
             max_batch_size: self.max_batch_size,
+            enable_memory_profiling: self.enable_memory_profiling,
         }
     }
 }
@@ -1149,6 +1151,7 @@ pub struct FaucetConfig {
     pub chain_listener_config: ChainListenerConfig,
     pub storage_path: PathBuf,
     pub max_batch_size: usize,
+    pub enable_memory_profiling: bool,
 }
 
 impl<C> FaucetService<C>
@@ -1203,6 +1206,7 @@ where
             pending_requests,
             request_notifier,
             max_batch_size: config.max_batch_size,
+            enable_memory_profiling: config.enable_memory_profiling,
         })
     }
 
@@ -1241,7 +1245,12 @@ where
         let index_handler = axum::routing::get(graphiql).post(Self::index_handler);
 
         #[cfg(feature = "metrics")]
-        monitoring_server::start_metrics(self.metrics_address(), cancellation_token.clone());
+        monitoring_server::start_metrics_with_profiling(
+            self.metrics_address(),
+            cancellation_token.clone(),
+            self.enable_memory_profiling,
+        )
+        .await;
 
         let app = Router::new()
             .route("/", index_handler)

--- a/linera-metrics/Cargo.toml
+++ b/linera-metrics/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 workspace = true
 
 [features]
-memory-profiling = ["jemalloc_pprof"]
+jemalloc = ["jemalloc_pprof"]
 
 [dependencies]
 anyhow.workspace = true

--- a/linera-metrics/src/lib.rs
+++ b/linera-metrics/src/lib.rs
@@ -5,5 +5,5 @@
 
 pub mod monitoring_server;
 
-#[cfg(feature = "memory-profiling")]
+#[cfg(feature = "jemalloc")]
 pub mod memory_profiler;

--- a/linera-metrics/src/memory_profiler.rs
+++ b/linera-metrics/src/memory_profiler.rs
@@ -22,12 +22,33 @@ pub enum MemoryProfilerError {
     ProfCtlNotAvailable,
     #[error("another profiler is already running")]
     AnotherProfilerAlreadyRunning,
+    #[error("failed to activate jemalloc profiling: {0}")]
+    ActivationFailed(String),
 }
 
 /// Memory profiler using safe jemalloc_pprof wrapper (pull model only)
 pub struct MemoryProfiler;
 
 impl MemoryProfiler {
+    /// Activates jemalloc profiling at runtime.
+    ///
+    /// This enables sampling (prof_active) which is off by default to avoid
+    /// the libgcc DWARF unwinder livelock (jemalloc/jemalloc#2282).
+    pub async fn activate() -> Result<(), MemoryProfilerError> {
+        if let Some(prof_ctl) = PROF_CTL.as_ref() {
+            let mut prof_ctl = prof_ctl.lock().await;
+
+            prof_ctl
+                .activate()
+                .map_err(|e| MemoryProfilerError::ActivationFailed(e.to_string()))?;
+
+            info!("jemalloc memory profiling activated");
+            Ok(())
+        } else {
+            Err(MemoryProfilerError::ProfCtlNotAvailable)
+        }
+    }
+
     pub fn check_prof_ctl() -> Result<(), MemoryProfilerError> {
         // Check if jemalloc profiling is available
         if let Some(prof_ctl) = PROF_CTL.as_ref() {

--- a/linera-metrics/src/monitoring_server.rs
+++ b/linera-metrics/src/monitoring_server.rs
@@ -8,44 +8,89 @@ use tokio::net::ToSocketAddrs;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-#[cfg(feature = "memory-profiling")]
+#[cfg(feature = "jemalloc")]
 use crate::memory_profiler::MemoryProfiler;
+
+/// Whether memory profiling endpoints should be enabled on the metrics server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryProfiling {
+    Enabled,
+    Disabled,
+}
+
+impl From<bool> for MemoryProfiling {
+    fn from(enabled: bool) -> Self {
+        if enabled {
+            MemoryProfiling::Enabled
+        } else {
+            MemoryProfiling::Disabled
+        }
+    }
+}
+
+impl MemoryProfiling {
+    /// Attempts to activate jemalloc memory profiling if requested.
+    ///
+    /// Returns `MemoryProfiling::Enabled` only if activation succeeds. If the flag is
+    /// false, or jemalloc is not compiled in, or activation fails (e.g. `MALLOC_CONF` not
+    /// set), returns `MemoryProfiling::Disabled` with an appropriate warning.
+    #[cfg(feature = "jemalloc")]
+    pub async fn try_activate(requested: bool) -> Self {
+        if !requested {
+            return MemoryProfiling::Disabled;
+        }
+        match MemoryProfiler::activate().await {
+            Ok(()) => MemoryProfiling::Enabled,
+            Err(e) => {
+                tracing::warn!(
+                    "--enable-memory-profiling was passed but profiling could not be activated: {}",
+                    e
+                );
+                MemoryProfiling::Disabled
+            }
+        }
+    }
+
+    /// Non-jemalloc fallback: always returns `Disabled`, warns if profiling was requested.
+    #[cfg(not(feature = "jemalloc"))]
+    pub async fn try_activate(requested: bool) -> Self {
+        if requested {
+            tracing::warn!(
+                "--enable-memory-profiling was passed but the jemalloc feature is not compiled in"
+            );
+        }
+        MemoryProfiling::Disabled
+    }
+}
+
+/// Activates memory profiling if requested and starts the metrics server.
+///
+/// This is the single entry point that handles both activation and server startup,
+/// avoiding duplication across binaries.
+pub async fn start_metrics_with_profiling(
+    address: impl ToSocketAddrs + Debug + Send + 'static,
+    shutdown_signal: CancellationToken,
+    enable_memory_profiling: bool,
+) {
+    let memory_profiling = MemoryProfiling::try_activate(enable_memory_profiling).await;
+    start_metrics(address, shutdown_signal, memory_profiling);
+}
 
 pub fn start_metrics(
     address: impl ToSocketAddrs + Debug + Send + 'static,
     shutdown_signal: CancellationToken,
+    memory_profiling: MemoryProfiling,
 ) {
-    start_metrics_with_extras(address, shutdown_signal, None);
+    start_metrics_with_extras(address, shutdown_signal, memory_profiling, None);
 }
 
 pub fn start_metrics_with_extras(
     address: impl ToSocketAddrs + Debug + Send + 'static,
     shutdown_signal: CancellationToken,
+    memory_profiling: MemoryProfiling,
     extra_routes: Option<Router>,
 ) {
-    #[cfg(feature = "memory-profiling")]
-    let mut app = {
-        // Try to add memory profiling endpoint
-        match MemoryProfiler::check_prof_ctl() {
-            Ok(()) => {
-                info!("Memory profiling available, enabling /debug/pprof and /debug/flamegraph endpoints");
-                Router::new()
-                    .route("/metrics", get(serve_metrics))
-                    .route("/debug/pprof", get(MemoryProfiler::heap_profile))
-                    .route("/debug/flamegraph", get(MemoryProfiler::heap_flamegraph))
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "Memory profiling not available: {}, serving metrics-only",
-                    e
-                );
-                Router::new().route("/metrics", get(serve_metrics))
-            }
-        }
-    };
-
-    #[cfg(not(feature = "memory-profiling"))]
-    let mut app = Router::new().route("/metrics", get(serve_metrics));
+    let mut app = metrics_router(memory_profiling);
 
     if let Some(extra) = extra_routes {
         app = app.merge(extra);
@@ -65,6 +110,36 @@ pub fn start_metrics_with_extras(
             panic!("Error serving metrics: {}", e);
         }
     });
+}
+
+fn metrics_router(memory_profiling: MemoryProfiling) -> Router {
+    #[cfg(feature = "jemalloc")]
+    if memory_profiling == MemoryProfiling::Enabled {
+        match MemoryProfiler::check_prof_ctl() {
+            Ok(()) => {
+                info!("Memory profiling enabled, registering /debug/pprof and /debug/flamegraph endpoints");
+                return Router::new()
+                    .route("/metrics", get(serve_metrics))
+                    .route("/debug/pprof", get(MemoryProfiler::heap_profile))
+                    .route("/debug/flamegraph", get(MemoryProfiler::heap_flamegraph));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Memory profiling requested but not available: {}, serving metrics-only",
+                    e
+                );
+            }
+        }
+    }
+
+    #[cfg(not(feature = "jemalloc"))]
+    if memory_profiling == MemoryProfiling::Enabled {
+        tracing::warn!(
+            "Memory profiling requested but jemalloc feature is not compiled in, serving metrics-only"
+        );
+    }
+
+    Router::new().route("/metrics", get(serve_metrics))
 }
 
 async fn serve_metrics() -> Result<String, AxumError> {

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -52,12 +52,10 @@ metrics = [
     "linera-faucet-server/metrics",
     "linera-metrics",
 ]
-jemalloc = ["tikv-jemallocator"]
-memory-profiling = [
-    "metrics",
-    "jemalloc",
+jemalloc = [
+    "tikv-jemallocator",
     "tikv-jemallocator/profiling",
-    "linera-metrics/memory-profiling",
+    "linera-metrics/jemalloc",
 ]
 opentelemetry = ["linera-base/opentelemetry", "linera-rpc/opentelemetry"]
 storage-service = ["linera-storage-service"]

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -8,21 +8,17 @@
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-// jemalloc configuration for memory profiling with jemalloc_pprof
-// prof:true,prof_active:true - Enable profiling from start
-// lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-
-// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
-#[allow(non_upper_case_globals)]
+/// Configure jemalloc profiling infrastructure at startup with sampling disabled.
+/// Profiling is activated at runtime only when `--enable-memory-profiling` is passed.
+///
+/// `lg_prof_sample` is log2 of the average sampling interval in bytes. Common values:
+///   19 = 512 KiB (industry default — Facebook, Materialize, Reth, TiKV)
+///   20 = 1 MiB
+///   21 = 2 MiB (lower overhead, coarser profiles)
+/// Override at runtime via MALLOC_CONF env var, e.g. MALLOC_CONF=lg_prof_sample:19.
+#[cfg(feature = "jemalloc")]
 #[export_name = "malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
-
-// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
-#[allow(non_upper_case_globals)]
-#[export_name = "_rjem_malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
 mod options;
 use std::{
@@ -794,6 +790,7 @@ impl Runnable for Job {
                             monitoring_server::start_metrics(
                                 metrics_address,
                                 shutdown_notifier.clone(),
+                                monitoring_server::MemoryProfiling::Disabled,
                             );
                         }
 
@@ -1103,6 +1100,7 @@ impl Runnable for Job {
                             monitoring_server::start_metrics(
                                 metrics_address,
                                 shutdown_notifier.clone(),
+                                monitoring_server::MemoryProfiling::Disabled,
                             );
                         }
 
@@ -1292,6 +1290,7 @@ impl Runnable for Job {
                     query_cache_size,
                     query_subscriptions,
                     cancellation_token.clone(),
+                    options.enable_memory_profiling(),
                 );
                 service.run(cancellation_token, command_receiver).await?;
             }
@@ -1325,6 +1324,7 @@ impl Runnable for Job {
                         u64::try_from(et.timestamp_micros()).expect("End timestamp before 1970");
                     Timestamp::from(micros)
                 });
+
                 let config = FaucetConfig {
                     port,
                     #[cfg(with_metrics)]
@@ -1337,6 +1337,7 @@ impl Runnable for Job {
                     chain_listener_config: config,
                     storage_path,
                     max_batch_size,
+                    enable_memory_profiling: options.enable_memory_profiling(),
                 };
                 let faucet = FaucetService::new(config, context).await?;
                 let cancellation_token = CancellationToken::new();

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -43,6 +43,10 @@ pub struct Options {
     #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
     pub otlp_exporter_endpoint: Option<String>,
 
+    /// Enable jemalloc memory profiling endpoints on the metrics server.
+    #[cfg(feature = "jemalloc")]
+    #[arg(long, env = "LINERA_ENABLE_MEMORY_PROFILING")]
+    pub enable_memory_profiling: bool,
     /// Subcommand.
     #[command(subcommand)]
     pub command: ClientCommand,
@@ -51,6 +55,17 @@ pub struct Options {
 impl Options {
     pub fn init() -> Self {
         <Options as clap::Parser>::parse()
+    }
+
+    pub fn enable_memory_profiling(&self) -> bool {
+        #[cfg(feature = "jemalloc")]
+        {
+            self.enable_memory_profiling
+        }
+        #[cfg(not(feature = "jemalloc"))]
+        {
+            false
+        }
     }
 
     pub async fn create_client_context<S, Si>(

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -154,12 +154,19 @@ struct RunOptions {
     /// Port for the metrics server.
     #[arg(long)]
     pub metrics_port: Option<u16>,
+
+    /// Enable jemalloc memory profiling endpoints on the metrics server.
+    #[cfg(feature = "jemalloc")]
+    #[arg(long, env = "LINERA_ENABLE_MEMORY_PROFILING")]
+    pub enable_memory_profiling: bool,
 }
 
+#[cfg_attr(not(with_metrics), allow(unused_variables))]
 async fn start_health_server(
     address: std::net::SocketAddr,
     shutdown_signal: CancellationToken,
     health: Arc<AtomicBool>,
+    enable_memory_profiling: bool,
 ) {
     let health_router = axum::Router::new().route(
         "/health",
@@ -176,7 +183,16 @@ async fn start_health_server(
     );
 
     #[cfg(with_metrics)]
-    monitoring_server::start_metrics_with_extras(address, shutdown_signal, Some(health_router));
+    {
+        let memory_profiling =
+            monitoring_server::MemoryProfiling::try_activate(enable_memory_profiling).await;
+        monitoring_server::start_metrics_with_extras(
+            address,
+            shutdown_signal,
+            memory_profiling,
+            Some(health_router),
+        );
+    }
 
     #[cfg(not(with_metrics))]
     {
@@ -199,6 +215,8 @@ async fn start_health_server(
 struct ExporterContext {
     node_options: NodeOptions,
     config: BlockExporterConfig,
+    #[cfg(with_metrics)]
+    enable_memory_profiling: bool,
 }
 
 #[async_trait]
@@ -213,10 +231,21 @@ impl Runnable for ExporterContext {
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
         let health = Arc::new(AtomicBool::new(true));
+        let enable_memory_profiling = {
+            #[cfg(with_metrics)]
+            {
+                self.enable_memory_profiling
+            }
+            #[cfg(not(with_metrics))]
+            {
+                false
+            }
+        };
         start_health_server(
             self.config.metrics_address(),
             shutdown_notifier.clone(),
             health.clone(),
+            enable_memory_profiling,
         )
         .await;
 
@@ -245,15 +274,6 @@ impl Runnable for ExporterContext {
     }
 }
 
-impl ExporterContext {
-    fn new(node_options: NodeOptions, config: BlockExporterConfig) -> ExporterContext {
-        Self {
-            config,
-            node_options,
-        }
-    }
-}
-
 fn main() -> Result<()> {
     linera_base::tracing::init("linera-exporter");
     let cli = <Cli as clap::Parser>::parse();
@@ -264,6 +284,18 @@ fn main() -> Result<()> {
 }
 
 impl RunOptions {
+    #[cfg(with_metrics)]
+    fn enable_memory_profiling(&self) -> bool {
+        #[cfg(feature = "jemalloc")]
+        {
+            self.enable_memory_profiling
+        }
+        #[cfg(not(feature = "jemalloc"))]
+        {
+            false
+        }
+    }
+
     fn run(&self) -> anyhow::Result<()> {
         let config_string = fs_err::read_to_string(&self.config_path)
             .expect("Unable to read the configuration file");
@@ -289,7 +321,12 @@ impl RunOptions {
             }
         }
 
-        let context = ExporterContext::new(node_options, config);
+        let context = ExporterContext {
+            node_options,
+            config,
+            #[cfg(with_metrics)]
+            enable_memory_profiling: self.enable_memory_profiling(),
+        };
 
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .thread_name("block-exporter-worker")
@@ -515,7 +552,13 @@ mod health_tests {
         // Start the production health server on a free port.
         let health_port = get_free_port().await?;
         let health_addr = std::net::SocketAddr::from(([127, 0, 0, 1], health_port));
-        start_health_server(health_addr, cancellation_token.clone(), health.clone()).await;
+        start_health_server(
+            health_addr,
+            cancellation_token.clone(),
+            health.clone(),
+            false,
+        )
+        .await;
 
         // Start a faulty indexer destination.
         let indexer_port = get_free_port().await?;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1223,6 +1223,7 @@ where
     query_cache: Option<Arc<QueryResponseCache>>,
     query_subscriptions: Option<Arc<crate::query_subscription::QuerySubscriptionManager>>,
     cancellation_token: CancellationToken,
+    enable_memory_profiling: bool,
 }
 
 impl<C> Clone for NodeService<C>
@@ -1241,6 +1242,7 @@ where
             query_cache: self.query_cache.clone(),
             query_subscriptions: self.query_subscriptions.clone(),
             cancellation_token: self.cancellation_token.clone(),
+            enable_memory_profiling: self.enable_memory_profiling,
         }
     }
 }
@@ -1265,6 +1267,7 @@ where
         query_cache_size: Option<usize>,
         query_subscriptions: Option<Arc<crate::query_subscription::QuerySubscriptionManager>>,
         cancellation_token: CancellationToken,
+        enable_memory_profiling: bool,
     ) -> Self {
         let query_cache = query_cache_size.map(|size| Arc::new(QueryResponseCache::new(size)));
         Self {
@@ -1278,6 +1281,7 @@ where
             query_cache,
             query_subscriptions,
             cancellation_token,
+            enable_memory_profiling,
         }
     }
 
@@ -1327,7 +1331,12 @@ where
             axum::routing::get(util::graphiql).post(Self::application_handler);
 
         #[cfg(with_metrics)]
-        monitoring_server::start_metrics(self.metrics_address(), cancellation_token.clone());
+        monitoring_server::start_metrics_with_profiling(
+            self.metrics_address(),
+            cancellation_token.clone(),
+            self.enable_memory_profiling,
+        )
+        .await;
 
         let base_router = Router::new()
             .route("/", index_handler)

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -301,12 +301,21 @@ where
         ),
         err,
     )]
-    pub async fn run(self, shutdown_signal: CancellationToken) -> Result<()> {
+    pub async fn run(
+        self,
+        shutdown_signal: CancellationToken,
+        _enable_memory_profiling: bool,
+    ) -> Result<()> {
         info!("Starting proxy");
         let mut join_set = JoinSet::new();
 
         #[cfg(with_metrics)]
-        monitoring_server::start_metrics(self.metrics_address(), shutdown_signal.clone());
+        monitoring_server::start_metrics_with_profiling(
+            self.metrics_address(),
+            shutdown_signal.clone(),
+            _enable_memory_profiling,
+        )
+        .await;
 
         let (health_reporter, health_service) = tonic_health::server::health_reporter();
         health_reporter

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -5,21 +5,11 @@
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-// jemalloc configuration for memory profiling with jemalloc_pprof
-// prof:true,prof_active:true - Enable profiling from start
-// lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-
-// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
-#[allow(non_upper_case_globals)]
+/// Configure jemalloc profiling infrastructure at startup with sampling disabled.
+/// Profiling is activated at runtime only when `--enable-memory-profiling` is passed.
+#[cfg(feature = "jemalloc")]
 #[export_name = "malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
-
-// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
-#[allow(non_upper_case_globals)]
-#[export_name = "_rjem_malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
@@ -100,6 +90,24 @@ pub struct ProxyOptions {
     /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
     #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
     otlp_exporter_endpoint: Option<String>,
+
+    /// Enable jemalloc memory profiling endpoints on the metrics server.
+    #[cfg(feature = "jemalloc")]
+    #[arg(long, env = "LINERA_ENABLE_MEMORY_PROFILING")]
+    enable_memory_profiling: bool,
+}
+
+impl ProxyOptions {
+    fn enable_memory_profiling(&self) -> bool {
+        #[cfg(feature = "jemalloc")]
+        {
+            self.enable_memory_profiling
+        }
+        #[cfg(not(feature = "jemalloc"))]
+        {
+            false
+        }
+    }
 }
 
 /// A Linera Proxy, either gRPC or over 'Simple Transport', meaning TCP or UDP.
@@ -118,16 +126,19 @@ struct ProxyContext {
     send_timeout: Duration,
     recv_timeout: Duration,
     id: usize,
+    enable_memory_profiling: bool,
 }
 
 impl ProxyContext {
     pub fn from_options(options: &ProxyOptions) -> Result<Self> {
         let config = util::read_json(&options.config_path)?;
+
         Ok(Self {
             config,
             send_timeout: options.send_timeout,
             recv_timeout: options.recv_timeout,
             id: options.id.unwrap_or(0),
+            enable_memory_profiling: options.enable_memory_profiling(),
         })
     }
 }
@@ -142,10 +153,20 @@ impl Runnable for ProxyContext {
     {
         let shutdown_notifier = CancellationToken::new();
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
+
+        let enable_memory_profiling = self.enable_memory_profiling;
         let proxy = Proxy::from_context(self, storage)?;
         match proxy {
-            Proxy::Simple(simple_proxy) => simple_proxy.run(shutdown_notifier).await,
-            Proxy::Grpc(grpc_proxy) => grpc_proxy.run(shutdown_notifier).await,
+            Proxy::Simple(simple_proxy) => {
+                simple_proxy
+                    .run(shutdown_notifier, enable_memory_profiling)
+                    .await
+            }
+            Proxy::Grpc(grpc_proxy) => {
+                grpc_proxy
+                    .run(shutdown_notifier, enable_memory_profiling)
+                    .await
+            }
         }
     }
 }
@@ -263,13 +284,22 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     #[instrument(name = "SimpleProxy::run", skip_all, fields(port = self.public_config.port, metrics_port = self.metrics_port()), err)]
-    async fn run(self, shutdown_signal: CancellationToken) -> Result<()> {
+    async fn run(
+        self,
+        shutdown_signal: CancellationToken,
+        _enable_memory_profiling: bool,
+    ) -> Result<()> {
         info!("Starting proxy");
         let mut join_set = JoinSet::new();
         let address = self.get_listen_address();
 
         #[cfg(with_metrics)]
-        monitoring_server::start_metrics(address, shutdown_signal.clone());
+        monitoring_server::start_metrics_with_profiling(
+            address,
+            shutdown_signal.clone(),
+            _enable_memory_profiling,
+        )
+        .await;
 
         self.public_config
             .protocol

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -252,6 +252,7 @@ async fn main() -> std::io::Result<()> {
         None,  // no query cache for schema export
         None,
         tokio_util::sync::CancellationToken::new(),
+        false, // memory profiling disabled for schema export
     );
     let schema = service.schema().sdl();
     print!("{}", schema);

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -8,21 +8,11 @@
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-// jemalloc configuration for memory profiling with jemalloc_pprof
-// prof:true,prof_active:true - Enable profiling from start
-// lg_prof_sample:19 - Sample every 512KB for good detail/overhead balance
-
-// Linux/other platforms: use unprefixed malloc (with unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", not(target_os = "macos")))]
-#[allow(non_upper_case_globals)]
+/// Configure jemalloc profiling infrastructure at startup with sampling disabled.
+/// Profiling is activated at runtime only when `--enable-memory-profiling` is passed.
+#[cfg(feature = "jemalloc")]
 #[export_name = "malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
-
-// macOS: use prefixed malloc (without unprefixed_malloc_on_supported_platforms)
-#[cfg(all(feature = "memory-profiling", target_os = "macos"))]
-#[allow(non_upper_case_globals)]
-#[export_name = "_rjem_malloc_conf"]
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
+pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
 use std::{
     borrow::Cow,
@@ -73,6 +63,8 @@ struct ServerContext {
     chain_info_max_received_log_entries: usize,
     block_cache_size: usize,
     execution_state_cache_size: usize,
+    #[cfg(with_metrics)]
+    enable_memory_profiling: bool,
 }
 
 impl ServerContext {
@@ -112,6 +104,7 @@ impl ServerContext {
         states: Vec<(WorkerState<S>, ShardId, ShardConfig)>,
         protocol: simple::TransportProtocol,
         shutdown_signal: CancellationToken,
+        _enable_memory_profiling: bool,
     ) -> JoinSet<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
@@ -134,6 +127,7 @@ impl ServerContext {
                 monitoring_server::start_metrics(
                     (listen_address.clone(), port),
                     shutdown_signal.clone(),
+                    monitoring_server::MemoryProfiling::from(_enable_memory_profiling),
                 );
             }
 
@@ -167,6 +161,7 @@ impl ServerContext {
         listen_address: &str,
         states: Vec<(WorkerState<S>, ShardId, ShardConfig)>,
         shutdown_signal: CancellationToken,
+        _enable_memory_profiling: bool,
     ) -> JoinSet<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
@@ -180,6 +175,7 @@ impl ServerContext {
                 monitoring_server::start_metrics(
                     (listen_address.to_string(), port),
                     shutdown_signal.clone(),
+                    monitoring_server::MemoryProfiling::from(_enable_memory_profiling),
                 );
             }
 
@@ -229,6 +225,17 @@ impl Runnable for ServerContext {
 
         tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
+        // Activate memory profiling once before per-shard start_metrics calls.
+        #[cfg(with_metrics)]
+        let enable_memory_profiling = {
+            let memory_profiling =
+                monitoring_server::MemoryProfiling::try_activate(self.enable_memory_profiling)
+                    .await;
+            memory_profiling == monitoring_server::MemoryProfiling::Enabled
+        };
+        #[cfg(not(with_metrics))]
+        let enable_memory_profiling = false;
+
         // Run the server
         let states = match self.shard {
             Some(shard) => {
@@ -245,11 +252,20 @@ impl Runnable for ServerContext {
         };
 
         let mut join_set = match self.server_config.internal_network.protocol {
-            NetworkProtocol::Simple(protocol) => {
-                self.spawn_simple(&listen_address, states, protocol, shutdown_notifier)
-            }
+            NetworkProtocol::Simple(protocol) => self.spawn_simple(
+                &listen_address,
+                states,
+                protocol,
+                shutdown_notifier,
+                enable_memory_profiling,
+            ),
             NetworkProtocol::Grpc(tls_config) => match tls_config {
-                TlsConfig::ClearText => self.spawn_grpc(&listen_address, states, shutdown_notifier),
+                TlsConfig::ClearText => self.spawn_grpc(
+                    &listen_address,
+                    states,
+                    shutdown_notifier,
+                    enable_memory_profiling,
+                ),
                 TlsConfig::Tls => bail!("TLS not supported between proxy and shards."),
             },
         };
@@ -278,6 +294,37 @@ struct ServerOptions {
     /// The number of Tokio blocking threads to use.
     #[arg(long, env = "LINERA_SERVER_TOKIO_BLOCKING_THREADS")]
     tokio_blocking_threads: Option<usize>,
+
+    /// Size of the block cache (default: 5000)
+    #[arg(long, env = "LINERA_BLOCK_CACHE_SIZE", default_value = "5000")]
+    block_cache_size: usize,
+
+    /// Size of the execution state cache (default: 10000)
+    #[arg(
+        long,
+        env = "LINERA_EXECUTION_STATE_CACHE_SIZE",
+        default_value = "10000"
+    )]
+    execution_state_cache_size: usize,
+
+    /// Enable jemalloc memory profiling endpoints on the metrics server.
+    #[cfg(feature = "jemalloc")]
+    #[arg(long, env = "LINERA_ENABLE_MEMORY_PROFILING")]
+    enable_memory_profiling: bool,
+}
+
+impl ServerOptions {
+    #[cfg(with_metrics)]
+    fn enable_memory_profiling(&self) -> bool {
+        #[cfg(feature = "jemalloc")]
+        {
+            self.enable_memory_profiling
+        }
+        #[cfg(not(feature = "jemalloc"))]
+        {
+            false
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
@@ -515,6 +562,8 @@ async fn run(options: ServerOptions) {
         otlp_exporter_endpoint_for(&options.command),
     );
 
+    #[cfg(with_metrics)]
+    let enable_memory_profiling = options.enable_memory_profiling();
     match options.command {
         ServerCommand::Run {
             server_config_path,
@@ -544,6 +593,8 @@ async fn run(options: ServerOptions) {
                 chain_info_max_received_log_entries,
                 block_cache_size: common_storage_options.block_cache_size,
                 execution_state_cache_size: common_storage_options.execution_state_cache_size,
+                #[cfg(with_metrics)]
+                enable_memory_profiling,
             };
             let wasm_runtime = wasm_runtime.with_wasm_default();
             let store_config = storage_config

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -16,6 +16,7 @@ darling = {{ version = ">=0.20, <0.23" }}
 serde_with = {{ version = ">=3, <3.18" }}
 time = {{ version = ">=0.3, <0.3.47" }}
 time-core = {{ version = ">=0.1, <0.1.8" }}
+unicode-segmentation = {{ version = ">=1.9, <1.13" }}
 
 [dev-dependencies]
 {linera_sdk_dev_dep}


### PR DESCRIPTION
## Motivation

Backport of #5601 to `testnet_conway`. Adds jemalloc as the global allocator and exposes
an `--enable-memory-profiling` CLI flag that activates jemalloc heap profiling and a
`/debug/pprof` endpoint on the metrics server.

Beyond profiling, switching to jemalloc fixes severe memory bloat caused by glibc malloc
fragmentation under heavy async RocksDB workloads. Workers on the default glibc
allocator grow to 50+ GB over a few days, while workers on jemalloc remain stable.

## Proposal

Cherry-pick of `14f2a9f5848` onto `testnet_conway`.

## Test Plan

CI

