### PR TITLE
Introduce the `LazyRegisterView` and make it work with `description`, `application_permissions` and `ownership`.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -439,8 +439,8 @@ where
     }
 
     /// Invariant for the states of active chains.
-    pub async fn is_active(&self) -> bool {
-        self.execution_state.system.is_active().await
+    pub async fn is_active(&self) -> Result<bool, ChainError> {
+        Ok(self.execution_state.system.is_active().await?)
     }
 
     /// Initializes the chain if it is not active yet.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -439,8 +439,8 @@ where
     }
 
     /// Invariant for the states of active chains.
-    pub fn is_active(&self) -> bool {
-        self.execution_state.system.is_active()
+    pub async fn is_active(&self) -> bool {
+        self.execution_state.system.is_active().await
     }
 
     /// Initializes the chain if it is not active yet.
@@ -463,7 +463,7 @@ where
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
         // Last, reset the consensus state based on the current ownership.
         self.manager.reset(
-            self.execution_state.system.ownership.get().clone(),
+            self.execution_state.system.ownership.get().await?.clone(),
             BlockHeight(0),
             local_time,
             maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights()),
@@ -573,8 +573,8 @@ where
             .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
     }
 
-    pub fn ownership(&self) -> &ChainOwnership {
-        self.execution_state.system.ownership.get()
+    pub async fn ownership(&self) -> Result<&ChainOwnership, ChainError> {
+        Ok(self.execution_state.system.ownership.get().await?)
     }
 
     /// Removes the incoming message bundles in the block from the inboxes.
@@ -983,7 +983,11 @@ where
         }
 
         Self::check_app_permissions(
-            self.execution_state.system.application_permissions.get(),
+            self.execution_state
+                .system
+                .application_permissions
+                .get()
+                .await?,
             &block,
         )?;
 
@@ -1023,7 +1027,8 @@ where
         self.process_outgoing_messages(block).await?;
 
         // Last, reset the consensus state based on the current ownership.
-        self.reset_chain_manager(block.header.height.try_add_one()?, local_time)?;
+        self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
+            .await?;
 
         // Advance to next block height.
         let tip = self.tip_state.get_mut();
@@ -1058,12 +1063,13 @@ where
     }
 
     /// Returns whether this is a child chain.
-    pub fn is_child(&self) -> bool {
-        let Some(description) = self.execution_state.system.description.get() else {
+    pub async fn is_child(&self) -> Result<bool, ChainError> {
+        let description = self.execution_state.system.description.get().await?;
+        let Some(description) = description else {
             // Root chains are always initialized, so this must be a child chain.
-            return true;
+            return Ok(true);
         };
-        description.is_child()
+        Ok(description.is_child())
     }
 
     /// Verifies that the block is valid according to the chain's application permission settings.
@@ -1152,13 +1158,13 @@ where
     }
 
     /// Resets the chain manager for the next block height.
-    fn reset_chain_manager(
+    async fn reset_chain_manager(
         &mut self,
         next_height: BlockHeight,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
-        let ownership = self.execution_state.system.ownership.get().clone();
+        let ownership = self.execution_state.system.ownership.get().await?.clone();
         let fallback_owners =
             maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights());
         self.pending_validated_blobs.clear();

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1113,7 +1113,7 @@ where
         }
         inbox.observe_size_metric();
         drop(inbox);
-        if !self.config.allow_inactive_chains && !self.chain.is_active().await {
+        if !self.config.allow_inactive_chains && !self.chain.is_active().await? {
             // Refuse to create a chain state if the chain is still inactive by
             // now. Accordingly, do not send a confirmation, so that the
             // cross-chain update is retried later.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -610,7 +610,7 @@ where
             .get()
             .already_validated_block(certificate.inner().height())?
         {
-            return Ok((self.chain_info_response(), NetworkActions::default()));
+            return Ok((self.chain_info_response().await?, NetworkActions::default()));
         }
         ensure!(
             certificate.inner().epoch() == chain_epoch,
@@ -626,7 +626,7 @@ where
             .handle_timeout_certificate(certificate, self.storage.clock().current_time());
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
-        Ok((self.chain_info_response(), actions))
+        Ok((self.chain_info_response().await?, actions))
     }
 
     /// Tries to load all blobs published in this proposal.
@@ -659,7 +659,7 @@ where
         let missing_blob_ids = missing_blob_ids(&maybe_blobs);
         if !missing_blob_ids.is_empty() {
             let chain = &mut self.chain;
-            if chain.ownership().open_multi_leader_rounds {
+            if chain.ownership().await?.open_multi_leader_rounds {
                 // TODO(#3203): Allow multiple pending proposals on permissionless chains.
                 chain.pending_proposed_blobs.clear();
             }
@@ -717,7 +717,7 @@ where
         if already_committed_block || should_skip_validated_block()? {
             // If we just processed the same pending block, return the chain info unchanged.
             return Ok((
-                self.chain_info_response(),
+                self.chain_info_response().await?,
                 NetworkActions::default(),
                 BlockOutcome::Skipped,
             ));
@@ -750,7 +750,11 @@ where
         )?;
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
-        Ok((self.chain_info_response(), actions, BlockOutcome::Processed))
+        Ok((
+            self.chain_info_response().await?,
+            actions,
+            BlockOutcome::Processed,
+        ))
     }
 
     /// Processes a confirmed block (aka a commit).
@@ -775,7 +779,11 @@ where
             let actions = self.create_network_actions(None).await?;
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
                 .await;
-            return Ok((self.chain_info_response(), actions, BlockOutcome::Skipped));
+            return Ok((
+                self.chain_info_response().await?,
+                actions,
+                BlockOutcome::Skipped,
+            ));
         }
 
         // We haven't processed the block - verify the certificate first
@@ -866,7 +874,7 @@ where
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
                 .await;
             return Ok((
-                self.chain_info_response(),
+                self.chain_info_response().await?,
                 actions,
                 BlockOutcome::Preprocessed,
             ));
@@ -999,7 +1007,11 @@ where
         self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
             .await;
 
-        Ok((self.chain_info_response(), actions, BlockOutcome::Processed))
+        Ok((
+            self.chain_info_response().await?,
+            actions,
+            BlockOutcome::Processed,
+        ))
     }
 
     /// Schedules a notification for when cross-chain messages are delivered up to the given
@@ -1101,7 +1113,7 @@ where
         }
         inbox.observe_size_metric();
         drop(inbox);
-        if !self.config.allow_inactive_chains && !self.chain.is_active() {
+        if !self.config.allow_inactive_chains && !self.chain.is_active().await {
             // Refuse to create a chain state if the chain is still inactive by
             // now. Accordingly, do not send a confirmation, so that the
             // cross-chain update is retried later.
@@ -1570,7 +1582,7 @@ where
             .clock()
             .current_time()
             .delta_since(event_data.timestamp);
-        if elapsed >= chain.ownership().timeout_config.fallback_duration {
+        if elapsed >= chain.ownership().await?.timeout_config.fallback_duration {
             let chain_id = chain.chain_id();
             let height = chain.tip_state.get().next_block_height;
             let key_pair = self.config.key_pair();
@@ -1619,7 +1631,7 @@ where
         }
         ensure!(was_expected, WorkerError::UnexpectedBlob);
         self.save().await?;
-        Ok(self.chain_info_response())
+        self.chain_info_response().await
     }
 
     /// Returns a stored [`Certificate`] for the chain's block at the requested [`BlockHeight`].
@@ -1757,7 +1769,8 @@ where
             Box::pin(self.execute_block(block, local_time, round, published_blobs, policy)).await?;
 
         // No need to sign: only used internally.
-        let mut response = ChainInfoResponse::new(&self.chain, None);
+        let info = ChainInfo::from_chain_view(&self.chain).await?;
+        let mut response = ChainInfoResponse::new(info, None);
         if let Some(owner) = executed_block.header.authenticated_owner {
             response.info.requested_owner_balance = self
                 .chain
@@ -1847,7 +1860,7 @@ where
         }
         if chain.manager.check_proposed_block(&proposal)? == manager::Outcome::Skip {
             // We already voted for this block.
-            return Ok((self.chain_info_response(), NetworkActions::default()));
+            return Ok((self.chain_info_response().await?, NetworkActions::default()));
         }
         let local_time = self.storage.clock().current_time();
 
@@ -1931,7 +1944,7 @@ where
         }
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
-        Ok((self.chain_info_response(), actions))
+        Ok((self.chain_info_response().await?, actions))
     }
 
     /// Prepares a [`ChainInfoResponse`] for a [`ChainInfoQuery`].
@@ -1944,7 +1957,7 @@ where
     ) -> Result<ChainInfoResponse, WorkerError> {
         self.initialize_and_save_if_needed().await?;
         let chain = &self.chain;
-        let mut info = ChainInfo::from(chain);
+        let mut info = ChainInfo::from_chain_view(chain).await?;
         if query.request_committees {
             info.requested_committees = Some(chain.execution_state.system.committees.get().clone());
         }
@@ -2102,8 +2115,9 @@ where
         Ok(())
     }
 
-    pub(crate) fn chain_info_response(&self) -> ChainInfoResponse {
-        ChainInfoResponse::new(&self.chain, self.config.key_pair())
+    pub(crate) async fn chain_info_response(&self) -> Result<ChainInfoResponse, WorkerError> {
+        let info = ChainInfo::from_chain_view(&self.chain).await?;
+        Ok(ChainInfoResponse::new(info, self.config.key_pair()))
     }
 
     /// Stores the chain state in persistent storage.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2184,6 +2184,7 @@ impl<Env: Environment> ChainClient<Env> {
             .system
             .ownership
             .get()
+            .await?
             .clone())
     }
 
@@ -2217,6 +2218,7 @@ impl<Env: Environment> ChainClient<Env> {
             .system
             .application_permissions
             .get()
+            .await?
             .clone())
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -21,7 +21,7 @@ use linera_chain::{
 };
 use linera_execution::{committee::Committee, ExecutionRuntimeContext};
 use linera_storage::ChainRuntimeContext;
-use linera_views::context::Context;
+use linera_views::{context::Context, ViewError};
 use serde::{Deserialize, Serialize};
 
 use crate::client::chain_client;
@@ -278,18 +278,18 @@ impl CrossChainRequest {
     }
 }
 
-impl<C, S> From<&ChainStateView<C>> for ChainInfo
-where
-    C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
-    ChainRuntimeContext<S>: ExecutionRuntimeContext,
-{
-    fn from(view: &ChainStateView<C>) -> Self {
+impl ChainInfo {
+    pub async fn from_chain_view<C, S>(view: &ChainStateView<C>) -> Result<Self, ViewError>
+    where
+        C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
+        ChainRuntimeContext<S>: ExecutionRuntimeContext,
+    {
         let system_state = &view.execution_state.system;
         let tip_state = view.tip_state.get();
-        ChainInfo {
+        Ok(ChainInfo {
             chain_id: view.chain_id(),
             epoch: *system_state.epoch.get(),
-            description: system_state.description.get().clone(),
+            description: system_state.description.get().await?.clone(),
             manager: Box::new(ChainManagerInfo::from(&view.manager)),
             chain_balance: *system_state.balance.get(),
             block_hash: tip_state.block_hash,
@@ -303,7 +303,7 @@ where
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
             requested_previous_event_blocks: BTreeMap::new(),
-        }
+        })
     }
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -723,7 +723,7 @@ where
                 if matches!(error, linera_base::crypto::CryptoError::InvalidSignature {..})
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -767,7 +767,7 @@ where
         ) if matches!(**execution_error, ExecutionError::IncorrectTransferAmount))
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1059,7 +1059,7 @@ where
         Err(WorkerError::InvalidOwner)
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1115,7 +1115,7 @@ where
             })
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
 
@@ -1124,7 +1124,7 @@ where
         .handle_block_proposal(block_proposal0.clone())
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     let block = chain.manager.validated_vote().unwrap().value().block();
     // Multi-leader round - it's not confirmed yet.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
@@ -1136,7 +1136,7 @@ where
         .handle_validated_certificate(block_certificate0)
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     let block = chain.manager.confirmed_vote().unwrap().value().block();
     // Should be confirmed after handling the certificate.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
@@ -1153,7 +1153,7 @@ where
         .await?;
 
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     let block = chain.manager.validated_vote().unwrap().value().block();
     assert!(block.matches_proposed_block(&block_proposal1.content.block));
     assert!(chain.manager.confirmed_vote().is_none());
@@ -1243,7 +1243,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active().await);
+        assert!(chain.is_active().await?);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(1));
     }
 
@@ -1268,7 +1268,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active().await);
+        assert!(chain.is_active().await?);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(2));
     }
 
@@ -1280,7 +1280,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active().await);
+        assert!(chain.is_active().await?);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(3));
     }
 
@@ -1671,7 +1671,7 @@ where
         ) if matches!(**execution_error, ExecutionError::InsufficientBalance { .. }))
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1710,7 +1710,7 @@ where
         .await?;
     chain_info_response.check(env.executing_worker().public_key())?;
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none()); // It was a multi-leader
                                                        // round.
     let validated_certificate =
@@ -1723,7 +1723,7 @@ where
         .await?;
     chain_info_response.check(env.executing_worker().public_key())?;
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert!(chain.manager.validated_vote().is_none()); // Should be confirmed by now.
     let pending_vote = chain.manager.confirmed_vote().unwrap().lite();
     assert_eq!(
@@ -1920,7 +1920,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert_eq!(Amount::ZERO, *chain.execution_state.system.balance.get());
     assert_eq!(
         BlockHeight::from(1),
@@ -1961,7 +1961,7 @@ where
     assert_eq!(chain.confirmed_log.count(), 1);
     assert_eq!(Some(certificate.hash()), chain.tip_state.get().block_hash);
     let chain = env.worker().chain_state_view(chain_2).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     Ok(())
 }
 
@@ -2001,7 +2001,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let new_sender_chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(new_sender_chain.is_active().await);
+    assert!(new_sender_chain.is_active().await?);
     assert_eq!(
         Amount::ZERO,
         *new_sender_chain.execution_state.system.balance.get()
@@ -2016,7 +2016,7 @@ where
         new_sender_chain.tip_state.get().block_hash
     );
     let new_recipient_chain = env.executing_worker().chain_state_view(chain_2).await?;
-    assert!(new_recipient_chain.is_active().await);
+    assert!(new_recipient_chain.is_active().await?);
     assert_eq!(
         Amount::MAX,
         *new_recipient_chain.execution_state.system.balance.get()
@@ -2055,7 +2055,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
 
     // With the new optimization, transfers to the same chain should not create messages.
@@ -2106,7 +2106,7 @@ where
 
     // Check the sender chain
     let chain_1_state = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain_1_state.is_active().await);
+    assert!(chain_1_state.is_active().await?);
     assert_eq!(
         Amount::ZERO,
         *chain_1_state.execution_state.system.balance.get()
@@ -2188,7 +2188,7 @@ where
         .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate.clone()))
         .await?;
     let chain = env.worker().chain_state_view(chain_2).await?;
-    assert!(chain.is_active().await);
+    assert!(chain.is_active().await?);
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
     assert_eq!(BlockHeight::ZERO, chain.tip_state.get().next_block_height);
     let inbox = chain
@@ -2449,7 +2449,7 @@ where
 
     {
         let recipient_chain = env.executing_worker().chain_state_view(chain_2).await?;
-        assert!(recipient_chain.is_active().await);
+        assert!(recipient_chain.is_active().await?);
         assert_eq!(
             *recipient_chain.execution_state.system.balance.get(),
             Amount::from_tokens(4)
@@ -2667,7 +2667,7 @@ where
 
     {
         let chain = env.executing_worker().chain_state_view(chain_2).await?;
-        assert!(chain.is_active().await);
+        assert!(chain.is_active().await?);
         assert_no_removed_bundles(&chain).await;
     }
 
@@ -2705,7 +2705,7 @@ where
 
     {
         let chain = env.worker.chain_state_view(chain_1).await?;
-        assert!(chain.is_active().await);
+        assert!(chain.is_active().await?);
         assert_no_removed_bundles(&chain).await;
     }
     Ok(())
@@ -2764,7 +2764,7 @@ where
         .await?;
     {
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active().await);
+        assert!(admin_chain.is_active().await?);
         assert_no_removed_bundles(&admin_chain).await;
         assert_eq!(
             BlockHeight::from(1),
@@ -2830,7 +2830,7 @@ where
     {
         // The child is active and has not migrated yet.
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active().await);
+        assert!(user_chain.is_active().await?);
         assert_eq!(
             BlockHeight::ZERO,
             user_chain.tip_state.get().next_block_height
@@ -2907,7 +2907,7 @@ where
         .await?;
     {
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active().await);
+        assert!(user_chain.is_active().await?);
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -3002,7 +3002,7 @@ where
 
     // The transfer was started..
     let user_chain = env.worker().chain_state_view(user_id).await?;
-    assert!(user_chain.is_active().await);
+    assert!(user_chain.is_active().await?);
     assert_eq!(
         BlockHeight::from(1),
         user_chain.tip_state.get().next_block_height
@@ -3015,7 +3015,7 @@ where
 
     // .. and the message has gone through.
     let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-    assert!(admin_chain.is_active().await);
+    assert!(admin_chain.is_active().await?);
     assert_eq!(admin_chain.inboxes.indices().await?.len(), 1);
     matches!(
         &admin_chain
@@ -3127,7 +3127,7 @@ where
     {
         // The transfer was started..
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active().await);
+        assert!(user_chain.is_active().await?);
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -3140,7 +3140,7 @@ where
 
         // .. but the message hasn't gone through.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active().await);
+        assert!(admin_chain.is_active().await?);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
 
@@ -3181,7 +3181,7 @@ where
     {
         // The admin chain has an anticipated message.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active().await);
+        assert!(admin_chain.is_active().await?);
         assert!(admin_chain
             .inboxes
             .try_load_entry(&user_id)
@@ -3202,7 +3202,7 @@ where
     {
         // The admin chain has no more anticipated messages.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active().await);
+        assert!(admin_chain.is_active().await?);
         assert_no_removed_bundles(&admin_chain).await;
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -723,7 +723,7 @@ where
                 if matches!(error, linera_base::crypto::CryptoError::InvalidSignature {..})
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -767,7 +767,7 @@ where
         ) if matches!(**execution_error, ExecutionError::IncorrectTransferAmount))
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1059,7 +1059,7 @@ where
         Err(WorkerError::InvalidOwner)
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1115,7 +1115,7 @@ where
             })
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
 
@@ -1124,7 +1124,7 @@ where
         .handle_block_proposal(block_proposal0.clone())
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     let block = chain.manager.validated_vote().unwrap().value().block();
     // Multi-leader round - it's not confirmed yet.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
@@ -1136,7 +1136,7 @@ where
         .handle_validated_certificate(block_certificate0)
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     let block = chain.manager.confirmed_vote().unwrap().value().block();
     // Should be confirmed after handling the certificate.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
@@ -1153,7 +1153,7 @@ where
         .await?;
 
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     let block = chain.manager.validated_vote().unwrap().value().block();
     assert!(block.matches_proposed_block(&block_proposal1.content.block));
     assert!(chain.manager.confirmed_vote().is_none());
@@ -1243,7 +1243,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(1));
     }
 
@@ -1268,7 +1268,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(2));
     }
 
@@ -1280,7 +1280,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(3));
     }
 
@@ -1671,7 +1671,7 @@ where
         ) if matches!(**execution_error, ExecutionError::InsufficientBalance { .. }))
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1710,7 +1710,7 @@ where
         .await?;
     chain_info_response.check(env.executing_worker().public_key())?;
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert!(chain.manager.confirmed_vote().is_none()); // It was a multi-leader
                                                        // round.
     let validated_certificate =
@@ -1723,7 +1723,7 @@ where
         .await?;
     chain_info_response.check(env.executing_worker().public_key())?;
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert!(chain.manager.validated_vote().is_none()); // Should be confirmed by now.
     let pending_vote = chain.manager.confirmed_vote().unwrap().lite();
     assert_eq!(
@@ -1920,7 +1920,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert_eq!(Amount::ZERO, *chain.execution_state.system.balance.get());
     assert_eq!(
         BlockHeight::from(1),
@@ -1961,7 +1961,7 @@ where
     assert_eq!(chain.confirmed_log.count(), 1);
     assert_eq!(Some(certificate.hash()), chain.tip_state.get().block_hash);
     let chain = env.worker().chain_state_view(chain_2).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     Ok(())
 }
 
@@ -2001,7 +2001,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let new_sender_chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(new_sender_chain.is_active());
+    assert!(new_sender_chain.is_active().await);
     assert_eq!(
         Amount::ZERO,
         *new_sender_chain.execution_state.system.balance.get()
@@ -2016,7 +2016,7 @@ where
         new_sender_chain.tip_state.get().block_hash
     );
     let new_recipient_chain = env.executing_worker().chain_state_view(chain_2).await?;
-    assert!(new_recipient_chain.is_active());
+    assert!(new_recipient_chain.is_active().await);
     assert_eq!(
         Amount::MAX,
         *new_recipient_chain.execution_state.system.balance.get()
@@ -2055,7 +2055,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
 
     // With the new optimization, transfers to the same chain should not create messages.
@@ -2106,7 +2106,7 @@ where
 
     // Check the sender chain
     let chain_1_state = env.executing_worker().chain_state_view(chain_1).await?;
-    assert!(chain_1_state.is_active());
+    assert!(chain_1_state.is_active().await);
     assert_eq!(
         Amount::ZERO,
         *chain_1_state.execution_state.system.balance.get()
@@ -2188,7 +2188,7 @@ where
         .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate.clone()))
         .await?;
     let chain = env.worker().chain_state_view(chain_2).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await);
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
     assert_eq!(BlockHeight::ZERO, chain.tip_state.get().next_block_height);
     let inbox = chain
@@ -2449,7 +2449,7 @@ where
 
     {
         let recipient_chain = env.executing_worker().chain_state_view(chain_2).await?;
-        assert!(recipient_chain.is_active());
+        assert!(recipient_chain.is_active().await);
         assert_eq!(
             *recipient_chain.execution_state.system.balance.get(),
             Amount::from_tokens(4)
@@ -2667,7 +2667,7 @@ where
 
     {
         let chain = env.executing_worker().chain_state_view(chain_2).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await);
         assert_no_removed_bundles(&chain).await;
     }
 
@@ -2705,7 +2705,7 @@ where
 
     {
         let chain = env.worker.chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await);
         assert_no_removed_bundles(&chain).await;
     }
     Ok(())
@@ -2764,7 +2764,7 @@ where
         .await?;
     {
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await);
         assert_no_removed_bundles(&admin_chain).await;
         assert_eq!(
             BlockHeight::from(1),
@@ -2830,7 +2830,7 @@ where
     {
         // The child is active and has not migrated yet.
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active());
+        assert!(user_chain.is_active().await);
         assert_eq!(
             BlockHeight::ZERO,
             user_chain.tip_state.get().next_block_height
@@ -2907,7 +2907,7 @@ where
         .await?;
     {
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active());
+        assert!(user_chain.is_active().await);
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -3002,7 +3002,7 @@ where
 
     // The transfer was started..
     let user_chain = env.worker().chain_state_view(user_id).await?;
-    assert!(user_chain.is_active());
+    assert!(user_chain.is_active().await);
     assert_eq!(
         BlockHeight::from(1),
         user_chain.tip_state.get().next_block_height
@@ -3015,7 +3015,7 @@ where
 
     // .. and the message has gone through.
     let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-    assert!(admin_chain.is_active());
+    assert!(admin_chain.is_active().await);
     assert_eq!(admin_chain.inboxes.indices().await?.len(), 1);
     matches!(
         &admin_chain
@@ -3127,7 +3127,7 @@ where
     {
         // The transfer was started..
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active());
+        assert!(user_chain.is_active().await);
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -3140,7 +3140,7 @@ where
 
         // .. but the message hasn't gone through.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
 
@@ -3181,7 +3181,7 @@ where
     {
         // The admin chain has an anticipated message.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await);
         assert!(admin_chain
             .inboxes
             .try_load_entry(&user_id)
@@ -3202,7 +3202,7 @@ where
     {
         // The admin chain has no more anticipated messages.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await);
         assert_no_removed_bundles(&admin_chain).await;
     }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -309,12 +309,18 @@ where
             }
 
             ChainOwnership { callback } => {
-                let ownership = self.state.system.ownership.get().clone();
+                let ownership = self.state.system.ownership.get().await?.clone();
                 callback.respond(ownership);
             }
 
             ApplicationPermissions { callback } => {
-                let permissions = self.state.system.application_permissions.get().clone();
+                let permissions = self
+                    .state
+                    .system
+                    .application_permissions
+                    .get()
+                    .await?
+                    .clone();
                 callback.respond(permissions);
             }
 
@@ -435,7 +441,7 @@ where
                 application_id,
                 callback,
             } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 if !app_permissions.can_manage_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
@@ -449,7 +455,7 @@ where
                 ownership,
                 callback,
             } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 if !app_permissions.can_manage_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
@@ -463,7 +469,7 @@ where
                 application_permissions,
                 callback,
             } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 if !app_permissions.can_manage_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
@@ -700,7 +706,7 @@ where
             }
 
             GetApplicationPermissions { callback } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 callback.respond(app_permissions.clone());
             }
 

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -66,8 +66,8 @@ impl<C: Send + Sync + Context> ExecutionStateView<C> {
 #[async_graphql::Object(cache_control(no_cache))]
 impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     #[graphql(derived(name = "description"))]
-    async fn _description(&self) -> &Option<ChainDescription> {
-        self.description.get()
+    async fn _description(&self) -> Result<&Option<ChainDescription>, async_graphql::Error> {
+        Ok(self.description.get().await?)
     }
 
     #[graphql(derived(name = "epoch"))]
@@ -86,8 +86,8 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     }
 
     #[graphql(derived(name = "ownership"))]
-    async fn _ownership(&self) -> &ChainOwnership {
-        self.ownership.get()
+    async fn _ownership(&self) -> Result<&ChainOwnership, async_graphql::Error> {
+        Ok(self.ownership.get().await?)
     }
 
     #[graphql(derived(name = "balance"))]

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -32,6 +32,7 @@ use linera_views::{
     register_view::RegisterView,
     set_view::SetView,
     views::{ClonableView, ReplaceContext, View},
+    ViewError,
 };
 use serde::{Deserialize, Serialize};
 
@@ -341,19 +342,11 @@ where
     C::Extra: ExecutionRuntimeContext,
 {
     /// Invariant for the states of active chains.
-    pub async fn is_active(&self) -> bool {
-        let description = match self.description.get().await {
-            Ok(description) => description,
-            Err(_) => return false,
-        };
-        let ownership = match self.ownership.get().await {
-            Ok(ownership) => ownership,
-            Err(_) => return false,
-        };
-        description.is_some()
-            && ownership.is_active()
+    pub async fn is_active(&self) -> Result<bool, ViewError> {
+        Ok(self.description.get().await?.is_some()
+            && self.ownership.get().await?.is_active()
             && self.current_committee().is_some()
-            && self.admin_chain_id.get().is_some()
+            && self.admin_chain_id.get().is_some())
     }
 
     /// Returns the current committee, if any.

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -27,6 +27,7 @@ use linera_base::{
 };
 use linera_views::{
     context::Context,
+    lazy_register_view::LazyRegisterView,
     map_view::MapView,
     register_view::RegisterView,
     set_view::SetView,
@@ -78,7 +79,7 @@ mod metrics {
 #[allocative(bound = "C")]
 pub struct SystemExecutionStateView<C> {
     /// How the chain was created. May be unknown for inactive chains.
-    pub description: RegisterView<C, Option<ChainDescription>>,
+    pub description: LazyRegisterView<C, Option<ChainDescription>>,
     /// The number identifying the current configuration.
     pub epoch: RegisterView<C, Epoch>,
     /// The admin of the chain.
@@ -89,7 +90,7 @@ pub struct SystemExecutionStateView<C> {
     // (e.g. the `OpenChain` operation).
     pub committees: RegisterView<C, BTreeMap<Epoch, Committee>>,
     /// Ownership of the chain.
-    pub ownership: RegisterView<C, ChainOwnership>,
+    pub ownership: LazyRegisterView<C, ChainOwnership>,
     /// Balance of the chain. (Available to any user able to create blocks in the chain.)
     pub balance: RegisterView<C, Amount>,
     /// Balances attributed to a given owner.
@@ -101,7 +102,7 @@ pub struct SystemExecutionStateView<C> {
     /// Whether this chain has been closed.
     pub closed: RegisterView<C, bool>,
     /// Permissions for applications on this chain.
-    pub application_permissions: RegisterView<C, ApplicationPermissions>,
+    pub application_permissions: LazyRegisterView<C, ApplicationPermissions>,
     /// Blobs that have been used or published on this chain.
     pub used_blobs: SetView<C, BlobId>,
     /// The event stream subscriptions of applications on this chain.
@@ -340,9 +341,17 @@ where
     C::Extra: ExecutionRuntimeContext,
 {
     /// Invariant for the states of active chains.
-    pub fn is_active(&self) -> bool {
-        self.description.get().is_some()
-            && self.ownership.get().is_active()
+    pub async fn is_active(&self) -> bool {
+        let description = match self.description.get().await {
+            Ok(description) => description,
+            Err(_) => return false,
+        };
+        let ownership = match self.ownership.get().await {
+            Ok(ownership) => ownership,
+            Err(_) => return false,
+        };
+        description.is_some()
+            && ownership.is_active()
             && self.current_committee().is_some()
             && self.admin_chain_id.get().is_some()
     }
@@ -669,7 +678,11 @@ where
         if source == AccountOwner::CHAIN {
             ensure!(
                 authenticated_owner.is_some()
-                    && self.ownership.get().is_owner(&authenticated_owner.unwrap()),
+                    && self
+                        .ownership
+                        .get()
+                        .await?
+                        .is_owner(&authenticated_owner.unwrap()),
                 ExecutionError::UnauthenticatedTransferOwner
             );
         } else {
@@ -857,7 +870,7 @@ where
     /// Initializes the system application state on a newly opened chain.
     /// Returns `Ok(true)` if the chain was already initialized, `Ok(false)` if it wasn't.
     pub async fn initialize_chain(&mut self, chain_id: ChainId) -> Result<bool, ExecutionError> {
-        if self.description.get().is_some() {
+        if self.description.get().await?.is_some() {
             // already initialized
             return Ok(true);
         }
@@ -929,20 +942,11 @@ where
             block_height,
             chain_index,
         };
+        let committees = self.committees.get();
         let init_chain_config = config.init_chain_config(
             *self.epoch.get(),
-            self.committees
-                .get()
-                .keys()
-                .min()
-                .copied()
-                .unwrap_or(Epoch::ZERO),
-            self.committees
-                .get()
-                .keys()
-                .max()
-                .copied()
-                .unwrap_or(Epoch::ZERO),
+            committees.keys().min().copied().unwrap_or(Epoch::ZERO),
+            committees.keys().max().copied().unwrap_or(Epoch::ZERO),
         );
         let chain_description = ChainDescription::new(chain_origin, init_chain_config, timestamp);
         let child_id = chain_description.id();

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -148,7 +148,7 @@ pub trait RegisterMockApplication {
     /// Returns the chain to use for the creation of the application.
     ///
     /// This is included in the mocked [`ApplicationId`].
-    fn creator_chain_id(&self) -> ChainId;
+    async fn creator_chain_id(&self) -> ChainId;
 
     /// Registers a new [`MockApplication`] and returns it with the [`ApplicationId`] that was
     /// used for it.
@@ -186,8 +186,8 @@ where
     C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
-    fn creator_chain_id(&self) -> ChainId {
-        self.system.creator_chain_id()
+    async fn creator_chain_id(&self) -> ChainId {
+        self.system.creator_chain_id().await
     }
 
     async fn register_mock_application_with(
@@ -207,8 +207,8 @@ where
     C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
-    fn creator_chain_id(&self) -> ChainId {
-        self.description.get().as_ref().expect(
+    async fn creator_chain_id(&self) -> ChainId {
+        self.description.get().await.expect("failed to load description").as_ref().expect(
             "Can't register applications on a system state with no associated `ChainDescription`",
         ).into()
     }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -153,7 +153,7 @@ impl SystemExecutionState {
 }
 
 impl RegisterMockApplication for SystemExecutionState {
-    fn creator_chain_id(&self) -> ChainId {
+    async fn creator_chain_id(&self) -> ChainId {
         self.description.as_ref().expect(
             "Can't register applications on a system state with no associated `ChainDescription`",
         ).into()

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -1136,7 +1136,7 @@ async fn test_change_ownership_system_api() -> anyhow::Result<()> {
         .await?;
 
     // Verify the ownership was changed.
-    assert_eq!(*view.system.ownership.get(), new_ownership);
+    assert_eq!(*view.system.ownership.get().await?, new_ownership);
 
     Ok(())
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1248,7 +1248,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         .await
         .expect("should initialize chain correctly");
     assert_eq!(*child_view.system.balance.get(), Amount::ONE);
-    assert_eq!(*child_view.system.ownership.get(), child_ownership);
+    assert_eq!(*child_view.system.ownership.get().await?, child_ownership);
     assert_eq!(
         *child_view.system.committees.get(),
         [(Epoch::ZERO, committee)]
@@ -1256,7 +1256,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
             .collect::<BTreeMap<_, _>>()
     );
     assert_eq!(
-        *child_view.system.application_permissions.get(),
+        *child_view.system.application_permissions.get().await?,
         ApplicationPermissions::new_single(application_id)
     );
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -240,7 +240,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
             .await?;
         let mut chain = self.load_chain(id).await?;
         assert!(
-            !chain.is_active().await,
+            !chain.is_active().await?,
             "Attempting to create a chain twice"
         );
         let current_time = self.clock().current_time();

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -239,7 +239,10 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         self.write_blob(&Blob::new_chain_description(&description))
             .await?;
         let mut chain = self.load_chain(id).await?;
-        assert!(!chain.is_active(), "Attempting to create a chain twice");
+        assert!(
+            !chain.is_active().await,
+            "Attempting to create a chain twice"
+        );
         let current_time = self.clock().current_time();
         chain.initialize_if_needed(current_time).await?;
         chain.save().await?;

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -121,6 +121,6 @@ pub use generic_array;
 pub use sha3;
 pub use views::{
     bucket_queue_view, collection_view, hashable_wrapper, historical_hash_wrapper,
-    key_value_store_view, log_view, map_view, queue_view, reentrant_collection_view, register_view,
-    set_view,
+    key_value_store_view, lazy_register_view, log_view, map_view, queue_view,
+    reentrant_collection_view, register_view, set_view,
 };

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -180,13 +180,13 @@ where
         if let Some(value) = &self.update {
             return Ok(value);
         }
-        if self.stored_value.get().is_none() {
-            let key = self.context.base_key().bytes.clone();
-            let bytes = self.context.store().read_value_bytes(&key).await?;
-            let value = from_bytes_option_or_default(&bytes)?;
-            let _ = self.stored_value.set(Box::new(value));
+        if let Some(value) = self.stored_value.get() {
+            return Ok(value);
         }
-        Ok(self.stored_value.get().unwrap())
+        let key = self.context.base_key().bytes.clone();
+        let bytes = self.context.store().read_value_bytes(&key).await?;
+        let value = from_bytes_option_or_default(&bytes)?;
+        Ok(self.stored_value.get_or_init(|| Box::new(value)))
     }
 
     /// Sets the value in the register.

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -233,13 +233,8 @@ where
     pub async fn get_mut(&mut self) -> Result<&mut T, ViewError> {
         self.delete_storage_first = false;
         if self.update.is_none() {
-            if self.stored_value.get().is_none() {
-                let key = self.context.base_key().bytes.clone();
-                let bytes = self.context.store().read_value_bytes(&key).await?;
-                let value = from_bytes_option_or_default(&bytes)?;
-                let _ = self.stored_value.set(Box::new(value));
-            }
-            self.update = Some(self.stored_value.get().unwrap().clone());
+            let update = self.get().await?.clone();
+            self.update = Some(Box::new(update));
         }
         Ok(self.update.as_mut().unwrap())
     }

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -1,0 +1,327 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::OnceLock;
+
+use allocative::Allocative;
+#[cfg(with_metrics)]
+use linera_base::prometheus_util::MeasureLatency as _;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    batch::Batch,
+    common::{from_bytes_option_or_default, HasherOutput},
+    context::Context,
+    hashable_wrapper::WrappedHashableContainerView,
+    store::ReadableKeyValueStore,
+    views::{ClonableView, HashableView, Hasher, ReplaceContext, View},
+    ViewError,
+};
+
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use prometheus::HistogramVec;
+
+    /// The runtime of hash computation
+    pub static LAZY_REGISTER_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "lazy_register_view_hash_runtime",
+            "LazyRegisterView hash runtime",
+            &[],
+            exponential_bucket_latencies(5.0),
+        )
+    });
+}
+
+/// A view that supports modifying a single value of type `T`.
+/// Unlike [`crate::register_view::RegisterView`], the value is not loaded from storage until it is first accessed.
+#[derive(Debug, Allocative)]
+#[allocative(bound = "C, T: Allocative")]
+pub struct LazyRegisterView<C, T> {
+    /// Whether to clear storage before applying updates.
+    delete_storage_first: bool,
+    /// The view context.
+    #[allocative(skip)]
+    context: C,
+    /// The value persisted in storage, loaded lazily on first access.
+    /// `OnceLock` replaces both the `Mutex` and the `Option` that were
+    /// previously used: empty means not yet loaded, set means loaded.
+    #[allocative(skip)]
+    stored_value: OnceLock<Box<T>>,
+    /// Pending update not yet persisted to storage.
+    update: Option<Box<T>>,
+}
+
+impl<C, T, C2> ReplaceContext<C2> for LazyRegisterView<C, T>
+where
+    C: Context,
+    C2: Context,
+    T: Default + Send + Sync + Serialize + DeserializeOwned + Clone,
+{
+    type Target = LazyRegisterView<C2, T>;
+
+    async fn with_context(
+        &mut self,
+        ctx: impl FnOnce(&Self::Context) -> C2 + Clone,
+    ) -> Self::Target {
+        let stored_value = match self.stored_value.get_mut() {
+            Some(value) => OnceLock::from(value.clone()),
+            None => OnceLock::new(),
+        };
+        LazyRegisterView {
+            delete_storage_first: self.delete_storage_first,
+            context: ctx(&self.context),
+            stored_value,
+            update: self.update.clone(),
+        }
+    }
+}
+
+impl<C, T> View for LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Default + Send + Sync + Serialize + DeserializeOwned,
+{
+    const NUM_INIT_KEYS: usize = 0;
+
+    type Context = C;
+
+    fn context(&self) -> C {
+        self.context.clone()
+    }
+
+    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![])
+    }
+
+    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        Ok(Self {
+            delete_storage_first: false,
+            context,
+            stored_value: OnceLock::new(),
+            update: None,
+        })
+    }
+
+    fn rollback(&mut self) {
+        self.delete_storage_first = false;
+        self.update = None;
+    }
+
+    async fn has_pending_changes(&self) -> bool {
+        if self.delete_storage_first {
+            return true;
+        }
+        self.update.is_some()
+    }
+
+    fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
+        let mut delete_view = false;
+        if self.delete_storage_first {
+            batch.delete_key(self.context.base_key().bytes.clone());
+            delete_view = true;
+        } else if let Some(value) = &self.update {
+            let key = self.context.base_key().bytes.clone();
+            batch.put_key_value(key, value)?;
+        }
+        Ok(delete_view)
+    }
+
+    fn post_save(&mut self) {
+        if self.delete_storage_first {
+            self.stored_value = OnceLock::from(Box::<T>::default());
+        } else if let Some(value) = self.update.take() {
+            self.stored_value = OnceLock::from(value);
+        }
+        self.delete_storage_first = false;
+        self.update = None;
+    }
+
+    fn clear(&mut self) {
+        self.delete_storage_first = true;
+        self.update = Some(Box::default());
+    }
+}
+
+impl<C, T> ClonableView for LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        let stored_value = match self.stored_value.get_mut() {
+            Some(value) => OnceLock::from(value.clone()),
+            None => OnceLock::new(),
+        };
+        Ok(LazyRegisterView {
+            delete_storage_first: self.delete_storage_first,
+            context: self.context.clone(),
+            stored_value,
+            update: self.update.clone(),
+        })
+    }
+}
+
+impl<C, T> LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Default + DeserializeOwned,
+{
+    /// Ensures the stored value is loaded from storage into the `OnceLock` cache.
+    async fn ensure_stored_value(&self) -> Result<(), ViewError> {
+        if self.stored_value.get().is_some() {
+            return Ok(());
+        }
+        let key = self.context.base_key().bytes.clone();
+        let bytes = self.context.store().read_value_bytes(&key).await?;
+        let value: T = from_bytes_option_or_default(&bytes)?;
+        // If another caller raced us, `set` is a no-op and the value is dropped.
+        let _ = self.stored_value.set(Box::new(value));
+        Ok(())
+    }
+
+    /// Access the current value in the register.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::lazy_register_view::LazyRegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let register = LazyRegisterView::<_, u32>::load(context).await.unwrap();
+    /// let value = register.get().await.unwrap();
+    /// assert_eq!(*value, 0);
+    /// # })
+    /// ```
+    pub async fn get(&self) -> Result<&T, ViewError> {
+        if let Some(value) = &self.update {
+            return Ok(value);
+        }
+        self.ensure_stored_value().await?;
+        Ok(self.stored_value.get().unwrap())
+    }
+
+    /// Sets the value in the register.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::lazy_register_view::LazyRegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut register = LazyRegisterView::load(context).await.unwrap();
+    /// register.set(5);
+    /// let value = register.get().await.unwrap();
+    /// assert_eq!(*value, 5);
+    /// # })
+    /// ```
+    pub fn set(&mut self, value: T) {
+        self.delete_storage_first = false;
+        self.update = Some(Box::new(value));
+    }
+
+    /// Obtains the extra data.
+    pub fn extra(&self) -> &C::Extra {
+        self.context.extra()
+    }
+}
+
+impl<C, T> LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Clone + Default + Serialize + DeserializeOwned,
+{
+    /// Obtains a mutable reference to the value in the register.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::lazy_register_view::LazyRegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut register: LazyRegisterView<_, u32> = LazyRegisterView::load(context).await.unwrap();
+    /// let value = register.get_mut().await.unwrap();
+    /// assert_eq!(*value, 0);
+    /// # })
+    /// ```
+    pub async fn get_mut(&mut self) -> Result<&mut T, ViewError> {
+        self.delete_storage_first = false;
+        if self.update.is_none() {
+            self.ensure_stored_value().await?;
+            let stored = self.stored_value.get().unwrap();
+            self.update = Some(stored.clone());
+        }
+        Ok(self.update.as_mut().unwrap())
+    }
+
+    fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
+        #[cfg(with_metrics)]
+        let _hash_latency = metrics::LAZY_REGISTER_VIEW_HASH_RUNTIME.measure_latency();
+        let value: &T = if let Some(value) = &self.update {
+            value
+        } else {
+            self.stored_value
+                .get()
+                .expect("stored value must be loaded before hashing")
+        };
+        let mut hasher = sha3::Sha3_256::default();
+        hasher.update_with_bcs_bytes(value)?;
+        Ok(hasher.finalize())
+    }
+}
+
+impl<C, T> HashableView for LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
+{
+    type Hasher = sha3::Sha3_256;
+
+    async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.ensure_stored_value().await?;
+        self.compute_hash()
+    }
+
+    async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.ensure_stored_value().await?;
+        self.compute_hash()
+    }
+}
+
+/// Type wrapping `LazyRegisterView` while memoizing the hash.
+pub type HashedLazyRegisterView<C, T> =
+    WrappedHashableContainerView<C, LazyRegisterView<C, T>, HasherOutput>;
+
+#[cfg(with_graphql)]
+mod graphql {
+    use std::borrow::Cow;
+
+    use super::LazyRegisterView;
+    use crate::context::Context;
+
+    impl<C, T> async_graphql::OutputType for LazyRegisterView<C, T>
+    where
+        C: Context,
+        T: async_graphql::OutputType + Default + Send + Sync + serde::de::DeserializeOwned,
+    {
+        fn type_name() -> Cow<'static, str> {
+            T::type_name()
+        }
+
+        fn create_type_info(registry: &mut async_graphql::registry::Registry) -> String {
+            T::create_type_info(registry)
+        }
+
+        async fn resolve(
+            &self,
+            ctx: &async_graphql::ContextSelectionSet<'_>,
+            field: &async_graphql::Positioned<async_graphql::parser::types::Field>,
+        ) -> async_graphql::ServerResult<async_graphql::Value> {
+            self.get()
+                .await
+                .map_err(|e| async_graphql::ServerError::new(e.to_string(), Some(field.pos)))?
+                .resolve(ctx, field)
+                .await
+        }
+    }
+}

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -67,10 +67,7 @@ where
         &mut self,
         ctx: impl FnOnce(&Self::Context) -> C2 + Clone,
     ) -> Self::Target {
-        let stored_value = match self.stored_value.get_mut() {
-            Some(value) => OnceLock::from(value.clone()),
-            None => OnceLock::new(),
-        };
+        let stored_value = self.stored_value.clone();
         LazyRegisterView {
             delete_storage_first: self.delete_storage_first,
             context: ctx(&self.context),
@@ -152,10 +149,7 @@ where
     T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
 {
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
-        let stored_value = match self.stored_value.get_mut() {
-            Some(value) => OnceLock::from(value.clone()),
-            None => OnceLock::new(),
-        };
+        let stored_value = self.stored_value.clone();
         Ok(LazyRegisterView {
             delete_storage_first: self.delete_storage_first,
             context: self.context.clone(),
@@ -170,19 +164,6 @@ where
     C: Context,
     T: Default + DeserializeOwned,
 {
-    /// Ensures the stored value is loaded from storage into the `OnceLock` cache.
-    async fn ensure_stored_value(&self) -> Result<(), ViewError> {
-        if self.stored_value.get().is_some() {
-            return Ok(());
-        }
-        let key = self.context.base_key().bytes.clone();
-        let bytes = self.context.store().read_value_bytes(&key).await?;
-        let value: T = from_bytes_option_or_default(&bytes)?;
-        // If another caller raced us, `set` is a no-op and the value is dropped.
-        let _ = self.stored_value.set(Box::new(value));
-        Ok(())
-    }
-
     /// Access the current value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -199,7 +180,12 @@ where
         if let Some(value) = &self.update {
             return Ok(value);
         }
-        self.ensure_stored_value().await?;
+        if self.stored_value.get().is_none() {
+            let key = self.context.base_key().bytes.clone();
+            let bytes = self.context.store().read_value_bytes(&key).await?;
+            let value = from_bytes_option_or_default(&bytes)?;
+            let _ = self.stored_value.set(Box::new(value));
+        }
         Ok(self.stored_value.get().unwrap())
     }
 
@@ -247,25 +233,22 @@ where
     pub async fn get_mut(&mut self) -> Result<&mut T, ViewError> {
         self.delete_storage_first = false;
         if self.update.is_none() {
-            self.ensure_stored_value().await?;
-            let stored = self.stored_value.get().unwrap();
-            self.update = Some(stored.clone());
+            if self.stored_value.get().is_none() {
+                let key = self.context.base_key().bytes.clone();
+                let bytes = self.context.store().read_value_bytes(&key).await?;
+                let value = from_bytes_option_or_default(&bytes)?;
+                let _ = self.stored_value.set(Box::new(value));
+            }
+            self.update = Some(self.stored_value.get().unwrap().clone());
         }
         Ok(self.update.as_mut().unwrap())
     }
 
-    fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
+    async fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
         #[cfg(with_metrics)]
         let _hash_latency = metrics::LAZY_REGISTER_VIEW_HASH_RUNTIME.measure_latency();
-        let value: &T = if let Some(value) = &self.update {
-            value
-        } else {
-            self.stored_value
-                .get()
-                .expect("stored value must be loaded before hashing")
-        };
         let mut hasher = sha3::Sha3_256::default();
-        hasher.update_with_bcs_bytes(value)?;
+        hasher.update_with_bcs_bytes(self.get().await?)?;
         Ok(hasher.finalize())
     }
 }
@@ -278,13 +261,11 @@ where
     type Hasher = sha3::Sha3_256;
 
     async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        self.ensure_stored_value().await?;
-        self.compute_hash()
+        self.compute_hash().await
     }
 
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
-        self.ensure_stored_value().await?;
-        self.compute_hash()
+        self.compute_hash().await
     }
 }
 

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -18,6 +18,9 @@ mod tests;
 /// The `RegisterView` implements a register for a single value.
 pub mod register_view;
 
+/// The `LazyRegisterView` implements a register for a single value with lazy loading.
+pub mod lazy_register_view;
+
 /// The `LogView` implements a log list that can be pushed.
 pub mod log_view;
 

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -554,3 +554,71 @@ async fn test_register_view_to_lazy_register_view() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_lazy_register_view() -> anyhow::Result<()> {
+    let context = MemoryContext::new_for_testing(());
+
+    // A freshly loaded LazyRegisterView returns the default value.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert_eq!(*lazy.get().await?, 0);
+    assert!(!lazy.has_pending_changes().await);
+    drop(lazy);
+
+    // Set a value, verify it reads back, and persist.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    lazy.set(42);
+    assert!(lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 42);
+    save_view(&context, &mut lazy).await?;
+    assert!(!lazy.has_pending_changes().await);
+    drop(lazy);
+
+    // Reload and verify the persisted value is lazily fetched.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert!(!lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 42);
+    drop(lazy);
+
+    // Test get_mut: modify via mutable reference and persist.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    *lazy.get_mut().await? = 100;
+    assert!(lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 100);
+    save_view(&context, &mut lazy).await?;
+    drop(lazy);
+
+    // Verify the mutation was persisted.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert_eq!(*lazy.get().await?, 100);
+    drop(lazy);
+
+    // Test rollback: set a value then rollback, should read the stored value.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    lazy.set(999);
+    assert_eq!(*lazy.get().await?, 999);
+    lazy.rollback();
+    assert!(!lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 100);
+    drop(lazy);
+
+    // Test clear: clears to default and persists.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    lazy.clear();
+    assert!(lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 0);
+    save_view(&context, &mut lazy).await?;
+    drop(lazy);
+
+    // Verify cleared value was persisted as default.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert_eq!(*lazy.get().await?, 0);
+
+    // Test hashing: two views with the same value produce the same hash.
+    let hash1 = lazy.hash().await?;
+    let mut lazy2 = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    let hash2 = lazy2.hash_mut().await?;
+    assert_eq!(hash1, hash2);
+
+    Ok(())
+}

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -17,6 +17,7 @@ use crate::store::{KeyValueDatabase, TestKeyValueDatabase};
 use crate::{
     batch::Batch,
     context::{Context, MemoryContext},
+    lazy_register_view::LazyRegisterView,
     queue_view::QueueView,
     reentrant_collection_view::ReentrantCollectionView,
     register_view::{HashedRegisterView, RegisterView},
@@ -525,6 +526,31 @@ where
         let mut entry = collection.try_load_entry_mut(&key).await?;
         entry.set(value);
     }
+
+    Ok(())
+}
+
+/// Saves a value using a `RegisterView`, then reopens it as a `LazyRegisterView`
+/// and checks that the value is correctly read back.
+#[tokio::test]
+async fn test_register_view_to_lazy_register_view() -> anyhow::Result<()> {
+    let context = MemoryContext::new_for_testing(());
+
+    // Write a value with RegisterView and persist it.
+    let mut register = RegisterView::<_, String>::load(context.clone()).await?;
+    register.set("hello".to_owned());
+    save_view(&context, &mut register).await?;
+    drop(register);
+
+    // Reopen the same storage location as a LazyRegisterView.
+    let lazy = LazyRegisterView::<_, String>::load(context.clone()).await?;
+
+    // The value should not have been loaded yet.
+    assert!(!lazy.has_pending_changes().await);
+
+    // Reading should lazily fetch the persisted value.
+    let value = lazy.get().await?;
+    assert_eq!(value, "hello");
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The `RegisterView` load function is accessing the value under control when called.

This is a problem if the value in question is big. So, we introduce a `LazyRegisterView` that is loaded
only when appropriate.

## Proposal

Introduce a `LazyRegisterView` that is backward compatible with the `RegisterView`.
We are forced to use interior mutability. Because otherwise the "get()" becomes  `&mut self`.
In contexts of `&self` this forces us to introduce a `read_value` that reads the value without modifying.

The code is changed accordingly in a straightforward way.

## Test Plan

CI
A test that proves backward compatibility of `RegisterView` / `LazyRegisterView` is introduced.

## Release Plan

To `testnet_conway`.

## Links

None