### PR TITLE
[frontport] Observe inbox_size metric once per inbox instead of once per bundle (#5794)

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -628,6 +628,7 @@ where
                     );
                 }
             }
+            inbox.observe_size_metric();
             if inbox.added_bundles.count() == 0 {
                 self.nonempty_inboxes.get_mut().remove(&origin);
             }

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -194,6 +194,14 @@ where
         }
     }
 
+    /// Observes the current inbox size in the metrics histogram.
+    pub fn observe_size_metric(&self) {
+        #[cfg(with_metrics)]
+        metrics::INBOX_SIZE
+            .with_label_values(&[])
+            .observe(self.added_bundles.count() as f64);
+    }
+
     /// Consumes a bundle from the inbox.
     ///
     /// Returns `true` if the bundle was already known, i.e. it was present in `added_bundles`.
@@ -253,10 +261,6 @@ where
                 false
             }
         };
-        #[cfg(with_metrics)]
-        metrics::INBOX_SIZE
-            .with_label_values(&[])
-            .observe(self.added_bundles.count() as f64);
         self.next_cursor_to_remove.set(cursor.try_add_one()?);
         Ok(already_known)
     }
@@ -309,10 +313,6 @@ where
             None => {
                 // Otherwise, schedule the messages for execution.
                 self.added_bundles.push_back(bundle);
-                #[cfg(with_metrics)]
-                metrics::INBOX_SIZE
-                    .with_label_values(&[])
-                    .observe(self.added_bundles.count() as f64);
                 true
             }
         };

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -950,6 +950,7 @@ where
                 )
                 .await?;
         }
+        inbox.observe_size_metric();
         drop(inbox);
         if !self.config.allow_inactive_chains && !self.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by


### PR DESCRIPTION
## Motivation

Frontport of #5794 from `testnet_conway` to `main`.

The `inbox_size` histogram was observed per bundle (inside loops), skewing quantile aggregations on dashboards.

## Proposal

Move `INBOX_SIZE` observation out of per-bundle methods into callers, after all bundles for a given inbox are processed. Add `observe_size_metric()` on `InboxStateView`.

## Test Plan

CI