### PR TITLE
[frontport] Retry gRPC subscription streams on HTTP 502 Bad Gateway (#5489)

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -115,6 +115,15 @@ impl GrpcClient {
                 trace!("gRPC connection reset: {status:?}; retrying");
                 true
             }
+            Code::Internal if status.message().contains("502 Bad Gateway") => {
+                // When a proxy/ingress returns HTTP 502 (e.g. during rolling restarts),
+                // tonic's frame decoder fails on the non-gRPC response body before the
+                // HTTP-to-gRPC status mapping can run, producing Code::Internal instead
+                // of Code::Unavailable. Per the gRPC spec, HTTP 502 maps to UNAVAILABLE
+                // which is retryable. This works around tonic#2365.
+                trace!("gRPC proxy error (502): {status:?}; retrying");
+                true
+            }
             Code::NotFound => false, // This code is used if e.g. the validator is missing blobs.
             Code::InvalidArgument
             | Code::AlreadyExists


### PR DESCRIPTION
## Motivation

Frontport of https://github.com/linera-io/linera-protocol/pull/5489 from
`testnet_conway`.

gRPC notification subscription streams fail permanently on HTTP 502 Bad Gateway errors
(common during proxy restarts or rolling updates). The client should retry these
transient errors instead of giving up.

## Proposal

Add HTTP 502 Bad Gateway to the set of retryable gRPC status codes for subscription
streams.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
