### PR TITLE
[frontport] Split blob_cache_size into individual cache size flags (#5769)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -268,6 +268,18 @@ Client implementation and command-line tool for the Linera blockchain
 * `--blob-cache-size <BLOB_CACHE_SIZE>` — The maximal number of entries in the blob cache
 
   Default value: `1000`
+* `--confirmed-block-cache-size <CONFIRMED_BLOCK_CACHE_SIZE>` — The maximal number of entries in the confirmed block cache
+
+  Default value: `1000`
+* `--lite-certificate-cache-size <LITE_CERTIFICATE_CACHE_SIZE>` — The maximal number of entries in the lite certificate cache
+
+  Default value: `1000`
+* `--certificate-raw-cache-size <CERTIFICATE_RAW_CACHE_SIZE>` — The maximal number of entries in the raw certificate cache
+
+  Default value: `1000`
+* `--event-cache-size <EVENT_CACHE_SIZE>` — The maximal number of entries in the event cache
+
+  Default value: `1000`
 * `--storage-replication-factor <STORAGE_REPLICATION_FACTOR>` — The replication factor for the keyspace
 
   Default value: `1`

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -137,6 +137,11 @@ spec:
                 --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
                 --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
+                --blob-cache-size {{ .Values.storageCacheSizes.blobCacheSize | int }} \
+                --confirmed-block-cache-size {{ .Values.storageCacheSizes.confirmedBlockCacheSize | int }} \
+                --lite-certificate-cache-size {{ .Values.storageCacheSizes.liteCertificateCacheSize | int }} \
+                --certificate-raw-cache-size {{ .Values.storageCacheSizes.certificateRawCacheSize | int }} \
+                --event-cache-size {{ .Values.storageCacheSizes.eventCacheSize | int }} \
                 --id "$ORDINAL" \
                 /config/server.json
           env:

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -142,6 +142,11 @@ spec:
                 --storage-max-cache-value-size {{ .Values.storageCacheConfig.maxCacheValueSize | int }} \
                 --storage-max-cache-find-keys-size {{ .Values.storageCacheConfig.maxCacheFindKeysSize | int }} \
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
+                --blob-cache-size {{ .Values.storageCacheSizes.blobCacheSize | int }} \
+                --confirmed-block-cache-size {{ .Values.storageCacheSizes.confirmedBlockCacheSize | int }} \
+                --lite-certificate-cache-size {{ .Values.storageCacheSizes.liteCertificateCacheSize | int }} \
+                --certificate-raw-cache-size {{ .Values.storageCacheSizes.certificateRawCacheSize | int }} \
+                --event-cache-size {{ .Values.storageCacheSizes.eventCacheSize | int }} \
                 --block-cache-size {{ .Values.blockCacheSize | int }} \
                 --execution-state-cache-size {{ .Values.executionStateCacheSize | int }} \
                 {{- if .Values.crossChainQueueSize }}

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -93,6 +93,15 @@ storageCacheConfig:
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
+# Individual cache sizes for DbStorage ValueCaches
+# These control the number of entries in each in-memory LRU cache
+storageCacheSizes:
+  blobCacheSize: 1000
+  confirmedBlockCacheSize: 10000
+  liteCertificateCacheSize: 5000
+  certificateRawCacheSize: 5000
+  eventCacheSize: 5000
+
 # Block cache size (number of entries)
 blockCacheSize: 20000
 

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -86,6 +86,22 @@ struct ServeOptions {
     /// The maximal number of entries in the blob cache.
     #[arg(long, default_value = "1000")]
     blob_cache_size: usize,
+
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000")]
+    confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000")]
+    lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000")]
+    certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000")]
+    event_cache_size: usize,
 }
 
 fn main() -> Result<()> {
@@ -113,7 +129,13 @@ impl ServeOptions {
             &self.fungible_app_id_file,
             &self.evm_private_key,
             self.port,
-            self.blob_cache_size,
+            linera_storage::StorageCacheSizes {
+                blob_cache_size: self.blob_cache_size,
+                confirmed_block_cache_size: self.confirmed_block_cache_size,
+                lite_certificate_cache_size: self.lite_certificate_cache_size,
+                certificate_raw_cache_size: self.certificate_raw_cache_size,
+                event_cache_size: self.event_cache_size,
+            },
         )
         .await
     }

--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -310,7 +310,7 @@ pub async fn run(
     fungible_app_id_file: &str,
     evm_private_key: &str,
     port: u16,
-    blob_cache_size: usize,
+    cache_sizes: linera_storage::StorageCacheSizes,
 ) -> Result<()> {
     tracing_subscriber::fmt::init();
 
@@ -337,7 +337,7 @@ pub async fn run(
         &config,
         "bridge-relay",
         Some(WasmRuntime::default()),
-        blob_cache_size,
+        cache_sizes,
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -32,7 +32,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, Query, QueryResponse, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::DbStorage;
+use linera_storage::{DbStorage, StorageCacheSizes};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use serde::{Deserialize, Serialize};
 use wrapped_fungible::{InitialState, WrappedParameters};
@@ -102,7 +102,13 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &config,
         "e2l-bridge-e2e-test",
         Some(WasmRuntime::default()),
-        1000,
+        StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        },
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -36,7 +36,7 @@ use linera_base::identifiers::Account;
 use wrapped_fungible::{
     InitialState, WrappedFungibleOperation, WrappedFungibleTokenAbi, WrappedParameters,
 };
-use linera_storage::DbStorage;
+use linera_storage::{DbStorage, StorageCacheSizes};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -75,7 +75,13 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &config,
         "bridge-e2e-test",
         Some(WasmRuntime::default()),
-        1000,
+        StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        },
     )
     .await?;
 

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -71,6 +71,22 @@ pub struct RocksDbConfig {
     /// The maximal number of entries in the blob cache.
     #[arg(long, default_value = "1000")]
     pub blob_cache_size: usize,
+
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000")]
+    pub confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000")]
+    pub event_cache_size: usize,
 }
 
 pub type RocksDbRunner = Runner<RocksDbDatabase, RocksDbConfig>;

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -66,6 +66,22 @@ pub struct ScyllaDbConfig {
     #[arg(long, default_value = "1000")]
     pub blob_cache_size: usize,
 
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000")]
+    pub confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000")]
+    pub certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000")]
+    pub event_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1")]
     pub replication_factor: u32,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -76,7 +76,7 @@ use linera_service::{
     controller::Controller,
     node_service::NodeService,
     project::{self, Project},
-    storage::{Runnable, RunnableWithStore},
+    storage::{Runnable, RunnableWithStore, StorageCacheSizes},
     task_processor::TaskProcessor,
     util,
 };
@@ -1882,7 +1882,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -1927,7 +1927,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                     &config,
                     &namespace,
                     None,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?;
                 genesis_config.initialize_storage(&mut storage).await?;
@@ -1952,7 +1952,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                     &config,
                     &namespace,
                     None,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?;
                 let blob_ids = storage.list_blob_ids().await?;
@@ -1967,7 +1967,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                     &config,
                     &namespace,
                     None,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?;
                 let chain_ids = storage.list_chain_ids().await?;
@@ -1985,7 +1985,7 @@ impl RunnableWithStore for DatabaseToolJob<'_> {
                     &config,
                     &namespace,
                     None,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?;
                 let event_ids = storage.list_event_ids().await?;

--- a/linera-service/src/cli/options.rs
+++ b/linera-service/src/cli/options.rs
@@ -113,11 +113,11 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
-        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        let cache_sizes = self.common.common_storage_options.storage_cache_sizes();
         let output = Box::pin(store_config.run_with_storage(
             self.common.wasm_runtime.with_wasm_default(),
             self.common.application_logs,
-            blob_cache_size,
+            cache_sizes,
             job,
         ))
         .await?;
@@ -129,8 +129,8 @@ impl Options {
         debug!("Running command using storage configuration: {storage_config}");
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
-        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
-        let output = Box::pin(store_config.run_with_store(blob_cache_size, job)).await?;
+        let cache_sizes = self.common.common_storage_options.storage_cache_sizes();
+        let output = Box::pin(store_config.run_with_store(cache_sizes, job)).await?;
         Ok(output)
     }
 
@@ -140,9 +140,9 @@ impl Options {
         let store_config =
             storage_config.add_common_storage_options(&self.common.common_storage_options)?;
         let wallet = self.wallet()?;
-        let blob_cache_size = self.common.common_storage_options.blob_cache_size;
+        let cache_sizes = self.common.common_storage_options.storage_cache_sizes();
         store_config
-            .initialize(blob_cache_size, wallet.genesis_config())
+            .initialize(cache_sizes, wallet.genesis_config())
             .await?;
         Ok(())
     }

--- a/linera-service/src/exporter/main.rs
+++ b/linera-service/src/exporter/main.rs
@@ -279,11 +279,11 @@ impl RunOptions {
                 .storage_config
                 .add_common_storage_options(&self.common_storage_options)
                 .unwrap();
-            let blob_cache_size = self.common_storage_options.blob_cache_size;
+            let cache_sizes = self.common_storage_options.storage_cache_sizes();
             // Exporters are part of validator infrastructure and should not output contract logs.
             let allow_application_logs = false;
             store_config
-                .run_with_storage(None, allow_application_logs, blob_cache_size, context)
+                .run_with_storage(None, allow_application_logs, cache_sizes, context)
                 .boxed()
                 .await
         };
@@ -323,9 +323,9 @@ impl DestinationsCommand {
             action,
         };
 
-        let blob_cache_size = options.common_storage_options.blob_cache_size;
+        let cache_sizes = options.common_storage_options.storage_cache_sizes();
         store_config
-            .run_with_storage(None, false, blob_cache_size, context)
+            .run_with_storage(None, false, cache_sizes, context)
             .await?
             .map_err(Into::into)
     }

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -600,14 +600,14 @@ impl ProxyOptions {
         let store_config = self
             .storage_config
             .add_common_storage_options(&self.common_storage_options)?;
-        let blob_cache_size = self.common_storage_options.blob_cache_size;
+        let cache_sizes = self.common_storage_options.storage_cache_sizes();
         // Proxies are part of validator infrastructure and should not output contract logs.
         let allow_application_logs = false;
         store_config
             .run_with_storage(
                 None,
                 allow_application_logs,
-                blob_cache_size,
+                cache_sizes,
                 ProxyContext::from_options(self)?,
             )
             .boxed()

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -609,9 +609,9 @@ async fn run(options: ServerOptions) {
                 .unwrap();
             // Validators should not output contract logs.
             let allow_application_logs = false;
-            let blob_cache_size = common_storage_options.blob_cache_size;
+            let cache_sizes = common_storage_options.storage_cache_sizes();
             store_config
-                .run_with_storage(wasm_runtime, allow_application_logs, blob_cache_size, job)
+                .run_with_storage(wasm_runtime, allow_application_logs, cache_sizes, job)
                 .boxed()
                 .await
                 .unwrap()

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use linera_client::config::GenesisConfig;
 use linera_execution::WasmRuntime;
+pub use linera_storage::StorageCacheSizes;
 use linera_storage::{DbStorage, Storage, DEFAULT_NAMESPACE};
 #[cfg(feature = "storage-service")]
 use linera_storage_service::{
@@ -86,12 +87,38 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "1000", global = true)]
     pub blob_cache_size: usize,
 
+    /// The maximal number of entries in the confirmed block cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub confirmed_block_cache_size: usize,
+
+    /// The maximal number of entries in the lite certificate cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub lite_certificate_cache_size: usize,
+
+    /// The maximal number of entries in the raw certificate cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub certificate_raw_cache_size: usize,
+
+    /// The maximal number of entries in the event cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub event_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1", global = true)]
     pub storage_replication_factor: u32,
 }
 
 impl CommonStorageOptions {
+    pub fn storage_cache_sizes(&self) -> StorageCacheSizes {
+        StorageCacheSizes {
+            blob_cache_size: self.blob_cache_size,
+            confirmed_block_cache_size: self.confirmed_block_cache_size,
+            lite_certificate_cache_size: self.lite_certificate_cache_size,
+            certificate_raw_cache_size: self.certificate_raw_cache_size,
+            event_cache_size: self.event_cache_size,
+        }
+    }
+
     pub fn storage_cache_config(&self) -> StorageCacheConfig {
         StorageCacheConfig {
             max_cache_size: self.storage_max_cache_size,
@@ -637,7 +664,7 @@ pub trait RunnableWithStore {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -650,7 +677,7 @@ impl StoreConfig {
         self,
         wasm_runtime: Option<WasmRuntime>,
         allow_application_logs: bool,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         job: Job,
     ) -> Result<Job::Output, anyhow::Error>
     where
@@ -666,7 +693,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -681,7 +708,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -693,7 +720,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -705,7 +732,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -717,7 +744,7 @@ impl StoreConfig {
                     &config,
                     &namespace,
                     wasm_runtime,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?
                 .with_allow_application_logs(allow_application_logs);
@@ -725,14 +752,13 @@ impl StoreConfig {
             }
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
             StoreConfig::DualRocksDbScyllaDb { config, namespace } => {
-                let storage = DbStorage::<
-                    DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>,
-                    _,
-                >::connect(
-                    &config, &namespace, wasm_runtime, blob_cache_size
-                )
-                .await?
-                .with_allow_application_logs(allow_application_logs);
+                let storage =
+                    DbStorage::<
+                        DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>,
+                        _,
+                    >::connect(&config, &namespace, wasm_runtime, cache_sizes)
+                    .await?
+                    .with_allow_application_logs(allow_application_logs);
                 Ok(job.run(storage).await)
             }
         }
@@ -741,7 +767,7 @@ impl StoreConfig {
     #[allow(unused_variables)]
     pub async fn run_with_store<Job>(
         self,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         job: Job,
     ) -> Result<Job::Output, anyhow::Error>
     where
@@ -753,26 +779,26 @@ impl StoreConfig {
             }
             #[cfg(feature = "storage-service")]
             StoreConfig::StorageService { config, namespace } => Ok(job
-                .run::<StorageServiceDatabase>(config, namespace, blob_cache_size)
+                .run::<StorageServiceDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb { config, namespace } => Ok(job
-                .run::<RocksDbDatabase>(config, namespace, blob_cache_size)
+                .run::<RocksDbDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(feature = "dynamodb")]
             StoreConfig::DynamoDb { config, namespace } => Ok(job
-                .run::<DynamoDbDatabase>(config, namespace, blob_cache_size)
+                .run::<DynamoDbDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb { config, namespace } => Ok(job
-                .run::<ScyllaDbDatabase>(config, namespace, blob_cache_size)
+                .run::<ScyllaDbDatabase>(config, namespace, cache_sizes)
                 .await?),
             #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
             StoreConfig::DualRocksDbScyllaDb { config, namespace } => Ok(job
                 .run::<DualDatabase<RocksDbDatabase, ScyllaDbDatabase, ChainStatesFirstAssignment>>(
                     config,
                     namespace,
-                    blob_cache_size,
+                    cache_sizes,
                 )
                 .await?),
         }
@@ -780,10 +806,10 @@ impl StoreConfig {
 
     pub async fn initialize(
         self,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         config: &GenesisConfig,
     ) -> Result<(), anyhow::Error> {
-        self.run_with_store(blob_cache_size, InitializeStorageJob(config))
+        self.run_with_store(cache_sizes, InitializeStorageJob(config))
             .await
     }
 }
@@ -798,7 +824,7 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         self,
         config: D::Config,
         namespace: String,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self::Output, anyhow::Error>
     where
         D: KeyValueDatabase + Clone + Send + Sync + 'static,
@@ -806,7 +832,7 @@ impl RunnableWithStore for InitializeStorageJob<'_> {
         D::Error: Send + Sync,
     {
         let mut storage =
-            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None, blob_cache_size)
+            DbStorage::<D, _>::maybe_create_and_connect(&config, &namespace, None, cache_sizes)
                 .await?;
         self.0.initialize_storage(&mut storage).await?;
         Ok(())

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -376,6 +376,16 @@ impl MultiPartitionBatch {
     }
 }
 
+/// Individual cache sizes for each `ValueCache` in `DbStorage`.
+#[derive(Clone, Copy, Debug)]
+pub struct StorageCacheSizes {
+    pub blob_cache_size: usize,
+    pub confirmed_block_cache_size: usize,
+    pub lite_certificate_cache_size: usize,
+    pub certificate_raw_cache_size: usize,
+    pub event_cache_size: usize,
+}
+
 /// Raw certificate bytes: (lite_certificate_bytes, confirmed_block_bytes).
 type RawCertificate = (Vec<u8>, Vec<u8>);
 
@@ -1361,7 +1371,7 @@ impl<Database, C> DbStorage<Database, C> {
     fn new(
         database: Database,
         wasm_runtime: Option<WasmRuntime>,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
         clock: C,
     ) -> Self {
         Self {
@@ -1373,11 +1383,17 @@ impl<Database, C> DbStorage<Database, C> {
             wasm_runtime,
             user_contracts: Arc::new(papaya::HashMap::new()),
             user_services: Arc::new(papaya::HashMap::new()),
-            blob_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            confirmed_block_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            lite_certificate_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            certificate_raw_cache: Arc::new(ValueCache::new(blob_cache_size)),
-            event_cache: Arc::new(ValueCache::new(blob_cache_size)),
+            blob_cache: Arc::new(ValueCache::new(cache_sizes.blob_cache_size)),
+            confirmed_block_cache: Arc::new(ValueCache::new(
+                cache_sizes.confirmed_block_cache_size,
+            )),
+            lite_certificate_cache: Arc::new(ValueCache::new(
+                cache_sizes.lite_certificate_cache_size,
+            )),
+            certificate_raw_cache: Arc::new(ValueCache::new(
+                cache_sizes.certificate_raw_cache_size,
+            )),
+            event_cache: Arc::new(ValueCache::new(cache_sizes.event_cache_size)),
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }
     }
@@ -1399,30 +1415,20 @@ where
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self, Database::Error> {
         let database = Database::maybe_create_and_connect(config, namespace).await?;
-        Ok(Self::new(
-            database,
-            wasm_runtime,
-            blob_cache_size,
-            WallClock,
-        ))
+        Ok(Self::new(database, wasm_runtime, cache_sizes, WallClock))
     }
 
     pub async fn connect(
         config: &Database::Config,
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
-        blob_cache_size: usize,
+        cache_sizes: StorageCacheSizes,
     ) -> Result<Self, Database::Error> {
         let database = Database::connect(config, namespace).await?;
-        Ok(Self::new(
-            database,
-            wasm_runtime,
-            blob_cache_size,
-            WallClock,
-        ))
+        Ok(Self::new(database, wasm_runtime, cache_sizes, WallClock))
     }
 }
 
@@ -1453,7 +1459,19 @@ where
         clock: TestClock,
     ) -> Result<Self, Database::Error> {
         let database = Database::recreate_and_connect(&config, namespace).await?;
-        Ok(Self::new(database, wasm_runtime, 1000, clock))
+        let default_cache_sizes = StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        };
+        Ok(Self::new(
+            database,
+            wasm_runtime,
+            default_cache_sizes,
+            clock,
+        ))
     }
 }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -39,7 +39,7 @@ use linera_views::{context::Context, views::RootView, ViewError};
 pub use crate::db_storage::metrics;
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
-pub use crate::db_storage::{ChainStatesFirstAssignment, DbStorage, WallClock};
+pub use crate::db_storage::{ChainStatesFirstAssignment, DbStorage, StorageCacheSizes, WallClock};
 
 /// The default namespace to be used when none is specified
 pub const DEFAULT_NAMESPACE: &str = "default";

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -19,7 +19,13 @@ pub async fn get_storage(
         },
         namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
-        1000,
+        linera_storage::StorageCacheSizes {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            lite_certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+        },
     )
     .await?
     .with_allow_application_logs(true))


### PR DESCRIPTION
## Motivation

A single blob_cache_size parameter does not allow fine-grained tuning of individual storage caches.

## Proposal

Split blob_cache_size into individual flags: blob_cache_size, confirmed_block_cache_size, certificate_cache_size, contains_blob_cache_size, and contains_value_cache_size.

Frontport of #5769.

## Test Plan

CI