### PR TITLE
Rename lite-certificate-cache-size flag in k8s helm templates

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -139,7 +139,7 @@ spec:
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
                 --blob-cache-size {{ .Values.storageCacheSizes.blobCacheSize | int }} \
                 --confirmed-block-cache-size {{ .Values.storageCacheSizes.confirmedBlockCacheSize | int }} \
-                --lite-certificate-cache-size {{ .Values.storageCacheSizes.liteCertificateCacheSize | int }} \
+                --certificate-cache-size {{ .Values.storageCacheSizes.certificateCacheSize | int }} \
                 --certificate-raw-cache-size {{ .Values.storageCacheSizes.certificateRawCacheSize | int }} \
                 --event-cache-size {{ .Values.storageCacheSizes.eventCacheSize | int }} \
                 --id "$ORDINAL" \

--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -144,7 +144,7 @@ spec:
                 --storage-max-cache-find-key-values-size {{ .Values.storageCacheConfig.maxCacheFindKeyValuesSize | int }} \
                 --blob-cache-size {{ .Values.storageCacheSizes.blobCacheSize | int }} \
                 --confirmed-block-cache-size {{ .Values.storageCacheSizes.confirmedBlockCacheSize | int }} \
-                --lite-certificate-cache-size {{ .Values.storageCacheSizes.liteCertificateCacheSize | int }} \
+                --certificate-cache-size {{ .Values.storageCacheSizes.certificateCacheSize | int }} \
                 --certificate-raw-cache-size {{ .Values.storageCacheSizes.certificateRawCacheSize | int }} \
                 --event-cache-size {{ .Values.storageCacheSizes.eventCacheSize | int }} \
                 --block-cache-size {{ .Values.blockCacheSize | int }} \

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -98,7 +98,7 @@ storageCacheConfig:
 storageCacheSizes:
   blobCacheSize: 1000
   confirmedBlockCacheSize: 10000
-  liteCertificateCacheSize: 5000
+  certificateCacheSize: 5000
   certificateRawCacheSize: 50000
   eventCacheSize: 20000
 


### PR DESCRIPTION
## Motivation

#5859 (frontport of #5769, "Split blob_cache_size into individual cache size flags")
renamed `lite_certificate_cache_size` → `certificate_cache_size` in the Rust code,
including the CLI flag (`--certificate-cache-size`, see `CLI.md:274` and
`linera-service/src/storage.rs`).

The k8s helm templates were not updated and still emit the old flag, which breaks
validator pods on images built from post-#5859 code:

```
error: unexpected argument '--lite-certificate-cache-size' found
tip: a similar argument exists: '--certificate-cache-size'
```

This was observed on Conway `validator-4` while piloting an unrelated chain-worker TTL
fix (pm-app image `8b72b18`, linera-protocol submodule at `36f1a4d`). Both `proxy-2` and
`shards-7` pods crash-looped with the error above. The deployment was unblocked with a
local hotfix in the `linera-infra`-side submodule checkout; this PR is the proper
upstream rename.

## Proposal

Rename the three remaining references so e emitted CLI flag matches the binary:

- `kubernetes/linera-validator/templates/proxy.yaml`: `--lite-certificate-cache-size` →
`--certificate-cache-size`
- `kubernetes/linera-validator/templates/shards.yaml`: same
- `kubernetes/linera-validator/values.yaml`:
`storageCacheSizes.liteCertificateCacheSize` → `storageCacheSizes.certificateCacheSize`

No other references to `liteCertificateCacheSize` / `LITE_CERTIFICATE_CACHE_SIZE` remain
in the repo (verified with `grep -rn`). The `linera-infra`, `pm-infra`, and `pm-app`
repos do not override `liteCertificateCacheSize` anywhere outside their pinned
`linera-protocol` submodule copies, so no coordinated changes are required.

## Test Plan

- `helm lint kubernetes/linera-validator/` passes.
- `helm template` of the chart no longer emits `--lite-certificate-cache-size`;
validator pods that previously crash-looped on `pm-app:8b72b18` come up cleanly after
the fix is in.
- CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch
