### PR TITLE
Backport #5602: Use libunwind for jemalloc memory profiling stack traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10601,9 +10601,8 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "git+https://github.com/linera-io/jemallocator.git?rev=16f3e75fb145e12f5ae15ed232d1368d4539fc14#16f3e75fb145e12f5ae15ed232d1368d4539fc14"
 dependencies = [
  "cc",
  "libc",
@@ -10611,9 +10610,8 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+version = "0.6.1"
+source = "git+https://github.com/linera-io/jemallocator.git?rev=16f3e75fb145e12f5ae15ed232d1368d4539fc14#16f3e75fb145e12f5ae15ed232d1368d4539fc14"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,7 +261,7 @@ test-log = { version = "0.2.15", default-features = false, features = [
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
 thiserror-context = "0.1.1"
-tikv-jemallocator = "0.6.0"
+tikv-jemallocator = { git = "https://github.com/linera-io/jemallocator.git", rev = "16f3e75fb145e12f5ae15ed232d1368d4539fc14" }
 tokio = "1.36.0"
 tokio-stream = "0.1.14"
 tokio-test = "0.4.3"
@@ -407,3 +407,7 @@ range_minus_one = "deny"
 range_plus_one = "deny"
 ref_option_ref = "deny"
 str_split_at_newline = "deny"
+
+[patch.crates-io]
+tikv-jemallocator = { git = "https://github.com/linera-io/jemallocator.git", rev = "16f3e75fb145e12f5ae15ed232d1368d4539fc14" }
+tikv-jemalloc-sys = { git = "https://github.com/linera-io/jemallocator.git", rev = "16f3e75fb145e12f5ae15ed232d1368d4539fc14" }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
 ARG build_features=scylladb,metrics,opentelemetry,jemalloc
-ARG rustflags="-C force-frame-pointers=yes"
+ARG rustflags="-C force-frame-pointers=yes -L /usr/lib/x86_64-linux-gnu"
 
 FROM rust:1.86-slim-bookworm AS builder
 ARG git_commit
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     protobuf-compiler \
     clang \
-    make
+    make \
+    libunwind-dev
 
 COPY . .
 
@@ -72,7 +73,8 @@ LABEL build_date=$build_date
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    openssl
+    openssl \
+    libunwind8
 RUN update-ca-certificates
 
 COPY --from=binaries \

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -54,7 +54,7 @@ metrics = [
 ]
 jemalloc = [
     "tikv-jemallocator",
-    "tikv-jemallocator/profiling",
+    "tikv-jemallocator/profiling_libunwind",
     "linera-metrics/jemalloc",
 ]
 opentelemetry = ["linera-base/opentelemetry", "linera-rpc/opentelemetry"]


### PR DESCRIPTION
## Motivation

Backport of #5602, stacked on the backport of #5601. Switches jemalloc's stack trace
collection from the default (frame pointers) to libunwind, which produces complete stack
traces in release builds without requiring frame pointers.

## Proposal

Cherry-pick of `9a3f534cbdb` onto the backport of #5601.

## Test Plan

CI
