### PR TITLE
Add `get_next_expected_events` worker method.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1122,6 +1122,23 @@ where
         Ok(self.chain.next_expected_events.get(&stream_id).await?)
     }
 
+    /// Gets the `next_expected_events` indices for the given streams.
+    pub(crate) async fn get_next_expected_events(
+        &self,
+        stream_ids: Vec<StreamId>,
+    ) -> Result<BTreeMap<StreamId, u32>, WorkerError> {
+        let values = self
+            .chain
+            .next_expected_events
+            .multi_get(&stream_ids)
+            .await?;
+        Ok(stream_ids
+            .into_iter()
+            .zip(values)
+            .filter_map(|(id, val)| Some((id, val?)))
+            .collect())
+    }
+
     /// Gets received certificate trackers.
     pub(crate) async fn get_received_certificate_trackers(
         &self,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1380,7 +1380,7 @@ impl<Env: Environment> Client<Env> {
     /// `local_next_block_height` (blocks below that are already executed locally).
     async fn download_event_bearing_blocks(
         &self,
-        sender_chain_id: ChainId,
+        publisher_chain_id: ChainId,
         initial_blocks: BTreeSet<(BlockHeight, CryptoHash)>,
         local_next_block_height: BlockHeight,
         subscribed_streams: &BTreeSet<StreamId>,
@@ -1393,19 +1393,13 @@ impl<Env: Environment> Client<Env> {
 
         let mut certificates = BTreeMap::new();
         let mut blocks_to_fetch = initial_blocks;
-        let next_expected_events = subscribed_streams
-            .iter()
-            .zip(
-                self.local_node
-                    .chain_state_view(sender_chain_id)
-                    .await?
-                    .next_expected_events
-                    .multi_get(subscribed_streams)
-                    .await?
-                    .into_iter()
-                    .map(|maybe_index| maybe_index.unwrap_or_default()),
+        let next_expected_events = self
+            .local_node
+            .next_expected_events(
+                publisher_chain_id,
+                subscribed_streams.iter().cloned().collect(),
             )
-            .collect::<BTreeMap<_, _>>();
+            .await?;
 
         while let Some((current_height, current_hash)) = blocks_to_fetch.pop_last() {
             if current_height < local_next_block_height {
@@ -1422,9 +1416,15 @@ impl<Env: Environment> Client<Env> {
             } else {
                 let downloaded = self
                     .requests_scheduler
-                    .download_certificates(remote_node, sender_chain_id, current_height, 1)
+                    .download_certificates(remote_node, publisher_chain_id, current_height, 1)
                     .await?;
                 let Some(certificate) = downloaded.into_iter().next() else {
+                    tracing::debug!(
+                        validator = remote_node.address(),
+                        %publisher_chain_id,
+                        height = %current_height,
+                        "failed to download event publisher block"
+                    );
                     continue;
                 };
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -391,6 +391,19 @@ where
             .await?)
     }
 
+    /// Gets the `next_expected_events` indices for the given streams.
+    pub async fn next_expected_events(
+        &self,
+        chain_id: ChainId,
+        stream_ids: Vec<StreamId>,
+    ) -> Result<BTreeMap<StreamId, u32>, LocalNodeError> {
+        Ok(self
+            .node
+            .state
+            .next_expected_events(chain_id, stream_ids)
+            .await?)
+    }
+
     /// Gets received certificate trackers.
     pub async fn get_received_certificate_trackers(
         &self,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1424,6 +1424,18 @@ where
         .await
     }
 
+    /// Gets the `next_expected_events` indices for the given streams.
+    pub async fn next_expected_events(
+        &self,
+        chain_id: ChainId,
+        stream_ids: Vec<StreamId>,
+    ) -> Result<BTreeMap<StreamId, u32>, WorkerError> {
+        self.chain_read(chain_id, |guard| async move {
+            guard.get_next_expected_events(stream_ids).await
+        })
+        .await
+    }
+
     /// Gets received certificate trackers.
     pub async fn get_received_certificate_trackers(
         &self,


### PR DESCRIPTION
Partial port of https://github.com/linera-io/linera-protocol/pull/5899.

## Motivation

We are using `chain_state_view()` in the client again.

## Proposal

Replace it with a new `get_next_expected_events` worker method.

The rest of #5899 is not needed: The `main` version of `download_certificates_for_events` is already better, since on `main` we have the index→height map for events.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Testnet PR: #5899.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
