### PR TITLE
[frontport] Change dashboard auto-refresh from 5s to 10s (#5716)

### DIFF
--- a/docker/dashboards/linera-general.json
+++ b/docker/dashboards/linera-general.json
@@ -1083,7 +1083,7 @@
       "type": "table"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 39,
   "tags": [
     "linera"

--- a/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
@@ -6146,7 +6146,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [

--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -3415,7 +3415,7 @@
     }
   ],
   "preload": false,
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 42,
   "tags": [
     "linera"

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/rocksdb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/rocksdb.json
@@ -2331,7 +2331,7 @@
     }
   ],
   "preload": false,
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 42,
   "tags": [
     "linera",

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
@@ -2361,7 +2361,7 @@
     }
   ],
   "preload": false,
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 42,
   "tags": [
     "linera",

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
@@ -3669,7 +3669,7 @@
     }
   ],
   "preload": false,
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 42,
   "tags": [
     "linera"

--- a/kubernetes/linera-validator/grafana-dashboards/linera/traces.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/traces.json
@@ -689,7 +689,7 @@
       "type": "row"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 39,
   "tags": [
     "linera"

--- a/kubernetes/linera-validator/grafana-dashboards/linera/views.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/views.json
@@ -1244,7 +1244,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "5s",
+  "refresh": "10s",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [

--- a/kubernetes/linera-validator/grafana-dashboards/scylla-manager/scylla-manager.3.4.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla-manager/scylla-manager.3.4.json
@@ -1473,7 +1473,7 @@
             "type": "text"
         }
     ],
-    "refresh": "5s",
+    "refresh": "10s",
     "schemaVersion": 26,
     "style": "dark",
     "tags": [

--- a/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-os.6.2.json
+++ b/kubernetes/linera-validator/grafana-dashboards/scylla/scylla-os.6.2.json
@@ -1916,7 +1916,7 @@
             "type": "text"
         }
     ],
-    "refresh": "5s",
+    "refresh": "10s",
     "schemaVersion": 26,
     "style": "dark",
     "tags": [


### PR DESCRIPTION
## Motivation

5s auto-refresh creates unnecessary load on Prometheus/Grafana for dashboards that don't
need sub-10s granularity.

## Proposal

Change the default auto-refresh interval from 5s to 10s across all dashboards.

Frontport of #5716.

## Test Plan

CI
