### PR TITLE
[frontport] Increase histogram bucket limits for WASM/EVM metrics (#5816)

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -102,7 +102,7 @@ pub(crate) mod metrics {
             "wasm_fuel_used_per_block",
             "Wasm fuel used per block",
             &[],
-            exponential_bucket_interval(10.0, 1_000_000.0),
+            exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
 
@@ -111,7 +111,7 @@ pub(crate) mod metrics {
             "evm_fuel_used_per_block",
             "EVM fuel used per block",
             &[],
-            exponential_bucket_interval(10.0, 1_000_000.0),
+            exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
 

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -127,7 +127,7 @@ mod metrics {
             "evm_contract_instantiation_latency",
             "EVM contract instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 
@@ -136,7 +136,7 @@ mod metrics {
             "evm_service_instantiation_latency",
             "EVM service instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -53,7 +53,7 @@ mod metrics {
             "wasm_contract_instantiation_latency",
             "Wasm contract instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 
@@ -62,7 +62,7 @@ mod metrics {
             "wasm_service_instantiation_latency",
             "Wasm service instantiation latency",
             &[],
-            exponential_bucket_latencies(1.0),
+            exponential_bucket_latencies(100.0),
         )
     });
 }


### PR DESCRIPTION
Frontport of #5816 from `testnet_conway` to `main`. Increases histogram bucket upper limits by 100x for WASM/EVM instantiation latency and fuel used metrics.

## Test Plan

CI