### PR TITLE
[frontport] Add --staging-bundles-time-budget-ms for time-budgeted bundle staging (#5393)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -141,6 +141,7 @@ Client implementation and command-line tool for the Linera blockchain
    Discarded bundles can be retried in the next block.
 
   Default value: `3`
+* `--staging-bundles-time-budget-ms <STAGING_BUNDLES_TIME_BUDGET>` — Time budget for staging message bundles in milliseconds. When set, limits bundle execution by time rather than by count. This overrides `max_pending_message_bundles` for bundle limiting purposes
 * `--chain-worker-ttl-ms <CHAIN_WORKER_TTL>` — The duration in milliseconds after which an idle chain worker will free its memory. Use 0 to disable expiry
 
   Default value: `30000`

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -16,6 +16,7 @@ use linera_base::{
     ensure,
     identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, StreamId},
     ownership::ChainOwnership,
+    time::{Duration, Instant},
 };
 use linera_execution::{
     committee::Committee, system::EPOCH_STREAM_NAME, ExecutionRuntimeContext, ExecutionStateView,
@@ -37,8 +38,8 @@ use crate::{
     block::{Block, ConfirmedBlock},
     block_tracker::BlockExecutionTracker,
     data_types::{
-        BlockExecutionOutcome, BundleExecutionPolicy, ChainAndHeight, IncomingBundle,
-        MessageAction, MessageBundle, ProposedBlock, Transaction,
+        BlockExecutionOutcome, BundleExecutionPolicy, BundleFailurePolicy, ChainAndHeight,
+        IncomingBundle, MessageAction, MessageBundle, ProposedBlock, Transaction,
     },
     inbox::{InboxError, InboxStateView},
     manager::ChainManager,
@@ -668,7 +669,7 @@ where
     ) -> Result<(BlockExecutionOutcome, ResourceTracker), ChainError> {
         // AutoRetry is incompatible with replaying oracle responses because discarding or
         // rejecting bundles would change which transactions execute.
-        if !matches!(exec_policy, BundleExecutionPolicy::Abort) {
+        if !matches!(exec_policy.on_failure, BundleFailurePolicy::Abort) {
             assert!(
                 replaying_oracle_responses.is_none(),
                 "Cannot use AutoRetry policy when replaying oracle responses"
@@ -714,17 +715,31 @@ where
         )?;
 
         // Extract max_failures from exec_policy.
-        let max_failures = match exec_policy {
-            BundleExecutionPolicy::Abort => 0,
-            BundleExecutionPolicy::AutoRetry { max_failures } => max_failures,
+        let max_failures = match exec_policy.on_failure {
+            BundleFailurePolicy::Abort => 0,
+            BundleFailurePolicy::AutoRetry { max_failures } => max_failures,
         };
-        let auto_retry = !matches!(exec_policy, BundleExecutionPolicy::Abort);
+        let auto_retry = !matches!(exec_policy.on_failure, BundleFailurePolicy::Abort);
         let mut failure_count = 0u32;
+
+        let time_budget = exec_policy.time_budget;
+        let mut cumulative_bundle_time = Duration::ZERO;
 
         let mut i = 0;
         while i < block.transactions.len() {
             let transaction = &mut block.transactions[i];
             let is_bundle = matches!(transaction, Transaction::ReceiveMessages(_));
+
+            // If we have a time budget and it's been exceeded, discard remaining bundles.
+            if is_bundle && time_budget.is_some_and(|budget| cumulative_bundle_time >= budget) {
+                info!(
+                    ?cumulative_bundle_time,
+                    ?time_budget,
+                    "Time budget for bundle staging exceeded, discarding remaining bundles"
+                );
+                Self::discard_remaining_bundles(block, i, None);
+                continue;
+            }
 
             // Checkpoint before bundle transactions if using auto-retry.
             let checkpoint = if auto_retry && is_bundle {
@@ -736,9 +751,19 @@ where
                 None
             };
 
+            let bundle_start = if is_bundle && time_budget.is_some() {
+                Some(Instant::now())
+            } else {
+                None
+            };
+
             let result = block_execution_tracker
                 .execute_transaction(&*transaction, round, chain)
                 .await;
+
+            if let Some(start) = bundle_start {
+                cumulative_bundle_time += start.elapsed();
+            }
 
             // If the transaction executed successfully, we move on to the next one.
             // On transient errors (e.g. missing blobs) we fail, so it can be retried after

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -18,6 +18,7 @@ use linera_base::{
     },
     doc_scalar, ensure, hex, hex_debug,
     identifiers::{Account, AccountOwner, ApplicationId, BlobId, ChainId, StreamId},
+    time::Duration,
 };
 use linera_execution::{committee::Committee, Message, MessageKind, Operation, OutgoingMessage};
 use serde::{Deserialize, Serialize};
@@ -324,7 +325,7 @@ pub enum MessageAction {
 
 /// Policy for handling message bundle execution failures during block execution.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum BundleExecutionPolicy {
+pub enum BundleFailurePolicy {
     /// Abort block execution on any bundle failure. The proposal is never modified.
     #[default]
     Abort,
@@ -342,6 +343,25 @@ pub enum BundleExecutionPolicy {
         /// Maximum number of discarded bundles before discarding all remaining message bundles.
         max_failures: u32,
     },
+}
+
+/// Policy for executing message bundles during block execution.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct BundleExecutionPolicy {
+    /// What to do when a bundle fails.
+    pub on_failure: BundleFailurePolicy,
+    /// Optional time budget for bundle execution.
+    pub time_budget: Option<Duration>,
+}
+
+impl BundleExecutionPolicy {
+    /// Returns a policy suitable for committed blocks: abort on failure, no time budget.
+    pub fn committed() -> Self {
+        BundleExecutionPolicy {
+            on_failure: BundleFailurePolicy::Abort,
+            time_budget: None,
+        }
+    }
 }
 
 /// A set of messages from a single block, for a single destination.

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -71,7 +71,7 @@ impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
             None,
             published_blobs,
             None,
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await
     }

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -62,6 +62,12 @@ pub struct Options {
     #[arg(long, default_value = "3")]
     pub max_block_limit_errors: u32,
 
+    /// Time budget for staging message bundles in milliseconds. When set, limits bundle
+    /// execution by time rather than by count. This overrides `max_pending_message_bundles`
+    /// for bundle limiting purposes.
+    #[arg(long = "staging-bundles-time-budget-ms", value_parser = util::parse_millis)]
+    pub staging_bundles_time_budget: Option<Duration>,
+
     /// The duration in milliseconds after which an idle chain worker will free its memory.
     /// Use 0 to disable expiry.
     #[arg(
@@ -283,6 +289,7 @@ impl Options {
         chain_client::Options {
             max_pending_message_bundles: self.max_pending_message_bundles,
             max_block_limit_errors: self.max_block_limit_errors,
+            staging_bundles_time_budget: self.staging_bundles_time_budget,
             message_policy,
             cross_chain_message_delivery,
             quorum_grace_period: self.quorum_grace_period,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -835,7 +835,7 @@ where
                     None,
                     &published_blobs,
                     oracle_responses,
-                    BundleExecutionPolicy::Abort,
+                    BundleExecutionPolicy::committed(),
                 )
                 .await?;
             // We should always agree on the messages and state hash.
@@ -1526,7 +1526,7 @@ where
                 local_time,
                 round.multi_leader(),
                 &published_blobs,
-                BundleExecutionPolicy::Abort,
+                BundleExecutionPolicy::committed(),
             ))
             .await?;
             executed_block

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -35,8 +35,8 @@ use linera_base::{
 use linera_base::{data_types::Bytecode, vm::VmRuntime};
 use linera_chain::{
     data_types::{
-        BlockProposal, BundleExecutionPolicy, ChainAndHeight, IncomingBundle, ProposedBlock,
-        Transaction,
+        BlockProposal, BundleExecutionPolicy, BundleFailurePolicy, ChainAndHeight, IncomingBundle,
+        ProposedBlock, Transaction,
     },
     manager::LockingBlock,
     types::{
@@ -88,6 +88,10 @@ pub struct Options {
     ///
     /// Discarded bundles can be retried in the next block.
     pub max_block_limit_errors: u32,
+    /// Time budget for staging message bundles. When set, limits bundle execution by time
+    /// rather than by count. This overrides `max_pending_message_bundles` for bundle limiting
+    /// purposes.
+    pub staging_bundles_time_budget: Option<Duration>,
     /// The policy for automatically handling incoming messages.
     pub message_policy: MessagePolicy,
     /// Whether to block on cross-chain message delivery.
@@ -123,6 +127,7 @@ impl Options {
         Options {
             max_pending_message_bundles: 10,
             max_block_limit_errors: 3,
+            staging_bundles_time_budget: None,
             message_policy: MessagePolicy::new_accept_all(),
             cross_chain_message_delivery: CrossChainMessageDelivery::NonBlocking,
             quorum_grace_period: DEFAULT_QUORUM_GRACE_PERIOD,
@@ -132,6 +137,18 @@ impl Options {
             sender_certificate_download_batch_size: DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
             max_joined_tasks: 100,
             allow_fast_blocks: false,
+        }
+    }
+}
+
+impl Options {
+    /// Builds the [`BundleExecutionPolicy`] based on the client options.
+    pub fn bundle_execution_policy(&self) -> BundleExecutionPolicy {
+        BundleExecutionPolicy {
+            on_failure: BundleFailurePolicy::AutoRetry {
+                max_failures: self.max_block_limit_errors,
+            },
+            time_budget: self.staging_bundles_time_budget,
         }
     }
 }
@@ -517,11 +534,16 @@ impl<Env: Environment> ChainClient<Env> {
             );
         }
 
+        let max_bundles = if self.options.staging_bundles_time_budget.is_some() {
+            usize::MAX
+        } else {
+            self.options.max_pending_message_bundles
+        };
         Ok(info
             .requested_pending_message_bundles
             .into_iter()
             .filter_map(|bundle| bundle.apply_policy(&self.options.message_policy))
-            .take(self.options.max_pending_message_bundles)
+            .take(max_bundles)
             .collect())
     }
 
@@ -1429,9 +1451,7 @@ impl<Env: Environment> ChainClient<Env> {
                 proposed_block,
                 round,
                 blobs.clone(),
-                BundleExecutionPolicy::AutoRetry {
-                    max_failures: self.options.max_block_limit_errors,
-                },
+                self.options.bundle_execution_policy(),
             )
             .await?;
         let (proposed_block, _) = block.clone().into_proposal();
@@ -1607,9 +1627,7 @@ impl<Env: Environment> ChainClient<Env> {
                 block,
                 None,
                 Vec::new(),
-                BundleExecutionPolicy::AutoRetry {
-                    max_failures: self.options.max_block_limit_errors,
-                },
+                self.options.bundle_execution_policy(),
             )
             .await
         {
@@ -1807,7 +1825,7 @@ impl<Env: Environment> ChainClient<Env> {
                             proposed_block,
                             None,
                             blobs.clone(),
-                            BundleExecutionPolicy::Abort,
+                            BundleExecutionPolicy::committed(),
                         )
                         .await?
                         .0;
@@ -1826,7 +1844,7 @@ impl<Env: Environment> ChainClient<Env> {
                     proposed_block,
                     round,
                     blobs.clone(),
-                    BundleExecutionPolicy::Abort,
+                    BundleExecutionPolicy::committed(),
                 )
                 .await?;
             debug!("Proposing the local pending block.");

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -23,8 +23,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle, OperationResult,
-        OutgoingMessageExt,
+        BundleExecutionPolicy, BundleFailurePolicy, IncomingBundle, MessageAction, MessageBundle,
+        OperationResult, OutgoingMessageExt,
     },
     test::{make_child_block, make_first_block, BlockTestExt},
 };
@@ -452,7 +452,10 @@ where
             proposed_block.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::AutoRetry { max_failures: 3 },
+            BundleExecutionPolicy {
+                on_failure: BundleFailurePolicy::AutoRetry { max_failures: 3 },
+                time_budget: None,
+            },
         )
         .await?;
 
@@ -478,7 +481,7 @@ where
             modified_block.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await?;
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -575,7 +575,7 @@ where
     ) -> Result<ConfirmedBlockCertificate, anyhow::Error> {
         let (_, block, _, _) = self
             .executing_worker
-            .stage_block_execution(proposal, None, blobs, BundleExecutionPolicy::Abort)
+            .stage_block_execution(proposal, None, blobs, BundleExecutionPolicy::committed())
             .await?;
         let certificate = self.make_certificate(ConfirmedBlock::new(block));
         self.executing_worker
@@ -884,7 +884,12 @@ where
     // Stage execution to get the block for certificate creation.
     let (_, block, _, _) = env
         .executing_worker()
-        .stage_block_execution(proposed_block, None, vec![], BundleExecutionPolicy::Abort)
+        .stage_block_execution(
+            proposed_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     // Past timestamp should be handled immediately (and succeed).
     let result = env
@@ -911,7 +916,12 @@ where
         .unwrap();
     let (_, block, _, _) = env
         .executing_worker()
-        .stage_block_execution(proposed_block, None, vec![], BundleExecutionPolicy::Abort)
+        .stage_block_execution(
+            proposed_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let result = env
         .executing_worker()
@@ -937,7 +947,12 @@ where
         .unwrap();
     let (_, block, _, _) = env
         .executing_worker()
-        .stage_block_execution(proposed_block, None, vec![], BundleExecutionPolicy::Abort)
+        .stage_block_execution(
+            proposed_block,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
 
     // Spawn the proposal handling. It should not complete immediately.
@@ -3441,7 +3456,12 @@ where
         .with_authenticated_owner(Some(owner0));
     let (_, block0, _, _) = env
         .executing_worker()
-        .stage_block_execution(proposed_block0, None, vec![], BundleExecutionPolicy::Abort)
+        .stage_block_execution(
+            proposed_block0,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value0 = ConfirmedBlock::new(block0);
     let certificate0 = env.make_certificate(value0.clone());
@@ -3514,7 +3534,7 @@ where
             proposed_block1.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await?;
     let proposal1_wrong_owner = proposed_block1
@@ -3572,7 +3592,7 @@ where
             proposed_block2.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await?;
 
@@ -3721,7 +3741,12 @@ where
         });
     let (_, block0, _, _) = env
         .executing_worker()
-        .stage_block_execution(proposed_block0, None, vec![], BundleExecutionPolicy::Abort)
+        .stage_block_execution(
+            proposed_block0,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value0 = ConfirmedBlock::new(block0);
     let certificate0 = env.make_certificate(value0.clone());
@@ -3845,7 +3870,12 @@ where
         });
     let (_, block0, _, _) = env
         .executing_worker()
-        .stage_block_execution(proposed_block0, None, vec![], BundleExecutionPolicy::Abort)
+        .stage_block_execution(
+            proposed_block0,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
         .await?;
     let value0 = ConfirmedBlock::new(block0);
     let certificate0 = env.make_certificate(value0.clone());
@@ -3877,7 +3907,7 @@ where
             proposed_block1.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await?;
     let value1 = ConfirmedBlock::new(block1);
@@ -3947,7 +3977,7 @@ where
             proposed_block2.clone(),
             None,
             vec![],
-            BundleExecutionPolicy::Abort,
+            BundleExecutionPolicy::committed(),
         )
         .await?;
     let value2 = ValidatedBlock::new(block2.clone());
@@ -4461,7 +4491,7 @@ where
     // Test stage_block_execution directly - this should fail with IncorrectMessageOrder.
     assert_matches!(
         env.executing_worker()
-            .stage_block_execution(bad_proposed_block.clone(), None, vec![], BundleExecutionPolicy::Abort)
+            .stage_block_execution(bad_proposed_block.clone(), None, vec![], BundleExecutionPolicy::committed())
             .await,
         Err(WorkerError::ChainError(chain_error))
             if matches!(*chain_error, ChainError::IncorrectMessageOrder { .. })

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -253,7 +253,7 @@ impl BlockBuilder {
                 self.block,
                 None,
                 published_blobs,
-                BundleExecutionPolicy::Abort,
+                BundleExecutionPolicy::committed(),
             )
             .await?;
 


### PR DESCRIPTION
## Motivation

Frontport of https://github.com/linera-io/linera-protocol/pull/5393 from
`testnet_conway`.

Currently, block staging limits incoming message bundles by count
(`max_pending_message_bundles`), which doesn't account for the variable cost of
executing different bundles. This adds a time-based budget that gives operators direct
control over block execution latency.

## Proposal

- Add `--staging-bundles-time-budget-ms` CLI option. When set, the client includes as
many bundles as can be executed within the time budget instead of limiting by count.
- Refactor `BundleExecutionPolicy` enum into `BundleFailurePolicy` (Abort/AutoRetry) +
`BundleExecutionPolicy` struct that combines failure policy with optional time budget.
- Only `ReceiveMessages` bundles are time-budgeted; operations always execute.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

