### PR TITLE
[frontport] Add k8sattributes processor to enrich trace spans with Kubernetes metadata (#5477)

### DIFF
--- a/kubernetes/linera-validator/values-observability-alloy.yaml.gotmpl
+++ b/kubernetes/linera-validator/values-observability-alloy.yaml.gotmpl
@@ -205,10 +205,9 @@ alloy:
       }
       {{- end }}
 
-      {{- if eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
-      // ==================== Tempo Traces Collection ====================
-      // Receives traces via OTLP and forwards to BOTH local Tempo (preserves local monitoring)
-      // AND central Tempo (external monitoring stack)
+      // ==================== Trace Pipeline (always active) ====================
+      // Receives traces via OTLP, enriches with k8s metadata, forwards to local Tempo.
+      // If TEMPO_ENABLED, also forwards to central Tempo.
 
       // OTLP receiver for traces
       otelcol.receiver.otlp "default" {
@@ -221,16 +220,39 @@ alloy:
         }
 
         output {
-          // Fan-out to both local and central Tempo
+          traces = [otelcol.processor.k8sattributes.default.input]
+        }
+      }
+
+      otelcol.processor.k8sattributes "default" {
+        extract {
+          metadata = [
+            "k8s.namespace.name",
+            "k8s.pod.name",
+            "k8s.container.name",
+            "k8s.node.name",
+            "k8s.deployment.name",
+            "k8s.statefulset.name",
+          ]
+        }
+
+        pod_association {
+          source {
+            from = "connection"
+          }
+        }
+
+        output {
           traces = [
             otelcol.exporter.otlp.local_tempo.input,
+            {{- if eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
             otelcol.exporter.otlphttp.central.input,
+            {{- end }}
           ]
         }
       }
 
-      // Export traces to LOCAL Tempo (preserves existing local monitoring)
-      // Uses gRPC OTLP to local Tempo in tempo namespace
+      // Export traces to LOCAL Tempo (always active)
       otelcol.exporter.otlp "local_tempo" {
         client {
           endpoint = "tempo.tempo.svc.cluster.local:4317"
@@ -241,6 +263,7 @@ alloy:
         }
       }
 
+      {{- if eq (env "LINERA_HELMFILE_SET_TEMPO_ENABLED" | default "false") "true" }}
       // Export traces to external/central Tempo
       otelcol.exporter.otlphttp "central" {
         client {


### PR DESCRIPTION
## Motivation

Frontport of https://github.com/linera-io/linera-protocol/pull/5477 from
`testnet_conway`.

Trace spans lack Kubernetes context (pod name, namespace, node), making it harder to
correlate traces with specific pods during investigations.

## Proposal

Add k8sattributes processor to the Alloy OTLP pipeline so trace spans are enriched with
Kubernetes metadata (pod name, namespace, node name, deployment) before being exported
to Tempo.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

