### PR TITLE
[frontport] Increase cache sizes and improve cache dashboard visibility (#5774)

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
@@ -1375,7 +1375,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "Ratio of cache hits to total cache accesses for value cache",
+      "description": "Ratio of cache hits to total cache accesses for value cache, broken down by value type",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1461,14 +1461,115 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[1m]))\n/\n(\n  sum (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[1m]))\n+ (\n    sum (rate(linera_value_cache_miss{validator=~\"$validator\", job=\"linera-linera-server\"}[1m]))\n    or on (validator) vector(0)\n  )\n)",
+          "expr": "sum by (value_type) (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[5m]))\n/\n(\n  sum by (value_type) (rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[5m]))\n  + sum by (value_type) (rate(linera_value_cache_miss{validator=~\"$validator\", job=\"linera-linera-server\"}[5m]))\n)",
           "instant": false,
-          "legendFormat": "Cache Hit Ratio",
+          "legendFormat": "{{value_type}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Value Cache Hit Ratio",
+      "title": "Value Cache Hit Ratio by Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rate of value cache operations (hits + misses) per second, broken down by value type. Helps distinguish 0% hit ratio due to zero traffic vs actual misses.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 69,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (value_type) (\n  rate(linera_value_cache_hit{validator=~\"$validator\", job=\"linera-linera-server\"}[5m])\n  + rate(linera_value_cache_miss{validator=~\"$validator\", job=\"linera-linera-server\"}[5m])\n)",
+          "instant": false,
+          "legendFormat": "{{value_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Value Cache Operations Rate by Type",
       "type": "timeseries"
     },
     {

--- a/kubernetes/linera-validator/grafana-dashboards/linera/views.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/views.json
@@ -685,8 +685,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_cache_fault{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_cache_success{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_cache_fault{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -799,8 +799,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_read_value_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_read_value_cache_hits{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_read_value_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -900,8 +900,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_contains_key_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_contains_key_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_contains_key_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -1001,8 +1001,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_find_keys_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_find_keys_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_find_keys_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }
@@ -1102,8 +1102,8 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "(\n    sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    /\n    (\n        sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n        + sum(rate(linera_num_find_key_values_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m])) by (instance)\n    )\n) * 100",
-          "legendFormat": "{{instance}}",
+          "expr": "(\n    sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    /\n    (\n        sum(rate(linera_num_find_key_values_by_prefix_cache_hit{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n        + sum(rate(linera_num_find_key_values_by_prefix_cache_miss{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))\n    )\n) * 100",
+          "legendFormat": "Hit %",
           "range": true,
           "refId": "A"
         }


### PR DESCRIPTION
## Motivation

Frontport of #5774 from `testnet_conway` to `main`.

ScyllaDB read latency p99 spikes caused by cache miss cascades. Increasing application-level cache sizes absorbs bursts, reducing pressure on ScyllaDB. Dashboard panels also needed better granularity to diagnose cache behavior per type.

## Proposal

- Increase `maxCacheSize` to 1GB, `maxCacheEntries` to 500K, `maxCacheValueSize` to 500MB, `maxCacheFindKeysSize` to 200MB, `eventCacheSize` to 20K
- Replace aggregate "Value Cache Hit Ratio" panel with per-value_type breakdown
- Add "Value Cache Operations Rate by Type" panel
- Remove per-instance breakdown from Views dashboard cache panels

## Test Plan

CI