### PR TITLE
Better use the block value cache.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -38,7 +38,7 @@ use linera_execution::{
     Committee, ExecutionRuntimeContext as _, ExecutionStateView, Query, QueryContext, QueryOutcome,
     ResourceTracker, ServiceRuntimeEndpoint,
 };
-use linera_storage::{Clock as _, ResultReadConfirmedBlocks, Storage};
+use linera_storage::{Clock as _, Storage};
 use linera_views::{
     context::{Context, InactiveContext},
     views::{ClonableView, ReplaceContext as _, RootView as _, View as _},
@@ -603,15 +603,10 @@ where
         let hashes = self.chain.block_hashes(heights.iter().copied()).await?;
 
         let blocks = self.read_confirmed_blocks(hashes.clone()).await?;
-        let blocks = match ResultReadConfirmedBlocks::new(blocks, hashes) {
-            ResultReadConfirmedBlocks::Blocks(blocks) => blocks,
-            ResultReadConfirmedBlocks::InvalidHashes(hashes) => {
-                return Err(WorkerError::ReadCertificatesError(hashes))
-            }
-        };
 
         let mut height_to_blocks = HashMap::new();
-        for block in blocks {
+        for (block, hash) in blocks.into_iter().zip(hashes) {
+            let block = block.ok_or_else(|| WorkerError::ReadCertificatesError(vec![hash]))?;
             let hashed_block = block.into_inner();
             height_to_blocks.insert(hashed_block.inner().header.height, hashed_block);
         }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -414,30 +414,6 @@ impl ResultReadCertificates {
     }
 }
 
-/// The result of processing the obtained read confirmed blocks.
-pub enum ResultReadConfirmedBlocks {
-    Blocks(Vec<ConfirmedBlock>),
-    InvalidHashes(Vec<CryptoHash>),
-}
-
-impl ResultReadConfirmedBlocks {
-    /// Creating the processed read confirmed blocks.
-    pub fn new(blocks: Vec<Option<ConfirmedBlock>>, hashes: Vec<CryptoHash>) -> Self {
-        let (blocks, invalid_hashes) = blocks
-            .into_iter()
-            .zip(hashes)
-            .partition_map::<Vec<_>, Vec<_>, _, _, _>(|(block, hash)| match block {
-                Some(block) => itertools::Either::Left(block),
-                None => itertools::Either::Right(hash),
-            });
-        if invalid_hashes.is_empty() {
-            Self::Blocks(blocks)
-        } else {
-            Self::InvalidHashes(invalid_hashes)
-        }
-    }
-}
-
 /// An implementation of `ExecutionRuntimeContext` suitable for the core protocol.
 #[derive(Clone)]
 pub struct ChainRuntimeContext<S> {


### PR DESCRIPTION
## Motivation

There are a few places in the chain worker where we read blocks from storage that might be in the cache.

## Proposal

Consult the cache first. Put loaded blocks into the cache.

## Test Plan

CI

## Release Plan

- Port to main
- Hotfix validators
- Release SDK

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
