### PR TITLE
[testnet] Strengthen the condition of the use of the mutate function.

### DIFF
--- a/linera-core/src/environment/wallet/memory.rs
+++ b/linera-core/src/environment/wallet/memory.rs
@@ -69,11 +69,7 @@ impl Memory {
             .collect::<Vec<_>>()
     }
 
-    pub fn mutate<R>(
-        &self,
-        chain_id: ChainId,
-        mut mutate: impl FnMut(&mut Chain) -> R,
-    ) -> Option<R> {
+    pub fn mutate<R>(&self, chain_id: ChainId, mutate: impl Fn(&mut Chain) -> R) -> Option<R> {
         use papaya::Operation::*;
 
         let mut outcome = None;
@@ -126,7 +122,7 @@ impl Wallet for Memory {
     async fn modify(
         &self,
         id: ChainId,
-        f: impl FnMut(&mut Chain) + Send,
+        f: impl Fn(&mut Chain) + Send,
     ) -> Result<Option<()>, Self::Error> {
         Ok(self.mutate(id, f))
     }

--- a/linera-core/src/environment/wallet/mod.rs
+++ b/linera-core/src/environment/wallet/mod.rs
@@ -86,10 +86,14 @@ pub trait Wallet {
     async fn try_insert(&self, id: ChainId, chain: Chain) -> Result<Option<Chain>, Self::Error>;
 
     /// Modifies a chain in the wallet. Returns `Ok(None)` if the chain doesn't exist.
+    ///
+    /// The closure may be called more than once (e.g. on CAS contention), so it
+    /// must be idempotent. `Fn` (not `FnMut`) is required to discourage reliance
+    /// on mutable captured state.
     async fn modify(
         &self,
         id: ChainId,
-        f: impl FnMut(&mut Chain) + Send,
+        f: impl Fn(&mut Chain) + Send,
     ) -> Result<Option<()>, Self::Error>;
 
     fn chain_ids(&self) -> impl Stream<Item = Result<ChainId, Self::Error>> {
@@ -136,7 +140,7 @@ impl<W: Deref<Target: Wallet> + linera_base::util::traits::AutoTraits> Wallet fo
     async fn modify(
         &self,
         id: ChainId,
-        f: impl FnMut(&mut Chain) + Send,
+        f: impl Fn(&mut Chain) + Send,
     ) -> Result<Option<()>, Self::Error> {
         self.deref().modify(id, f).await
     }

--- a/linera-core/src/environment/wallet/persistent.rs
+++ b/linera-core/src/environment/wallet/persistent.rs
@@ -53,7 +53,7 @@ impl Wallet for PersistentWallet {
     async fn modify(
         &self,
         id: ChainId,
-        f: impl FnMut(&mut Chain) + Send,
+        f: impl Fn(&mut Chain) + Send,
     ) -> Result<Option<()>, Self::Error> {
         self.mutate(id, f).transpose()
     }
@@ -163,7 +163,7 @@ impl PersistentWallet {
     pub fn mutate<R>(
         &self,
         chain_id: ChainId,
-        mutate: impl FnMut(&mut Chain) -> R,
+        mutate: impl Fn(&mut Chain) -> R,
     ) -> Option<Result<R, persistent::file::Error>> {
         self.0
             .chains


### PR DESCRIPTION
## Motivation

The function .compute of papaya::HashMap has some possible vulnerability when being used with
an incorrect function. An examination of the code did not reveal any bug, but has revealed that the allowed
functions are too wide.

Backport #5752

## Proposal

Strengthening the use of the mutate function.

## Test Plan

CI

## Release Plan

Backport to `testnet_conway`.

## Links

None