### PR TITLE
Docker build logs: failures last, with ::group:: markers

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -150,22 +150,35 @@ jobs:
             PIDS="${PIDS} ${TYPE}:$!"
           done
 
-          EXIT_CODE=0
+          SUCCESS_NAMES=""
+          FAILED_NAMES=""
           for NAME_PID in ${PIDS}; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
-            if ! wait "$PID"; then
-              EXIT_CODE=1
+            if wait "$PID"; then
+              SUCCESS_NAMES="${SUCCESS_NAMES} ${NAME}"
+            else
+              FAILED_NAMES="${FAILED_NAMES} ${NAME}"
               echo "::error::${NAME} build failed"
             fi
-            echo "==================== ${NAME} logs ===================="
-            cat "/tmp/build-${NAME}.log" 2>/dev/null || true
-            echo "==================== end ${NAME} logs ===================="
           done
 
-          if [[ $EXIT_CODE -ne 0 ]]; then
-            echo "One or more image builds failed"
-            exit $EXIT_CODE
+          # Print successes first, then failures, so the last thing
+          # on screen when a build fails is the failing log.
+          for NAME in ${SUCCESS_NAMES}; do
+            echo "::group::${NAME} (success)"
+            cat "/tmp/build-${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+          for NAME in ${FAILED_NAMES}; do
+            echo "::group::${NAME} (FAILED)"
+            cat "/tmp/build-${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+
+          if [ -n "${FAILED_NAMES}" ]; then
+            echo "One or more image builds failed:${FAILED_NAMES}"
+            exit 1
           fi
 
           echo "Build complete."

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -117,22 +117,35 @@ jobs:
             "${BRIDGE_IMAGE_BRANCH}" "${BRIDGE_IMAGE_SHORT}" "${BRIDGE_IMAGE_LONG}" "Bridge" &
           PID_BRIDGE=$!
 
-          EXIT_CODE=0
+          SUCCESS_NAMES=""
+          FAILED_NAMES=""
           for NAME_PID in Linera:$PID_LINERA Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Bridge:$PID_BRIDGE; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
-            if ! wait "$PID"; then
-              EXIT_CODE=1
+            if wait "$PID"; then
+              SUCCESS_NAMES="${SUCCESS_NAMES} ${NAME}"
+            else
+              FAILED_NAMES="${FAILED_NAMES} ${NAME}"
               echo "::error::${NAME} build failed"
             fi
-            echo "==================== ${NAME} logs ===================="
-            cat "/tmp/${NAME}.log" || true
-            echo "==================== end ${NAME} logs ===================="
           done
 
-          if [[ $EXIT_CODE -ne 0 ]]; then
-            echo "One or more image builds failed"
-            exit $EXIT_CODE
+          # Print successes first, then failures, so the last thing
+          # on screen when a build fails is the failing log.
+          for NAME in ${SUCCESS_NAMES}; do
+            echo "::group::${NAME} (success)"
+            cat "/tmp/${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+          for NAME in ${FAILED_NAMES}; do
+            echo "::group::${NAME} (FAILED)"
+            cat "/tmp/${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+
+          if [ -n "${FAILED_NAMES}" ]; then
+            echo "One or more image builds failed:${FAILED_NAMES}"
+            exit 1
           fi
 
           echo "All image builds completed successfully!"


### PR DESCRIPTION
## Motivation

When `docker_image.yml` or `build_image.yml` has one failing image among four, the
failure log is currently buried in the middle of GitHub Actions output. You have to hunt
for the `::error::` annotation, then scroll back up past ~30k lines of successful Rust
compilation to find which image failed and why.

Hit this debugging #5990 today — the failing Explorer log was sandwiched between the
Linera/Indexer success logs and the Exporter success logs. Every diagnosis required
scrolling through two irrelevant multi-megabyte build logs.

## Proposal

Small UX change to both `docker_image.yml` and `build_image.yml`:

1. **Separate successes and failures during the `wait` loop.** Collect image names into
`SUCCESS_NAMES` / `FAILED_NAMES` as each build finishes.
2. **Print logs successes-first, failures-last.** The last thing on screen when a build
fails is the failing log itself — one scroll to the root cause.
3. **Wrap each build's log in `::group::` / `::endgro` markers.** GitHub Actions
renders these as collapsible sections; by default only the group containing the failure
is expanded, so the successful build spam collapses out of the way.
4. **Keep the `::error::` annotation** so the summary-page banner still identifies which
image failed at a glance.

Script contract is otherwise unchanged: same log contents, same exit code semantics,
same `All image builds completed successfully!` / non-zero exit on failure. Net diff:
+44 / -18 lines across the two files.

## Test Plan

Local `bash -n` on both extracted run blocks: syntax OK.

Behavior walkthrough:

- **All pass:** `SUCCESS_NAMES` populated, `FAILED_NAMES` empty. Each build's log
printed inside a collapsed `::group::` (success), exit 0, `"All image builds completed
successfully!"`.
- **Mixed:** successes print first (collapsed by default), then failures print last
(auto-expanded), summary banner shows `::error::${NAME} build failed` per failed image,
step exits 1 with `"One or more image builds failed: Explorer"`.
- **All fail:** no success section, all failure groups print, step exits 1.

Can't really test this locally without triggering a real workflow run. Will verify by
dispatching `Build Image` on this branch once pushed (same pattern used to verify #5990)
— with `image_type=explorer` it should exercise the success-list code path.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

