### PR TITLE
Remove unused functions and types

### DIFF
--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -36,17 +36,6 @@ pub type ValidatorSignature = secp256k1::Secp256k1Signature;
 /// The key pair of a validator.
 pub type ValidatorKeypair = secp256k1::Secp256k1KeyPair;
 
-/// Signature scheme used for the public key.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
-pub enum SignatureScheme {
-    /// Ed25519
-    Ed25519,
-    /// secp256k1
-    Secp256k1,
-    /// EVM secp256k1
-    EvmSecp256k1,
-}
-
 /// The public key of a chain owner.
 /// The corresponding private key is allowed to propose blocks
 /// on the chain and transfer account's tokens.
@@ -217,15 +206,6 @@ impl AccountSecretKey {
 }
 
 impl AccountPublicKey {
-    /// Returns the signature scheme of the public key.
-    pub fn scheme(&self) -> SignatureScheme {
-        match self {
-            AccountPublicKey::Ed25519(_) => SignatureScheme::Ed25519,
-            AccountPublicKey::Secp256k1(_) => SignatureScheme::Secp256k1,
-            AccountPublicKey::EvmSecp256k1(_) => SignatureScheme::EvmSecp256k1,
-        }
-    }
-
     /// Returns the byte representation of the public key.
     pub fn as_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).expect("serialization to bytes should not fail")

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -773,11 +773,6 @@ pub enum ChainOrigin {
 }
 
 impl ChainOrigin {
-    /// Whether the chain was created by another chain.
-    pub fn is_child(&self) -> bool {
-        matches!(self, ChainOrigin::Child { .. })
-    }
-
     /// Returns the root chain number, if this is a root chain.
     pub fn root(&self) -> Option<u32> {
         match self {
@@ -927,10 +922,6 @@ impl ChainDescription {
         self.timestamp
     }
 
-    /// Whether the chain was created by another chain.
-    pub fn is_child(&self) -> bool {
-        self.origin.is_child()
-    }
 }
 
 impl BcsHashable<'_> for ChainDescription {}

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -9,11 +9,9 @@ use std::ops;
 use std::{
     collections::HashSet,
     fmt::{self, Display},
-    fs,
     hash::Hash,
     io, iter,
     num::ParseIntError,
-    path::Path,
     str::FromStr,
     sync::Arc,
 };
@@ -195,12 +193,6 @@ impl TimeDelta {
         TimeDelta(secs.saturating_mul(1_000_000))
     }
 
-    /// Returns the given duration, rounded to the nearest microsecond and capped to the maximum
-    /// [`TimeDelta`] value.
-    pub fn from_duration(duration: Duration) -> Self {
-        TimeDelta::from_micros(u64::try_from(duration.as_micros()).unwrap_or(u64::MAX))
-    }
-
     /// Returns this [`TimeDelta`] as a number of microseconds.
     pub const fn as_micros(&self) -> u64 {
         self.0
@@ -370,24 +362,6 @@ pub struct SendMessageRequest<Message> {
     pub grant: Resources,
     /// The message itself.
     pub message: Message,
-}
-
-impl<Message> SendMessageRequest<Message>
-where
-    Message: Serialize,
-{
-    /// Serializes the internal `Message` type into raw bytes.
-    pub fn into_raw(self) -> SendMessageRequest<Vec<u8>> {
-        let message = bcs::to_bytes(&self.message).expect("Failed to serialize message");
-
-        SendMessageRequest {
-            destination: self.destination,
-            authenticated: self.authenticated,
-            is_tracked: self.is_tracked,
-            grant: self.grant,
-            message,
-        }
-    }
 }
 
 /// An error type for arithmetic errors.
@@ -1519,11 +1493,6 @@ impl Blob {
     /// Gets a reference to the inner blob's bytes.
     pub fn bytes(&self) -> &[u8] {
         self.content.bytes()
-    }
-
-    /// Loads data blob from a file.
-    pub fn load_data_blob_from_file(path: impl AsRef<Path>) -> io::Result<Self> {
-        Ok(Self::new_data(fs::read(path)?))
     }
 
     /// Returns whether the blob is of [`BlobType::Committee`] variant.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1009,6 +1009,7 @@ impl ApplicationPermissions {
 
     /// Creates new `ApplicationPermissions` where the given applications are the only ones
     /// whose operations are allowed and mandatory, and they can also manage the chain.
+    #[cfg(with_testing)]
     pub fn new_multiple(app_ids: Vec<ApplicationId>) -> Self {
         Self {
             execute_operations: Some(app_ids.clone()),

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -921,7 +921,6 @@ impl ChainDescription {
     pub fn timestamp(&self) -> Timestamp {
         self.timestamp
     }
-
 }
 
 impl BcsHashable<'_> for ChainDescription {}

--- a/linera-base/src/hashed.rs
+++ b/linera-base/src/hashed.rs
@@ -21,19 +21,7 @@ pub struct Hashed<T> {
 }
 
 impl<T> Hashed<T> {
-    /// Creates an instance of [`Hashed`] with the given `hash` value.
-    ///
-    /// Note on usage: This method is unsafe because it allows the caller to create a Hashed
-    /// with a hash that doesn't match the value. This is necessary for the rewrite state when
-    /// signers sign over old `Certificate` type.
-    pub fn unchecked_new(value: T, hash: CryptoHash) -> Self {
-        Self { value, hash }
-    }
-
     /// Creates an instance of [`Hashed`] with the given `value`.
-    ///
-    /// Note: Contrary to its `unchecked_new` counterpart, this method is safe because it
-    /// calculates the hash from the value.
     pub fn new<'de>(value: T) -> Self
     where
         T: BcsHashable<'de>,

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -49,25 +49,6 @@ impl Request {
         }
     }
 
-    /// Creates an HTTP POST [`Request`] for a `url` with a body that's the `payload` serialized to
-    /// JSON.
-    pub fn post_json(
-        url: impl Into<String>,
-        payload: &impl Serialize,
-    ) -> Result<Self, serde_json::Error> {
-        Ok(Request {
-            method: Method::Post,
-            url: url.into(),
-            headers: vec![Header::new("Content-Type", b"application/json")],
-            body: serde_json::to_vec(payload)?,
-        })
-    }
-
-    /// Adds a header to this [`Request`].
-    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<Vec<u8>>) -> Self {
-        self.headers.push(Header::new(name, value));
-        self
-    }
 }
 
 /// The method used in an HTTP request.
@@ -175,11 +156,6 @@ impl Response {
         }
     }
 
-    /// Adds a header to this [`Response`].
-    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<Vec<u8>>) -> Self {
-        self.headers.push(Header::new(name, value));
-        self
-    }
 }
 
 /// A header for an HTTP request or response.

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -48,7 +48,6 @@ impl Request {
             body: payload.into(),
         }
     }
-
 }
 
 /// The method used in an HTTP request.
@@ -155,7 +154,6 @@ impl Response {
             body: vec![],
         }
     }
-
 }
 
 /// A header for an HTTP request or response.

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -466,16 +466,6 @@ impl std::str::FromStr for GenericApplicationId {
     }
 }
 
-impl GenericApplicationId {
-    /// Returns the `ApplicationId`, or `None` if it is `System`.
-    pub fn user_application_id(&self) -> Option<&ApplicationId> {
-        if let GenericApplicationId::User(app_id) = self {
-            Some(app_id)
-        } else {
-            None
-        }
-    }
-}
 
 impl<A> From<ApplicationId<A>> for AccountOwner {
     fn from(app_id: ApplicationId<A>) -> Self {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -466,7 +466,6 @@ impl std::str::FromStr for GenericApplicationId {
     }
 }
 
-
 impl<A> From<ApplicationId<A>> for AccountOwner {
     fn from(app_id: ApplicationId<A>) -> Self {
         if app_id.is_evm() {

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -142,12 +142,6 @@ impl ChainOwnership {
         self
     }
 
-    /// Fixes the given owner as the leader of the first single-leader round on all heights.
-    pub fn with_first_leader(mut self, owner: AccountOwner) -> Self {
-        self.first_leader = Some(owner);
-        self
-    }
-
     /// Returns whether there are any owners or super owners or it is a public chain.
     pub fn is_active(&self) -> bool {
         !self.super_owners.is_empty()

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -137,6 +137,7 @@ impl ChainOwnership {
     }
 
     /// Adds a regular owner.
+    #[cfg(with_testing)]
     pub fn with_regular_owner(mut self, owner: AccountOwner, weight: u64) -> Self {
         self.owners.insert(owner, weight);
         self

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -44,19 +44,6 @@ pub fn register_int_counter(name: &str, description: &str) -> IntCounter {
     register_int_counter!(counter_opts).expect("IntCounter can be created")
 }
 
-/// Wrapper around Prometheus `register_int_counter!` macro with `linera` namespace and a subsystem.
-/// Results in metrics named `linera_<subsystem>_<name>`.
-pub fn register_int_counter_with_subsystem(
-    subsystem: &str,
-    name: &str,
-    description: &str,
-) -> IntCounter {
-    let counter_opts = Opts::new(name, description)
-        .namespace(LINERA_NAMESPACE)
-        .subsystem(subsystem);
-    register_int_counter!(counter_opts).expect("IntCounter can be created")
-}
-
 /// Wrapper around Prometheus `register_histogram_vec!` macro which also sets the `linera` namespace
 pub fn register_histogram_vec(
     name: &str,

--- a/linera-base/src/vm.rs
+++ b/linera-base/src/vm.rs
@@ -101,6 +101,7 @@ impl EvmOperation {
     }
 
     /// Creates an `EvmQuery` from the input.
+    #[cfg(with_testing)]
     pub fn to_evm_query(&self) -> Result<EvmQuery, bcs::Error> {
         Ok(EvmQuery::Operation(self.to_bytes()?))
     }

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -72,9 +72,6 @@ impl<T: CertificateValue> GenericCertificate<T> {
         self.value.hash()
     }
 
-    pub fn destructure(self) -> (T, Round, Vec<(ValidatorPublicKey, ValidatorSignature)>) {
-        (self.value, self.round, self.signatures)
-    }
 
     pub fn signatures(&self) -> &Vec<(ValidatorPublicKey, ValidatorSignature)> {
         &self.signatures

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -72,7 +72,6 @@ impl<T: CertificateValue> GenericCertificate<T> {
         self.value.hash()
     }
 
-
     pub fn signatures(&self) -> &Vec<(ValidatorPublicKey, ValidatorSignature)> {
         &self.signatures
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1062,16 +1062,6 @@ where
         Ok(updated_streams)
     }
 
-    /// Returns whether this is a child chain.
-    pub async fn is_child(&self) -> Result<bool, ChainError> {
-        let description = self.execution_state.system.description.get().await?;
-        let Some(description) = description else {
-            // Root chains are always initialized, so this must be a child chain.
-            return Ok(true);
-        };
-        Ok(description.is_child())
-    }
-
     /// Verifies that the block is valid according to the chain's application permission settings.
     #[instrument(skip_all, fields(
         block_height = %block.height,

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -98,14 +98,6 @@ impl ProposedBlock {
         })
     }
 
-    /// Returns the number of incoming messages.
-    pub fn message_count(&self) -> usize {
-        self.incoming_bundles()
-            .map(|im| im.bundle.messages.len())
-            .sum()
-    }
-
-
     /// Returns all operations in this block.
     pub fn operations(&self) -> impl Iterator<Item = &Operation> {
         self.transactions.iter().filter_map(|tx| match tx {

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -98,12 +98,6 @@ impl ProposedBlock {
         })
     }
 
-    /// Returns an iterator over all incoming [`PostedMessage`]s in this block.
-    pub fn incoming_messages(&self) -> impl Iterator<Item = &PostedMessage> {
-        self.incoming_bundles()
-            .flat_map(|incoming_bundle| &incoming_bundle.bundle.messages)
-    }
-
     /// Returns the number of incoming messages.
     pub fn message_count(&self) -> usize {
         self.incoming_bundles()
@@ -111,10 +105,6 @@ impl ProposedBlock {
             .sum()
     }
 
-    /// Returns an iterator over all transactions as references.
-    pub fn transaction_refs(&self) -> impl Iterator<Item = &Transaction> {
-        self.transactions.iter()
-    }
 
     /// Returns all operations in this block.
     pub fn operations(&self) -> impl Iterator<Item = &Operation> {
@@ -670,9 +660,6 @@ impl BlockExecutionOutcome {
         self.blobs.iter().flatten().map(|blob| blob.id())
     }
 
-    pub fn created_blobs_ids(&self) -> HashSet<BlobId> {
-        self.iter_created_blobs_ids().collect()
-    }
 }
 
 /// The data a block proposer signs.

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -651,7 +651,6 @@ impl BlockExecutionOutcome {
     pub fn iter_created_blobs_ids(&self) -> impl Iterator<Item = BlobId> + '_ {
         self.blobs.iter().flatten().map(|blob| blob.id())
     }
-
 }
 
 /// The data a block proposer signs.

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -267,16 +267,6 @@ where
         self.validated_vote.get().as_ref()
     }
 
-    /// Returns the most recent timeout vote we cast.
-    pub fn timeout_vote(&self) -> Option<&Vote<Timeout>> {
-        self.timeout_vote.get().as_ref()
-    }
-
-    /// Returns the most recent fallback vote we cast.
-    pub fn fallback_vote(&self) -> Option<&Vote<Timeout>> {
-        self.fallback_vote.get().as_ref()
-    }
-
     /// Returns the lowest round where we can still vote to validate or confirm a block. This is
     /// the round to which the timeout applies.
     ///

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -54,6 +54,7 @@ pub struct ChainWorkerConfig {
 
 impl ChainWorkerConfig {
     /// Configures the `key_pair` in this [`ChainWorkerConfig`].
+    #[cfg(with_testing)]
     pub fn with_key_pair(mut self, key_pair: Option<ValidatorSecretKey>) -> Self {
         self.key_pair = key_pair.map(Arc::new);
         self

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -18,7 +18,7 @@ use futures::{
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     abi::Abi,
-    crypto::{signer, AccountPublicKey, CryptoHash, Signer, ValidatorPublicKey},
+    crypto::{signer, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
         ChainDescription, Epoch, MessagePolicy, Round, Timestamp,
@@ -51,7 +51,7 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, SystemOperation, EPOCH_STREAM_NAME,
         REMOVED_EPOCH_STREAM_NAME,
     },
-    ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemQuery, SystemResponse,
+    ExecutionError, Operation, Query, QueryOutcome,
 };
 use linera_storage::{Clock as _, Storage as _};
 use linera_views::ViewError;
@@ -1510,11 +1510,12 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     /// Queries a system application.
+    #[cfg(with_testing)]
     #[instrument(level = "trace", skip(query))]
     pub async fn query_system_application(
         &self,
-        query: SystemQuery,
-    ) -> Result<QueryOutcome<SystemResponse>, Error> {
+        query: linera_execution::SystemQuery,
+    ) -> Result<QueryOutcome<linera_execution::SystemResponse>, Error> {
         let (
             QueryOutcome {
                 response,
@@ -1523,7 +1524,7 @@ impl<Env: Environment> ChainClient<Env> {
             _,
         ) = self.query_application(Query::System(query), None).await?;
         match response {
-            QueryResponse::System(response) => Ok(QueryOutcome {
+            linera_execution::QueryResponse::System(response) => Ok(QueryOutcome {
                 response,
                 operations,
             }),
@@ -1548,7 +1549,7 @@ impl<Env: Environment> ChainClient<Env> {
             _,
         ) = self.query_application(query, None).await?;
         match response {
-            QueryResponse::User(response_bytes) => {
+            linera_execution::QueryResponse::User(response_bytes) => {
                 let response = serde_json::from_slice(&response_bytes)?;
                 Ok(QueryOutcome {
                     response,
@@ -2115,10 +2116,11 @@ impl<Env: Environment> ChainClient<Env> {
     /// Rotates the key of the chain.
     ///
     /// Replaces current owners of the chain with the new key pair.
+    #[cfg(with_testing)]
     #[instrument(level = "trace")]
     pub async fn rotate_key_pair(
         &self,
-        public_key: AccountPublicKey,
+        public_key: linera_base::crypto::AccountPublicKey,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
         self.transfer_ownership(public_key.into()).await
     }
@@ -2603,6 +2605,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// Sends money to a chain.
     /// Do not check balance. (This may block the client)
     /// Do not confirm the transaction.
+    #[cfg(with_testing)]
     #[instrument(level = "trace")]
     pub async fn transfer_to_account_unsafe_unconfirmed(
         &self,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -428,12 +428,6 @@ impl<Env: Environment> ChainClient<Env> {
         self.preferred_owner = Some(preferred_owner);
     }
 
-    /// Unsets the preferred owner for signing the blocks.
-    #[instrument(level = "trace", skip(self))]
-    pub fn unset_preferred_owner(&mut self) {
-        self.preferred_owner = None;
-    }
-
     /// Obtains a `ChainStateView` for this client's chain.
     #[instrument(level = "trace")]
     pub async fn chain_state_view(

--- a/linera-core/src/client/requests_scheduler/node_info.rs
+++ b/linera-core/src/client/requests_scheduler/node_info.rs
@@ -109,11 +109,6 @@ impl<Env: Environment> NodeInfo<Env> {
         self.total_requests += 1;
     }
 
-    /// Returns the current EMA success rate.
-    pub(super) fn ema_success_rate(&self) -> f64 {
-        self.ema_success_rate
-    }
-
     /// Returns the total number of requests processed.
     pub(super) fn total_requests(&self) -> u64 {
         self.total_requests

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -468,29 +468,6 @@ impl<Env: Environment> RequestsScheduler<Env> {
         self.in_flight_tracker.get_alternative_peers(key).await
     }
 
-    /// Returns current performance metrics for all managed nodes.
-    ///
-    /// Each entry contains:
-    /// - Performance score (f64, normalized 0.0-1.0)
-    /// - EMA success rate (f64, 0.0-1.0)
-    /// - Total requests processed (u64)
-    ///
-    /// Useful for monitoring and debugging node performance.
-    pub async fn get_node_scores(&self) -> BTreeMap<ValidatorPublicKey, (f64, f64, u64)> {
-        let nodes = self.nodes.read().await;
-        let mut result = BTreeMap::new();
-
-        for (key, info) in nodes.iter() {
-            let score = info.calculate_score().await;
-            result.insert(
-                *key,
-                (score, info.ema_success_rate(), info.total_requests()),
-            );
-        }
-
-        result
-    }
-
     /// Wraps a request operation with performance tracking and capacity management.
     ///
     /// This method:

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -81,18 +81,8 @@ impl ChainInfoQuery {
         }
     }
 
-    pub fn test_next_block_height(mut self, height: BlockHeight) -> Self {
-        self.test_next_block_height = Some(height);
-        self
-    }
-
     pub fn with_committees(mut self) -> Self {
         self.request_committees = true;
-        self
-    }
-
-    pub fn with_owner_balance(mut self, owner: AccountOwner) -> Self {
-        self.request_owner_balance = owner;
         self
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -126,6 +126,7 @@ impl ChainInfoQuery {
         self
     }
 
+    #[cfg(with_testing)]
     pub fn with_fallback(mut self) -> Self {
         self.request_fallback = true;
         self

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -650,13 +650,6 @@ where
     }
 
     #[instrument(level = "trace", skip(self))]
-    pub fn with_reset_on_incorrect_outcome(mut self, minutes: Option<u64>) -> Self {
-        self.chain_worker_config.reset_on_incorrect_outcome =
-            minutes.map(|m| Duration::from_secs(m * 60));
-        self
-    }
-
-    #[instrument(level = "trace", skip(self))]
     pub fn nickname(&self) -> &str {
         &self.chain_worker_config.nickname
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
@@ -625,13 +625,15 @@ where
 {
     /// Returns an instance with the specified set of chain IDs whose incoming bundles
     /// should be processed first.
+    #[cfg(with_testing)]
     #[instrument(level = "trace", skip(self, origins))]
-    pub fn with_priority_bundle_origins(mut self, origins: HashSet<ChainId>) -> Self {
+    pub fn with_priority_bundle_origins(mut self, origins: std::collections::HashSet<ChainId>) -> Self {
         self.chain_worker_config.priority_bundle_origins = origins;
         self
     }
 
     /// Returns an instance with the specified cross-chain message chunk limit.
+    #[cfg(with_testing)]
     #[instrument(level = "trace", skip(self))]
     pub fn with_cross_chain_message_chunk_limit(mut self, limit: usize) -> Self {
         self.chain_worker_config.cross_chain_message_chunk_limit = limit;
@@ -639,10 +641,12 @@ where
     }
 
     /// Sets the cross-chain message chunk limit.
+    #[cfg(with_testing)]
     pub fn set_cross_chain_message_chunk_limit(&mut self, limit: usize) {
         self.chain_worker_config.cross_chain_message_chunk_limit = limit;
     }
 
+    #[cfg(with_testing)]
     #[instrument(level = "trace", skip(self, value))]
     pub fn with_allow_revert_confirm(mut self, value: bool) -> Self {
         self.chain_worker_config.allow_revert_confirm = value;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -627,7 +627,10 @@ where
     /// should be processed first.
     #[cfg(with_testing)]
     #[instrument(level = "trace", skip(self, origins))]
-    pub fn with_priority_bundle_origins(mut self, origins: std::collections::HashSet<ChainId>) -> Self {
+    pub fn with_priority_bundle_origins(
+        mut self,
+        origins: std::collections::HashSet<ChainId>,
+    ) -> Self {
         self.chain_worker_config.priority_bundle_origins = origins;
         self
     }

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -277,12 +277,6 @@ impl Committee {
         }
     }
 
-    pub fn keys_and_weights(&self) -> impl Iterator<Item = (ValidatorPublicKey, u64)> + '_ {
-        self.validators
-            .iter()
-            .map(|(name, validator)| (*name, validator.votes))
-    }
-
     pub fn account_keys_and_weights(&self) -> impl Iterator<Item = (AccountPublicKey, u64)> + '_ {
         self.validators
             .values()

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -2,53 +2,16 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
+use std::{borrow::Cow, collections::BTreeMap};
 
 use allocative::Allocative;
 use linera_base::{
-    crypto::{AccountPublicKey, CryptoError, ValidatorPublicKey},
+    crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::ArithmeticError,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::policy::ResourceControlPolicy;
-
-/// The identity of a validator.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct ValidatorName(pub ValidatorPublicKey);
-
-impl Serialize for ValidatorName {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&self.to_string())
-        } else {
-            serializer.serialize_newtype_struct("ValidatorName", &self.0)
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for ValidatorName {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = String::deserialize(deserializer)?;
-            let value = Self::from_str(&s).map_err(serde::de::Error::custom)?;
-            Ok(value)
-        } else {
-            #[derive(Deserialize)]
-            #[serde(rename = "ValidatorName")]
-            struct ValidatorNameDerived(ValidatorPublicKey);
-
-            let value = ValidatorNameDerived::deserialize(deserializer)?;
-            Ok(Self(value.0))
-        }
-    }
-}
 
 /// Public state of a validator.
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, Allocative)]
@@ -198,26 +161,6 @@ impl<'a> From<&'a Committee> for CommitteeMinimal<'a> {
             validators: Cow::Borrowed(validators),
             policy: Cow::Borrowed(policy),
         }
-    }
-}
-
-impl std::fmt::Display for ValidatorName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        self.0.fmt(f)
-    }
-}
-
-impl std::str::FromStr for ValidatorName {
-    type Err = CryptoError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ValidatorName(ValidatorPublicKey::from_str(s)?))
-    }
-}
-
-impl From<ValidatorPublicKey> for ValidatorName {
-    fn from(value: ValidatorPublicKey) -> Self {
-        Self(value)
     }
 }
 

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -283,12 +283,6 @@ impl Committee {
             .map(|validator| (validator.account_public_key, validator.votes))
     }
 
-    pub fn network_address(&self, author: &ValidatorPublicKey) -> Option<&str> {
-        self.validators
-            .get(author)
-            .map(|state| state.network_address.as_ref())
-    }
-
     pub fn quorum_threshold(&self) -> u64 {
         self.quorum_threshold
     }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -303,7 +303,6 @@ pub struct SystemResponse {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default, Debug, Serialize, Deserialize)]
 pub struct UserData(pub Option<[u8; 32]>);
 
-
 #[derive(Debug)]
 pub struct CreateApplicationResult {
     pub app_id: ApplicationId,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -7,7 +7,7 @@
 mod tests;
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 
@@ -303,33 +303,6 @@ pub struct SystemResponse {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default, Debug, Serialize, Deserialize)]
 pub struct UserData(pub Option<[u8; 32]>);
 
-impl UserData {
-    pub fn from_option_string(opt_str: Option<String>) -> Result<Self, usize> {
-        // Convert the Option<String> to Option<[u8; 32]>
-        let option_array = match opt_str {
-            Some(s) => {
-                // Convert the String to a Vec<u8>
-                let vec = s.into_bytes();
-                if vec.len() <= 32 {
-                    // Create an array from the Vec<u8>
-                    let mut array = [b' '; 32];
-
-                    // Copy bytes from the vector into the array
-                    let len = vec.len().min(32);
-                    array[..len].copy_from_slice(&vec[..len]);
-
-                    Some(array)
-                } else {
-                    return Err(vec.len());
-                }
-            }
-            None => None,
-        };
-
-        // Return the UserData with the converted Option<[u8; 32]>
-        Ok(UserData(option_array))
-    }
-}
 
 #[derive(Debug)]
 pub struct CreateApplicationResult {
@@ -1030,45 +1003,6 @@ where
             .await?;
 
         Ok(description)
-    }
-
-    /// Retrieves the recursive dependencies of applications and applies a topological sort.
-    pub async fn find_dependencies(
-        &mut self,
-        mut stack: Vec<ApplicationId>,
-        txn_tracker: &mut TransactionTracker,
-    ) -> Result<Vec<ApplicationId>, ExecutionError> {
-        // What we return at the end.
-        let mut result = Vec::new();
-        // The entries already inserted in `result`.
-        let mut sorted = HashSet::new();
-        // The entries for which dependencies have already been pushed once to the stack.
-        let mut seen = HashSet::new();
-
-        while let Some(id) = stack.pop() {
-            if sorted.contains(&id) {
-                continue;
-            }
-            if seen.contains(&id) {
-                // Second time we see this entry. It was last pushed just before its
-                // dependencies -- which are now fully sorted.
-                sorted.insert(id);
-                result.push(id);
-                continue;
-            }
-            // First time we see this entry:
-            // 1. Mark it so that its dependencies are no longer pushed to the stack.
-            seen.insert(id);
-            // 2. Schedule all the (yet unseen) dependencies, then this entry for a second visit.
-            stack.push(id);
-            let app = self.describe_application(id, txn_tracker).await?;
-            for child in app.required_application_ids.iter().rev() {
-                if !seen.contains(child) {
-                    stack.push(*child);
-                }
-            }
-        }
-        Ok(result)
     }
 
     /// Records a blob that is used in this block. If this is the first use on this chain, creates

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -352,9 +352,6 @@ impl From<::wasmer::InstantiationError> for WasmExecutionError {
 pub mod test {
     use std::{path::Path, sync::LazyLock};
 
-    #[cfg(with_fs)]
-    use super::{WasmContractModule, WasmRuntime, WasmServiceModule};
-
     fn build_applications_in_directory(dir: &str) -> Result<(), std::io::Error> {
         let output = std::process::Command::new("cargo")
             .current_dir(dir)
@@ -394,15 +391,4 @@ pub mod test {
         Err(std::io::Error::last_os_error())
     }
 
-    #[cfg(with_fs)]
-    pub async fn build_example_application(
-        name: &str,
-        wasm_runtime: impl Into<Option<WasmRuntime>>,
-    ) -> Result<(WasmContractModule, WasmServiceModule), anyhow::Error> {
-        let (contract_path, service_path) = get_example_bytecode_paths(name)?;
-        let wasm_runtime = wasm_runtime.into().unwrap_or_default();
-        let contract = WasmContractModule::from_file(&contract_path, wasm_runtime).await?;
-        let service = WasmServiceModule::from_file(&service_path, wasm_runtime).await?;
-        Ok((contract, service))
-    }
 }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -390,5 +390,4 @@ pub mod test {
         }
         Err(std::io::Error::last_os_error())
     }
-
 }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -632,11 +632,6 @@ impl TestClock {
         self.lock().sleep_callback = Some(Box::new(callback));
     }
 
-    /// Clears the sleep callback.
-    pub fn clear_sleep_callback(&self) {
-        self.lock().sleep_callback = None;
-    }
-
     fn lock(&self) -> std::sync::MutexGuard<'_, TestClockInner> {
         self.0.lock().expect("poisoned TestClock mutex")
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -625,6 +625,7 @@ impl TestClock {
     ///
     /// The callback receives the target timestamp and should return `true` if the clock
     /// should auto-advance to that time, or `false` if the sleep should block normally.
+    #[cfg(with_testing)]
     pub fn set_sleep_callback<F>(&self, callback: F)
     where
         F: Fn(Timestamp) -> bool + Send + Sync + 'static,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -420,30 +420,6 @@ impl ResultReadCertificates {
     }
 }
 
-/// The result of processing the obtained read confirmed blocks.
-pub enum ResultReadConfirmedBlocks {
-    Blocks(Vec<ConfirmedBlock>),
-    InvalidHashes(Vec<CryptoHash>),
-}
-
-impl ResultReadConfirmedBlocks {
-    /// Creating the processed read confirmed blocks.
-    pub fn new(blocks: Vec<Option<ConfirmedBlock>>, hashes: Vec<CryptoHash>) -> Self {
-        let (blocks, invalid_hashes) = blocks
-            .into_iter()
-            .zip(hashes)
-            .partition_map::<Vec<_>, Vec<_>, _, _, _>(|(block, hash)| match block {
-                Some(block) => itertools::Either::Left(block),
-                None => itertools::Either::Right(hash),
-            });
-        if invalid_hashes.is_empty() {
-            Self::Blocks(blocks)
-        } else {
-            Self::InvalidHashes(invalid_hashes)
-        }
-    }
-}
-
 /// An implementation of `ExecutionRuntimeContext` suitable for the core protocol.
 #[derive(Clone)]
 pub struct ChainRuntimeContext<S> {


### PR DESCRIPTION
## Motivation

Many functions and types which are internal, that is which are not part of `linera-sdk` or `linera-views` are not used and can be removed.

## Proposal

Do a systematic search for such functions. Also mark the functions that are used only in tests as `#[cfg(with_testing)]`.

## Test Plan

CI

## Release Plan

The same analysis can likely be done on `testnet_conway`.

## Links

None