### PR TITLE
Log IncorrectOutcome as error instead of debug

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -413,7 +413,6 @@ impl WorkerError {
             | WorkerError::InvalidEpoch { .. }
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
-            | WorkerError::IncorrectOutcome { .. }
             | WorkerError::InvalidTimestamp { .. }
             | WorkerError::MissingCertificateValue
             | WorkerError::InvalidLiteCertificate
@@ -433,7 +432,8 @@ impl WorkerError {
             | WorkerError::ChainActorSendError { .. }
             | WorkerError::ChainActorRecvError { .. }
             | WorkerError::Thread(_)
-            | WorkerError::ReadCertificatesError(_) => true,
+            | WorkerError::ReadCertificatesError(_)
+            | WorkerError::IncorrectOutcome { .. } => true,
             WorkerError::ChainError(chain_error) => chain_error.is_local(),
         }
     }

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -102,10 +102,7 @@ mod method_name_tests {
 
     #[test]
     fn non_grpc_no_dot_in_service() {
-        assert_eq!(
-            extract_grpc_method_name("/NoDotService/Method"),
-            "non_grpc"
-        );
+        assert_eq!(extract_grpc_method_name("/NoDotService/Method"), "non_grpc");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`WorkerError::IncorrectOutcome` fires when a certified block (already signed by a
validator quorum) produces a different execution result on the local node. This
indicates state corruption, non-determinism, or a consensus-breaking bug — all serious
local node issues.

Despite this, it was classified as `is_local() = false`, which means both the gRPC and
simple servers logged it at `debug` level — effectively invisible in production.

## Proposal

Move `IncorrectOutcome` from the `is_local() = false` branch to `is_local() = true` in
`WorkerError::is_local()`. This causes the `log_error` methods in both
`linera-rpc/src/grpc/server.rs` and `linera-rpc/src/simple/server.rs` to emit it at
`error!` level instead of `debug!`.

Audited all other errors in the `false` branch (`CryptoError`, `InvalidOwner`,
`InvalidSigner`, `UnexpectedBlockHeight`, `InvalidEpoch`, `InvalidTimestamp`,
`BlobsNotFound`, etc.) — they are correctly classified as potentially caused by bad peer
messages. Also audited `ChainError::is_local()` and `ExecutionError::is_local()` — no
other misclassifications found.

## Test Plan

CI
