### PR TITLE
[frontport] Add per-method breakdown to proxy and server request metrics (#5795)

### DIFF
--- a/kubernetes/linera-validator/templates/linera-recording-rules.yaml
+++ b/kubernetes/linera-validator/templates/linera-recording-rules.yaml
@@ -66,11 +66,9 @@ spec:
   - name: linera.request.rules
     rules:
     - record: linera:proxy_request_latency:rate1m
-      expr: sum(rate(linera_proxy_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator)
+      expr: sum(rate(linera_proxy_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator, method_name)
     - record: linera:server_request_latency:rate1m
-      expr: sum(rate(linera_server_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator)
-    - record: linera:server_request_latency_per_request_type:rate1m
-      expr: sum(rate(linera_server_request_latency_per_request_type_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator, method_name)
+      expr: sum(rate(linera_server_request_latency_bucket{job=~"linera-linera-server|linera-linera-proxy"}[1m])) by (le, validator, method_name)
 
   - name: linera.storage.rules
     rules:

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -41,3 +41,72 @@ pub const GRPC_MAX_MESSAGE_SIZE: usize = 16 * MEBIBYTE;
 /// Limit of gRPC message size up to which we will try to populate with data when estimating.
 /// We leave 30% of buffer for the rest of the message and potential underestimation.
 pub const GRPC_CHUNKED_MESSAGE_FILL_LIMIT: usize = GRPC_MAX_MESSAGE_SIZE * 7 / 10;
+
+/// Prometheus label for the gRPC method name.
+pub const METHOD_NAME_LABEL: &str = "method_name";
+
+/// Prometheus label for distinguishing organic vs synthetic (benchmark) traffic.
+pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
+
+/// Extracts the gRPC method name from a request URI path.
+///
+/// gRPC paths have the form `/{package}.{Service}/{Method}` — the first segment
+/// always contains a dot. Non-gRPC requests (health checks, bot probes, etc.) return
+/// `"non_grpc"` to prevent unbounded label cardinality.
+pub fn extract_grpc_method_name(path: &str) -> &str {
+    let parts: Vec<&str> = path.splitn(3, '/').collect();
+    if parts.len() == 3 && parts[1].contains('.') {
+        parts[2]
+    } else {
+        "non_grpc"
+    }
+}
+
+#[cfg(test)]
+mod method_name_tests {
+    use super::*;
+
+    #[test]
+    fn grpc_unary_method() {
+        assert_eq!(
+            extract_grpc_method_name("/rpc.v1.ValidatorNode/HandleBlockProposal"),
+            "HandleBlockProposal"
+        );
+    }
+
+    #[test]
+    fn grpc_streaming_method() {
+        assert_eq!(
+            extract_grpc_method_name("/rpc.v1.ValidatorNode/SubscribeToNotifications"),
+            "SubscribeToNotifications"
+        );
+    }
+
+    #[test]
+    fn health_check_path() {
+        assert_eq!(
+            extract_grpc_method_name("/grpc.health.v1.Health/Check"),
+            "Check"
+        );
+    }
+
+    #[test]
+    fn non_grpc_root_path() {
+        assert_eq!(extract_grpc_method_name("/"), "non_grpc");
+    }
+
+    #[test]
+    fn non_grpc_plain_path() {
+        assert_eq!(extract_grpc_method_name("/healthz"), "non_grpc");
+    }
+
+    #[test]
+    fn non_grpc_no_dot_in_service() {
+        assert_eq!(extract_grpc_method_name("/NoDotService/Method"), "non_grpc");
+    }
+
+    #[test]
+    fn empty_path() {
+        assert_eq!(extract_grpc_method_name(""), "non_grpc");
+    }
+}

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -59,11 +59,7 @@ mod metrics {
     };
     use prometheus::{HistogramVec, IntCounterVec};
 
-    /// Label for distinguishing organic vs synthetic (benchmark) traffic.
-    pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
-
-    /// Label for the gRPC method name.
-    pub const METHOD_NAME_LABEL: &str = "method_name";
+    use super::super::{METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
 
     pub static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
@@ -321,20 +317,8 @@ where
         #[cfg(with_metrics)]
         let start = Instant::now();
 
-        // Extract the gRPC method name from the URI path. gRPC paths have the form
-        // `/{package}.{Service}/{Method}` — the first segment always contains a dot.
-        // Non-gRPC requests (bot probes, health checks, etc.) are bucketed as
-        // "non_grpc" to prevent unbounded label cardinality.
         #[cfg(with_metrics)]
-        let method_name = {
-            let path = request.uri().path();
-            let parts: Vec<&str> = path.splitn(3, '/').collect();
-            if parts.len() == 3 && parts[1].contains('.') {
-                parts[2].to_owned()
-            } else {
-                "non_grpc".to_owned()
-            }
-        };
+        let method_name = super::extract_grpc_method_name(request.uri().path()).to_owned();
 
         // Extract traffic type from request extensions (set by OtelContextLayer).
         // When opentelemetry is enabled but no baggage is set, defaults to "organic".

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -66,13 +66,8 @@ mod metrics {
     use linera_base::prometheus_util::{
         linear_bucket_interval, register_histogram_vec, register_int_counter_vec,
     };
+    use linera_rpc::grpc::{METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
     use prometheus::{HistogramVec, IntCounterVec};
-
-    /// Label for distinguishing organic vs synthetic (benchmark) traffic.
-    pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
-
-    /// Label for the gRPC method name.
-    pub const METHOD_NAME_LABEL: &str = "method_name";
 
     pub static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
@@ -141,20 +136,9 @@ where
         #[cfg(with_metrics)]
         let start = linera_base::time::Instant::now();
 
-        // Extract the gRPC method name from the URI path. gRPC paths have the form
-        // `/{package}.{Service}/{Method}` — the first segment always contains a dot.
-        // Non-gRPC requests (bot probes, health checks, etc.) are bucketed as
-        // "non_grpc" to prevent unbounded label cardinality.
         #[cfg(with_metrics)]
-        let method_name = {
-            let path = request.uri().path();
-            let parts: Vec<&str> = path.splitn(3, '/').collect();
-            if parts.len() == 3 && parts[1].contains('.') {
-                parts[2].to_owned()
-            } else {
-                "non_grpc".to_owned()
-            }
-        };
+        let method_name =
+            linera_rpc::grpc::extract_grpc_method_name(request.uri().path()).to_owned();
 
         #[cfg(all(with_metrics, feature = "opentelemetry"))]
         let traffic_type: &'static str = get_traffic_type_from_request(&request);


### PR DESCRIPTION
## Motivation

Frontport of #5795 from `testnet_conway` to `main`.

Proxy and server middleware metrics lack method-level breakdown, making it impossible to identify which gRPC methods drive request volume or latency.

## Proposal

- Add `method_name` label to proxy/server request count and latency metrics
- Extract shared `extract_grpc_method_name()` helper
- Remove redundant `server_request_latency_per_request_type` histogram
- Update recording rules to preserve `method_name`

## Test Plan

CI