### PR TITLE
Relayer updates committes

### DIFF
--- a/docker/docker-compose.bridge-test.yml
+++ b/docker/docker-compose.bridge-test.yml
@@ -28,7 +28,7 @@ services:
     networks:
       - linera-network
 
-  # 1. ScyllaDB - storage backend for linera network and exporter
+  # 1. ScyllaDB - storage backend for linera network
   scylla-setup:
     image: ubuntu:24.04
     privileged: true
@@ -83,14 +83,10 @@ services:
           --path ${LINERA_NET_PATH:-/tmp/wallet} \
           --with-faucet \
           --faucet-port ${FAUCET_PORT:-8080} \
-          --with-block-exporter \
-          --exporter-address linera-block-exporter \
-          --exporter-port ${BLOCK_EXPORTER_PORT:-8882} \
           $${HTTP_REQUEST_ALLOW_LIST:+--http-request-allow-list $$HTTP_REQUEST_ALLOW_LIST}
     environment:
       - RUST_LOG=linera=info
       - FAUCET_PORT=${FAUCET_PORT:-8080}
-      - BLOCK_EXPORTER_PORT=${BLOCK_EXPORTER_PORT:-8882}
       - LINERA_NET_PATH=${LINERA_NET_PATH:-/tmp/wallet}
       - HTTP_REQUEST_ALLOW_LIST=${HTTP_REQUEST_ALLOW_LIST:-anvil}
     healthcheck:
@@ -109,35 +105,7 @@ services:
     networks:
       - linera-network
 
-  # 3. Storage init - waits for network to initialize storage
-  storage-init:
-    image: "${LINERA_NETWORK_IMAGE:-linera-test}"
-    pull_policy: if_not_present
-    command:
-      - sh
-      - -c
-      - |
-        echo "Waiting for storage namespace to be initialized..."
-        while true; do
-          ./linera storage check-existence --storage scylladb:tcp:scylla:9042:table_default_server_0_db
-          status=$$?
-          if [ $$status -eq 0 ]; then
-            echo "Storage namespace exists, exporter can start."
-            exit 0
-          else
-            echo "Storage not ready (status: $$status), retrying in 5 seconds..."
-            sleep 5
-          fi
-        done
-    depends_on:
-      linera-network:
-        condition: service_started
-      scylla:
-        condition: service_healthy
-    networks:
-      - linera-network
-
-  # 4a. Bridge args init - queries faucet for committee data and outputs constructor args
+  # 3a. Bridge args init - queries faucet for committee data and outputs constructor args
   bridge-args-init:
     image: "${LINERA_BRIDGE_IMAGE:-linera-bridge}"
     pull_policy: if_not_present
@@ -157,7 +125,7 @@ services:
     networks:
       - linera-network
 
-  # 4b. Bridge init - deploys LightClient contract to Anvil using constructor args
+  # 3b. Bridge init - deploys LightClient contract to Anvil using constructor args
   bridge-init:
     image: "${FOUNDRY_IMAGE:-foundry-jq}"
     pull_policy: if_not_present
@@ -223,63 +191,7 @@ services:
     networks:
       - linera-network
 
-  # 5. Block Exporter - starts after storage is initialized and LightClient is deployed
-  linera-block-exporter:
-    image: "${LINERA_EXPORTER_IMAGE:-linera-exporter}"
-    pull_policy: if_not_present
-    ports:
-      - "${BLOCK_EXPORTER_PORT:-8882}:${BLOCK_EXPORTER_PORT:-8882}"
-      - "${EXPORTER_METRICS_PORT:-9091}:9091"
-    command:
-      - sh
-      - -c
-      - |
-        echo "Waiting for LightClient contract address..."
-        while [ ! -f /shared/light-client-address ]; do
-          sleep 1
-        done
-        LIGHT_CLIENT_ADDRESS=$$(cat /shared/light-client-address)
-        echo "Using LightClient at: $$LIGHT_CLIENT_ADDRESS"
-
-        # Generate exporter config with EVM destination
-        cat > /tmp/exporter-config.toml << TOML
-        id = 1
-        metrics_port = 9091
-
-        [service_config]
-        host = "0.0.0.0"
-        port = ${BLOCK_EXPORTER_PORT:-8882}
-
-        [[destination_config.destinations]]
-        kind = "EvmChain"
-        endpoint = "http://anvil:8545"
-        light_client_address = "$$LIGHT_CLIENT_ADDRESS"
-        private_key = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
-        TOML
-
-        exec ./linera-exporter run \
-          --storage scylladb:tcp:scylla:9042:table_default_server_0_db \
-          --config-path /tmp/exporter-config.toml
-    environment:
-      - BLOCK_EXPORTER_PORT=${BLOCK_EXPORTER_PORT:-8882}
-    volumes:
-      - bridge-shared:/shared:ro
-      - ./exporter-data:/data
-    depends_on:
-      storage-init:
-        condition: service_completed_successfully
-      bridge-init:
-        condition: service_completed_successfully
-    healthcheck:
-      test: ["CMD-SHELL", "nc -z localhost ${BLOCK_EXPORTER_PORT:-8882}"]
-      interval: 5s
-      timeout: 3s
-      retries: 10
-      start_period: 20s
-    networks:
-      - linera-network
-
-  # 6a. Bridge chain init - claims a chain for the relay before the relay starts.
+  # 4a. Bridge chain init - claims a chain for the relay before the relay starts.
   #     Writes bridge-chain-id and relay-owner to /shared/ so the setup script
   #     and the relay can use them.
   bridge-chain-init:
@@ -325,7 +237,7 @@ services:
       linera-network:
         condition: service_healthy
 
-  # 6b. Relay server - processes inbox, forwards blocks to EVM.
+  # 4b. Relay server - processes inbox, forwards blocks to EVM.
   #     Uses the chain claimed by bridge-chain-init.
   #     Bridge address is resolved from /shared/bridge-address (written by setup script).
   # Uses network_mode: service:linera-network so that localhost:13001 reaches the

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -140,6 +140,13 @@ fn main() -> Result<()> {
 #[cfg(feature = "relay")]
 impl ServeOptions {
     async fn run(&self) -> Result<()> {
+        linera_base::tracing::init("linera-bridge");
+
+        // Tonic pulls in rustls 0.23 which requires an explicit crypto provider.
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("failed to install rustls crypto provider");
+
         Box::pin(linera_bridge::relay::run(
             &self.rpc_url,
             self.faucet_url.as_deref(),

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -90,6 +90,11 @@ struct ServeOptions {
     #[arg(long)]
     linera_fungible_address: String,
 
+    /// Address of the LightClient contract on EVM.
+    /// When provided, skips discovering it via FungibleBridge.lightClient().
+    #[arg(long)]
+    evm_light_client_address: Option<String>,
+
     /// EVM private key for signing addBlock transactions
     #[arg(long)]
     evm_private_key: String,
@@ -147,6 +152,7 @@ impl ServeOptions {
             &self.linera_bridge_address,
             &self.linera_fungible_address,
             &self.evm_private_key,
+            self.evm_light_client_address.as_deref(),
             self.port,
             &self.common_storage_options,
             self.monitor_scan_interval,

--- a/linera-bridge/src/relay/committee.rs
+++ b/linera-bridge/src/relay/committee.rs
@@ -67,7 +67,13 @@ where
     S: Storage + Clone + Send + Sync + 'static,
     P: Provider,
 {
-    let current_epoch = evm_client.get_current_epoch().await?;
+    let current_epoch = match evm_client.get_current_epoch().await {
+        Ok(epoch) => epoch,
+        Err(e) => {
+            tracing::info!("LightClient not initialized yet, skipping catch-up: {e:#}");
+            return Ok(());
+        }
+    };
     tracing::info!(
         current_epoch,
         %admin_chain_id,

--- a/linera-bridge/src/relay/committee.rs
+++ b/linera-bridge/src/relay/committee.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Detects committee rotation operations on the admin chain and relays
+//! them to the EVM LightClient contract.
+
+use alloy::providers::Provider;
+use anyhow::{Context as _, Result};
+use linera_base::{
+    data_types::{BlockHeight, Epoch},
+    identifiers::{BlobId, BlobType, ChainId},
+};
+use linera_chain::types::ConfirmedBlockCertificate;
+use linera_execution::{system::AdminOperation, Operation, SystemOperation};
+use linera_storage::Storage;
+
+use super::evm::EvmClient;
+use crate::evm::client::extract_validator_keys;
+
+/// Scans a certificate for a `CreateCommittee` operation.
+/// Returns the epoch and blob hash if found.
+pub fn find_create_committee(
+    cert: &ConfirmedBlockCertificate,
+) -> Option<(Epoch, linera_base::crypto::CryptoHash)> {
+    cert.inner().block().body.operations().find_map(|op| {
+        if let Operation::System(boxed) = op {
+            if let SystemOperation::Admin(AdminOperation::CreateCommittee {
+                epoch,
+                blob_hash,
+                ..
+            }) = boxed.as_ref()
+            {
+                return Some((*epoch, *blob_hash));
+            }
+        }
+        None
+    })
+}
+
+/// Relays a single committee update to the LightClient contract.
+pub async fn relay_committee<P: Provider>(
+    evm_client: &EvmClient<P>,
+    cert: &ConfirmedBlockCertificate,
+    committee_blob_bytes: &[u8],
+) -> Result<()> {
+    let validator_keys = extract_validator_keys(committee_blob_bytes)?;
+    let cert_bytes = bcs::to_bytes(cert).context("failed to BCS-serialize certificate")?;
+
+    let tx_hash = evm_client
+        .add_committee(&cert_bytes, committee_blob_bytes, validator_keys)
+        .await?;
+
+    tracing::info!(%tx_hash, "Relayed committee to LightClient");
+    Ok(())
+}
+
+/// Catches up the LightClient with any committee updates missed while offline.
+/// Scans admin chain blocks and relays committees newer than the LightClient's
+/// current epoch. Must succeed before the relay enters the main serve loop.
+pub async fn catch_up<S, P>(
+    storage: &S,
+    evm_client: &EvmClient<P>,
+    admin_chain_id: ChainId,
+    admin_chain_height: BlockHeight,
+) -> Result<()>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    P: Provider,
+{
+    let current_epoch = evm_client.get_current_epoch().await?;
+    tracing::info!(
+        current_epoch,
+        %admin_chain_id,
+        %admin_chain_height,
+        "Checking for missed committee updates"
+    );
+
+    let heights: Vec<BlockHeight> = (0..admin_chain_height.0).map(BlockHeight).collect();
+
+    if heights.is_empty() {
+        tracing::info!("No admin chain blocks to scan");
+        return Ok(());
+    }
+
+    let certs = storage
+        .read_certificates_by_heights(admin_chain_id, &heights)
+        .await?;
+
+    let mut relayed = 0u32;
+    for cert in certs.into_iter().flatten() {
+        if let Some((epoch, blob_hash)) = find_create_committee(&cert) {
+            if epoch.0 <= current_epoch.into() {
+                continue;
+            }
+            let blob_id = BlobId::new(blob_hash, BlobType::Committee);
+            let blob = storage
+                .read_blob(blob_id)
+                .await?
+                .with_context(|| format!("committee blob {blob_id} not found in storage"))?;
+
+            tracing::info!(?epoch, "Relaying missed committee update");
+            relay_committee(evm_client, &cert, blob.bytes())
+                .await
+                .with_context(|| format!("failed to relay committee for epoch {epoch:?}"))?;
+            relayed += 1;
+        }
+    }
+
+    if relayed > 0 {
+        tracing::info!(relayed, "Committee catch-up complete");
+    } else {
+        tracing::info!("LightClient is up to date");
+    }
+    Ok(())
+}

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -64,13 +64,22 @@ pub struct EvmClient<P> {
 }
 
 impl<P: Provider> EvmClient<P> {
-    pub fn new(provider: P, bridge_addr: Address, relayer_addr: Address) -> Self {
+    pub fn new(
+        provider: P,
+        bridge_addr: Address,
+        relayer_addr: Address,
+        light_client_override: Option<Address>,
+    ) -> Self {
+        let light_client_addr = tokio::sync::OnceCell::new();
+        if let Some(addr) = light_client_override {
+            light_client_addr.set(addr).ok();
+        }
         Self {
             provider,
             bridge_addr,
             relayer_addr,
             deposit_event_sig: deposit_event_signature(),
-            light_client_addr: tokio::sync::OnceCell::new(),
+            light_client_addr,
         }
     }
 

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -4,11 +4,12 @@
 //! Centralized EVM client for all bridge EVM interactions.
 
 use alloy::{
-    primitives::{Address, B256, U256},
+    primitives::{Address, Bytes, B256, U256},
     providers::Provider,
     rpc::types::{Filter, Log},
     sol,
 };
+use alloy_sol_types::SolCall;
 use anyhow::{Context as _, Result};
 
 use crate::proof::deposit_event_signature;
@@ -17,7 +18,18 @@ sol! {
     #[sol(rpc)]
     interface IFungibleBridge {
         function addBlock(bytes calldata data) external;
+        function lightClient() external view returns (address);
     }
+}
+
+sol! {
+    function addCommittee(
+        bytes calldata data,
+        bytes calldata committeeBlob,
+        bytes[] calldata validators
+    ) external;
+
+    function currentEpoch() external view returns (uint32);
 }
 
 /// Must match `evm_bridge::BridgeOperation` variant-for-variant for BCS compatibility.
@@ -48,6 +60,7 @@ pub struct EvmClient<P> {
     bridge_addr: Address,
     relayer_addr: Address,
     deposit_event_sig: B256,
+    light_client_addr: tokio::sync::OnceCell<Address>,
 }
 
 impl<P: Provider> EvmClient<P> {
@@ -57,6 +70,7 @@ impl<P: Provider> EvmClient<P> {
             bridge_addr,
             relayer_addr,
             deposit_event_sig: deposit_event_signature(),
+            light_client_addr: tokio::sync::OnceCell::new(),
         }
     }
 
@@ -129,5 +143,65 @@ impl<P: Provider> EvmClient<P> {
             "addBlock transaction confirmed"
         );
         Ok(())
+    }
+
+    /// Discovers the LightClient contract address from the FungibleBridge.
+    pub async fn get_light_client_address(&self) -> Result<Address> {
+        self.light_client_addr
+            .get_or_try_init(|| async {
+                let bridge = IFungibleBridge::new(self.bridge_addr, &self.provider);
+                let addr = bridge
+                    .lightClient()
+                    .call()
+                    .await
+                    .context("failed to query FungibleBridge.lightClient()")?;
+                Ok(addr)
+            })
+            .await
+            .copied()
+    }
+
+    /// Queries the LightClient's current epoch.
+    pub async fn get_current_epoch(&self) -> Result<u32> {
+        let lc_addr = self.get_light_client_address().await?;
+        let call = currentEpochCall {};
+        let tx = alloy::rpc::types::TransactionRequest::default()
+            .to(lc_addr)
+            .input(call.abi_encode().into());
+        let result = self
+            .provider
+            .call(tx)
+            .await
+            .context("failed to query LightClient.currentEpoch()")?;
+        let epoch = currentEpochCall::abi_decode_returns(&result)
+            .context("failed to decode currentEpoch response")?;
+        Ok(epoch)
+    }
+
+    /// Relays a committee update to the LightClient contract.
+    pub async fn add_committee(
+        &self,
+        certificate_bytes: &[u8],
+        committee_blob: &[u8],
+        validator_keys: Vec<Vec<u8>>,
+    ) -> Result<alloy::primitives::TxHash> {
+        let lc_addr = self.get_light_client_address().await?;
+        let call = addCommitteeCall {
+            data: Bytes::copy_from_slice(certificate_bytes),
+            committeeBlob: Bytes::copy_from_slice(committee_blob),
+            validators: validator_keys.into_iter().map(Bytes::from).collect(),
+        };
+        let tx = alloy::rpc::types::TransactionRequest::default()
+            .to(lc_addr)
+            .input(call.abi_encode().into());
+        let receipt = self
+            .provider
+            .send_transaction(tx)
+            .await
+            .context("addCommittee send failed")?
+            .get_receipt()
+            .await
+            .context("addCommittee receipt failed")?;
+        Ok(receipt.transaction_hash)
     }
 }

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -97,13 +97,6 @@ pub async fn run(
     max_retries: u32,
     sqlite_path: Option<&Path>,
 ) -> Result<()> {
-    linera_base::tracing::init("linera-bridge");
-
-    // Tonic pulls in rustls 0.23 which requires an explicit crypto provider.
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .expect("failed to install rustls crypto provider");
-
     tracing::info!("Starting bridge relay server...");
 
     // ── Resolve paths (same defaults as linera binary: ~/.config/linera/) ──

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -13,6 +13,7 @@
 
 use linera_base::crypto::Signer as _;
 
+mod committee;
 pub mod evm;
 pub mod linera;
 pub(crate) mod metrics;

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -89,6 +89,7 @@ pub async fn run(
     linera_bridge_address: &str,
     linera_fungible_address: &str,
     evm_private_key: &str,
+    evm_light_client_address: Option<&str>,
     port: u16,
     common_storage_options: &CommonStorageOptions,
     monitor_scan_interval: u64,
@@ -201,7 +202,7 @@ pub async fn run(
     )
     .await?;
 
-    // ── Sync admin chain (always) ──
+    // ── Sync admin chain ──
     tracing::info!(%admin_chain_id, "Syncing admin chain from validators...");
     let admin_client = ctx.make_chain_client(admin_chain_id).await?;
     admin_client.synchronize_from_validators().await?;
@@ -270,6 +271,7 @@ pub async fn run(
         linera_bridge_address,
         linera_fungible_address,
         evm_private_key,
+        evm_light_client_address,
         port,
         monitor_scan_interval,
         monitor_start_block,
@@ -290,6 +292,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     linera_bridge_address: &str,
     linera_fungible_address: &str,
     evm_private_key: &str,
+    evm_light_client_address: Option<&str>,
     port: u16,
     monitor_scan_interval: u64,
     monitor_start_block: u64,
@@ -312,7 +315,16 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
         .with_simple_nonce_management()
         .connect_http(rpc_url.parse().context("invalid RPC URL")?);
 
-    let evm_client = Arc::new(evm::EvmClient::new(provider, bridge_addr, relayer_addr));
+    let light_client_addr: Option<Address> = evm_light_client_address
+        .map(|s| s.parse())
+        .transpose()
+        .context("invalid --evm-light-client-address")?;
+    let evm_client = Arc::new(evm::EvmClient::new(
+        provider,
+        bridge_addr,
+        relayer_addr,
+        light_client_addr,
+    ));
 
     // ── Catch up LightClient with any missed committee rotations ──
     committee::catch_up(
@@ -340,7 +352,11 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     ));
 
     // ── Start notification listener ──
-    let mut notifications = chain_client.subscribe()?;
+    // Subscribe to admin chain notifications so we detect committee updates
+    // when synchronize_publisher_chains downloads new admin chain blocks.
+    let chain_notifications = chain_client.subscribe()?;
+    let admin_notifications = chain_client.subscribe_to(admin_chain_id)?;
+    let mut notifications = futures::stream::select(chain_notifications, admin_notifications);
     let (listener, _abort_handle, _) = chain_client.listen().await?;
     let chain_listener_handle = tokio::spawn(listener);
 

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -31,7 +31,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::{client::ChainClient, worker::Reason};
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::DbStorage;
+use linera_storage::{DbStorage, Storage as _};
 use linera_storage_runtime::{CommonStorageOptions, StorageConfig, StoreConfig};
 use linera_views::backends::rocks_db::RocksDbDatabase;
 use linera_wallet_json::PersistentWallet;
@@ -205,7 +205,8 @@ pub async fn run(
     tracing::info!(%admin_chain_id, "Syncing admin chain from validators...");
     let admin_client = ctx.make_chain_client(admin_chain_id).await?;
     admin_client.synchronize_from_validators().await?;
-    tracing::info!("Admin chain synced");
+    let admin_chain_height = admin_client.chain_info().await?.next_block_height;
+    tracing::info!(%admin_chain_height, "Admin chain synced");
 
     // ── Resolve bridge chain ──
     let (chain_id, _owner) = if let Some(cid) = chain_id_arg {
@@ -275,6 +276,8 @@ pub async fn run(
         max_retries,
         sqlite_path,
         &db_path,
+        admin_chain_id,
+        admin_chain_height,
     ))
     .await
 }
@@ -293,6 +296,8 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     max_retries: u32,
     sqlite_path_override: Option<&Path>,
     storage_dir: &Path,
+    admin_chain_id: ChainId,
+    admin_chain_height: linera_base::data_types::BlockHeight,
 ) -> Result<()> {
     // ── Set up centralized clients ──
     let bridge_addr: Address = evm_bridge_address
@@ -308,6 +313,16 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
         .connect_http(rpc_url.parse().context("invalid RPC URL")?);
 
     let evm_client = Arc::new(evm::EvmClient::new(provider, bridge_addr, relayer_addr));
+
+    // ── Catch up LightClient with any missed committee rotations ──
+    committee::catch_up(
+        chain_client.storage_client(),
+        &evm_client,
+        admin_chain_id,
+        admin_chain_height,
+    )
+    .await
+    .context("committee catch-up failed")?;
 
     let bridge_app_id: ApplicationId = linera_bridge_address
         .parse()
@@ -450,6 +465,39 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
                         break;
                     }
                 };
+
+                // Handle admin chain committee updates.
+                if notification.chain_id == admin_chain_id {
+                    if let Reason::NewBlock { height, .. } = &notification.reason {
+                        tracing::debug!(%height, "New admin chain block, checking for committee update");
+                        let heights = vec![*height];
+                        if let Ok(certs) = chain_client
+                            .storage_client()
+                            .read_certificates_by_heights(admin_chain_id, &heights)
+                            .await
+                        {
+                            for cert in certs.into_iter().flatten() {
+                                if let Some((epoch, blob_hash)) = committee::find_create_committee(&cert) {
+                                    let blob_id = linera_base::identifiers::BlobId::new(
+                                        blob_hash,
+                                        linera_base::identifiers::BlobType::Committee,
+                                    );
+                                    match chain_client.storage_client().read_blob(blob_id).await {
+                                        Ok(Some(blob)) => {
+                                            match committee::relay_committee(&evm_client, &cert, blob.bytes()).await {
+                                                Ok(()) => tracing::info!(?epoch, "Committee update relayed"),
+                                                Err(e) => tracing::error!(?epoch, error = %e, "Failed to relay committee"),
+                                            }
+                                        }
+                                        Ok(None) => tracing::error!(?blob_id, "Committee blob not found"),
+                                        Err(e) => tracing::error!(error = %e, "Failed to read committee blob"),
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
 
                 if !matches!(notification.reason, Reason::NewIncomingBundle { .. }) {
                     continue;

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -3682,7 +3682,6 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "tokio",
- "url",
 ]
 
 [[package]]

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -1082,6 +1082,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1114,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,10 +1143,13 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -1123,10 +1157,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "tokio",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1145,6 +1184,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1206,6 +1246,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1305,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1428,6 +1489,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "c-kzg"
 version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1568,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1598,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1559,6 +1650,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2162,6 +2262,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2315,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dunce"
@@ -2414,6 +2541,17 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
@@ -2563,6 +2701,17 @@ dependencies = [
 
 [[package]]
 name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
@@ -2676,6 +2825,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "fungible"
 version = "0.1.0"
 dependencies = [
@@ -2732,6 +2887,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2979,6 +3145,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "hdrhistogram"
 version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
 ]
 
 [[package]]
@@ -3577,6 +3761,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128"
@@ -3597,6 +3784,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3612,6 +3809,43 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3675,13 +3909,36 @@ dependencies = [
  "alloy-trie",
  "anyhow",
  "async-trait",
+ "axum",
  "bcs",
+ "clap",
+ "dirs",
+ "fs-err",
+ "futures",
+ "hex",
  "linera-base",
+ "linera-chain",
+ "linera-client",
+ "linera-core",
  "linera-execution",
+ "linera-faucet-client",
+ "linera-storage",
+ "linera-storage-runtime",
+ "linera-views",
+ "linera-wallet-json",
  "op-alloy-network",
+ "prometheus",
+ "reqwest 0.11.27",
+ "rustls 0.23.37",
  "serde",
+ "serde_json",
+ "sqlx",
  "thiserror 1.0.69",
  "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "wrapped-fungible",
 ]
 
 [[package]]
@@ -3700,9 +3957,11 @@ dependencies = [
  "linera-faucet-client",
  "linera-persistent",
  "linera-storage",
+ "linera-storage-runtime",
  "linera-views",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "tempfile",
@@ -3998,6 +4257,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "linera-storage-runtime"
+version = "0.15.15"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cfg_aliases",
+ "clap",
+ "fs-err",
+ "linera-core",
+ "linera-execution",
+ "linera-storage",
+ "linera-views",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "linera-version"
 version = "0.15.15"
 dependencies = [
@@ -4040,6 +4317,7 @@ dependencies = [
  "papaya",
  "prometheus",
  "rand 0.8.5",
+ "rocksdb",
  "serde",
  "sha3",
  "static_assertions",
@@ -4061,6 +4339,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "linera-wallet-json"
+version = "0.15.15"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "fs-err",
+ "futures",
+ "linera-base",
+ "linera-core",
+ "linera-persistent",
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -4290,6 +4583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,6 +4626,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -4481,6 +4794,22 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -4713,6 +5042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "papaya"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,6 +5256,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -5141,7 +5487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph",
@@ -5160,7 +5506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5443,6 +5789,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5670,6 +6027,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ruint"
 version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,6 +6170,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5839,6 +6227,7 @@ version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6146,6 +6535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6229,6 +6629,17 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6389,6 +6800,196 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls 0.23.37",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera 0.8.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume 0.11.1",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6405,6 +7006,17 @@ name = "static_assertions_next"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -6623,7 +7235,7 @@ dependencies = [
  "docker-compose-types",
  "docker_credential",
  "either",
- "etcetera",
+ "etcetera 0.11.0",
  "ferroid",
  "futures",
  "http 1.4.0",
@@ -7299,10 +7911,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7404,6 +8037,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7450,6 +8089,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -7668,7 +8313,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61acb9ce02bf1d1b520049ba93d5454f0ffcd7e8559cd727c83b90b393f64b1d"
 dependencies = [
- "flume",
+ "flume 0.12.0",
  "pin-project-lite",
  "web-thread-select",
 ]
@@ -7711,11 +8356,30 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]

--- a/linera-bridge/tests/e2e/Cargo.toml
+++ b/linera-bridge/tests/e2e/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = "1"
 bcs = "0.1.6"
 futures = "0.3"
 linera-base = { path = "../../../linera-base" }
-linera-bridge = { path = "../../../linera-bridge" }
+linera-bridge = { path = "../../../linera-bridge", features = ["relay"] }
 linera-client = { path = "../../../linera-client", default-features = false, features = [
     "wasmer",
 ] }
@@ -37,12 +37,14 @@ linera-execution = { path = "../../../linera-execution" }
 linera-faucet-client = { path = "../../../linera-faucet/client" }
 linera-persistent = { path = "../../../linera-persistent", features = ["fs"] }
 linera-storage = { path = "../../../linera-storage", features = ["wasmer"] }
+linera-storage-runtime = { path = "../../../linera-storage-runtime" }
 linera-views = { path = "../../../linera-views" }
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "rustls-tls",
 ] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -4,13 +4,14 @@
 //! Shared helpers for linera-bridge end-to-end tests that require
 //! `testcontainers` with docker-compose support.
 
-use std::process::Command;
+use std::{process::Command, sync::Arc};
 
 use alloy::primitives::Address;
 use testcontainers::{
     compose::DockerCompose,
     core::{CmdWaitFor, ExecCommand},
 };
+use tokio::io::AsyncBufReadExt as _;
 
 /// Path inside the container where `linera net up --path` stores wallet files.
 /// Must match the `LINERA_NET_PATH` default in docker-compose.bridge-test.yml.
@@ -217,6 +218,59 @@ pub async fn wait_for_light_client(
     }
     dump_compose_logs(project_name, compose_file);
     panic!("LightClient not deployed within timeout");
+}
+
+/// Monitors a child process's stderr for fatal error patterns.
+/// Returns a handle that can be checked in polling loops to bail early.
+///
+/// Captured lines are re-emitted via `eprintln!` so they appear in test output on failure.
+pub struct StderrMonitor {
+    fatal_error: Arc<std::sync::Mutex<Option<String>>>,
+}
+
+impl StderrMonitor {
+    /// Fatal patterns that indicate a bug (not a transient error).
+    const FATAL_PATTERNS: &[&str] = &[
+        "panicked at",
+        "RuntimeError: unreachable",
+        "deserialization error",
+    ];
+
+    /// Spawns a background task that reads stderr and watches for fatal errors.
+    /// The child process must have `stderr(Stdio::piped())`.
+    pub fn spawn(child: &mut tokio::process::Child, prefix: &str) -> Self {
+        let stderr = child.stderr.take().expect("child stderr was piped");
+        let fatal_error: Arc<std::sync::Mutex<Option<String>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let fatal = fatal_error.clone();
+        let prefix = prefix.to_owned();
+        tokio::spawn(async move {
+            let mut lines = tokio::io::BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                eprintln!("[{prefix}] {line}");
+                if Self::FATAL_PATTERNS.iter().any(|p| line.contains(p)) {
+                    let mut guard = fatal.lock().unwrap();
+                    if guard.is_none() {
+                        *guard = Some(line);
+                    }
+                }
+            }
+        });
+        Self { fatal_error }
+    }
+
+    /// Returns the first fatal error if one was detected, or `None`.
+    pub fn check(&self) -> Option<String> {
+        self.fatal_error.lock().unwrap().clone()
+    }
+
+    /// Bails with the fatal error message if one was detected.
+    pub fn bail_if_fatal(&self) -> anyhow::Result<()> {
+        if let Some(ref err) = *self.fatal_error.lock().unwrap() {
+            anyhow::bail!("Child process hit a fatal error:\n{err}");
+        }
+        Ok(())
+    }
 }
 
 /// Starts docker compose stack with pre-cleanup of stale state.

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -4,14 +4,13 @@
 //! Shared helpers for linera-bridge end-to-end tests that require
 //! `testcontainers` with docker-compose support.
 
-use std::{process::Command, sync::Arc};
+use std::process::Command;
 
 use alloy::primitives::Address;
 use testcontainers::{
     compose::DockerCompose,
     core::{CmdWaitFor, ExecCommand},
 };
-use tokio::io::AsyncBufReadExt as _;
 
 /// Path inside the container where `linera net up --path` stores wallet files.
 /// Must match the `LINERA_NET_PATH` default in docker-compose.bridge-test.yml.
@@ -220,57 +219,11 @@ pub async fn wait_for_light_client(
     panic!("LightClient not deployed within timeout");
 }
 
-/// Monitors a child process's stderr for fatal error patterns.
-/// Returns a handle that can be checked in polling loops to bail early.
-///
-/// Captured lines are re-emitted via `eprintln!` so they appear in test output on failure.
-pub struct StderrMonitor {
-    fatal_error: Arc<std::sync::Mutex<Option<String>>>,
-}
-
-impl StderrMonitor {
-    /// Fatal patterns that indicate a bug (not a transient error).
-    const FATAL_PATTERNS: &[&str] = &[
-        "panicked at",
-        "RuntimeError: unreachable",
-        "deserialization error",
-    ];
-
-    /// Spawns a background task that reads stderr and watches for fatal errors.
-    /// The child process must have `stderr(Stdio::piped())`.
-    pub fn spawn(child: &mut tokio::process::Child, prefix: &str) -> Self {
-        let stderr = child.stderr.take().expect("child stderr was piped");
-        let fatal_error: Arc<std::sync::Mutex<Option<String>>> =
-            Arc::new(std::sync::Mutex::new(None));
-        let fatal = fatal_error.clone();
-        let prefix = prefix.to_owned();
-        tokio::spawn(async move {
-            let mut lines = tokio::io::BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                eprintln!("[{prefix}] {line}");
-                if Self::FATAL_PATTERNS.iter().any(|p| line.contains(p)) {
-                    let mut guard = fatal.lock().unwrap();
-                    if guard.is_none() {
-                        *guard = Some(line);
-                    }
-                }
-            }
-        });
-        Self { fatal_error }
-    }
-
-    /// Returns the first fatal error if one was detected, or `None`.
-    pub fn check(&self) -> Option<String> {
-        self.fatal_error.lock().unwrap().clone()
-    }
-
-    /// Bails with the fatal error message if one was detected.
-    pub fn bail_if_fatal(&self) -> anyhow::Result<()> {
-        if let Some(ref err) = *self.fatal_error.lock().unwrap() {
-            anyhow::bail!("Child process hit a fatal error:\n{err}");
-        }
-        Ok(())
-    }
+/// Installs the rustls crypto provider if not already set.
+/// Required because enabling the `relay` feature links rustls which
+/// needs an explicit provider before any TLS usage.
+pub fn ensure_rustls_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 /// Starts docker compose stack with pre-cleanup of stale state.

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -188,6 +188,37 @@ pub async fn query_deposit_processed<E: linera_core::environment::Environment>(
     Ok(response["data"]["isDepositProcessed"].as_bool() == Some(true))
 }
 
+/// Waits for the `bridge-init` container to deploy the LightClient contract.
+/// Must be called before deploying any test contracts to avoid a nonce race
+/// (bridge-init and the test both use Anvil account 0).
+pub async fn wait_for_light_client(
+    compose: &DockerCompose,
+    project_name: &str,
+    compose_file: &std::path::Path,
+) {
+    tracing::info!("Waiting for LightClient deployment (bridge-init)...");
+    for attempt in 0..60 {
+        let result = exec_output(
+            compose,
+            "foundry-tools",
+            &format!(
+                "cast code {} --rpc-url http://anvil:8545",
+                light_client_address()
+            ),
+            project_name,
+            compose_file,
+        )
+        .await;
+        if result.trim() != "0x" && !result.trim().is_empty() {
+            tracing::info!(attempt, "LightClient deployed");
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+    dump_compose_logs(project_name, compose_file);
+    panic!("LightClient not deployed within timeout");
+}
+
 /// Starts docker compose stack with pre-cleanup of stale state.
 pub async fn start_compose(compose_file: &std::path::Path, project_name: &str) -> DockerCompose {
     let compose_file_str = compose_file

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -33,7 +33,7 @@ use linera_base::{
 };
 use linera_bridge_e2e::{
     compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
-    start_compose, ANVIL_PRIVATE_KEY,
+    start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -86,6 +86,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
 
     // ── Phase 1: Start docker compose stack ──
     let compose = start_compose(&compose_file, project_name).await;
+    wait_for_light_client(&compose, project_name, &compose_file).await;
 
     // ── Phase 2: Create Linera client, claim chains ──
     tracing::info!("Creating programmatic Linera client...");

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -15,6 +15,8 @@
 //! 3. FungibleBridge with real applicationId (EVM)
 //! 4. evm-bridge app with bridge address (Linera)
 
+#![recursion_limit = "512"]
+
 use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 
 use alloy::{
@@ -33,7 +35,7 @@ use linera_base::{
 };
 use linera_bridge_e2e::{
     compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
-    start_compose, wait_for_light_client, StderrMonitor, ANVIL_PRIVATE_KEY,
+    start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -81,6 +83,7 @@ sol! {
 #[ignore] // Requires pre-built docker images, Wasm, and relay binary
 async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_test_writer().try_init().ok();
+    linera_bridge_e2e::ensure_rustls_provider();
     let compose_file = compose_file_path();
     let project_name = "linera-auto-scan-test";
 
@@ -320,17 +323,10 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         .wallet(evm_wallet)
         .connect_http(rpc_url);
 
-    let relay_binary = repo_root.join("target/debug/linera-bridge");
-    anyhow::ensure!(
-        relay_binary.exists(),
-        "Relay binary not found at {relay_binary:?}. \
-         Run: cargo build -p linera-bridge --features relay"
-    );
-
     let relay_dir = tempfile::tempdir()?;
     let wallet_path = relay_dir.path().join("wallet.json");
     let keystore_path = relay_dir.path().join("keystore.json");
-    let storage_path = format!("rocksdb:{}", relay_dir.path().join("client.db").display());
+    let storage_config = format!("rocksdb:{}", relay_dir.path().join("client.db").display());
 
     {
         use linera_persistent::Persist;
@@ -338,44 +334,34 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         ks.persist().await?;
     }
 
-    // The relay creates its own chain_client for chain A.
-    // We keep cc_a alive for diagnostics but don't create blocks on it.
-
-    let relay_port = 3002;
-    tracing::info!("Starting relay binary...");
-    let mut relay_process = tokio::process::Command::new(&relay_binary)
-        .args([
-            "serve",
-            "--rpc-url",
+    let relay_port = 3002u16;
+    let bridge_addr_str = format!("{bridge_addr}");
+    let bridge_app_str = format!("{bridge_app_id}");
+    let fungible_app_str = format!("{fungible_app_id}");
+    tracing::info!("Starting relay...");
+    let relay_handle = tokio::spawn(async move {
+        Box::pin(linera_bridge::relay::run(
             "http://localhost:8545",
-            "--faucet-url",
-            "http://localhost:8080",
-            "--wallet",
-            wallet_path.to_str().unwrap(),
-            "--keystore",
-            keystore_path.to_str().unwrap(),
-            "--storage",
-            &storage_path,
-            &format!("--linera-bridge-chain-id={chain_a}"),
-            &format!("--linera-bridge-chain-owner={owner_a}"),
-            &format!("--evm-bridge-address={bridge_addr}"),
-            &format!("--linera-bridge-address={bridge_app_id}"),
-            &format!("--linera-fungible-address={fungible_app_id}"),
-            &format!("--evm-private-key={ANVIL_PRIVATE_KEY}"),
-            &format!("--port={relay_port}"),
-            "--monitor-scan-interval",
-            "5",
-            "--max-retries",
-            "5",
-        ])
-        .env("RUST_LOG", "linera=info,linera_bridge=debug")
-        .kill_on_drop(true)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .context("failed to spawn relay binary")?;
-
-    let relay_monitor = StderrMonitor::spawn(&mut relay_process, "relay");
+            Some("http://localhost:8080"),
+            Some(wallet_path.as_path()),
+            Some(keystore_path.as_path()),
+            Some(&storage_config),
+            Some(chain_a),
+            Some(owner_a),
+            &bridge_addr_str,
+            &bridge_app_str,
+            &fungible_app_str,
+            ANVIL_PRIVATE_KEY,
+            None,
+            relay_port,
+            &linera_storage_runtime::CommonStorageOptions::with_defaults(),
+            5,  // monitor_scan_interval
+            0,  // monitor_start_block
+            5,  // max_retries
+            None,
+        ))
+        .await
+    });
 
     let relay_url = format!("http://localhost:{relay_port}");
     let client = reqwest::Client::new();
@@ -391,7 +377,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             break;
         }
         if attempt == 29 {
-            relay_process.kill().await.ok();
+            relay_handle.abort();
             anyhow::bail!("Relay did not become ready");
         }
     }
@@ -454,7 +440,9 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     for attempt in 0..60 {
         tokio::time::sleep(Duration::from_secs(5)).await;
 
-        relay_monitor.bail_if_fatal()?;
+        if relay_handle.is_finished() {
+            anyhow::bail!("Relay exited unexpectedly: {:?}", relay_handle.await);
+        }
 
         // Sync chain B to receive minted tokens.
         cc_b.synchronize_from_validators().await?;
@@ -474,7 +462,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             }
         }
         if attempt == 59 {
-            relay_process.kill().await.ok();
+            relay_handle.abort();
             anyhow::bail!("Deposit not auto-processed within timeout");
         }
     }
@@ -515,18 +503,20 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     for attempt in 0..60 {
         tokio::time::sleep(Duration::from_secs(5)).await;
 
-        relay_monitor.bail_if_fatal()?;
+        if relay_handle.is_finished() {
+            anyhow::bail!("Relay exited unexpectedly: {:?}", relay_handle.await);
+        }
 
         let balance = erc20_contract.balanceOf(evm_recipient_addr).call().await?;
         tracing::info!(attempt, ?balance, "ERC-20 balance");
 
         if balance >= expected_balance {
-            relay_process.kill().await.ok();
+            relay_handle.abort();
             tracing::info!("Test passed! Both directions: EVM→Linera deposit + Linera→EVM burn.");
             return Ok(());
         }
     }
 
-    relay_process.kill().await.ok();
+    relay_handle.abort();
     anyhow::bail!("Burn not forwarded to EVM within timeout");
 }

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -33,7 +33,7 @@ use linera_base::{
 };
 use linera_bridge_e2e::{
     compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
-    start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
+    start_compose, wait_for_light_client, StderrMonitor, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -371,9 +371,11 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         .env("RUST_LOG", "linera=info,linera_bridge=debug")
         .kill_on_drop(true)
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .context("failed to spawn relay binary")?;
+
+    let relay_monitor = StderrMonitor::spawn(&mut relay_process, "relay");
 
     let relay_url = format!("http://localhost:{relay_port}");
     let client = reqwest::Client::new();
@@ -452,6 +454,8 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     for attempt in 0..60 {
         tokio::time::sleep(Duration::from_secs(5)).await;
 
+        relay_monitor.bail_if_fatal()?;
+
         // Sync chain B to receive minted tokens.
         cc_b.synchronize_from_validators().await?;
         cc_b.process_inbox().await?;
@@ -510,6 +514,8 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
 
     for attempt in 0..60 {
         tokio::time::sleep(Duration::from_secs(5)).await;
+
+        relay_monitor.bail_if_fatal()?;
 
         let balance = erc20_contract.balanceOf(evm_recipient_addr).call().await?;
         tracing::info!(attempt, ?balance, "ERC-20 balance");

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -10,7 +10,7 @@ use alloy::{providers::ProviderBuilder, sol};
 use linera_base::crypto::{AccountPublicKey, ValidatorKeypair};
 use linera_bridge_e2e::{
     compose_file_path, create_extra_wallet, dump_compose_logs, exec_ok, extra_wallet_env,
-    light_client_address, start_compose,
+    light_client_address, start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
 };
 
 sol! {
@@ -40,6 +40,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
     let project_name = "linera-bridge-test";
 
     let compose = start_compose(&compose_file, project_name).await;
+    wait_for_light_client(&compose, project_name, &compose_file).await;
 
     // Verify initial epoch is 0.
     let epoch = query_current_epoch().await?;

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! End-to-end test: trigger a committee rotation on Linera and verify the exporter relays
+//! End-to-end test: trigger a committee rotation on Linera and verify the relay relays
 //! it to the LightClient contract on Anvil (via docker-compose).
 
 use std::time::{Duration, Instant};
@@ -74,10 +74,10 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
     )
     .await;
 
-    tracing::info!("Committee rotation triggered, waiting for exporter to relay...");
+    tracing::info!("Committee rotation triggered, waiting for relay to forward...");
 
     // Poll until epoch advances to 1 (timeout 120s — compose startup is already done,
-    // but the exporter needs to pick up the new committee and relay it).
+    // but the relay needs to pick up the new committee and relay it).
     let timeout = Duration::from_secs(120);
     let poll_interval = Duration::from_secs(3);
     let start = Instant::now();

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -1,20 +1,20 @@
+#![recursion_limit = "512"]
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 //! End-to-end test: trigger a committee rotation on Linera and verify the relay relays
 //! it to the LightClient contract on Anvil (via docker-compose).
 
-use std::{path::PathBuf, time::{Duration, Instant}};
+use std::time::{Duration, Instant};
 
 use alloy::{providers::ProviderBuilder, sol};
-use anyhow::Context as _;
 use linera_base::{
     crypto::{AccountPublicKey, InMemorySigner, ValidatorKeypair},
     identifiers::AccountOwner,
 };
 use linera_bridge_e2e::{
     compose_file_path, create_extra_wallet, dump_compose_logs, exec_ok, extra_wallet_env,
-    light_client_address, start_compose, wait_for_light_client, StderrMonitor, ANVIL_PRIVATE_KEY,
+    light_client_address, start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
 };
 use linera_faucet_client::Faucet;
 
@@ -41,6 +41,7 @@ async fn query_current_epoch() -> anyhow::Result<u32> {
 #[ignore] // Requires pre-built docker images: `make -C linera-bridge build-all`
 async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_test_writer().try_init().ok();
+    linera_bridge_e2e::ensure_rustls_provider();
     let compose_file = compose_file_path();
     let project_name = "linera-bridge-test";
 
@@ -68,55 +69,38 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
         ks.persist().await?;
     }
 
-    // Start a local relay in committee-only mode (no bridge app IDs needed).
-    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(3)
-        .context("manifest dir has fewer than 3 ancestors")?
-        .to_path_buf();
-    let relay_binary = repo_root.join("target/debug/linera-bridge");
-    anyhow::ensure!(
-        relay_binary.exists(),
-        "Relay binary not found at {relay_binary:?}. \
-         Run: cargo build -p linera-bridge --features relay"
-    );
-
-    let relay_port = 3003;
+    // Start the relay as an in-process background task.
     let light_client = light_client_address();
     let wallet_path = relay_dir.path().join("wallet.json");
-    let storage_path = format!("rocksdb:{}", relay_dir.path().join("client.db").display());
-    let mut relay_process = tokio::process::Command::new(&relay_binary)
-        .args([
-            "serve",
-            "--rpc-url",
+    let storage_config = format!("rocksdb:{}", relay_dir.path().join("client.db").display());
+    let relay_port = 3003u16;
+
+    let relay_handle = tokio::spawn(async move {
+        Box::pin(linera_bridge::relay::run(
             "http://localhost:8545",
-            "--faucet-url",
-            "http://localhost:8080",
-            "--wallet",
-            wallet_path.to_str().unwrap(),
-            "--keystore",
-            keystore_path.to_str().unwrap(),
-            "--storage",
-            &storage_path,
-            &format!("--linera-bridge-chain-id={relay_chain_id}"),
-            &format!("--linera-bridge-chain-owner={relay_owner}"),
+            Some("http://localhost:8080"),
+            Some(wallet_path.as_path()),
+            Some(keystore_path.as_path()),
+            Some(&storage_config),
+            Some(relay_chain_id),
+            Some(relay_owner),
             // Dummy values — committee relay only needs the LightClient, not the bridge apps.
-            "--evm-bridge-address=0x0000000000000000000000000000000000000000",
-            "--linera-bridge-address=0000000000000000000000000000000000000000000000000000000000000000",
-            "--linera-fungible-address=0000000000000000000000000000000000000000000000000000000000000000",
-            &format!("--evm-light-client-address={light_client}"),
-            &format!("--evm-private-key={ANVIL_PRIVATE_KEY}"),
-            &format!("--port={relay_port}"),
-        ])
-        .env("RUST_LOG", "linera=info,linera_bridge=debug")
-        .kill_on_drop(true)
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .context("failed to spawn relay binary")?;
+            "0x0000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            ANVIL_PRIVATE_KEY,
+            Some(&light_client.to_string()),
+            relay_port,
+            &linera_storage_runtime::CommonStorageOptions::with_defaults(),
+            5,  // monitor_scan_interval
+            0,  // monitor_start_block
+            5,  // max_retries
+            None,
+        ))
+        .await
+    });
 
-    let relay_monitor = StderrMonitor::spawn(&mut relay_process, "relay");
-
+    // Wait for relay's HTTP server to be ready.
     let relay_url = format!("http://localhost:{relay_port}");
     let client = reqwest::Client::new();
     for attempt in 0..30 {
@@ -131,7 +115,6 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             break;
         }
         if attempt == 29 {
-            relay_process.kill().await.ok();
             anyhow::bail!("Relay did not become ready");
         }
     }
@@ -177,6 +160,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             Ok(epoch) if epoch >= 1 => {
                 tracing::info!(epoch, "Epoch advanced");
                 assert_eq!(epoch, 1, "epoch should be exactly 1 after one rotation");
+                relay_handle.abort();
                 return Ok(());
             }
             Ok(epoch) => {
@@ -187,7 +171,12 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             }
         }
 
+        if relay_handle.is_finished() {
+            anyhow::bail!("Relay exited unexpectedly: {:?}", relay_handle.await);
+        }
+
         if start.elapsed() > timeout {
+            relay_handle.abort();
             dump_compose_logs(project_name, &compose_file);
             anyhow::bail!(
                 "Timed out waiting for epoch to advance to 1 (waited {:?})",
@@ -196,6 +185,5 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
         }
 
         tokio::time::sleep(poll_interval).await;
-        relay_monitor.bail_if_fatal()?;
     }
 }

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -4,14 +4,19 @@
 //! End-to-end test: trigger a committee rotation on Linera and verify the relay relays
 //! it to the LightClient contract on Anvil (via docker-compose).
 
-use std::time::{Duration, Instant};
+use std::{path::PathBuf, time::{Duration, Instant}};
 
 use alloy::{providers::ProviderBuilder, sol};
-use linera_base::crypto::{AccountPublicKey, ValidatorKeypair};
+use anyhow::Context as _;
+use linera_base::{
+    crypto::{AccountPublicKey, InMemorySigner, ValidatorKeypair},
+    identifiers::AccountOwner,
+};
 use linera_bridge_e2e::{
     compose_file_path, create_extra_wallet, dump_compose_logs, exec_ok, extra_wallet_env,
-    light_client_address, start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
+    light_client_address, start_compose, wait_for_light_client, StderrMonitor, ANVIL_PRIVATE_KEY,
 };
+use linera_faucet_client::Faucet;
 
 sol! {
     #[sol(rpc)]
@@ -46,6 +51,90 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
     let epoch = query_current_epoch().await?;
     assert_eq!(epoch, 0, "initial epoch should be 0");
     tracing::info!(epoch, "Initial epoch verified");
+
+    // Claim a chain for the relay so it can listen for admin chain notifications.
+    let faucet = Faucet::new("http://localhost:8080".to_string());
+    let mut signer = InMemorySigner::new(None);
+    let relay_owner = AccountOwner::from(signer.generate_new());
+    let relay_chain_desc = faucet.claim(&relay_owner).await?;
+    let relay_chain_id = relay_chain_desc.id();
+    tracing::info!(%relay_chain_id, %relay_owner, "Relay chain claimed");
+
+    let relay_dir = tempfile::tempdir()?;
+    let keystore_path = relay_dir.path().join("keystore.json");
+    {
+        use linera_persistent::Persist;
+        let mut ks = linera_persistent::File::new(&keystore_path, signer)?;
+        ks.persist().await?;
+    }
+
+    // Start a local relay in committee-only mode (no bridge app IDs needed).
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .context("manifest dir has fewer than 3 ancestors")?
+        .to_path_buf();
+    let relay_binary = repo_root.join("target/debug/linera-bridge");
+    anyhow::ensure!(
+        relay_binary.exists(),
+        "Relay binary not found at {relay_binary:?}. \
+         Run: cargo build -p linera-bridge --features relay"
+    );
+
+    let relay_port = 3003;
+    let light_client = light_client_address();
+    let wallet_path = relay_dir.path().join("wallet.json");
+    let storage_path = format!("rocksdb:{}", relay_dir.path().join("client.db").display());
+    let mut relay_process = tokio::process::Command::new(&relay_binary)
+        .args([
+            "serve",
+            "--rpc-url",
+            "http://localhost:8545",
+            "--faucet-url",
+            "http://localhost:8080",
+            "--wallet",
+            wallet_path.to_str().unwrap(),
+            "--keystore",
+            keystore_path.to_str().unwrap(),
+            "--storage",
+            &storage_path,
+            &format!("--linera-bridge-chain-id={relay_chain_id}"),
+            &format!("--linera-bridge-chain-owner={relay_owner}"),
+            // Dummy values — committee relay only needs the LightClient, not the bridge apps.
+            "--evm-bridge-address=0x0000000000000000000000000000000000000000",
+            "--linera-bridge-address=0000000000000000000000000000000000000000000000000000000000000000",
+            "--linera-fungible-address=0000000000000000000000000000000000000000000000000000000000000000",
+            &format!("--evm-light-client-address={light_client}"),
+            &format!("--evm-private-key={ANVIL_PRIVATE_KEY}"),
+            &format!("--port={relay_port}"),
+        ])
+        .env("RUST_LOG", "linera=info,linera_bridge=debug")
+        .kill_on_drop(true)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("failed to spawn relay binary")?;
+
+    let relay_monitor = StderrMonitor::spawn(&mut relay_process, "relay");
+
+    let relay_url = format!("http://localhost:{relay_port}");
+    let client = reqwest::Client::new();
+    for attempt in 0..30 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        if client
+            .get(format!("{relay_url}/metrics"))
+            .send()
+            .await
+            .is_ok()
+        {
+            tracing::info!(attempt, "Relay is ready");
+            break;
+        }
+        if attempt == 29 {
+            relay_process.kill().await.ok();
+            anyhow::bail!("Relay did not become ready");
+        }
+    }
 
     create_extra_wallet(&compose, project_name, &compose_file).await;
 
@@ -107,5 +196,6 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
         }
 
         tokio::time::sleep(poll_interval).await;
+        relay_monitor.bail_if_fatal()?;
     }
 }

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -1,6 +1,7 @@
-#![recursion_limit = "512"]
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
+#![recursion_limit = "512"]
 
 //! End-to-end test: trigger a committee rotation on Linera and verify the relay relays
 //! it to the LightClient contract on Anvil (via docker-compose).

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -24,7 +24,7 @@ use linera_base::{
 use linera_bridge::proof::gen::{DepositProofClient as _, HttpDepositProofClient};
 use linera_bridge_e2e::{
     compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
-    start_compose,
+    start_compose, wait_for_light_client,
     ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
@@ -95,6 +95,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
 
     // ── Phase 1: Start docker compose stack ──
     let compose = start_compose(&compose_file, project_name).await;
+    wait_for_light_client(&compose, project_name, &compose_file).await;
 
     // ── Phase 2: Create programmatic Linera client and claim chain ──
     tracing::info!("Creating programmatic Linera client...");

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -90,6 +90,7 @@ sol! {
 #[ignore] // Requires pre-built docker images and Wasm: `make -C linera-bridge build-all`
 async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_test_writer().try_init().ok();
+    linera_bridge_e2e::ensure_rustls_provider();
     let compose_file = compose_file_path();
     let project_name = "linera-e2l-bridge-test";
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -55,6 +55,7 @@ sol! {
 #[ignore] // Requires pre-built docker images and Wasm: `make -C linera-bridge build-all`
 async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_test_writer().try_init().ok();
+    linera_bridge_e2e::ensure_rustls_provider();
     let compose_file = compose_file_path();
     let project_name = "linera-bridge-test";
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -25,7 +25,7 @@ use linera_base::{
 };
 use linera_bridge_e2e::{
     compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
-    start_compose, ANVIL_PRIVATE_KEY,
+    start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::{environment::wallet::Memory, worker::Reason};
@@ -59,6 +59,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     let project_name = "linera-bridge-test";
 
     let compose = start_compose(&compose_file, project_name).await;
+    wait_for_light_client(&compose, project_name, &compose_file).await;
 
     // ── 1. Create programmatic Linera client ──
     tracing::info!("Creating programmatic Linera client...");

--- a/linera-storage-runtime/src/lib.rs
+++ b/linera-storage-runtime/src/lib.rs
@@ -144,6 +144,12 @@ impl CommonStorageOptions {
             max_cache_find_key_values_size: self.storage_max_cache_find_key_values_size,
         }
     }
+
+    /// Returns options matching the clap-defined defaults.
+    pub fn with_defaults() -> Self {
+        use clap::Parser as _;
+        Self::parse_from(std::iter::empty::<String>())
+    }
 }
 
 /// The configuration of the key value store in use.


### PR DESCRIPTION
## Motivation

The bridge relay needs to detect committee rotations on the Linera admin chain and relay them to the EVM LightClient contract. Previously, the block exporter handled this — this PR moves that responsibility into the relay and removes the exporter from the bridge test stack.

## Proposal

**Committee detection and relay** (`relay/committee.rs`): Scans admin chain blocks for `CreateCommittee` operations, extracts the committee blob, and calls `addCommittee()` on the EVM LightClient. Includes
catch-up on startup (scans historical blocks) and live detection via admin chain notifications.

**LightClient ABI on EvmClient** (`relay/evm.rs`): Added `get_current_epoch()` and `add_committee()` methods that interact with the LightClient contract (discovered via `FungibleBridge.lightClient()`). Optional
`--evm-light-client-address` CLI arg skips the discovery step.

**Admin chain notification subscription** (`relay/mod.rs`): The relay subscribes to admin chain notifications via `subscribe_to(admin_chain_id)` and merges them into the main notification stream. On `NewBlock`
for the admin chain, it reads the certificate and relays any committee update.

**Remove block exporter from test stack** (`docker-compose.bridge-test.yml`): Removed the exporter service, storage-init service, and `--with-block-exporter` flags from the network command.

**E2E test improvements** (`tests/e2e/`):
- `wait_for_light_client()`: Prevents a nonce race between `bridge-init` and test contract deployments on the same Anvil account.
- `StderrMonitor`: Reusable helper that detects fatal WASM errors in child process stderr and bails immediately instead of timing out.
- `committee_rotation` test: Spawns a local relay with dummy bridge app IDs and the real LightClient address.

## Test Plan

All 4 bridge e2e tests pass (`cd linera-bridge/tests/e2e && cargo test -- --ignored`):
- `test_auto_deposit_scan` — deposit + burn via relay auto-scanning
- `test_committee_rotation_updates_evm_light_client` — committee relay to LightClient (epoch 0→1)
- `test_evm_to_linera_bridge` — manual deposit proof submission
- `test_fungible_bridge_transfers_to_evm` — Linera→EVM block submission

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)