### PR TITLE
[testnet] Compress block heights as ranges in certificate download debug logs

### DIFF
--- a/linera-core/src/client/requests_scheduler/request.rs
+++ b/linera-core/src/client/requests_scheduler/request.rs
@@ -1,24 +1,26 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt;
-
+use custom_debug_derive::Debug;
 use linera_base::{
     data_types::{Blob, BlobContent, BlockHeight},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::types::ConfirmedBlockCertificate;
 
-use crate::{client::requests_scheduler::cache::SubsumingKey, data_types::CompressedHeights};
+use crate::{
+    client::requests_scheduler::cache::SubsumingKey, data_types::debug_compressed_heights,
+};
 
 /// Unique identifier for different types of download requests.
 ///
 /// Used for request deduplication to avoid redundant downloads of the same data.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RequestKey {
     /// Download certificates by specific heights
     Certificates {
         chain_id: ChainId,
+        #[debug(with = "debug_compressed_heights")]
         heights: Vec<BlockHeight>,
     },
     /// Download a blob by ID
@@ -27,27 +29,6 @@ pub enum RequestKey {
     PendingBlob { chain_id: ChainId, blob_id: BlobId },
     /// Download certificate for a specific blob
     CertificateForBlob(BlobId),
-}
-
-impl fmt::Debug for RequestKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RequestKey::Certificates { chain_id, heights } => f
-                .debug_struct("Certificates")
-                .field("chain_id", chain_id)
-                .field("heights", &CompressedHeights(heights))
-                .finish(),
-            RequestKey::Blob(blob_id) => f.debug_tuple("Blob").field(blob_id).finish(),
-            RequestKey::PendingBlob { chain_id, blob_id } => f
-                .debug_struct("PendingBlob")
-                .field("chain_id", chain_id)
-                .field("blob_id", blob_id)
-                .finish(),
-            RequestKey::CertificateForBlob(blob_id) => {
-                f.debug_tuple("CertificateForBlob").field(blob_id).finish()
-            }
-        }
-    }
 }
 
 impl RequestKey {

--- a/linera-core/src/client/requests_scheduler/request.rs
+++ b/linera-core/src/client/requests_scheduler/request.rs
@@ -1,18 +1,20 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::fmt;
+
 use linera_base::{
     data_types::{Blob, BlobContent, BlockHeight},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::types::ConfirmedBlockCertificate;
 
-use crate::client::requests_scheduler::cache::SubsumingKey;
+use crate::{client::requests_scheduler::cache::SubsumingKey, data_types::CompressedHeights};
 
 /// Unique identifier for different types of download requests.
 ///
 /// Used for request deduplication to avoid redundant downloads of the same data.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum RequestKey {
     /// Download certificates by specific heights
     Certificates {
@@ -25,6 +27,27 @@ pub enum RequestKey {
     PendingBlob { chain_id: ChainId, blob_id: BlobId },
     /// Download certificate for a specific blob
     CertificateForBlob(BlobId),
+}
+
+impl fmt::Debug for RequestKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RequestKey::Certificates { chain_id, heights } => f
+                .debug_struct("Certificates")
+                .field("chain_id", chain_id)
+                .field("heights", &CompressedHeights(heights))
+                .finish(),
+            RequestKey::Blob(blob_id) => f.debug_tuple("Blob").field(blob_id).finish(),
+            RequestKey::PendingBlob { chain_id, blob_id } => f
+                .debug_struct("PendingBlob")
+                .field("chain_id", chain_id)
+                .field("blob_id", blob_id)
+                .finish(),
+            RequestKey::CertificateForBlob(blob_id) => {
+                f.debug_tuple("CertificateForBlob").field(blob_id).finish()
+            }
+        }
+    }
 }
 
 impl RequestKey {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -94,7 +94,7 @@ pub struct ChainInfoQuery {
     #[debug(skip_if = Not::not)]
     pub request_fallback: bool,
     /// Query for certificate hashes at block heights.
-    #[debug(skip_if = Vec::is_empty)]
+    #[debug(skip_if = Vec::is_empty, with = "debug_compressed_heights")]
     pub request_sent_certificate_hashes_by_heights: Vec<BlockHeight>,
     #[serde(default = "default_true")]
     pub create_network_actions: bool,
@@ -346,10 +346,60 @@ impl ChainInfoResponse {
 impl BcsSignable<'_> for ChainInfo {}
 
 /// Request for downloading certificates by heights.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CertificatesByHeightRequest {
     pub chain_id: ChainId,
     pub heights: Vec<BlockHeight>,
+}
+
+/// Wrapper for displaying a sorted slice of [`BlockHeight`] as compressed ranges.
+///
+/// Contiguous heights are shown as `start..end` (inclusive), with gaps producing
+/// comma-separated entries: `[14810..15309, 15311, 15320..15400]`.
+pub(crate) struct CompressedHeights<'a>(pub(crate) &'a [BlockHeight]);
+
+/// Formats a `Vec<BlockHeight>` as compressed ranges for use with `#[debug(with = "...")]`.
+#[allow(clippy::ptr_arg)]
+pub(crate) fn debug_compressed_heights(
+    heights: &Vec<BlockHeight>,
+    f: &mut fmt::Formatter<'_>,
+) -> fmt::Result {
+    fmt::Debug::fmt(&CompressedHeights(heights), f)
+}
+
+impl fmt::Debug for CompressedHeights<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let heights = self.0;
+        write!(f, "[")?;
+        let mut index = 0;
+        while index < heights.len() {
+            if index > 0 {
+                write!(f, ", ")?;
+            }
+            let range_start = u64::from(heights[index]);
+            let mut range_end = range_start;
+            while index + 1 < heights.len() && u64::from(heights[index + 1]) == range_end + 1 {
+                index += 1;
+                range_end = u64::from(heights[index]);
+            }
+            if range_start == range_end {
+                write!(f, "{range_start}")?;
+            } else {
+                write!(f, "{range_start}..{range_end}")?;
+            }
+            index += 1;
+        }
+        write!(f, "]")
+    }
+}
+
+impl fmt::Debug for CertificatesByHeightRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CertificatesByHeightRequest")
+            .field("chain_id", &self.chain_id)
+            .field("heights", &CompressedHeights(&self.heights))
+            .finish()
+    }
 }
 
 /// The outcome of trying to commit a list of operations to the chain.
@@ -420,5 +470,58 @@ impl<T> ClientOutcome<T> {
             ClientOutcome::WaitForTimeout(timeout) => Ok(ClientOutcome::WaitForTimeout(timeout)),
             ClientOutcome::Conflict(certificate) => Ok(ClientOutcome::Conflict(certificate)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::data_types::BlockHeight;
+
+    use super::CompressedHeights;
+
+    #[test]
+    fn test_compressed_heights_empty() {
+        let heights: Vec<BlockHeight> = vec![];
+        assert_eq!(format!("{:?}", CompressedHeights(&heights)), "[]");
+    }
+
+    #[test]
+    fn test_compressed_heights_single() {
+        let heights = vec![BlockHeight::from(5)];
+        assert_eq!(format!("{:?}", CompressedHeights(&heights)), "[5]");
+    }
+
+    #[test]
+    fn test_compressed_heights_contiguous() {
+        let heights: Vec<BlockHeight> = (100..=105).map(BlockHeight::from).collect();
+        assert_eq!(format!("{:?}", CompressedHeights(&heights)), "[100..105]");
+    }
+
+    #[test]
+    fn test_compressed_heights_with_gaps() {
+        let heights = vec![
+            BlockHeight::from(1),
+            BlockHeight::from(2),
+            BlockHeight::from(3),
+            BlockHeight::from(5),
+            BlockHeight::from(7),
+            BlockHeight::from(8),
+            BlockHeight::from(9),
+            BlockHeight::from(10),
+        ];
+        assert_eq!(
+            format!("{:?}", CompressedHeights(&heights)),
+            "[1..3, 5, 7..10]"
+        );
+    }
+
+    #[test]
+    fn test_compressed_heights_all_isolated() {
+        let heights = vec![
+            BlockHeight::from(1),
+            BlockHeight::from(5),
+            BlockHeight::from(10),
+        ];
+        assert_eq!(format!("{:?}", CompressedHeights(&heights)), "[1, 5, 10]");
     }
 }

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -378,7 +378,9 @@ impl fmt::Debug for CompressedHeights<'_> {
             }
             let range_start = u64::from(heights[index]);
             let mut range_end = range_start;
-            while index + 1 < heights.len() && u64::from(heights[index + 1]) == range_end + 1 {
+            while index + 1 < heights.len()
+                && range_end.checked_add(1) == Some(u64::from(heights[index + 1]))
+            {
                 index += 1;
                 range_end = u64::from(heights[index]);
             }


### PR DESCRIPTION
## Motivation

Backport of #5953.

When syncing a chain, each certificate batch download logs a
`CertificatesByHeightRequest` via the `client_delegate!` debug macro. With batch size
500, this produces ~15KB log lines listing every individual `BlockHeight(N)`:

```
request=CertificatesByHeightRequest { chain_id: 01fc3cf7..., heights:
[BlockHeight(14810), BlockHeight(14811), BlockHeight(14812), ... BlockHeight(15309)] }
```

The same problem affects `RequestKey::Certificates` in scheduler trace logs and
`ChainInfoQuery::request_sent_certificate_hashes_by_heights` in chain info query debug
logs.

## Proposal

Add a `CompressedHeights` formatter that displays contiguous block heights as ranges.
The same information, just readable:

```
request=CertificatesByHeightRequest { chain_id: 01fc3cf7..., heights: [14810..15309] }
```

Gaps are preserved: `[1..3, 5, 7..10]`.

Applied to all three structs that contain `Vec<BlockHeight>` fields logged at
debug/trace level:
- `CertificatesByHeightRequest` — custom `Debug` impl
- `RequestKey::Certificates` — custom `Debug` impl
- `ChainInfoQuery::request_sent_certificate_hashes_by_heights` — `#[debug(with =
"...")]`

## Test Plan

CI. Unit tests cover edge cases: empty, single element, contiguous range, gaps, and
all-isolated heights.
