### PR TITLE
Check local storage before downloading sender certificates from validators

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1189,32 +1189,14 @@ impl<Env: Environment> Client<Env> {
                     remote_heights.iter().copied().zip(local_certs.into_iter())
                 {
                     if let Some(certificate) = maybe_cert {
-                        let certificate = Arc::unwrap_or_clone(certificate);
-                        let check_result =
-                            Self::check_certificate(max_epoch, committees_ref, &certificate);
-                        let check_ok = check_result
-                            .map(|r| r.into_result().is_ok())
-                            .unwrap_or(false);
                         let chain_id = certificate.block().header.chain_id;
-                        if check_ok {
-                            let mode = ReceiveCertificateMode::AlreadyChecked;
-                            if self
-                                .receive_sender_certificate(certificate, mode, None)
-                                .await
-                                .is_ok()
-                            {
-                                if let Err(error) = sender.send(ChainAndHeight { chain_id, height })
-                                {
-                                    error!(
-                                        %chain_id, %height, %error,
-                                        "failed to send chain and height over the channel",
-                                    );
-                                }
-                                continue;
-                            }
+                        if let Err(error) = sender.send(ChainAndHeight { chain_id, height })
+                        {
+                            error!(
+                                %chain_id, %height, %error,
+                                "failed to send chain and height over the channel",
+                            );
                         }
-                        // Check or receive failed — try downloading from a validator.
-                        still_needed.push(height);
                     } else {
                         still_needed.push(height);
                     }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1185,13 +1185,10 @@ impl<Env: Environment> Client<Env> {
                 .await
             {
                 let mut still_needed = Vec::new();
-                for (height, maybe_cert) in
-                    remote_heights.iter().copied().zip(local_certs.into_iter())
-                {
+                for (height, maybe_cert) in remote_heights.iter().copied().zip(local_certs) {
                     if let Some(certificate) = maybe_cert {
                         let chain_id = certificate.block().header.chain_id;
-                        if let Err(error) = sender.send(ChainAndHeight { chain_id, height })
-                        {
+                        if let Err(error) = sender.send(ChainAndHeight { chain_id, height }) {
                             error!(
                                 %chain_id, %height, %error,
                                 "failed to send chain and height over the channel",

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -340,6 +340,24 @@ impl<Env: Environment> Client<Env> {
         self.environment.storage()
     }
 
+    /// Tries to read a certificate from local storage, using the hash if available
+    /// (fast path) or falling back to a height-based lookup.
+    async fn try_read_local_certificate(
+        &self,
+        chain_id: ChainId,
+        height: BlockHeight,
+        hash: Option<CryptoHash>,
+    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, chain_client::Error> {
+        if let Some(hash) = hash {
+            return Ok(self.storage_client().read_certificate(hash).await?);
+        }
+        let results = self
+            .storage_client()
+            .read_certificates_by_heights(chain_id, &[height])
+            .await?;
+        Ok(results.into_iter().next().flatten())
+    }
+
     pub fn validator_node_provider(&self) -> &Env::Network {
         self.environment.network()
     }
@@ -1159,6 +1177,54 @@ impl<Env: Environment> Client<Env> {
         let committees_ref = &committees;
         let mut nodes = nodes.to_vec();
         while !remote_heights.is_empty() {
+            // Check local storage first — certificates may already be available from
+            // a prior sync cycle, another receiver chain, or a concurrent notification.
+            if let Ok(local_certs) = self
+                .storage_client()
+                .read_certificates_by_heights(sender_chain_id, &remote_heights)
+                .await
+            {
+                let mut still_needed = Vec::new();
+                for (height, maybe_cert) in
+                    remote_heights.iter().copied().zip(local_certs.into_iter())
+                {
+                    if let Some(certificate) = maybe_cert {
+                        let certificate = Arc::unwrap_or_clone(certificate);
+                        let check_result =
+                            Self::check_certificate(max_epoch, committees_ref, &certificate);
+                        let check_ok = check_result
+                            .map(|r| r.into_result().is_ok())
+                            .unwrap_or(false);
+                        let chain_id = certificate.block().header.chain_id;
+                        if check_ok {
+                            let mode = ReceiveCertificateMode::AlreadyChecked;
+                            if self
+                                .receive_sender_certificate(certificate, mode, None)
+                                .await
+                                .is_ok()
+                            {
+                                if let Err(error) = sender.send(ChainAndHeight { chain_id, height })
+                                {
+                                    error!(
+                                        %chain_id, %height, %error,
+                                        "failed to send chain and height over the channel",
+                                    );
+                                }
+                                continue;
+                            }
+                        }
+                        // Check or receive failed — try downloading from a validator.
+                        still_needed.push(height);
+                    } else {
+                        still_needed.push(height);
+                    }
+                }
+                remote_heights = still_needed;
+                if remote_heights.is_empty() {
+                    break;
+                }
+            }
+
             let remote_heights_ref = &remote_heights;
             let certificates = match communicate_concurrently(
                 &nodes,
@@ -1330,23 +1396,36 @@ impl<Env: Environment> Client<Env> {
         // the chain of previous_message_blocks back to next_outbox_height.
         let mut certificates = BTreeMap::new();
         let mut current_height = height;
+        // On the first iteration we only have a height; subsequent iterations
+        // also carry the hash from `previous_message_blocks`.
+        let mut current_hash: Option<CryptoHash> = None;
 
         // Stop if we've reached the height we've already processed.
         while current_height >= next_outbox_height {
-            // Download the certificate for this height.
-            let downloaded = self
-                .requests_scheduler
-                .download_certificates_by_heights(
-                    remote_node,
-                    sender_chain_id,
-                    vec![current_height],
-                )
-                .await?;
-            let Some(certificate) = downloaded.into_iter().next() else {
-                return Err(chain_client::Error::CannotDownloadMissingSenderBlock {
-                    chain_id: sender_chain_id,
-                    height: current_height,
-                });
+            // Try local storage first — avoids a validator round-trip when
+            // the certificate was already downloaded by a prior sync cycle,
+            // another receiver chain, or a concurrent notification handler.
+            let certificate = if let Some(local) = self
+                .try_read_local_certificate(sender_chain_id, current_height, current_hash)
+                .await?
+            {
+                Arc::unwrap_or_clone(local)
+            } else {
+                let downloaded = self
+                    .requests_scheduler
+                    .download_certificates_by_heights(
+                        remote_node,
+                        sender_chain_id,
+                        vec![current_height],
+                    )
+                    .await?;
+                let Some(certificate) = downloaded.into_iter().next() else {
+                    return Err(chain_client::Error::CannotDownloadMissingSenderBlock {
+                        chain_id: sender_chain_id,
+                        height: current_height,
+                    });
+                };
+                certificate
             };
 
             // Validate the certificate.
@@ -1355,18 +1434,19 @@ impl<Env: Environment> Client<Env> {
 
             // Check if there's a previous message block to our chain.
             let block = certificate.block();
-            let next_height = block
+            let next = block
                 .body
                 .previous_message_blocks
                 .get(&receiver_chain_id)
-                .map(|(_prev_hash, prev_height)| *prev_height);
+                .map(|(prev_hash, prev_height)| (*prev_hash, *prev_height));
 
             // Store this certificate.
             certificates.insert(current_height, certificate);
 
-            if let Some(prev_height) = next_height {
-                // Continue with the previous block.
+            if let Some((prev_hash, prev_height)) = next {
+                // Continue with the previous block (now with its hash for local lookup).
                 current_height = prev_height;
+                current_hash = Some(prev_hash);
             } else {
                 // No more dependencies.
                 break;


### PR DESCRIPTION
## Motivation

Two client functions download sender chain certificates from validators without first
checking local storage (RocksDB). After a worker restart, when multiple managed chains
sync from the same sender, the first chain's sync stores the certificates in RocksDB —
but subsequent chains re-download the same certificates from validators instead of
reading them locally. The same redundancy occurs when notification-driven downloads race
with `find_received_certificates`.

A third function in the same file, `download_event_bearing_blocks`, already follows the
correct pattern: it calls `storage_client().read_certificate(hash)` before downloading.
These changes make the two remaining functions consistent with that pattern.

## Proposal

**`download_sender_block_with_sending_ancestors`** (`linera-core/src/client/mod.rs`):
- Now checks RocksDB before downloading each certificate while walking the
`previous_message_blocks` chain
- Uses hash-based lookup when the hash is ailable from `previous_message_blocks`
(previously discarded as `_prev_hash`), falls back to height-based lookup on the first
iteration
- Introduced a small `try_read_local_certificate` helper shared with future callers

**`download_and_process_sender_chain`** (`linera-core/src/client/mod.rs`):
- Batch-checks RocksDB via `read_certificates_by_heights` at the top of each loop
iteration
- Processes locally-found certificates immediately, only downloads the remaining heights
from validators

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch
