### PR TITLE
[frontport] Increase cache sizes (#5774)

### DIFF
--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -77,9 +77,9 @@ storageReplicationFactor: 1
 # These settings control memory usage for caching storage queries
 storageCacheConfig:
   # Maximum total cache size in bytes
-  maxCacheSize: 200000000
+  maxCacheSize: 1000000000
   # Maximum number of entries in the cache
-  maxCacheEntries: 200000
+  maxCacheEntries: 500000
   # Maximum size of a single value entry in bytes
   maxValueEntrySize: 1000000
   # Maximum size of a single find-keys entry in bytes
@@ -87,9 +87,9 @@ storageCacheConfig:
   # Maximum size of a single find-key-values entry in bytes
   maxFindKeyValuesEntrySize: 1000000
   # Maximum total size of value entries in bytes
-  maxCacheValueSize: 200000000
+  maxCacheValueSize: 500000000
   # Maximum total size of find-keys entries in bytes
-  maxCacheFindKeysSize: 40000000
+  maxCacheFindKeysSize: 200000000
   # Maximum total size of find-key-values entries in bytes
   maxCacheFindKeyValuesSize: 10000000
 
@@ -100,7 +100,7 @@ storageCacheSizes:
   confirmedBlockCacheSize: 10000
   liteCertificateCacheSize: 5000
   certificateRawCacheSize: 50000
-  eventCacheSize: 5000
+  eventCacheSize: 20000
 
 # Block cache size (number of entries)
 blockCacheSize: 20000


### PR DESCRIPTION
## Motivation

Frontport of #5774 (values.yaml portion) from `testnet_conway` to `main`.

Increase application-level cache sizes to absorb PM worker market bursts at layer 1,
reducing pressure on ScyllaDB.

## Proposal

Helm chart cache size increases:
- `maxCacheSize`: 200MB → 1GB
- `maxCacheEntries`: 200K → 500K
- `maxCacheValueSize`: 200MB → 500MB
- `maxCacheFindKeysSize`: 40MB → 200MB
- `eventCacheSize`: 5K → 20K

## Test Plan

CI
