### PR TITLE
Add streaming DownloadBlobs RPC endpoint

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -36,6 +36,9 @@ use crate::{
 /// A pinned [`Stream`] of Notifications.
 pub type NotificationStream = BoxStream<'static, Notification>;
 
+/// A pinned [`Stream`] of blob contents returned by batch downloads.
+pub type BlobStream = BoxStream<'static, Result<BlobContent, NodeError>>;
+
 /// Whether to wait for the delivery of outgoing cross-chain messages.
 #[derive(Debug, Default, Clone, Copy)]
 pub enum CrossChainMessageDelivery {
@@ -123,6 +126,11 @@ pub trait ValidatorNode {
 
     /// Downloads a blob. Returns an error if the validator does not have the blob.
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
+
+    /// Downloads a batch of blobs as a stream. The stream yields one blob per
+    /// requested id, in order. On mid-stream errors, the caller can retry the
+    /// remaining blob ids against another validator.
+    async fn download_blobs(&self, blob_ids: Vec<BlobId>) -> Result<BlobStream, NodeError>;
 
     /// Downloads a blob that belongs to a pending proposal or the locking block on a chain.
     async fn download_pending_blob(

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -224,6 +224,17 @@ impl<N: ValidatorNode> RemoteNode<N> {
         }
     }
 
+    /// Streams a batch of blobs from the validator. Each yielded item is
+    /// a `Result<Blob, NodeError>` — the caller can drive the stream incrementally
+    /// and, on error, track which blob IDs still need to be fetched.
+    #[instrument(level = "trace")]
+    pub async fn download_blobs(
+        &self,
+        blob_ids: Vec<BlobId>,
+    ) -> Result<crate::node::BlobStream, NodeError> {
+        self.node.download_blobs(blob_ids).await
+    }
+
     /// Downloads a list of certificates from the given chain.
     #[instrument(level = "trace")]
     pub async fn download_certificates_by_heights(

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -205,6 +205,22 @@ where
             .await
     }
 
+    async fn download_blobs(
+        &self,
+        blob_ids: Vec<BlobId>,
+    ) -> Result<crate::node::BlobStream, NodeError> {
+        let this = self.clone();
+        let stream = futures::stream::unfold(blob_ids.into_iter(), move |mut iter| {
+            let this = this.clone();
+            async move {
+                let blob_id = iter.next()?;
+                let result = this.download_blob(blob_id).await;
+                Some((result, iter))
+            }
+        });
+        Ok(Box::pin(stream))
+    }
+
     async fn download_pending_blob(
         &self,
         chain_id: ChainId,

--- a/linera-exporter/src/test_utils.rs
+++ b/linera-exporter/src/test_utils.rs
@@ -188,6 +188,9 @@ impl DummyValidator {
 impl ValidatorNode for DummyValidator {
     type SubscribeStream =
         UnboundedReceiverStream<Result<linera_rpc::grpc::api::Notification, Status>>;
+    type DownloadBlobsStream = std::pin::Pin<
+        Box<dyn futures::Stream<Item = Result<linera_rpc::grpc::api::BlobContent, Status>> + Send>,
+    >;
 
     async fn handle_confirmed_certificate(
         &self,
@@ -323,6 +326,13 @@ impl ValidatorNode for DummyValidator {
         &self,
         _request: Request<linera_rpc::grpc::api::BlobId>,
     ) -> Result<Response<linera_rpc::grpc::api::BlobContent>, Status> {
+        unimplemented!()
+    }
+
+    async fn download_blobs(
+        &self,
+        _request: Request<linera_rpc::grpc::api::BlobIds>,
+    ) -> Result<Response<Self::DownloadBlobsStream>, Status> {
         unimplemented!()
     }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -72,6 +72,9 @@ service ValidatorNode {
   // Download a blob.
   rpc DownloadBlob(BlobId) returns (BlobContent);
 
+  // Download a batch of blobs as a stream.
+  rpc DownloadBlobs(BlobIds) returns (stream BlobContent);
+
   // Download a blob that belongs to a pending block on the given chain.
   rpc DownloadPendingBlob(PendingBlobRequest) returns (PendingBlobResult);
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -14,7 +14,7 @@ use linera_chain::{
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
-    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
+    node::{BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
 };
 
 use crate::grpc::GrpcClient;
@@ -192,6 +192,15 @@ impl ValidatorNode for Client {
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => simple_client.download_blob(blob_id).await?,
+        })
+    }
+
+    async fn download_blobs(&self, blob_ids: Vec<BlobId>) -> Result<BlobStream, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.download_blobs(blob_ids).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.download_blobs(blob_ids).await?,
         })
     }
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -45,7 +45,7 @@ mod metrics {
 
 use linera_core::{
     data_types::{CertificatesByHeightRequest, ChainInfoResponse},
-    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
+    node::{BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
     worker::Notification,
 };
 use linera_version::VersionInfo;
@@ -484,6 +484,32 @@ impl ValidatorNode for GrpcClient {
     #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         Ok(client_delegate!(self, download_blob, blob_id)?.try_into()?)
+    }
+
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
+    async fn download_blobs(&self, blob_ids: Vec<BlobId>) -> Result<BlobStream, NodeError> {
+        debug!(
+            handler = "download_blobs",
+            num_blobs = blob_ids.len(),
+            "sending gRPC request"
+        );
+        let request = api::BlobIds::try_from(blob_ids)?;
+        let stream = self
+            .client
+            .clone()
+            .download_blobs(request)
+            .await
+            .map_err(|status| NodeError::GrpcError {
+                error: status.to_string(),
+            })?
+            .into_inner();
+        let blob_stream = stream.map(|result| match result {
+            Ok(proto_blob) => BlobContent::try_from(proto_blob).map_err(NodeError::from),
+            Err(status) => Err(NodeError::GrpcError {
+                error: status.to_string(),
+            }),
+        });
+        Ok(Box::pin(blob_stream))
     }
 
     #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -46,6 +46,7 @@ pub enum RpcMessage {
     ChainInfoQuery(Box<ChainInfoQuery>),
     UploadBlob(Box<BlobContent>),
     DownloadBlob(Box<BlobId>),
+    DownloadBlobs(Vec<BlobId>),
     DownloadPendingBlob(Box<(ChainId, BlobId)>),
     HandlePendingBlob(Box<(ChainId, BlobContent)>),
     DownloadConfirmedBlock(Box<CryptoHash>),
@@ -115,6 +116,7 @@ impl RpcMessage {
             | UploadBlob(_)
             | UploadBlobResponse(_)
             | DownloadBlob(_)
+            | DownloadBlobs(_)
             | DownloadBlobResponse(_)
             | DownloadPendingBlobResponse(_)
             | DownloadConfirmedBlock(_)
@@ -151,6 +153,7 @@ impl RpcMessage {
             | ShardInfoQuery(_)
             | UploadBlob(_)
             | DownloadBlob(_)
+            | DownloadBlobs(_)
             | DownloadConfirmedBlock(_)
             | BlobLastUsedBy(_)
             | BlobLastUsedByCertificate(_)

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -17,7 +17,7 @@ use linera_chain::{
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
-    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
+    node::{BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
 };
 use linera_version::VersionInfo;
 
@@ -195,6 +195,39 @@ impl ValidatorNode for SimpleClient {
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         self.query(RpcMessage::DownloadBlob(Box::new(blob_id)))
             .await
+    }
+
+    async fn download_blobs(&self, blob_ids: Vec<BlobId>) -> Result<BlobStream, NodeError> {
+        let mut stream = self
+            .network
+            .protocol
+            .connect((self.network.host.clone(), self.network.port))
+            .await
+            .map_err(|e| NodeError::ClientIoError {
+                error: e.to_string(),
+            })?;
+        timer::timeout(
+            self.send_timeout,
+            stream.send(RpcMessage::DownloadBlobs(blob_ids)),
+        )
+        .await
+        .map_err(|timeout| NodeError::ClientIoError {
+            error: timeout.to_string(),
+        })?
+        .map_err(|e| NodeError::ClientIoError {
+            error: e.to_string(),
+        })?;
+        let blob_stream = stream.filter_map(|result| async {
+            match result {
+                Ok(RpcMessage::DownloadBlobResponse(blob)) => Some(Ok(*blob)),
+                Ok(RpcMessage::Error(err)) => Some(Err(*err)),
+                Ok(_) => Some(Err(NodeError::UnexpectedMessage)),
+                Err(e) => Some(Err(NodeError::ClientIoError {
+                    error: e.to_string(),
+                })),
+            }
+        });
+        Ok(Box::pin(blob_stream))
     }
 
     async fn download_pending_blob(

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -390,6 +390,7 @@ where
             | RpcMessage::ShardInfoQuery(_)
             | RpcMessage::ShardInfoResponse(_)
             | RpcMessage::DownloadBlob(_)
+            | RpcMessage::DownloadBlobs(_)
             | RpcMessage::DownloadBlobResponse(_)
             | RpcMessage::DownloadPendingBlobResponse(_)
             | RpcMessage::DownloadConfirmedBlock(_)

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -16,7 +16,7 @@ use futures::{
     stream::{self, FuturesUnordered, SplitSink, SplitStream},
     Sink, SinkExt, Stream, StreamExt, TryStreamExt,
 };
-use linera_base::identifiers::ChainId;
+use linera_base::identifiers::{BlobId, ChainId};
 use linera_core::{JoinSetExt as _, TaskHandle};
 use serde::{Deserialize, Serialize};
 use tokio::{
@@ -92,6 +92,16 @@ pub trait MessageHandler: Clone {
     async fn handle_subscribe(
         &mut self,
         _chains: Vec<ChainId>,
+    ) -> Option<Pin<Box<dyn Stream<Item = RpcMessage> + Send>>> {
+        None
+    }
+
+    /// Handle a batch blob download request by streaming one
+    /// `RpcMessage::DownloadBlobResponse` per requested blob ID.
+    /// Returns `None` if not supported.
+    async fn handle_download_blobs(
+        &mut self,
+        _blob_ids: Vec<BlobId>,
     ) -> Option<Pin<Box<dyn Stream<Item = RpcMessage> + Send>>> {
         None
     }
@@ -475,6 +485,10 @@ where
                         self.handle_subscription(chains).await;
                         return;
                     }
+                    Some(Ok(RpcMessage::DownloadBlobs(blob_ids))) => {
+                        self.handle_download_blobs(blob_ids).await;
+                        return;
+                    }
                     Some(Ok(message)) => self.handle_message(message).await,
                     Some(Err(error)) => {
                         Self::handle_error(&error);
@@ -507,6 +521,27 @@ where
                     Some(notification) => {
                         if let Err(error) = self.connection.send(notification).await {
                             error!("Failed to send notification: {error}");
+                            break;
+                        }
+                    }
+                    None => break,
+                }
+            }
+        }
+    }
+
+    /// Handles a batch blob download request by streaming one response per blob.
+    async fn handle_download_blobs(&mut self, blob_ids: Vec<BlobId>) {
+        let Some(mut stream) = self.handler.handle_download_blobs(blob_ids).await else {
+            return;
+        };
+        loop {
+            tokio::select! { biased;
+                _ = self.shutdown_signal.cancelled() => break,
+                msg = stream.next() => match msg {
+                    Some(message) => {
+                        if let Err(error) = self.connection.send(message).await {
+                            error!("Failed to send blob response: {error}");
                             break;
                         }
                     }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1043,137 +1043,142 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: BlobId
     8:
+      DownloadBlobs:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: BlobId
+    9:
       DownloadPendingBlob:
         NEWTYPE:
           TUPLE:
             - TYPENAME: ChainId
             - TYPENAME: BlobId
-    9:
+    10:
       HandlePendingBlob:
         NEWTYPE:
           TUPLE:
             - TYPENAME: ChainId
             - TYPENAME: BlobContent
-    10:
+    11:
       DownloadConfirmedBlock:
         NEWTYPE:
           TYPENAME: CryptoHash
-    11:
+    12:
       DownloadCertificates:
         NEWTYPE:
           SEQ:
             TYPENAME: CryptoHash
-    12:
+    13:
       DownloadCertificatesByHeights:
         TUPLE:
           - TYPENAME: ChainId
           - SEQ:
               TYPENAME: BlockHeight
-    13:
+    14:
       BlobLastUsedBy:
         NEWTYPE:
           TYPENAME: BlobId
-    14:
+    15:
       MissingBlobIds:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    15:
+    16:
       EventBlockHeights:
         NEWTYPE:
           SEQ:
             TYPENAME: EventId
-    16:
-      VersionInfoQuery: UNIT
     17:
-      NetworkDescriptionQuery: UNIT
+      VersionInfoQuery: UNIT
     18:
+      NetworkDescriptionQuery: UNIT
+    19:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    19:
+    20:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    20:
+    21:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    21:
+    22:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    22:
+    23:
       NetworkDescriptionResponse:
         NEWTYPE:
           TYPENAME: NetworkDescription
-    23:
+    24:
       UploadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobId
-    24:
+    25:
       DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    25:
+    26:
       DownloadPendingBlobResponse:
         NEWTYPE:
           TYPENAME: BlobContent
-    26:
+    27:
       DownloadConfirmedBlockResponse:
         NEWTYPE:
           TYPENAME: Block
-    27:
+    28:
       DownloadCertificatesResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: ConfirmedBlockCertificate
-    28:
+    29:
       DownloadCertificatesByHeightsResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: ConfirmedBlockCertificate
-    29:
+    30:
       BlobLastUsedByResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    30:
+    31:
       MissingBlobIdsResponse:
         NEWTYPE:
           SEQ:
             TYPENAME: BlobId
-    31:
+    32:
       EventBlockHeightsResponse:
         NEWTYPE:
           SEQ:
             OPTION:
               TYPENAME: BlockHeight
-    32:
+    33:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest
-    33:
+    34:
       BlobLastUsedByCertificate:
         NEWTYPE:
           TYPENAME: BlobId
-    34:
+    35:
       BlobLastUsedByCertificateResponse:
         NEWTYPE:
           TYPENAME: ConfirmedBlockCertificate
-    35:
+    36:
       ShardInfoQuery:
         NEWTYPE:
           TYPENAME: ChainId
-    36:
+    37:
       ShardInfoResponse:
         NEWTYPE:
           TYPENAME: ShardInfo
-    37:
+    38:
       SubscribeNotifications:
         NEWTYPE:
           SEQ:
             TYPENAME: ChainId
-    38:
+    39:
       Notification:
         NEWTYPE:
           TYPENAME: Notification

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -449,6 +449,8 @@ where
     S: Storage + Clone + Send + Sync + 'static,
 {
     type SubscribeStream = UnboundedReceiverStream<Result<Notification, Status>>;
+    type DownloadBlobsStream =
+        std::pin::Pin<Box<dyn futures::Stream<Item = Result<BlobContent, Status>> + Send>>;
 
     #[instrument(skip_all, err(Display), fields(method = "handle_block_proposal"))]
     async fn handle_block_proposal(
@@ -614,6 +616,30 @@ where
             .map(Arc::unwrap_or_clone)
             .ok_or_else(|| Status::not_found(format!("Blob not found {}", blob_id)))?;
         Ok(Response::new(blob.into_content().try_into()?))
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "download_blobs"))]
+    async fn download_blobs(
+        &self,
+        request: Request<BlobIds>,
+    ) -> Result<Response<Self::DownloadBlobsStream>, Status> {
+        let blob_ids = Vec::<linera_base::identifiers::BlobId>::try_from(request.into_inner())?;
+        let blobs = self
+            .0
+            .storage
+            .read_blobs(&blob_ids)
+            .await
+            .map_err(Self::view_error_to_status)?;
+        let stream = futures::stream::iter(blob_ids.into_iter().zip(blobs).map(
+            |(blob_id, maybe_blob)| {
+                let blob = maybe_blob
+                    .map(Arc::unwrap_or_clone)
+                    .ok_or_else(|| Status::not_found(format!("Blob not found {}", blob_id)))?;
+                BlobContent::try_from(blob.into_content())
+                    .map_err(|err| Status::internal(err.to_string()))
+            },
+        ));
+        Ok(Response::new(Box::pin(stream)))
     }
 
     #[instrument(skip_all, err(Display), fields(method = "download_pending_blob"))]

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -16,7 +16,10 @@ use std::{net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
 use anyhow::{anyhow, bail, ensure, Result};
 use async_trait::async_trait;
 use futures::{stream::SelectAll, FutureExt as _, SinkExt, Stream, StreamExt};
-use linera_base::{identifiers::ChainId, listen_for_shutdown_signals};
+use linera_base::{
+    identifiers::{BlobId, ChainId},
+    listen_for_shutdown_signals,
+};
 use linera_client::config::ValidatorServerConfig;
 use linera_core::{node::NodeError, JoinSetExt as _};
 #[cfg(with_metrics)]
@@ -283,6 +286,31 @@ where
         chains: Vec<ChainId>,
     ) -> Option<Pin<Box<dyn Stream<Item = RpcMessage> + Send>>> {
         self.subscribe_to_shards(chains).await
+    }
+
+    async fn handle_download_blobs(
+        &mut self,
+        blob_ids: Vec<BlobId>,
+    ) -> Option<Pin<Box<dyn Stream<Item = RpcMessage> + Send>>> {
+        let blobs = match self.storage.read_blobs(&blob_ids).await {
+            Ok(blobs) => blobs,
+            Err(error) => {
+                return Some(Box::pin(futures::stream::once(async move {
+                    RpcMessage::Error(Box::new(NodeError::from(error)))
+                })));
+            }
+        };
+        let messages =
+            blob_ids
+                .into_iter()
+                .zip(blobs)
+                .map(|(blob_id, maybe_blob)| match maybe_blob {
+                    Some(blob) => RpcMessage::DownloadBlobResponse(Box::new(
+                        Arc::unwrap_or_clone(blob).into_content(),
+                    )),
+                    None => RpcMessage::Error(Box::new(NodeError::BlobsNotFound(vec![blob_id]))),
+                });
+        Some(Box::pin(futures::stream::iter(messages)))
     }
 }
 
@@ -553,6 +581,7 @@ where
             | NetworkDescriptionResponse(_)
             | ShardInfoResponse(_)
             | DownloadBlobResponse(_)
+            | DownloadBlobs(_)
             | DownloadPendingBlob(_)
             | DownloadPendingBlobResponse(_)
             | HandlePendingBlob(_)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -121,6 +121,13 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn download_blobs(
+        &self,
+        _: Vec<BlobId>,
+    ) -> Result<linera_core::node::BlobStream, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn download_certificate(
         &self,
         _: CryptoHash,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -866,11 +866,12 @@ where
         if blob_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let mut blobs = Vec::new();
-        for blob_id in blob_ids {
-            blobs.push(self.read_blob(*blob_id).await?);
-        }
-        Ok(blobs)
+        // Each blob lives under its own root_key (partition), so cross-partition
+        // reads can't be coalesced into a single IN query. The ScyllaDB best
+        // practice is parallel queries via the shard-aware driver, which routes
+        // each query to the right shard on the right node. RocksDB benefits too:
+        // concurrent point lookups let the scheduler overlap cache/SST reads.
+        futures::future::try_join_all(blob_ids.iter().map(|blob_id| self.read_blob(*blob_id))).await
     }
 
     #[instrument(skip_all, fields(%blob_id))]
@@ -893,11 +894,12 @@ where
         if blob_ids.is_empty() {
             return Ok(Vec::new());
         }
-        let mut blob_states = Vec::new();
-        for blob_id in blob_ids {
-            blob_states.push(self.read_blob_state(*blob_id).await?);
-        }
-        Ok(blob_states)
+        futures::future::try_join_all(
+            blob_ids
+                .iter()
+                .map(|blob_id| self.read_blob_state(*blob_id)),
+        )
+        .await
     }
 
     #[instrument(skip_all, fields(blob_id = %blob.id()))]


### PR DESCRIPTION
## Motivation

During chain sync, each blob referenced by a batch of certificates is downloaded via a
separate `DownloadBlob(BlobId) -> BlobContent` unary RPC call. Batches with hundreds of
new blobs fire hundreds of sequential round trips before the certificates can be
processed, which becomes the dominant bottleneck: measured sync logs show ~63% of
wall-clock time is spent waiting for blob downloads to complete.

A batch, streaming RPC lets the validator serve multiple blobs on a single connection
and lets the caller process blobs as they arrive instead of waiting for the full batch.

## Proposal

Add a new streaming RPC endpoint on validators. No caller code is switched over in this
PR — the existing singular `DownloadBlob` is kept for backwards compatibility, so
validators can be deployed before clients start using the new endpoint.

- Proto: `rpc DownloadBlobs(BlobIds) returns (stream BlobContent)`
- `ValidatorNode` trait: `async fn download_blobs(&self, blob_ids: Vec<BlobId>) ->
Result<BlobStream, NodeError>` where `BlobStream = BoxStream<'static,
Result<BlobContent, NodeError>>`
- gRPC transport: tonic native server streaming
- Simple transport: one dedicated connection per request, server sends one
`RpcMessage::DownloadBlobResponse` per blob, client filters them into a stream (same
pattern as `subscribe`)
- Server-side `DbStorage::read_blobs` (and `read_blob_states`) are changed from a
sequential loop into `futures::future::try_join_all` of per-blob reads. Each blob lives
under its own `root_key` (its own ScyllaDB partition), so cross-partition reads can't be
coalesced into a single `IN` query — the ScyllaDB-recommended approach is concurrent
per-partition queries via the shard-aware driver, which spreads the load across all
shards and nodes instead of funnelling through a single coordinator. RocksDB also
benefits: tokio can overlap the per-blob cache/SST lookups.

Callers will migrate to the new RPC in a follow-up PR (with retry-on-mid-am-error
logic that replays only the remaining blob ids on another validator).

## Test Plan

CI. The new RPC is additive and no existing caller code is changed, so existing tests
exercise the unchanged `DownloadBlob` path. The new endpoint will be validated
end-to-end in the follow-up PR that switches callers over.

## Release Plan
- These changes should be backported to the latest `testnet` branch
