### PR TITLE
On RevertConfirm, don't re-add the lowest block if it's not sending messages

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1364,7 +1364,7 @@ where
 
         let mut heights_to_readd = Vec::new();
         let mut current_height = latest_height;
-        while current_height > missing_height {
+        while current_height >= missing_height {
             heights_to_readd.push(current_height);
             // Load the block at current_height to find the previous message block
             let hash = match &*self.chain.block_hashes([current_height]).await? {
@@ -1391,8 +1391,6 @@ where
                 _ => break,
             }
         }
-        // Include the missing height itself (the loop stops before pushing it).
-        heights_to_readd.push(missing_height);
 
         // 2. Re-add the heights to the outbox.
         let mut outbox = self.chain.outboxes.try_load_entry_mut(&recipient).await?;


### PR DESCRIPTION
## Motivation

In handle_revert_confirm we explicitly add the `missing_height` to the outbox. This was fine originally, when `RevertConfirm` was only used when a genuine gap was detected while handling a confirmed certificate or an `UpdateRecipient` message.

However, when we fully re-execute a chain, we send `RevertConfirm` with `BlockHeight::ZERO` to all senders, even if they didn't send a message at height 0.

## Proposal

Only add `missing_height` if it's in `previous_message_blocks` of the subsequent sending block.

## Test Plan

CI

## Release Plan

- These changes should be released in a validator hotfix.

## Links

- This is split from #5886 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
