### PR TITLE
[frontport] Make block cache and execution state cache sizes configurable via CLI (#5770)

### DIFF
--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -142,6 +142,8 @@ spec:
                 --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
                 --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
+                --block-cache-size {{ .Values.blockCacheSize | int }} \
+                --execution-state-cache-size {{ .Values.executionStateCacheSize | int }} \
                 {{- if .Values.crossChainQueueSize }}
                 --cross-chain-queue-size {{ .Values.crossChainQueueSize }}
                 {{- end }}

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -93,6 +93,12 @@ storageCacheConfig:
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
+# Block cache size (number of entries)
+blockCacheSize: 20000
+
+# Execution state cache size (number of entries)
+executionStateCacheSize: 20000
+
 # Dual storage mode (RocksDB + ScyllaDB)
 dualStore: false
 

--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -356,8 +356,8 @@ pub async fn run(
         &Default::default(),
         None,
         genesis_config,
-        10_000,
-        10_000,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
     )
     .await?;
     tracing::info!("Client context created");

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -117,8 +117,8 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &Default::default(),
         None,
         genesis_config,
-        10_000,
-        10_000,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -90,8 +90,8 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &Default::default(),
         None,
         genesis_config,
-        10_000,
-        10_000,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
     )
     .await?;
 

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -15,6 +15,7 @@ use linera_core::{
     environment,
     test_utils::{MemoryStorageBuilder, StorageBuilder as _, TestBuilder},
     wallet,
+    worker::{DEFAULT_BLOCK_CACHE_SIZE, DEFAULT_EXECUTION_STATE_CACHE_SIZE},
 };
 use linera_storage::Storage;
 use tokio_util::sync::CancellationToken;
@@ -120,8 +121,8 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             Some(Duration::from_secs(1)),
             HashSet::new(),
             chain_client::Options::test_default(),
-            5_000,
-            10_000,
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             &linera_core::client::RequestsSchedulerConfig::default(),
         )),
     };
@@ -234,8 +235,8 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
             Some(Duration::from_secs(1)),
             HashSet::new(),
             chain_client::Options::test_default(),
-            5_000,
-            10_000,
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             &linera_core::client::RequestsSchedulerConfig::default(),
         )),
     };
@@ -390,8 +391,8 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
             Some(Duration::from_secs(1)),
             HashSet::new(),
             chain_client::Options::test_default(),
-            5_000,
-            10_000,
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             &linera_core::client::RequestsSchedulerConfig::default(),
         )),
     };
@@ -466,8 +467,8 @@ async fn test_chain_listener_listen_command_adds_chains_to_wallet() -> anyhow::R
             Some(Duration::from_secs(1)),
             HashSet::new(),
             chain_client::Options::test_default(),
-            5_000,
-            10_000,
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             &linera_core::client::RequestsSchedulerConfig::default(),
         )),
     };
@@ -584,8 +585,8 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
             Some(Duration::from_secs(1)),
             HashSet::new(),
             chain_client::Options::test_default(),
-            5_000,
-            10_000,
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             &linera_core::client::RequestsSchedulerConfig::default(),
         )),
     };

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -57,7 +57,10 @@ use crate::{
         ValidatorNodeProvider,
     },
     notifier::ChannelNotifier,
-    worker::{Notification, ProcessableCertificate, WorkerState},
+    worker::{
+        Notification, ProcessableCertificate, WorkerState, DEFAULT_BLOCK_CACHE_SIZE,
+        DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+    },
 };
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -1098,8 +1101,8 @@ where
             Some(Duration::from_secs(1)),
             HashSet::new(),
             options,
-            5_000,
-            10_000,
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             &crate::client::RequestsSchedulerConfig::default(),
         ));
         Ok(client.create_chain_client(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -72,6 +72,9 @@ use crate::{
     notifier::Notifier,
 };
 
+pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 5_000;
+pub const DEFAULT_EXECUTION_STATE_CACHE_SIZE: usize = 10_000;
+
 #[cfg(test)]
 #[path = "unit_tests/worker_tests.rs"]
 mod worker_tests;


### PR DESCRIPTION
## Motivation

Block cache and execution state cache sizes are hardcoded, preventing operators from tuning them for different workloads.

## Proposal

Make block_cache_size and execution_state_cache_size configurable via CLI flags, with named default constants replacing magic numbers throughout the codebase.

Frontport of #5770.

## Test Plan

CI