### PR TITLE
[frontport] Switch ScyllaDB compaction to LCS and enable immediate tombstone GC (#5682)

### DIFF
--- a/.github/workflows/instruction-count-benchmarks.yml
+++ b/.github/workflows/instruction-count-benchmarks.yml
@@ -78,6 +78,7 @@ jobs:
       run: cargo bench -p linera-views --bench gungraun_views --no-run
     - name: Download baseline artifact
       id: download-baseline
+      continue-on-error: true
       run: |
         BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
         MERGE_BASE=$(git merge-base HEAD "origin/$BASE_REF")

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -920,12 +920,8 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
                     PRIMARY KEY (root_key, k) \
                 ) \
                 WITH compaction = {{ \
-                    'class'            : 'SizeTieredCompactionStrategy', \
-                    'min_sstable_size' : 52428800, \
-                    'bucket_low'       : 0.5, \
-                    'bucket_high'      : 1.5, \
-                    'min_threshold'    : 4, \
-                    'max_threshold'    : 32 \
+                    'class'          : 'LeveledCompactionStrategy', \
+                    'sstable_size_in_mb' : 160 \
                 }} \
                 AND compression = {{ \
                     'sstable_compression': 'LZ4Compressor', \
@@ -933,7 +929,9 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
                 }} \
                 AND caching = {{ \
                     'enabled': 'true' \
-                }}",
+                }} \
+                AND gc_grace_seconds = 0 \
+                AND tombstone_gc = {{'mode': 'immediate'}}",
                 KEYSPACE, namespace
             ))
             .await?;


### PR DESCRIPTION
## Motivation

ScyllaDB read latencies spiked on testnet-conway due to tombstone accumulation and
SSTable count explosion. STCS compaction couldn't keep up with the write rate, SSTable
counts reached 165 (target: 4), and the default `gc_grace_seconds` of 10 days prevented
tombstone purging during compaction. Once the working set exceeded cache capacity, reads
fell to disk and had to scan through 100+ tombstone-heavy SSTables, saturating the
reader concurrency semaphore and causing p99 read latency to spike to seconds.

## Proposal

- Switch compaction strategy from `SizeTieredCompactionStrategy` to
`LeveledCompactionStrategy` with 160MB SSTable size. LCS keeps SSTable counts bounded
and reads only touch 1-2 SSTables per level.
- Set `gc_grace_seconds = 0` since we run RF=1 with a single node per cluster.
- Set `tombstone_gc = immediate` so compaction can purge tombstones without waiting for
any grace period or repair cycle.

Frontport of #5682.

## Test Plan

CI

