### PR TITLE
Fix inverted chain worker TTL assignment

### DIFF
--- a/linera-core/src/chain_worker/handle.rs
+++ b/linera-core/src/chain_worker/handle.rs
@@ -137,9 +137,9 @@ pub(crate) fn create_chain_worker<S: Storage + Clone + 'static>(
     let chain_id = state.chain().chain_id();
     let arc = Arc::new(RwLock::new(state));
     let ttl = if is_tracked {
-        config.sender_chain_ttl
-    } else {
         config.ttl
+    } else {
+        config.sender_chain_ttl
     };
     if let Some(ttl) = ttl {
         spawn_keep_alive(chain_id, Arc::clone(&arc), last_access, ttl);

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -178,6 +178,7 @@ where
                 allow_messages_from_deprecated_epochs: is_client,
                 long_lived_services: has_long_lived_services,
                 block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
+                sender_chain_ttl: None,
                 ..ChainWorkerConfig::default()
             }
             .with_key_pair(Some(keypair.secret_key));


### PR DESCRIPTION
## Motivation

The chain worker TTL logic in `create_chain_worker` assigns `sender_chain_ttl` (short,
default 100ms) to tracked/owned chains and `ttl` (long, default 30min) to untracked
sender chains. This is backwards — tracked chains are the node's own high-value chains
that should stay loaded, while sender chains are transient and should be evicted
quickly.

On PM workers, this means market and event chains (FullChain mode) get evicted after
100ms of idle time, triggering expensive RocksDB reloads (~500ms p99) on every
subsequent request. Meanwhile, random user chains that sent a single order stay cached
for 30 minutes.

Production metrics from PM worker-5 (BTC-1 market chain):
- 6.4 chain state loads/second due to constant eviction of owned chains
- p99 load_chain latency: 509ms
- p99 queue wait: 686ms (requests queueing behind reloads)

On validators this has no effect because `chain_modes` is `None`, so `is_tracked` is
always `false` and all chains get `ttl`.

## Proposal

Flip the condition so tracked chains get the long TTL and sender chains get the short
one.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch
