### PR TITLE
[frontport] Inject traceID and spanID into log output for logs-to-traces correlation (#5476)

### DIFF
--- a/linera-service/src/tracing/mod.rs
+++ b/linera-service/src/tracing/mod.rs
@@ -27,6 +27,11 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
     EnvFilter,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use {
+    ::opentelemetry::trace::TraceContextExt as _, tracing_opentelemetry::OtelData,
+    tracing_subscriber::fmt::FormatEvent,
+};
 
 pub(crate) struct EnvConfig {
     pub(crate) env_filter: EnvFilter,
@@ -129,6 +134,45 @@ pub(crate) fn open_log_file(log_name: &str) -> Option<File> {
     )
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+struct WithTraceContext;
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<S, N> FormatEvent<S, N> for WithTraceContext
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &fmt::FmtContext<'_, S, N>,
+        mut writer: fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        if let Some(scope) = ctx.event_scope() {
+            for span in scope {
+                let extensions = span.extensions();
+                if let Some(otel_data) = extensions.get::<OtelData>() {
+                    // For root spans, trace_id is on the builder.
+                    // For child spans, it's inherited from the parent context.
+                    let trace_id = otel_data
+                        .builder
+                        .trace_id
+                        .unwrap_or_else(|| otel_data.parent_cx.span().span_context().trace_id());
+                    if trace_id != ::opentelemetry::trace::TraceId::INVALID {
+                        write!(writer, "traceID={trace_id} ")?;
+                    }
+                    if let Some(span_id) = otel_data.builder.span_id {
+                        write!(writer, "spanID={span_id} ")?;
+                    }
+                    break;
+                }
+            }
+        }
+        Format::default().format_event(ctx, writer, event)
+    }
+}
+
 /// Applies a requested `formatting` to the log output of the provided `layer`.
 ///
 /// Returns a boxed [`Layer`] with the formatting applied to the original `layer`.
@@ -145,7 +189,16 @@ where
     match formatting.unwrap_or("plain") {
         "json" => layer.json().boxed(),
         "pretty" => layer.pretty().boxed(),
-        "plain" => layer.boxed(),
+        "plain" => {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                layer.event_format(WithTraceContext).boxed()
+            }
+            #[cfg(target_arch = "wasm32")]
+            {
+                layer.boxed()
+            }
+        }
         format => {
             panic!("Invalid RUST_LOG_FORMAT: `{format}`.  Valid values are `json` or `pretty`.")
         }


### PR DESCRIPTION
## Motivation

Frontport of https://github.com/linera-io/linera-protocol/pull/5476 from
`testnet_conway`.

Logs and traces are currently disconnected — there's no way to jump from a log line in
Loki to the corresponding trace in Tempo.

## Proposal

Inject OpenTelemetry traceID and spanID into structured log output so Grafana can
correlate logs with traces automatically.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

