### PR TITLE
Batch certificate reads in ValidatorUpdater to prevent OOM

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -33,7 +33,7 @@ use tokio::sync::mpsc;
 use tracing::{instrument, Level};
 
 use crate::{
-    client::{chain_client, Client},
+    client::{chain_client, Client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE},
     data_types::{ChainInfo, ChainInfoQuery},
     environment::Environment,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
@@ -778,14 +778,16 @@ where
             return Ok(info);
         }
 
-        // Send any additional missing certificates in order
-        let certificates = self
-            .read_certificates_for_heights(chain_id, heights)
-            .await?;
-
-        for certificate in certificates {
-            self.send_confirmed_certificate(certificate, delivery)
+        let batch_size = DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE as usize;
+        for chunk in heights.chunks(batch_size) {
+            let certificates = self
+                .read_certificates_for_heights(chain_id, chunk.to_vec())
                 .await?;
+
+            for certificate in certificates {
+                self.send_confirmed_certificate(certificate, delivery)
+                    .await?;
+            }
         }
 
         Ok(info)


### PR DESCRIPTION
## Motivation

PM-infra workers running `linera service` are OOMing when
`ValidatorUpdater::sync_chain_height` reads all missing certificates from local storage
in a single unbounded batch. When a validator is behind by for example thousands of blocks and there
are 13 validators being synced concurrently via `communicate_with_quorum`, memory usage
spikes from 40% to OOM on a 60 GiB container in under 8 minutes.

Pyroscope memory profiling on worker-5 confirmed `read_certificates_for_heights`
accounts for **63\.6% of all allocations**.
The call chain is:

```
ChainListener::run → synchronize_chain_state → send_block_proposal
→ send_chain_information → sync_chain_height → read_certificates_for_heights
(unbounded)
```

## Proposal

Chunk the heiin `sync_chain_height` using
`DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE` (500), reading and sending certificates in
batches instead of all at once. Each batch is dropped before the next one is loaded,
bounding peak memory per validator updater to ~500 certificates.

The existing 500-certificate batch limit only applied to remote downloads from
validators (`Client::synchronize_chain_state`), not to local storage reads in the
updater path. This change applies the same bound to both.

## Test Plan

CI