### PR TITLE
Don't fetch blob when retrying x-chain requests for sender chains (#5998)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -234,22 +234,14 @@ where
     pub(crate) async fn handle_chain_info_query(
         &mut self,
         query: ChainInfoQuery,
-    ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        let create_network_actions = query.create_network_actions;
+    ) -> Result<ChainInfoResponse, WorkerError> {
         if let Some((height, round)) = query.request_leader_timeout {
             self.vote_for_leader_timeout(height, round).await?;
         }
         if query.request_fallback {
             self.vote_for_fallback().await?;
         }
-        let response = self.prepare_chain_info_response(query).await?;
-        // Trigger any outgoing cross-chain messages that haven't been confirmed yet.
-        let actions = if create_network_actions {
-            self.create_network_actions(None).await?
-        } else {
-            NetworkActions::default()
-        };
-        Ok((response, actions))
+        self.prepare_chain_info_response(query).await
     }
 
     /// Returns the requested blob, if it belongs to the current locking block or pending proposal.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -220,6 +220,15 @@ where
         self.service_runtime_task.take()
     }
 
+    /// Returns the pending cross-chain network actions for this chain, without
+    /// initializing the chain's execution state. Intended for callers that only
+    /// need to re-emit cross-chain requests from the outbox of a sender chain
+    /// whose `ChainDescription` we may never have needed.
+    #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
+    pub(crate) async fn cross_chain_network_actions(&self) -> Result<NetworkActions, WorkerError> {
+        self.create_network_actions(None).await
+    }
+
     /// Handles a [`ChainInfoQuery`], potentially voting on the next block.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn handle_chain_info_query(

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -62,14 +62,6 @@ pub struct ChainInfoQuery {
     #[debug(skip_if = Vec::is_empty)]
     #[cfg_attr(with_testing, strategy(proptest::strategy::Just(Vec::new())))]
     pub request_previous_event_blocks: Vec<StreamId>,
-    #[serde(default = "default_true")]
-    pub create_network_actions: bool,
-}
-
-// Default value for create_network_actions.
-// Default for bool returns false.
-fn default_true() -> bool {
-    true
 }
 
 impl ChainInfoQuery {
@@ -86,7 +78,6 @@ impl ChainInfoQuery {
             request_fallback: false,
             request_sent_certificate_hashes_by_heights: Vec::new(),
             request_previous_event_blocks: Vec::new(),
-            create_network_actions: false,
         }
     }
 
@@ -137,11 +128,6 @@ impl ChainInfoQuery {
 
     pub fn with_fallback(mut self) -> Self {
         self.request_fallback = true;
-        self
-    }
-
-    pub fn with_network_actions(mut self) -> Self {
-        self.create_network_actions = true;
         self
     }
 }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -118,9 +118,7 @@ where
         &self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
-        // In local nodes, cross-chain actions will be handled internally, so we discard them.
-        let (response, _actions) = self.node.state.handle_chain_info_query(query).await?;
-        Ok(response)
+        Ok(self.node.state.handle_chain_info_query(query).await?)
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -264,16 +264,22 @@ where
     }
 
     /// Handles any pending local cross-chain requests.
+    ///
+    /// Does not initialize the sender chain's execution state, so it is safe to
+    /// call even when the sender's `ChainDescription` blob is not in local storage.
+    /// Previously this went through `handle_chain_info_query`, which unconditionally
+    /// initialized the worker and therefore forced a `ChainDescription` download on
+    /// every call.
     #[instrument(level = "trace", skip(self, notifier))]
     pub async fn retry_pending_cross_chain_requests(
         &self,
         sender_chain: ChainId,
         notifier: &impl Notifier,
     ) -> Result<(), LocalNodeError> {
-        let (_response, actions) = self
+        let actions = self
             .node
             .state
-            .handle_chain_info_query(ChainInfoQuery::new(sender_chain).with_network_actions())
+            .cross_chain_network_actions(sender_chain)
             .await?;
         let mut requests = VecDeque::from_iter(actions.cross_chain_requests);
         while let Some(request) = requests.pop_front() {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, InMemorySigner},
     data_types::*,
-    identifiers::{Account, AccountOwner, ApplicationId},
+    identifiers::{Account, AccountOwner, ApplicationId, BlobId, BlobType},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -1387,6 +1387,13 @@ where
     Ok(())
 }
 
+/// The sender chain should be stored sparsely in the receiver's node: only blocks
+/// that sent messages to us should be downloaded, not the intermediate ones. When
+/// the sender is a non-root chain (so its `ChainDescription` blob isn't in the
+/// receiver's genesis storage) and the sender's height-0 block doesn't send to us,
+/// the `ChainDescription` itself should never be downloaded either — not during
+/// the initial message processing, and not during a later re-sync that routes the
+/// sender through `retry_pending_cross_chain_requests_from_sender_chains`.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]
@@ -1395,12 +1402,42 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
-    let mut builder = TestBuilder::new(storage_builder, 2, 0, signer).await?;
-    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let owner = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();
 
+    // Open the sender as a non-root chain so that its `ChainDescription` isn't
+    // pre-populated in the receiver's genesis storage. We also make the sender's
+    // first block a burn rather than a transfer to the receiver: that keeps the
+    // message-sending blocks at height >= 1, so preprocessing them never requires
+    // the sender's `ChainDescription` (only height-0 blocks do).
+    let sender_public_key = builder.signer.generate_new();
+    let sender_ownership = ChainOwnership::single(sender_public_key.into())
+        .with_regular_owner(sender_public_key.into(), 100);
+    let (sender_description, _creation_certificate) = Box::pin(owner.open_chain(
+        sender_ownership,
+        ApplicationPermissions::default(),
+        Amount::from_tokens(4),
+    ))
+    .await
+    .unwrap_ok_committed();
+    let sender_id = sender_description.id();
+    let sender_chain_desc_blob_id = BlobId::new(sender_id.0, BlobType::ChainDescription);
+
+    let mut sender = builder
+        .make_client(sender_id, None, BlockHeight::ZERO)
+        .await?;
+    sender.set_preferred_owner(sender_public_key.into());
+    sender.synchronize_from_validators().await?;
+
+    // Heights 0 and 2 are burns; heights 1 and 3 send to the receiver.
     let cert0 = sender
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    let cert1 = sender
         .transfer_to_account(
             AccountOwner::CHAIN,
             Amount::ONE,
@@ -1408,11 +1445,11 @@ where
         )
         .await
         .unwrap_ok_committed();
-    let cert1 = sender
+    let cert2 = sender
         .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
         .unwrap_ok_committed();
-    let cert2 = sender
+    let cert3 = sender
         .transfer_to_account(
             AccountOwner::CHAIN,
             Amount::ONE,
@@ -1421,12 +1458,14 @@ where
         .await
         .unwrap_ok_committed();
 
-    // Process the notification about the incoming message.
+    // Process the notification about the most recent incoming message. This walks
+    // back along `previous_message_blocks` and preprocesses only the sender blocks
+    // that sent to us (heights 1 and 3).
     let notification = Notification {
         chain_id: receiver_id,
         reason: Reason::NewIncomingBundle {
-            origin: cert2.block().header.chain_id,
-            height: cert2.block().header.height,
+            origin: sender_id,
+            height: cert3.block().header.height,
         },
     };
     let validator = builder
@@ -1439,25 +1478,31 @@ where
         .await;
     receiver.process_inbox().await?;
 
-    // The first and last blocks sent something to the receiver. The middle one didn't.
-    // So the sender chain should have a gap.
+    // Only the blocks that sent something to the receiver should be in local
+    // storage. The burn blocks in between — and the sender's `ChainDescription`
+    // blob itself — should never have been downloaded.
+    let storage = receiver.storage_client();
+    assert!(!storage.contains_certificate(cert0.hash()).await?);
+    assert!(storage.contains_certificate(cert1.hash()).await?);
+    assert!(!storage.contains_certificate(cert2.hash()).await?);
+    assert!(storage.contains_certificate(cert3.hash()).await?);
     assert!(
-        receiver
-            .storage_client()
-            .contains_certificate(cert0.hash())
-            .await?
+        !storage.contains_blob(sender_chain_desc_blob_id).await?,
+        "preprocessing non-height-0 sender blocks must not download the ChainDescription",
     );
+
+    // `process_notification_from` does not advance the client's
+    // `received_certificate_trackers`, so a subsequent `synchronize_from_validators`
+    // still sees (sender, 1) and (sender, 3) in the received log. But the sender's
+    // outbox has those heights scheduled locally now, so `find_received_certificates`
+    // filters them out and routes the sender through
+    // `retry_pending_cross_chain_requests_from_sender_chains`. Before the fix this
+    // initialized the sender's chain worker inside the receiver's node and, on
+    // failing to find the `ChainDescription` blob in storage, triggered a download.
+    receiver.synchronize_from_validators().await?;
     assert!(
-        !receiver
-            .storage_client()
-            .contains_certificate(cert1.hash())
-            .await?
-    );
-    assert!(
-        receiver
-            .storage_client()
-            .contains_certificate(cert2.hash())
-            .await?
+        !storage.contains_blob(sender_chain_desc_blob_id).await?,
+        "retry_pending_cross_chain_requests must not download the ChainDescription",
     );
 
     Ok(())

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -484,8 +484,7 @@ where
                 .await
                 .map_err(Into::into),
         };
-        // In a local node cross-chain messages can't get lost, so we can ignore the actions here.
-        sender.send(result.map(|(info, _actions)| info))
+        sender.send(result)
     }
 
     async fn do_subscribe(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2471,7 +2471,7 @@ where
         assert_eq!(recipient_chain.received_log.count(), 1);
     }
     let query = ChainInfoQuery::new(chain_2).with_received_log_excluding_first_n(0);
-    let (response, _actions) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query)
         .await?;
@@ -3248,7 +3248,7 @@ where
     let stream_id = StreamId::system(NEW_EPOCH_STREAM_NAME);
     let query =
         ChainInfoQuery::new(admin_chain_id).with_previous_event_blocks(vec![stream_id.clone()]);
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query)
         .await?;
@@ -3526,7 +3526,7 @@ where
     clock.set(response.info.manager.round_timeout.unwrap());
 
     // Now the validator will sign a leader timeout vote.
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query)
         .await?;
@@ -3622,7 +3622,7 @@ where
         .handle_validated_certificate(certificate)
         .await?;
     let query_values = ChainInfoQuery::new(chain_1).with_manager_values();
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query_values.clone())
         .await?;
@@ -3663,7 +3663,7 @@ where
         .executing_worker()
         .handle_block_proposal(proposal)
         .await?;
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query_values.clone())
         .await?;
@@ -3714,7 +3714,7 @@ where
     worker
         .handle_validated_certificate(certificate.clone())
         .await?;
-    let (response, _) = worker.handle_chain_info_query(query_values).await?;
+    let response = worker.handle_chain_info_query(query_values).await?;
     assert_eq!(
         response.info.manager.requested_locking,
         Some(Box::new(LockingBlock::Regular(certificate)))
@@ -3809,7 +3809,7 @@ where
     clock.set(response.info.manager.round_timeout.unwrap());
 
     // Now the validator will sign a leader timeout vote.
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query)
         .await?;
@@ -3842,7 +3842,7 @@ where
         .await?;
     assert_matches!(actions.notifications[0].reason, Reason::NewRound { .. });
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query_values)
         .await?;
@@ -4015,7 +4015,7 @@ where
         .handle_block_proposal(proposal)
         .await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query_values)
         .await?;
@@ -4061,7 +4061,7 @@ where
     let query = ChainInfoQuery::new(chain_id)
         .with_fallback()
         .with_committees();
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query.clone())
         .await?;
@@ -4073,7 +4073,7 @@ where
 
     // Even if a long time passes: Without a new epoch there's no fallback mode.
     clock.add(fallback_duration);
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query.clone())
         .await?;
@@ -4098,7 +4098,7 @@ where
         .await?;
 
     // Epoch was just created at time 0: No fallback mode yet.
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query.clone())
         .await?;
@@ -4106,7 +4106,7 @@ where
 
     // Advance time past the fallback_duration. Now we should vote for fallback.
     clock.add(fallback_duration);
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query.clone())
         .await?;
@@ -4121,7 +4121,7 @@ where
         .await?;
 
     // Now we are in fallback mode, and the validator is the leader.
-    let (response, _) = env
+    let response = env
         .executing_worker()
         .handle_chain_info_query(query.clone())
         .await?;
@@ -4598,7 +4598,7 @@ where
 
     // Query pending bundles and verify priority chain's bundle comes first.
     let query = ChainInfoQuery::new(chain_2).with_pending_message_bundles();
-    let (response, _actions) = env.worker().handle_chain_info_query(query).await?;
+    let response = env.worker().handle_chain_info_query(query).await?;
     let bundles = &response.info.requested_pending_message_bundles;
 
     assert_eq!(bundles.len(), 2);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1589,6 +1589,19 @@ where
         .await
     }
 
+    /// Returns the pending cross-chain network actions for this chain without
+    /// initializing its execution state. Safe to call on chains whose
+    /// `ChainDescription` blob is not available locally.
+    pub async fn cross_chain_network_actions(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<NetworkActions, WorkerError> {
+        self.chain_read(chain_id, |guard| async move {
+            guard.cross_chain_network_actions().await
+        })
+        .await
+    }
+
     /// Gets tip state and outbox info for next_outbox_heights calculation.
     pub async fn get_tip_state_and_outbox_info(
         &self,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1299,7 +1299,7 @@ where
     pub async fn handle_chain_info_query(
         &self,
         query: ChainInfoQuery,
-    ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
+    ) -> Result<ChainInfoResponse, WorkerError> {
         trace!("{} <-- {:?}", self.nickname(), query);
         #[cfg(with_metrics)]
         metrics::CHAIN_INFO_QUERIES.inc();

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -262,7 +262,7 @@ message ChainInfoQuery {
   optional bytes request_sent_certificate_hashes_by_heights = 11;
 
   // Query the previous event blocks for specific streams.
-  optional bytes request_previous_event_blocks = 13;
+  optional bytes request_previous_event_blocks = 12;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -261,9 +261,6 @@ message ChainInfoQuery {
   // Query for certificate hashes at block heights sent from the chain.
   optional bytes request_sent_certificate_hashes_by_heights = 11;
 
-  // Whether to create network actions as part of the query.
-  optional bool create_network_actions = 12;
-
   // Query the previous event blocks for specific streams.
   optional bytes request_previous_event_blocks = 13;
 }

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -643,7 +643,6 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_fallback: chain_info_query.request_fallback,
             request_sent_certificate_hashes_by_heights,
             request_previous_event_blocks,
-            create_network_actions: chain_info_query.create_network_actions.unwrap_or(true),
         })
     }
 }
@@ -676,7 +675,6 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
-            create_network_actions: Some(chain_info_query.create_network_actions),
             request_previous_event_blocks: Some(request_previous_event_blocks),
         })
     }
@@ -1240,7 +1238,6 @@ pub mod tests {
             request_fallback: true,
             request_sent_certificate_hashes_by_heights: (3..8).map(BlockHeight::from).collect(),
             request_previous_event_blocks: Vec::new(),
-            create_network_actions: true,
         };
         round_trip_check::<_, api::ChainInfoQuery>(&chain_info_query_some);
     }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -901,9 +901,8 @@ where
         let query = request.into_inner().try_into()?;
         trace!(?query, "Handling chain info query");
         match self.state.clone().handle_chain_info_query(query).await {
-            Ok((info, actions)) => {
+            Ok(info) => {
                 Self::log_request_success("handle_chain_info_query", traffic_type);
-                self.handle_network_actions(actions);
                 Ok(Response::new(info.try_into()?))
             }
             Err(error) => {

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -303,12 +303,7 @@ where
             }
             RpcMessage::ChainInfoQuery(message) => {
                 match self.server.state.handle_chain_info_query(*message).await {
-                    Ok((info, actions)) => {
-                        // Cross-shard requests
-                        self.handle_network_actions(actions);
-                        // Response
-                        Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
-                    }
+                    Ok(info) => Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info)))),
                     Err(error) => {
                         self.log_error(&error, "Failed to handle chain info query");
                         Err(error.into())

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -364,7 +364,6 @@ ChainInfoQuery:
     - request_previous_event_blocks:
         SEQ:
           TYPENAME: StreamId
-    - create_network_actions: BOOL
 ChainInfoResponse:
   STRUCT:
     - info:

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -297,7 +297,7 @@ impl ActiveChain {
         &self,
     ) -> Option<(ConfirmedBlockCertificate, ResourceTracker)> {
         let chain_id = self.id();
-        let (information, _) = self
+        let information = self
             .validator
             .worker()
             .handle_chain_info_query(ChainInfoQuery::new(chain_id).with_pending_message_bundles())


### PR DESCRIPTION
Port of #5998.

## Motivation

`LocalNodeClient::retry_pending_cross_chain_requests` went through `handle_chain_info_query`, which unconditionally calls `initialize_and_save_if_needed`. For a sender chain whose `ChainDescription` blob was never needed locally (e.g. only non-height-0 blocks preprocessed), the init step would fail with `BlobsNotFound` and the caller would download the `ChainDescription` from validators — once per sender per sync.


## Proposal

Add a dedicated worker entry point (`cross_chain_network_actions`) that computes pending cross-chain requests from the outbox without touching execution state, and route the retry through it.

## Test Plan

A test was extended to assert that a sparse sender chain's description wasn't downloaded.

## Release Plan

- Backport, but without the change to the format.

## Links

- `testnet_conway` version: #5998.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)