### PR TITLE
Add per-method breakdown to proxy and server request metrics

### DIFF
--- a/kubernetes/linera-validator/templates/linera-recording-rules.yaml
+++ b/kubernetes/linera-validator/templates/linera-recording-rules.yaml
@@ -66,11 +66,9 @@ spec:
   - name: linera.request.rules
     rules:
     - record: linera:proxy_request_latency:rate1m
-      expr: sum(rate(linera_proxy_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator)
+      expr: sum(rate(linera_proxy_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator, method_name)
     - record: linera:server_request_latency:rate1m
-      expr: sum(rate(linera_server_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator)
-    - record: linera:server_request_latency_per_request_type:rate1m
-      expr: sum(rate(linera_server_request_latency_per_request_type_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator, method_name)
+      expr: sum(rate(linera_server_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator, method_name)
 
   - name: linera.storage.rules
     rules:

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -41,3 +41,75 @@ pub const GRPC_MAX_MESSAGE_SIZE: usize = 16 * MEBIBYTE;
 /// Limit of gRPC message size up to which we will try to populate with data when estimating.
 /// We leave 30% of buffer for the rest of the message and potential underestimation.
 pub const GRPC_CHUNKED_MESSAGE_FILL_LIMIT: usize = GRPC_MAX_MESSAGE_SIZE * 7 / 10;
+
+/// Prometheus label for the gRPC method name.
+pub const METHOD_NAME_LABEL: &str = "method_name";
+
+/// Prometheus label for distinguishing organic vs synthetic (benchmark) traffic.
+pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
+
+/// Extracts the gRPC method name from a request URI path.
+///
+/// gRPC paths have the form `/{package}.{Service}/{Method}` — the first segment
+/// always contains a dot. Non-gRPC requests (health checks, bot probes, etc.) return
+/// `"non_grpc"` to prevent unbounded label cardinality.
+pub fn extract_grpc_method_name(path: &str) -> &str {
+    let parts: Vec<&str> = path.splitn(3, '/').collect();
+    if parts.len() == 3 && parts[1].contains('.') {
+        parts[2]
+    } else {
+        "non_grpc"
+    }
+}
+
+#[cfg(test)]
+mod method_name_tests {
+    use super::*;
+
+    #[test]
+    fn grpc_unary_method() {
+        assert_eq!(
+            extract_grpc_method_name("/rpc.v1.ValidatorNode/HandleBlockProposal"),
+            "HandleBlockProposal"
+        );
+    }
+
+    #[test]
+    fn grpc_streaming_method() {
+        assert_eq!(
+            extract_grpc_method_name("/rpc.v1.ValidatorNode/SubscribeToNotifications"),
+            "SubscribeToNotifications"
+        );
+    }
+
+    #[test]
+    fn health_check_path() {
+        assert_eq!(
+            extract_grpc_method_name("/grpc.health.v1.Health/Check"),
+            "Check"
+        );
+    }
+
+    #[test]
+    fn non_grpc_root_path() {
+        assert_eq!(extract_grpc_method_name("/"), "non_grpc");
+    }
+
+    #[test]
+    fn non_grpc_plain_path() {
+        assert_eq!(extract_grpc_method_name("/healthz"), "non_grpc");
+    }
+
+    #[test]
+    fn non_grpc_no_dot_in_service() {
+        assert_eq!(
+            extract_grpc_method_name("/NoDotService/Method"),
+            "non_grpc"
+        );
+    }
+
+    #[test]
+    fn empty_path() {
+        assert_eq!(extract_grpc_method_name(""), "non_grpc");
+    }
+}

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -10,11 +10,9 @@ use std::{
 use futures::{
     channel::mpsc, future::BoxFuture, stream::FuturesUnordered, FutureExt as _, StreamExt as _,
 };
-use linera_base::{
-    data_types::Blob,
-    identifiers::ChainId,
-    time::{Duration, Instant},
-};
+#[cfg(with_metrics)]
+use linera_base::time::Instant;
+use linera_base::{data_types::Blob, identifiers::ChainId, time::Duration};
 use linera_core::{
     join_set_ext::JoinSet,
     node::NodeError,
@@ -61,17 +59,13 @@ mod metrics {
     };
     use prometheus::{HistogramVec, IntCounterVec};
 
-    /// Label for distinguishing organic vs synthetic (benchmark) traffic.
-    pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
-
-    /// Label for the gRPC method name.
-    pub const METHOD_NAME_LABEL: &str = "method_name";
+    use super::super::{METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
 
     pub static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
             "server_request_latency",
             "Server request latency",
-            &[TRAFFIC_TYPE_LABEL],
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
             linear_bucket_interval(1.0, 25.0, 2000.0),
         )
     });
@@ -80,7 +74,7 @@ mod metrics {
         register_int_counter_vec(
             "server_request_count",
             "Server request count",
-            &[TRAFFIC_TYPE_LABEL],
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
         )
     });
 
@@ -99,16 +93,6 @@ mod metrics {
             &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
         )
     });
-
-    pub static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> =
-        LazyLock::new(|| {
-            register_histogram_vec(
-                "server_request_latency_per_request_type",
-                "Server request latency per request type",
-                &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-                linear_bucket_interval(1.0, 25.0, 2000.0),
-            )
-        });
 
     pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
@@ -333,6 +317,9 @@ where
         #[cfg(with_metrics)]
         let start = Instant::now();
 
+        #[cfg(with_metrics)]
+        let method_name = super::extract_grpc_method_name(request.uri().path()).to_owned();
+
         // Extract traffic type from request extensions (set by OtelContextLayer).
         // When opentelemetry is enabled but no baggage is set, defaults to "organic".
         // When opentelemetry is disabled, defaults to "unknown".
@@ -347,10 +334,10 @@ where
             #[cfg(with_metrics)]
             {
                 metrics::SERVER_REQUEST_LATENCY
-                    .with_label_values(&[traffic_type])
+                    .with_label_values(&[&method_name, traffic_type])
                     .observe(start.elapsed().as_secs_f64() * 1000.0);
                 metrics::SERVER_REQUEST_COUNT
-                    .with_label_values(&[traffic_type])
+                    .with_label_values(&[&method_name, traffic_type])
                     .inc();
             }
             Ok(response)
@@ -645,18 +632,10 @@ where
         .await;
     }
 
-    fn log_request_outcome_and_latency(
-        start: Instant,
-        success: bool,
-        method_name: &str,
-        traffic_type: &str,
-    ) {
+    fn log_request_outcome(success: bool, method_name: &str, traffic_type: &str) {
         #![cfg_attr(not(with_metrics), allow(unused_variables))]
         #[cfg(with_metrics)]
         {
-            metrics::SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE
-                .with_label_values(&[method_name, traffic_type])
-                .observe(start.elapsed().as_secs_f64() * 1000.0);
             if success {
                 metrics::SERVER_REQUEST_SUCCESS
                     .with_label_values(&[method_name, traffic_type])
@@ -709,29 +688,18 @@ where
         &self,
         request: Request<BlockProposal>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let proposal = request.into_inner().try_into()?;
         trace!(?proposal, "Handling block proposal");
         Ok(Response::new(
             match self.state.clone().handle_block_proposal(proposal).await {
                 Ok((info, actions)) => {
-                    Self::log_request_outcome_and_latency(
-                        start,
-                        true,
-                        "handle_block_proposal",
-                        traffic_type,
-                    );
+                    Self::log_request_outcome(true, "handle_block_proposal", traffic_type);
                     self.handle_network_actions(actions);
                     info.try_into()?
                 }
                 Err(error) => {
-                    Self::log_request_outcome_and_latency(
-                        start,
-                        false,
-                        "handle_block_proposal",
-                        traffic_type,
-                    );
+                    Self::log_request_outcome(false, "handle_block_proposal", traffic_type);
                     self.log_error(&error, "Failed to handle block proposal");
                     NodeError::from(error).try_into()?
                 }
@@ -752,7 +720,6 @@ where
         &self,
         request: Request<LiteCertificate>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let HandleLiteCertRequest {
             certificate,
@@ -768,12 +735,7 @@ where
         .await
         {
             Ok((info, actions)) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "handle_lite_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "handle_lite_certificate", traffic_type);
                 self.handle_network_actions(actions);
                 if let Some(receiver) = receiver {
                     if let Err(e) = receiver.await {
@@ -783,12 +745,7 @@ where
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "handle_lite_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "handle_lite_certificate", traffic_type);
                 self.log_error(&error, "Failed to handle lite certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -808,7 +765,6 @@ where
         &self,
         request: Request<api::HandleConfirmedCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let HandleConfirmedCertificateRequest {
             certificate,
@@ -823,12 +779,7 @@ where
             .await
         {
             Ok((info, actions)) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "handle_confirmed_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "handle_confirmed_certificate", traffic_type);
                 self.handle_network_actions(actions);
                 if let Some(receiver) = receiver {
                     if let Err(e) = receiver.await {
@@ -838,12 +789,7 @@ where
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "handle_confirmed_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "handle_confirmed_certificate", traffic_type);
                 self.log_error(&error, "Failed to handle confirmed certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -863,7 +809,6 @@ where
         &self,
         request: Request<api::HandleValidatedCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let HandleValidatedCertificateRequest { certificate } = request.into_inner().try_into()?;
         trace!(?certificate, "Handling certificate");
@@ -874,22 +819,12 @@ where
             .await
         {
             Ok((info, actions)) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "handle_validated_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "handle_validated_certificate", traffic_type);
                 self.handle_network_actions(actions);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "handle_validated_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "handle_validated_certificate", traffic_type);
                 self.log_error(&error, "Failed to handle validated certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -909,7 +844,6 @@ where
         &self,
         request: Request<api::HandleTimeoutCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let HandleTimeoutCertificateRequest { certificate } = request.into_inner().try_into()?;
         trace!(?certificate, "Handling Timeout certificate");
@@ -920,21 +854,11 @@ where
             .await
         {
             Ok((info, _actions)) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "handle_timeout_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "handle_timeout_certificate", traffic_type);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "handle_timeout_certificate",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "handle_timeout_certificate", traffic_type);
                 self.log_error(&error, "Failed to handle timeout certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -954,28 +878,17 @@ where
         &self,
         request: Request<ChainInfoQuery>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let query = request.into_inner().try_into()?;
         trace!(?query, "Handling chain info query");
         match self.state.clone().handle_chain_info_query(query).await {
             Ok((info, actions)) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "handle_chain_info_query",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "handle_chain_info_query", traffic_type);
                 self.handle_network_actions(actions);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "handle_chain_info_query",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "handle_chain_info_query", traffic_type);
                 self.log_error(&error, "Failed to handle chain info query");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -995,7 +908,6 @@ where
         &self,
         request: Request<PendingBlobRequest>,
     ) -> Result<Response<PendingBlobResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let (chain_id, blob_id) = request.into_inner().try_into()?;
         trace!(?chain_id, ?blob_id, "Download pending blob");
@@ -1006,21 +918,11 @@ where
             .await
         {
             Ok(blob) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "download_pending_blob",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "download_pending_blob", traffic_type);
                 Ok(Response::new(blob.into_content().try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "download_pending_blob",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "download_pending_blob", traffic_type);
                 self.log_error(&error, "Failed to download pending blob");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -1040,7 +942,6 @@ where
         &self,
         request: Request<HandlePendingBlobRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let (chain_id, blob_content) = request.into_inner().try_into()?;
         let blob = Blob::new(blob_content);
@@ -1048,21 +949,11 @@ where
         trace!(?chain_id, ?blob_id, "Handle pending blob");
         match self.state.clone().handle_pending_blob(chain_id, blob).await {
             Ok(info) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "handle_pending_blob",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "handle_pending_blob", traffic_type);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "handle_pending_blob",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "handle_pending_blob", traffic_type);
                 self.log_error(&error, "Failed to handle pending blob");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -1082,7 +973,6 @@ where
         &self,
         request: Request<api::PreviousEventBlocksRequest>,
     ) -> Result<Response<api::PreviousEventBlocksResponse>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let (chain_id, stream_ids) = request.into_inner().try_into()?;
         match self
@@ -1092,21 +982,11 @@ where
             .await
         {
             Ok(result) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "previous_event_blocks",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "previous_event_blocks", traffic_type);
                 Ok(Response::new(result.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "previous_event_blocks",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "previous_event_blocks", traffic_type);
                 self.log_error(&error, "Failed to get previous event blocks");
                 Err(Status::internal(NodeError::from(error).to_string()))
             }
@@ -1126,7 +1006,6 @@ where
         &self,
         request: Request<CrossChainRequest>,
     ) -> Result<Response<()>, Status> {
-        let start = Instant::now();
         let traffic_type = Self::get_traffic_type(&request);
         let cross_chain_request = request.into_inner().try_into()?;
         trace!(?cross_chain_request, "Handling cross-chain request");
@@ -1137,21 +1016,11 @@ where
             .await
         {
             Ok(actions) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    true,
-                    "handle_cross_chain_request",
-                    traffic_type,
-                );
+                Self::log_request_outcome(true, "handle_cross_chain_request", traffic_type);
                 self.handle_network_actions(actions)
             }
             Err(error) => {
-                Self::log_request_outcome_and_latency(
-                    start,
-                    false,
-                    "handle_cross_chain_request",
-                    traffic_type,
-                );
+                Self::log_request_outcome(false, "handle_cross_chain_request", traffic_type);
                 let nickname = self.state.nickname();
                 error!(nickname, %error, "Failed to handle cross-chain request");
             }

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -71,19 +71,14 @@ mod metrics {
     use linera_base::prometheus_util::{
         linear_bucket_interval, register_histogram_vec, register_int_counter_vec,
     };
+    use linera_rpc::grpc::{METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
     use prometheus::{HistogramVec, IntCounterVec};
-
-    /// Label for distinguishing organic vs synthetic (benchmark) traffic.
-    pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
-
-    /// Label for the gRPC method name.
-    pub const METHOD_NAME_LABEL: &str = "method_name";
 
     pub static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
             "proxy_request_latency",
             "Proxy request latency",
-            &[TRAFFIC_TYPE_LABEL],
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
             linear_bucket_interval(1.0, 50.0, 2000.0),
         )
     });
@@ -91,7 +86,7 @@ mod metrics {
         register_int_counter_vec(
             "proxy_request_count",
             "Proxy request count",
-            &[TRAFFIC_TYPE_LABEL],
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
         )
     });
 
@@ -146,20 +141,9 @@ where
         #[cfg(with_metrics)]
         let start = linera_base::time::Instant::now();
 
-        // Extract the gRPC method name from the URI path. gRPC paths have the form
-        // `/{package}.{Service}/{Method}` — the first segment always contains a dot.
-        // Non-gRPC requests (bot probes, health checks, etc.) are bucketed as
-        // "non_grpc" to prevent unbounded label cardinality.
         #[cfg(with_metrics)]
-        let method_name = {
-            let path = request.uri().path();
-            let parts: Vec<&str> = path.splitn(3, '/').collect();
-            if parts.len() == 3 && parts[1].contains('.') {
-                parts[2].to_owned()
-            } else {
-                "non_grpc".to_owned()
-            }
-        };
+        let method_name =
+            linera_rpc::grpc::extract_grpc_method_name(request.uri().path()).to_owned();
 
         #[cfg(all(with_metrics, feature = "opentelemetry"))]
         let traffic_type: &'static str = get_traffic_type_from_request(&request);
@@ -172,10 +156,10 @@ where
             #[cfg(with_metrics)]
             {
                 metrics::PROXY_REQUEST_LATENCY
-                    .with_label_values(&[traffic_type])
+                    .with_label_values(&[&method_name, traffic_type])
                     .observe(start.elapsed().as_secs_f64() * 1000.0);
                 metrics::PROXY_REQUEST_COUNT
-                    .with_label_values(&[traffic_type])
+                    .with_label_values(&[&method_name, traffic_type])
                     .inc();
 
                 let is_error = !response.status().is_success()


### PR DESCRIPTION
## Motivation

The proxy and server middleware track request count and latency, but only with a
`traffic_type` label — there's no method-level breakdown. This makes it impossible to
tell which gRPC methods are driving request volume or latency from the primary
dashboards.

## Proposal

Add a `method_name` label to the four core middleware metrics:
- `linera_proxy_request_latency`
- `linera_proxy_request_count`
- `linera_server_request_latency`
- `linera_server_request_count`

The method name is extracted from the gRPC URI path (`/{package}.{Service}/{Method}` →
`Method`). Non-gRPC requests (health checks, bot probes) are labeled `non_grpc` to
prevent unbounded cardinality.

The extraction logic already existed inline in the proxy for the success/error counters
— it's now pulled into a shared `extract_grpc_method_name()` helper in
`linera_rpc::grpc` alongside the shared label constants.

Since `server_request_latency` now has `method_name`, the separate
`serverst_latency_per_request_type` histogram is redundant and removed, along with
the per-handler `Instant::now()` / latency recording that fed it — latency is already
captured in the middleware layer.

Recording rules are updated to preserve `method_name` in the pre-aggregated series.

Dashboard changes will follow in a separate PR after deployment.

## Test Plan

CI
