### PR TITLE
[frontport] Add Prometheus metrics for WASM bytecode sizes (#5643)

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1246,6 +1246,11 @@ impl CompressedBytecode {
         let _decompression_latency = metrics::BYTECODE_DECOMPRESSION_LATENCY.measure_latency();
         let bytes = zstd::stream::decode_all(&**self.compressed_bytes)?;
 
+        #[cfg(with_metrics)]
+        metrics::BYTECODE_DECOMPRESSED_SIZE_BYTES
+            .with_label_values(&[])
+            .observe(bytes.len() as f64);
+
         Ok(Bytecode { bytes })
     }
 }
@@ -1289,6 +1294,11 @@ impl CompressedBytecode {
                 .read_to_end(&mut bytes)
                 .expect("Reading from a slice in memory should not result in I/O errors");
         }
+
+        #[cfg(with_metrics)]
+        BYTECODE_DECOMPRESSED_SIZE_BYTES
+            .with_label_values(&[])
+            .observe(bytes.len() as f64);
 
         Ok(Bytecode { bytes })
     }
@@ -1719,7 +1729,9 @@ mod metrics {
 
     use prometheus::HistogramVec;
 
-    use crate::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use crate::prometheus_util::{
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
+    };
 
     /// The time it takes to compress a bytecode.
     pub static BYTECODE_COMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -1738,6 +1750,15 @@ mod metrics {
             "Bytecode decompression latency",
             &[],
             exponential_bucket_latencies(10.0),
+        )
+    });
+
+    pub static BYTECODE_DECOMPRESSED_SIZE_BYTES: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "wasm_bytecode_decompressed_size_bytes",
+            "Decompressed size in bytes of WASM bytecodes stored on-chain",
+            &[],
+            exponential_bucket_interval(10_000.0, 100_000_000.0),
         )
     });
 }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -45,7 +45,9 @@ use crate::{
 mod metrics {
     use std::sync::LazyLock;
 
-    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use linera_base::prometheus_util::{
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram_vec,
+    };
     use prometheus::HistogramVec;
 
     pub static CONTRACT_INSTANTIATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -63,6 +65,15 @@ mod metrics {
             "Wasm service instantiation latency",
             &[],
             exponential_bucket_latencies(1.0),
+        )
+    });
+
+    pub static WASM_BYTECODE_SIZE_BYTES: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "wasm_bytecode_size_bytes",
+            "Size in bytes of WASM bytecodes being loaded",
+            &["type"],
+            exponential_bucket_interval(10_000.0, 100_000_000.0),
         )
     });
 }

--- a/linera-execution/src/wasm/module_cache.rs
+++ b/linera-execution/src/wasm/module_cache.rs
@@ -46,11 +46,18 @@ impl<Module> ModuleCache<Module> {
 impl<Module: Clone> ModuleCache<Module> {
     /// Returns a `Module` for the requested `bytecode`, creating it with `module_builder` and
     /// adding it to the cache if it doesn't already exist in the cache.
+    #[cfg_attr(not(with_metrics), allow(unused_variables))]
     pub fn get_or_insert_with<E>(
         &mut self,
         bytecode: Bytecode,
+        bytecode_type: &str,
         module_builder: impl FnOnce(Bytecode) -> Result<Module, E>,
     ) -> Result<Module, E> {
+        #[cfg(with_metrics)]
+        super::metrics::WASM_BYTECODE_SIZE_BYTES
+            .with_label_values(&[bytecode_type])
+            .observe(bytecode.as_ref().len() as f64);
+
         if let Some(module) = self.get(&bytecode) {
             Ok(module)
         } else {

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -76,7 +76,7 @@ impl WasmContractModule {
     pub async fn from_wasmer(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
         let module = contract_cache
-            .get_or_insert_with(contract_bytecode, |bytecode| {
+            .get_or_insert_with(contract_bytecode, "contract", |bytecode| {
                 let metered_bytecode = add_metering(&bytecode)?;
                 wasmer::Module::new(&*CONTRACT_ENGINE, metered_bytecode)
                     .map_err(anyhow::Error::from)
@@ -116,7 +116,7 @@ impl WasmServiceModule {
     pub async fn from_wasmer(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
         let module = service_cache
-            .get_or_insert_with(service_bytecode, |bytecode| {
+            .get_or_insert_with(service_bytecode, "service", |bytecode| {
                 wasmer::Module::new(&*SERVICE_ENGINE, bytecode).map_err(anyhow::Error::from)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -62,7 +62,7 @@ impl WasmContractModule {
     pub async fn from_wasmtime(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
         let module = contract_cache
-            .get_or_insert_with(contract_bytecode, |bytecode| {
+            .get_or_insert_with(contract_bytecode, "contract", |bytecode| {
                 let metered_bytecode = add_metering(&bytecode)?;
                 Module::new(&CONTRACT_ENGINE, metered_bytecode)
             })
@@ -99,7 +99,7 @@ impl WasmServiceModule {
     pub async fn from_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
         let module = service_cache
-            .get_or_insert_with(service_bytecode, |bytecode| {
+            .get_or_insert_with(service_bytecode, "service", |bytecode| {
                 Module::new(&SERVICE_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;


### PR DESCRIPTION
## Motivation

We have no visibility into the size distribution of WASM bytecodes being loaded or
stored on-chain. This makes it harder to reason about memory pressure, cache
effectiveness, and on-chain storage costs.

## Proposal

Add two new Prometheus histogram metrics:

- **`wasm_bytecode_size_bytes`** — Records the size of every bytecode passed to
`ModuleCache::get_or_insert_with` (both cache hits and misses). Labeled with `type`
(`"contract"` or `"service"`) to distinguish them.

- **`wasm_bytecode_decompressed_size_bytes`** — Records the decompressed size of
bytecodes right after zstd decompression in `CompressedBytecode::decompress()`.

Both use `exponential_bucket_interval(10_000.0, 100_000_000.0)` for buckets spanning
10KB to 100MB.

Frontport of #5643.

## Test Plan

CI
