### PR TITLE
[frontport] Add source label to DbStorage metrics for cache vs DB visibility (#5780)

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -49,16 +49,24 @@ pub mod metrics {
     use std::sync::LazyLock;
 
     use linera_base::prometheus_util::{
-        exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
+        exponential_bucket_latencies, register_histogram_vec, register_int_counter,
+        register_int_counter_vec,
     };
-    use prometheus::{HistogramVec, IntCounterVec};
+    use prometheus::{HistogramVec, IntCounter, IntCounterVec};
+
+    /// Label name for distinguishing cache hits vs DB reads.
+    pub(super) const SOURCE_LABEL: &str = "source";
+    /// Label value for items served from the in-memory cache.
+    pub(super) const CACHE: &str = "cache";
+    /// Label value for items served from the database.
+    pub(super) const DB: &str = "db";
 
     /// The metric counting how often a blob is tested for existence from storage
     pub(super) static CONTAINS_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
             "contains_blob",
             "The metric counting how often a blob is tested for existence from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -67,7 +75,7 @@ pub mod metrics {
         register_int_counter_vec(
             "contains_blobs",
             "The metric counting how often multiple blobs are tested for existence from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -76,7 +84,7 @@ pub mod metrics {
         register_int_counter_vec(
             "contains_blob_state",
             "The metric counting how often a blob state is tested for existence from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -85,7 +93,7 @@ pub mod metrics {
         register_int_counter_vec(
             "contains_certificate",
             "The metric counting how often a certificate is tested for existence from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -95,7 +103,7 @@ pub mod metrics {
         register_int_counter_vec(
             "read_confirmed_block",
             "The metric counting how often a hashed confirmed block is read from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -106,7 +114,7 @@ pub mod metrics {
             register_int_counter_vec(
                 "read_confirmed_blocks",
                 "The metric counting how often confirmed blocks are read from storage",
-                &[],
+                &[SOURCE_LABEL],
             )
         });
 
@@ -116,7 +124,7 @@ pub mod metrics {
         register_int_counter_vec(
             "read_blob",
             "The metric counting how often a blob is read from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -126,27 +134,16 @@ pub mod metrics {
         register_int_counter_vec(
             "read_blob_state",
             "The metric counting how often a blob state is read from storage",
-            &[],
-        )
-    });
-
-    /// The metric counting how often blob states are read from storage.
-    #[doc(hidden)]
-    pub(super) static READ_BLOB_STATES_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "read_blob_states",
-            "The metric counting how often blob states are read from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
     /// The metric counting how often a blob is written to storage.
     #[doc(hidden)]
-    pub(super) static WRITE_BLOB_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
+    pub(super) static WRITE_BLOB_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
             "write_blob",
             "The metric counting how often a blob is written to storage",
-            &[],
         )
     });
 
@@ -156,7 +153,7 @@ pub mod metrics {
         register_int_counter_vec(
             "read_certificate",
             "The metric counting how often a certificate is read from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -166,17 +163,16 @@ pub mod metrics {
         register_int_counter_vec(
             "read_certificates",
             "The metric counting how often certificate are read from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
     /// The metric counting how often a certificate is written to storage.
     #[doc(hidden)]
-    pub static WRITE_CERTIFICATE_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
+    pub static WRITE_CERTIFICATE_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
             "write_certificate",
             "The metric counting how often a certificate is written to storage",
-            &[],
         )
     });
 
@@ -197,7 +193,7 @@ pub mod metrics {
         register_int_counter_vec(
             "read_event",
             "The metric counting how often an event is read from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
@@ -206,17 +202,16 @@ pub mod metrics {
         register_int_counter_vec(
             "contains_event",
             "The metric counting how often an event is tested for existence from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
     /// The metric counting how often an event is written to storage.
     #[doc(hidden)]
-    pub(super) static WRITE_EVENT_COUNTER: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
+    pub(super) static WRITE_EVENT_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
             "write_event",
             "The metric counting how often an event is written to storage",
-            &[],
         )
     });
 
@@ -226,17 +221,16 @@ pub mod metrics {
         register_int_counter_vec(
             "network_description",
             "The metric counting how often the network description is read from storage",
-            &[],
+            &[SOURCE_LABEL],
         )
     });
 
     /// The metric counting how often the network description is written to storage.
     #[doc(hidden)]
-    pub(super) static WRITE_NETWORK_DESCRIPTION: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
+    pub(super) static WRITE_NETWORK_DESCRIPTION: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
             "write_network_description",
             "The metric counting how often the network description is written to storage",
-            &[],
         )
     });
 }
@@ -282,7 +276,7 @@ impl MultiPartitionBatch {
 
     fn add_blob(&mut self, blob: &Blob) {
         #[cfg(with_metrics)]
-        metrics::WRITE_BLOB_COUNTER.with_label_values(&[]).inc();
+        metrics::WRITE_BLOB_COUNTER.inc();
         let root_key = RootKey::BlobId(blob.id()).bytes();
         let key = BLOB_KEY.to_vec();
         self.put_key_value(root_key, key, blob.bytes().to_vec());
@@ -309,9 +303,7 @@ impl MultiPartitionBatch {
         certificate: &ConfirmedBlockCertificate,
     ) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
-        metrics::WRITE_CERTIFICATE_COUNTER
-            .with_label_values(&[])
-            .inc();
+        metrics::WRITE_CERTIFICATE_COUNTER.inc();
         let hash = certificate.hash();
 
         // Write certificate data by hash
@@ -354,7 +346,7 @@ impl MultiPartitionBatch {
 
     fn add_event(&mut self, event_id: &EventId, value: Vec<u8>) {
         #[cfg(with_metrics)]
-        metrics::WRITE_EVENT_COUNTER.with_label_values(&[]).inc();
+        metrics::WRITE_EVENT_COUNTER.inc();
         let key = to_event_key(event_id);
         let root_key = RootKey::Event(event_id.chain_id).bytes();
         self.put_key_value(root_key, key, value);
@@ -365,9 +357,7 @@ impl MultiPartitionBatch {
         information: &NetworkDescription,
     ) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
-        metrics::WRITE_NETWORK_DESCRIPTION
-            .with_label_values(&[])
-            .inc();
+        metrics::WRITE_NETWORK_DESCRIPTION.inc();
         let root_key = RootKey::NetworkDescription.bytes();
         let key = NETWORK_DESCRIPTION_KEY.to_vec();
         let value = bcs::to_bytes(information)?;
@@ -664,22 +654,40 @@ where
     #[instrument(level = "trace", skip_all, fields(%blob_id))]
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {
         if self.blob_cache.contains(&blob_id) {
+            #[cfg(with_metrics)]
+            metrics::CONTAINS_BLOB_COUNTER
+                .with_label_values(&[metrics::CACHE])
+                .inc();
             return Ok(true);
         }
         let root_key = RootKey::BlobId(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
         let test = store.contains_key(BLOB_KEY).await?;
         #[cfg(with_metrics)]
-        metrics::CONTAINS_BLOB_COUNTER.with_label_values(&[]).inc();
+        metrics::CONTAINS_BLOB_COUNTER
+            .with_label_values(&[metrics::DB])
+            .inc();
         Ok(test)
     }
 
     #[instrument(skip_all, fields(blob_count = blob_ids.len()))]
     async fn missing_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<BlobId>, ViewError> {
         let mut missing_blobs = Vec::new();
+        #[cfg(with_metrics)]
+        let mut cache_hits: u64 = 0;
+        #[cfg(with_metrics)]
+        let mut db_checks: u64 = 0;
         for blob_id in blob_ids {
             if self.blob_cache.contains(blob_id) {
+                #[cfg(with_metrics)]
+                {
+                    cache_hits += 1;
+                }
                 continue;
+            }
+            #[cfg(with_metrics)]
+            {
+                db_checks += 1;
             }
             let root_key = RootKey::BlobId(*blob_id).bytes();
             let store = self.database.open_shared(&root_key)?;
@@ -688,7 +696,18 @@ where
             }
         }
         #[cfg(with_metrics)]
-        metrics::CONTAINS_BLOBS_COUNTER.with_label_values(&[]).inc();
+        {
+            if cache_hits > 0 {
+                metrics::CONTAINS_BLOBS_COUNTER
+                    .with_label_values(&[metrics::CACHE])
+                    .inc_by(cache_hits);
+            }
+            if db_checks > 0 {
+                metrics::CONTAINS_BLOBS_COUNTER
+                    .with_label_values(&[metrics::DB])
+                    .inc_by(db_checks);
+            }
+        }
         Ok(missing_blobs)
     }
 
@@ -699,7 +718,7 @@ where
         let test = store.contains_key(BLOB_STATE_KEY).await?;
         #[cfg(with_metrics)]
         metrics::CONTAINS_BLOB_STATE_COUNTER
-            .with_label_values(&[])
+            .with_label_values(&[metrics::DB])
             .inc();
         Ok(test)
     }
@@ -710,6 +729,10 @@ where
         hash: CryptoHash,
     ) -> Result<Option<ConfirmedBlock>, ViewError> {
         if let Some(block) = self.confirmed_block_cache.get(&hash) {
+            #[cfg(with_metrics)]
+            metrics::READ_CONFIRMED_BLOCK_COUNTER
+                .with_label_values(&[metrics::CACHE])
+                .inc();
             return Ok(Some(block));
         }
         let root_key = RootKey::BlockHash(hash).bytes();
@@ -717,7 +740,7 @@ where
         let value = store.read_value::<ConfirmedBlock>(BLOCK_KEY).await?;
         #[cfg(with_metrics)]
         metrics::READ_CONFIRMED_BLOCK_COUNTER
-            .with_label_values(&[])
+            .with_label_values(&[metrics::DB])
             .inc();
         if let Some(ref block) = value {
             self.confirmed_block_cache.insert(&hash, block.clone());
@@ -757,22 +780,39 @@ where
             }
         }
         #[cfg(with_metrics)]
-        metrics::READ_CONFIRMED_BLOCKS_COUNTER
-            .with_label_values(&[])
-            .inc_by(hashes.len() as u64);
+        {
+            let cache_hits = (hashes.len() - misses.len()) as u64;
+            if cache_hits > 0 {
+                metrics::READ_CONFIRMED_BLOCKS_COUNTER
+                    .with_label_values(&[metrics::CACHE])
+                    .inc_by(cache_hits);
+            }
+            let db_reads = misses.len() as u64;
+            if db_reads > 0 {
+                metrics::READ_CONFIRMED_BLOCKS_COUNTER
+                    .with_label_values(&[metrics::DB])
+                    .inc_by(db_reads);
+            }
+        }
         Ok(results)
     }
 
     #[instrument(skip_all, fields(%blob_id))]
     async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, ViewError> {
         if let Some(blob) = self.blob_cache.get(&blob_id) {
+            #[cfg(with_metrics)]
+            metrics::READ_BLOB_COUNTER
+                .with_label_values(&[metrics::CACHE])
+                .inc();
             return Ok(Some(blob));
         }
         let root_key = RootKey::BlobId(blob_id).bytes();
         let store = self.database.open_shared(&root_key)?;
         let maybe_blob_bytes = store.read_value_bytes(BLOB_KEY).await?;
         #[cfg(with_metrics)]
-        metrics::READ_BLOB_COUNTER.with_label_values(&[]).inc();
+        metrics::READ_BLOB_COUNTER
+            .with_label_values(&[metrics::DB])
+            .inc();
         let result =
             maybe_blob_bytes.map(|blob_bytes| Blob::new_with_id_unchecked(blob_id, blob_bytes));
         if let Some(ref blob) = result {
@@ -790,10 +830,6 @@ where
         for blob_id in blob_ids {
             blobs.push(self.read_blob(*blob_id).await?);
         }
-        #[cfg(with_metrics)]
-        metrics::READ_BLOB_COUNTER
-            .with_label_values(&[])
-            .inc_by(blob_ids.len() as u64);
         Ok(blobs)
     }
 
@@ -804,7 +840,7 @@ where
         let blob_state = store.read_value::<BlobState>(BLOB_STATE_KEY).await?;
         #[cfg(with_metrics)]
         metrics::READ_BLOB_STATE_COUNTER
-            .with_label_values(&[])
+            .with_label_values(&[metrics::DB])
             .inc();
         Ok(blob_state)
     }
@@ -821,10 +857,6 @@ where
         for blob_id in blob_ids {
             blob_states.push(self.read_blob_state(*blob_id).await?);
         }
-        #[cfg(with_metrics)]
-        metrics::READ_BLOB_STATES_COUNTER
-            .with_label_values(&[])
-            .inc_by(blob_ids.len() as u64);
         Ok(blob_states)
     }
 
@@ -924,6 +956,10 @@ where
             || (self.lite_certificate_cache.contains(&hash)
                 && self.confirmed_block_cache.contains(&hash))
         {
+            #[cfg(with_metrics)]
+            metrics::CONTAINS_CERTIFICATE_COUNTER
+                .with_label_values(&[metrics::CACHE])
+                .inc();
             return Ok(true);
         }
         let root_key = RootKey::BlockHash(hash).bytes();
@@ -931,7 +967,7 @@ where
         let results = store.contains_keys(&get_block_keys()).await?;
         #[cfg(with_metrics)]
         metrics::CONTAINS_CERTIFICATE_COUNTER
-            .with_label_values(&[])
+            .with_label_values(&[metrics::DB])
             .inc();
         Ok(results[0] && results[1])
     }
@@ -944,6 +980,10 @@ where
         // Deserialized components cache: combine LiteCertificate + ConfirmedBlock
         if let Some(lite) = self.lite_certificate_cache.get(&hash) {
             if let Some(block) = self.confirmed_block_cache.get(&hash) {
+                #[cfg(with_metrics)]
+                metrics::READ_CERTIFICATE_COUNTER
+                    .with_label_values(&[metrics::CACHE])
+                    .inc();
                 return Ok(lite.with_value(block));
             }
         }
@@ -951,6 +991,10 @@ where
         if let Some((lite_cert_bytes, confirmed_block_bytes)) =
             self.certificate_raw_cache.get(&hash)
         {
+            #[cfg(with_metrics)]
+            metrics::READ_CERTIFICATE_COUNTER
+                .with_label_values(&[metrics::CACHE])
+                .inc();
             return self
                 .deserialize_and_cache_certificate(&lite_cert_bytes, &confirmed_block_bytes);
         }
@@ -960,7 +1004,7 @@ where
         let values = store.read_multi_values_bytes(&get_block_keys()).await?;
         #[cfg(with_metrics)]
         metrics::READ_CERTIFICATE_COUNTER
-            .with_label_values(&[])
+            .with_label_values(&[metrics::DB])
             .inc();
         let Some(lite_cert_bytes) = values[0].as_ref() else {
             return Ok(None);
@@ -1028,9 +1072,20 @@ where
             }
         }
         #[cfg(with_metrics)]
-        metrics::READ_CERTIFICATES_COUNTER
-            .with_label_values(&[])
-            .inc_by(hashes.len() as u64);
+        {
+            let cache_hits = (hashes.len() - misses.len()) as u64;
+            if cache_hits > 0 {
+                metrics::READ_CERTIFICATES_COUNTER
+                    .with_label_values(&[metrics::CACHE])
+                    .inc_by(cache_hits);
+            }
+            let db_reads = misses.len() as u64;
+            if db_reads > 0 {
+                metrics::READ_CERTIFICATES_COUNTER
+                    .with_label_values(&[metrics::DB])
+                    .inc_by(db_reads);
+            }
+        }
         Ok(results)
     }
 
@@ -1154,6 +1209,10 @@ where
     #[instrument(skip_all, fields(event_id = ?event_id))]
     async fn read_event(&self, event_id: EventId) -> Result<Option<Vec<u8>>, ViewError> {
         if let Some(event) = self.event_cache.get(&event_id) {
+            #[cfg(with_metrics)]
+            metrics::READ_EVENT_COUNTER
+                .with_label_values(&[metrics::CACHE])
+                .inc();
             return Ok(Some(event));
         }
         let event_key = to_event_key(&event_id);
@@ -1161,7 +1220,9 @@ where
         let store = self.database.open_shared(&root_key)?;
         let event = store.read_value_bytes(&event_key).await?;
         #[cfg(with_metrics)]
-        metrics::READ_EVENT_COUNTER.with_label_values(&[]).inc();
+        metrics::READ_EVENT_COUNTER
+            .with_label_values(&[metrics::DB])
+            .inc();
         if let Some(ref e) = event {
             self.event_cache.insert(&event_id, e.clone());
         }
@@ -1170,12 +1231,21 @@ where
 
     #[instrument(skip_all, fields(event_id = ?event_id))]
     async fn contains_event(&self, event_id: EventId) -> Result<bool, ViewError> {
+        if self.event_cache.contains(&event_id) {
+            #[cfg(with_metrics)]
+            metrics::CONTAINS_EVENT_COUNTER
+                .with_label_values(&[metrics::CACHE])
+                .inc();
+            return Ok(true);
+        }
         let event_key = to_event_key(&event_id);
         let root_key = RootKey::Event(event_id.chain_id).bytes();
         let store = self.database.open_shared(&root_key)?;
         let exists = store.contains_key(&event_key).await?;
         #[cfg(with_metrics)]
-        metrics::CONTAINS_EVENT_COUNTER.with_label_values(&[]).inc();
+        metrics::CONTAINS_EVENT_COUNTER
+            .with_label_values(&[metrics::DB])
+            .inc();
         Ok(exists)
     }
 
@@ -1228,7 +1298,7 @@ where
         let maybe_value = store.read_value(NETWORK_DESCRIPTION_KEY).await?;
         #[cfg(with_metrics)]
         metrics::READ_NETWORK_DESCRIPTION
-            .with_label_values(&[])
+            .with_label_values(&[metrics::DB])
             .inc();
         Ok(maybe_value)
     }


### PR DESCRIPTION
## Motivation

Frontport of #5780 from `testnet_conway` to `main`.

DbStorage metrics are inconsistent after ValueCache additions — cache hits are invisible for single-item reads, batch reads double-count, and `contains_event` bypasses the event cache.

## Proposal

- Add `source` label ("cache"/"db") to all 17 IntCounterVec metrics
- Fix double-counting in `read_blobs` and `read_blob_states`
- Add cache check to `contains_event`
- Remove dead `READ_BLOB_STATES_COUNTER`

## Test Plan

CI