### PR TITLE
Increase notification timeout for remote testnet compatibility tests

### DIFF
--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -37,6 +37,8 @@ env:
   RUST_LOG_FORMAT: plain
   # The remote faucet for this branch
   LINERA_FAUCET_URL: https://faucet.testnet-conway.linera.net
+  # Remote testnet notifications can be slow due to validator latency
+  LINERA_TEST_NOTIFICATION_TIMEOUT_MS: 60000
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation

The `remote_compatibility.yml` workflow tests against the live testnet, where validator latency can cause notifications to take longer than the 10-second default.

## Proposal

Set `LINERA_TEST_NOTIFICATION_TIMEOUT_MS` to 60 seconds to avoid flaky timeouts in `test_controller`.

## Test Plan

CI

I also tried `test_controller` against the testnet locally a few times.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related: https://github.com/linera-io/linera-protocol/issues/5723
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
