### PR TITLE
[frontport] Expose storage cache CLI flags in the Helm chart (#5767)

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -129,6 +129,14 @@ spec:
               exec ./linera-proxy \
                 --storage scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042 \
                 --storage-replication-factor {{ .Values.storageReplicationFactor | quote }} \
+                --storage-max-cache-size {{ .Values.storageCacheConfig.maxCacheSize | int }} \
+                --storage-max-cache-entries {{ .Values.storageCacheConfig.maxCacheEntries | int }} \
+                --storage-max-value-entry-size {{ .Values.storageCacheConfig.maxValueEntrySize | int }} \
+                --storage-max-find-keys-entry-size {{ .Values.storageCacheConfig.maxFindKeysEntrySize | int }} \
+                --storage-max-find-key-values-entry-size {{ .Values.storageCacheConfig.maxFindKeyValuesEntrySize | int }} \
+                --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
+                --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
+                --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
                 --id "$ORDINAL" \
                 /config/server.json
           env:

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -134,6 +134,14 @@ spec:
                 --server /config/server.json \
                 --shard $ORDINAL \
                 --storage-replication-factor {{ .Values.storageReplicationFactor | quote }} \
+                --storage-max-cache-size {{ .Values.storageCacheConfig.maxCacheSize | int }} \
+                --storage-max-cache-entries {{ .Values.storageCacheConfig.maxCacheEntries | int }} \
+                --storage-max-value-entry-size {{ .Values.storageCacheConfig.maxValueEntrySize | int }} \
+                --storage-max-find-keys-entry-size {{ .Values.storageCacheConfig.maxFindKeysEntrySize | int }} \
+                --storage-max-find-key-values-entry-size {{ .Values.storageCacheConfig.maxFindKeyValuesEntrySize | int }} \
+                --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
+                --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
+                --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
                 {{- if .Values.crossChainQueueSize }}
                 --cross-chain-queue-size {{ .Values.crossChainQueueSize }}
                 {{- end }}

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -73,6 +73,26 @@ storage: "scylladb:tcp:scylla-client.scylla.svc.cluster.local:9042"
 # Storage replication factor
 storageReplicationFactor: 1
 
+# LRU cache configuration for storage operations
+# These settings control memory usage for caching storage queries
+storageCacheConfig:
+  # Maximum total cache size in bytes
+  maxCacheSize: 50000000
+  # Maximum number of entries in the cache
+  maxCacheEntries: 50000
+  # Maximum size of a single value entry in bytes
+  maxValueEntrySize: 1000000
+  # Maximum size of a single find-keys entry in bytes
+  maxFindKeysEntrySize: 1000000
+  # Maximum size of a single find-key-values entry in bytes
+  maxFindKeyValuesEntrySize: 1000000
+  # Maximum total size of value entries in bytes
+  maxCacheValueSize: 50000000
+  # Maximum total size of find-keys entries in bytes
+  maxCacheFindKeysSize: 10000000
+  # Maximum total size of find-key-values entries in bytes
+  maxCacheFindKeyValuesSize: 10000000
+
 # Dual storage mode (RocksDB + ScyllaDB)
 dualStore: false
 


### PR DESCRIPTION
## Motivation

Storage cache configuration flags are not exposed in the Helm chart, requiring manual container arg overrides to tune cache sizes.

## Proposal

Expose all 8 storage cache CLI flags in the proxy and shard templates, with configurable defaults in values.yaml.

Frontport of #5767.

## Test Plan

CI