### PR TITLE
[frontport] Batch certificate reads in ValidatorUpdater to prevent OOM (#5800)

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -33,7 +33,7 @@ use tokio::sync::mpsc;
 use tracing::{instrument, Level};
 
 use crate::{
-    client::{chain_client, Client},
+    client::{chain_client, Client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE},
     data_types::{ChainInfo, ChainInfoQuery},
     environment::Environment,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},


### PR DESCRIPTION
## Motivation

Frontport of #5800 from `testnet_conway` to `main`.

Workers OOM when `ValidatorUpdater::sync_chain_height` reads all missing certificates from local storage in a single unbounded batch during concurrent validator syncing.

## Proposal

Chunk reads in `sync_chain_height` using `DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE` (500), reading and sending certificates in batches instead of all at once.

## Test Plan

CI