### PR TITLE
[frontport] Add linera-cache to packages.txt (#5745)

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -11,6 +11,7 @@ linera-views
 linera-execution
 linera-chain
 linera-storage-service
+linera-cache
 linera-storage
 linera-core
 linera-ethereum


### PR DESCRIPTION
## Motivation

The new linera-cache crate was missing from packages.txt.

## Proposal

Add linera-cache to the packages list.

Frontport of #5745.

## Test Plan

CI