### PR TITLE
[frontport] Log IncorrectOutcome as error instead of debug (#5815)

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -411,7 +411,6 @@ impl WorkerError {
             | WorkerError::InvalidEpoch { .. }
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
-            | WorkerError::IncorrectOutcome { .. }
             | WorkerError::InvalidTimestamp { .. }
             | WorkerError::MissingCertificateValue
             | WorkerError::InvalidLiteCertificate
@@ -428,7 +427,8 @@ impl WorkerError {
             | WorkerError::PreprocessedBlocksEntryNotFound { .. }
             | WorkerError::MissingNetworkDescription
             | WorkerError::Thread(_)
-            | WorkerError::ReadCertificatesError(_) => true,
+            | WorkerError::ReadCertificatesError(_)
+            | WorkerError::IncorrectOutcome { .. } => true,
             WorkerError::ChainError(chain_error) => chain_error.is_local(),
         }
     }


### PR DESCRIPTION
Frontport of #5815 from `testnet_conway` to `main`. Moves IncorrectOutcome to is_local()=true so it logs at error level instead of debug.

## Test Plan

CI