### PR TITLE
Enable debug log re-runs across CI workflows

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -17,7 +17,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: warn
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'warn' }}
   GCP_REGISTRY: us-docker.pkg.dev/linera-io-dev/linera-public-registry
 
 permissions:

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -27,7 +27,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: warn
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'warn' }}
   DOCKER_COMPOSE_WAIT: "true"
 
 permissions:

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -28,7 +28,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: warn
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'warn' }}
 
 permissions:
   contents: read

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -27,7 +27,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings --cfg=web_sys_unstable_apis
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: warn
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'warn' }}
   DOCKER_COMPOSE_WAIT: "true"
 
 permissions:

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -18,7 +18,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
-  RUST_LOG: warn
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'warn' }}
   RUST_LOG_FORMAT: plain
   LINERA_TEST_ITERATIONS: 1000
 

--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -33,7 +33,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=info
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'info' }}
   RUST_LOG_FORMAT: plain
   # The remote faucet for this branch
   LINERA_FAUCET_URL: https://faucet.testnet-conway.linera.net

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=info
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'info' }}
   RUST_LOG_FORMAT: plain
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   LINERA_WALLET: /tmp/local-linera-net/wallet_0.json

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -30,7 +30,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: warn
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'warn' }}
 
 permissions:
   contents: read
@@ -60,7 +60,7 @@ jobs:
         docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla:6.1 --smp 1
     - name: Run ScyllaDB tests
       run: |
-        RUST_LOG=linera=info cargo test --locked --features scylladb -- scylla --nocapture
+        RUST_LOG=${{ runner.debug == '1' && 'linera=debug' || 'linera=info' }} cargo test --locked --features scylladb -- scylla --nocapture
     - name: Run ScyllaDB opentelemetry tests
       run: |
-        RUST_LOG=linera=info cargo test test_end_to_end_benchmark::scylladb_ --features scylladb,opentelemetry
+        RUST_LOG=${{ runner.debug == '1' && 'linera=debug' || 'linera=info' }} cargo test test_end_to_end_benchmark::scylladb_ --features scylladb,opentelemetry

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -28,7 +28,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=debug
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'info' }}
   RUST_LOG_FORMAT: plain
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   LINERA_WALLET: /tmp/local-linera-net/wallet_0.json

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -22,7 +22,7 @@ env:
   # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=debug
+  RUST_LOG: ${{ runner.debug == '1' && 'linera=debug' || 'info' }}
   RUST_LOG_FORMAT: plain
   LINERA_STORAGE_SERVICE: 127.0.0.1:1235
   LINERA_WALLET: /tmp/local-linera-net/wallet_0.json


### PR DESCRIPTION
## Motivation

When a CI job fails, there's no easy way to re-run it with debug-level logging to
investigate the failure.

## Proposal

Key `RUST_LOG` off `runner.debug` in all 10 workflows that set it. When someone clicks
"Re-run jobs" and checks "Enable debug logging" in the GitHub UI, the re-run
automatically gets `linera=debug`. Default log levels are preserved (`info` or `warn`
depending on the workflow).

The two workflows that already had `linera=debug` as their default (test-readmes, web)
are lowered to `info` to match the rest.

## Test Plan

CI
