### PR TITLE
Make first_non_admin_chain deterministic by sorting chain IDs

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -3,7 +3,9 @@
 
 use std::sync::Arc;
 
-use futures::{Future, StreamExt as _, TryStreamExt as _};
+#[cfg(not(web))]
+use futures::StreamExt as _;
+use futures::{Future, TryStreamExt as _};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{ChainDescription, Epoch, Timestamp},
@@ -381,14 +383,17 @@ impl<Env: Environment> ClientContext<Env> {
 
     pub async fn first_non_admin_chain(&self) -> Result<ChainId, Error> {
         let admin_chain_id = self.admin_chain_id();
-        std::pin::pin!(self
+        let chain_ids = self
             .wallet()
             .chain_ids()
-            .try_filter(|chain_id| futures::future::ready(*chain_id != admin_chain_id)))
-        .next()
-        .await
-        .expect("No non-admin chain specified in wallet with no non-admin chain")
-        .map_err(Error::wallet)
+            .try_filter(|chain_id| futures::future::ready(*chain_id != admin_chain_id))
+            .try_collect::<Vec<ChainId>>()
+            .await
+            .map_err(Error::wallet)?;
+        Ok(chain_ids
+            .into_iter()
+            .min()
+            .expect("No non-admin chain specified in wallet with no non-admin chain"))
     }
 
     // TODO(#5084) this should match the `NodeProvider` from the `Environment`


### PR DESCRIPTION
## Motivation

`first_non_admin_chain()` returns a non-deterministic result across process restarts.
The wallet's in-memory storage uses `papaya::HashMap`, whose iteration order depends on
hash seeds and memory layout. This caused the testnet-conway faucet to silently switch
between different chains on every restart (confirmed via Loki logs showing 4 different
chains across 4 restarts), breaking user claim tracking each time.

## Proposal

Collect and sort the non-admin chain IDs before picking the first one. `ChainId`
ordering is by hash bytes — arbitrary but deterministic, which is all that's needed.

The serialization path (`Memory::serialize`) already sorts for stable JSON output, but
the in-memory iteration paths (`chain_ids()`, `items()`) do not. This fix targets the
only caller that depends on "first" having a stable meaning.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

