### PR TITLE
Add proxy and shard restart annotations to Linera Grafana dashboards

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
@@ -12,6 +12,40 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_proxy_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 152, 48, 1)",
+        "limit": 100,
+        "name": "proxy_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "proxy restart",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -12,6 +12,40 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_proxy_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 152, 48, 1)",
+        "limit": 100,
+        "name": "proxy_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "proxy restart",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/logs.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/logs.json
@@ -12,6 +12,40 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_proxy_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 152, 48, 1)",
+        "limit": 100,
+        "name": "proxy_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "proxy restart",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/rocksdb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/rocksdb.json
@@ -12,6 +12,23 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{job=~\"$job\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
@@ -12,6 +12,40 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_proxy_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 152, 48, 1)",
+        "limit": 100,
+        "name": "proxy_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "proxy restart",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
@@ -12,6 +12,40 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_proxy_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 152, 48, 1)",
+        "limit": 100,
+        "name": "proxy_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "proxy restart",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/traces.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/traces.json
@@ -12,6 +12,40 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_proxy_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 152, 48, 1)",
+        "limit": 100,
+        "name": "proxy_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "proxy restart",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/views.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/views.json
@@ -12,6 +12,40 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_proxy_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 152, 48, 1)",
+        "limit": 100,
+        "name": "proxy_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "proxy restart",
+        "type": "tags"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count{validator=~\"$validator\"}[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/vms/ethereum.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/vms/ethereum.json
@@ -12,6 +12,23 @@
         "iconColor": "rgba(0, 211, 255, 1)",
         "name": "Annotations & Alerts",
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "enable": true,
+        "expr": "sum by (instance, validator) (resets(linera_server_request_count[$__rate_interval])) > 0",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "limit": 100,
+        "name": "shard_restart",
+        "showIn": 0,
+        "tagKeys": "instance,validator",
+        "tags": [],
+        "titleFormat": "shard restart",
+        "type": "tags"
       }
     ]
   },


### PR DESCRIPTION
## Motivation

When investigating production issues, correlating metric anomalies with pod restarts
requires cross-referencing with kubectl or kube-state-metrics. The ScyllaDB dashboards
already show red vertical lines on pod restarts (via `resets()` on
`scylla_gossip_heart_beat`), but Linera dashboards had no equivalent.

## Proposal

Add Grafana restart annotations to all 9 Linera dashboards using `resets()` on the
existing `linera_proxy_request_count` and `linera_server_request_count` counters. These
monotonic counters reset to zero on process restart, so `resets() > 0` draws a vertical
line at the exact moment a pod restarted.

Queries are aggregated with `sum by (instance, validator)` to produce one annotation per
pod restart rather than one per method_name label value.

- **7 dashboards** (general, execution, views, traces, logs, storage, scylladb) get both
proxy (orange) and shard (red) restart annotations, filtered by `$validator`
- **rocksdb** gets shard restart only, filtered by `$job`
- **ethereum** gets shard restart only, unfiltered

Color-coded: orange for proxy restarts, red for shard restarts.

## Test Plan

CI. Validated live on central monitoring Grafana — annotations render correctly with one
line per pod restart event.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

