### PR TITLE
Add `rejected_bundle_count` metric

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -102,7 +102,7 @@ mod metrics {
         exponential_bucket_interval, register_histogram, register_histogram_vec,
         register_int_counter, register_int_counter_vec,
     };
-    use linera_chain::types::ConfirmedBlockCertificate;
+    use linera_chain::{data_types::MessageAction, types::ConfirmedBlockCertificate};
     use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec};
 
     pub static NUM_ROUNDS_IN_CERTIFICATE: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -128,6 +128,9 @@ mod metrics {
 
     pub static INCOMING_BUNDLE_COUNT: LazyLock<IntCounter> =
         LazyLock::new(|| register_int_counter("incoming_bundle_count", "Incoming bundle count"));
+
+    pub static REJECTED_BUNDLE_COUNT: LazyLock<IntCounter> =
+        LazyLock::new(|| register_int_counter("rejected_bundle_count", "Rejected bundle count"));
 
     pub static INCOMING_MESSAGE_COUNT: LazyLock<IntCounter> =
         LazyLock::new(|| register_int_counter("incoming_message_count", "Incoming message count"));
@@ -185,6 +188,7 @@ mod metrics {
         round_number: u32,
         confirmed_transactions: u64,
         confirmed_incoming_bundles: u64,
+        confirmed_rejected_bundles: u64,
         confirmed_incoming_messages: u64,
         confirmed_operations: u64,
         validators_with_signatures: Vec<String>,
@@ -200,6 +204,12 @@ mod metrics {
                 confirmed_transactions: certificate.block().body.transactions.len() as u64,
                 confirmed_incoming_bundles: certificate.block().body.incoming_bundles().count()
                     as u64,
+                confirmed_rejected_bundles: certificate
+                    .block()
+                    .body
+                    .incoming_bundles()
+                    .filter(|b| b.action == MessageAction::Reject)
+                    .count() as u64,
                 confirmed_incoming_messages: certificate
                     .block()
                     .body
@@ -230,6 +240,9 @@ mod metrics {
                     .inc_by(self.confirmed_transactions);
                 if self.confirmed_incoming_bundles > 0 {
                     INCOMING_BUNDLE_COUNT.inc_by(self.confirmed_incoming_bundles);
+                }
+                if self.confirmed_rejected_bundles > 0 {
+                    REJECTED_BUNDLE_COUNT.inc_by(self.confirmed_rejected_bundles);
                 }
                 if self.confirmed_incoming_messages > 0 {
                     INCOMING_MESSAGE_COUNT.inc_by(self.confirmed_incoming_messages);


### PR DESCRIPTION
## Motivation

Lots of rejected messages can be a warning sign, and in some cases they are entirely unexpected.

## Proposal

Track the number of rejected bundles in confirmed blocks, alongside the existing `incoming_bundle_count counter`.

## Test Plan

CI

## Release Plan

- Port to `testnet_conway`
- Release SDK
- Hotfix validators

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
