### PR TITLE
Implement the execution of messages together.

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -201,10 +201,8 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         C::Extra: ExecutionRuntimeContext,
     {
         Box::pin(async move {
-            // For Reject bundles or bundles with few messages, use the per-message path.
-            if incoming_bundle.action == MessageAction::Reject
-                || !Self::can_batch_bundle(incoming_bundle)
-            {
+            // For Reject bundles, use the per-message path.
+            if incoming_bundle.action == MessageAction::Reject {
                 for posted_message in incoming_bundle.messages() {
                     Box::pin(self.execute_message_in_block(
                         chain,
@@ -225,15 +223,13 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
 
             let messages: Vec<_> = incoming_bundle.messages().collect();
 
-            // Pre-group user messages by application, preserving order.
+            // Group user messages by application, preserving order.
             let mut app_batches: BTreeMap<ApplicationId, Vec<usize>> = BTreeMap::new();
             for (i, pm) in messages.iter().enumerate() {
                 if let Message::User { application_id, .. } = &pm.message {
                     app_batches.entry(*application_id).or_default().push(i);
                 }
             }
-            // Only apps with ≥2 messages benefit from batching.
-            app_batches.retain(|_, indices| indices.len() >= 2);
 
             let mut executed_apps: BTreeSet<ApplicationId> = BTreeSet::new();
             let mut i = 0;
@@ -241,51 +237,48 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             while i < messages.len() {
                 let posted_message = messages[i];
 
-                // Check if this message belongs to a batchable group.
+                // User messages are executed through the batched path.
                 if let Message::User { application_id, .. } = &posted_message.message {
-                    if let Some(indices) = app_batches.get(application_id) {
-                        if executed_apps.insert(*application_id) {
-                            // First time seeing this app — execute the whole batch.
-                            let app_id = *application_id;
-                            let batch: Vec<_> = indices
-                                .iter()
-                                .map(|&idx| {
-                                    let pm = messages[idx];
-                                    let context = MessageContext {
-                                        chain_id: self.chain_id,
-                                        origin: incoming_bundle.origin,
-                                        is_bouncing: pm.is_bouncing(),
-                                        height: self.block_height,
-                                        round,
-                                        authenticated_owner: pm.authenticated_owner,
-                                        refund_grant_to: pm.refund_grant_to,
-                                        timestamp: self.timestamp,
-                                    };
-                                    let Message::User { bytes, .. } = pm.message.clone() else {
-                                        unreachable!("already checked these are User messages")
-                                    };
-                                    (context, bytes, pm.grant)
-                                })
-                                .collect();
+                    if executed_apps.insert(*application_id) {
+                        let app_id = *application_id;
+                        let indices = &app_batches[&app_id];
+                        let batch: Vec<_> = indices
+                            .iter()
+                            .map(|&idx| {
+                                let pm = messages[idx];
+                                let context = MessageContext {
+                                    chain_id: self.chain_id,
+                                    origin: incoming_bundle.origin,
+                                    is_bouncing: pm.is_bouncing(),
+                                    height: self.block_height,
+                                    round,
+                                    authenticated_owner: pm.authenticated_owner,
+                                    refund_grant_to: pm.refund_grant_to,
+                                    timestamp: self.timestamp,
+                                };
+                                let Message::User { bytes, .. } = pm.message.clone() else {
+                                    unreachable!("already checked these are User messages")
+                                };
+                                (context, bytes, pm.grant)
+                            })
+                            .collect();
 
-                            let mut actor = ExecutionStateActor::new(
-                                chain,
-                                txn_tracker,
-                                self.resource_controller,
-                            );
-                            actor
-                                .execute_messages_batched(app_id, batch)
-                                .await
-                                .with_execution_context(chain_execution_context)?;
-                        }
-                        // Already executed as part of the batch — skip.
-                        i += 1;
-                        continue;
+                        let mut actor = ExecutionStateActor::new(
+                            chain,
+                            txn_tracker,
+                            self.resource_controller,
+                        );
+                        actor
+                            .execute_messages_batched(app_id, batch)
+                            .await
+                            .with_execution_context(chain_execution_context)?;
                     }
+                    // Already executed as part of the batch — skip.
+                    i += 1;
+                    continue;
                 }
 
-                // Single message, non-batchable user message, or system message:
-                // fall back to the per-message path.
+                // System messages: fall back to the per-message path.
                 Box::pin(self.execute_message_in_block(
                     chain,
                     posted_message,
@@ -299,24 +292,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
 
             Ok(())
         })
-    }
-
-    /// Returns true if the bundle contains at least two user messages targeting the
-    /// same application — the case where batched execution avoids redundant runtime
-    /// creation and finalize calls.
-    fn can_batch_bundle(incoming_bundle: &IncomingBundle) -> bool {
-        if incoming_bundle.action != MessageAction::Accept {
-            return false;
-        }
-        let mut seen = BTreeSet::new();
-        for pm in incoming_bundle.messages() {
-            if let Message::User { application_id, .. } = &pm.message {
-                if !seen.insert(application_id) {
-                    return true;
-                }
-            }
-        }
-        false
     }
 
     /// Executes a message as part of an incoming bundle in a block.

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -13,7 +13,7 @@ use linera_base::prometheus_util::MeasureLatency;
 use linera_base::{
     data_types::{Amount, Blob, BlockHeight, Event, OracleResponse, Timestamp},
     ensure,
-    identifiers::{AccountOwner, BlobId, ChainId, StreamId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, StreamId},
 };
 use linera_execution::{
     execution_state_actor::ExecutionStateActor, ExecutionRuntimeContext, ExecutionStateView,
@@ -218,47 +218,39 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                 return Ok(());
             }
 
-            // Accept bundle — group consecutive zero-grant user messages by application_id.
+            // Accept bundle — group all user messages by application_id.
             let chain_execution_context =
                 ChainExecutionContext::IncomingBundle(txn_tracker.transaction_index());
             ensure!(!chain.system.closed.get(), ChainError::ClosedChain);
 
             let messages: Vec<_> = incoming_bundle.messages().collect();
+
+            // Pre-group user messages by application, preserving order.
+            let mut app_batches: BTreeMap<ApplicationId, Vec<usize>> = BTreeMap::new();
+            for (i, pm) in messages.iter().enumerate() {
+                if let Message::User { application_id, .. } = &pm.message {
+                    app_batches.entry(*application_id).or_default().push(i);
+                }
+            }
+            // Only apps with ≥2 messages benefit from batching.
+            app_batches.retain(|_, indices| indices.len() >= 2);
+
+            let mut executed_apps: BTreeSet<ApplicationId> = BTreeSet::new();
             let mut i = 0;
 
             while i < messages.len() {
                 let posted_message = messages[i];
 
-                // Check if this starts a batchable group: zero-grant user message.
-                if posted_message.grant.is_zero() {
-                    if let Message::User { application_id, .. } = &posted_message.message {
-                        let app_id = *application_id;
-                        let start = i;
-                        let mut end = i + 1;
-                        // Extend the group while the next message is also a zero-grant
-                        // user message targeting the same application.
-                        while end < messages.len() {
-                            if !messages[end].grant.is_zero() {
-                                break;
-                            }
-                            let Message::User {
-                                application_id: next_app_id,
-                                ..
-                            } = &messages[end].message
-                            else {
-                                break;
-                            };
-                            if *next_app_id != app_id {
-                                break;
-                            }
-                            end += 1;
-                        }
-
-                        if end - start > 1 {
-                            // Build the batch of (context, bytes) pairs.
-                            let batch: Vec<_> = messages[start..end]
+                // Check if this message belongs to a batchable group.
+                if let Message::User { application_id, .. } = &posted_message.message {
+                    if let Some(indices) = app_batches.get(application_id) {
+                        if executed_apps.insert(*application_id) {
+                            // First time seeing this app — execute the whole batch.
+                            let app_id = *application_id;
+                            let batch: Vec<_> = indices
                                 .iter()
-                                .map(|pm| {
+                                .map(|&idx| {
+                                    let pm = messages[idx];
                                     let context = MessageContext {
                                         chain_id: self.chain_id,
                                         origin: incoming_bundle.origin,
@@ -272,7 +264,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                                     let Message::User { bytes, .. } = pm.message.clone() else {
                                         unreachable!("already checked these are User messages")
                                     };
-                                    (context, bytes)
+                                    (context, bytes, pm.grant)
                                 })
                                 .collect();
 
@@ -285,10 +277,10 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                                 .execute_messages_batched(app_id, batch)
                                 .await
                                 .with_execution_context(chain_execution_context)?;
-
-                            i = end;
-                            continue;
                         }
+                        // Already executed as part of the batch — skip.
+                        i += 1;
+                        continue;
                     }
                 }
 
@@ -309,32 +301,17 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         })
     }
 
-    /// Returns true if the bundle contains at least two consecutive zero-grant user
-    /// messages targeting the same application — the case where batched execution
-    /// avoids redundant runtime creation and finalize calls.
+    /// Returns true if the bundle contains at least two user messages targeting the
+    /// same application — the case where batched execution avoids redundant runtime
+    /// creation and finalize calls.
     fn can_batch_bundle(incoming_bundle: &IncomingBundle) -> bool {
         if incoming_bundle.action != MessageAction::Accept {
             return false;
         }
-        let messages: Vec<_> = incoming_bundle.messages().collect();
-        if messages.len() < 2 {
-            return false;
-        }
-        for window in messages.windows(2) {
-            let (pm_a, pm_b) = (window[0], window[1]);
-            if !pm_a.grant.is_zero() || !pm_b.grant.is_zero() {
-                continue;
-            }
-            if let (
-                Message::User {
-                    application_id: a, ..
-                },
-                Message::User {
-                    application_id: b, ..
-                },
-            ) = (&pm_a.message, &pm_b.message)
-            {
-                if a == b {
+        let mut seen = BTreeSet::new();
+        for pm in incoming_bundle.messages() {
+            if let Message::User { application_id, .. } = &pm.message {
+                if !seen.insert(application_id) {
                     return true;
                 }
             }

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -263,11 +263,8 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                             })
                             .collect();
 
-                        let mut actor = ExecutionStateActor::new(
-                            chain,
-                            txn_tracker,
-                            self.resource_controller,
-                        );
+                        let mut actor =
+                            ExecutionStateActor::new(chain, txn_tracker, self.resource_controller);
                         actor
                             .execute_messages_batched(app_id, batch)
                             .await

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    pin::Pin,
+};
 
 use custom_debug_derive::Debug;
 #[cfg(with_metrics)]
@@ -28,6 +32,12 @@ use crate::{
     },
     ChainError, ChainExecutionContext, ExecutionResultExt,
 };
+
+/// A boxed future that is `Send` on non-web targets but not required to be `Send` on web/wasm.
+#[cfg(not(web))]
+type BoxedFuture<'a> = Pin<Box<dyn Future<Output = Result<(), ChainError>> + Send + 'a>>;
+#[cfg(web)]
+type BoxedFuture<'a> = Pin<Box<dyn Future<Output = Result<(), ChainError>> + 'a>>;
 
 /// Tracks execution of transactions within a block.
 /// Captures the resource policy, produced messages, oracle responses and events.
@@ -121,16 +131,8 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                 self.resource_controller_mut()
                     .track_block_size_of(&incoming_bundle)
                     .with_execution_context(chain_execution_context)?;
-                for posted_message in incoming_bundle.messages() {
-                    Box::pin(self.execute_message_in_block(
-                        chain,
-                        posted_message,
-                        incoming_bundle,
-                        round,
-                        &mut txn_tracker,
-                    ))
+                self.execute_incoming_bundle(chain, incoming_bundle, round, &mut txn_tracker)
                     .await?;
-                }
             }
             Transaction::ExecuteOperation(operation) => {
                 self.resource_controller_mut()
@@ -178,6 +180,166 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             self.oracle_responses()?,
             &self.blobs,
         ))
+    }
+
+    /// Executes all messages in an incoming bundle. Groups consecutive zero-grant
+    /// user messages targeting the same application for batched execution
+    /// (shared runtime, single finalize).
+    ///
+    /// Returns a boxed `dyn Future` so its (deeply nested) internal type does not
+    /// inflate the `execute_transaction` future's `Send`-bound type graph, which
+    /// is walked by callers as deep as `linera-faucet-server`.
+    fn execute_incoming_bundle<'s, C>(
+        &'s mut self,
+        chain: &'s mut ExecutionStateView<C>,
+        incoming_bundle: &'s IncomingBundle,
+        round: Option<u32>,
+        txn_tracker: &'s mut TransactionTracker,
+    ) -> BoxedFuture<'s>
+    where
+        C: Context + Clone + 'static,
+        C::Extra: ExecutionRuntimeContext,
+    {
+        Box::pin(async move {
+            // For Reject bundles or bundles with few messages, use the per-message path.
+            if incoming_bundle.action == MessageAction::Reject
+                || !Self::can_batch_bundle(incoming_bundle)
+            {
+                for posted_message in incoming_bundle.messages() {
+                    Box::pin(self.execute_message_in_block(
+                        chain,
+                        posted_message,
+                        incoming_bundle,
+                        round,
+                        txn_tracker,
+                    ))
+                    .await?;
+                }
+                return Ok(());
+            }
+
+            // Accept bundle — group consecutive zero-grant user messages by application_id.
+            let chain_execution_context =
+                ChainExecutionContext::IncomingBundle(txn_tracker.transaction_index());
+            ensure!(!chain.system.closed.get(), ChainError::ClosedChain);
+
+            let messages: Vec<_> = incoming_bundle.messages().collect();
+            let mut i = 0;
+
+            while i < messages.len() {
+                let posted_message = messages[i];
+
+                // Check if this starts a batchable group: zero-grant user message.
+                if posted_message.grant.is_zero() {
+                    if let Message::User { application_id, .. } = &posted_message.message {
+                        let app_id = *application_id;
+                        let start = i;
+                        let mut end = i + 1;
+                        // Extend the group while the next message is also a zero-grant
+                        // user message targeting the same application.
+                        while end < messages.len() {
+                            if !messages[end].grant.is_zero() {
+                                break;
+                            }
+                            let Message::User {
+                                application_id: next_app_id,
+                                ..
+                            } = &messages[end].message
+                            else {
+                                break;
+                            };
+                            if *next_app_id != app_id {
+                                break;
+                            }
+                            end += 1;
+                        }
+
+                        if end - start > 1 {
+                            // Build the batch of (context, bytes) pairs.
+                            let batch: Vec<_> = messages[start..end]
+                                .iter()
+                                .map(|pm| {
+                                    let context = MessageContext {
+                                        chain_id: self.chain_id,
+                                        origin: incoming_bundle.origin,
+                                        is_bouncing: pm.is_bouncing(),
+                                        height: self.block_height,
+                                        round,
+                                        authenticated_owner: pm.authenticated_owner,
+                                        refund_grant_to: pm.refund_grant_to,
+                                        timestamp: self.timestamp,
+                                    };
+                                    let Message::User { bytes, .. } = pm.message.clone() else {
+                                        unreachable!("already checked these are User messages")
+                                    };
+                                    (context, bytes)
+                                })
+                                .collect();
+
+                            let mut actor = ExecutionStateActor::new(
+                                chain,
+                                txn_tracker,
+                                self.resource_controller,
+                            );
+                            actor
+                                .execute_messages_batched(app_id, batch)
+                                .await
+                                .with_execution_context(chain_execution_context)?;
+
+                            i = end;
+                            continue;
+                        }
+                    }
+                }
+
+                // Single message, non-batchable user message, or system message:
+                // fall back to the per-message path.
+                Box::pin(self.execute_message_in_block(
+                    chain,
+                    posted_message,
+                    incoming_bundle,
+                    round,
+                    txn_tracker,
+                ))
+                .await?;
+                i += 1;
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Returns true if the bundle contains at least two consecutive zero-grant user
+    /// messages targeting the same application — the case where batched execution
+    /// avoids redundant runtime creation and finalize calls.
+    fn can_batch_bundle(incoming_bundle: &IncomingBundle) -> bool {
+        if incoming_bundle.action != MessageAction::Accept {
+            return false;
+        }
+        let messages: Vec<_> = incoming_bundle.messages().collect();
+        if messages.len() < 2 {
+            return false;
+        }
+        for window in messages.windows(2) {
+            let (pm_a, pm_b) = (window[0], window[1]);
+            if !pm_a.grant.is_zero() || !pm_b.grant.is_zero() {
+                continue;
+            }
+            if let (
+                Message::User {
+                    application_id: a, ..
+                },
+                Message::User {
+                    application_id: b, ..
+                },
+            ) = (&pm_a.message, &pm_b.message)
+            {
+                if a == b {
+                    return true;
+                }
+            }
+        }
+        false
     }
 
     /// Executes a message as part of an incoming bundle in a block.

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -16,9 +16,10 @@ use linera_base::{
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, StreamId},
 };
 use linera_execution::{
-    execution_state_actor::ExecutionStateActor, ExecutionRuntimeContext, ExecutionStateView,
-    Message, MessageContext, MessageKind, OperationContext, OutgoingMessage, ResourceController,
-    ResourceTracker, SystemExecutionStateView, TransactionOutcome, TransactionTracker,
+    execution_state_actor::{ExecutionStateActor, MessageBatch},
+    ExecutionRuntimeContext, ExecutionStateView, Message, MessageContext, MessageKind,
+    OperationContext, OutgoingMessage, ResourceController, ResourceTracker,
+    SystemExecutionStateView, TransactionOutcome, TransactionTracker,
 };
 use linera_views::context::Context;
 use tracing::instrument;
@@ -182,20 +183,21 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         ))
     }
 
-    /// Executes all messages in an incoming bundle. Groups consecutive zero-grant
-    /// user messages targeting the same application for batched execution
-    /// (shared runtime, single finalize).
+    /// Executes all messages in an incoming bundle. User messages targeting the same
+    /// application share a runtime (batched execution with a single finalize), while
+    /// system messages use the per-message path. Messages are executed in their
+    /// original order within the bundle.
     ///
     /// Returns a boxed `dyn Future` so its (deeply nested) internal type does not
     /// inflate the `execute_transaction` future's `Send`-bound type graph, which
     /// is walked by callers as deep as `linera-faucet-server`.
-    fn execute_incoming_bundle<'s, C>(
-        &'s mut self,
-        chain: &'s mut ExecutionStateView<C>,
-        incoming_bundle: &'s IncomingBundle,
+    fn execute_incoming_bundle<'a, C>(
+        &'a mut self,
+        chain: &'a mut ExecutionStateView<C>,
+        incoming_bundle: &'a IncomingBundle,
         round: Option<u32>,
-        txn_tracker: &'s mut TransactionTracker,
-    ) -> BoxedFuture<'s>
+        txn_tracker: &'a mut TransactionTracker,
+    ) -> BoxedFuture<'a>
     where
         C: Context + Clone + 'static,
         C::Extra: ExecutionRuntimeContext,
@@ -216,75 +218,87 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                 return Ok(());
             }
 
-            // Accept bundle — group all user messages by application_id.
+            // Accept bundle — execute messages in original order, batching user
+            // messages by application (shared runtime, single finalize per app).
             let chain_execution_context =
                 ChainExecutionContext::IncomingBundle(txn_tracker.transaction_index());
             ensure!(!chain.system.closed.get(), ChainError::ClosedChain);
 
-            let messages: Vec<_> = incoming_bundle.messages().collect();
+            let mut actor = ExecutionStateActor::new(chain, txn_tracker, self.resource_controller);
 
-            // Group user messages by application, preserving order.
-            let mut app_batches: BTreeMap<ApplicationId, Vec<usize>> = BTreeMap::new();
-            for (i, pm) in messages.iter().enumerate() {
-                if let Message::User { application_id, .. } = &pm.message {
-                    app_batches.entry(*application_id).or_default().push(i);
-                }
-            }
+            let mut batches: BTreeMap<ApplicationId, MessageBatch> = BTreeMap::new();
 
-            let mut executed_apps: BTreeSet<ApplicationId> = BTreeSet::new();
-            let mut i = 0;
-
-            while i < messages.len() {
-                let posted_message = messages[i];
-
-                // User messages are executed through the batched path.
-                if let Message::User { application_id, .. } = &posted_message.message {
-                    if executed_apps.insert(*application_id) {
+            for posted_message in incoming_bundle.messages() {
+                match &posted_message.message {
+                    Message::User {
+                        application_id,
+                        bytes,
+                    } => {
                         let app_id = *application_id;
-                        let indices = &app_batches[&app_id];
-                        let batch: Vec<_> = indices
-                            .iter()
-                            .map(|&idx| {
-                                let pm = messages[idx];
-                                let context = MessageContext {
-                                    chain_id: self.chain_id,
-                                    origin: incoming_bundle.origin,
-                                    is_bouncing: pm.is_bouncing(),
-                                    height: self.block_height,
-                                    round,
-                                    authenticated_owner: pm.authenticated_owner,
-                                    refund_grant_to: pm.refund_grant_to,
-                                    timestamp: self.timestamp,
-                                };
-                                let Message::User { bytes, .. } = pm.message.clone() else {
-                                    unreachable!("already checked these are User messages")
-                                };
-                                (context, bytes, pm.grant)
-                            })
-                            .collect();
+                        let context = MessageContext {
+                            chain_id: self.chain_id,
+                            origin: incoming_bundle.origin,
+                            is_bouncing: posted_message.is_bouncing(),
+                            height: self.block_height,
+                            round,
+                            authenticated_owner: posted_message.authenticated_owner,
+                            refund_grant_to: posted_message.refund_grant_to,
+                            timestamp: self.timestamp,
+                        };
 
-                        let mut actor =
-                            ExecutionStateActor::new(chain, txn_tracker, self.resource_controller);
+                        // Lazily start a batch for this application.
+                        if let std::collections::btree_map::Entry::Vacant(e) = batches.entry(app_id)
+                        {
+                            let batch = actor
+                                .start_message_batch(app_id, context)
+                                .await
+                                .with_execution_context(chain_execution_context)?;
+                            e.insert(batch);
+                        }
+
+                        let batch = batches.get_mut(&app_id).expect("just inserted");
                         actor
-                            .execute_messages_batched(app_id, batch)
+                            .drive_message_in_batch(
+                                batch,
+                                context,
+                                bytes.clone(),
+                                posted_message.grant,
+                            )
                             .await
                             .with_execution_context(chain_execution_context)?;
                     }
-                    // Already executed as part of the batch — skip.
-                    i += 1;
-                    continue;
+                    Message::System(_) => {
+                        let context = MessageContext {
+                            chain_id: self.chain_id,
+                            origin: incoming_bundle.origin,
+                            is_bouncing: posted_message.is_bouncing(),
+                            height: self.block_height,
+                            round,
+                            authenticated_owner: posted_message.authenticated_owner,
+                            refund_grant_to: posted_message.refund_grant_to,
+                            timestamp: self.timestamp,
+                        };
+                        let mut grant = posted_message.grant;
+                        Box::pin(actor.execute_message(
+                            context,
+                            posted_message.message.clone(),
+                            (grant > Amount::ZERO).then_some(&mut grant),
+                        ))
+                        .await
+                        .with_execution_context(chain_execution_context)?;
+                        actor
+                            .send_refund(context, grant)
+                            .with_execution_context(chain_execution_context)?;
+                    }
                 }
+            }
 
-                // System messages: fall back to the per-message path.
-                Box::pin(self.execute_message_in_block(
-                    chain,
-                    posted_message,
-                    incoming_bundle,
-                    round,
-                    txn_tracker,
-                ))
-                .await?;
-                i += 1;
+            // Finalize all batches.
+            for (_app_id, batch) in batches {
+                actor
+                    .finalize_message_batch(batch)
+                    .await
+                    .with_execution_context(chain_execution_context)?;
             }
 
             Ok(())

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -246,14 +246,21 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                             timestamp: self.timestamp,
                         };
 
-                        // Lazily start a batch for this application.
-                        if let std::collections::btree_map::Entry::Vacant(e) = batches.entry(app_id)
-                        {
+                        // If this app doesn't have an active batch, finalize all
+                        // existing batches first so their state is flushed to views.
+                        // This ensures cross-app calls see up-to-date state.
+                        if !batches.contains_key(&app_id) {
+                            for (_id, batch) in std::mem::take(&mut batches) {
+                                actor
+                                    .finalize_message_batch(batch)
+                                    .await
+                                    .with_execution_context(chain_execution_context)?;
+                            }
                             let batch = actor
                                 .start_message_batch(app_id, context)
                                 .await
                                 .with_execution_context(chain_execution_context)?;
-                            e.insert(batch);
+                            batches.insert(app_id, batch);
                         }
 
                         let batch = batches.get_mut(&app_id).expect("just inserted");
@@ -268,6 +275,13 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                             .with_execution_context(chain_execution_context)?;
                     }
                     Message::System(_) => {
+                        // Finalize all batches before executing a system message.
+                        for (_id, batch) in std::mem::take(&mut batches) {
+                            actor
+                                .finalize_message_batch(batch)
+                                .await
+                                .with_execution_context(chain_execution_context)?;
+                        }
                         let context = MessageContext {
                             chain_id: self.chain_id,
                             origin: incoming_bundle.origin,
@@ -293,7 +307,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                 }
             }
 
-            // Finalize all batches.
+            // Finalize remaining batches.
             for (_app_id, batch) in batches {
                 actor
                     .finalize_message_batch(batch)

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -5,11 +5,13 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    future::Future,
+    pin::Pin,
     sync::Arc,
 };
 
 use custom_debug_derive::Debug;
-use futures::{channel::mpsc, StreamExt as _};
+use futures::{channel::mpsc, FutureExt as _, StreamExt as _};
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
@@ -39,6 +41,19 @@ use crate::{
     OperationContext, OutgoingMessage, ProcessStreamsContext, QueryContext, QueryOutcome,
     ResourceController, SystemMessage, TransactionTracker, UserContractCode, UserServiceCode,
 };
+
+/// A boxed future that is `Send` on non-web targets but not required to be `Send` on web/wasm.
+#[cfg(not(web))]
+type BoxedFuture<'a> = Pin<Box<dyn Future<Output = Result<(), ExecutionError>> + Send + 'a>>;
+#[cfg(web)]
+type BoxedFuture<'a> = Pin<Box<dyn Future<Output = Result<(), ExecutionError>> + 'a>>;
+
+/// A message action to be sent to the runtime thread during batched execution.
+struct BatchedMessageAction {
+    context: MessageContext,
+    bytes: Vec<u8>,
+    done: oneshot::Sender<Result<(), ExecutionError>>,
+}
 
 /// Actor for handling requests to the execution state.
 pub struct ExecutionStateActor<'a, C> {
@@ -1040,6 +1055,237 @@ where
         self.resource_controller.tracker = controller.tracker;
 
         Ok(())
+    }
+
+    /// Executes multiple user messages on a shared contract runtime, calling `finalize`
+    /// only once at the end. Between each message, the actor handles execution state
+    /// requests and runs `process_subscriptions`.
+    ///
+    /// All messages must target the same `application_id`, belong to the same bundle,
+    /// and have a zero grant — the batching fast path does not handle per-message grant
+    /// accounting.
+    ///
+    /// The returned future is explicitly boxed to hide its inner (deeply nested) type
+    /// from `Send`-bound checking at far-away call sites. Without this boxing the
+    /// transitive type graph in crates like `linera-faucet-server` would blow past
+    /// their `recursion_limit` during `Send` inference.
+    #[instrument(skip_all, fields(application_id = %application_id, batch_size = messages.len()))]
+    pub fn execute_messages_batched<'s>(
+        &'s mut self,
+        application_id: ApplicationId,
+        messages: Vec<(MessageContext, Vec<u8>)>,
+    ) -> BoxedFuture<'s> {
+        Box::pin(async move {
+            assert!(!messages.is_empty());
+
+            let chain_id = self.state.context().extra().chain_id();
+
+            let initial_balance = self
+                .resource_controller
+                .with_state(&mut self.state.system)
+                .await?
+                .balance()?;
+            let controller = ResourceController::new(
+                self.resource_controller.policy().clone(),
+                self.resource_controller.tracker,
+                initial_balance,
+            );
+
+            let is_free = self
+                .resource_controller
+                .policy()
+                .is_free_app(&application_id);
+
+            let (execution_state_sender, mut execution_state_receiver) =
+                futures::channel::mpsc::unbounded();
+
+            let (codes, descriptions): (Vec<_>, Vec<_>) =
+                self.contract_and_dependencies(application_id).await?;
+
+            let allow_application_logs = self
+                .state
+                .context()
+                .extra()
+                .execution_runtime_config()
+                .allow_application_logs;
+
+            // Channel for actor→runtime: sends per-message actions with a done signal.
+            let (action_sender, action_receiver) =
+                std::sync::mpsc::channel::<BatchedMessageAction>();
+
+            let first_context = messages[0].0;
+            let height = first_context.height;
+            let round = first_context.round;
+
+            // Spawn the runtime thread. It waits for actions on the channel, executes each
+            // without finalize, then finalizes once when the channel is closed.
+            let contract_runtime_task = self
+                .state
+                .context()
+                .extra()
+                .thread_pool()
+                .run_send(JsVec(codes), move |codes| async move {
+                    let mut controller = controller;
+                    controller.is_free = is_free;
+                    // The runtime is seeded from the first message; the executing-message
+                    // state and message bytes are updated per message before each action.
+                    let seed_action = UserAction::Message(first_context, Vec::new());
+                    let runtime = ContractSyncRuntime::new(
+                        execution_state_sender,
+                        chain_id,
+                        first_context.refund_grant_to,
+                        controller,
+                        &seed_action,
+                        allow_application_logs,
+                    );
+
+                    for (code, description) in codes.0.into_iter().zip(descriptions) {
+                        runtime.preload_contract(
+                            ApplicationId::from(&description),
+                            code,
+                            description,
+                        );
+                    }
+
+                    let mut last_signer = first_context.authenticated_owner;
+
+                    // Process all actions from the channel.
+                    while let Ok(action) = action_receiver.recv() {
+                        runtime.update_message_context(
+                            &action.context,
+                            action.context.refund_grant_to,
+                        );
+                        last_signer = action.context.authenticated_owner;
+
+                        let user_action = UserAction::Message(action.context, action.bytes);
+                        let result = runtime.run_action_without_finalize(
+                            application_id,
+                            chain_id,
+                            user_action,
+                        );
+
+                        let is_err = result.is_err();
+                        let _ = action.done.send(result.map(|_| ()));
+                        if is_err {
+                            // On error, skip finalize and abort the batch. The actor will
+                            // see the error on the done channel and stop sending.
+                            return Err(ExecutionError::InternalError(
+                                "Batch aborted due to action error",
+                            ));
+                        }
+                    }
+
+                    // All actions done — finalize and return the resource controller.
+                    runtime.finalize_and_finish(chain_id, last_signer, height, round)
+                })
+                .await;
+
+            self.resource_controller.is_free = is_free;
+
+            let mut batch_result: Result<(), ExecutionError> = Ok(());
+            for (msg_context, bytes) in messages {
+                match self
+                    .drive_batched_action(
+                        &action_sender,
+                        &mut execution_state_receiver,
+                        msg_context,
+                        bytes,
+                    )
+                    .await
+                {
+                    Ok(()) => {}
+                    Err(err) => {
+                        batch_result = Err(err);
+                        break;
+                    }
+                }
+                if let Err(err) = self.process_subscriptions(msg_context.into()).await {
+                    batch_result = Err(err);
+                    break;
+                }
+            }
+
+            // Drop the action sender to signal the runtime thread to finalize.
+            drop(action_sender);
+
+            // Drain remaining execution state requests (from finalize).
+            self.drain_execution_requests(&mut execution_state_receiver)
+                .await?;
+
+            let runtime_result = contract_runtime_task.await?;
+            self.resource_controller.is_free = false;
+
+            // Propagate any error encountered during the actor-side loop.
+            batch_result?;
+
+            let controller = runtime_result?;
+            self.resource_controller
+                .with_state(&mut self.state.system)
+                .await?
+                .merge_balance(initial_balance, controller.balance()?)?;
+            self.resource_controller.tracker = controller.tracker;
+
+            Ok(())
+        })
+    }
+
+    /// Sends a single batched message action to the runtime thread and drives the
+    /// actor-side request loop until the runtime signals completion.
+    ///
+    /// Returns a boxed `dyn Future` so its (deeply nested) internal state does not
+    /// inflate the enclosing `execute_messages_batched` future's type. Without this,
+    /// `Send`-bound inference at far-away call sites overflows the recursion limit.
+    fn drive_batched_action<'s>(
+        &'s mut self,
+        action_sender: &'s std::sync::mpsc::Sender<BatchedMessageAction>,
+        execution_state_receiver: &'s mut mpsc::UnboundedReceiver<ExecutionRequest>,
+        msg_context: MessageContext,
+        bytes: Vec<u8>,
+    ) -> BoxedFuture<'s> {
+        Box::pin(async move {
+            let (done_sender, done_receiver) = oneshot::channel();
+            let mut done_receiver = done_receiver.fuse();
+
+            action_sender
+                .send(BatchedMessageAction {
+                    context: msg_context,
+                    bytes,
+                    done: done_sender,
+                })
+                .map_err(|_| {
+                    ExecutionError::InternalError("Runtime thread terminated unexpectedly")
+                })?;
+
+            loop {
+                futures::select! {
+                    maybe_request = execution_state_receiver.next() => {
+                        if let Some(request) = maybe_request {
+                            self.handle_request(request).await?;
+                        }
+                    }
+                    result = &mut done_receiver => {
+                        return result.map_err(|_| ExecutionError::MissingRuntimeResponse)?;
+                    }
+                }
+            }
+        })
+    }
+
+    /// Drains any remaining execution-state requests after the batched runtime
+    /// thread has signalled it is done (typically emitted during `finalize`).
+    ///
+    /// Returned as a boxed `dyn Future` for the same `Send`-inference reasons as
+    /// `drive_batched_action`.
+    fn drain_execution_requests<'s>(
+        &'s mut self,
+        execution_state_receiver: &'s mut mpsc::UnboundedReceiver<ExecutionRequest>,
+    ) -> BoxedFuture<'s> {
+        Box::pin(async move {
+            while let Some(request) = execution_state_receiver.next().await {
+                self.handle_request(request).await?;
+            }
+            Ok(())
+        })
     }
 
     #[instrument(skip_all, fields(

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -52,7 +52,9 @@ type BoxedFuture<'a> = Pin<Box<dyn Future<Output = Result<(), ExecutionError>> +
 struct BatchedMessageAction {
     context: MessageContext,
     bytes: Vec<u8>,
-    done: oneshot::Sender<Result<(), ExecutionError>>,
+    grant: Amount,
+    /// Receives `Ok(grant_remainder)` on success, or an error.
+    done: oneshot::Sender<Result<Amount, ExecutionError>>,
 }
 
 /// Actor for handling requests to the execution state.
@@ -1059,22 +1061,23 @@ where
 
     /// Executes multiple user messages on a shared contract runtime, calling `finalize`
     /// only once at the end. Between each message, the actor handles execution state
-    /// requests and runs `process_subscriptions`.
+    /// requests, runs `process_subscriptions`, and issues grant refunds.
     ///
-    /// All messages must target the same `application_id`, belong to the same bundle,
-    /// and have a zero grant — the batching fast path does not handle per-message grant
-    /// accounting.
+    /// All messages must target the same `application_id` and belong to the same bundle.
+    /// Each message carries its own grant; the runtime credits the grant before execution
+    /// and computes the remainder afterwards so that the actor can issue per-message
+    /// refunds.
     ///
     /// The returned future is explicitly boxed to hide its inner (deeply nested) type
     /// from `Send`-bound checking at far-away call sites. Without this boxing the
     /// transitive type graph in crates like `linera-faucet-server` would blow past
     /// their `recursion_limit` during `Send` inference.
     #[instrument(skip_all, fields(application_id = %application_id, batch_size = messages.len()))]
-    pub fn execute_messages_batched<'s>(
-        &'s mut self,
+    pub fn execute_messages_batched<'b>(
+        &'b mut self,
         application_id: ApplicationId,
-        messages: Vec<(MessageContext, Vec<u8>)>,
-    ) -> BoxedFuture<'s> {
+        messages: Vec<(MessageContext, Vec<u8>, Amount)>,
+    ) -> BoxedFuture<'b> {
         Box::pin(async move {
             assert!(!messages.is_empty());
 
@@ -1157,6 +1160,10 @@ where
                         );
                         last_signer = action.context.authenticated_owner;
 
+                        // Credit the grant before execution so the runtime can draw from it.
+                        let balance_before = runtime.resource_controller_balance()?;
+                        runtime.credit_resource_controller(action.grant)?;
+
                         let user_action = UserAction::Message(action.context, action.bytes);
                         let result = runtime.run_action_without_finalize(
                             application_id,
@@ -1164,13 +1171,25 @@ where
                             user_action,
                         );
 
-                        let is_err = result.is_err();
-                        let _ = action.done.send(result.map(|_| ()));
-                        if is_err {
+                        if let Err(err) = result {
+                            let _ = action.done.send(Err(err));
                             // On error, skip finalize and abort the batch. The actor will
                             // see the error on the done channel and stop sending.
                             return Err(ExecutionError::InternalError(
                                 "Batch aborted due to action error",
+                            ));
+                        }
+
+                        // Compute the grant remainder and remove it from the balance.
+                        // If cost <= grant: remainder = grant - cost, base balance unchanged.
+                        // If cost > grant: remainder = 0, base balance reduced by (cost - grant).
+                        let balance_after = runtime.resource_controller_balance()?;
+                        let grant_remainder = balance_after.saturating_sub(balance_before);
+                        runtime.debit_resource_controller(grant_remainder)?;
+
+                        if action.done.send(Ok(grant_remainder)).is_err() {
+                            return Err(ExecutionError::InternalError(
+                                "Actor dropped done receiver",
                             ));
                         }
                     }
@@ -1183,13 +1202,14 @@ where
             self.resource_controller.is_free = is_free;
 
             let mut batch_result: Result<(), ExecutionError> = Ok(());
-            for (msg_context, bytes) in messages {
+            for (msg_context, bytes, grant) in messages {
                 match self
                     .drive_batched_action(
                         &action_sender,
                         &mut execution_state_receiver,
                         msg_context,
                         bytes,
+                        grant,
                     )
                     .await
                 {
@@ -1235,13 +1255,14 @@ where
     /// Returns a boxed `dyn Future` so its (deeply nested) internal state does not
     /// inflate the enclosing `execute_messages_batched` future's type. Without this,
     /// `Send`-bound inference at far-away call sites overflows the recursion limit.
-    fn drive_batched_action<'s>(
-        &'s mut self,
-        action_sender: &'s std::sync::mpsc::Sender<BatchedMessageAction>,
-        execution_state_receiver: &'s mut mpsc::UnboundedReceiver<ExecutionRequest>,
+    fn drive_batched_action<'b>(
+        &'b mut self,
+        action_sender: &'b std::sync::mpsc::Sender<BatchedMessageAction>,
+        execution_state_receiver: &'b mut mpsc::UnboundedReceiver<ExecutionRequest>,
         msg_context: MessageContext,
         bytes: Vec<u8>,
-    ) -> BoxedFuture<'s> {
+        grant: Amount,
+    ) -> BoxedFuture<'b> {
         Box::pin(async move {
             let (done_sender, done_receiver) = oneshot::channel();
             let mut done_receiver = done_receiver.fuse();
@@ -1250,13 +1271,14 @@ where
                 .send(BatchedMessageAction {
                     context: msg_context,
                     bytes,
+                    grant,
                     done: done_sender,
                 })
                 .map_err(|_| {
                     ExecutionError::InternalError("Runtime thread terminated unexpectedly")
                 })?;
 
-            loop {
+            let grant_remainder = loop {
                 futures::select! {
                     maybe_request = execution_state_receiver.next() => {
                         if let Some(request) = maybe_request {
@@ -1264,10 +1286,14 @@ where
                         }
                     }
                     result = &mut done_receiver => {
-                        return result.map_err(|_| ExecutionError::MissingRuntimeResponse)?;
+                        break result.map_err(|_| ExecutionError::MissingRuntimeResponse)??;
                     }
                 }
-            }
+            };
+
+            self.send_refund(msg_context, grant_remainder)?;
+
+            Ok(())
         })
     }
 
@@ -1276,10 +1302,10 @@ where
     ///
     /// Returned as a boxed `dyn Future` for the same `Send`-inference reasons as
     /// `drive_batched_action`.
-    fn drain_execution_requests<'s>(
-        &'s mut self,
-        execution_state_receiver: &'s mut mpsc::UnboundedReceiver<ExecutionRequest>,
-    ) -> BoxedFuture<'s> {
+    fn drain_execution_requests<'b>(
+        &'b mut self,
+        execution_state_receiver: &'b mut mpsc::UnboundedReceiver<ExecutionRequest>,
+    ) -> BoxedFuture<'b> {
         Box::pin(async move {
             while let Some(request) = execution_state_receiver.next().await {
                 self.handle_request(request).await?;

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -57,6 +57,31 @@ struct BatchedMessageAction {
     done: oneshot::Sender<Result<Amount, ExecutionError>>,
 }
 
+/// A boxed future that resolves to the runtime thread's result.
+#[cfg(not(web))]
+type RuntimeTask = Pin<
+    Box<
+        dyn Future<Output = Result<Result<ResourceController, ExecutionError>, ExecutionError>>
+            + Send,
+    >,
+>;
+#[cfg(web)]
+type RuntimeTask = Pin<
+    Box<dyn Future<Output = Result<Result<ResourceController, ExecutionError>, ExecutionError>>>,
+>;
+
+/// Handle for an in-progress batched message execution.
+///
+/// Created by [`ExecutionStateActor::start_message_batch`], fed messages via
+/// [`ExecutionStateActor::drive_message_in_batch`], and finalized via
+/// [`ExecutionStateActor::finalize_message_batch`].
+pub struct MessageBatch {
+    action_sender: std::sync::mpsc::Sender<BatchedMessageAction>,
+    execution_state_receiver: mpsc::UnboundedReceiver<ExecutionRequest>,
+    runtime_task: RuntimeTask,
+    initial_balance: Amount,
+}
+
 /// Actor for handling requests to the execution state.
 pub struct ExecutionStateActor<'a, C> {
     state: &'a mut ExecutionStateView<C>,
@@ -1059,206 +1084,131 @@ where
         Ok(())
     }
 
-    /// Executes multiple user messages on a shared contract runtime, calling `finalize`
-    /// only once at the end. Between each message, the actor handles execution state
-    /// requests, runs `process_subscriptions`, and issues grant refunds.
+    /// Starts a batched message execution for the given application. Spawns a runtime
+    /// thread that waits for messages on a channel, executes each without finalize,
+    /// and finalizes once when the batch is finalized.
     ///
-    /// All messages must target the same `application_id` and belong to the same bundle.
-    /// Each message carries its own grant; the runtime credits the grant before execution
-    /// and computes the remainder afterwards so that the actor can issue per-message
-    /// refunds.
-    ///
-    /// The returned future is explicitly boxed to hide its inner (deeply nested) type
-    /// from `Send`-bound checking at far-away call sites. Without this boxing the
-    /// transitive type graph in crates like `linera-faucet-server` would blow past
-    /// their `recursion_limit` during `Send` inference.
-    #[instrument(skip_all, fields(application_id = %application_id, batch_size = messages.len()))]
-    pub fn execute_messages_batched<'b>(
-        &'b mut self,
+    /// `seed_context` is the first message's context, used to seed the runtime.
+    pub async fn start_message_batch(
+        &mut self,
         application_id: ApplicationId,
-        messages: Vec<(MessageContext, Vec<u8>, Amount)>,
-    ) -> BoxedFuture<'b> {
-        Box::pin(async move {
-            assert!(!messages.is_empty());
+        seed_context: MessageContext,
+    ) -> Result<MessageBatch, ExecutionError> {
+        let chain_id = self.state.context().extra().chain_id();
 
-            let chain_id = self.state.context().extra().chain_id();
+        let initial_balance = self
+            .resource_controller
+            .with_state(&mut self.state.system)
+            .await?
+            .balance()?;
+        let controller = ResourceController::new(
+            self.resource_controller.policy().clone(),
+            self.resource_controller.tracker,
+            initial_balance,
+        );
 
-            let initial_balance = self
-                .resource_controller
-                .with_state(&mut self.state.system)
-                .await?
-                .balance()?;
-            let controller = ResourceController::new(
-                self.resource_controller.policy().clone(),
-                self.resource_controller.tracker,
-                initial_balance,
-            );
+        let is_free = self
+            .resource_controller
+            .policy()
+            .is_free_app(&application_id);
 
-            let is_free = self
-                .resource_controller
-                .policy()
-                .is_free_app(&application_id);
+        let (execution_state_sender, execution_state_receiver) =
+            futures::channel::mpsc::unbounded();
 
-            let (execution_state_sender, mut execution_state_receiver) =
-                futures::channel::mpsc::unbounded();
+        let (codes, descriptions): (Vec<_>, Vec<_>) =
+            self.contract_and_dependencies(application_id).await?;
 
-            let (codes, descriptions): (Vec<_>, Vec<_>) =
-                self.contract_and_dependencies(application_id).await?;
+        let allow_application_logs = self
+            .state
+            .context()
+            .extra()
+            .execution_runtime_config()
+            .allow_application_logs;
 
-            let allow_application_logs = self
-                .state
-                .context()
-                .extra()
-                .execution_runtime_config()
-                .allow_application_logs;
+        let (action_sender, action_receiver) = std::sync::mpsc::channel::<BatchedMessageAction>();
 
-            // Channel for actor→runtime: sends per-message actions with a done signal.
-            let (action_sender, action_receiver) =
-                std::sync::mpsc::channel::<BatchedMessageAction>();
+        let height = seed_context.height;
+        let round = seed_context.round;
 
-            let first_context = messages[0].0;
-            let height = first_context.height;
-            let round = first_context.round;
+        // Spawn the runtime thread. It waits for actions on the channel, executes each
+        // without finalize, then finalizes once when the channel is closed.
+        let contract_runtime_task = self
+            .state
+            .context()
+            .extra()
+            .thread_pool()
+            .run_send(JsVec(codes), move |codes| async move {
+                let mut controller = controller;
+                controller.is_free = is_free;
+                let seed_action = UserAction::Message(seed_context, Vec::new());
+                let runtime = ContractSyncRuntime::new(
+                    execution_state_sender,
+                    chain_id,
+                    seed_context.refund_grant_to,
+                    controller,
+                    &seed_action,
+                    allow_application_logs,
+                );
 
-            // Spawn the runtime thread. It waits for actions on the channel, executes each
-            // without finalize, then finalizes once when the channel is closed.
-            let contract_runtime_task = self
-                .state
-                .context()
-                .extra()
-                .thread_pool()
-                .run_send(JsVec(codes), move |codes| async move {
-                    let mut controller = controller;
-                    controller.is_free = is_free;
-                    // The runtime is seeded from the first message; the executing-message
-                    // state and message bytes are updated per message before each action.
-                    let seed_action = UserAction::Message(first_context, Vec::new());
-                    let runtime = ContractSyncRuntime::new(
-                        execution_state_sender,
-                        chain_id,
-                        first_context.refund_grant_to,
-                        controller,
-                        &seed_action,
-                        allow_application_logs,
-                    );
+                for (code, description) in codes.0.into_iter().zip(descriptions) {
+                    runtime.preload_contract(ApplicationId::from(&description), code, description);
+                }
 
-                    for (code, description) in codes.0.into_iter().zip(descriptions) {
-                        runtime.preload_contract(
-                            ApplicationId::from(&description),
-                            code,
-                            description,
-                        );
+                let mut last_signer = seed_context.authenticated_owner;
+
+                while let Ok(action) = action_receiver.recv() {
+                    runtime.update_message_context(&action.context, action.context.refund_grant_to);
+                    last_signer = action.context.authenticated_owner;
+
+                    // Credit the grant before execution so the runtime can draw from it.
+                    let balance_before = runtime.resource_controller_balance()?;
+                    runtime.credit_resource_controller(action.grant)?;
+
+                    let user_action = UserAction::Message(action.context, action.bytes);
+                    let result =
+                        runtime.run_action_without_finalize(application_id, chain_id, user_action);
+
+                    if let Err(err) = result {
+                        let _ = action.done.send(Err(err));
+                        return Err(ExecutionError::InternalError(
+                            "Batch aborted due to action error",
+                        ));
                     }
 
-                    let mut last_signer = first_context.authenticated_owner;
+                    // Compute the grant remainder and remove it from the balance.
+                    // If cost <= grant: remainder = grant - cost, base balance unchanged.
+                    // If cost > grant: remainder = 0, base balance reduced by (cost - grant).
+                    let balance_after = runtime.resource_controller_balance()?;
+                    let grant_remainder = balance_after.saturating_sub(balance_before);
+                    runtime.debit_resource_controller(grant_remainder)?;
 
-                    // Process all actions from the channel.
-                    while let Ok(action) = action_receiver.recv() {
-                        runtime.update_message_context(
-                            &action.context,
-                            action.context.refund_grant_to,
-                        );
-                        last_signer = action.context.authenticated_owner;
-
-                        // Credit the grant before execution so the runtime can draw from it.
-                        let balance_before = runtime.resource_controller_balance()?;
-                        runtime.credit_resource_controller(action.grant)?;
-
-                        let user_action = UserAction::Message(action.context, action.bytes);
-                        let result = runtime.run_action_without_finalize(
-                            application_id,
-                            chain_id,
-                            user_action,
-                        );
-
-                        if let Err(err) = result {
-                            let _ = action.done.send(Err(err));
-                            // On error, skip finalize and abort the batch. The actor will
-                            // see the error on the done channel and stop sending.
-                            return Err(ExecutionError::InternalError(
-                                "Batch aborted due to action error",
-                            ));
-                        }
-
-                        // Compute the grant remainder and remove it from the balance.
-                        // If cost <= grant: remainder = grant - cost, base balance unchanged.
-                        // If cost > grant: remainder = 0, base balance reduced by (cost - grant).
-                        let balance_after = runtime.resource_controller_balance()?;
-                        let grant_remainder = balance_after.saturating_sub(balance_before);
-                        runtime.debit_resource_controller(grant_remainder)?;
-
-                        if action.done.send(Ok(grant_remainder)).is_err() {
-                            return Err(ExecutionError::InternalError(
-                                "Actor dropped done receiver",
-                            ));
-                        }
-                    }
-
-                    // All actions done — finalize and return the resource controller.
-                    runtime.finalize_and_finish(chain_id, last_signer, height, round)
-                })
-                .await;
-
-            self.resource_controller.is_free = is_free;
-
-            let mut batch_result: Result<(), ExecutionError> = Ok(());
-            for (msg_context, bytes, grant) in messages {
-                match self
-                    .drive_batched_action(
-                        &action_sender,
-                        &mut execution_state_receiver,
-                        msg_context,
-                        bytes,
-                        grant,
-                    )
-                    .await
-                {
-                    Ok(()) => {}
-                    Err(err) => {
-                        batch_result = Err(err);
-                        break;
+                    if action.done.send(Ok(grant_remainder)).is_err() {
+                        return Err(ExecutionError::InternalError("Actor dropped done receiver"));
                     }
                 }
-                if let Err(err) = self.process_subscriptions(msg_context.into()).await {
-                    batch_result = Err(err);
-                    break;
-                }
-            }
 
-            // Drop the action sender to signal the runtime thread to finalize.
-            drop(action_sender);
+                runtime.finalize_and_finish(chain_id, last_signer, height, round)
+            })
+            .await;
 
-            // Drain remaining execution state requests (from finalize).
-            self.drain_execution_requests(&mut execution_state_receiver)
-                .await?;
+        self.resource_controller.is_free = is_free;
 
-            let runtime_result = contract_runtime_task.await?;
-            self.resource_controller.is_free = false;
-
-            // Propagate any error encountered during the actor-side loop.
-            batch_result?;
-
-            let controller = runtime_result?;
-            self.resource_controller
-                .with_state(&mut self.state.system)
-                .await?
-                .merge_balance(initial_balance, controller.balance()?)?;
-            self.resource_controller.tracker = controller.tracker;
-
-            Ok(())
+        Ok(MessageBatch {
+            action_sender,
+            execution_state_receiver,
+            runtime_task: Box::pin(async move { contract_runtime_task.await.map_err(Into::into) }),
+            initial_balance,
         })
     }
 
-    /// Sends a single batched message action to the runtime thread and drives the
-    /// actor-side request loop until the runtime signals completion.
+    /// Sends a single message to an in-progress batch and drives the actor-side request
+    /// loop until the runtime signals completion. Issues a grant refund if applicable.
     ///
-    /// Returns a boxed `dyn Future` so its (deeply nested) internal state does not
-    /// inflate the enclosing `execute_messages_batched` future's type. Without this,
-    /// `Send`-bound inference at far-away call sites overflows the recursion limit.
-    fn drive_batched_action<'b>(
+    /// Returns a boxed `dyn Future` to hide its deeply nested internal type from
+    /// `Send`-bound inference at far-away call sites.
+    pub fn drive_message_in_batch<'b>(
         &'b mut self,
-        action_sender: &'b std::sync::mpsc::Sender<BatchedMessageAction>,
-        execution_state_receiver: &'b mut mpsc::UnboundedReceiver<ExecutionRequest>,
+        batch: &'b mut MessageBatch,
         msg_context: MessageContext,
         bytes: Vec<u8>,
         grant: Amount,
@@ -1267,7 +1217,8 @@ where
             let (done_sender, done_receiver) = oneshot::channel();
             let mut done_receiver = done_receiver.fuse();
 
-            action_sender
+            batch
+                .action_sender
                 .send(BatchedMessageAction {
                     context: msg_context,
                     bytes,
@@ -1280,7 +1231,7 @@ where
 
             let grant_remainder = loop {
                 futures::select! {
-                    maybe_request = execution_state_receiver.next() => {
+                    maybe_request = batch.execution_state_receiver.next() => {
                         if let Some(request) = maybe_request {
                             self.handle_request(request).await?;
                         }
@@ -1293,23 +1244,44 @@ where
 
             self.send_refund(msg_context, grant_remainder)?;
 
+            self.process_subscriptions(msg_context.into()).await?;
+
             Ok(())
         })
     }
 
-    /// Drains any remaining execution-state requests after the batched runtime
-    /// thread has signalled it is done (typically emitted during `finalize`).
+    /// Finalizes an in-progress batch: signals the runtime thread to finalize, drains
+    /// remaining execution-state requests, and merges the balance back.
     ///
-    /// Returned as a boxed `dyn Future` for the same `Send`-inference reasons as
-    /// `drive_batched_action`.
-    fn drain_execution_requests<'b>(
-        &'b mut self,
-        execution_state_receiver: &'b mut mpsc::UnboundedReceiver<ExecutionRequest>,
-    ) -> BoxedFuture<'b> {
+    /// Returns a boxed `dyn Future` to hide its deeply nested internal type from
+    /// `Send`-bound inference at far-away call sites.
+    pub fn finalize_message_batch(&mut self, batch: MessageBatch) -> BoxedFuture<'_> {
         Box::pin(async move {
+            let MessageBatch {
+                action_sender,
+                mut execution_state_receiver,
+                runtime_task,
+                initial_balance,
+            } = batch;
+
+            // Drop the action sender to signal the runtime thread to finalize.
+            drop(action_sender);
+
+            // Drain remaining execution state requests (from finalize).
             while let Some(request) = execution_state_receiver.next().await {
                 self.handle_request(request).await?;
             }
+
+            let runtime_result = runtime_task.await?;
+            self.resource_controller.is_free = false;
+
+            let controller = runtime_result?;
+            self.resource_controller
+                .with_state(&mut self.state.system)
+                .await?
+                .merge_balance(initial_balance, controller.balance()?)?;
+            self.resource_controller.tracker = controller.tracker;
+
             Ok(())
         })
     }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1155,6 +1155,43 @@ impl ContractSyncRuntime {
         inner.executing_message = Some(ExecutingMessage::from(context));
         inner.refund_grant_to = refund_grant_to;
     }
+
+    /// Returns the current balance of the resource controller.
+    pub(crate) fn resource_controller_balance(&self) -> Result<Amount, ExecutionError> {
+        let handle = self
+            .0
+            .as_ref()
+            .expect("Runtime should not be used after being consumed");
+        Ok(handle.inner().resource_controller.balance()?)
+    }
+
+    /// Credits the resource controller balance by the given amount.
+    pub(crate) fn credit_resource_controller(&self, amount: Amount) -> Result<(), ExecutionError> {
+        let handle = self
+            .0
+            .as_ref()
+            .expect("Runtime should not be used after being consumed");
+        handle
+            .inner()
+            .resource_controller
+            .account
+            .try_add_assign(amount)?;
+        Ok(())
+    }
+
+    /// Debits the resource controller balance by the given amount.
+    pub(crate) fn debit_resource_controller(&self, amount: Amount) -> Result<(), ExecutionError> {
+        let handle = self
+            .0
+            .as_ref()
+            .expect("Runtime should not be used after being consumed");
+        handle
+            .inner()
+            .resource_controller
+            .account
+            .try_sub_assign(amount)?;
+        Ok(())
+    }
 }
 
 impl ContractSyncRuntimeHandle {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1104,6 +1104,57 @@ impl ContractSyncRuntime {
 
         Ok((result, runtime.resource_controller))
     }
+
+    /// Executes a single action without finalizing. Used for batched message execution
+    /// where multiple messages share a runtime and finalize is called once at the end.
+    pub(crate) fn run_action_without_finalize(
+        &self,
+        application_id: ApplicationId,
+        chain_id: ChainId,
+        action: UserAction,
+    ) -> Result<Option<Vec<u8>>, ExecutionError> {
+        self.0
+            .as_ref()
+            .expect("Runtime should not be used after being consumed")
+            .run_action_without_finalize(application_id, chain_id, action)
+    }
+
+    /// Finalizes all loaded applications and consumes the runtime, returning
+    /// the resource controller.
+    pub(crate) fn finalize_and_finish(
+        mut self,
+        chain_id: ChainId,
+        authenticated_owner: Option<AccountOwner>,
+        height: BlockHeight,
+        round: Option<u32>,
+    ) -> Result<ResourceController, ExecutionError> {
+        let finalize_context = FinalizeContext {
+            authenticated_owner,
+            chain_id,
+            height,
+            round,
+        };
+        self.deref_mut().finalize(finalize_context)?;
+        let runtime = self
+            .into_inner()
+            .expect("Runtime clones should have been freed by now");
+        Ok(runtime.resource_controller)
+    }
+
+    /// Updates the per-message context for the next message in a batch.
+    pub(crate) fn update_message_context(
+        &self,
+        context: &MessageContext,
+        refund_grant_to: Option<Account>,
+    ) {
+        let handle = self
+            .0
+            .as_ref()
+            .expect("Runtime should not be used after being consumed");
+        let mut inner = handle.inner();
+        inner.executing_message = Some(ExecutingMessage::from(context));
+        inner.refund_grant_to = refund_grant_to;
+    }
 }
 
 impl ContractSyncRuntimeHandle {
@@ -1144,6 +1195,37 @@ impl ContractSyncRuntimeHandle {
         let result = self.execute(application_id, signer, closure)?;
         self.finalize(finalize_context)?;
         Ok(result)
+    }
+
+    /// Executes a single action without calling finalize afterwards.
+    #[instrument(skip_all, fields(application_id = %application_id))]
+    fn run_action_without_finalize(
+        &self,
+        application_id: ApplicationId,
+        chain_id: ChainId,
+        action: UserAction,
+    ) -> Result<Option<Vec<u8>>, ExecutionError> {
+        {
+            let runtime = self.inner();
+            assert_eq!(runtime.chain_id, chain_id);
+            assert_eq!(runtime.height, action.height());
+        }
+
+        let signer = action.signer();
+        let closure = move |code: &mut UserContractInstance| match action {
+            UserAction::Instantiate(_context, argument) => {
+                code.instantiate(argument).map(|()| None)
+            }
+            UserAction::Operation(_context, operation) => {
+                code.execute_operation(operation).map(Option::Some)
+            }
+            UserAction::Message(_context, message) => code.execute_message(message).map(|()| None),
+            UserAction::ProcessStreams(_context, updates) => {
+                code.process_streams(updates).map(|()| None)
+            }
+        };
+
+        self.execute(application_id, signer, closure)
     }
 
     /// Notifies all loaded applications that execution is finalizing.


### PR DESCRIPTION
## Motivation

When executing the messages of a `IncomingBundle`, we have a bunch of messages to execute.
However, when doing so, if we have say 10 messages to the same application, then what happens
is that 10 times the instance is created and 10 times the `finalize()`.

Fixes #5698 

## Proposal

Call finalize only at the end of the message bundle.

## Test Plan

CI.

## Release Plan

This is a breaking change that cannot be backported to `testnet_conway`.

## Links

None.