### PR TITLE
Remove notifiers from the list when closed.

### DIFF
--- a/linera-core/src/chain_worker/delivery_notifier.rs
+++ b/linera-core/src/chain_worker/delivery_notifier.rs
@@ -28,6 +28,7 @@ pub struct DeliveryNotifier {
 
 impl DeliveryNotifier {
     /// Registers a delivery `notifier` for a desired [`BlockHeight`].
+    /// Also prunes any closed oneshot senders to prevent unbounded accumulation.
     pub(super) fn register(&self, height: BlockHeight, notifier: oneshot::Sender<()>) {
         let mut notifiers = self
             .notifiers
@@ -35,6 +36,20 @@ impl DeliveryNotifier {
             .expect("Panics should never happen while holding a lock to the `notifiers`");
 
         notifiers.entry(height).or_default().push(notifier);
+
+        // Prune entries where all senders have been closed (receiver dropped).
+        notifiers.retain(|_, senders| {
+            senders.retain(|s| !s.is_closed());
+            !senders.is_empty()
+        });
+    }
+
+    /// Returns `true` if there are no pending notifiers.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.notifiers
+            .lock()
+            .expect("Panics should never happen while holding a lock to the `notifiers`")
+            .is_empty()
     }
 
     /// Notifies that all messages up to `height` have been delivered.

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -28,12 +28,20 @@ impl<N> Default for ChannelNotifier<N> {
 
 impl<N> ChannelNotifier<N> {
     /// Registers a sender for notifications on the given chain IDs.
+    /// Also prunes any closed senders encountered during the update.
     pub fn add_sender(&self, chain_ids: Vec<ChainId>, sender: &UnboundedSender<N>) {
         let pinned = self.inner.pin();
         for id in chain_ids {
             pinned.update_or_insert_with(
                 id,
-                |senders| senders.iter().cloned().chain([sender.clone()]).collect(),
+                |senders| {
+                    senders
+                        .iter()
+                        .filter(|s| !s.is_closed())
+                        .cloned()
+                        .chain([sender.clone()])
+                        .collect()
+                },
                 || vec![sender.clone()],
             );
         }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -487,32 +487,59 @@ type ChainWorkerFuture<S> = Shared<oneshot::Receiver<ChainWorkerWeak<S>>>;
 /// Callers that find a pending entry clone the `Shared` future and await it.
 type ChainWorkerMap<S> = Arc<papaya::HashMap<ChainId, ChainWorkerFuture<S>>>;
 
+/// Default sweep interval when no TTL is configured. Dead weak references
+/// and empty delivery notifiers still need periodic cleanup.
+const DEFAULT_SWEEP_INTERVAL: Duration = Duration::from_secs(60);
+
 /// Starts a background task that periodically removes dead weak references
-/// from the chain handle map. The actual lifetime management is handled by
-/// each handle's keep-alive task.
+/// from the chain handle map and empty delivery notifiers. The actual
+/// lifetime management is handled by each handle's keep-alive task.
 fn start_sweep<S: Storage + Clone + 'static>(
     chain_workers: &ChainWorkerMap<S>,
+    delivery_notifiers: &Arc<Mutex<DeliveryNotifiers>>,
     config: &ChainWorkerConfig,
 ) {
-    // Sweep at the smaller of the two TTLs. If both are None, workers
-    // live forever so there's nothing to sweep.
+    // Sweep at the smaller of the two TTLs, or a default interval if
+    // neither TTL is set (dead weak refs and delivery notifiers still
+    // need cleanup).
     let interval = match (config.ttl, config.sender_chain_ttl) {
-        (None, None) => return,
+        (None, None) => DEFAULT_SWEEP_INTERVAL,
         (Some(d), None) | (None, Some(d)) => d,
         (Some(a), Some(b)) => a.min(b),
     };
     let weak_map = Arc::downgrade(chain_workers);
+    let weak_notifiers = Arc::downgrade(delivery_notifiers);
     linera_base::Task::spawn(async move {
         loop {
             linera_base::time::timer::sleep(interval).await;
-            let Some(map) = weak_map.upgrade() else {
-                break;
+
+            // Sweep dead chain worker entries.
+            let map_alive = if let Some(map) = weak_map.upgrade() {
+                map.pin_owned().retain(|_, shared| match shared.peek() {
+                    Some(Ok(weak)) => weak.strong_count() > 0,
+                    Some(Err(_)) => false, // Loading failed; clean up.
+                    None => true,          // Still loading; keep.
+                });
+                drop(map);
+                true
+            } else {
+                false
             };
-            map.pin_owned().retain(|_, shared| match shared.peek() {
-                Some(Ok(weak)) => weak.strong_count() > 0,
-                Some(Err(_)) => false, // Loading failed; clean up.
-                None => true,          // Still loading; keep.
-            });
+
+            // Sweep delivery notifiers whose inner BTreeMap is empty.
+            let notifiers_alive = if let Some(notifiers) = weak_notifiers.upgrade() {
+                let mut guard = notifiers.lock().unwrap();
+                guard.retain(|_, notifier| !notifier.is_empty());
+                drop(guard);
+                drop(notifiers);
+                true
+            } else {
+                false
+            };
+
+            if !map_alive && !notifiers_alive {
+                break;
+            }
         }
     })
     .forget();
@@ -663,7 +690,8 @@ where
         chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
     ) -> Self {
         let chain_workers = Arc::new(papaya::HashMap::new());
-        start_sweep(&chain_workers, &chain_worker_config);
+        let delivery_notifiers: Arc<Mutex<DeliveryNotifiers>> = Arc::default();
+        start_sweep(&chain_workers, &delivery_notifiers, &chain_worker_config);
         let block_cache_size = chain_worker_config.block_cache_size;
         let execution_state_cache_size = chain_worker_config.execution_state_cache_size;
         WorkerState {
@@ -672,7 +700,7 @@ where
             block_cache: Arc::new(ValueCache::new(block_cache_size)),
             execution_state_cache: Arc::new(ValueCache::new(execution_state_cache_size)),
             chain_modes,
-            delivery_notifiers: Arc::default(),
+            delivery_notifiers,
             chain_workers,
         }
     }

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -16,6 +16,7 @@ darling = {{ version = ">=0.20, <0.23" }}
 serde_with = {{ version = ">=3, <3.18" }}
 time = {{ version = ">=0.3, <0.3.47" }}
 time-core = {{ version = ">=0.1, <0.1.8" }}
+unicode-segmentation = {{ version = ">=1, <1.13" }}
 
 [dev-dependencies]
 {linera_sdk_dev_dep}


### PR DESCRIPTION
## Motivation

We are exposed to OOM problems.
A small place where we can improve the situation is with respect to dead notifiers: We need to remove them.

## Proposal

We do the following:
* When registering a sender, drop the closed ones.
* The background sweep is now done even when no TTL is set.
* The sweep process stops when there is no notifiers to take care of.

## Test Plan

CI.

## Release Plan

Can be backported to `testnet_conway`.

## Links

None