### PR TITLE
[testnet] Group operations for maybe_get_required_blobs

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -552,6 +552,24 @@ where
         self.locking_blobs.get(blob_id).await
     }
 
+    /// Returns the requested blobs if they belong to the proposal or the locking block.
+    pub async fn pending_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<Option<Blob>>, ViewError> {
+        let mut blobs = self.proposed_blobs.multi_get(blob_ids).await?;
+        let mut missing_indices = Vec::new();
+        let mut missing_blob_ids = Vec::new();
+        for (i, (blob, blob_id)) in blobs.iter().zip(blob_ids).enumerate() {
+            if blob.is_none() {
+                missing_indices.push(i);
+                missing_blob_ids.push(blob_id);
+            }
+        }
+        let second_blobs = self.locking_blobs.multi_get(missing_blob_ids).await?;
+        for (blob, i) in second_blobs.into_iter().zip(missing_indices) {
+            blobs[i] = blob;
+        }
+        Ok(blobs)
+    }
+
     /// Updates `current_round` and `round_timeout` if necessary.
     ///
     /// This must be called after every change to `timeout`, `locking`, `proposed` or

--- a/linera-chain/src/pending_blobs.rs
+++ b/linera-chain/src/pending_blobs.rs
@@ -43,6 +43,16 @@ impl<C> PendingBlobsView<C>
 where
     C: Clone + Context,
 {
+    pub async fn multi_get(&self, blob_ids: &[BlobId]) -> Result<Vec<Option<Blob>>, ViewError> {
+        Ok(self
+            .pending_blobs
+            .multi_get(blob_ids)
+            .await?
+            .into_iter()
+            .map(|x| x.flatten())
+            .collect())
+    }
+
     pub async fn get(&self, blob_id: &BlobId) -> Result<Option<Blob>, ViewError> {
         Ok(self.pending_blobs.get(blob_id).await?.flatten())
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2127,7 +2127,7 @@ where
     }
 }
 
-/// Returns the missing indices and corresponding blob_ids.
+/// Returns the missing indices and corresponding blob IDs.
 fn missing_indices_blob_ids(maybe_blobs: &[(BlobId, Option<Blob>)]) -> (Vec<usize>, Vec<BlobId>) {
     let mut missing_indices = Vec::new();
     let mut missing_blob_ids = Vec::new();

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -6,7 +6,6 @@
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap},
-    iter,
     sync::{self, Arc},
 };
 
@@ -286,40 +285,61 @@ where
     async fn maybe_get_required_blobs(
         &self,
         blob_ids: impl IntoIterator<Item = BlobId>,
-        mut created_blobs: Option<BTreeMap<BlobId, Blob>>,
+        created_blobs: Option<BTreeMap<BlobId, Blob>>,
     ) -> Result<BTreeMap<BlobId, Option<Blob>>, WorkerError> {
-        let mut maybe_blobs = BTreeMap::from_iter(blob_ids.into_iter().zip(iter::repeat(None)));
+        let maybe_blobs = blob_ids.into_iter().collect::<BTreeSet<_>>();
+        let mut maybe_blobs = maybe_blobs
+            .into_iter()
+            .map(|x| (x, None))
+            .collect::<Vec<(BlobId, Option<Blob>)>>();
 
-        for (blob_id, maybe_blob) in &mut maybe_blobs {
-            if let Some(blob) = created_blobs
-                .as_mut()
-                .and_then(|blob_map| blob_map.remove(blob_id))
-            {
-                *maybe_blob = Some(blob);
-            } else if let Some(blob) = self.chain.manager.pending_blob(blob_id).await? {
-                *maybe_blob = Some(blob);
-            } else if let Some(blob) = self.chain.pending_validated_blobs.get(blob_id).await? {
-                *maybe_blob = Some(blob);
-            } else {
-                for (_, pending_blobs) in self
-                    .chain
-                    .pending_proposed_blobs
-                    .try_load_all_entries()
-                    .await?
-                {
-                    if let Some(blob) = pending_blobs.get(blob_id).await? {
-                        *maybe_blob = Some(blob);
+        if let Some(mut blob_map) = created_blobs {
+            for (blob_id, value) in &mut maybe_blobs {
+                if let Some(blob) = blob_map.remove(blob_id) {
+                    *value = Some(blob);
+                }
+            }
+        }
+
+        let (missing_indices, missing_blob_ids) = missing_indices_blob_ids(&maybe_blobs);
+        let second_block_blobs = self.chain.manager.pending_blobs(&missing_blob_ids).await?;
+        for (index, blob) in missing_indices.into_iter().zip(second_block_blobs) {
+            maybe_blobs[index].1 = blob;
+        }
+
+        let (missing_indices, missing_blob_ids) = missing_indices_blob_ids(&maybe_blobs);
+        let third_block_blobs = self
+            .chain
+            .pending_validated_blobs
+            .multi_get(&missing_blob_ids)
+            .await?;
+        for (index, blob) in missing_indices.into_iter().zip(third_block_blobs) {
+            maybe_blobs[index].1 = blob;
+        }
+
+        let (missing_indices, missing_blob_ids) = missing_indices_blob_ids(&maybe_blobs);
+        if !missing_indices.is_empty() {
+            let all_entries_pending_blobs = self
+                .chain
+                .pending_proposed_blobs
+                .try_load_all_entries()
+                .await?;
+            for (index, blob_id) in missing_indices.into_iter().zip(missing_blob_ids) {
+                for (_, pending_blobs) in &all_entries_pending_blobs {
+                    if let Some(blob) = pending_blobs.get(&blob_id).await? {
+                        maybe_blobs[index].1 = Some(blob);
                         break;
                     }
                 }
             }
         }
-        let missing_blob_ids = missing_blob_ids(&maybe_blobs);
-        let blobs_from_storage = self.storage.read_blobs(&missing_blob_ids).await?;
-        for (blob_id, maybe_blob) in missing_blob_ids.into_iter().zip(blobs_from_storage) {
-            maybe_blobs.insert(blob_id, maybe_blob);
+
+        let (missing_indices, missing_blob_ids) = missing_indices_blob_ids(&maybe_blobs);
+        let fourth_block_blobs = self.storage.read_blobs(&missing_blob_ids).await?;
+        for (index, blob) in missing_indices.into_iter().zip(fourth_block_blobs) {
+            maybe_blobs[index].1 = blob;
         }
-        Ok(maybe_blobs)
+        Ok(maybe_blobs.into_iter().collect())
     }
 
     /// Creates cross-chain requests for a single recipient from its outbox.
@@ -2105,6 +2125,19 @@ where
         }
         Ok(())
     }
+}
+
+/// Returns the missing indices and corresponding blob_ids.
+fn missing_indices_blob_ids(maybe_blobs: &[(BlobId, Option<Blob>)]) -> (Vec<usize>, Vec<BlobId>) {
+    let mut missing_indices = Vec::new();
+    let mut missing_blob_ids = Vec::new();
+    for (index, (blob_id, blob)) in maybe_blobs.iter().enumerate() {
+        if blob.is_none() {
+            missing_indices.push(index);
+            missing_blob_ids.push(*blob_id);
+        }
+    }
+    (missing_indices, missing_blob_ids)
 }
 
 /// Returns the blob IDs whose corresponding value is `None`.


### PR DESCRIPTION
## Motivation

The pending_proposed_blobs needs to be simplified. But before that, we can restructure the access code.

Backport #4938 

## Proposal

Process the different cases by blocks so as to group the operations.

## Test Plan

CI

## Release Plan

This is the backport to `testnet_conway`.

## Links

None.