### PR TITLE
[frontport] Make time budget and count limit work together for bundle staging (#5507)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -135,13 +135,13 @@ Client implementation and command-line tool for the Linera blockchain
   Default value: `4000`
 * `--max-pending-message-bundles <MAX_PENDING_MESSAGE_BUNDLES>` — The maximum number of incoming message bundles to include in a block proposal
 
-  Default value: `10`
+  Default value: `300`
 * `--max-block-limit-errors <MAX_BLOCK_LIMIT_ERRORS>` — Maximum number of message bundles to discard from a block proposal due to block limit errors before discarding all remaining bundles.
 
    Discarded bundles can be retried in the next block.
 
   Default value: `3`
-* `--staging-bundles-time-budget-ms <STAGING_BUNDLES_TIME_BUDGET>` — Time budget for staging message bundles in milliseconds. When set, limits bundle execution by time rather than by count. This overrides `max_pending_message_bundles` for bundle limiting purposes
+* `--staging-bundles-time-budget-ms <STAGING_BUNDLES_TIME_BUDGET>` — Time budget for staging message bundles in milliseconds. When set, limits bundle execution by wall-clock time, in addition to the count limit from `max_pending_message_bundles`
 * `--chain-worker-ttl-ms <CHAIN_WORKER_TTL>` — The duration in milliseconds after which an idle chain worker will free its memory. Use 0 to disable expiry
 
   Default value: `30000`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -52,7 +52,7 @@ pub struct Options {
     pub recv_timeout: Duration,
 
     /// The maximum number of incoming message bundles to include in a block proposal.
-    #[arg(long, default_value = "10")]
+    #[arg(long, default_value = "300")]
     pub max_pending_message_bundles: usize,
 
     /// Maximum number of message bundles to discard from a block proposal due to block limit
@@ -63,8 +63,8 @@ pub struct Options {
     pub max_block_limit_errors: u32,
 
     /// Time budget for staging message bundles in milliseconds. When set, limits bundle
-    /// execution by time rather than by count. This overrides `max_pending_message_bundles`
-    /// for bundle limiting purposes.
+    /// execution by wall-clock time, in addition to the count limit from
+    /// `max_pending_message_bundles`.
     #[arg(long = "staging-bundles-time-budget-ms", value_parser = util::parse_millis)]
     pub staging_bundles_time_budget: Option<Duration>,
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -88,9 +88,8 @@ pub struct Options {
     ///
     /// Discarded bundles can be retried in the next block.
     pub max_block_limit_errors: u32,
-    /// Time budget for staging message bundles. When set, limits bundle execution by time
-    /// rather than by count. This overrides `max_pending_message_bundles` for bundle limiting
-    /// purposes.
+    /// Time budget for staging message bundles. When set, limits bundle execution by
+    /// wall-clock time, in addition to the count limit from `max_pending_message_bundles`.
     pub staging_bundles_time_budget: Option<Duration>,
     /// The policy for automatically handling incoming messages.
     pub message_policy: MessagePolicy,
@@ -534,16 +533,11 @@ impl<Env: Environment> ChainClient<Env> {
             );
         }
 
-        let max_bundles = if self.options.staging_bundles_time_budget.is_some() {
-            usize::MAX
-        } else {
-            self.options.max_pending_message_bundles
-        };
         Ok(info
             .requested_pending_message_bundles
             .into_iter()
             .filter_map(|bundle| bundle.apply_policy(&self.options.message_policy))
-            .take(max_bundles)
+            .take(self.options.max_pending_message_bundles)
             .collect())
     }
 


### PR DESCRIPTION
## Motivation

Frontport of https://github.com/linera-io/linera-protocol/pull/5507 from
`testnet_conway`.

Follow-up to #5393. When `--staging-bundles-time-budget-ms` is set, the count limit
(`max_pending_message_bundles`) was completely bypassed. Both limits should apply
together.

## Proposal

- Remove the `usize::MAX` override so `max_pending_message_bundles` always applies
regardless of whether a time budget is set
- Increase default `max_pending_message_bundles` from 10 to 300, so the time budget
becomes the effective limiter in practice
- Update doc comments to say the time budget works "in addition to" the count limit

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

