### PR TITLE
[testnet] Increase client-side histogram bucket range to 10 seconds

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -83,7 +83,7 @@ mod metrics {
                 "process_inbox_latency",
                 "process_inbox latency",
                 &[],
-                exponential_bucket_latencies(500.0),
+                exponential_bucket_latencies(10_000.0),
             )
         });
 
@@ -92,7 +92,7 @@ mod metrics {
             "prepare_chain_latency",
             "prepare_chain latency",
             &[],
-            exponential_bucket_latencies(500.0),
+            exponential_bucket_latencies(10_000.0),
         )
     });
 
@@ -101,7 +101,7 @@ mod metrics {
             "synchronize_chain_state_latency",
             "synchronize_chain_state latency",
             &[],
-            exponential_bucket_latencies(500.0),
+            exponential_bucket_latencies(10_000.0),
         )
     });
 
@@ -110,7 +110,7 @@ mod metrics {
             "execute_block_latency",
             "execute_block latency",
             &[],
-            exponential_bucket_latencies(500.0),
+            exponential_bucket_latencies(10_000.0),
         )
     });
 
@@ -119,7 +119,7 @@ mod metrics {
             "find_received_certificates_latency",
             "find_received_certificates latency",
             &[],
-            exponential_bucket_latencies(500.0),
+            exponential_bucket_latencies(10_000.0),
         )
     });
 }


### PR DESCRIPTION
## Motivation

Backport of #5996.

Several client-side latency histograms (`process_inbox_latency`,
`execute_block_latency`,
`prepare_chain_latency`, `synchronize_chain_state_latency`,
`find_received_certificates_latency`)
have a maximum bucket of 500ms. On PM workers, 47-60% of `process_inbox` and
`execute_block`
calls exceed 500ms, making the p99 peg at exactly 500 with no visibility into the actual
tail.

## Proposal

Increase the bucket range from 500ms to 10,000ms (10 seconds) for all five metrics.

## Test Plan

CI
