### PR TITLE
[testnet] Deduplicate certificate download/processing code

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -509,17 +509,17 @@ impl<Env: Environment> Client<Env> {
     }
 
     /// Loads and processes certificates from local storage for the given chain, from the
-    /// current local height up to `stop`. Returns the chain info after processing.
+    /// current local height up to `end`. Returns the chain info after processing.
     async fn load_local_certificates(
         &self,
         chain_id: ChainId,
-        stop: BlockHeight,
+        end: BlockHeight,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
-        let mut info = self.local_node.chain_info(chain_id).await?;
-        let next_height = info.next_block_height;
+        let mut last_info = self.local_node.chain_info(chain_id).await?;
+        let next_height = last_info.next_block_height;
         let hashes = self
             .local_node
-            .get_preprocessed_block_hashes(chain_id, next_height, stop)
+            .get_preprocessed_block_hashes(chain_id, next_height, end)
             .await?;
         let certificates = self.storage_client().read_certificates(&hashes).await?;
         let certificates = match ResultReadCertificates::new(certificates, hashes) {
@@ -529,9 +529,9 @@ impl<Env: Environment> Client<Env> {
             }
         };
         for certificate in certificates {
-            info = self.handle_certificate(certificate).await?.info;
+            last_info = self.handle_certificate(certificate).await?.info;
         }
-        Ok(info)
+        Ok(last_info)
     }
 
     /// Downloads and processes all certificates up to (excluding) the specified height from the


### PR DESCRIPTION
Backport of the fixes in #5812.

## Motivation

In #5812 some inefficiencies and duplications were fixed.

## Proposal

- Extract `load_local_certificates` helper to share local-storage loading between `download_certificates_from` and `download_certificates_using_all`. It now re-fetches chain info after processing, so callers get the updated `next_block_height` (previously the original height was returned, causing redundant re-downloads).
- Unify `process_certificates_using_all` into `process_certificates` by accepting a slice of nodes instead of a single node reference.
- Both download methods now return non-optional `Box<ChainInfo>`, simplifying their callers.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- 
## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
