### PR TITLE
[frontport] Replace selective COPY patterns with COPY . . in all Dockerfiles (#5621)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,9 +15,7 @@
 README-secret.md
 # github related files
 .github/
-**/target/
-scripts/target
-examples/target
+**/target
 Dockerfile
 .dockerignore
 .gitignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,35 +32,7 @@ RUN apt-get update && apt-get install -y \
     clang \
     make
 
-COPY examples examples
-COPY linera-base linera-base
-COPY linera-chain linera-chain
-COPY linera-client linera-client
-COPY linera-core linera-core
-COPY linera-bridge linera-bridge
-COPY linera-ethereum linera-ethereum
-COPY linera-execution linera-execution
-COPY linera-explorer linera-explorer
-COPY linera-faucet linera-faucet
-COPY linera-indexer linera-indexer
-COPY linera-metrics linera-metrics
-COPY linera-rpc linera-rpc
-COPY linera-sdk linera-sdk
-COPY linera-sdk-derive linera-sdk-derive
-COPY linera-service linera-service
-COPY linera-service-graphql-client linera-service-graphql-client
-COPY linera-storage linera-storage
-COPY linera-storage-service linera-storage-service
-COPY linera-summary linera-summary
-COPY linera-persistent linera-persistent
-COPY linera-version linera-version
-COPY linera-views linera-views
-COPY linera-views-derive linera-views-derive
-COPY linera-witty linera-witty
-COPY linera-witty-macros linera-witty-macros
-COPY scripts scripts
-COPY web web
-COPY rust-toolchain* Cargo.* ./
+COPY . .
 
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -51,18 +51,7 @@ ARG rustflags
 
 COPY --from=planner /app/recipe.json recipe.json
 
-# linera-version's build.rs uses include!() for type definitions and hashes
-# files from other crates at build-script runtime.  These must exist before
-# `cargo chef cook` because cook triggers the build script.
-COPY linera-version/src/serde_pretty linera-version/src/serde_pretty
-COPY linera-version/src/version_info linera-version/src/version_info
-COPY linera-version/api-hashes.json linera-version/api-hashes.json
-COPY linera-rpc/tests/snapshots linera-rpc/tests/snapshots
-COPY linera-service-graphql-client/gql linera-service-graphql-client/gql
-COPY linera-sdk/wit linera-sdk/wit
-
-# Examples workspace stubs for dev-dep resolution during cook.
-COPY --from=planner /examples-stubs examples
+COPY . .
 
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}

--- a/docker/Dockerfile.exporter
+++ b/docker/Dockerfile.exporter
@@ -40,35 +40,7 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     clang
 
-COPY examples examples
-COPY linera-base linera-base
-COPY linera-bridge linera-bridge
-COPY linera-chain linera-chain
-COPY linera-client linera-client
-COPY linera-core linera-core
-COPY linera-ethereum linera-ethereum
-COPY linera-explorer linera-explorer
-COPY linera-execution linera-execution
-COPY linera-faucet linera-faucet
-COPY linera-indexer linera-indexer
-COPY linera-metrics linera-metrics
-COPY linera-rpc linera-rpc
-COPY linera-sdk linera-sdk
-COPY linera-sdk-derive linera-sdk-derive
-COPY linera-service linera-service
-COPY linera-service-graphql-client linera-service-graphql-client
-COPY linera-storage linera-storage
-COPY linera-storage-service linera-storage-service
-COPY linera-summary linera-summary
-COPY linera-persistent linera-persistent
-COPY linera-version linera-version
-COPY linera-views linera-views
-COPY linera-views-derive linera-views-derive
-COPY web web
-COPY linera-witty linera-witty
-COPY linera-witty-macros linera-witty-macros
-COPY scripts scripts
-COPY rust-toolchain* Cargo.* ./
+COPY . .
 
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}

--- a/docker/Dockerfile.indexer
+++ b/docker/Dockerfile.indexer
@@ -40,34 +40,7 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     clang
 
-COPY examples examples
-COPY linera-base linera-base
-COPY linera-bridge linera-bridge
-COPY linera-chain linera-chain
-COPY linera-client linera-client
-COPY linera-core linera-core
-COPY linera-ethereum linera-ethereum
-COPY linera-explorer linera-explorer
-COPY linera-execution linera-execution
-COPY linera-faucet linera-faucet
-COPY linera-indexer linera-indexer
-COPY linera-metrics linera-metrics
-COPY linera-rpc linera-rpc
-COPY linera-sdk linera-sdk
-COPY linera-sdk-derive linera-sdk-derive
-COPY linera-service linera-service
-COPY linera-service-graphql-client linera-service-graphql-client
-COPY linera-storage linera-storage
-COPY linera-storage-service linera-storage-service
-COPY linera-summary linera-summary
-COPY linera-persistent linera-persistent
-COPY linera-version linera-version
-COPY linera-views linera-views
-COPY linera-views-derive linera-views-derive
-COPY linera-witty linera-witty
-COPY linera-witty-macros linera-witty-macros
-COPY rust-toolchain* Cargo.* ./
-COPY web web
+COPY . .
 
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}


### PR DESCRIPTION
## Motivation

Frontport of https://github.com/linera-io/linera-protocol/pull/5621 from
`testnet_conway`.

The Dockerfiles use fragile selective COPY patterns that break whenever a new crate or
file is added. They require manual maintenance and cause Docker build failures.

## Proposal

Replace all selective COPY patterns with `COPY . .` in Dockerfiles, relying on
`.dockerignore` to exclude unwanted files. This eliminates the maintenance burden of
keeping COPY lists in sync with the workspace structure.

Updated `.dockerignore` to use `**/target` glob to cover all target directories.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

