### PR TITLE
[frontport] Increase storage cache defaults for Conway (#5771)

### DIFF
--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -77,9 +77,9 @@ storageReplicationFactor: 1
 # These settings control memory usage for caching storage queries
 storageCacheConfig:
   # Maximum total cache size in bytes
-  maxCacheSize: 50000000
+  maxCacheSize: 200000000
   # Maximum number of entries in the cache
-  maxCacheEntries: 50000
+  maxCacheEntries: 200000
   # Maximum size of a single value entry in bytes
   maxValueEntrySize: 1000000
   # Maximum size of a single find-keys entry in bytes
@@ -87,9 +87,9 @@ storageCacheConfig:
   # Maximum size of a single find-key-values entry in bytes
   maxFindKeyValuesEntrySize: 1000000
   # Maximum total size of value entries in bytes
-  maxCacheValueSize: 50000000
+  maxCacheValueSize: 200000000
   # Maximum total size of find-keys entries in bytes
-  maxCacheFindKeysSize: 10000000
+  maxCacheFindKeysSize: 40000000
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
@@ -99,7 +99,7 @@ storageCacheSizes:
   blobCacheSize: 1000
   confirmedBlockCacheSize: 10000
   liteCertificateCacheSize: 5000
-  certificateRawCacheSize: 5000
+  certificateRawCacheSize: 50000
   eventCacheSize: 5000
 
 # Block cache size (number of entries)


### PR DESCRIPTION
## Motivation

Frontport of #5771 from `testnet_conway` to `main`.

Two cache bottlenecks on Conway: per-chain storage LRU caches with 20-25% hit rates causing excess ScyllaDB reads, and certificate_raw_cache with 13.4% hit rate accounting for 90% of proxy cache traffic.

## Proposal

Increase Helm chart cache defaults:
- `maxCacheSize`: 50MB → 200MB
- `maxCacheEntries`: 50K → 200K
- `maxCacheValueSize`: 50MB → 200MB
- `maxCacheFindKeysSize`: 10MB → 40MB
- `certificateRawCacheSize`: 5K → 50K

## Test Plan

CI