### PR TITLE
Don't fetch blob when retrying x-chain requests for sender chains

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -219,6 +219,17 @@ where
         self.service_runtime_task.take()
     }
 
+    /// Returns the pending cross-chain network actions for this chain, without
+    /// initializing the chain's execution state. Intended for callers that only
+    /// need to re-emit cross-chain requests from the outbox of a sender chain
+    /// whose `ChainDescription` we may never have needed.
+    #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
+    pub(crate) async fn cross_chain_network_actions(
+        &self,
+    ) -> Result<NetworkActions, WorkerError> {
+        self.create_network_actions(None).await
+    }
+
     /// Handles a [`ChainInfoQuery`], potentially voting on the next block.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn handle_chain_info_query(

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -224,9 +224,7 @@ where
     /// need to re-emit cross-chain requests from the outbox of a sender chain
     /// whose `ChainDescription` we may never have needed.
     #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
-    pub(crate) async fn cross_chain_network_actions(
-        &self,
-    ) -> Result<NetworkActions, WorkerError> {
+    pub(crate) async fn cross_chain_network_actions(&self) -> Result<NetworkActions, WorkerError> {
         self.create_network_actions(None).await
     }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -264,16 +264,22 @@ where
     }
 
     /// Handles any pending local cross-chain requests.
+    ///
+    /// Does not initialize the sender chain's execution state, so it is safe to
+    /// call even when the sender's `ChainDescription` blob is not in local storage.
+    /// Previously this went through `handle_chain_info_query`, which unconditionally
+    /// initialized the worker and therefore forced a `ChainDescription` download on
+    /// every call.
     #[instrument(level = "trace", skip(self, notifier))]
     pub async fn retry_pending_cross_chain_requests(
         &self,
         sender_chain: ChainId,
         notifier: &impl Notifier,
     ) -> Result<(), LocalNodeError> {
-        let (_response, actions) = self
+        let actions = self
             .node
             .state
-            .handle_chain_info_query(ChainInfoQuery::new(sender_chain).with_network_actions())
+            .cross_chain_network_actions(sender_chain)
             .await?;
         let mut requests = VecDeque::from_iter(actions.cross_chain_requests);
         while let Some(request) = requests.pop_front() {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1325,7 +1325,9 @@ where
     let sender_id = sender_description.id();
     let sender_chain_desc_blob_id = BlobId::new(sender_id.0, BlobType::ChainDescription);
 
-    let mut sender = builder.make_client(sender_id, None, BlockHeight::ZERO).await?;
+    let mut sender = builder
+        .make_client(sender_id, None, BlockHeight::ZERO)
+        .await?;
     sender.set_preferred_owner(sender_public_key.into());
     sender.synchronize_from_validators().await?;
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, InMemorySigner},
     data_types::*,
-    identifiers::{Account, AccountOwner, ApplicationId},
+    identifiers::{Account, AccountOwner, ApplicationId, BlobId, BlobType},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -1286,6 +1286,13 @@ where
     Ok(())
 }
 
+/// The sender chain should be stored sparsely in the receiver's node: only blocks
+/// that sent messages to us should be downloaded, not the intermediate ones. When
+/// the sender is a non-root chain (so its `ChainDescription` blob isn't in the
+/// receiver's genesis storage) and the sender's height-0 block doesn't send to us,
+/// the `ChainDescription` itself should never be downloaded either — not during
+/// the initial message processing, and not during a later re-sync that routes the
+/// sender through `retry_pending_cross_chain_requests_from_sender_chains`.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]
@@ -1294,12 +1301,40 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
-    let mut builder = TestBuilder::new(storage_builder, 2, 0, signer).await?;
-    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let owner = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();
 
+    // Open the sender as a non-root chain so that its `ChainDescription` isn't
+    // pre-populated in the receiver's genesis storage. We also make the sender's
+    // first block a burn rather than a transfer to the receiver: that keeps the
+    // message-sending blocks at height >= 1, so preprocessing them never requires
+    // the sender's `ChainDescription` (only height-0 blocks do).
+    let sender_public_key = builder.signer.generate_new();
+    let sender_ownership = ChainOwnership::single(sender_public_key.into())
+        .with_regular_owner(sender_public_key.into(), 100);
+    let (sender_description, _creation_certificate) = Box::pin(owner.open_chain(
+        sender_ownership,
+        ApplicationPermissions::default(),
+        Amount::from_tokens(4),
+    ))
+    .await
+    .unwrap_ok_committed();
+    let sender_id = sender_description.id();
+    let sender_chain_desc_blob_id = BlobId::new(sender_id.0, BlobType::ChainDescription);
+
+    let mut sender = builder.make_client(sender_id, None, BlockHeight::ZERO).await?;
+    sender.set_preferred_owner(sender_public_key.into());
+    sender.synchronize_from_validators().await?;
+
+    // Heights 0 and 2 are burns; heights 1 and 3 send to the receiver.
     let cert0 = sender
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    let cert1 = sender
         .transfer_to_account(
             AccountOwner::CHAIN,
             Amount::ONE,
@@ -1307,11 +1342,11 @@ where
         )
         .await
         .unwrap_ok_committed();
-    let cert1 = sender
+    let cert2 = sender
         .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
         .unwrap_ok_committed();
-    let cert2 = sender
+    let cert3 = sender
         .transfer_to_account(
             AccountOwner::CHAIN,
             Amount::ONE,
@@ -1320,12 +1355,14 @@ where
         .await
         .unwrap_ok_committed();
 
-    // Process the notification about the incoming message.
+    // Process the notification about the most recent incoming message. This walks
+    // back along `previous_message_blocks` and preprocesses only the sender blocks
+    // that sent to us (heights 1 and 3).
     let notification = Notification {
         chain_id: receiver_id,
         reason: Reason::NewIncomingBundle {
-            origin: cert2.block().header.chain_id,
-            height: cert2.block().header.height,
+            origin: sender_id,
+            height: cert3.block().header.height,
         },
     };
     let validator = builder
@@ -1338,25 +1375,31 @@ where
         .await;
     receiver.process_inbox().await?;
 
-    // The first and last blocks sent something to the receiver. The middle one didn't.
-    // So the sender chain should have a gap.
+    // Only the blocks that sent something to the receiver should be in local
+    // storage. The burn blocks in between — and the sender's `ChainDescription`
+    // blob itself — should never have been downloaded.
+    let storage = receiver.storage_client();
+    assert!(!storage.contains_certificate(cert0.hash()).await?);
+    assert!(storage.contains_certificate(cert1.hash()).await?);
+    assert!(!storage.contains_certificate(cert2.hash()).await?);
+    assert!(storage.contains_certificate(cert3.hash()).await?);
     assert!(
-        receiver
-            .storage_client()
-            .contains_certificate(cert0.hash())
-            .await?
+        !storage.contains_blob(sender_chain_desc_blob_id).await?,
+        "preprocessing non-height-0 sender blocks must not download the ChainDescription",
     );
+
+    // `process_notification_from` does not advance the client's
+    // `received_certificate_trackers`, so a subsequent `synchronize_from_validators`
+    // still sees (sender, 1) and (sender, 3) in the received log. But the sender's
+    // outbox has those heights scheduled locally now, so `find_received_certificates`
+    // filters them out and routes the sender through
+    // `retry_pending_cross_chain_requests_from_sender_chains`. Before the fix this
+    // initialized the sender's chain worker inside the receiver's node and, on
+    // failing to find the `ChainDescription` blob in storage, triggered a download.
+    receiver.synchronize_from_validators().await?;
     assert!(
-        !receiver
-            .storage_client()
-            .contains_certificate(cert1.hash())
-            .await?
-    );
-    assert!(
-        receiver
-            .storage_client()
-            .contains_certificate(cert2.hash())
-            .await?
+        !storage.contains_blob(sender_chain_desc_blob_id).await?,
+        "retry_pending_cross_chain_requests must not download the ChainDescription",
     );
 
     Ok(())

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1540,6 +1540,19 @@ where
         .await
     }
 
+    /// Returns the pending cross-chain network actions for this chain without
+    /// initializing its execution state. Safe to call on chains whose
+    /// `ChainDescription` blob is not available locally.
+    pub async fn cross_chain_network_actions(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<NetworkActions, WorkerError> {
+        self.chain_read(chain_id, |guard| async move {
+            guard.cross_chain_network_actions().await
+        })
+        .await
+    }
+
     /// Gets tip state and outbox info for next_outbox_heights calculation.
     pub async fn get_tip_state_and_outbox_info(
         &self,


### PR DESCRIPTION
## Motivation

`LocalNodeClient::retry_pending_cross_chain_requests` went through `handle_chain_info_query`, which unconditionally calls `initialize_and_save_if_needed`. For a sender chain whose `ChainDescription` blob was never needed locally (e.g. only non-height-0 blocks preprocessed), the init step would fail with `BlobsNotFound` and the caller would download the `ChainDescription` from validators — once per sender per sync.


## Proposal

Add a dedicated worker entry point (`cross_chain_network_actions`) that computes pending cross-chain requests from the outbox without touching execution state, and route the retry through it.

## Test Plan

A test was extended to assert that a sparse sender chain's description wasn't downloaded.

## Release Plan

- Port to `main`.
- Release SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
