### PR TITLE
Add version to tikv-jemallocator git dependency to fix docs CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,7 +261,7 @@ test-log = { version = "0.2.15", default-features = false, features = [
 test-strategy = "0.3.1"
 thiserror = "1.0.65"
 thiserror-context = "0.1.1"
-tikv-jemallocator = { git = "https://github.com/linera-io/jemallocator.git", rev = "16f3e75fb145e12f5ae15ed232d1368d4539fc14" }
+tikv-jemallocator = { version = "0.6", git = "https://github.com/linera-io/jemallocator.git", rev = "16f3e75fb145e12f5ae15ed232d1368d4539fc14" }
 tokio = "1.36.0"
 tokio-stream = "0.1.14"
 tokio-test = "0.4.3"


### PR DESCRIPTION
## Motivation

The `test-crates-and-docrs` CI job has been failing on `testnet_conway` since the
backport of #5602 (#5792). `cargo package` requires all dependencies to have a `version`
field — the backport included the git spec but dropped `version = "0.6"`.

## Proposal

Add `version = "0.6"` to the `tikv-jemallocator` workspace dependency, matching what
#5602 has on `main`. The `[patch.crates-io]` section still ensures the git fork is used
at build time; the version is only needed so `cargo package` knows what to reference
when
stripping git specs for packaging.

Also temporarily adds a `pull_request` trigger to the Documentation workflow so the fix
can be verified on this PR before merging. **This trigger should be removed before or
after merge.**

## Test Plan

- CI — the `test-crates-and-docrs` job will run on this PR via the temporary trigger

