### PR TITLE
Don't print WARN for a single validator's errors. (#6007)

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -333,7 +333,7 @@ impl ValidatorNode for GrpcClient {
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_chain_info_query, query)?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError> {
         let retry_delay = self.retry_delay;
         let max_retries = self.max_retries;
@@ -468,29 +468,29 @@ impl ValidatorNode for GrpcClient {
         Ok(Box::pin(notification_stream))
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
         let req = ();
         Ok(client_delegate!(self, get_version_info, req)?.into())
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn get_network_description(&self) -> Result<NetworkDescription, NodeError> {
         let req = ();
         Ok(client_delegate!(self, get_network_description, req)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
         Ok(client_delegate!(self, upload_blob, content)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         Ok(client_delegate!(self, download_blob, blob_id)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn download_pending_blob(
         &self,
         chain_id: ChainId,
@@ -500,7 +500,7 @@ impl ValidatorNode for GrpcClient {
         client_delegate!(self, download_pending_blob, req)?.try_into()
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
@@ -510,7 +510,7 @@ impl ValidatorNode for GrpcClient {
         GrpcClient::try_into_chain_info(client_delegate!(self, handle_pending_blob, req)?)
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn download_certificate(
         &self,
         hash: CryptoHash,
@@ -523,7 +523,7 @@ impl ValidatorNode for GrpcClient {
         .map_err(|_| NodeError::UnexpectedCertificateValue)
     }
 
-    #[instrument(target = "grpc_client", skip_all, err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn download_certificates(
         &self,
         hashes: Vec<CryptoHash>,
@@ -559,7 +559,7 @@ impl ValidatorNode for GrpcClient {
         Ok(certs_collected)
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn download_certificates_by_heights(
         &self,
         chain_id: ChainId,
@@ -607,12 +607,12 @@ impl ValidatorNode for GrpcClient {
         Ok(certs_collected)
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
         Ok(client_delegate!(self, blob_last_used_by, blob_id)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn missing_blob_ids(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
         Ok(client_delegate!(self, missing_blob_ids, blob_ids)?.try_into()?)
     }
@@ -625,7 +625,7 @@ impl ValidatorNode for GrpcClient {
         Ok(client_delegate!(self, blob_last_used_by_certificate, blob_id)?.try_into()?)
     }
 
-    #[instrument(target = "grpc_client", skip(self), err(level = Level::WARN), fields(address = self.address))]
+    #[instrument(target = "grpc_client", skip(self), err(level = Level::DEBUG), fields(address = self.address))]
     async fn previous_event_blocks(
         &self,
         chain_id: ChainId,


### PR DESCRIPTION
Backport of #6007.

## Motivation

A single validator returning an error shouldn't cause a WARN log in a client, in a BFT system.

## Proposal

Reduce log levels in the gRPC client to DEBUG.

## Test Plan

CI

## Release Plan

- Release SDK.

## Links

- PR to `main`: #6007
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
