### PR TITLE
[frontport] Add Total line to proxy requests per second dashboard panel (#5811)

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -130,6 +130,18 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(linera_proxy_request_count{validator=~\"$validator\", job=~\"linera-linera-server|linera-linera-proxy\"}[1m]))",
+          "hide": false,
+          "legendFormat": "Total",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Proxy requests per second (averaged for the past minute)",


### PR DESCRIPTION
Frontport of #5811 from `testnet_conway` to `main`. Adds Total line to proxy requests per second dashboard panel.

## Test Plan

CI