### PR TITLE
[frontport] Add missing README.md for linera-cache to fix documentation CI (#5748)

### DIFF
--- a/linera-cache/README.md
+++ b/linera-cache/README.md
@@ -1,0 +1,13 @@
+<!-- cargo-rdme start -->
+
+Caching utilities for the Linera protocol.
+
+<!-- cargo-rdme end -->
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of the [Apache 2.0 license](../LICENSE).


### PR DESCRIPTION
## Motivation

The linera-cache crate was missing a README.md, causing documentation CI to fail.

## Proposal

Add README.md for linera-cache.

Frontport of #5748.

## Test Plan

CI