### PR TITLE
Increase histogram bucket limits for WASM/EVM metrics

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -105,7 +105,7 @@ pub(crate) mod metrics {
             "wasm_fuel_used_per_block",
             "Wasm fuel used per block",
             &[],
-            exponential_bucket_interval(10.0, 1_000_000.0),
+            exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
 
@@ -114,7 +114,7 @@ pub(crate) mod metrics {
             "evm_fuel_used_per_block",
             "EVM fuel used per block",
             &[],
-            exponential_bucket_interval(10.0, 1_000_000.0),
+            exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
 

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -180,7 +180,7 @@ mod metrics {
             "evm_contract_instantiation_latency",
             "EVM contract instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 
@@ -189,7 +189,7 @@ mod metrics {
             "evm_service_instantiation_latency",
             "EVM service instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -55,7 +55,7 @@ mod metrics {
             "wasm_contract_instantiation_latency",
             "Wasm contract instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 
@@ -64,7 +64,7 @@ mod metrics {
             "wasm_service_instantiation_latency",
             "Wasm service instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 


### PR DESCRIPTION
## Motivation

The p99 for WASM contract instantiation latency and WASM fuel used per block are pegged
at the histogram bucket ceiling (1ms and 1M respectively). Prometheus can't interpolate
beyond the last bucket boundary, so we're blind to the actual values.

## Proposal

Increase the upper bucket limit by 100x for all 6 affected histogram metrics:

| Metric | Old max | New max |
|---|---|---|
| `wasm_contract_instantiation_latency` | 1 ms | 100 ms |
| `wasm_service_instantiation_latency` | 1 ms | 100 ms |
| `evm_contract_instantiation_latency` | 1 ms | 100 ms |
| `evm_service_instantiation_latency` | 1 ms | 100 ms |
| `wasm_fuel_used_per_block` | 1M | 100M |
| `evm_fuel_used_per_block` | 1M | 100M |

The bucket generation uses exponential steps with factor 3.0, so this adds ~4 extra
buckets per metric — negligible overhead.

## Test Plan

CI
