### PR TITLE
[testnet] Add error_type label to server and proxy error metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5607,6 +5607,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "social",
+ "strum 0.26.3",
  "sync_wrapper 1.0.2",
  "test-case",
  "test-log",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4026,6 +4026,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "strum 0.26.3",
  "sync_wrapper 1.0.2",
  "test-log",
  "test-strategy",

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -32,7 +32,7 @@ use linera_execution::ExecutionError;
 use linera_views::ViewError;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, strum::IntoStaticStr)]
 pub enum ChainError {
     #[error("Cryptographic error: {0}")]
     CryptoError(#[from] CryptoError),
@@ -211,6 +211,21 @@ impl ChainError {
             | ChainError::InternalError(_)
             | ChainError::BcsError(_) => true,
             ChainError::ExecutionError(execution_error, _) => execution_error.is_local(),
+        }
+    }
+
+    /// Returns the qualified error variant name for the `error_type` metric label,
+    /// e.g. `"ChainError::UnexpectedBlockHeight"`.
+    ///
+    /// For `ExecutionError` variants, delegates to `ExecutionError::error_type()`
+    /// to surface the underlying error name rather than just `"ExecutionError"`.
+    pub fn error_type(&self) -> String {
+        match self {
+            ChainError::ExecutionError(execution_error, _) => execution_error.error_type(),
+            other => {
+                let variant: &'static str = other.into();
+                format!("ChainError::{variant}")
+            }
         }
     }
 }

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -76,6 +76,7 @@ proptest = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std_rng"] }
 serde.workspace = true
 serde_json.workspace = true
+strum.workspace = true
 sync_wrapper.workspace = true
 test-log = { workspace = true, optional = true }
 test-strategy = { workspace = true, optional = true }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -307,7 +307,7 @@ pub enum Reason {
 }
 
 /// Error type for worker operations.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, strum::IntoStaticStr)]
 pub enum WorkerError {
     #[error(transparent)]
     CryptoError(#[from] CryptoError),
@@ -451,6 +451,21 @@ impl WorkerError {
             | WorkerError::IncorrectOutcome { .. }
             | WorkerError::PoisonedWorker => true,
             WorkerError::ChainError(chain_error) => chain_error.is_local(),
+        }
+    }
+
+    /// Returns the qualified error variant name for the `error_type` metric label,
+    /// e.g. `"WorkerError::UnexpectedBlockHeight"`.
+    ///
+    /// For `ChainError` variants, delegates to `ChainError::error_type()` to
+    /// surface the underlying error name rather than just `"ChainError"`.
+    pub fn error_type(&self) -> String {
+        match self {
+            WorkerError::ChainError(chain_error) => chain_error.error_type(),
+            other => {
+                let variant: &'static str = other.into();
+                format!("WorkerError::{variant}")
+            }
         }
     }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -249,7 +249,7 @@ const _: () = {
 };
 
 /// A type for errors happening during execution.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, strum::IntoStaticStr)]
 pub enum ExecutionError {
     #[error(transparent)]
     ViewError(#[from] ViewError),
@@ -445,6 +445,13 @@ impl ExecutionError {
             | ExecutionError::InternalError(_)
             | ExecutionError::IoError(_) => true,
         }
+    }
+
+    /// Returns the qualified error variant name for the `error_type` metric label,
+    /// e.g. `"ExecutionError::BlobsNotFound"`.
+    pub fn error_type(&self) -> String {
+        let variant: &'static str = self.into();
+        format!("ExecutionError::{variant}")
     }
 
     /// Returns whether this error is caused by a per-block limit being exceeded.

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -48,6 +48,9 @@ pub const METHOD_NAME_LABEL: &str = "method_name";
 /// Prometheus label for distinguishing organic vs synthetic (benchmark) traffic.
 pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
 
+/// Prometheus label for the error variant name, e.g. `"WorkerError::UnexpectedBlockHeight"`.
+pub const ERROR_TYPE_LABEL: &str = "error_type";
+
 /// Extracts the gRPC method name from a request URI path.
 ///
 /// gRPC paths have the form `/{package}.{Service}/{Method}` — the first segment

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -59,7 +59,7 @@ mod metrics {
     };
     use prometheus::{HistogramVec, IntCounterVec};
 
-    use super::super::{METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
+    use super::super::{ERROR_TYPE_LABEL, METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
 
     pub static SERVER_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
@@ -90,7 +90,7 @@ mod metrics {
         register_int_counter_vec(
             "server_request_error",
             "Server request error",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL, ERROR_TYPE_LABEL],
         )
     });
 
@@ -632,20 +632,20 @@ where
         .await;
     }
 
-    fn log_request_outcome(success: bool, method_name: &str, traffic_type: &str) {
+    fn log_request_success(method_name: &str, traffic_type: &str) {
         #![cfg_attr(not(with_metrics), allow(unused_variables))]
         #[cfg(with_metrics)]
-        {
-            if success {
-                metrics::SERVER_REQUEST_SUCCESS
-                    .with_label_values(&[method_name, traffic_type])
-                    .inc();
-            } else {
-                metrics::SERVER_REQUEST_ERROR
-                    .with_label_values(&[method_name, traffic_type])
-                    .inc();
-            }
-        }
+        metrics::SERVER_REQUEST_SUCCESS
+            .with_label_values(&[method_name, traffic_type])
+            .inc();
+    }
+
+    fn log_request_error(method_name: &str, traffic_type: &str, error_type: &str) {
+        #![cfg_attr(not(with_metrics), allow(unused_variables))]
+        #[cfg(with_metrics)]
+        metrics::SERVER_REQUEST_ERROR
+            .with_label_values(&[method_name, traffic_type, error_type])
+            .inc();
     }
 
     /// Extracts traffic type from a tonic request's extensions.
@@ -694,12 +694,16 @@ where
         Ok(Response::new(
             match self.state.clone().handle_block_proposal(proposal).await {
                 Ok((info, actions)) => {
-                    Self::log_request_outcome(true, "handle_block_proposal", traffic_type);
+                    Self::log_request_success("handle_block_proposal", traffic_type);
                     self.handle_network_actions(actions);
                     info.try_into()?
                 }
                 Err(error) => {
-                    Self::log_request_outcome(false, "handle_block_proposal", traffic_type);
+                    Self::log_request_error(
+                        "handle_block_proposal",
+                        traffic_type,
+                        &error.error_type(),
+                    );
                     self.log_error(&error, "Failed to handle block proposal");
                     NodeError::from(error).try_into()?
                 }
@@ -735,7 +739,7 @@ where
         .await
         {
             Ok((info, actions)) => {
-                Self::log_request_outcome(true, "handle_lite_certificate", traffic_type);
+                Self::log_request_success("handle_lite_certificate", traffic_type);
                 self.handle_network_actions(actions);
                 if let Some(receiver) = receiver {
                     if let Err(e) = receiver.await {
@@ -745,7 +749,11 @@ where
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "handle_lite_certificate", traffic_type);
+                Self::log_request_error(
+                    "handle_lite_certificate",
+                    traffic_type,
+                    &error.error_type(),
+                );
                 self.log_error(&error, "Failed to handle lite certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -779,7 +787,7 @@ where
             .await
         {
             Ok((info, actions)) => {
-                Self::log_request_outcome(true, "handle_confirmed_certificate", traffic_type);
+                Self::log_request_success("handle_confirmed_certificate", traffic_type);
                 self.handle_network_actions(actions);
                 if let Some(receiver) = receiver {
                     if let Err(e) = receiver.await {
@@ -789,7 +797,11 @@ where
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "handle_confirmed_certificate", traffic_type);
+                Self::log_request_error(
+                    "handle_confirmed_certificate",
+                    traffic_type,
+                    &error.error_type(),
+                );
                 self.log_error(&error, "Failed to handle confirmed certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -819,12 +831,16 @@ where
             .await
         {
             Ok((info, actions)) => {
-                Self::log_request_outcome(true, "handle_validated_certificate", traffic_type);
+                Self::log_request_success("handle_validated_certificate", traffic_type);
                 self.handle_network_actions(actions);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "handle_validated_certificate", traffic_type);
+                Self::log_request_error(
+                    "handle_validated_certificate",
+                    traffic_type,
+                    &error.error_type(),
+                );
                 self.log_error(&error, "Failed to handle validated certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -854,11 +870,15 @@ where
             .await
         {
             Ok((info, _actions)) => {
-                Self::log_request_outcome(true, "handle_timeout_certificate", traffic_type);
+                Self::log_request_success("handle_timeout_certificate", traffic_type);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "handle_timeout_certificate", traffic_type);
+                Self::log_request_error(
+                    "handle_timeout_certificate",
+                    traffic_type,
+                    &error.error_type(),
+                );
                 self.log_error(&error, "Failed to handle timeout certificate");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -883,12 +903,16 @@ where
         trace!(?query, "Handling chain info query");
         match self.state.clone().handle_chain_info_query(query).await {
             Ok((info, actions)) => {
-                Self::log_request_outcome(true, "handle_chain_info_query", traffic_type);
+                Self::log_request_success("handle_chain_info_query", traffic_type);
                 self.handle_network_actions(actions);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "handle_chain_info_query", traffic_type);
+                Self::log_request_error(
+                    "handle_chain_info_query",
+                    traffic_type,
+                    &error.error_type(),
+                );
                 self.log_error(&error, "Failed to handle chain info query");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -918,11 +942,11 @@ where
             .await
         {
             Ok(blob) => {
-                Self::log_request_outcome(true, "download_pending_blob", traffic_type);
+                Self::log_request_success("download_pending_blob", traffic_type);
                 Ok(Response::new(blob.into_content().try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "download_pending_blob", traffic_type);
+                Self::log_request_error("download_pending_blob", traffic_type, &error.error_type());
                 self.log_error(&error, "Failed to download pending blob");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -949,11 +973,11 @@ where
         trace!(?chain_id, ?blob_id, "Handle pending blob");
         match self.state.clone().handle_pending_blob(chain_id, blob).await {
             Ok(info) => {
-                Self::log_request_outcome(true, "handle_pending_blob", traffic_type);
+                Self::log_request_success("handle_pending_blob", traffic_type);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "handle_pending_blob", traffic_type);
+                Self::log_request_error("handle_pending_blob", traffic_type, &error.error_type());
                 self.log_error(&error, "Failed to handle pending blob");
                 Ok(Response::new(NodeError::from(error).try_into()?))
             }
@@ -982,11 +1006,11 @@ where
             .await
         {
             Ok(result) => {
-                Self::log_request_outcome(true, "previous_event_blocks", traffic_type);
+                Self::log_request_success("previous_event_blocks", traffic_type);
                 Ok(Response::new(result.try_into()?))
             }
             Err(error) => {
-                Self::log_request_outcome(false, "previous_event_blocks", traffic_type);
+                Self::log_request_error("previous_event_blocks", traffic_type, &error.error_type());
                 self.log_error(&error, "Failed to get previous event blocks");
                 Err(Status::internal(NodeError::from(error).to_string()))
             }
@@ -1016,13 +1040,16 @@ where
             .await
         {
             Ok(actions) => {
-                Self::log_request_outcome(true, "handle_cross_chain_request", traffic_type);
+                Self::log_request_success("handle_cross_chain_request", traffic_type);
                 self.handle_network_actions(actions)
             }
             Err(error) => {
-                Self::log_request_outcome(false, "handle_cross_chain_request", traffic_type);
-                let nickname = self.state.nickname();
-                error!(nickname, %error, "Failed to handle cross-chain request");
+                Self::log_request_error(
+                    "handle_cross_chain_request",
+                    traffic_type,
+                    &error.error_type(),
+                );
+                self.log_error(&error, "Failed to handle cross-chain request");
             }
         }
         Ok(Response::new(()))

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "strum",
  "sync_wrapper 1.0.2",
  "test-log",
  "test-strategy",

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -71,7 +71,7 @@ mod metrics {
     use linera_base::prometheus_util::{
         linear_bucket_interval, register_histogram_vec, register_int_counter_vec,
     };
-    use linera_rpc::grpc::{METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
+    use linera_rpc::grpc::{ERROR_TYPE_LABEL, METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL};
     use prometheus::{HistogramVec, IntCounterVec};
 
     pub static PROXY_REQUEST_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -102,9 +102,17 @@ mod metrics {
         register_int_counter_vec(
             "proxy_request_error",
             "Proxy request error",
-            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL, ERROR_TYPE_LABEL],
         )
     });
+}
+
+#[cfg(with_metrics)]
+fn grpc_status_name(status: Option<&str>) -> String {
+    match status {
+        Some(code) => format!("{:?}", tonic::Code::from_bytes(code.as_bytes())),
+        None => "HTTP_ERROR".to_owned(),
+    }
 }
 
 #[derive(Clone)]
@@ -162,16 +170,18 @@ where
                     .with_label_values(&[&method_name, traffic_type])
                     .inc();
 
-                let is_error = !response.status().is_success()
-                    || response
-                        .headers()
-                        .get("grpc-status")
-                        .and_then(|v| v.to_str().ok())
-                        .is_some_and(|s| s != "0");
+                let grpc_status = response
+                    .headers()
+                    .get("grpc-status")
+                    .and_then(|v| v.to_str().ok());
+
+                let is_error =
+                    !response.status().is_success() || grpc_status.is_some_and(|s| s != "0");
 
                 if is_error {
+                    let error_type = grpc_status_name(grpc_status);
                     metrics::PROXY_REQUEST_ERROR
-                        .with_label_values(&[&method_name, traffic_type])
+                        .with_label_values(&[&method_name, traffic_type, &error_type])
                         .inc();
                 } else {
                     metrics::PROXY_REQUEST_SUCCESS


### PR DESCRIPTION
## Motivation

Backport of #5951 to testnet_conway.

The `server_request_error` and `proxy_request_error` metrics count all errors with no
distinction between error types, making it impossible to determine what's actually
failing from the dashboard.

## Proposal

**Server metric**: Add an `error_type` label to `server_request_error` containing the
qualified error variant name, e.g. `WorkerError::UnexpectedBlockHeight`,
`ChainError::MissingCrossChainUpdate`, `ExecutionError::BlobsNotFound`. Uses
`strum::IntoStaticStr` to derive variant names automatically. For wrapped errors, the
label surfaces the innermost error variant.

**Proxy metric**: Add an `error_type` label to `proxy_request_error` with the gRPC
status code name (e.g. `DeadlineExceeded`, `Cancelled`, `Unavailable`). For non-gRPC
HTTP errors, the label is `HTTP_ERROR`.

Also splits `log_request_outcome` into `log_request_success` and `log_request_error`,
and normalizes `handle_cross_chain_request` to use the shared `log_error()` method.

No changes to log levels.

## Test Plan

CI

