### PR TITLE
Fix inverted chain worker TTL assignment

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -413,9 +413,9 @@ where
     fn ttl_timeout(&self) -> Timestamp {
         let now = self.storage.clock().current_time();
         let timeout = if self.is_tracked {
-            self.config.sender_chain_ttl
-        } else {
             self.config.ttl
+        } else {
+            self.config.sender_chain_ttl
         };
         let ttl = TimeDelta::from_micros(u64::try_from(timeout.as_micros()).unwrap_or(u64::MAX));
         now.saturating_add(ttl)


### PR DESCRIPTION
## Motivation

The chain worker TTL logic assigns `sender_chain_ttl` (short, default 100ms on PM
workers) to tracked/owned chains and `ttl` (long, default 30min) to untracked sender
chains. This is the opposite of what PR #4665 intended:

> "We don't need to keep chain workers for sender chains in memory for as long as the
tracked chains."

On PM workers, this means market and event chains (FullChain mode) get evicted after
100ms of idle time, triggering RocksDB reloads (~500ms p99) on every subsequent request.
Meanwhile, transient user chains that sent a single order stay cached for 30 minutes.

On validators this has no effect (`chain_modes` is `None`, so `is_tracked` is always
`false`).

The bug was introduced in #4630 (2025-10-02).

## Proposal

Flip the condition so tracked chains get `ttl` and sender chains get `sender_chain_ttl`.

## Test Plan

CI
