### PR TITLE
Observe inbox_size metric once per inbox instead of once per bundle

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -669,6 +669,7 @@ where
                     );
                 }
             }
+            inbox.observe_size_metric();
             if inbox.added_bundles.count() == 0 {
                 if let Some(set) = self.nonempty_inboxes.get_mut() {
                     set.remove(&origin);

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -194,6 +194,14 @@ where
         }
     }
 
+    /// Observes the current inbox size in the metrics histogram.
+    pub fn observe_size_metric(&self) {
+        #[cfg(with_metrics)]
+        metrics::INBOX_SIZE
+            .with_label_values(&[])
+            .observe(self.added_bundles.count() as f64);
+    }
+
     /// Consumes a bundle from the inbox.
     ///
     /// Returns `true` if the bundle was already known, i.e. it was present in `added_bundles`.
@@ -253,10 +261,6 @@ where
                 false
             }
         };
-        #[cfg(with_metrics)]
-        metrics::INBOX_SIZE
-            .with_label_values(&[])
-            .observe(self.added_bundles.count() as f64);
         self.next_cursor_to_remove.set(cursor.try_add_one()?);
         Ok(already_known)
     }
@@ -309,10 +313,6 @@ where
             None => {
                 // Otherwise, schedule the messages for execution.
                 self.added_bundles.push_back(bundle);
-                #[cfg(with_metrics)]
-                metrics::INBOX_SIZE
-                    .with_label_values(&[])
-                    .observe(self.added_bundles.count() as f64);
                 true
             }
         };

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1114,6 +1114,7 @@ where
                 )
                 .await?;
         }
+        inbox.observe_size_metric();
         drop(inbox);
         if !self.config.allow_inactive_chains && !self.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by


### PR DESCRIPTION
## Motivation

The `inbox_size` histogram is observed inside `add_bundle` and `remove_bundle`, both of
which are called in loops (per bundle). This means a block that processes 100 bundles
from one inbox produces 100 histogram observations with intermediate values (99, 98, 97,
..., 0), skewing the quantile aggregations (p50/p90/p99) on the Grafana dashboard.

## Proposal

Move the `INBOX_SIZE` observation out of the per-bundle methods and into the callers,
after all bundles for a given inbox have been processed:

- `remove_bundles_from_inboxes`: observe once per inbox after the inner bundle loop
- `process_cross_chain_update`: observe once after the bundle loop, before dropping the
inbox

This makes the observation count proportional to the number of inboxes touched, not the
number of bundles processed. For the remove path, that's once per distinct origin in the
block. For the add path, it's once per cross-chain update.

Added `observe_size_metric()` on `InboxStateView` so both call sites (in `linera-chain`
and `linera-core`) can use it.

## Test Plan

CI.
