### PR TITLE
Update the functionality of `linera project`.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1186,6 +1186,7 @@ Create a new Linera project
 ###### **Options:**
 
 * `--linera-root <LINERA_ROOT>` — Use the given clone of the Linera repository instead of remote crates
+* `--dir <DIR>` — Use the given directory for the project instead of creating a new one. The directory will be created if it doesn't exist
 
 
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -1366,6 +1366,11 @@ pub enum ProjectCommand {
         /// Use the given clone of the Linera repository instead of remote crates.
         #[arg(long)]
         linera_root: Option<PathBuf>,
+
+        /// Use the given directory for the project instead of creating a new one.
+        /// The directory will be created if it doesn't exist.
+        #[arg(long)]
+        dir: Option<PathBuf>,
     },
 
     /// Test a Linera project.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2289,11 +2289,7 @@ async fn run(options: &Options) -> Result<i32, Error> {
                 dir,
             } => {
                 let start_time = Instant::now();
-                Project::create_new(
-                    name,
-                    linera_root.as_ref().map(AsRef::as_ref),
-                    dir.clone(),
-                )?;
+                Project::create_new(name, linera_root.as_ref().map(AsRef::as_ref), dir.clone())?;
                 info!(
                     "New project created in {} ms",
                     start_time.elapsed().as_millis()

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1639,7 +1639,7 @@ impl Runnable for Job {
                     let argument = read_json(json_argument, json_argument_path)?;
                     let project_path = path.unwrap_or_else(|| env::current_dir().unwrap());
 
-                    let project = project::Project::from_existing_project(project_path)?;
+                    let project = project::Project::from_existing_project(&project_path)?;
                     let (contract_path, service_path) = project.build(name)?;
 
                     let module_id = context
@@ -2299,7 +2299,7 @@ async fn run(options: &Options) -> Result<i32, Error> {
             ProjectCommand::Test { path } => {
                 let start_time = Instant::now();
                 let path = path.clone().unwrap_or_else(|| env::current_dir().unwrap());
-                let project = Project::from_existing_project(path)?;
+                let project = Project::from_existing_project(&path)?;
                 project.test()?;
                 info!(
                     "Test project created in {} ms",

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2283,9 +2283,17 @@ async fn run(options: &Options) -> Result<i32, Error> {
         }
 
         ClientCommand::Project(project_command) => match project_command {
-            ProjectCommand::New { name, linera_root } => {
+            ProjectCommand::New {
+                name,
+                linera_root,
+                dir,
+            } => {
                 let start_time = Instant::now();
-                Project::create_new(name, linera_root.as_ref().map(AsRef::as_ref))?;
+                Project::create_new(
+                    name,
+                    linera_root.as_ref().map(AsRef::as_ref),
+                    dir.clone(),
+                )?;
                 info!(
                     "New project created in {} ms",
                     start_time.elapsed().as_millis()
@@ -2305,6 +2313,15 @@ async fn run(options: &Options) -> Result<i32, Error> {
             }
             ProjectCommand::PublishAndCreate { .. } => {
                 let start_time = Instant::now();
+                let wallet_path = options.wallet_path()?;
+                ensure!(
+                    wallet_path.exists(),
+                    "No wallet found at {}. \
+                     Please initialize a wallet first, e.g. \
+                     `linera wallet init --faucet <FAUCET_URL>` or \
+                     `linera wallet init --genesis <PATH>`.",
+                    wallet_path.display()
+                );
                 options.run_with_storage(Job(options.clone())).await??;
                 info!(
                     "Project published and created in {} ms",

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -19,17 +19,27 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn create_new(name: &str, linera_root: Option<&Path>) -> Result<Self> {
+    pub fn create_new(
+        name: &str,
+        linera_root: Option<&Path>,
+        dir: Option<PathBuf>,
+    ) -> Result<Self> {
         ensure!(
             !name.contains(std::path::is_separator),
             "Project name {name} should not contain path-separators",
         );
-        let root = PathBuf::from(name);
-        ensure!(
-            !root.exists(),
-            "Directory {} already exists",
-            root.display(),
-        );
+        let root = match dir {
+            Some(dir) => dir,
+            None => {
+                let root = PathBuf::from(name);
+                ensure!(
+                    !root.exists(),
+                    "Directory {} already exists",
+                    root.display(),
+                );
+                root
+            }
+        };
         ensure!(
             root.extension().is_none(),
             "Project name {name} should not have a file extension",
@@ -71,9 +81,17 @@ impl Project {
     }
 
     pub fn from_existing_project(root: PathBuf) -> Result<Self> {
+        let root = root.canonicalize().with_context(|| {
+            format!(
+                "Could not find project at {}. \
+                 Make sure the specified directory exists.",
+                root.display()
+            )
+        })?;
         ensure!(
-            root.exists(),
-            "could not find project at {}",
+            root.join("Cargo.toml").exists(),
+            "No Cargo.toml found at {}. \
+             The path must point to a Rust project directory.",
             root.display()
         );
         Ok(Self { root })
@@ -115,13 +133,13 @@ impl Project {
 
     fn create_source_directory(project_root: &Path) -> Result<PathBuf> {
         let source_directory = project_root.join("src");
-        fs_err::create_dir(&source_directory)?;
+        fs_err::create_dir_all(&source_directory)?;
         Ok(source_directory)
     }
 
     fn create_test_directory(project_root: &Path) -> Result<PathBuf> {
         let test_directory = project_root.join("tests");
-        fs_err::create_dir(&test_directory)?;
+        fs_err::create_dir_all(&test_directory)?;
         Ok(test_directory)
     }
 

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -80,7 +80,7 @@ impl Project {
         Ok(Self { root })
     }
 
-    pub fn from_existing_project(root: PathBuf) -> Result<Self> {
+    pub fn from_existing_project(root: &Path) -> Result<Self> {
         let root = root.canonicalize().with_context(|| {
             format!(
                 "Could not find project at {}. \

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -352,7 +352,7 @@ impl RocksDbStoreInternal {
         let max_stream_queries = config.max_stream_queries;
         let spawn_mode = config.spawn_mode;
         if !std::path::Path::exists(&path_buf) {
-            std::fs::create_dir(path_buf.clone())?;
+            std::fs::create_dir_all(path_buf.clone())?;
         }
         let sys = System::new_with_specifics(
             RefreshKind::nothing().with_memory(MemoryRefreshKind::nothing().with_ram()),


### PR DESCRIPTION
## Motivation

The function `linera project` is one that many first time programmer will use to create an initial project. It is valuable to have it working very nicely.

Fixes https://github.com/linera-io/linera-protocol/issues/4676
Fixes https://github.com/linera-io/linera-protocol/issues/2989

## Proposal

The following functionality are now working.

Create a project in an existing directory:
```bash
linera project new my-app
```

Use an existing directory instead:
```bash
mkdir -p /tmp/my-existing-dir
linera project new my-app --dir /tmp/my-existing-dir
```

Run publish-and-create from inside a subdirectory (Previously this would fail with "No such file or directory"):
```bash
cd examples/counter
linera project publish-and-create . --json-argument 0
```

Or with an explicit relative path:
```bash
cd examples
linera project publish-and-create counter --json-argument 0
```






## Test Plan

CI

## Release Plan

It can be backported to `testnet_conway`.

## Links

None