### PR TITLE
[frontport] Add validator address to subscription stream error logs (#5580)

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -324,6 +324,7 @@ impl ValidatorNode for GrpcClient {
         let retry_delay = self.retry_delay;
         let max_retries = self.max_retries;
         let max_backoff = self.max_backoff;
+        let address = self.address.clone();
         // Use shared atomic counter so unfold can reset it on successful reconnection.
         let retry_count = Arc::new(AtomicU32::new(0));
         let subscription_request = SubscriptionRequest {
@@ -405,12 +406,12 @@ impl ValidatorNode for GrpcClient {
                     true
                 })
             })
-            .filter_map(|result| {
+            .filter_map(move |result| {
                 future::ready(match result {
                     Ok(notification @ Some(_)) => notification,
                     Ok(None) => None,
                     Err(err) => {
-                        warn!("{}", err);
+                        warn!(%address, "{}", err);
                         None
                     }
                 })


### PR DESCRIPTION
## Motivation

Frontport of https://github.com/linera-io/linera-protocol/pull/5580 from
`testnet_conway`.

When a gRPC notification subscription stream fails, the error log doesn't include which
validator it was connected to, making it hard to diagnose connectivity issues.

## Proposal

Add the validator address to subscription stream error log messages.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

