### PR TITLE
Remove `ValueCache::get` and rename `get_hashed` as `get`.

### DIFF
--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -51,11 +51,6 @@ where
         Self::track_cache_usage(value)
     }
 
-    /// Returns a clone of the value from the cache, if present.
-    pub fn get(&self, key: &K) -> Option<V> {
-        Self::track_cache_usage(self.cache.get(key))
-    }
-
     /// Returns `true` if the cache contains an entry for the given key.
     pub fn contains(&self, key: &K) -> bool {
         self.cache.peek(key).is_some()
@@ -103,7 +98,7 @@ impl<T: Clone + Send + Sync + 'static> ValueCache<CryptoHash, T> {
     ///
     /// The hash used as the cache key is combined with the stored value to
     /// reconstruct the [`Hashed<T>`] without redundant storage.
-    pub fn get_hashed(&self, hash: &CryptoHash) -> Option<Hashed<T>> {
+    pub fn get(&self, hash: &CryptoHash) -> Option<Hashed<T>> {
         let value = Self::track_cache_usage(self.cache.get(hash))?;
         Some(Hashed::unchecked_new(value, *hash))
     }
@@ -178,7 +173,7 @@ mod tests {
         let cache = ValueCache::<CryptoHash, TestValue>::new(TEST_CACHE_SIZE);
         let hash = CryptoHash::test_hash("Missing value");
 
-        assert!(cache.get_hashed(&hash).is_none());
+        assert!(cache.get(&hash).is_none());
         assert!(!cache.contains(&hash));
     }
 
@@ -190,7 +185,7 @@ mod tests {
 
         assert!(cache.insert_hashed(Cow::Borrowed(&value)));
         assert!(cache.contains(&hash));
-        assert_eq!(cache.get_hashed(&hash), Some(value));
+        assert_eq!(cache.get(&hash), Some(value));
     }
 
     #[test]
@@ -204,7 +199,7 @@ mod tests {
 
         for value in &values {
             assert!(cache.contains(&value.hash()));
-            assert_eq!(cache.get_hashed(&value.hash()).as_ref(), Some(value));
+            assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
         }
     }
 
@@ -217,7 +212,7 @@ mod tests {
 
         for value in &values {
             assert!(cache.contains(&value.hash()));
-            assert_eq!(cache.get_hashed(&value.hash()).as_ref(), Some(value));
+            assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
         }
     }
 
@@ -234,7 +229,7 @@ mod tests {
 
         for value in &values {
             assert!(cache.contains(&value.hash()));
-            assert_eq!(cache.get_hashed(&value.hash()).as_ref(), Some(value));
+            assert_eq!(cache.get(&value.hash()).as_ref(), Some(value));
         }
     }
 
@@ -266,7 +261,7 @@ mod tests {
 
         // Insert the promoted entry first, then access it to mark it as "hot".
         cache.insert_hashed(Cow::Borrowed(&promoted));
-        cache.get_hashed(&promoted_hash);
+        cache.get(&promoted_hash);
 
         // Insert many more entries to force evictions.
         let extras = create_test_values(1..=TEST_CACHE_SIZE as u64 * 2);

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -400,7 +400,7 @@ where
         let mut uncached_hashes = Vec::new();
 
         for (i, hash) in hashes.iter().enumerate() {
-            if let Some(hashed_block) = self.block_values.get_hashed(hash) {
+            if let Some(hashed_block) = self.block_values.get(hash) {
                 blocks.push(Some(ConfirmedBlock::from_hashed(hashed_block)));
             } else {
                 blocks.push(None);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -635,7 +635,7 @@ where
     ) -> Result<Either<ConfirmedBlockCertificate, ValidatedBlockCertificate>, WorkerError> {
         let block = self
             .block_cache
-            .get_hashed(&certificate.value.value_hash)
+            .get(&certificate.value.value_hash)
             .ok_or(WorkerError::MissingCertificateValue)?;
 
         match certificate.value.kind {


### PR DESCRIPTION
## Motivation

Subsequent to PR #5803 we restructured the `block_cache` of `testnet_conway`.
But contrary to PR #5798, we had to keep `get` and `get_hashed` since both were used.
However, that is no longer the case after other changes.

## Proposal

Remove `get` from `value_cache` and rename `get_hashed` as `get`.
This aligns it with `main`.

## Test Plan

CI

## Release Plan

This is to `testnet_conway`.

## Links

None.