### PR TITLE
Add Total line to proxy requests per second dashboard panel

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -130,6 +130,18 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_proxy_request_count{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Proxy requests per second (averaged for the past minute)",


### PR DESCRIPTION
## Motivation

The proxy requests per second panel only shows per-instance lines. Since the load
balancer distributes requests across proxy replicas (round-robin, no session affinity),
the total request rate hitting the validator is the sum across all proxies. Having a
Total line makes it easy to see aggregate traffic at a glance.

## Proposal

Add a second PromQL query to the "Proxy requests per second" panel that sums across
all instances without the `by (instance)` clause, matching the pattern already used
in the "Server requests per second" panel.

## Test Plan

Already verified on the live Grafana dashboard — Total line renders correctly alongside
per-instance lines.
