### PR TITLE
[testnet] Introduce the use of LazyRegisterView in the system.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -479,8 +479,8 @@ where
     }
 
     /// Invariant for the states of active chains.
-    pub fn is_active(&self) -> bool {
-        self.execution_state.system.is_active()
+    pub async fn is_active(&self) -> Result<bool, ChainError> {
+        Ok(self.execution_state.system.is_active().await?)
     }
 
     /// Initializes the chain if it is not active yet.
@@ -502,7 +502,7 @@ where
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
         // Last, reset the consensus state based on the current ownership.
         self.manager.reset(
-            self.execution_state.system.ownership.get().clone(),
+            self.execution_state.system.ownership.get().await?.clone(),
             BlockHeight(0),
             local_time,
             maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights()),
@@ -614,8 +614,8 @@ where
             .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
     }
 
-    pub fn ownership(&self) -> &ChainOwnership {
-        self.execution_state.system.ownership.get()
+    pub async fn ownership(&self) -> Result<&ChainOwnership, ChainError> {
+        Ok(self.execution_state.system.ownership.get().await?)
     }
 
     /// Removes the incoming message bundles in the block from the inboxes.
@@ -1035,7 +1035,11 @@ where
                     .contains(FLAG_MANDATORY_APPS_NEED_ACCEPTED_MESSAGE)
             });
         Self::check_app_permissions(
-            self.execution_state.system.application_permissions.get(),
+            self.execution_state
+                .system
+                .application_permissions
+                .get()
+                .await?,
             &block,
             mandatory_apps_need_accepted_message,
         )?;
@@ -1131,7 +1135,8 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         // Last, reset the consensus state based on the current ownership.
-        self.reset_chain_manager(block.header.height.try_add_one()?, local_time)?;
+        self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
+            .await?;
 
         // Advance to next block height.
         let tip = self.tip_state.get_mut();
@@ -1166,12 +1171,13 @@ where
     }
 
     /// Returns whether this is a child chain.
-    pub fn is_child(&self) -> bool {
-        let Some(description) = self.execution_state.system.description.get() else {
+    pub async fn is_child(&self) -> Result<bool, ChainError> {
+        let description = self.execution_state.system.description.get().await?;
+        let Some(description) = description else {
             // Root chains are always initialized, so this must be a child chain.
-            return true;
+            return Ok(true);
         };
-        description.is_child()
+        Ok(description.is_child())
     }
 
     /// Verifies that the block is valid according to the chain's application permission settings.
@@ -1260,13 +1266,13 @@ where
     }
 
     /// Resets the chain manager for the next block height.
-    fn reset_chain_manager(
+    async fn reset_chain_manager(
         &mut self,
         next_height: BlockHeight,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
         let maybe_committee = self.execution_state.system.current_committee().into_iter();
-        let ownership = self.execution_state.system.ownership.get().clone();
+        let ownership = self.execution_state.system.ownership.get().await?.clone();
         let fallback_owners =
             maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights());
         self.pending_validated_blobs.clear();

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1975,8 +1975,7 @@ where
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, WorkerError> {
         self.initialize_and_save_if_needed().await?;
-        let chain = &self.chain;
-        let mut info = ChainInfo::from_chain_view(chain).await?;
+        let mut info = ChainInfo::from_chain_view(&self.chain).await?;
         if query.request_committees {
             info.requested_committees =
                 Some(self.chain.execution_state.system.committees.get().clone());

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -734,7 +734,11 @@ where
         )?;
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
-        Ok((self.chain_info_response().await?, actions, BlockOutcome::Processed))
+        Ok((
+            self.chain_info_response().await?,
+            actions,
+            BlockOutcome::Processed,
+        ))
     }
 
     /// Initializes `next_expected_events` from `stream_event_counts` (which reflects
@@ -790,7 +794,11 @@ where
             let actions = self.create_network_actions(None).await?;
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
                 .await;
-            return Ok((self.chain_info_response().await?, actions, BlockOutcome::Skipped));
+            return Ok((
+                self.chain_info_response().await?,
+                actions,
+                BlockOutcome::Skipped,
+            ));
         }
 
         // We haven't processed the block - verify the certificate first
@@ -1024,7 +1032,11 @@ where
         self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
             .await;
 
-        Ok((self.chain_info_response().await?, actions, BlockOutcome::Processed))
+        Ok((
+            self.chain_info_response().await?,
+            actions,
+            BlockOutcome::Processed,
+        ))
     }
 
     /// Schedules a notification for when cross-chain messages are delivered up to the given

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -594,7 +594,7 @@ where
             .get()
             .already_validated_block(certificate.inner().height())?
         {
-            return Ok((self.chain_info_response(), NetworkActions::default()));
+            return Ok((self.chain_info_response().await?, NetworkActions::default()));
         }
         ensure!(
             certificate.inner().epoch() == chain_epoch,
@@ -610,7 +610,7 @@ where
             .handle_timeout_certificate(certificate, self.storage.clock().current_time());
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
-        Ok((self.chain_info_response(), actions))
+        Ok((self.chain_info_response().await?, actions))
     }
 
     /// Tries to load all blobs published in this proposal.
@@ -643,7 +643,7 @@ where
         let missing_blob_ids = missing_blob_ids(&maybe_blobs);
         if !missing_blob_ids.is_empty() {
             let chain = &mut self.chain;
-            if chain.ownership().open_multi_leader_rounds {
+            if chain.ownership().await?.open_multi_leader_rounds {
                 // TODO(#3203): Allow multiple pending proposals on permissionless chains.
                 chain.pending_proposed_blobs.clear();
             }
@@ -701,7 +701,7 @@ where
         if already_committed_block || should_skip_validated_block()? {
             // If we just processed the same pending block, return the chain info unchanged.
             return Ok((
-                self.chain_info_response(),
+                self.chain_info_response().await?,
                 NetworkActions::default(),
                 BlockOutcome::Skipped,
             ));
@@ -734,7 +734,7 @@ where
         )?;
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
-        Ok((self.chain_info_response(), actions, BlockOutcome::Processed))
+        Ok((self.chain_info_response().await?, actions, BlockOutcome::Processed))
     }
 
     /// Initializes `next_expected_events` from `stream_event_counts` (which reflects
@@ -790,7 +790,7 @@ where
             let actions = self.create_network_actions(None).await?;
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
                 .await;
-            return Ok((self.chain_info_response(), actions, BlockOutcome::Skipped));
+            return Ok((self.chain_info_response().await?, actions, BlockOutcome::Skipped));
         }
 
         // We haven't processed the block - verify the certificate first
@@ -885,7 +885,7 @@ where
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
                 .await;
             return Ok((
-                self.chain_info_response(),
+                self.chain_info_response().await?,
                 actions,
                 BlockOutcome::Preprocessed,
             ));
@@ -1024,7 +1024,7 @@ where
         self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
             .await;
 
-        Ok((self.chain_info_response(), actions, BlockOutcome::Processed))
+        Ok((self.chain_info_response().await?, actions, BlockOutcome::Processed))
     }
 
     /// Schedules a notification for when cross-chain messages are delivered up to the given
@@ -1126,7 +1126,7 @@ where
         }
         inbox.observe_size_metric();
         drop(inbox);
-        if !self.config.allow_inactive_chains && !self.chain.is_active() {
+        if !self.config.allow_inactive_chains && !self.chain.is_active().await? {
             // Refuse to create a chain state if the chain is still inactive by
             // now. Accordingly, do not send a confirmation, so that the
             // cross-chain update is retried later.
@@ -1639,7 +1639,7 @@ where
         }
         ensure!(was_expected, WorkerError::UnexpectedBlob);
         self.save().await?;
-        Ok(self.chain_info_response())
+        self.chain_info_response().await
     }
 
     /// Returns a stored [`Certificate`] for the chain's block at the requested [`BlockHeight`].
@@ -1776,7 +1776,8 @@ where
             Box::pin(self.execute_block(block, local_time, round, published_blobs, policy)).await?;
 
         // No need to sign: only used internally.
-        let mut response = ChainInfoResponse::new(&self.chain, None);
+        let info = ChainInfo::from_chain_view(&self.chain).await?;
+        let mut response = ChainInfoResponse::new(info, None);
         if let Some(signer) = signer {
             response.info.requested_owner_balance = self
                 .chain
@@ -1866,7 +1867,7 @@ where
         }
         if chain.manager.check_proposed_block(&proposal)? == manager::Outcome::Skip {
             // We already voted for this block.
-            return Ok((self.chain_info_response(), NetworkActions::default()));
+            return Ok((self.chain_info_response().await?, NetworkActions::default()));
         }
         let local_time = self.storage.clock().current_time();
 
@@ -1950,7 +1951,7 @@ where
         }
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
-        Ok((self.chain_info_response(), actions))
+        Ok((self.chain_info_response().await?, actions))
     }
 
     /// Prepares a [`ChainInfoResponse`] for a [`ChainInfoQuery`].
@@ -1962,7 +1963,8 @@ where
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, WorkerError> {
         self.initialize_and_save_if_needed().await?;
-        let mut info = ChainInfo::from(&self.chain);
+        let chain = &self.chain;
+        let mut info = ChainInfo::from_chain_view(chain).await?;
         if query.request_committees {
             info.requested_committees =
                 Some(self.chain.execution_state.system.committees.get().clone());
@@ -2117,8 +2119,9 @@ where
         Ok(())
     }
 
-    pub(crate) fn chain_info_response(&self) -> ChainInfoResponse {
-        ChainInfoResponse::new(&self.chain, self.config.key_pair())
+    pub(crate) async fn chain_info_response(&self) -> Result<ChainInfoResponse, WorkerError> {
+        let info = ChainInfo::from_chain_view(&self.chain).await?;
+        Ok(ChainInfoResponse::new(info, self.config.key_pair()))
     }
 
     /// Stores the chain state in persistent storage.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2232,6 +2232,7 @@ impl<Env: Environment> ChainClient<Env> {
             .system
             .ownership
             .get()
+            .await?
             .clone())
     }
 
@@ -2264,6 +2265,7 @@ impl<Env: Environment> ChainClient<Env> {
             .system
             .application_permissions
             .get()
+            .await?
             .clone())
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -21,7 +21,7 @@ use linera_chain::{
 };
 use linera_execution::{committee::Committee, ExecutionRuntimeContext};
 use linera_storage::ChainRuntimeContext;
-use linera_views::context::Context;
+use linera_views::{context::Context, ViewError};
 use serde::{Deserialize, Serialize};
 
 use crate::client::chain_client;
@@ -294,18 +294,18 @@ impl CrossChainRequest {
     }
 }
 
-impl<C, S> From<&ChainStateView<C>> for ChainInfo
-where
-    C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
-    ChainRuntimeContext<S>: ExecutionRuntimeContext,
-{
-    fn from(view: &ChainStateView<C>) -> Self {
+impl ChainInfo {
+    pub async fn from_chain_view<C, S>(view: &ChainStateView<C>) -> Result<Self, ViewError>
+    where
+        C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
+        ChainRuntimeContext<S>: ExecutionRuntimeContext,
+    {
         let system_state = &view.execution_state.system;
         let tip_state = view.tip_state.get();
-        ChainInfo {
+        Ok(ChainInfo {
             chain_id: view.chain_id(),
             epoch: *system_state.epoch.get(),
-            description: system_state.description.get().clone(),
+            description: system_state.description.get().await?.clone(),
             manager: Box::new(ChainManagerInfo::from(&view.manager)),
             chain_balance: *system_state.balance.get(),
             block_hash: tip_state.block_hash,
@@ -318,13 +318,13 @@ where
             requested_sent_certificate_hashes: Vec::new(),
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
-        }
+        })
     }
 }
 
 impl ChainInfoResponse {
-    pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&ValidatorSecretKey>) -> Self {
-        let info = Box::new(info.into());
+    pub fn new(info: ChainInfo, key_pair: Option<&ValidatorSecretKey>) -> Self {
+        let info = Box::new(info);
         let signature = key_pair.map(|kp| ValidatorSignature::new(&*info, kp));
         Self { info, signature }
     }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -611,7 +611,7 @@ where
                 if matches!(error, linera_base::crypto::CryptoError::InvalidSignature {..})
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -655,7 +655,7 @@ where
         ) if matches!(**execution_error, ExecutionError::IncorrectTransferAmount))
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -951,7 +951,7 @@ where
         Err(WorkerError::InvalidOwner)
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1008,7 +1008,7 @@ where
             })
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
 
@@ -1017,7 +1017,7 @@ where
         .handle_block_proposal(block_proposal0.clone())
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     let block = chain.manager.validated_vote().unwrap().value().block();
     // Multi-leader round - it's not confirmed yet.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
@@ -1029,7 +1029,7 @@ where
         .handle_validated_certificate(block_certificate0)
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     let block = chain.manager.confirmed_vote().unwrap().value().block();
     // Should be confirmed after handling the certificate.
     assert!(block.matches_proposed_block(&block_proposal0.content.block));
@@ -1046,7 +1046,7 @@ where
         .await?;
 
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     let block = chain.manager.validated_vote().unwrap().value().block();
     assert!(block.matches_proposed_block(&block_proposal1.content.block));
     assert!(chain.manager.confirmed_vote().is_none());
@@ -1139,7 +1139,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await?);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(1));
     }
 
@@ -1164,7 +1164,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await?);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(2));
     }
 
@@ -1176,7 +1176,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await?);
         assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(3));
     }
 
@@ -1584,7 +1584,7 @@ where
         ) if matches!(**execution_error, ExecutionError::InsufficientBalance { .. }))
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none());
     assert!(chain.manager.validated_vote().is_none());
     Ok(())
@@ -1621,7 +1621,7 @@ where
         env.worker().handle_block_proposal(block_proposal).await?;
     chain_info_response.check(env.worker().public_key())?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert!(chain.manager.confirmed_vote().is_none()); // It was a multi-leader
                                                        // round.
     let validated_certificate =
@@ -1634,7 +1634,7 @@ where
         .await?;
     chain_info_response.check(env.worker().public_key())?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert!(chain.manager.validated_vote().is_none()); // Should be confirmed by now.
     let pending_vote = chain.manager.confirmed_vote().unwrap().lite();
     assert_eq!(
@@ -1907,7 +1907,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert_eq!(Amount::ZERO, *chain.execution_state.system.balance.get());
     assert_eq!(
         BlockHeight::from(1),
@@ -1948,7 +1948,7 @@ where
     assert_eq!(chain.confirmed_log.count(), 1);
     assert_eq!(Some(certificate.hash()), chain.tip_state.get().block_hash);
     let chain = env.worker().chain_state_view(chain_2).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     Ok(())
 }
 
@@ -1989,7 +1989,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let new_sender_chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(new_sender_chain.is_active());
+    assert!(new_sender_chain.is_active().await?);
     assert_eq!(
         Amount::ZERO,
         *new_sender_chain.execution_state.system.balance.get()
@@ -2004,7 +2004,7 @@ where
         new_sender_chain.tip_state.get().block_hash
     );
     let new_recipient_chain = env.worker().chain_state_view(chain_2).await?;
-    assert!(new_recipient_chain.is_active());
+    assert!(new_recipient_chain.is_active().await?);
     assert_eq!(
         Amount::MAX,
         *new_recipient_chain.execution_state.system.balance.get()
@@ -2045,7 +2045,7 @@ where
         .fully_handle_certificate_with_notifications(certificate.clone(), &())
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
 
     // With the new optimization, transfers to the same chain should not create messages.
@@ -2098,7 +2098,7 @@ where
 
     // Check the sender chain
     let chain_1_state = env.worker().chain_state_view(chain_1).await?;
-    assert!(chain_1_state.is_active());
+    assert!(chain_1_state.is_active().await?);
     assert_eq!(
         Amount::ZERO,
         *chain_1_state.execution_state.system.balance.get()
@@ -2178,7 +2178,7 @@ where
         .handle_cross_chain_request(update_recipient_direct(chain_2, &certificate.clone()))
         .await?;
     let chain = env.worker().chain_state_view(chain_2).await?;
-    assert!(chain.is_active());
+    assert!(chain.is_active().await?);
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
     assert_eq!(BlockHeight::ZERO, chain.tip_state.get().next_block_height);
     let inbox = chain
@@ -2445,7 +2445,7 @@ where
 
     {
         let recipient_chain = env.worker().chain_state_view(chain_2).await?;
-        assert!(recipient_chain.is_active());
+        assert!(recipient_chain.is_active().await?);
         assert_eq!(
             *recipient_chain.execution_state.system.balance.get(),
             Amount::from_tokens(4)
@@ -2673,7 +2673,7 @@ where
 
     {
         let chain = env.worker().chain_state_view(chain_2).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await?);
         assert_no_removed_bundles(&chain).await;
     }
 
@@ -2714,7 +2714,7 @@ where
 
     {
         let chain = env.worker.chain_state_view(chain_1).await?;
-        assert!(chain.is_active());
+        assert!(chain.is_active().await?);
         assert_no_removed_bundles(&chain).await;
     }
     Ok(())
@@ -2773,7 +2773,7 @@ where
         .await?;
     {
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await?);
         assert_no_removed_bundles(&admin_chain).await;
         assert_eq!(
             BlockHeight::from(1),
@@ -2846,7 +2846,7 @@ where
     {
         // The child is active and has not migrated yet.
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active());
+        assert!(user_chain.is_active().await?);
         assert_eq!(
             BlockHeight::ZERO,
             user_chain.tip_state.get().next_block_height
@@ -2928,7 +2928,7 @@ where
         .await?;
     {
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active());
+        assert!(user_chain.is_active().await?);
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -3034,7 +3034,7 @@ where
 
     // The transfer was started..
     let user_chain = env.worker().chain_state_view(user_id).await?;
-    assert!(user_chain.is_active());
+    assert!(user_chain.is_active().await?);
     assert_eq!(
         BlockHeight::from(1),
         user_chain.tip_state.get().next_block_height
@@ -3047,7 +3047,7 @@ where
 
     // .. and the message has gone through.
     let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-    assert!(admin_chain.is_active());
+    assert!(admin_chain.is_active().await?);
     assert_eq!(admin_chain.inboxes.indices().await?.len(), 1);
     matches!(
         &admin_chain
@@ -3168,7 +3168,7 @@ where
     {
         // The transfer was started..
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active());
+        assert!(user_chain.is_active().await?);
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -3181,7 +3181,7 @@ where
 
         // .. but the message hasn't gone through.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await?);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
 
@@ -3230,7 +3230,7 @@ where
     {
         // The admin chain has an anticipated message.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await?);
         assert!(admin_chain
             .inboxes
             .try_load_entry(&user_id)
@@ -3251,7 +3251,7 @@ where
     {
         // The admin chain has no more anticipated messages.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active());
+        assert!(admin_chain.is_active().await?);
         assert_no_removed_bundles(&admin_chain).await;
     }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -239,12 +239,18 @@ where
             }
 
             ChainOwnership { callback } => {
-                let ownership = self.state.system.ownership.get().clone();
+                let ownership = self.state.system.ownership.get().await?.clone();
                 callback.respond(ownership);
             }
 
             ApplicationPermissions { callback } => {
-                let permissions = self.state.system.application_permissions.get().clone();
+                let permissions = self
+                    .state
+                    .system
+                    .application_permissions
+                    .get()
+                    .await?
+                    .clone();
                 callback.respond(permissions);
             }
 
@@ -365,7 +371,7 @@ where
                 application_id,
                 callback,
             } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 if !app_permissions.can_close_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
@@ -379,7 +385,7 @@ where
                 ownership,
                 callback,
             } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 if !app_permissions.can_close_chain(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
@@ -393,7 +399,7 @@ where
                 application_permissions,
                 callback,
             } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 if !app_permissions.can_change_application_permissions(&application_id) {
                     callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
@@ -615,7 +621,7 @@ where
             }
 
             GetApplicationPermissions { callback } => {
-                let app_permissions = self.state.system.application_permissions.get();
+                let app_permissions = self.state.system.application_permissions.get().await?;
                 callback.respond(app_permissions.clone());
             }
 

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -66,8 +66,8 @@ impl<C: Send + Sync + Context> ExecutionStateView<C> {
 #[async_graphql::Object(cache_control(no_cache))]
 impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     #[graphql(derived(name = "description"))]
-    async fn _description(&self) -> &Option<ChainDescription> {
-        self.description.get()
+    async fn _description(&self) -> Result<&Option<ChainDescription>, async_graphql::Error> {
+        Ok(self.description.get().await?)
     }
 
     #[graphql(derived(name = "epoch"))]
@@ -86,8 +86,8 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     }
 
     #[graphql(derived(name = "ownership"))]
-    async fn _ownership(&self) -> &ChainOwnership {
-        self.ownership.get()
+    async fn _ownership(&self) -> Result<&ChainOwnership, async_graphql::Error> {
+        Ok(self.ownership.get().await?)
     }
 
     #[graphql(derived(name = "balance"))]

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -25,10 +25,12 @@ use linera_base::{
 };
 use linera_views::{
     context::Context,
+    lazy_register_view::HashedLazyRegisterView,
     map_view::HashedMapView,
     register_view::HashedRegisterView,
     set_view::HashedSetView,
     views::{ClonableView, HashableView, ReplaceContext, View},
+    ViewError,
 };
 use serde::{Deserialize, Serialize};
 
@@ -67,7 +69,7 @@ mod metrics {
 #[allocative(bound = "C")]
 pub struct SystemExecutionStateView<C> {
     /// How the chain was created. May be unknown for inactive chains.
-    pub description: HashedRegisterView<C, Option<ChainDescription>>,
+    pub description: HashedLazyRegisterView<C, Option<ChainDescription>>,
     /// The number identifying the current configuration.
     pub epoch: HashedRegisterView<C, Epoch>,
     /// The admin of the chain.
@@ -78,7 +80,7 @@ pub struct SystemExecutionStateView<C> {
     // (e.g. the `OpenChain` operation).
     pub committees: HashedRegisterView<C, BTreeMap<Epoch, Committee>>,
     /// Ownership of the chain.
-    pub ownership: HashedRegisterView<C, ChainOwnership>,
+    pub ownership: HashedLazyRegisterView<C, ChainOwnership>,
     /// Balance of the chain. (Available to any user able to create blocks in the chain.)
     pub balance: HashedRegisterView<C, Amount>,
     /// Balances attributed to a given owner.
@@ -88,7 +90,7 @@ pub struct SystemExecutionStateView<C> {
     /// Whether this chain has been closed.
     pub closed: HashedRegisterView<C, bool>,
     /// Permissions for applications on this chain.
-    pub application_permissions: HashedRegisterView<C, ApplicationPermissions>,
+    pub application_permissions: HashedLazyRegisterView<C, ApplicationPermissions>,
     /// Blobs that have been used or published on this chain.
     pub used_blobs: HashedSetView<C, BlobId>,
     /// The event stream subscriptions of applications on this chain.
@@ -320,11 +322,11 @@ where
     C::Extra: ExecutionRuntimeContext,
 {
     /// Invariant for the states of active chains.
-    pub fn is_active(&self) -> bool {
-        self.description.get().is_some()
-            && self.ownership.get().is_active()
+    pub async fn is_active(&self) -> Result<bool, ViewError> {
+        Ok(self.description.get().await?.is_some()
+            && self.ownership.get().await?.is_active()
             && self.current_committee().is_some()
-            && self.admin_chain_id.get().is_some()
+            && self.admin_chain_id.get().is_some())
     }
 
     /// Returns the current committee, if any.
@@ -644,6 +646,7 @@ where
                     && self
                         .ownership
                         .get()
+                        .await?
                         .verify_owner(&authenticated_signer.unwrap()),
                 ExecutionError::UnauthenticatedTransferOwner
             );
@@ -765,7 +768,7 @@ where
     /// Initializes the system application state on a newly opened chain.
     /// Returns `Ok(true)` if the chain was already initialized, `Ok(false)` if it wasn't.
     pub async fn initialize_chain(&mut self, chain_id: ChainId) -> Result<bool, ExecutionError> {
-        if self.description.get().is_some() {
+        if self.description.get().await?.is_some() {
             // already initialized
             return Ok(true);
         }
@@ -836,20 +839,11 @@ where
             block_height,
             chain_index,
         };
+        let committees = self.committees.get();
         let init_chain_config = config.init_chain_config(
             *self.epoch.get(),
-            self.committees
-                .get()
-                .keys()
-                .min()
-                .copied()
-                .unwrap_or(Epoch::ZERO),
-            self.committees
-                .get()
-                .keys()
-                .max()
-                .copied()
-                .unwrap_or(Epoch::ZERO),
+            committees.keys().min().copied().unwrap_or(Epoch::ZERO),
+            committees.keys().max().copied().unwrap_or(Epoch::ZERO),
         );
         let chain_description = ChainDescription::new(chain_origin, init_chain_config, timestamp);
         let child_id = chain_description.id();

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -148,7 +148,7 @@ pub trait RegisterMockApplication {
     /// Returns the chain to use for the creation of the application.
     ///
     /// This is included in the mocked [`ApplicationId`].
-    fn creator_chain_id(&self) -> ChainId;
+    async fn creator_chain_id(&self) -> ChainId;
 
     /// Registers a new [`MockApplication`] and returns it with the [`ApplicationId`] that was
     /// used for it.
@@ -186,8 +186,8 @@ where
     C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
-    fn creator_chain_id(&self) -> ChainId {
-        self.system.creator_chain_id()
+    async fn creator_chain_id(&self) -> ChainId {
+        self.system.creator_chain_id().await
     }
 
     async fn register_mock_application_with(
@@ -207,8 +207,8 @@ where
     C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
-    fn creator_chain_id(&self) -> ChainId {
-        self.description.get().as_ref().expect(
+    async fn creator_chain_id(&self) -> ChainId {
+        self.description.get().await.expect("failed to load description").as_ref().expect(
             "Can't register applications on a system state with no associated `ChainDescription`",
         ).into()
     }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -153,7 +153,7 @@ impl SystemExecutionState {
 }
 
 impl RegisterMockApplication for SystemExecutionState {
-    fn creator_chain_id(&self) -> ChainId {
+    async fn creator_chain_id(&self) -> ChainId {
         self.description.as_ref().expect(
             "Can't register applications on a system state with no associated `ChainDescription`",
         ).into()

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -1136,7 +1136,7 @@ async fn test_change_ownership_system_api() -> anyhow::Result<()> {
         .await?;
 
     // Verify the ownership was changed.
-    assert_eq!(*view.system.ownership.get(), new_ownership);
+    assert_eq!(*view.system.ownership.get().await?, new_ownership);
 
     Ok(())
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1248,7 +1248,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
         .await
         .expect("should initialize chain correctly");
     assert_eq!(*child_view.system.balance.get(), Amount::ONE);
-    assert_eq!(*child_view.system.ownership.get(), child_ownership);
+    assert_eq!(*child_view.system.ownership.get().await?, child_ownership);
     assert_eq!(
         *child_view.system.committees.get(),
         [(Epoch::ZERO, committee)]
@@ -1256,7 +1256,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
             .collect::<BTreeMap<_, _>>()
     );
     assert_eq!(
-        *child_view.system.application_permissions.get(),
+        *child_view.system.application_permissions.get().await?,
         ApplicationPermissions::new_single(application_id)
     );
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -242,7 +242,10 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         self.write_blob(&Blob::new_chain_description(&description))
             .await?;
         let mut chain = self.load_chain(id).await?;
-        assert!(!chain.is_active(), "Attempting to create a chain twice");
+        assert!(
+            !chain.is_active().await?,
+            "Attempting to create a chain twice"
+        );
         let current_time = self.clock().current_time();
         chain.initialize_if_needed(current_time).await?;
         chain.save().await?;

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -122,6 +122,6 @@ pub use sha3;
 /// Expose the created views.
 pub use views::{
     bucket_queue_view, collection_view, hashable_wrapper, historical_hash_wrapper,
-    key_value_store_view, log_view, map_view, queue_view, reentrant_collection_view, register_view,
-    set_view,
+    key_value_store_view, lazy_register_view, log_view, map_view, queue_view,
+    reentrant_collection_view, register_view, set_view,
 };

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -1,0 +1,303 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::OnceLock;
+
+use allocative::Allocative;
+#[cfg(with_metrics)]
+use linera_base::prometheus_util::MeasureLatency as _;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    batch::Batch,
+    common::{from_bytes_option_or_default, HasherOutput},
+    context::Context,
+    hashable_wrapper::WrappedHashableContainerView,
+    store::ReadableKeyValueStore,
+    views::{ClonableView, HashableView, Hasher, ReplaceContext, View},
+    ViewError,
+};
+
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{exponential_bucket_latencies, register_histogram_vec};
+    use prometheus::HistogramVec;
+
+    /// The runtime of hash computation
+    pub static LAZY_REGISTER_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "lazy_register_view_hash_runtime",
+            "LazyRegisterView hash runtime",
+            &[],
+            exponential_bucket_latencies(5.0),
+        )
+    });
+}
+
+/// A view that supports modifying a single value of type `T`.
+/// Unlike [`crate::register_view::RegisterView`], the value is not loaded from storage until it is first accessed.
+#[derive(Debug, Allocative)]
+#[allocative(bound = "C, T: Allocative")]
+pub struct LazyRegisterView<C, T> {
+    /// Whether to clear storage before applying updates.
+    delete_storage_first: bool,
+    /// The view context.
+    #[allocative(skip)]
+    context: C,
+    /// The value persisted in storage, loaded lazily on first access.
+    /// `OnceLock` replaces both the `Mutex` and the `Option` that were
+    /// previously used: empty means not yet loaded, set means loaded.
+    #[allocative(skip)]
+    stored_value: OnceLock<Box<T>>,
+    /// Pending update not yet persisted to storage.
+    update: Option<Box<T>>,
+}
+
+impl<C, T, C2> ReplaceContext<C2> for LazyRegisterView<C, T>
+where
+    C: Context,
+    C2: Context,
+    T: Default + Send + Sync + Serialize + DeserializeOwned + Clone,
+{
+    type Target = LazyRegisterView<C2, T>;
+
+    async fn with_context(
+        &mut self,
+        ctx: impl FnOnce(&Self::Context) -> C2 + Clone,
+    ) -> Self::Target {
+        let stored_value = self.stored_value.clone();
+        LazyRegisterView {
+            delete_storage_first: self.delete_storage_first,
+            context: ctx(&self.context),
+            stored_value,
+            update: self.update.clone(),
+        }
+    }
+}
+
+impl<C, T> View for LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Default + Send + Sync + Serialize + DeserializeOwned,
+{
+    const NUM_INIT_KEYS: usize = 0;
+
+    type Context = C;
+
+    fn context(&self) -> &C {
+        &self.context
+    }
+
+    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![])
+    }
+
+    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        Ok(Self {
+            delete_storage_first: false,
+            context,
+            stored_value: OnceLock::new(),
+            update: None,
+        })
+    }
+
+    fn rollback(&mut self) {
+        self.delete_storage_first = false;
+        self.update = None;
+    }
+
+    async fn has_pending_changes(&self) -> bool {
+        if self.delete_storage_first {
+            return true;
+        }
+        self.update.is_some()
+    }
+
+    fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
+        let mut delete_view = false;
+        if self.delete_storage_first {
+            batch.delete_key(self.context.base_key().bytes.clone());
+            delete_view = true;
+        } else if let Some(value) = &self.update {
+            let key = self.context.base_key().bytes.clone();
+            batch.put_key_value(key, value)?;
+        }
+        Ok(delete_view)
+    }
+
+    fn post_save(&mut self) {
+        if self.delete_storage_first {
+            self.stored_value = OnceLock::from(Box::<T>::default());
+        } else if let Some(value) = self.update.take() {
+            self.stored_value = OnceLock::from(value);
+        }
+        self.delete_storage_first = false;
+        self.update = None;
+    }
+
+    fn clear(&mut self) {
+        self.delete_storage_first = true;
+        self.update = Some(Box::default());
+    }
+}
+
+impl<C, T> ClonableView for LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        let stored_value = self.stored_value.clone();
+        Ok(LazyRegisterView {
+            delete_storage_first: self.delete_storage_first,
+            context: self.context.clone(),
+            stored_value,
+            update: self.update.clone(),
+        })
+    }
+}
+
+impl<C, T> LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Default + DeserializeOwned,
+{
+    /// Access the current value in the register.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::lazy_register_view::LazyRegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let register = LazyRegisterView::<_, u32>::load(context).await.unwrap();
+    /// let value = register.get().await.unwrap();
+    /// assert_eq!(*value, 0);
+    /// # })
+    /// ```
+    pub async fn get(&self) -> Result<&T, ViewError> {
+        if let Some(value) = &self.update {
+            return Ok(value);
+        }
+        if let Some(value) = self.stored_value.get() {
+            return Ok(value);
+        }
+        let key = self.context.base_key().bytes.clone();
+        let bytes = self.context.store().read_value_bytes(&key).await?;
+        let value = from_bytes_option_or_default(&bytes)?;
+        Ok(self.stored_value.get_or_init(|| Box::new(value)))
+    }
+
+    /// Sets the value in the register.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::lazy_register_view::LazyRegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut register = LazyRegisterView::load(context).await.unwrap();
+    /// register.set(5);
+    /// let value = register.get().await.unwrap();
+    /// assert_eq!(*value, 5);
+    /// # })
+    /// ```
+    pub fn set(&mut self, value: T) {
+        self.delete_storage_first = false;
+        self.update = Some(Box::new(value));
+    }
+
+    /// Obtains the extra data.
+    pub fn extra(&self) -> &C::Extra {
+        self.context.extra()
+    }
+}
+
+impl<C, T> LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Clone + Default + Serialize + DeserializeOwned,
+{
+    /// Obtains a mutable reference to the value in the register.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::lazy_register_view::LazyRegisterView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut register: LazyRegisterView<_, u32> = LazyRegisterView::load(context).await.unwrap();
+    /// let value = register.get_mut().await.unwrap();
+    /// assert_eq!(*value, 0);
+    /// # })
+    /// ```
+    pub async fn get_mut(&mut self) -> Result<&mut T, ViewError> {
+        self.delete_storage_first = false;
+        if self.update.is_none() {
+            let update = self.get().await?.clone();
+            self.update = Some(Box::new(update));
+        }
+        Ok(self.update.as_mut().unwrap())
+    }
+
+    async fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
+        #[cfg(with_metrics)]
+        let _hash_latency = metrics::LAZY_REGISTER_VIEW_HASH_RUNTIME.measure_latency();
+        let mut hasher = sha3::Sha3_256::default();
+        hasher.update_with_bcs_bytes(self.get().await?)?;
+        Ok(hasher.finalize())
+    }
+}
+
+impl<C, T> HashableView for LazyRegisterView<C, T>
+where
+    C: Context,
+    T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
+{
+    type Hasher = sha3::Sha3_256;
+
+    async fn hash_mut(&mut self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.compute_hash().await
+    }
+
+    async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
+        self.compute_hash().await
+    }
+}
+
+/// Type wrapping `LazyRegisterView` while memoizing the hash.
+pub type HashedLazyRegisterView<C, T> =
+    WrappedHashableContainerView<C, LazyRegisterView<C, T>, HasherOutput>;
+
+#[cfg(with_graphql)]
+mod graphql {
+    use std::borrow::Cow;
+
+    use super::LazyRegisterView;
+    use crate::context::Context;
+
+    impl<C, T> async_graphql::OutputType for LazyRegisterView<C, T>
+    where
+        C: Context,
+        T: async_graphql::OutputType + Default + Send + Sync + serde::de::DeserializeOwned,
+    {
+        fn type_name() -> Cow<'static, str> {
+            T::type_name()
+        }
+
+        fn create_type_info(registry: &mut async_graphql::registry::Registry) -> String {
+            T::create_type_info(registry)
+        }
+
+        async fn resolve(
+            &self,
+            ctx: &async_graphql::ContextSelectionSet<'_>,
+            field: &async_graphql::Positioned<async_graphql::parser::types::Field>,
+        ) -> async_graphql::ServerResult<async_graphql::Value> {
+            self.get()
+                .await
+                .map_err(|e| async_graphql::ServerError::new(e.to_string(), Some(field.pos)))?
+                .resolve(ctx, field)
+                .await
+        }
+    }
+}

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -18,6 +18,9 @@ mod tests;
 /// The `RegisterView` implements a register for a single value.
 pub mod register_view;
 
+/// The `LazyRegisterView` implements a register for a single value with lazy loading.
+pub mod lazy_register_view;
+
 /// The `LogView` implements a log list that can be pushed.
 pub mod log_view;
 

--- a/linera-views/src/views/unit_tests/views.rs
+++ b/linera-views/src/views/unit_tests/views.rs
@@ -17,6 +17,7 @@ use crate::store::{KeyValueDatabase, TestKeyValueDatabase};
 use crate::{
     batch::Batch,
     context::{Context, MemoryContext},
+    lazy_register_view::LazyRegisterView,
     queue_view::QueueView,
     reentrant_collection_view::ReentrantCollectionView,
     register_view::{HashedRegisterView, RegisterView},
@@ -525,6 +526,99 @@ where
         let mut entry = collection.try_load_entry_mut(&key).await?;
         entry.set(value);
     }
+
+    Ok(())
+}
+
+/// Saves a value using a `RegisterView`, then reopens it as a `LazyRegisterView`
+/// and checks that the value is correctly read back.
+#[tokio::test]
+async fn test_register_view_to_lazy_register_view() -> anyhow::Result<()> {
+    let context = MemoryContext::new_for_testing(());
+
+    // Write a value with RegisterView and persist it.
+    let mut register = RegisterView::<_, String>::load(context.clone()).await?;
+    register.set("hello".to_owned());
+    save_view(&context, &mut register).await?;
+    drop(register);
+
+    // Reopen the same storage location as a LazyRegisterView.
+    let lazy = LazyRegisterView::<_, String>::load(context.clone()).await?;
+
+    // The value should not have been loaded yet.
+    assert!(!lazy.has_pending_changes().await);
+
+    // Reading should lazily fetch the persisted value.
+    let value = lazy.get().await?;
+    assert_eq!(value, "hello");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lazy_register_view() -> anyhow::Result<()> {
+    let context = MemoryContext::new_for_testing(());
+
+    // A freshly loaded LazyRegisterView returns the default value.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert_eq!(*lazy.get().await?, 0);
+    assert!(!lazy.has_pending_changes().await);
+    drop(lazy);
+
+    // Set a value, verify it reads back, and persist.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    lazy.set(42);
+    assert!(lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 42);
+    save_view(&context, &mut lazy).await?;
+    assert!(!lazy.has_pending_changes().await);
+    drop(lazy);
+
+    // Reload and verify the persisted value is lazily fetched.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert!(!lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 42);
+    drop(lazy);
+
+    // Test get_mut: modify via mutable reference and persist.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    *lazy.get_mut().await? = 100;
+    assert!(lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 100);
+    save_view(&context, &mut lazy).await?;
+    drop(lazy);
+
+    // Verify the mutation was persisted.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert_eq!(*lazy.get().await?, 100);
+    drop(lazy);
+
+    // Test rollback: set a value then rollback, should read the stored value.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    lazy.set(999);
+    assert_eq!(*lazy.get().await?, 999);
+    lazy.rollback();
+    assert!(!lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 100);
+    drop(lazy);
+
+    // Test clear: clears to default and persists.
+    let mut lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    lazy.clear();
+    assert!(lazy.has_pending_changes().await);
+    assert_eq!(*lazy.get().await?, 0);
+    save_view(&context, &mut lazy).await?;
+    drop(lazy);
+
+    // Verify cleared value was persisted as default.
+    let lazy = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    assert_eq!(*lazy.get().await?, 0);
+
+    // Test hashing: two views with the same value produce the same hash.
+    let hash1 = lazy.hash().await?;
+    let mut lazy2 = LazyRegisterView::<_, u32>::load(context.clone()).await?;
+    let hash2 = lazy2.hash_mut().await?;
+    assert_eq!(hash1, hash2);
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The RegisterView load function is accessing the value under control when called.

This is a problem if the value in question is big. So, we introduce a LazyRegisterView that is loaded
only when appropriate.

Backport of #5996 

## Proposal

Introduce a LazyRegisterView that is backward compatible with the RegisterView.
We are forced to use interior mutability. Because otherwise the "get()" becomes &mut self.
In contexts of &self this forces us to introduce a read_value that reads the value without modifying.

The code is changed accordingly in a straightforward way.

## Test Plan

CI
A test that proves backward compatibility of RegisterView / LazyRegisterView is introduced.

## Release Plan

This is to `testnet_conway`. So no release needed.

## Links

None.