### PR TITLE
Structural moves to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5615,6 +5615,7 @@ dependencies = [
  "linera-chain",
  "linera-core",
  "linera-execution",
+ "linera-persistent",
  "linera-storage",
  "linera-storage-service",
  "linera-version",

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1153,11 +1153,20 @@ impl Bytecode {
         Bytecode { bytes }
     }
 
-    /// Loads bytecode from a Wasm module file.
+    /// Loads bytecode from a Wasm module file asynchronously.
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn load_from_file(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
         let path = path.as_ref();
         let bytes = tokio::fs::read(path).await.map_err(|error| {
+            std::io::Error::new(error.kind(), format!("{}: {error}", path.display()))
+        })?;
+        Ok(Bytecode { bytes })
+    }
+
+    /// Loads bytecode from a Wasm module file synchronously.
+    pub fn load_from_file_sync(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {
+        let path = path.as_ref();
+        let bytes = fs::read(path).map_err(|error| {
             std::io::Error::new(error.kind(), format!("{}: {error}", path.display()))
         })?;
         Ok(Bytecode { bytes })

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -816,9 +816,11 @@ impl<Env: Environment> ClientContext<Env> {
         info!("Loading bytecode files");
         let contract_bytecode = Bytecode::load_from_file(&contract)
             .await
+            .map_err(error::Inner::Io)
             .with_context(|| format!("failed to load contract bytecode from {:?}", &contract))?;
         let service_bytecode = Bytecode::load_from_file(&service)
             .await
+            .map_err(error::Inner::Io)
             .with_context(|| format!("failed to load service bytecode from {:?}", &service))?;
 
         info!("Publishing module");
@@ -850,10 +852,12 @@ impl<Env: Environment> ClientContext<Env> {
         blob_path: PathBuf,
     ) -> Result<CryptoHash, Error> {
         info!("Loading data blob file");
-        let blob_bytes = fs::read(&blob_path).context(format!(
-            "failed to load data blob bytes from {:?}",
-            &blob_path
-        ))?;
+        let blob_bytes = fs::read(&blob_path)
+            .map_err(error::Inner::Io)
+            .context(format!(
+                "failed to load data blob bytes from {:?}",
+                &blob_path
+            ))?;
 
         info!("Publishing data blob");
         self.apply_client_command(chain_client, |chain_client| {

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -33,7 +33,7 @@ pub enum Error {
     #[error("there are {public_keys} public keys but {weights} weights")]
     MisalignedWeights { public_keys: usize, weights: usize },
     #[error("config error: {0}")]
-    Config(#[from] crate::config::Error),
+    Config(#[from] crate::config::GenesisConfigError),
 }
 
 util::impl_from_infallible!(Error);

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -5,33 +5,16 @@
 use std::iter::IntoIterator;
 
 use linera_base::{
-    crypto::{AccountPublicKey, BcsSignable, CryptoHash, ValidatorPublicKey, ValidatorSecretKey},
-    data_types::{
-        Amount, ArithmeticError, Blob, ChainDescription, ChainOrigin, Epoch, InitialChainConfig,
-        NetworkDescription, Timestamp,
-    },
-    identifiers::ChainId,
-    ownership::ChainOwnership,
+    crypto::{AccountPublicKey, ValidatorPublicKey, ValidatorSecretKey},
+    data_types::{ArithmeticError, Timestamp},
 };
+pub use linera_core::genesis_config::{Error as GenesisConfigError, GenesisConfig};
 use linera_execution::{
     committee::{Committee, ValidatorState},
     ResourceControlPolicy,
 };
 use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
-use linera_storage::Storage;
 use serde::{Deserialize, Serialize};
-
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("I/O error: {0}")]
-    IoError(#[from] std::io::Error),
-    #[error("chain error: {0}")]
-    Chain(#[from] linera_chain::ChainError),
-    #[error("storage is already initialized: {0:?}")]
-    StorageIsAlreadyInitialized(Box<NetworkDescription>),
-    #[error("no admin chain configured")]
-    NoAdminChain,
-}
 
 /// The public configuration of a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -81,181 +64,23 @@ impl CommitteeConfig {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct GenesisConfig {
-    pub committee: Committee,
-    pub timestamp: Timestamp,
-    pub chains: Vec<ChainDescription>,
-    pub network_name: String,
-}
-
-impl BcsSignable<'_> for GenesisConfig {}
-
-fn make_chain(
-    index: u32,
-    public_key: AccountPublicKey,
-    balance: Amount,
-    timestamp: Timestamp,
-) -> ChainDescription {
-    let origin = ChainOrigin::Root(index);
-    let config = InitialChainConfig {
-        application_permissions: Default::default(),
-        balance,
-        min_active_epoch: Epoch::ZERO,
-        max_active_epoch: Epoch::ZERO,
-        epoch: Epoch::ZERO,
-        ownership: ChainOwnership::single(public_key.into()),
-    };
-    ChainDescription::new(origin, config, timestamp)
-}
-
-impl GenesisConfig {
-    /// Creates a `GenesisConfig` with the first chain being the admin chain.
-    pub fn new(
-        committee: CommitteeConfig,
+impl CommitteeConfig {
+    /// Creates a `GenesisConfig` from this committee config with the first chain being the admin chain.
+    pub fn into_genesis(
+        self,
         timestamp: Timestamp,
         policy: ResourceControlPolicy,
         network_name: String,
         admin_public_key: AccountPublicKey,
-        admin_balance: Amount,
-    ) -> Result<Self, ArithmeticError> {
-        let committee = committee.into_committee(policy)?;
-        let admin_chain = make_chain(0, admin_public_key, admin_balance, timestamp);
-        Ok(Self {
+        admin_balance: linera_base::data_types::Amount,
+    ) -> Result<GenesisConfig, linera_base::data_types::ArithmeticError> {
+        let committee = self.into_committee(policy)?;
+        Ok(GenesisConfig::new(
             committee,
             timestamp,
-            chains: vec![admin_chain],
             network_name,
-        })
-    }
-
-    pub fn add_root_chain(
-        &mut self,
-        public_key: AccountPublicKey,
-        balance: Amount,
-    ) -> ChainDescription {
-        let description = make_chain(
-            self.chains.len() as u32,
-            public_key,
-            balance,
-            self.timestamp,
-        );
-        self.chains.push(description.clone());
-        description
-    }
-
-    pub fn admin_chain_description(&self) -> &ChainDescription {
-        &self.chains[0]
-    }
-
-    pub fn admin_chain_id(&self) -> ChainId {
-        self.admin_chain_description().id()
-    }
-
-    pub async fn initialize_storage<S>(&self, storage: &mut S) -> Result<(), Error>
-    where
-        S: Storage + Clone + 'static,
-    {
-        if let Some(description) = storage
-            .read_network_description()
-            .await
-            .map_err(linera_chain::ChainError::from)?
-        {
-            if description != self.network_description() {
-                // We can't initialize storage with a different network description.
-                tracing::error!(
-                    current_network=?description,
-                    new_network=?self.network_description(),
-                    "storage already initialized"
-                );
-                return Err(Error::StorageIsAlreadyInitialized(Box::new(description)));
-            }
-            tracing::debug!(?description, "storage already initialized");
-            return Ok(());
-        }
-        let network_description = self.network_description();
-        storage
-            .write_blob(&self.committee_blob())
-            .await
-            .map_err(linera_chain::ChainError::from)?;
-        storage
-            .write_network_description(&network_description)
-            .await
-            .map_err(linera_chain::ChainError::from)?;
-        for description in &self.chains {
-            storage.create_chain(description.clone()).await?;
-        }
-        Ok(())
-    }
-
-    pub fn hash(&self) -> CryptoHash {
-        CryptoHash::new(self)
-    }
-
-    pub fn committee_blob(&self) -> Blob {
-        Blob::new_committee(
-            bcs::to_bytes(&self.committee).expect("serializing a committee should succeed"),
-        )
-    }
-
-    pub fn network_description(&self) -> NetworkDescription {
-        NetworkDescription {
-            name: self.network_name.clone(),
-            genesis_config_hash: CryptoHash::new(self),
-            genesis_timestamp: self.timestamp,
-            genesis_committee_blob_hash: self.committee_blob().id().hash,
-            admin_chain_id: self.admin_chain_id(),
-        }
-    }
-}
-
-#[cfg(with_testing)]
-mod test {
-    use linera_base::data_types::Timestamp;
-    use linera_core::test_utils::{MemoryStorageBuilder, TestBuilder};
-    use linera_rpc::{
-        config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
-        simple::TransportProtocol,
-    };
-
-    use super::*;
-    use crate::config::{CommitteeConfig, GenesisConfig, ValidatorConfig};
-
-    impl GenesisConfig {
-        /// Create a new local `GenesisConfig` for testing.
-        pub fn new_testing(builder: &TestBuilder<MemoryStorageBuilder>) -> Self {
-            let network = ValidatorPublicNetworkPreConfig {
-                protocol: NetworkProtocol::Simple(TransportProtocol::Tcp),
-                host: "localhost".to_string(),
-                port: 8080,
-            };
-            let validators = builder
-                .initial_committee
-                .validators()
-                .iter()
-                .map(|(public_key, state)| ValidatorConfig {
-                    public_key: *public_key,
-                    network: network.clone(),
-                    account_key: state.account_public_key,
-                })
-                .collect();
-            let mut genesis_chains = builder.genesis_chains().into_iter();
-            let (admin_public_key, admin_balance) = genesis_chains
-                .next()
-                .expect("should have at least one chain");
-            let mut genesis_config = Self::new(
-                CommitteeConfig { validators },
-                Timestamp::from(0),
-                builder.initial_committee.policy().clone(),
-                "test network".to_string(),
-                admin_public_key,
-                admin_balance,
-            )
-            .expect("test committee votes should not overflow");
-            for (public_key, amount) in genesis_chains {
-                genesis_config.add_root_chain(public_key, amount);
-            }
-            genesis_config
-        }
+            admin_public_key,
+            admin_balance,
+        ))
     }
 }

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -98,7 +98,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let chain_id0 = client0.chain_id();
     let client1 = builder.add_root_chain(1, Amount::ONE).await?;
     // Start a chain listener for chain 0 with a new key.
-    let genesis_config = GenesisConfig::new_testing(&builder);
+    let genesis_config = GenesisConfig::new_for_testing(&builder);
     let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
     let epoch0 = client0.chain_info().await?.epoch;
@@ -208,7 +208,7 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
     let chain_a_id = chain_a.chain_id();
     let chain_b_id = chain_b.chain_id();
 
-    let genesis_config = GenesisConfig::new_testing(&builder);
+    let genesis_config = GenesisConfig::new_for_testing(&builder);
     let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
     let chain_a_info = chain_a.chain_info().await?;
@@ -368,7 +368,7 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
     let storage_builder = MemoryStorageBuilder::default();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer.clone()).await?;
     let client0 = builder.add_root_chain(0, Amount::ONE).await?;
-    let genesis_config = GenesisConfig::new_testing(&builder);
+    let genesis_config = GenesisConfig::new_for_testing(&builder);
     let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
 
@@ -443,7 +443,7 @@ async fn test_chain_listener_listen_command_adds_chains_to_wallet() -> anyhow::R
     let client0 = builder.add_root_chain(0, Amount::ONE).await?;
     let chain_id0 = client0.chain_id();
 
-    let genesis_config = GenesisConfig::new_testing(&builder);
+    let genesis_config = GenesisConfig::new_for_testing(&builder);
     let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
 
@@ -560,7 +560,7 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
         ))
         .await?;
 
-    let genesis_config = GenesisConfig::new_testing(&builder);
+    let genesis_config = GenesisConfig::new_for_testing(&builder);
     let admin_chain_id = genesis_config.admin_chain_id();
     let storage = builder.make_storage().await?;
 

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -30,6 +30,7 @@ test = [
     "test-strategy",
     "tokio/parking_lot",
 ]
+fs = ["anyhow", "dep:linera-persistent"]
 rocksdb = ["linera-views/rocksdb"]
 dynamodb = ["linera-views/dynamodb"]
 scylladb = ["linera-views/scylladb"]
@@ -62,6 +63,7 @@ futures.workspace = true
 linera-base.workspace = true
 linera-chain.workspace = true
 linera-execution.workspace = true
+linera-persistent = { workspace = true, optional = true, features = ["fs"] }
 linera-storage.workspace = true
 linera-version.workspace = true
 linera-views.workspace = true

--- a/linera-core/src/environment/wallet/mod.rs
+++ b/linera-core/src/environment/wallet/mod.rs
@@ -15,6 +15,11 @@ use crate::{client::PendingProposal, data_types::ChainInfo};
 mod memory;
 pub use memory::Memory;
 
+#[cfg(feature = "fs")]
+mod persistent;
+#[cfg(feature = "fs")]
+pub use self::persistent::PersistentWallet;
+
 #[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Chain {
     pub owner: Option<AccountOwner>,

--- a/linera-core/src/environment/wallet/persistent.rs
+++ b/linera-core/src/environment/wallet/persistent.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    iter::IntoIterator,
+    sync::{Arc, RwLock},
+};
+
+use futures::{stream, Stream};
+use linera_base::identifiers::{AccountOwner, ChainId};
+use linera_persistent as persistent;
+
+use super::{Chain, Memory, Wallet};
+use crate::GenesisConfig;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Data {
+    pub chains: Memory,
+    default: Arc<RwLock<Option<ChainId>>>,
+    genesis_config: GenesisConfig,
+}
+
+pub struct PersistentWallet(persistent::File<Data>);
+
+// TODO(#5081): `persistent` is no longer necessary here, we can move the locking
+// logic right here
+
+impl Wallet for PersistentWallet {
+    type Error = persistent::file::Error;
+
+    async fn get(&self, id: ChainId) -> Result<Option<Chain>, Self::Error> {
+        Ok(self.get(id))
+    }
+
+    async fn remove(&self, id: ChainId) -> Result<Option<Chain>, Self::Error> {
+        self.remove(id)
+    }
+
+    fn items(&self) -> impl Stream<Item = Result<(ChainId, Chain), Self::Error>> {
+        stream::iter(self.items().into_iter().map(Ok))
+    }
+
+    async fn insert(&self, id: ChainId, chain: Chain) -> Result<Option<Chain>, Self::Error> {
+        self.insert(id, &chain)
+    }
+
+    async fn try_insert(&self, id: ChainId, chain: Chain) -> Result<Option<Chain>, Self::Error> {
+        let chain = self.try_insert(id, chain)?;
+        self.save()?;
+        Ok(chain)
+    }
+
+    async fn modify(
+        &self,
+        id: ChainId,
+        f: impl Fn(&mut Chain) + Send,
+    ) -> Result<Option<()>, Self::Error> {
+        self.mutate(id, f).transpose()
+    }
+}
+
+impl Extend<(ChainId, Chain)> for PersistentWallet {
+    fn extend<It: IntoIterator<Item = (ChainId, Chain)>>(&mut self, chains: It) {
+        for (id, chain) in chains {
+            if self.0.chains.try_insert(id, chain).is_none() {
+                self.try_set_default(id);
+            }
+        }
+    }
+}
+
+impl PersistentWallet {
+    pub fn get(&self, id: ChainId) -> Option<Chain> {
+        self.0.chains.get(id)
+    }
+
+    pub fn remove(&self, id: ChainId) -> Result<Option<Chain>, persistent::file::Error> {
+        let chain = self.0.chains.remove(id);
+        {
+            let mut default = self.0.default.write().unwrap();
+            if *default == Some(id) {
+                *default = None;
+            }
+        }
+        self.0.save()?;
+        Ok(chain)
+    }
+
+    pub fn items(&self) -> Vec<(ChainId, Chain)> {
+        self.0.chains.items()
+    }
+
+    fn try_set_default(&self, id: ChainId) {
+        let mut guard = self.0.default.write().unwrap();
+        if guard.is_none() {
+            *guard = Some(id);
+        }
+    }
+
+    pub fn insert(
+        &self,
+        id: ChainId,
+        chain: &Chain,
+    ) -> Result<Option<Chain>, persistent::file::Error> {
+        let has_owner = chain.owner.is_some();
+        let old_chain = self.0.chains.insert(id, chain.clone());
+        if has_owner {
+            self.try_set_default(id);
+        }
+        self.0.save()?;
+        Ok(old_chain)
+    }
+
+    pub fn try_insert(
+        &self,
+        id: ChainId,
+        chain: Chain,
+    ) -> Result<Option<Chain>, persistent::file::Error> {
+        let chain = self.0.chains.try_insert(id, chain);
+        if chain.is_none() {
+            self.try_set_default(id);
+        }
+        self.save()?;
+        Ok(chain)
+    }
+
+    pub fn create(
+        path: &std::path::Path,
+        genesis_config: GenesisConfig,
+    ) -> Result<Self, persistent::file::Error> {
+        Ok(Self(persistent::File::new(
+            path,
+            Data {
+                chains: Memory::default(),
+                default: Arc::new(RwLock::new(None)),
+                genesis_config,
+            },
+        )?))
+    }
+
+    pub fn read(path: &std::path::Path) -> Result<Self, persistent::file::Error> {
+        Ok(Self(persistent::File::read(path)?))
+    }
+
+    pub fn genesis_config(&self) -> &GenesisConfig {
+        &self.0.genesis_config
+    }
+
+    pub fn genesis_admin_chain_id(&self) -> ChainId {
+        self.0.genesis_config.admin_chain_id()
+    }
+
+    pub fn default_chain(&self) -> Option<ChainId> {
+        *self.0.default.read().unwrap()
+    }
+
+    pub fn set_default_chain(&mut self, id: ChainId) -> Result<(), persistent::file::Error> {
+        assert!(self.0.chains.get(id).is_some());
+        *self.0.default.write().unwrap() = Some(id);
+        self.0.save()
+    }
+
+    pub fn mutate<R>(
+        &self,
+        chain_id: ChainId,
+        mutate: impl Fn(&mut Chain) -> R,
+    ) -> Option<Result<R, persistent::file::Error>> {
+        self.0
+            .chains
+            .mutate(chain_id, mutate)
+            .map(|outcome| self.0.save().map(|()| outcome))
+    }
+
+    pub fn forget_keys(&self, chain_id: ChainId) -> anyhow::Result<AccountOwner> {
+        self.mutate(chain_id, |chain| chain.owner.take())
+            .ok_or_else(|| anyhow::anyhow!("nonexistent chain `{chain_id}`"))??
+            .ok_or_else(|| anyhow::anyhow!("keypair not found for chain `{chain_id}`"))
+    }
+
+    pub fn forget_chain(&self, chain_id: ChainId) -> anyhow::Result<Chain> {
+        let chain = self
+            .0
+            .chains
+            .remove(chain_id)
+            .ok_or_else(|| anyhow::anyhow!("nonexistent chain `{chain_id}`"))?;
+        self.0.save()?;
+        Ok(chain)
+    }
+
+    pub fn save(&self) -> Result<(), persistent::file::Error> {
+        self.0.save()
+    }
+
+    pub fn num_chains(&self) -> usize {
+        self.0.chains.items().len()
+    }
+
+    pub fn chain_ids(&self) -> Vec<ChainId> {
+        self.0.chains.chain_ids()
+    }
+
+    pub fn owned_chain_ids(&self) -> Vec<ChainId> {
+        self.0.chains.owned_chain_ids()
+    }
+}

--- a/linera-core/src/genesis_config.rs
+++ b/linera-core/src/genesis_config.rs
@@ -1,0 +1,175 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_base::{
+    crypto::{AccountPublicKey, BcsSignable, CryptoHash},
+    data_types::{
+        Amount, Blob, ChainDescription, ChainOrigin, Epoch, InitialChainConfig, NetworkDescription,
+        Timestamp,
+    },
+    identifiers::ChainId,
+    ownership::ChainOwnership,
+};
+use linera_execution::committee::Committee;
+use linera_storage::Storage;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("chain error: {0}")]
+    Chain(#[from] linera_chain::ChainError),
+    #[error("storage is already initialized: {0:?}")]
+    StorageIsAlreadyInitialized(Box<NetworkDescription>),
+    #[error("no admin chain configured")]
+    NoAdminChain,
+}
+
+fn make_chain(
+    index: u32,
+    public_key: AccountPublicKey,
+    balance: Amount,
+    timestamp: Timestamp,
+) -> ChainDescription {
+    let origin = ChainOrigin::Root(index);
+    let config = InitialChainConfig {
+        application_permissions: Default::default(),
+        balance,
+        min_active_epoch: Epoch::ZERO,
+        max_active_epoch: Epoch::ZERO,
+        epoch: Epoch::ZERO,
+        ownership: ChainOwnership::single(public_key.into()),
+    };
+    ChainDescription::new(origin, config, timestamp)
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct GenesisConfig {
+    pub committee: Committee,
+    pub timestamp: Timestamp,
+    pub chains: Vec<ChainDescription>,
+    pub network_name: String,
+}
+
+impl BcsSignable<'_> for GenesisConfig {}
+
+impl GenesisConfig {
+    /// Creates a `GenesisConfig` with the first chain being the admin chain.
+    pub fn new(
+        committee: Committee,
+        timestamp: Timestamp,
+        network_name: String,
+        admin_public_key: AccountPublicKey,
+        admin_balance: Amount,
+    ) -> Self {
+        let admin_chain = make_chain(0, admin_public_key, admin_balance, timestamp);
+        Self {
+            committee,
+            timestamp,
+            chains: vec![admin_chain],
+            network_name,
+        }
+    }
+
+    pub fn add_root_chain(
+        &mut self,
+        public_key: AccountPublicKey,
+        balance: Amount,
+    ) -> ChainDescription {
+        let description = make_chain(
+            self.chains.len() as u32,
+            public_key,
+            balance,
+            self.timestamp,
+        );
+        self.chains.push(description.clone());
+        description
+    }
+
+    pub fn admin_chain_description(&self) -> &ChainDescription {
+        &self.chains[0]
+    }
+
+    pub fn admin_chain_id(&self) -> ChainId {
+        self.admin_chain_description().id()
+    }
+
+    pub async fn initialize_storage<S>(&self, storage: &mut S) -> Result<(), Error>
+    where
+        S: Storage + Clone + 'static,
+    {
+        if let Some(description) = storage
+            .read_network_description()
+            .await
+            .map_err(linera_chain::ChainError::from)?
+        {
+            if description != self.network_description() {
+                tracing::error!(
+                    current_network=?description,
+                    new_network=?self.network_description(),
+                    "storage already initialized"
+                );
+                return Err(Error::StorageIsAlreadyInitialized(Box::new(description)));
+            }
+            tracing::debug!(?description, "storage already initialized");
+            return Ok(());
+        }
+        let network_description = self.network_description();
+        storage
+            .write_blob(&self.committee_blob())
+            .await
+            .map_err(linera_chain::ChainError::from)?;
+        storage
+            .write_network_description(&network_description)
+            .await
+            .map_err(linera_chain::ChainError::from)?;
+        for description in &self.chains {
+            storage.create_chain(description.clone()).await?;
+        }
+        Ok(())
+    }
+
+    pub fn hash(&self) -> CryptoHash {
+        CryptoHash::new(self)
+    }
+
+    pub fn committee_blob(&self) -> Blob {
+        Blob::new_committee(
+            bcs::to_bytes(&self.committee).expect("serializing a committee should succeed"),
+        )
+    }
+
+    pub fn network_description(&self) -> NetworkDescription {
+        NetworkDescription {
+            name: self.network_name.clone(),
+            genesis_config_hash: CryptoHash::new(self),
+            genesis_timestamp: self.timestamp,
+            genesis_committee_blob_hash: self.committee_blob().id().hash,
+            admin_chain_id: self.admin_chain_id(),
+        }
+    }
+
+    /// Creates a `GenesisConfig` for testing from a `TestBuilder`.
+    #[cfg(with_testing)]
+    pub fn new_for_testing<B: crate::test_utils::StorageBuilder>(
+        builder: &crate::test_utils::TestBuilder<B>,
+    ) -> Self {
+        let mut genesis_chains = builder.genesis_chains().into_iter();
+        let (admin_public_key, admin_balance) = genesis_chains
+            .next()
+            .expect("should have at least one chain");
+        let mut genesis_config = Self::new(
+            builder.initial_committee.clone(),
+            Timestamp::from(0),
+            "test network".to_string(),
+            admin_public_key,
+            admin_balance,
+        );
+        for (public_key, amount) in genesis_chains {
+            genesis_config.add_root_chain(public_key, amount);
+        }
+        genesis_config
+    }
+}

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -32,10 +32,12 @@ pub use updater::DEFAULT_QUORUM_GRACE_PERIOD;
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};
 
 pub mod environment;
+pub mod genesis_config;
 pub use environment::{
     wallet::{self, Wallet},
     Environment,
 };
+pub use genesis_config::GenesisConfig;
 
 /// The maximum number of entries in a `received_log` included in a `ChainInfo` response.
 // TODO(#4638): Revisit the number.

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -99,7 +99,7 @@ linera-base.workspace = true
 linera-bridge.workspace = true
 linera-chain.workspace = true
 linera-client = { workspace = true, features = ["fs"] }
-linera-core.workspace = true
+linera-core = { workspace = true, features = ["fs"] }
 linera-execution = { workspace = true, features = ["fs"] }
 linera-faucet-client.workspace = true
 linera-faucet-server.workspace = true

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2206,8 +2206,7 @@ async fn run(options: &Options) -> Result<i32, Error> {
             });
             let mut genesis_config = persistent::File::new(
                 genesis_config_path,
-                GenesisConfig::new(
-                    committee_config,
+                committee_config.into_genesis(
                     timestamp,
                     policy,
                     network_name,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -79,6 +79,7 @@ use linera_service::{
     storage::{Runnable, RunnableWithStore},
     task_processor::TaskProcessor,
     util,
+    wallet::WalletExt as _,
 };
 use linera_storage::{DbStorage, Storage};
 use linera_views::store::{KeyValueDatabase, KeyValueStore};

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -1,26 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    iter::IntoIterator,
-    sync::{Arc, RwLock},
-};
-
-use futures::{stream, Stream};
 use linera_base::{
     data_types::{ChainDescription, ChainOrigin},
-    identifiers::{AccountOwner, ChainId},
+    identifiers::ChainId,
 };
-use linera_client::config::GenesisConfig;
 use linera_core::wallet;
-use linera_persistent as persistent;
-
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Data {
-    pub chains: wallet::Memory,
-    default: Arc<RwLock<Option<ChainId>>>,
-    genesis_config: GenesisConfig,
-}
+pub use linera_core::wallet::PersistentWallet as Wallet;
 
 struct ChainDetails {
     is_default: bool,
@@ -31,16 +17,16 @@ struct ChainDetails {
 }
 
 impl ChainDetails {
-    fn new(chain_id: ChainId, wallet: &Data) -> Self {
-        let Some(user_chain) = wallet.chains.get(chain_id) else {
+    fn new(chain_id: ChainId, wallet: &Wallet) -> Self {
+        let Some(user_chain) = wallet.get(chain_id) else {
             panic!("Chain {} not found.", chain_id);
         };
         ChainDetails {
-            is_default: Some(chain_id) == *wallet.default.read().unwrap(),
-            is_admin: chain_id == wallet.genesis_config.admin_chain_id(),
+            is_default: Some(chain_id) == wallet.default_chain(),
+            is_admin: chain_id == wallet.genesis_config().admin_chain_id(),
             chain_id,
             origin: wallet
-                .genesis_config
+                .genesis_config()
                 .chains
                 .iter()
                 .find(|description| description.id() == chain_id)
@@ -101,151 +87,13 @@ impl ChainDetails {
     }
 }
 
-pub struct Wallet(persistent::File<Data>);
-
-// TODO(#5081): `persistent` is no longer necessary here, we can move the locking
-// logic right here
-
-impl linera_core::Wallet for Wallet {
-    type Error = persistent::file::Error;
-
-    async fn get(&self, id: ChainId) -> Result<Option<wallet::Chain>, Self::Error> {
-        Ok(self.get(id))
-    }
-
-    async fn remove(&self, id: ChainId) -> Result<Option<wallet::Chain>, Self::Error> {
-        self.remove(id)
-    }
-
-    fn items(&self) -> impl Stream<Item = Result<(ChainId, wallet::Chain), Self::Error>> {
-        stream::iter(self.items().into_iter().map(Ok))
-    }
-
-    async fn insert(
-        &self,
-        id: ChainId,
-        chain: wallet::Chain,
-    ) -> Result<Option<wallet::Chain>, Self::Error> {
-        self.insert(id, &chain)
-    }
-
-    async fn try_insert(
-        &self,
-        id: ChainId,
-        chain: wallet::Chain,
-    ) -> Result<Option<wallet::Chain>, Self::Error> {
-        let chain = self.try_insert(id, chain)?;
-        self.save()?;
-        Ok(chain)
-    }
-
-    async fn modify(
-        &self,
-        id: ChainId,
-        f: impl Fn(&mut wallet::Chain) + Send,
-    ) -> Result<Option<()>, Self::Error> {
-        self.mutate(id, f).transpose()
-    }
+/// Extension methods for `Wallet` that provide display/presentation functionality.
+pub trait WalletExt {
+    fn pretty_print(&self, chain_ids: Vec<ChainId>);
 }
 
-impl Extend<(ChainId, wallet::Chain)> for Wallet {
-    fn extend<It: IntoIterator<Item = (ChainId, wallet::Chain)>>(&mut self, chains: It) {
-        for (id, chain) in chains {
-            if self.0.chains.try_insert(id, chain).is_none() {
-                self.try_set_default(id);
-            }
-        }
-    }
-}
-
-impl Wallet {
-    pub fn get(&self, id: ChainId) -> Option<wallet::Chain> {
-        self.0.chains.get(id)
-    }
-
-    pub fn remove(&self, id: ChainId) -> Result<Option<wallet::Chain>, persistent::file::Error> {
-        let chain = self.0.chains.remove(id);
-        {
-            let mut default = self.0.default.write().unwrap();
-            if *default == Some(id) {
-                *default = None;
-            }
-        }
-        self.0.save()?;
-        Ok(chain)
-    }
-
-    pub fn items(&self) -> Vec<(ChainId, wallet::Chain)> {
-        self.0.chains.items()
-    }
-
-    fn try_set_default(&self, id: ChainId) {
-        let mut guard = self.0.default.write().unwrap();
-        if guard.is_none() {
-            *guard = Some(id);
-        }
-    }
-
-    pub fn insert(
-        &self,
-        id: ChainId,
-        chain: &wallet::Chain,
-    ) -> Result<Option<wallet::Chain>, persistent::file::Error> {
-        let has_owner = chain.owner.is_some();
-        let old_chain = self.0.chains.insert(id, chain.clone());
-        if has_owner {
-            self.try_set_default(id);
-        }
-        self.0.save()?;
-        Ok(old_chain)
-    }
-
-    pub fn try_insert(
-        &self,
-        id: ChainId,
-        chain: wallet::Chain,
-    ) -> Result<Option<wallet::Chain>, persistent::file::Error> {
-        let chain = self.0.chains.try_insert(id, chain);
-        if chain.is_none() {
-            self.try_set_default(id);
-        }
-        self.save()?;
-        Ok(chain)
-    }
-
-    pub fn create(
-        path: &std::path::Path,
-        genesis_config: GenesisConfig,
-    ) -> Result<Self, persistent::file::Error> {
-        Ok(Self(persistent::File::new(
-            path,
-            Data {
-                chains: wallet::Memory::default(),
-                default: Arc::new(RwLock::new(None)),
-                genesis_config,
-            },
-        )?))
-    }
-
-    pub fn read(path: &std::path::Path) -> Result<Self, persistent::file::Error> {
-        Ok(Self(persistent::File::read(path)?))
-    }
-
-    pub fn genesis_config(&self) -> &GenesisConfig {
-        &self.0.genesis_config
-    }
-
-    pub fn genesis_admin_chain_id(&self) -> ChainId {
-        self.0.genesis_config.admin_chain_id()
-    }
-
-    // TODO(#5082): now that wallets only store chains, not keys, there's not much point in
-    // allowing wallets with no default chain (i.e. no chains)
-    pub fn default_chain(&self) -> Option<ChainId> {
-        *self.0.default.read().unwrap()
-    }
-
-    pub fn pretty_print(&self, chain_ids: Vec<ChainId>) {
+impl WalletExt for Wallet {
+    fn pretty_print(&self, chain_ids: Vec<ChainId>) {
         let chain_ids: Vec<_> = chain_ids.into_iter().collect();
         let total_chains = chain_ids.len();
 
@@ -254,7 +102,7 @@ impl Wallet {
 
         let mut chains = chain_ids
             .into_iter()
-            .map(|chain_id| ChainDetails::new(chain_id, &self.0))
+            .map(|chain_id| ChainDetails::new(chain_id, self))
             .collect::<Vec<_>>();
         // Print first the default, then the admin chain, then other root chains, and finally the
         // child chains.
@@ -270,55 +118,5 @@ impl Wallet {
             chain.print_paragraph();
         }
         println!("------------------------");
-    }
-
-    pub fn set_default_chain(&mut self, id: ChainId) -> Result<(), persistent::file::Error> {
-        assert!(self.0.chains.get(id).is_some());
-        *self.0.default.write().unwrap() = Some(id);
-        self.0.save()
-    }
-
-    pub fn mutate<R>(
-        &self,
-        chain_id: ChainId,
-        mutate: impl Fn(&mut wallet::Chain) -> R,
-    ) -> Option<Result<R, persistent::file::Error>> {
-        self.0
-            .chains
-            .mutate(chain_id, mutate)
-            .map(|outcome| self.0.save().map(|()| outcome))
-    }
-
-    pub fn forget_keys(&self, chain_id: ChainId) -> anyhow::Result<AccountOwner> {
-        self.mutate(chain_id, |chain| chain.owner.take())
-            .ok_or_else(|| anyhow::anyhow!("nonexistent chain `{chain_id}`"))??
-            .ok_or_else(|| anyhow::anyhow!("keypair not found for chain `{chain_id}`"))
-    }
-
-    pub fn forget_chain(&self, chain_id: ChainId) -> anyhow::Result<wallet::Chain> {
-        let chain = self
-            .0
-            .chains
-            .remove(chain_id)
-            .ok_or_else(|| anyhow::anyhow!("nonexistent chain `{chain_id}`"))?;
-        self.0.save()?;
-        Ok(chain)
-    }
-
-    pub fn save(&self) -> Result<(), persistent::file::Error> {
-        self.0.save()
-    }
-
-    pub fn num_chains(&self) -> usize {
-        self.0.chains.items().len()
-    }
-
-    pub fn chain_ids(&self) -> Vec<ChainId> {
-        self.0.chains.chain_ids()
-    }
-
-    /// Returns the list of all chain IDs for which we have a secret key.
-    pub fn owned_chain_ids(&self) -> Vec<ChainId> {
-        self.0.chains.owned_chain_ids()
     }
 }

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -95,7 +95,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
     builder.add_root_chain(0, Amount::ONE).await?;
     let chain_id = builder.admin_chain_id();
 
-    let genesis_config = GenesisConfig::new_testing(&builder);
+    let genesis_config = GenesisConfig::new_for_testing(&builder);
 
     let tmp_dir = tempfile::tempdir()?;
     let mut config_dir = tmp_dir.keep();

--- a/scripts/check_chain_loads.sh
+++ b/scripts/check_chain_loads.sh
@@ -38,10 +38,10 @@ if [ "$(grep 'linera-service/src/cli/main.rs' "$USAGES_FILE" | wc -l)" -eq 1 ]; 
     sed -i -e '/linera-service\/src\/cli\/main\.rs/d' "$USAGES_FILE"
 fi
 
-# The linera-client uses `create_chain` to initialize the storage from the genesis configuration,
+# The linera-core uses `create_chain` to initialize the storage from the genesis configuration,
 # and this is only called by the `database_tool`
-if [ "$(grep 'linera-client/src/config.rs' "$USAGES_FILE" | wc -l)" -eq 1 ]; then
-    sed -i -e '/linera-client\/src\/config\.rs/d' "$USAGES_FILE"
+if [ "$(grep 'linera-core/src/genesis_config.rs' "$USAGES_FILE" | wc -l)" -eq 1 ]; then
+    sed -i -e '/linera-core\/src\/genesis_config\.rs/d' "$USAGES_FILE"
 fi
 
 # Client::extend_with_chain uses it to add a new chain to the tracked wallet.


### PR DESCRIPTION
## Motivation

PR #5875 (backport-bridge-to-main) mixes structural code moves with bridge-specific changes,
making it hard to review. This PR extracts the structural moves so they can land independently,
shrinking #5875's diff to just the bridge work.

The reason why `PersistentWallet` and `GenesisConfig` were moved is that I wanted to use both in `linera-bridge` but they were part of `linera-service` which depends on `linera-bridge` – that creates a cyclic dependency. 

## Proposal

Three commits, each independently compilable:

1. **Add `Bytecode::load_from_file_sync`** — synchronous variant of `load_from_file` for
   non-async contexts.

2. **Move `GenesisConfig` from `linera-client` to `linera-core`** — the struct, its `Error`
   type, and `initialize_storage` move to `linera-core::genesis_config`. Re-exported from
   `linera-client::config` for backward compatibility. `CommitteeConfig::into_genesis` replaces
   the old `GenesisConfig::new(CommitteeConfig, ...)` constructor on the client side.

3. **Move `PersistentWallet` from `linera-service` to `linera-core`** — wallet persistence
   logic moves to `linera-core::environment::wallet::persistent`, gated behind a new `fs`
   feature. Display logic (`pretty_print`, `ChainDetails`) stays in `linera-service` behind a
   `WalletExt` trait. Also fixes a `thiserror_context` type ambiguity in `client_context.rs`
   triggered by `linera-persistent` entering the dependency graph.

All public API signatures are preserved — this is a pure structural move.

## Test Plan

- All three commits compile independently and pass `cargo clippy -D warnings` against
   `linera-service` (which pulls in the full dependency graph including feature-gated paths).
- No behavior changes — existing tests cover the moved code.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Unblocks #5875 by extracting structural moves from the bridge backport.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)