### PR TITLE
Add certificate_upload_batch_size CLI option for ValidatorUpdater

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -197,6 +197,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--certificate-download-batch-size <CERTIFICATE_DOWNLOAD_BATCH_SIZE>` — Maximum number of certificates that we download at a time from one validator when synchronizing one of our chains
 
   Default value: `500`
+* `--certificate-upload-batch-size <CERTIFICATE_UPLOAD_BATCH_SIZE>` — Maximum number of certificates read from local storage and uploaded to a validator at a time when synchronizing a chain
+
+  Default value: `500`
 * `--sender-certificate-download-batch-size <SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE>` — Maximum number of sender certificates we try to download and receive in one go when syncing sender chains
 
   Default value: `20000`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -15,7 +15,7 @@ use linera_base::{
 use linera_core::{
     client::{
         chain_client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
-        DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
     },
     node::CrossChainMessageDelivery,
     DEFAULT_QUORUM_GRACE_PERIOD,
@@ -213,6 +213,14 @@ pub struct Options {
     )]
     pub certificate_download_batch_size: u64,
 
+    /// Maximum number of certificates read from local storage and uploaded to a validator
+    /// at a time when synchronizing a chain.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
+    )]
+    pub certificate_upload_batch_size: u64,
+
     /// Maximum number of sender certificates we try to download and receive in one go
     /// when syncing sender chains.
     #[arg(
@@ -323,6 +331,7 @@ impl Options {
             blob_download_timeout: self.blob_download_timeout,
             certificate_batch_download_timeout: self.certificate_batch_download_timeout,
             certificate_download_batch_size: self.certificate_download_batch_size,
+            certificate_upload_batch_size: self.certificate_upload_batch_size,
             sender_certificate_download_batch_size: self.sender_certificate_download_batch_size,
             max_joined_tasks: self.max_joined_tasks,
             allow_fast_blocks: self.allow_fast_blocks,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -109,6 +109,9 @@ pub struct Options {
     /// Maximum number of certificates that we download at a time from one validator when
     /// synchronizing one of our chains.
     pub certificate_download_batch_size: u64,
+    /// Maximum number of certificates read from local storage and uploaded to a validator
+    /// at a time when synchronizing a chain.
+    pub certificate_upload_batch_size: u64,
     /// Maximum number of sender certificates we try to download and receive in one go
     /// when syncing sender chains.
     pub sender_certificate_download_batch_size: usize,
@@ -135,7 +138,8 @@ struct CircuitBreakerState {
 impl Options {
     pub fn test_default() -> Self {
         use super::{
-            DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE, DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
+            DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
         };
         use crate::DEFAULT_QUORUM_GRACE_PERIOD;
 
@@ -150,6 +154,7 @@ impl Options {
             blob_download_timeout: Duration::from_secs(1),
             certificate_batch_download_timeout: Duration::from_secs(1),
             certificate_download_batch_size: DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            certificate_upload_batch_size: DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
             sender_certificate_download_batch_size: DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
             max_joined_tasks: 100,
             allow_fast_blocks: false,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -123,6 +123,7 @@ mod metrics {
 }
 
 pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
+pub static DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE: usize = 20_000;
 
 #[derive(Debug, Clone, Copy)]
@@ -329,6 +330,10 @@ impl<Env: Environment> Client<Env> {
 
     pub fn validator_node_provider(&self) -> &Env::Network {
         self.environment.network()
+    }
+
+    pub(crate) fn options(&self) -> &chain_client::Options {
+        &self.options
     }
 
     /// Handles any pending local cross-chain requests, notifying subscribers.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -33,7 +33,7 @@ use tokio::sync::mpsc;
 use tracing::{instrument, Level};
 
 use crate::{
-    client::{chain_client, Client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE},
+    client::{chain_client, Client},
     data_types::{ChainInfo, ChainInfoQuery},
     environment::Environment,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
@@ -778,7 +778,7 @@ where
             return Ok(info);
         }
 
-        let batch_size = DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE as usize;
+        let batch_size = self.client.options().certificate_upload_batch_size as usize;
         for chunk in heights.chunks(batch_size) {
             let certificates = self
                 .read_certificates_for_heights(chain_id, chunk.to_vec())


### PR DESCRIPTION
## Motivation

The batch size used by `ValidatorUpdater::sync_chain_height` (added in #5800) was
hardcoded to `DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE`. Reviewers pointed out this is a
conceptually different operation — reading from local storage and uploading to
validators, not downloading — and should have its own configurable option.

## Proposal

- Add `--certificate-upload-batch-size` CLI option (default 500) separate from the
existing `--certificate-download-batch-size`
- Add `certificate_upload_batch_size` field to `chain_client::Options`
- Add `pub(crate) fn options()` accessor on `Client` so `ValidatorUpdater` can read the
configured value
- Wire the new option through the full CLI → `ChainClientOptions` → `ValidatorUpdater`
path

## Test Plan

CI