### PR TITLE
Migrate Docker image builds from Cloud Build to self-hosted OVH runners

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -1,0 +1,171 @@
+name: Build Image
+
+# Manually-triggered image build workflow. Replaces `gcloud builds submit` as
+# the generic "submit a build" interface for lineractl and ad-hoc rebuilds.
+# Runs on the linera-io-self-hosted-builder runner (OVH ci-k8s, c3-64 node).
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_type:
+        description: 'Which image to build'
+        required: true
+        type: choice
+        options:
+          - main
+          - indexer
+          - explorer
+          - exporter
+          - bridge
+          - all
+        default: main
+      image_tag:
+        description: 'Image tag (e.g., testnet_conway, a branch name, or arbitrary label)'
+        required: true
+        type: string
+      build_mode:
+        description: 'Build mode'
+        required: true
+        type: choice
+        options:
+          - release
+          - debug
+        default: release
+      ref:
+        description: 'Git ref to build (branch, tag, or commit SHA). Defaults to the current branch.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: linera-io-self-hosted-builder
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Auth service account
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Configure Docker to push to Artifact Registry
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+
+      - name: Set env variables
+        env:
+          IMAGE_TAG_INPUT: ${{ inputs.image_tag }}
+          BUILD_MODE_INPUT: ${{ inputs.build_mode }}
+        run: |
+          echo "GIT_COMMIT_SHORT=${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+          echo "GIT_COMMIT_LONG=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "IMAGE_TAG=${IMAGE_TAG_INPUT}" >> "$GITHUB_ENV"
+          echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_ENV"
+
+          if [ "${BUILD_MODE_INPUT}" = "debug" ]; then
+            echo "BUILD_FLAG=" >> "$GITHUB_ENV"
+            echo "BUILD_FOLDER=debug" >> "$GITHUB_ENV"
+          else
+            echo "BUILD_FLAG=--release" >> "$GITHUB_ENV"
+            echo "BUILD_FOLDER=release" >> "$GITHUB_ENV"
+          fi
+
+          echo "REGISTRY_BASE=us-docker.pkg.dev/linera-io-dev/linera-public-registry" >> "$GITHUB_ENV"
+
+      - name: Prune stale Docker layers
+        run: docker system prune -af --filter "until=24h" || true
+
+      - name: Build and push selected image(s)
+        env:
+          IMAGE_TYPE: ${{ inputs.image_type }}
+        run: |
+          set -e
+
+          build_and_push() {
+            local DOCKERFILE=$1
+            local IMAGE_NAME=$2
+            local BUILD_NAME=$3
+            local LOG_FILE="/tmp/build-${BUILD_NAME}.log"
+
+            local IMAGE_TAGGED="${REGISTRY_BASE}/${IMAGE_NAME}:${IMAGE_TAG}"
+            local IMAGE_SHORT="${REGISTRY_BASE}/${IMAGE_NAME}:${GIT_COMMIT_SHORT}"
+            local IMAGE_LONG="${REGISTRY_BASE}/${IMAGE_NAME}:${GIT_COMMIT_LONG}"
+
+            {
+              echo "========================================"
+              echo "Building ${BUILD_NAME} (${DOCKERFILE})"
+              echo "========================================"
+
+              DOCKER_BUILDKIT=1 docker build \
+                -t "${IMAGE_TAGGED}" \
+                -t "${IMAGE_SHORT}" \
+                -t "${IMAGE_LONG}" \
+                -f "${DOCKERFILE}" \
+                --build-arg "git_commit=${GIT_COMMIT_LONG}" \
+                --build-arg "build_date=${BUILD_DATE}" \
+                --build-arg "build_flag=${BUILD_FLAG}" \
+                --build-arg "build_folder=${BUILD_FOLDER}" \
+                .
+
+              echo "Pushing ${BUILD_NAME} images..."
+              docker push "${IMAGE_TAGGED}"
+              docker push "${IMAGE_SHORT}"
+              docker push "${IMAGE_LONG}"
+
+              echo "${BUILD_NAME} completed successfully"
+            } > "${LOG_FILE}" 2>&1
+          }
+
+          build_image_by_type() {
+            local TYPE=$1
+            case "${TYPE}" in
+              main)     build_and_push "docker/Dockerfile"           "linera"          "main"     ;;
+              indexer)  build_and_push "docker/Dockerfile.indexer"   "linera-indexer"  "indexer"  ;;
+              explorer) build_and_push "docker/Dockerfile.explorer"  "linera-explorer" "explorer" ;;
+              exporter) build_and_push "docker/Dockerfile.exporter"  "linera-exporter" "exporter" ;;
+              bridge)   build_and_push "docker/Dockerfile.bridge"    "linera-bridge"   "bridge"   ;;
+              *)        echo "Unknown image type: ${TYPE}" >&2; return 1 ;;
+            esac
+          }
+
+          if [ "${IMAGE_TYPE}" = "all" ]; then
+            TYPES="main indexer explorer exporter bridge"
+          else
+            TYPES="${IMAGE_TYPE}"
+          fi
+
+          PIDS=""
+          for TYPE in ${TYPES}; do
+            build_image_by_type "${TYPE}" &
+            PIDS="${PIDS} ${TYPE}:$!"
+          done
+
+          EXIT_CODE=0
+          for NAME_PID in ${PIDS}; do
+            NAME="${NAME_PID%%:*}"
+            PID="${NAME_PID##*:}"
+            if ! wait "$PID"; then
+              EXIT_CODE=1
+              echo "::error::${NAME} build failed"
+            fi
+            echo "==================== ${NAME} logs ===================="
+            cat "/tmp/build-${NAME}.log" 2>/dev/null || true
+            echo "==================== end ${NAME} logs ===================="
+          done
+
+          if [[ $EXIT_CODE -ne 0 ]]; then
+            echo "One or more image builds failed"
+            exit $EXIT_CODE
+          fi
+
+          echo "Build complete."

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   build-and-push:
-    runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 40
+    runs-on: linera-io-self-hosted-builder
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v4
@@ -26,154 +26,113 @@ jobs:
       - name: Set up Google Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
 
+      - name: Configure Docker to push to Artifact Registry
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+
       - name: Set env variables
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          # Set basic variables
-          if [ -n "${{ github.head_ref }}" ]; then
-            BRANCH_NAME="${{ github.head_ref }}"
+          if [ -n "${HEAD_REF}" ]; then
+            BRANCH_NAME="${HEAD_REF}"
           else
-            BRANCH_NAME="${{ github.ref_name }}"
+            BRANCH_NAME="${REF_NAME}"
           fi
 
-          echo "GIT_COMMIT_SHORT=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-          echo "GIT_COMMIT_LONG=${GITHUB_SHA}" >> $GITHUB_ENV
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_ENV
+          echo "GIT_COMMIT_SHORT=${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+          echo "GIT_COMMIT_LONG=${GITHUB_SHA}" >> "$GITHUB_ENV"
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
+          echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_ENV"
 
-          # Build configuration
-          echo "BUILD_TIMEOUT=3h" >> $GITHUB_ENV
-          echo "BUILD_MACHINE_TYPE=e2-highcpu-32" >> $GITHUB_ENV
-
-          # Image registry base
           REGISTRY_BASE="us-docker.pkg.dev/linera-io-dev/linera-public-registry"
-          LINERA_IMAGE_NAME="linera"
-          INDEXER_IMAGE_NAME="linera-indexer"
-          EXPLORER_IMAGE_NAME="linera-explorer"
-          EXPORTER_IMAGE_NAME="linera-exporter"
 
-          # Main linera image names
-          echo "LINERA_IMAGE_BRANCH=${REGISTRY_BASE}/${LINERA_IMAGE_NAME}:${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "LINERA_IMAGE_SHORT=${REGISTRY_BASE}/${LINERA_IMAGE_NAME}:${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-          echo "LINERA_IMAGE_LONG=${REGISTRY_BASE}/${LINERA_IMAGE_NAME}:${GITHUB_SHA}" >> $GITHUB_ENV
+          for IMAGE_VAR in LINERA:linera INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter BRIDGE:linera-bridge; do
+            VAR="${IMAGE_VAR%%:*}"
+            NAME="${IMAGE_VAR##*:}"
+            echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_NAME}" >> "$GITHUB_ENV"
+            echo "${VAR}_IMAGE_SHORT=${REGISTRY_BASE}/${NAME}:${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
+            echo "${VAR}_IMAGE_LONG=${REGISTRY_BASE}/${NAME}:${GITHUB_SHA}" >> "$GITHUB_ENV"
+          done
 
-          # Indexer image names
-          echo "INDEXER_IMAGE_BRANCH=${REGISTRY_BASE}/${INDEXER_IMAGE_NAME}:${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "INDEXER_IMAGE_SHORT=${REGISTRY_BASE}/${INDEXER_IMAGE_NAME}:${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-          echo "INDEXER_IMAGE_LONG=${REGISTRY_BASE}/${INDEXER_IMAGE_NAME}:${GITHUB_SHA}" >> $GITHUB_ENV
+      - name: Prune stale Docker layers
+        run: docker system prune -af --filter "until=24h" || true
 
-          # Explorer image names
-          echo "EXPLORER_IMAGE_BRANCH=${REGISTRY_BASE}/${EXPLORER_IMAGE_NAME}:${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "EXPLORER_IMAGE_SHORT=${REGISTRY_BASE}/${EXPLORER_IMAGE_NAME}:${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-          echo "EXPLORER_IMAGE_LONG=${REGISTRY_BASE}/${EXPLORER_IMAGE_NAME}:${GITHUB_SHA}" >> $GITHUB_ENV
-
-          # Exporter image names
-          echo "EXPORTER_IMAGE_BRANCH=${REGISTRY_BASE}/${EXPORTER_IMAGE_NAME}:${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "EXPORTER_IMAGE_SHORT=${REGISTRY_BASE}/${EXPORTER_IMAGE_NAME}:${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-          echo "EXPORTER_IMAGE_LONG=${REGISTRY_BASE}/${EXPORTER_IMAGE_NAME}:${GITHUB_SHA}" >> $GITHUB_ENV
-
-          # Bridge image names
-          BRIDGE_IMAGE_NAME="linera-bridge"
-          echo "BRIDGE_IMAGE_BRANCH=${REGISTRY_BASE}/${BRIDGE_IMAGE_NAME}:${BRANCH_NAME}" >> $GITHUB_ENV
-          echo "BRIDGE_IMAGE_SHORT=${REGISTRY_BASE}/${BRIDGE_IMAGE_NAME}:${GITHUB_SHA:0:7}" >> $GITHUB_ENV
-          echo "BRIDGE_IMAGE_LONG=${REGISTRY_BASE}/${BRIDGE_IMAGE_NAME}:${GITHUB_SHA}" >> $GITHUB_ENV
-
-      - name: Build and push all images in parallel using GCP Cloud Build
+      - name: Build and push all images in parallel
         run: |
           set -e
 
-          # Function to submit a build and return the build ID
-          submit_build() {
-            local CONFIG_FILE=$1
+          build_and_push() {
+            local DOCKERFILE=$1
             local IMAGE_BRANCH=$2
             local IMAGE_SHORT=$3
             local IMAGE_LONG=$4
             local BUILD_NAME=$5
+            local LOG_FILE="/tmp/${BUILD_NAME}.log"
 
-            BUILD_ID=$(gcloud builds submit . \
-              --config="$CONFIG_FILE" \
-              --substitutions="_IMAGE_PATH=${IMAGE_BRANCH},_IMAGE_NAME_SHORT_COMMIT=${IMAGE_SHORT},_IMAGE_NAME_LONG_COMMIT=${IMAGE_LONG},_GIT_COMMIT=${{ env.GIT_COMMIT_LONG }},_BUILD_DATE=${{ env.BUILD_DATE }},_BUILD_FLAG=--release,_BUILD_FOLDER=release" \
-              --timeout="${{ env.BUILD_TIMEOUT }}" \
-              --machine-type="${{ env.BUILD_MACHINE_TYPE }}" \
-              --async \
-              --format="value(id)")
-            echo "$BUILD_NAME build submitted: $BUILD_ID" >&2
-            echo "$BUILD_ID"
+            {
+              echo "========================================"
+              echo "Building ${BUILD_NAME} (${DOCKERFILE})"
+              echo "========================================"
+
+              DOCKER_BUILDKIT=1 docker build \
+                -t "${IMAGE_BRANCH}" \
+                -t "${IMAGE_SHORT}" \
+                -t "${IMAGE_LONG}" \
+                -f "${DOCKERFILE}" \
+                --build-arg "git_commit=${GIT_COMMIT_LONG}" \
+                --build-arg "build_date=${BUILD_DATE}" \
+                --build-arg "build_flag=--release" \
+                --build-arg "build_folder=release" \
+                .
+
+              echo "Pushing ${BUILD_NAME} images..."
+              docker push "${IMAGE_BRANCH}"
+              docker push "${IMAGE_SHORT}"
+              docker push "${IMAGE_LONG}"
+
+              echo "${BUILD_NAME} completed successfully"
+            } > "${LOG_FILE}" 2>&1
           }
 
-          # Function to stream logs and wait for build completion
-          stream_build_logs() {
-            local BUILD_ID=$1
-            local BUILD_NAME=$2
+          echo "Starting parallel builds..."
 
-            echo "========================================"
-            echo "Streaming logs for $BUILD_NAME (ID: $BUILD_ID)"
-            echo "========================================"
-
-            # Stream logs (exit code only reflects log streaming, not build result)
-            gcloud builds log "$BUILD_ID" --stream || true
-
-            # Check the actual Cloud Build status
-            local BUILD_STATUS
-            BUILD_STATUS=$(gcloud builds describe "$BUILD_ID" --format="value(status)")
-
-            if [[ "$BUILD_STATUS" == "SUCCESS" ]]; then
-              echo ""
-              echo "$BUILD_NAME completed successfully (status: $BUILD_STATUS)"
-            else
-              echo ""
-              echo "$BUILD_NAME failed (status: $BUILD_STATUS)"
-              echo "Logs: https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=linera-io-dev"
-              return 1
-            fi
-          }
-
-          echo "Submitting builds to GCP Cloud Build..."
-
-          # Submit all builds
-          BUILD_ID_LINERA=$(submit_build "docker/build-image.yaml" \
-            "${{ env.LINERA_IMAGE_BRANCH }}" "${{ env.LINERA_IMAGE_SHORT }}" "${{ env.LINERA_IMAGE_LONG }}" "Linera")
-
-          BUILD_ID_INDEXER=$(submit_build "docker/build-indexer-image.yaml" \
-            "${{ env.INDEXER_IMAGE_BRANCH }}" "${{ env.INDEXER_IMAGE_SHORT }}" "${{ env.INDEXER_IMAGE_LONG }}" "Indexer")
-
-          BUILD_ID_EXPLORER=$(submit_build "docker/build-explorer-image.yaml" \
-            "${{ env.EXPLORER_IMAGE_BRANCH }}" "${{ env.EXPLORER_IMAGE_SHORT }}" "${{ env.EXPLORER_IMAGE_LONG }}" "Explorer")
-
-          BUILD_ID_EXPORTER=$(submit_build "docker/build-exporter-image.yaml" \
-            "${{ env.EXPORTER_IMAGE_BRANCH }}" "${{ env.EXPORTER_IMAGE_SHORT }}" "${{ env.EXPORTER_IMAGE_LONG }}" "Exporter")
-
-          BUILD_ID_BRIDGE=$(submit_build "docker/build-bridge-image.yaml" \
-            "${{ env.BRIDGE_IMAGE_BRANCH }}" "${{ env.BRIDGE_IMAGE_SHORT }}" "${{ env.BRIDGE_IMAGE_LONG }}" "Bridge")
-
-          echo ""
-          echo "All builds submitted. Now streaming logs and waiting for completion..."
-          echo ""
-
-          # Stream all builds in parallel
-          stream_build_logs "$BUILD_ID_LINERA" "Linera build" &
+          build_and_push "docker/Dockerfile" \
+            "${LINERA_IMAGE_BRANCH}" "${LINERA_IMAGE_SHORT}" "${LINERA_IMAGE_LONG}" "Linera" &
           PID_LINERA=$!
-          stream_build_logs "$BUILD_ID_INDEXER" "Indexer build" &
+
+          build_and_push "docker/Dockerfile.indexer" \
+            "${INDEXER_IMAGE_BRANCH}" "${INDEXER_IMAGE_SHORT}" "${INDEXER_IMAGE_LONG}" "Indexer" &
           PID_INDEXER=$!
-          stream_build_logs "$BUILD_ID_EXPLORER" "Explorer build" &
+
+          build_and_push "docker/Dockerfile.explorer" \
+            "${EXPLORER_IMAGE_BRANCH}" "${EXPLORER_IMAGE_SHORT}" "${EXPLORER_IMAGE_LONG}" "Explorer" &
           PID_EXPLORER=$!
-          stream_build_logs "$BUILD_ID_EXPORTER" "Exporter build" &
+
+          build_and_push "docker/Dockerfile.exporter" \
+            "${EXPORTER_IMAGE_BRANCH}" "${EXPORTER_IMAGE_SHORT}" "${EXPORTER_IMAGE_LONG}" "Exporter" &
           PID_EXPORTER=$!
-          stream_build_logs "$BUILD_ID_BRIDGE" "Bridge build" &
+
+          build_and_push "docker/Dockerfile.bridge" \
+            "${BRIDGE_IMAGE_BRANCH}" "${BRIDGE_IMAGE_SHORT}" "${BRIDGE_IMAGE_LONG}" "Bridge" &
           PID_BRIDGE=$!
 
-          # Wait for all background jobs and check exit codes
           EXIT_CODE=0
-          wait $PID_LINERA || EXIT_CODE=$?
-          wait $PID_INDEXER || EXIT_CODE=$?
-          wait $PID_EXPLORER || EXIT_CODE=$?
-          wait $PID_EXPORTER || EXIT_CODE=$?
-          wait $PID_BRIDGE || EXIT_CODE=$?
+          for NAME_PID in Linera:$PID_LINERA Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Bridge:$PID_BRIDGE; do
+            NAME="${NAME_PID%%:*}"
+            PID="${NAME_PID##*:}"
+            if ! wait "$PID"; then
+              EXIT_CODE=1
+              echo "::error::${NAME} build failed"
+            fi
+            echo "==================== ${NAME} logs ===================="
+            cat "/tmp/${NAME}.log" || true
+            echo "==================== end ${NAME} logs ===================="
+          done
 
           if [[ $EXIT_CODE -ne 0 ]]; then
-            echo ""
             echo "One or more image builds failed"
             exit $EXIT_CODE
           fi
 
-          echo ""
           echo "All image builds completed successfully!"


### PR DESCRIPTION
## Motivation

Docker image builds OOM during Rust LTO linking on GCP Cloud Build's `e2-highcpu-32` (32
vCPU, 32 GB RAM). Cloud Build also costs ~$700/mo at current volume. The CI cluster
already has OVH c3-64 nodes (32 vCPU, 64 GB RAM) — same CPU count, 2x the RAM, ~10x
cheaper per build-hour.

## Proposal

**`docker_image.yml` — build locally on the runner instead of Cloud Build:**
- Runs on `linera-io-self-hosted-builder` (dedicated ARC runner with 56 GB DinD memory,
deployed via linera-io/linera-infra#893)
- Replaces `gcloud builds submit` with `docker build` + `docker push` directly on the
runner's DinD sidecar
- Adds `gcloud auth configure-docker` step for Artifact Registry authentication
- Keeps parallel builds (5 images as background processes, logs collected per-image)
- Fixes injection risk: `github.head_ref` / `github.ref_name` moved to `env:` block
- Timeout increased to 60 min to account for DinD overhead
- Adds Docker layer pruning step to prevent disk ustion

**`build_image.yml` — new `workflow_dispatch` workflow:**
- Replaces `gcloud builds submit` as the generic "submit a build" interface
- Anyone with repo access can trigger via `gh workflow run` — no kubeconfig or gcloud
needed
- Inputs: `image_type` (main/indexer/explorer/exporter/bridge/all), `image_tag`,
`build_mode` (release/debug), `ref` (git ref to build)
- Used by `lineractl build-image` (migrated in linera-io/linera-infra#893)
- All user inputs passed via `env:` blocks for injection safety

## Test Plan

After merge, trigger a test build:
```bash
gh workflow run build_image.yml --repo linera-io/linera-protocol --ref main \
-f image_type=exporter -f image_tag=test-builder -f build_mode=release
Then test the main image (the one that was OOMing):
gh workflow run build_image.yml --repo linera-io/linera-protocol --ref main \
-f image_type=main -f image_tag=test-builder -f build_mode=release
Verify images appear in Artifact Registry with correct tags. Once irmed, backport to
testnet_conway to unblock the broken docker_image workflow.

Release Plan

- These changes should be backported to the latest testnet branch, then
- be released in a validator hotfix.

