### PR TITLE
[frontport] Add global blob cache to DbStorage (#5718)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,3 +8,8 @@ rustflags = ["-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes"]
 [build]
 # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
 rustdocflags = ["-Arustdoc::redundant_explicit_links"]
+
+[env]
+# Prevent stack overflows in tests with deep async call stacks (e.g. wasmer wasm tests).
+# The default 2 MiB is not enough when DbStorage caches increase async future sizes.
+RUST_MIN_STACK = "8388608"

--- a/CLI.md
+++ b/CLI.md
@@ -265,6 +265,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--storage-max-cache-find-key-values-size <STORAGE_MAX_CACHE_FIND_KEY_VALUES_SIZE>` — The maximal memory used in the find_key_values_by_prefix cache
 
   Default value: `10000000`
+* `--blob-cache-size <BLOB_CACHE_SIZE>` — The maximal number of entries in the blob cache
+
+  Default value: `1000`
 * `--storage-replication-factor <STORAGE_REPLICATION_FACTOR>` — The replication factor for the keyspace
 
   Default value: `1`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6182,6 +6182,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-storage",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4052,6 +4052,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-views",

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -82,6 +82,10 @@ struct ServeOptions {
     /// Port to listen on for HTTP requests
     #[arg(long, default_value = "3001")]
     port: u16,
+
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000")]
+    blob_cache_size: usize,
 }
 
 fn main() -> Result<()> {
@@ -109,6 +113,7 @@ impl ServeOptions {
             &self.fungible_app_id_file,
             &self.evm_private_key,
             self.port,
+            self.blob_cache_size,
         )
         .await
     }

--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -310,6 +310,7 @@ pub async fn run(
     fungible_app_id_file: &str,
     evm_private_key: &str,
     port: u16,
+    blob_cache_size: usize,
 ) -> Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -336,6 +337,7 @@ pub async fn run(
         &config,
         "bridge-relay",
         Some(WasmRuntime::default()),
+        blob_cache_size,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -102,6 +102,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &config,
         "e2l-bridge-e2e-test",
         Some(WasmRuntime::default()),
+        1000,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -75,6 +75,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &config,
         "bridge-e2e-test",
         Some(WasmRuntime::default()),
+        1000,
     )
     .await?;
 

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -67,6 +67,10 @@ pub struct RocksDbConfig {
     /// The maximal memory used in the find_key_values_by_prefix cache in bytes.
     #[arg(long, default_value = "10000000")]
     pub max_cache_find_key_values_size: usize,
+
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000")]
+    pub blob_cache_size: usize,
 }
 
 pub type RocksDbRunner = Runner<RocksDbDatabase, RocksDbConfig>;

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -62,6 +62,10 @@ pub struct ScyllaDbConfig {
     #[arg(long, default_value = "10000000")]
     pub max_cache_find_key_values_size: usize,
 
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000")]
+    pub blob_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1")]
     pub replication_factor: u32,

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2410,6 +2410,7 @@ dependencies = [
  "futures",
  "itertools",
  "linera-base",
+ "linera-cache",
  "linera-chain",
  "linera-execution",
  "linera-views",

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1875,6 +1875,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -1915,8 +1916,13 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                 genesis_config_path,
             } => {
                 let genesis_config: GenesisConfig = util::read_json(genesis_config_path)?;
-                let mut storage =
-                    DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None).await?;
+                let mut storage = DbStorage::<D, _>::maybe_create_and_connect(
+                    &config,
+                    &namespace,
+                    None,
+                    blob_cache_size,
+                )
+                .await?;
                 genesis_config.initialize_storage(&mut storage).await?;
                 info!(
                     "Namespace {namespace} was initialized in {} ms",
@@ -1935,8 +1941,13 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                 }
             }
             DatabaseToolCommand::ListBlobIds => {
-                let storage =
-                    DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None).await?;
+                let storage = DbStorage::<D, _>::maybe_create_and_connect(
+                    &config,
+                    &namespace,
+                    None,
+                    blob_cache_size,
+                )
+                .await?;
                 let blob_ids = storage.list_blob_ids().await?;
                 info!("Blob IDs listed in {} ms", start_time.elapsed().as_millis());
                 info!("The list of blob IDs is:");
@@ -1945,8 +1956,13 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                 }
             }
             DatabaseToolCommand::ListChainIds => {
-                let storage =
-                    DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None).await?;
+                let storage = DbStorage::<D, _>::maybe_create_and_connect(
+                    &config,
+                    &namespace,
+                    None,
+                    blob_cache_size,
+                )
+                .await?;
                 let chain_ids = storage.list_chain_ids().await?;
                 info!(
                     "Chain IDs listed in {} ms",
@@ -1958,8 +1974,13 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                 }
             }
             DatabaseToolCommand::ListEventIds => {
-                let storage =
-                    DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None).await?;
+                let storage = DbStorage::<D, _>::maybe_create_and_connect(
+                    &config,
+                    &namespace,
+                    None,
+                    blob_cache_size,
+                )
+                .await?;
                 let event_ids = storage.list_event_ids().await?;
                 info!(
                     "Event IDs listed in {} ms",

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -113,9 +113,11 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
+        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
         let output = Box::pin(store_config.run_with_storage(
             self.common.wasm_runtime.with_wasm_default(),
             self.common.application_logs,
+            blob_cache_size,
             job,
         ))
         .await?;
@@ -127,7 +129,8 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
-        let output = Box::pin(store_config.run_with_store(job)).await?;
+        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        let output = Box::pin(store_config.run_with_store(blob_cache_size, job)).await?;
         Ok(output)
     }
 
@@ -137,7 +140,10 @@ impl Options {
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
         let wallet = self.wallet()?;
-        store_config.initialize(wallet.genesis_config()).await?;
+        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        store_config
+            .initialize(blob_cache_size, wallet.genesis_config())
+            .await?;
         Ok(())
     }
 

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -279,10 +279,11 @@ impl RunOptions {
                 .storage_config
                 .add_common_storage_options(&self.common_storage_options)
                 .unwrap();
+            let blob_cache_size = self.common_storage_options.blob_cache_size;
             // Exporters are part of validator infrastructure and should not output contract logs.
             let allow_application_logs = false;
             store_config
-                .run_with_storage(None, allow_application_logs, context)
+                .run_with_storage(None, allow_application_logs, blob_cache_size, context)
                 .boxed()
                 .await
         };
@@ -322,8 +323,9 @@ impl DestinationsCommand {
             action,
         };
 
+        let blob_cache_size = options.common_storage_options.blob_cache_size;
         store_config
-            .run_with_storage(None, false, context)
+            .run_with_storage(None, false, blob_cache_size, context)
             .await?
             .map_err(Into::into)
     }

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -600,12 +600,14 @@ impl ProxyOptions {
         let store_config = self
             .storage_config
             .add_common_storage_options(&self.common_storage_options)?;
+        let blob_cache_size = self.common_storage_options.blob_cache_size;
         // Proxies are part of validator infrastructure and should not output contract logs.
         let allow_application_logs = false;
         store_config
             .run_with_storage(
                 None,
                 allow_application_logs,
+                blob_cache_size,
                 ProxyContext::from_options(self)?,
             )
             .boxed()

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -609,8 +609,9 @@ async fn run(options: ServerOptions) {
                 .unwrap();
             // Validators should not output contract logs.
             let allow_application_logs = false;
+            let blob_cache_size = common_storage_options.blob_cache_size;
             store_config
-                .run_with_storage(wasm_runtime, allow_application_logs, job)
+                .run_with_storage(wasm_runtime, allow_application_logs, blob_cache_size, job)
                 .boxed()
                 .await
                 .unwrap()

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -82,6 +82,10 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "10000000", global = true)]
     pub storage_max_cache_find_key_values_size: usize,
 
+    /// The maximal number of entries in the blob cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub blob_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1", global = true)]
     pub storage_replication_factor: u32,
@@ -633,6 +637,7 @@ pub trait RunnableWithStore {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -645,6 +650,7 @@ impl StoreConfig {
         self,
         wasm_runtime: Option<WasmRuntime>,
         allow_application_logs: bool,
+        blob_cache_size: usize,
         job: Job,
     ) -> Result<Job::Output, anyhow::Error>
     where
@@ -660,6 +666,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
+                    blob_cache_size,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -674,6 +681,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
+                    blob_cache_size,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -681,26 +689,38 @@ impl StoreConfig {
             }
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb { config, namespace } => {
-                let storage =
-                    DbStorage::<RocksDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?
-                        .with_allow_application_logs(allow_application_logs);
+                let storage = DbStorage::<RocksDbDatabase, _>::connect(
+                    &config,
+                    &namespace,
+                    wasm_runtime,
+                    blob_cache_size,
+                )
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb { config, namespace } => {
-                let storage =
-                    DbStorage::<DynamoDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?
-                        .with_allow_application_logs(allow_application_logs);
+                let storage = DbStorage::<DynamoDbDatabase, _>::connect(
+                    &config,
+                    &namespace,
+                    wasm_runtime,
+                    blob_cache_size,
+                )
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb { config, namespace } => {
-                let storage =
-                    DbStorage::<ScyllaDbDatabase, _>::connect(&config, &namespace, wasm_runtime)
-                        .await?
-                        .with_allow_application_logs(allow_application_logs);
+                let storage = DbStorage::<ScyllaDbDatabase, _>::connect(
+                    &config,
+                    &namespace,
+                    wasm_runtime,
+                    blob_cache_size,
+                )
+                .await?
+                .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
@@ -708,7 +728,9 @@ impl StoreConfig {
                 let storage = DbStorage::<
                     DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>,
                     _,
-                >::connect(&config, &namespace, wasm_runtime)
+                >::connect(
+                    &config, &namespace, wasm_runtime, blob_cache_size
+                )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
@@ -717,7 +739,11 @@ impl StoreConfig {
     }
 
     #[allow(unused_variables)]
-    pub async fn run_with_store<Job>(self, job: Job) -> Result<Job::Output, anyhow::Error>
+    pub async fn run_with_store<Job>(
+        self,
+        blob_cache_size: usize,
+        job: Job,
+    ) -> Result<Job::Output, anyhow::Error>
     where
         Job: RunnableWithStore,
     {
@@ -726,32 +752,39 @@ impl StoreConfig {
                 Err(anyhow!("Cannot run admin operations on the memory store"))
             }
             #[cfg(feature = "storage-service")]
-            StoreConfig::StorageService { config, namespace } => {
-                Ok(job.run::<StorageServiceDatabase>(config, namespace).await?)
-            }
+            StoreConfig::StorageService { config, namespace } => Ok(job
+                .run::<StorageServiceDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(feature = "rocksdb")]
-            StoreConfig::RocksDb { config, namespace } => {
-                Ok(job.run::<RocksDbDatabase>(config, namespace).await?)
-            }
+            StoreConfig::RocksDb { config, namespace } => Ok(job
+                .run::<RocksDbDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(feature = "dynamodb")]
-            StoreConfig::DynamoDb { config, namespace } => {
-                Ok(job.run::<DynamoDbDatabase>(config, namespace).await?)
-            }
+            StoreConfig::DynamoDb { config, namespace } => Ok(job
+                .run::<DynamoDbDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(feature = "scylladb")]
-            StoreConfig::ScyllaDb { config, namespace } => {
-                Ok(job.run::<ScyllaDbDatabase>(config, namespace).await?)
-            }
+            StoreConfig::ScyllaDb { config, namespace } => Ok(job
+                .run::<ScyllaDbDatabase>(config, namespace, blob_cache_size)
+                .await?),
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
             StoreConfig::DualRocksDbScyllaDb { config, namespace } => Ok(job
                 .run::<DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>>(
-                    config, namespace,
+                    config,
+                    namespace,
+                    blob_cache_size,
                 )
                 .await?),
         }
     }
 
-    pub async fn initialize(self, config: &GenesisConfig) -> Result<(), anyhow::Error> {
-        self.run_with_store(InitializeStorageJob(config)).await
+    pub async fn initialize(
+        self,
+        blob_cache_size: usize,
+        config: &GenesisConfig,
+    ) -> Result<(), anyhow::Error> {
+        self.run_with_store(blob_cache_size, InitializeStorageJob(config))
+            .await
     }
 }
 
@@ -765,6 +798,7 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         self,
         config: D::Config,
         namespace: String,
+        blob_cache_size: usize,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -772,7 +806,8 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         D::Error: Send + Sync,
     {
         let mut storage =
-            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None).await?;
+            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None, blob_cache_size)
+                .await?;
         self.0.initialize_storage(&mut storage).await?;
         Ok(())
     }

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -25,6 +25,7 @@ metrics = [
     "linera-base/metrics",
     "linera-chain/metrics",
     "linera-execution/metrics",
+    "linera-cache/metrics",
     "linera-views/metrics",
 ]
 web = [
@@ -41,6 +42,7 @@ cfg-if.workspace = true
 futures.workspace = true
 itertools.workspace = true
 linera-base.workspace = true
+linera-cache.workspace = true
 linera-chain.workspace = true
 linera-execution.workspace = true
 linera-views.workspace = true

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -15,6 +15,7 @@ use linera_base::{
     data_types::{Blob, BlockHeight, NetworkDescription, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
 };
+use linera_cache::ValueCache;
 use linera_chain::{
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     ChainStateView,
@@ -384,6 +385,7 @@ pub struct DbStorage<Database, Clock = WallClock> {
     wasm_runtime: Option<WasmRuntime>,
     user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
+    blob_cache: Arc<ValueCache<BlobId, Blob>>,
     execution_runtime_config: ExecutionRuntimeConfig,
 }
 
@@ -718,12 +720,20 @@ where
 
     #[instrument(skip_all, fields(%blob_id))]
     async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError> {
+        if let Some(blob) = self.blob_cache.get(&blob_id) {
+            return Ok(Some(blob));
+        }
         let root_key = RootKey::BlobId(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
         let maybe_blob_bytes = store.read_value_bytes(BLOB_KEY).await?;
         #[cfg(with_metrics)]
         metrics::READ_BLOB_COUNTER.with_label_values(&[]).inc();
-        Ok(maybe_blob_bytes.map(|blob_bytes| Blob::new_with_id_unchecked(blob_id, blob_bytes)))
+        let result =
+            maybe_blob_bytes.map(|blob_bytes| Blob::new_with_id_unchecked(blob_id, blob_bytes));
+        if let Some(ref blob) = result {
+            self.blob_cache.insert(&blob_id, blob.clone());
+        }
+        Ok(result)
     }
 
     #[instrument(skip_all, fields(blob_ids_len = %blob_ids.len()))]
@@ -1280,7 +1290,12 @@ where
 }
 
 impl<Database, C> DbStorage<Database, C> {
-    fn new(database: Database, wasm_runtime: Option<WasmRuntime>, clock: C) -> Self {
+    fn new(
+        database: Database,
+        wasm_runtime: Option<WasmRuntime>,
+        blob_cache_size: usize,
+        clock: C,
+    ) -> Self {
         Self {
             database: Arc::new(database),
             clock,
@@ -1290,6 +1305,7 @@ impl<Database, C> DbStorage<Database, C> {
             wasm_runtime,
             user_contracts: Arc::new(papaya::HashMap::new()),
             user_services: Arc::new(papaya::HashMap::new()),
+            blob_cache: Arc::new(ValueCache::new(blob_cache_size)),
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }
     }
@@ -1311,18 +1327,30 @@ where
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
+        blob_cache_size: usize,
     ) -> Result<Self, Database::Error> {
         let database = Database::maybe_create_and_connect(config, namespace).await?;
-        Ok(Self::new(database, wasm_runtime, WallClock))
+        Ok(Self::new(
+            database,
+            wasm_runtime,
+            blob_cache_size,
+            WallClock,
+        ))
     }
 
     pub async fn connect(
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
+        blob_cache_size: usize,
     ) -> Result<Self, Database::Error> {
         let database = Database::connect(config, namespace).await?;
-        Ok(Self::new(database, wasm_runtime, WallClock))
+        Ok(Self::new(
+            database,
+            wasm_runtime,
+            blob_cache_size,
+            WallClock,
+        ))
     }
 }
 
@@ -1353,7 +1381,7 @@ where
         clock: TestClock,
     ) -> Result<Self, Database::Error> {
         let database = Database::recreate_and_connect(&config, namespace).await?;
-        Ok(Self::new(database, wasm_runtime, clock))
+        Ok(Self::new(database, wasm_runtime, 1000, clock))
     }
 }
 

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -19,6 +19,7 @@ pub async fn get_storage(
         },
         namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
+        1000,
     )
     .await?
     .with_allow_application_logs(true))


### PR DESCRIPTION
## Motivation

Blob reads from the database are not cached, leading to repeated expensive lookups for the same blobs.

## Proposal

Add a global blob cache (ValueCache) to DbStorage, threaded through all storage construction sites via a new blob_cache_size parameter.

Frontport of #5718.

## Test Plan

CI