### PR TITLE
[frontport] Circuit breaker for validator notification streams (#5717)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -158,6 +158,12 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-backoff-ms <MAX_BACKOFF>` — Maximum backoff delay for retrying to connect to a validator
 
   Default value: `30000`
+* `--notification-circuit-breaker-initial-probe-interval-ms <NOTIFICATION_CIRCUIT_BREAKER_INITIAL_PROBE_INTERVAL>` — Initial probe interval (ms) for the notification circuit breaker. When a validator's notification stream exhausts retries, the circuit breaker waits this long before probing again. Doubles on each failed probe
+
+  Default value: `300000`
+* `--notification-circuit-breaker-max-probe-interval-ms <NOTIFICATION_CIRCUIT_BREAKER_MAX_PROBE_INTERVAL>` — Maximum probe interval (ms) for the notification circuit breaker. The probe interval doubles on each failure but is capped at this value
+
+  Default value: `3600000`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
 * `--allow-fast-blocks` — Whether to allow creating blocks in the fast round. Fast blocks have lower latency but must be used carefully so that there are never any conflicting fast block proposals
 * `--long-lived-services` — (EXPERIMENTAL) Whether application services can persist in some cases between queries

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -112,6 +112,25 @@ pub struct Options {
     )]
     pub max_backoff: Duration,
 
+    /// Initial probe interval (ms) for the notification circuit breaker. When a validator's
+    /// notification stream exhausts retries, the circuit breaker waits this long before
+    /// probing again. Doubles on each failed probe.
+    #[arg(
+        long = "notification-circuit-breaker-initial-probe-interval-ms",
+        default_value = "300000",
+        value_parser = util::parse_millis
+    )]
+    pub notification_circuit_breaker_initial_probe_interval: Duration,
+
+    /// Maximum probe interval (ms) for the notification circuit breaker. The probe interval
+    /// doubles on each failure but is capped at this value.
+    #[arg(
+        long = "notification-circuit-breaker-max-probe-interval-ms",
+        default_value = "3600000",
+        value_parser = util::parse_millis
+    )]
+    pub notification_circuit_breaker_max_probe_interval: Duration,
+
     /// Whether to wait until a quorum of validators has confirmed that all sent cross-chain
     /// messages have been delivered.
     #[arg(long)]
@@ -303,6 +322,10 @@ impl Options {
             sender_certificate_download_batch_size: self.sender_certificate_download_batch_size,
             max_joined_tasks: self.max_joined_tasks,
             allow_fast_blocks: self.allow_fast_blocks,
+            notification_circuit_breaker_initial_probe_interval: self
+                .notification_circuit_breaker_initial_probe_interval,
+            notification_circuit_breaker_max_probe_interval: self
+                .notification_circuit_breaker_max_probe_interval,
         }
     }
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -113,6 +113,18 @@ pub struct Options {
     /// Whether to allow creating blocks in the fast round. Fast blocks have lower latency but
     /// must be used carefully so that there are never any conflicting fast block proposals.
     pub allow_fast_blocks: bool,
+    /// Initial probe interval for the notification circuit breaker. When a validator's
+    /// notification stream exhausts retries, the circuit breaker waits this long before
+    /// probing again. Doubles on each failed probe.
+    pub notification_circuit_breaker_initial_probe_interval: Duration,
+    /// Maximum probe interval for the notification circuit breaker. The probe interval
+    /// doubles on each failure but is capped at this value.
+    pub notification_circuit_breaker_max_probe_interval: Duration,
+}
+
+struct CircuitBreakerState {
+    next_probe_at: Instant,
+    probe_interval: Duration,
 }
 
 #[cfg(with_testing)]
@@ -136,6 +148,8 @@ impl Options {
             sender_certificate_download_batch_size: DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
             max_joined_tasks: 100,
             allow_fast_blocks: false,
+            notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
+            notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
         }
     }
 }
@@ -2800,7 +2814,8 @@ impl<Env: Environment> ChainClient<Env> {
             }
         }
 
-        let mut senders = HashMap::new(); // Senders to cancel notification streams.
+        let mut senders = HashMap::new();
+        let mut circuit_breakers: HashMap<ValidatorPublicKey, CircuitBreakerState> = HashMap::new();
         let notifications = self.subscribe()?;
         let (abortable_notifications, abort) = stream::abortable(self.subscribe()?);
 
@@ -2812,7 +2827,10 @@ impl<Env: Environment> ChainClient<Env> {
 
         let mut process_notifications = FuturesUnordered::new();
 
-        match self.update_notification_streams(&mut senders).await {
+        match self
+            .update_notification_streams(&mut senders, &mut circuit_breakers)
+            .await
+        {
             Ok(handler) => process_notifications.push(handler),
             Err(error) => error!("Failed to update committee: {error}"),
         };
@@ -2827,7 +2845,8 @@ impl<Env: Environment> ChainClient<Env> {
             {
                 if let Reason::NewBlock { .. } = notification.reason {
                     match Box::pin(await_while_polling(
-                        this.update_notification_streams(&mut senders).fuse(),
+                        this.update_notification_streams(&mut senders, &mut circuit_breakers)
+                            .fuse(),
                         &mut process_notifications,
                     ))
                     .await
@@ -2849,11 +2868,16 @@ impl<Env: Environment> ChainClient<Env> {
         Ok((update_streams, AbortOnDrop(abort), notifications))
     }
 
-    #[instrument(level = "trace", skip(senders))]
+    #[instrument(level = "trace", skip(senders, circuit_breakers))]
     async fn update_notification_streams(
         &self,
         senders: &mut HashMap<ValidatorPublicKey, AbortHandle>,
+        circuit_breakers: &mut HashMap<ValidatorPublicKey, CircuitBreakerState>,
     ) -> Result<impl Future<Output = ()>, Error> {
+        let initial_probe_interval = self
+            .options
+            .notification_circuit_breaker_initial_probe_interval;
+        let max_probe_interval = self.options.notification_circuit_breaker_max_probe_interval;
         let (nodes, local_node) = {
             // For EventsOnly chains we may not have the chain's own committee locally,
             // and attempting to fetch it would trigger a full sync. Use the admin
@@ -2873,19 +2897,72 @@ impl<Env: Environment> ChainClient<Env> {
                 .collect();
             (nodes, self.client.local_node.clone())
         };
-        // Drop removed validators.
+        // Detect circuit breaker state transitions before cleaning up senders.
+        for (validator, abort) in senders.iter() {
+            if abort.is_aborted() && nodes.contains_key(validator) {
+                if let Some(state) = circuit_breakers.get_mut(validator) {
+                    // Was probing -> probe failed -> escalate interval.
+                    state.probe_interval = (state.probe_interval * 2).min(max_probe_interval);
+                    state.next_probe_at = Instant::now() + state.probe_interval;
+                    warn!(
+                        %validator,
+                        chain_id = %self.chain_id,
+                        next_probe_in = ?state.probe_interval,
+                        "Validator still unhealthy after probe; increasing probe interval"
+                    );
+                } else {
+                    // First failure -> enter circuit breaker.
+                    circuit_breakers.insert(
+                        *validator,
+                        CircuitBreakerState {
+                            next_probe_at: Instant::now() + initial_probe_interval,
+                            probe_interval: initial_probe_interval,
+                        },
+                    );
+                    error!(
+                        %validator,
+                        chain_id = %self.chain_id,
+                        next_probe_in = ?initial_probe_interval,
+                        "Validator notification stream ended; entering circuit breaker"
+                    );
+                }
+            } else if !abort.is_aborted() && circuit_breakers.contains_key(validator) {
+                // Stream alive while in circuit breaker -> probe succeeded -> recovered.
+                info!(
+                    %validator,
+                    chain_id = %self.chain_id,
+                    "Validator recovered from circuit breaker"
+                );
+                circuit_breakers.remove(validator);
+            }
+        }
+
         senders.retain(|validator, abort| {
             if !nodes.contains_key(validator) {
                 abort.abort();
             }
             !abort.is_aborted()
         });
-        // Add tasks for new validators.
+        circuit_breakers.retain(|validator, _| nodes.contains_key(validator));
+
         let validator_tasks = FuturesUnordered::new();
         for (public_key, node) in nodes {
             let hash_map::Entry::Vacant(entry) = senders.entry(public_key) else {
                 continue;
             };
+
+            // Circuit breaker: skip if not time to probe yet.
+            if let Some(state) = circuit_breakers.get(&public_key) {
+                if Instant::now() < state.next_probe_at {
+                    continue;
+                }
+                debug!(
+                    validator = %public_key,
+                    chain_id = %self.chain_id,
+                    "Probing unhealthy validator"
+                );
+            }
+
             let address = node.address();
             let this = self.clone();
             let listening_mode_for_sync = self.listening_mode();
@@ -2966,7 +3043,7 @@ impl<Env: Environment> ChainClient<Env> {
                 warn!(
                     chain_id = %this.chain_id,
                     address = remote_node.address(),
-                    "Validator notification stream ended; will reconnect on next update"
+                    "Validator notification stream ended"
                 );
                 abort_on_exit.abort();
             });


### PR DESCRIPTION
## Motivation

Validators whose notification streams repeatedly fail currently get reconnected on every `update_notification_streams` call, flooding logs and wasting resources.

## Proposal

Add a circuit breaker that gates reconnection attempts using exponential backoff (5min → 1h cap). The circuit breaker tracks per-validator state: first failure enters the breaker, subsequent probe failures double the interval, and a successful probe recovers.

Frontport of #5717.

## Test Plan

CI