### PR TITLE
[backport] Docker build logs: failures last, with ::group:: markers

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -148,22 +148,35 @@ jobs:
             PIDS="${PIDS} ${TYPE}:$!"
           done
 
-          EXIT_CODE=0
+          SUCCESS_NAMES=""
+          FAILED_NAMES=""
           for NAME_PID in ${PIDS}; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
-            if ! wait "$PID"; then
-              EXIT_CODE=1
+            if wait "$PID"; then
+              SUCCESS_NAMES="${SUCCESS_NAMES} ${NAME}"
+            else
+              FAILED_NAMES="${FAILED_NAMES} ${NAME}"
               echo "::error::${NAME} build failed"
             fi
-            echo "==================== ${NAME} logs ===================="
-            cat "/tmp/build-${NAME}.log" 2>/dev/null || true
-            echo "==================== end ${NAME} logs ===================="
           done
 
-          if [[ $EXIT_CODE -ne 0 ]]; then
-            echo "One or more image builds failed"
-            exit $EXIT_CODE
+          # Print successes first, then failures, so the last thing
+          # on screen when a build fails is the failing log.
+          for NAME in ${SUCCESS_NAMES}; do
+            echo "::group::${NAME} (success)"
+            cat "/tmp/build-${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+          for NAME in ${FAILED_NAMES}; do
+            echo "::group::${NAME} (FAILED)"
+            cat "/tmp/build-${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+
+          if [ -n "${FAILED_NAMES}" ]; then
+            echo "One or more image builds failed:${FAILED_NAMES}"
+            exit 1
           fi
 
           echo "Build complete."

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -113,22 +113,35 @@ jobs:
             "${EXPORTER_IMAGE_BRANCH}" "${EXPORTER_IMAGE_SHORT}" "${EXPORTER_IMAGE_LONG}" "Exporter" &
           PID_EXPORTER=$!
 
-          EXIT_CODE=0
+          SUCCESS_NAMES=""
+          FAILED_NAMES=""
           for NAME_PID in Linera:$PID_LINERA Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
-            if ! wait "$PID"; then
-              EXIT_CODE=1
+            if wait "$PID"; then
+              SUCCESS_NAMES="${SUCCESS_NAMES} ${NAME}"
+            else
+              FAILED_NAMES="${FAILED_NAMES} ${NAME}"
               echo "::error::${NAME} build failed"
             fi
-            echo "==================== ${NAME} logs ===================="
-            cat "/tmp/${NAME}.log" || true
-            echo "==================== end ${NAME} logs ===================="
           done
 
-          if [[ $EXIT_CODE -ne 0 ]]; then
-            echo "One or more image builds failed"
-            exit $EXIT_CODE
+          # Print successes first, then failures, so the last thing
+          # on screen when a build fails is the failing log.
+          for NAME in ${SUCCESS_NAMES}; do
+            echo "::group::${NAME} (success)"
+            cat "/tmp/${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+          for NAME in ${FAILED_NAMES}; do
+            echo "::group::${NAME} (FAILED)"
+            cat "/tmp/${NAME}.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+
+          if [ -n "${FAILED_NAMES}" ]; then
+            echo "One or more image builds failed:${FAILED_NAMES}"
+            exit 1
           fi
 
           echo "All image builds completed successfully!"


### PR DESCRIPTION
## Motivation

Backport of #5995 to `testnet_conway`. Keeps branch in sync with `main`'s docker build
log UX improvements.

## Proposal

Identical logical change as #5995, adapted for `testnet_conway`'s workflow variants:
- `docker_image.yml`: `PID` list doesn't include `Bridge:$PID_BRIDGE` (no bridge image
on testnet_conway).
- `build_image.yml`: `image_type` choices don't include `bridge`.
- Otherwise byte-identical reorder logic.

See #5995 for full rationale (successes-first / failures-last, `::group::` wrapping,
`::error::` annotation kept).

## Test Plan

Local `bash -n` on both extracted run blocks: syntax OK.

Real-runner validation was done on #5995 ([Build Image run
24378066823](https://github.com/linera-io/linera-protocol/actions/runs/24378066823) —
green after runner's Docker daemon recovered). The log rendering logic doesn't depend on
branch, so the same validation applies here.

## Release Plan

- Nothing to do / These changes follow the usual relea cycle.

