### PR TITLE
Add opt-in recovery from inbox gaps and execution outcome mismatch

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -237,6 +237,11 @@ where
     pub preprocessed_blocks: MapView<C, BlockHeight, CryptoHash>,
     /// Inboxes with at least one pending added bundle. This allows us to avoid loading all inboxes.
     pub nonempty_inboxes: RegisterView<C, BTreeSet<ChainId>>,
+
+    /// The local wall-clock time when block 0 was last executed. Used to prevent
+    /// reset-on-incorrect-outcome from looping: if not enough time has elapsed since
+    /// the last reset, the error is returned instead.
+    pub block_zero_executed_at: RegisterView<C, Timestamp>,
 }
 
 /// Block-chaining state.
@@ -526,6 +531,15 @@ where
             .await
             .map_err(|error| match error {
                 InboxError::ViewError(error) => ChainError::ViewError(error),
+                InboxError::GapDetected {
+                    expected_height,
+                    actual_height,
+                } => ChainError::InboxGapDetected {
+                    chain_id,
+                    origin: *origin,
+                    expected_height,
+                    actual_height,
+                },
                 error => ChainError::InternalError(format!(
                     "while processing messages in certified block: {error}"
                 )),
@@ -1010,6 +1024,9 @@ where
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
+        if block.header.height == BlockHeight::ZERO {
+            self.block_zero_executed_at.set(local_time);
+        }
         self.execution_state_hash.set(Some(block.header.state_hash));
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block).await?;

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -123,6 +123,14 @@ pub(crate) enum InboxError {
         messages from the same origin"
     )]
     UnskippableBundle { bundle: MessageBundle },
+    #[error(
+        "Inbox gap: expected bundle at height {expected_height} \
+        but received height {actual_height}"
+    )]
+    GapDetected {
+        expected_height: BlockHeight,
+        actual_height: BlockHeight,
+    },
 }
 
 impl From<&MessageBundle> for Cursor {
@@ -174,6 +182,15 @@ impl From<(ChainId, ChainId, InboxError)> for ChainError {
                 chain_id,
                 origin,
                 bundle: Box::new(bundle),
+            },
+            InboxError::GapDetected {
+                expected_height,
+                actual_height,
+            } => ChainError::InboxGapDetected {
+                chain_id,
+                origin,
+                expected_height,
+                actual_height,
             },
         }
     }
@@ -235,11 +252,16 @@ where
         // Reconcile the bundle with the next added bundle, or mark it as removed.
         let already_known = match self.added_bundles.front().await? {
             Some(previous_bundle) => {
-                // Rationale: If the two cursors are equal, then the bundles should match.
-                // Otherwise, at this point we know that `self.next_cursor_to_add >
-                // Cursor::from(&previous_bundle) > cursor`. Notably, `bundle` will never be
-                // added in the future. Therefore, we should fail instead of adding
-                // it to `self.removed_bundles`.
+                let previous_cursor = Cursor::from(&previous_bundle);
+                if previous_cursor > cursor {
+                    // The sender delivered bundles starting at a later position
+                    // but never delivered the one at `cursor` — this is a gap.
+                    return Err(InboxError::GapDetected {
+                        expected_height: bundle.height,
+                        actual_height: previous_bundle.height,
+                    });
+                }
+                // The two cursors are equal, so the bundles should match.
                 ensure!(
                     bundle == &previous_bundle,
                     InboxError::UnexpectedBundle {
@@ -282,31 +304,44 @@ where
         // Find if the bundle was removed ahead of time.
         let newly_added = match self.removed_bundles.front().await? {
             Some(previous_bundle) => {
-                if Cursor::from(&previous_bundle) == cursor {
-                    // We already executed this bundle by anticipation. Remove it from
-                    // the queue.
-                    ensure!(
-                        bundle == previous_bundle,
-                        InboxError::UnexpectedBundle {
-                            previous_bundle,
-                            bundle,
-                        }
-                    );
-                    self.removed_bundles.delete_front();
-                    #[cfg(with_metrics)]
-                    metrics::REMOVED_BUNDLES
-                        .with_label_values(&[])
-                        .observe(self.removed_bundles.count() as f64);
-                } else {
-                    // The receiver has already executed a later bundle from the same
-                    // sender ahead of time so we should skip this one.
-                    ensure!(
-                        cursor < Cursor::from(&previous_bundle) && bundle.is_skippable(),
-                        InboxError::UnexpectedBundle {
-                            previous_bundle,
-                            bundle,
-                        }
-                    );
+                use std::cmp::Ordering;
+                let front_cursor = Cursor::from(&previous_bundle);
+                match cursor.cmp(&front_cursor) {
+                    Ordering::Equal => {
+                        // We already executed this bundle by anticipation. Remove it
+                        // from the queue.
+                        ensure!(
+                            bundle == previous_bundle,
+                            InboxError::UnexpectedBundle {
+                                previous_bundle,
+                                bundle,
+                            }
+                        );
+                        self.removed_bundles.delete_front();
+                        #[cfg(with_metrics)]
+                        metrics::REMOVED_BUNDLES
+                            .with_label_values(&[])
+                            .observe(self.removed_bundles.count() as f64);
+                    }
+                    Ordering::Greater => {
+                        // The incoming bundle is ahead of the earliest anticipated
+                        // removal — the bundles in between were never delivered.
+                        return Err(InboxError::GapDetected {
+                            expected_height: previous_bundle.height,
+                            actual_height: bundle.height,
+                        });
+                    }
+                    Ordering::Less => {
+                        // The receiver has already executed a later bundle from the
+                        // same sender ahead of time so we should skip this one.
+                        ensure!(
+                            bundle.is_skippable(),
+                            InboxError::UnexpectedBundle {
+                                previous_bundle,
+                                bundle,
+                            }
+                        );
+                    }
                 }
                 false
             }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -137,6 +137,16 @@ pub enum ChainError {
     CertificateValidatorReuse,
     #[error("Signatures in a certificate must form a quorum")]
     CertificateRequiresQuorum,
+    #[error(
+        "Inbox gap on chain {chain_id} from origin {origin}: \
+        expected height {expected_height}, got {actual_height}"
+    )]
+    InboxGapDetected {
+        chain_id: ChainId,
+        origin: ChainId,
+        expected_height: BlockHeight,
+        actual_height: BlockHeight,
+    },
     #[error("Internal error {0}")]
     InternalError(String),
     #[error("Block proposal has size {0} which is too large")]
@@ -197,6 +207,7 @@ impl ChainError {
             | ChainError::MissingCrossChainUpdate { .. } => false,
             ChainError::ViewError(_)
             | ChainError::UnexpectedMessage { .. }
+            | ChainError::InboxGapDetected { .. }
             | ChainError::InternalError(_)
             | ChainError::BcsError(_) => true,
             ChainError::ExecutionError(execution_error, _) => execution_error.is_local(),

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::BTreeSet;
+
 use allocative::Allocative;
 use linera_base::data_types::{ArithmeticError, BlockHeight};
 #[cfg(with_testing)]
@@ -71,6 +73,31 @@ where
         self.next_height_to_schedule.set(height.try_add_one()?);
         self.queue.push_back(height);
         Ok(true)
+    }
+
+    /// Re-adds heights to the outbox queue by merging them with existing entries.
+    /// Used by the `RevertConfirm` mechanism to undo a previous confirmation.
+    /// Returns the heights that were newly added.
+    pub async fn revert(
+        &mut self,
+        heights_to_add: &[BlockHeight],
+    ) -> Result<Vec<BlockHeight>, ViewError> {
+        let existing = self.queue.elements().await?;
+        let mut all_heights = existing.iter().copied().collect::<BTreeSet<_>>();
+        let new_heights = heights_to_add
+            .iter()
+            .filter(|h| !all_heights.contains(h))
+            .copied()
+            .collect::<Vec<_>>();
+        if new_heights.is_empty() {
+            return Ok(Vec::new());
+        }
+        all_heights.extend(new_heights.iter().copied());
+        self.clear();
+        for h in &all_heights {
+            self.schedule_message(*h).map_err(ViewError::from)?;
+        }
+        Ok(new_heights)
     }
 
     /// Marks all messages as received up to the given height.

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -128,7 +128,7 @@ async fn test_inbox_remove_then_add_skippable() {
     // NOT OK to forget about previous consumed bundles while backfilling.
     assert_matches!(
         view.add_bundle(make_bundle(hash, 1, 0, [2])).await,
-        Err(InboxError::UnexpectedBundle { .. })
+        Err(InboxError::GapDetected { .. })
     );
     // OK to backfill the two consumed bundles, with one skippable bundle in the middle.
     assert!(!view.add_bundle(make_bundle(hash, 0, 1, [1])).await.unwrap());
@@ -272,7 +272,7 @@ async fn test_inbox_remove_then_add_unskippable() {
     assert_matches!(
         view.add_bundle(make_unskippable_bundle(hash, 1, 1, [3]))
             .await,
-        Err(InboxError::UnexpectedBundle { .. })
+        Err(InboxError::GapDetected { .. })
     );
     // OK to add the two bundles.
     assert!(!view
@@ -337,4 +337,57 @@ async fn test_inbox_add_then_remove_mixed() {
     // Inbox is empty again.
     assert_eq!(view.added_bundles.count(), 0);
     assert_eq!(view.removed_bundles.count(), 0);
+}
+
+#[tokio::test]
+async fn test_inbox_gap_detected() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    // Remove bundles at heights 0 and 2 by anticipation.
+    assert!(!view
+        .remove_bundle(&make_bundle(hash, 0, 0, [0]))
+        .await
+        .unwrap());
+    assert!(!view
+        .remove_bundle(&make_bundle(hash, 2, 0, [2]))
+        .await
+        .unwrap());
+    // Adding height 0 reconciles with removed_bundles front.
+    assert!(!view.add_bundle(make_bundle(hash, 0, 0, [0])).await.unwrap());
+    // Adding height 2 directly (skipping height 1, which was never removed) is fine.
+    assert!(!view.add_bundle(make_bundle(hash, 2, 0, [2])).await.unwrap());
+    assert_eq!(view.removed_bundles.count(), 0);
+
+    // Now test the gap case: remove height 5, then try to add height 7 — gap detected.
+    assert!(!view
+        .remove_bundle(&make_bundle(hash, 5, 0, [5]))
+        .await
+        .unwrap());
+    assert_matches!(
+        view.add_bundle(make_bundle(hash, 7, 0, [7])).await,
+        Err(InboxError::GapDetected {
+            expected_height,
+            actual_height,
+        }) if expected_height == BlockHeight::from(5) && actual_height == BlockHeight::from(7)
+    );
+    // removed_bundles still has height 5 (inbox unchanged after gap error).
+    assert_eq!(view.removed_bundles.count(), 1);
+}
+
+#[tokio::test]
+async fn test_inbox_remove_gap_detected() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    // Sender delivers bundles at heights 0 and 2 (skipping height 1).
+    assert!(view.add_bundle(make_bundle(hash, 0, 0, [0])).await.unwrap());
+    assert!(view.add_bundle(make_bundle(hash, 2, 0, [2])).await.unwrap());
+    // Receiver tries to consume height 1, but the front of added_bundles is at height 2.
+    // This is a gap: the sender never delivered height 1.
+    assert_matches!(
+        view.remove_bundle(&make_bundle(hash, 1, 0, [1])).await,
+        Err(InboxError::GapDetected {
+            expected_height,
+            actual_height,
+        }) if expected_height == BlockHeight::from(1) && actual_height == BlockHeight::from(2)
+    );
 }

--- a/linera-chain/src/unit_tests/outbox_tests.rs
+++ b/linera-chain/src/unit_tests/outbox_tests.rs
@@ -33,3 +33,42 @@ async fn test_outbox() {
     );
     assert_eq!(view.queue.count(), 0);
 }
+
+#[tokio::test]
+async fn test_outbox_revert() {
+    let mut view = OutboxStateView::new().await;
+    // Schedule heights 0, 2, 4.
+    assert!(view.schedule_message(BlockHeight::ZERO).unwrap());
+    assert!(view.schedule_message(BlockHeight::from(2)).unwrap());
+    assert!(view.schedule_message(BlockHeight::from(4)).unwrap());
+    // Confirm up to height 2 (removes 0 and 2 from queue).
+    view.mark_messages_as_received(BlockHeight::from(2))
+        .await
+        .unwrap();
+    assert_eq!(view.queue.count(), 1); // only height 4 remains
+
+    // Revert: re-add heights 0 and 2.
+    let new = view
+        .revert(&[BlockHeight::ZERO, BlockHeight::from(2)])
+        .await
+        .unwrap();
+    assert_eq!(new, vec![BlockHeight::ZERO, BlockHeight::from(2)]);
+    // Queue now has all three heights in order.
+    let elements = view.queue.elements().await.unwrap();
+    assert_eq!(
+        elements,
+        vec![
+            BlockHeight::ZERO,
+            BlockHeight::from(2),
+            BlockHeight::from(4)
+        ]
+    );
+
+    // Reverting with already-present heights is a no-op.
+    let new = view
+        .revert(&[BlockHeight::from(2), BlockHeight::from(4)])
+        .await
+        .unwrap();
+    assert!(new.is_empty());
+    assert_eq!(view.queue.count(), 3);
+}

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -40,6 +40,12 @@ pub struct ChainWorkerConfig {
     pub execution_state_cache_size: usize,
     /// Chain IDs whose incoming bundles should be processed first.
     pub priority_bundle_origins: HashSet<ChainId>,
+    /// Whether to attempt recovery via `RevertConfirm` when an inbox gap is detected.
+    pub allow_revert_confirm: bool,
+    /// If set, reset the chain state and re-execute all blocks when an
+    /// `IncorrectOutcome` error is encountered — but only if the given duration has
+    /// elapsed since block 0 was last executed (to prevent reset loops).
+    pub reset_on_incorrect_outcome: Option<Duration>,
 }
 
 impl ChainWorkerConfig {
@@ -70,6 +76,8 @@ impl Default for ChainWorkerConfig {
             block_cache_size: 5000,
             execution_state_cache_size: 10_000,
             priority_bundle_origins: HashSet::new(),
+            allow_revert_confirm: false,
+            reset_on_incorrect_outcome: None,
         }
     }
 }

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -12,4 +12,4 @@ pub use self::config::ChainWorkerConfig;
 pub(super) use self::delivery_notifier::DeliveryNotifier;
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
-pub(crate) use self::state::{BlockOutcome, EventSubscriptionsResult};
+pub(crate) use self::state::{BlockOutcome, CrossChainUpdateResult, EventSubscriptionsResult};

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -118,6 +118,21 @@ pub enum BlockOutcome {
     Skipped,
 }
 
+/// The result of processing a cross-chain update.
+pub(crate) enum CrossChainUpdateResult {
+    /// The update was applied and the chain was saved up to the given height.
+    Updated(BlockHeight),
+    /// All bundles were already received; nothing to do.
+    NothingToDo,
+    /// A gap was detected in the inbox for messages from `origin`. If
+    /// `allow_revert_confirm` is enabled, a `RevertConfirm` request should be sent
+    /// to retransmit bundles starting from `retransmit_from`.
+    GapDetected {
+        origin: ChainId,
+        retransmit_from: BlockHeight,
+    },
+}
+
 impl<StorageClient> ChainWorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + 'static,
@@ -444,21 +459,39 @@ where
 
         let mut cross_chain_requests = Vec::new();
         for (recipient, heights) in heights_by_recipient {
+            // Extract the predecessor height for this recipient from the first
+            // block's `previous_message_blocks`. This lets the recipient detect
+            // gaps even before it consumes the missing message.
+            let previous_height = heights.first().and_then(|first_height| {
+                let block = height_to_blocks.get(first_height)?;
+                let (_, prev_height) =
+                    block.inner().body.previous_message_blocks.get(&recipient)?;
+                Some(*prev_height)
+            });
             let mut bundles = Vec::new();
             for height in heights {
-                let hashed_block = height_to_blocks
-                    .get(&height)
-                    .ok_or_else(|| ChainError::InternalError("missing block".to_string()))?;
+                let Some(hashed_block) = height_to_blocks.get(&height) else {
+                    tracing::warn!(
+                        %height,
+                        %recipient,
+                        "spurious entry in outbox; skipping this and higher sender blocks"
+                    );
+                    break;
+                };
                 bundles.extend(
                     hashed_block
                         .inner()
                         .message_bundles_for(recipient, hashed_block.hash()),
                 );
             }
+            if bundles.is_empty() {
+                continue;
+            }
             let request = CrossChainRequest::UpdateRecipient {
                 sender: self.chain.chain_id(),
                 recipient,
                 bundles,
+                previous_height,
             };
             cross_chain_requests.push(request);
         }
@@ -808,13 +841,35 @@ where
             );
         }
         let chain = &mut self.chain;
-        chain
+        match chain
             .remove_bundles_from_inboxes(
                 block.header.timestamp,
                 false,
                 block.body.incoming_bundles(),
             )
-            .await?;
+            .await
+        {
+            Ok(()) => {}
+            Err(ChainError::InboxGapDetected { origin, .. })
+                if self.config.allow_revert_confirm =>
+            {
+                let retransmit_from = self.get_inbox_next_height(origin).await?;
+                warn!(
+                    "Inbox gap detected for {chain_id} from {origin}: \
+                    requesting resend from {retransmit_from}",
+                );
+                let mut actions = NetworkActions::default();
+                actions
+                    .cross_chain_requests
+                    .push(CrossChainRequest::RevertConfirm {
+                        sender: origin,
+                        recipient: chain_id,
+                        retransmit_from,
+                    });
+                return Ok((self.chain_info_response(), actions, BlockOutcome::Skipped));
+            }
+            Err(e) => return Err(e.into()),
+        }
         let confirmed_block = if let Some(mut execution_state) =
             self.execution_state_cache.remove(&block_hash)
         {
@@ -841,13 +896,34 @@ where
                 )
                 .await?;
             // We should always agree on the messages and state hash.
-            ensure!(
-                outcome == verified,
-                WorkerError::IncorrectOutcome {
+            if outcome != verified {
+                if let Some(min_duration) = self.config.reset_on_incorrect_outcome {
+                    let block_zero_time = *self.chain.block_zero_executed_at.get();
+                    let elapsed = local_time.duration_since(block_zero_time);
+                    if elapsed >= min_duration {
+                        warn!(
+                            "IncorrectOutcome for block {height} on chain {chain_id}; \
+                            resetting chain state and re-executing"
+                        );
+                        return self
+                            .reset_and_reexecute_chain(
+                                block_hash,
+                                height,
+                                notify_when_messages_are_delivered,
+                            )
+                            .await;
+                    }
+                    warn!(
+                        "IncorrectOutcome for block {height} on chain {chain_id}; \
+                        not resetting because only {elapsed:?} elapsed since last \
+                        block 0 execution (minimum: {min_duration:?})"
+                    );
+                }
+                return Err(WorkerError::IncorrectOutcome {
                     submitted: Box::new(outcome),
                     computed: Box::new(verified),
-                }
-            );
+                });
+            }
             ConfirmedBlock::new(Block::new(proposed_block, verified))
         };
 
@@ -915,7 +991,8 @@ where
         &mut self,
         origin: ChainId,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Option<BlockHeight>, WorkerError> {
+        sender_previous_height: Option<BlockHeight>,
+    ) -> Result<CrossChainUpdateResult, WorkerError> {
         // Only process certificates with relevant heights and epochs.
         let mut inbox = self.chain.inboxes.try_load_entry_mut(&origin).await?;
         let next_height_to_receive = inbox.next_block_height_to_receive()?;
@@ -923,6 +1000,33 @@ where
             Some(bundle) => Some(bundle.height),
             None => None,
         };
+
+        // Proactive gap detection: if the sender declares a predecessor height that
+        // we haven't received yet, the inbox has a gap.
+        if let Some(prev) = sender_previous_height {
+            if prev >= next_height_to_receive {
+                let recipient = self.chain_id();
+                if self.config.allow_revert_confirm {
+                    warn!(
+                        "Inbox gap detected for {recipient} from {origin}: \
+                        sender declares previous height {prev} but we only have up to \
+                        {next_height_to_receive}; requesting resend",
+                    );
+                    return Ok(CrossChainUpdateResult::GapDetected {
+                        origin,
+                        retransmit_from: next_height_to_receive,
+                    });
+                }
+                return Err(ChainError::InboxGapDetected {
+                    chain_id: recipient,
+                    origin,
+                    expected_height: prev,
+                    actual_height: bundles.first().map(|(_, b)| b.height).unwrap_or_default(),
+                }
+                .into());
+            }
+        }
+
         let helper = CrossChainUpdateHelper::new(&self.config, &self.chain);
         let recipient = self.chain_id();
         let bundles = helper.select_message_bundles(
@@ -933,7 +1037,7 @@ where
             bundles,
         )?;
         let Some(last_updated_height) = bundles.last().map(|bundle| bundle.height) else {
-            return Ok(None);
+            return Ok(CrossChainUpdateResult::NothingToDo);
         };
         // Process the received messages in certificates.
         let local_time = self.storage.clock().current_time();
@@ -942,7 +1046,8 @@ where
             let add_to_received_log = previous_height != Some(bundle.height);
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
-            self.chain
+            match self
+                .chain
                 .receive_message_bundle_with_inbox(
                     &mut inbox,
                     &origin,
@@ -950,7 +1055,25 @@ where
                     local_time,
                     add_to_received_log,
                 )
-                .await?;
+                .await
+            {
+                Ok(()) => {}
+                Err(ChainError::InboxGapDetected { .. }) if self.config.allow_revert_confirm => {
+                    // Don't save — leave the inbox unchanged so the resend can
+                    // reconcile properly. Request from next_height_to_receive
+                    // rather than the specific gap height, so that all pending
+                    // removed_bundles entries can also be reconciled.
+                    warn!(
+                        "Inbox gap detected for {recipient} from {origin}: \
+                        requesting resend from {next_height_to_receive}",
+                    );
+                    return Ok(CrossChainUpdateResult::GapDetected {
+                        origin,
+                        retransmit_from: next_height_to_receive,
+                    });
+                }
+                Err(e) => return Err(e.into()),
+            }
         }
         inbox.observe_size_metric();
         drop(inbox);
@@ -959,14 +1082,14 @@ where
             // now. Accordingly, do not send a confirmation, so that the
             // cross-chain update is retried later.
             warn!(
-                "Refusing to deliver messages to {recipient:?} from {origin:?} \
+                "Refusing to deliver messages to {recipient} from {origin} \
                 at height {last_updated_height} because the recipient is still inactive",
             );
-            return Ok(None);
+            return Ok(CrossChainUpdateResult::NothingToDo);
         }
         // Save the chain.
         self.save().await?;
-        Ok(Some(last_updated_height))
+        Ok(CrossChainUpdateResult::Updated(last_updated_height))
     }
 
     /// Handles the cross-chain request confirming that the recipient was updated.
@@ -995,6 +1118,189 @@ where
         }
 
         Ok(())
+    }
+
+    /// Handles a `RevertConfirm` request: walks backward through
+    /// `previous_message_blocks` to find all block heights that sent messages to
+    /// `recipient` starting from the latest down to `retransmit_from`, re-adds them
+    /// to the outbox, and creates cross-chain update actions to resend the bundles.
+    #[instrument(skip_all, fields(
+        chain_id = %self.chain_id(),
+        %recipient,
+        %retransmit_from,
+    ))]
+    pub(crate) async fn handle_revert_confirm(
+        &mut self,
+        recipient: ChainId,
+        retransmit_from: BlockHeight,
+    ) -> Result<NetworkActions, WorkerError> {
+        // 1. Walk backward through previous_message_blocks to collect all heights
+        //    that sent messages to this recipient, from the latest down to retransmit_from.
+        let Some(latest_height) = self
+            .chain
+            .execution_state
+            .previous_message_blocks
+            .get(&recipient)
+            .await?
+        else {
+            warn!("RevertConfirm: no record of sending to {recipient}");
+            return Ok(NetworkActions::default());
+        };
+
+        let mut heights_to_re_add = Vec::new();
+        let mut current_height = latest_height;
+        while current_height >= retransmit_from {
+            // We arrived at current_height via previous_message_blocks links, starting from the
+            // chain state and following the links downwards. So these blocks should all be in
+            // confirmed_log or preprocessed_blocks already.
+            heights_to_re_add.push(current_height);
+            // Load the block at current_height to find the previous message block
+            let hash = match &*self.chain.block_hashes([current_height]).await? {
+                [hash] => *hash,
+                _ => {
+                    return Err(WorkerError::ConfirmedBlockHashNotFound {
+                        height: current_height,
+                        chain_id: self.chain_id(),
+                    })
+                }
+            };
+            let block = self
+                .storage
+                .read_confirmed_block(hash)
+                .await?
+                .ok_or_else(|| WorkerError::LocalBlockNotFound {
+                    height: current_height,
+                    chain_id: self.chain_id(),
+                })?;
+            match block.block().body.previous_message_blocks.get(&recipient) {
+                Some((_, prev_height)) if *prev_height >= retransmit_from => {
+                    current_height = *prev_height;
+                }
+                _ => break,
+            }
+        }
+
+        // 2. Re-add the heights to the outbox.
+        let new_heights = self
+            .chain
+            .outboxes
+            .try_load_entry_mut(&recipient)
+            .await?
+            .revert(&heights_to_re_add)
+            .await?;
+
+        if new_heights.is_empty() {
+            debug!("RevertConfirm: all heights already in outbox for {recipient}");
+            return Ok(NetworkActions::default());
+        }
+
+        // 3. Update outbox_counters (+1 per new height for this one recipient).
+        let new_heights_len = new_heights.len();
+        for h in new_heights {
+            *self.chain.outbox_counters.get_mut().entry(h).or_default() += 1;
+        }
+        self.chain.nonempty_outboxes.get_mut().insert(recipient);
+
+        // 4. Create cross-chain requests using existing infrastructure.
+        let actions = self.create_network_actions(None).await?;
+
+        // 5. Save chain state.
+        self.save().await?;
+
+        warn!(
+            "RevertConfirm: re-added {new_heights_len} heights to outbox for {recipient}, \
+            starting from height {retransmit_from}"
+        );
+
+        Ok(actions)
+    }
+
+    /// Resets the chain state completely and re-executes all confirmed blocks from storage.
+    /// Sends `RevertConfirm` to all known senders so they resend cross-chain messages.
+    #[instrument(skip_all, fields(
+        chain_id = %self.chain_id(),
+    ))]
+    async fn reset_and_reexecute_chain(
+        &mut self,
+        failed_block_hash: CryptoHash,
+        failed_height: BlockHeight,
+        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
+    ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+        let chain_id = self.chain_id();
+        let tip_height = self.chain.tip_state.get().next_block_height;
+
+        // 1. Collect all sender chain IDs and block hashes before clearing.
+        let sender_ids = self.chain.inboxes.indices().await?;
+        let hashes = self.chain.confirmed_log.read(..).await?;
+        let preprocessed = self.chain.preprocessed_blocks.index_values().await?;
+
+        // 2. Clear the chain state entirely and save.
+        self.chain.clear();
+        self.knows_chain_is_active = false;
+        self.save().await?;
+        warn!(
+            "Cleared chain state for {chain_id} up to height {tip_height}; \
+            re-executing all blocks"
+        );
+
+        // 3. Re-load certificates one at a time by hash and re-process them.
+        for (index, hash) in hashes.into_iter().enumerate() {
+            let height = BlockHeight(index as u64);
+            let cert = self
+                .storage
+                .read_certificate(hash)
+                .await?
+                .ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
+            Box::pin(self.process_confirmed_block(cert, None)).await?;
+        }
+        for (height, hash) in preprocessed {
+            let cert = self
+                .storage
+                .read_certificate(hash)
+                .await?
+                .ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
+            Box::pin(self.process_confirmed_block(cert, None)).await?;
+        }
+
+        // 4. Now process the original certificate that triggered the error.
+        let failed_certificate = self
+            .storage
+            .read_certificate(failed_block_hash)
+            .await?
+            .ok_or_else(|| WorkerError::LocalBlockNotFound {
+                height: failed_height,
+                chain_id,
+            })?;
+        let result = Box::pin(
+            self.process_confirmed_block(failed_certificate, notify_when_messages_are_delivered),
+        )
+        .await?;
+
+        // 5. Send RevertConfirm to all senders so they resend messages we may
+        //    have lost during the reset.
+        let (info, mut actions, outcome) = result;
+        for sender_id in sender_ids {
+            actions
+                .cross_chain_requests
+                .push(CrossChainRequest::RevertConfirm {
+                    sender: sender_id,
+                    recipient: chain_id,
+                    retransmit_from: BlockHeight::ZERO,
+                });
+        }
+
+        warn!(
+            "Chain {chain_id} reset and re-executed up to height {}; \
+            sent RevertConfirm to {} senders",
+            self.chain.tip_state.get().next_block_height,
+            actions
+                .cross_chain_requests
+                .iter()
+                .filter(|r| matches!(r, CrossChainRequest::RevertConfirm { .. }))
+                .count(),
+        );
+
+        Ok((info, actions, outcome))
     }
 
     #[instrument(skip_all, fields(

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -233,12 +233,25 @@ pub enum CrossChainRequest {
         sender: ChainId,
         recipient: ChainId,
         bundles: Vec<(Epoch, MessageBundle)>,
+        /// The height of the sender's previous block that sent messages to this
+        /// recipient (before the first bundle in this request). `None` if the first
+        /// bundle is the first message ever sent to this recipient.
+        previous_height: Option<BlockHeight>,
     },
     /// Acknowledge the height of the highest confirmed blocks communicated with `UpdateRecipient`.
     ConfirmUpdatedRecipient {
         sender: ChainId,
         recipient: ChainId,
         latest_height: BlockHeight,
+    },
+    /// Request the sender to revert a previous confirmation and resend bundles
+    /// starting from the given height. This is used to recover from state
+    /// inconsistencies where the recipient lost persisted state after a
+    /// confirmation was sent.
+    RevertConfirm {
+        sender: ChainId,
+        recipient: ChainId,
+        retransmit_from: BlockHeight,
     },
 }
 
@@ -249,6 +262,7 @@ impl CrossChainRequest {
         match self {
             UpdateRecipient { recipient, .. } => *recipient,
             ConfirmUpdatedRecipient { sender, .. } => *sender,
+            RevertConfirm { sender, .. } => *sender,
         }
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -649,11 +649,19 @@ fn update_recipient_direct(
     certificate: &ConfirmedBlockCertificate,
 ) -> CrossChainRequest {
     let sender = certificate.inner().block().header.chain_id;
+    let previous_height = certificate
+        .inner()
+        .block()
+        .body
+        .previous_message_blocks
+        .get(&recipient)
+        .map(|(_, h)| *h);
     let bundles = certificate.message_bundles_for(recipient).collect();
     CrossChainRequest::UpdateRecipient {
         sender,
         recipient,
         bundles,
+        previous_height,
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -65,7 +65,8 @@ impl<S: Storage> std::ops::Deref for ChainStateViewReadGuard<S> {
 pub(crate) use crate::chain_worker::EventSubscriptionsResult;
 use crate::{
     chain_worker::{
-        handle, state::ChainWorkerState, BlockOutcome, ChainWorkerConfig, DeliveryNotifier,
+        handle, state::ChainWorkerState, BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult,
+        DeliveryNotifier,
     },
     client::ListeningMode,
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -386,6 +387,18 @@ pub enum WorkerError {
         height: BlockHeight,
         chain_id: ChainId,
     },
+    #[error(
+        "confirmed_log/preprocessed_blocks entry at height {height} for chain {chain_id} not found"
+    )]
+    ConfirmedBlockHashNotFound {
+        height: BlockHeight,
+        chain_id: ChainId,
+    },
+    #[error("Block at height {height} on chain {chain_id} not found in local storage")]
+    LocalBlockNotFound {
+        height: BlockHeight,
+        chain_id: ChainId,
+    },
     #[error("The block proposal is invalid: {0}")]
     InvalidBlockProposal(String),
     #[error("Blob was not required by any pending block")]
@@ -426,6 +439,8 @@ impl WorkerError {
             | WorkerError::ViewError(_)
             | WorkerError::ConfirmedLogEntryNotFound { .. }
             | WorkerError::PreprocessedBlocksEntryNotFound { .. }
+            | WorkerError::ConfirmedBlockHashNotFound { .. }
+            | WorkerError::LocalBlockNotFound { .. }
             | WorkerError::MissingNetworkDescription
             | WorkerError::Thread(_)
             | WorkerError::ReadCertificatesError(_)
@@ -565,6 +580,19 @@ where
     #[instrument(level = "trace", skip(self, origins))]
     pub fn with_priority_bundle_origins(mut self, origins: HashSet<ChainId>) -> Self {
         self.chain_worker_config.priority_bundle_origins = origins;
+        self
+    }
+
+    #[instrument(level = "trace", skip(self, value))]
+    pub fn with_allow_revert_confirm(mut self, value: bool) -> Self {
+        self.chain_worker_config.allow_revert_confirm = value;
+        self
+    }
+
+    #[instrument(level = "trace", skip(self))]
+    pub fn with_reset_on_incorrect_outcome(mut self, minutes: Option<u64>) -> Self {
+        self.chain_worker_config.reset_on_incorrect_outcome =
+            minutes.map(|m| Duration::from_secs(m * 60));
         self
     }
 
@@ -994,9 +1022,12 @@ where
         origin: ChainId,
         recipient: ChainId,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Option<BlockHeight>, WorkerError> {
+        previous_height: Option<BlockHeight>,
+    ) -> Result<CrossChainUpdateResult, WorkerError> {
         self.chain_write(recipient, |mut guard| async move {
-            guard.process_cross_chain_update(origin, bundles).await
+            guard
+                .process_cross_chain_update(origin, bundles, previous_height)
+                .await
         })
         .await
     }
@@ -1266,26 +1297,41 @@ where
                 sender,
                 recipient,
                 bundles,
+                previous_height,
             } => {
                 let mut actions = NetworkActions::default();
                 let origin = sender;
-                let Some(height) = self
-                    .process_cross_chain_update(origin, recipient, bundles)
+                match self
+                    .process_cross_chain_update(origin, recipient, bundles, previous_height)
                     .await?
-                else {
-                    return Ok(actions);
-                };
-                actions.notifications.push(Notification {
-                    chain_id: recipient,
-                    reason: Reason::NewIncomingBundle { origin, height },
-                });
-                actions
-                    .cross_chain_requests
-                    .push(CrossChainRequest::ConfirmUpdatedRecipient {
-                        sender,
-                        recipient,
-                        latest_height: height,
-                    });
+                {
+                    CrossChainUpdateResult::NothingToDo => {}
+                    CrossChainUpdateResult::Updated(height) => {
+                        actions.notifications.push(Notification {
+                            chain_id: recipient,
+                            reason: Reason::NewIncomingBundle { origin, height },
+                        });
+                        actions.cross_chain_requests.push(
+                            CrossChainRequest::ConfirmUpdatedRecipient {
+                                sender,
+                                recipient,
+                                latest_height: height,
+                            },
+                        );
+                    }
+                    CrossChainUpdateResult::GapDetected {
+                        origin,
+                        retransmit_from,
+                    } => {
+                        actions
+                            .cross_chain_requests
+                            .push(CrossChainRequest::RevertConfirm {
+                                sender: origin,
+                                recipient,
+                                retransmit_from,
+                            });
+                    }
+                }
                 Ok(actions)
             }
             CrossChainRequest::ConfirmUpdatedRecipient {
@@ -1300,6 +1346,18 @@ where
                 })
                 .await?;
                 Ok(NetworkActions::default())
+            }
+            CrossChainRequest::RevertConfirm {
+                sender,
+                recipient,
+                retransmit_from,
+            } => {
+                self.chain_write(sender, |mut guard| async move {
+                    guard
+                        .handle_revert_confirm(recipient, retransmit_from)
+                        .await
+                })
+                .await
             }
         }
     }

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -198,6 +198,7 @@ message CrossChainRequest {
   oneof inner {
     UpdateRecipient update_recipient = 1;
     ConfirmUpdatedRecipient confirm_updated_recipient = 2;
+    RevertConfirm revert_confirm = 3;
   }
 }
 
@@ -207,6 +208,9 @@ message UpdateRecipient {
   ChainId sender = 1;
   ChainId recipient = 2;
   bytes bundles = 3;
+  // The height of the sender's previous block that sent messages to this recipient
+  // (before the first bundle). Absent if this is the first message ever.
+  optional BlockHeight previous_height = 4;
 }
 
 // Acknowledge the height of the highest confirmed blocks communicated with `UpdateRecipient`.
@@ -214,6 +218,13 @@ message ConfirmUpdatedRecipient {
   ChainId sender = 1;
   ChainId recipient = 2;
   BlockHeight latest_height = 3;
+}
+
+// Request the sender to revert a previous confirmation and resend bundles.
+message RevertConfirm {
+  ChainId sender = 1;
+  ChainId recipient = 2;
+  BlockHeight retransmit_from = 3;
 }
 
 // Request information on a chain.

--- a/linera-rpc/src/cross_chain_message_queue.rs
+++ b/linera-rpc/src/cross_chain_message_queue.rs
@@ -202,6 +202,9 @@ impl QueueId {
             } => (*sender, *recipient, true),
             CrossChainRequest::ConfirmUpdatedRecipient {
                 sender, recipient, ..
+            }
+            | CrossChainRequest::RevertConfirm {
+                sender, recipient, ..
             } => (*sender, *recipient, false),
         };
         QueueId {

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -285,10 +285,12 @@ impl TryFrom<api::CrossChainRequest> for CrossChainRequest {
                 sender,
                 recipient,
                 bundles,
+                previous_height,
             }) => CrossChainRequest::UpdateRecipient {
                 sender: try_proto_convert(sender)?,
                 recipient: try_proto_convert(recipient)?,
                 bundles: bincode::deserialize(&bundles)?,
+                previous_height: previous_height.map(Into::into),
             },
             Inner::ConfirmUpdatedRecipient(api::ConfirmUpdatedRecipient {
                 sender,
@@ -298,6 +300,17 @@ impl TryFrom<api::CrossChainRequest> for CrossChainRequest {
                 sender: try_proto_convert(sender)?,
                 recipient: try_proto_convert(recipient)?,
                 latest_height: latest_height
+                    .ok_or(GrpcProtoConversionError::MissingField)?
+                    .into(),
+            },
+            Inner::RevertConfirm(api::RevertConfirm {
+                sender,
+                recipient,
+                retransmit_from,
+            }) => CrossChainRequest::RevertConfirm {
+                sender: try_proto_convert(sender)?,
+                recipient: try_proto_convert(recipient)?,
+                retransmit_from: retransmit_from
                     .ok_or(GrpcProtoConversionError::MissingField)?
                     .into(),
             },
@@ -317,10 +330,12 @@ impl TryFrom<CrossChainRequest> for api::CrossChainRequest {
                 sender,
                 recipient,
                 bundles,
+                previous_height,
             } => Inner::UpdateRecipient(api::UpdateRecipient {
                 sender: Some(sender.into()),
                 recipient: Some(recipient.into()),
                 bundles: bincode::serialize(&bundles)?,
+                previous_height: previous_height.map(Into::into),
             }),
             CrossChainRequest::ConfirmUpdatedRecipient {
                 sender,
@@ -330,6 +345,15 @@ impl TryFrom<CrossChainRequest> for api::CrossChainRequest {
                 sender: Some(sender.into()),
                 recipient: Some(recipient.into()),
                 latest_height: Some(latest_height.into()),
+            }),
+            CrossChainRequest::RevertConfirm {
+                sender,
+                recipient,
+                retransmit_from,
+            } => Inner::RevertConfirm(api::RevertConfirm {
+                sender: Some(sender.into()),
+                recipient: Some(recipient.into()),
+                retransmit_from: Some(retransmit_from.into()),
             }),
         };
         Ok(Self { inner: Some(inner) })
@@ -1294,6 +1318,7 @@ pub mod tests {
             sender: dummy_chain_id(0),
             recipient: dummy_chain_id(0),
             bundles: vec![],
+            previous_height: Some(BlockHeight::from(42)),
         };
         round_trip_check::<_, api::CrossChainRequest>(&cross_chain_request_update_recipient);
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -1055,7 +1055,8 @@ impl GrpcProxyable for CrossChainRequest {
 
         match self.inner.as_ref()? {
             Inner::UpdateRecipient(api::UpdateRecipient { recipient, .. })
-            | Inner::ConfirmUpdatedRecipient(api::ConfirmUpdatedRecipient { recipient, .. }) => {
+            | Inner::ConfirmUpdatedRecipient(api::ConfirmUpdatedRecipient { recipient, .. })
+            | Inner::RevertConfirm(api::RevertConfirm { recipient, .. }) => {
                 recipient.clone()?.try_into().ok()
             }
         }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -482,6 +482,9 @@ CrossChainRequest:
                 TUPLE:
                   - TYPENAME: Epoch
                   - TYPENAME: MessageBundle
+          - previous_height:
+              OPTION:
+                TYPENAME: BlockHeight
     1:
       ConfirmUpdatedRecipient:
         STRUCT:
@@ -490,6 +493,15 @@ CrossChainRequest:
           - recipient:
               TYPENAME: ChainId
           - latest_height:
+              TYPENAME: BlockHeight
+    2:
+      RevertConfirm:
+        STRUCT:
+          - sender:
+              TYPENAME: ChainId
+          - recipient:
+              TYPENAME: ChainId
+          - retransmit_from:
               TYPENAME: BlockHeight
 CryptoHash:
   NEWTYPESTRUCT:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -391,6 +391,12 @@ type ChainStateExtendedView {
 	Inboxes with at least one pending added bundle. This allows us to avoid loading all inboxes.
 	"""
 	nonemptyInboxes: [ChainId!]!
+	"""
+	The local wall-clock time when block 0 was last executed. Used to prevent
+	reset-on-incorrect-outcome from looping: if not enough time has elapsed since
+	the last reset, the error is returned instead.
+	"""
+	blockZeroExecutedAt: Timestamp!
 }
 
 """

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -66,6 +66,8 @@ struct ServerContext {
     block_cache_size: usize,
     execution_state_cache_size: usize,
     chain_info_max_received_log_entries: usize,
+    allow_revert_confirm: bool,
+    reset_on_incorrect_outcome_mins: Option<u64>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -96,6 +98,10 @@ impl ServerContext {
             chain_info_max_received_log_entries: self.chain_info_max_received_log_entries,
             block_cache_size: self.block_cache_size,
             execution_state_cache_size: self.execution_state_cache_size,
+            allow_revert_confirm: self.allow_revert_confirm,
+            reset_on_incorrect_outcome: self
+                .reset_on_incorrect_outcome_mins
+                .map(|m| Duration::from_secs(m * 60)),
             ..ChainWorkerConfig::default()
         };
         let state = WorkerState::new(storage, config, None);
@@ -452,6 +458,18 @@ enum ServerCommand {
         )]
         chain_info_max_received_log_entries: usize,
 
+        /// Enable the RevertConfirm recovery mechanism for inbox gaps caused by
+        /// lost persisted state.
+        #[arg(long, default_value_t = false)]
+        allow_revert_confirm: bool,
+
+        /// On IncorrectOutcome errors, reset the chain state and re-execute all
+        /// blocks from scratch. Sends RevertConfirm to all known senders. The
+        /// value is the minimum number of minutes since the last reset before
+        /// another reset is allowed (to prevent loops).
+        #[arg(long)]
+        reset_on_incorrect_outcome_mins: Option<u64>,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -583,6 +601,8 @@ async fn run(options: ServerOptions) {
             wasm_runtime,
             chain_worker_ttl,
             chain_info_max_received_log_entries,
+            allow_revert_confirm,
+            reset_on_incorrect_outcome_mins,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -600,6 +620,8 @@ async fn run(options: ServerOptions) {
                 block_cache_size: options.block_cache_size,
                 execution_state_cache_size: options.execution_state_cache_size,
                 chain_info_max_received_log_entries,
+                allow_revert_confirm,
+                reset_on_incorrect_outcome_mins,
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };


### PR DESCRIPTION
Port of https://github.com/linera-io/linera-protocol/pull/5876, https://github.com/linera-io/linera-protocol/pull/5881, https://github.com/linera-io/linera-protocol/pull/5882, https://github.com/linera-io/linera-protocol/pull/5886, https://github.com/linera-io/linera-protocol/pull/5896, https://github.com/linera-io/linera-protocol/pull/5890 and https://github.com/linera-io/linera-protocol/pull/5900.

## Motivation

On the testnet, we added mechanisms to recover from failures to persist inbox updates and from `IncorrectOutcome` errors. These should not be reachable in theory, other than due to database corruptions, but it might still be useful to keep these recovery mechanisms.

## Proposal

Add `RevertConfirm` cross-chain request to recover from state inconsistencies where a recipient chain lost persisted inbox state after a confirmation was sent. When enabled via `--allow-revert-confirm`, the recipient detects inbox gaps and requests the sender to re-add outbox entries and resend bundles.

Also add `--reset-on-incorrect-outcome-mins` to reset and re-execute a chain's entire block history when an `IncorrectOutcome` error is detected (guarded by a minimum cooldown to prevent loops).

## Test Plan

Some tests were added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Testnet PRs: https://github.com/linera-io/linera-protocol/pull/5876, https://github.com/linera-io/linera-protocol/pull/5881, https://github.com/linera-io/linera-protocol/pull/5882, https://github.com/linera-io/linera-protocol/pull/5886, https://github.com/linera-io/linera-protocol/pull/5896, https://github.com/linera-io/linera-protocol/pull/5890, https://github.com/linera-io/linera-protocol/pull/5900
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
