### PR TITLE
Correct the lazy_register_view bug and add some reasons for the unrea…

### DIFF
--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -576,7 +576,7 @@ mod tests {
             let value_read = store.read_value_bytes(&segment_key).await.unwrap();
             let Some(value_read) = value_read else {
                 unreachable!(
-                    "Segment should exist after writing a value that spans multiple segments"
+                    "value_splitting test: segment key not found in underlying store right after a multi-segment write"
                 )
             };
             if index == 0 {

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -575,7 +575,7 @@ mod tests {
             segment_key.extend(bytes);
             let value_read = store.read_value_bytes(&segment_key).await.unwrap();
             let Some(value_read) = value_read else {
-                unreachable!()
+                unreachable!("Segment {index} should exist after writing a value that spans multiple segments")
             };
             if index == 0 {
                 value_concat.extend(&value_read[4..]);

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -575,7 +575,9 @@ mod tests {
             segment_key.extend(bytes);
             let value_read = store.read_value_bytes(&segment_key).await.unwrap();
             let Some(value_read) = value_read else {
-                unreachable!("Segment {index} should exist after writing a value that spans multiple segments")
+                unreachable!(
+                    "Segment should exist after writing a value that spans multiple segments"
+                )
             };
             if index == 0 {
                 value_concat.extend(&value_read[4..]);

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -458,7 +458,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
             Some(Cursor { offset, position }) => {
                 let bucket = &self.stored_buckets[offset];
                 let State::Loaded { data } = &bucket.state else {
-                    unreachable!();
+                    unreachable!("The front bucket should always be loaded");
                 };
                 Some(&data[position])
             }
@@ -486,7 +486,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
             Some(Cursor { offset, position }) => {
                 let bucket = self.stored_buckets.get_mut(offset).unwrap();
                 let State::Loaded { data } = &mut bucket.state else {
-                    unreachable!();
+                    unreachable!("The front bucket should always be loaded");
                 };
                 Some(data.get_mut(position).unwrap())
             }
@@ -617,7 +617,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
         }
         let state = &self.stored_buckets.back_mut().unwrap().state;
         let State::Loaded { data } = state else {
-            unreachable!();
+            unreachable!("The back bucket should be loaded after the read above");
         };
         Ok(Some(data.last().unwrap().clone()))
     }
@@ -728,7 +728,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
         } else {
             let mut increment = self.count() - count;
             let Some(cursor) = self.cursor else {
-                unreachable!();
+                unreachable!("Cursor should be Some when stored_count > 0");
             };
             let mut position = cursor.position;
             for offset in cursor.offset..self.stored_buckets.len() {
@@ -747,7 +747,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                 increment -= size;
                 position = 0;
             }
-            unreachable!();
+            unreachable!("The loop should have returned before exhausting all stored buckets");
         }
     }
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -747,7 +747,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                 increment -= size;
                 position = 0;
             }
-            unreachable!("The loop should have returned before exhausting all stored buckets");
+            unreachable!("BucketQueueView::read_back: iterated past all stored buckets without finding the requested position");
         }
     }
 

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -94,7 +94,7 @@ impl<W> std::ops::Deref for ReadGuardedView<'_, W> {
         match self {
             ReadGuardedView::Loaded { updates, short_key } => {
                 let Update::Set(view) = updates.get(short_key).unwrap() else {
-                    unreachable!();
+                    unreachable!("ReadGuardedView should only reference Update::Set entries");
                 };
                 view
             }
@@ -277,7 +277,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                         let view = W::new(context)?;
                         *entry = Update::Set(view);
                         let Update::Set(view) = entry else {
-                            unreachable!();
+                            unreachable!("Entry was just set to Update::Set");
                         };
                         Ok(view)
                     }
@@ -295,7 +295,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
                     W::load(context).await?
                 };
                 let Update::Set(view) = entry.insert(Update::Set(view)) else {
-                    unreachable!();
+                    unreachable!("Entry was just inserted as Update::Set");
                 };
                 Ok(view)
             }
@@ -518,7 +518,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
             match updates.get(short_key) {
                 Some(update) => {
                     let Update::Set(_) = update else {
-                        unreachable!();
+                        unreachable!("Loaded entries in updates should always be Update::Set");
                     };
                     let updates = self.updates.read().await;
                     let view = ReadGuardedView::Loaded {
@@ -839,7 +839,7 @@ impl<W: HashableView> HashableView for ByteCollectionView<W::Context, W> {
             let hash = match updates.get_mut(&key) {
                 Some(entry) => {
                     let Update::Set(view) = entry else {
-                        unreachable!();
+                        unreachable!("Loaded entries in updates should always be Update::Set");
                     };
                     view.hash_mut().await?
                 }
@@ -871,7 +871,7 @@ impl<W: HashableView> HashableView for ByteCollectionView<W::Context, W> {
             let hash = match updates.get(&key) {
                 Some(entry) => {
                     let Update::Set(view) = entry else {
-                        unreachable!();
+                        unreachable!("Loaded entries in updates should always be Update::Set");
                     };
                     view.hash().await?
                 }

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -231,11 +231,11 @@ where
     /// # })
     /// ```
     pub async fn get_mut(&mut self) -> Result<&mut T, ViewError> {
-        self.delete_storage_first = false;
         if self.update.is_none() {
             let update = self.get().await?.clone();
             self.update = Some(Box::new(update));
         }
+        self.delete_storage_first = false;
         Ok(self.update.as_mut().unwrap())
     }
 

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -954,7 +954,7 @@ where
             }
         };
         let Update::Set(value) = update else {
-            unreachable!("All branches above produce Update::Set")
+            unreachable!("ByteMapView::get_mut_or_default: update entry is Update::Removed but every match arm above must insert Update::Set")
         };
         Ok(value)
     }

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -954,7 +954,7 @@ where
             }
         };
         let Update::Set(value) = update else {
-            unreachable!()
+            unreachable!("All branches above produce Update::Set")
         };
         Ok(value)
     }

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -591,7 +591,9 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
             .into_iter()
             .map(|short_key| {
                 let Some(Update::Set(view)) = self.updates.get(&short_key) else {
-                    unreachable!("Entry should have been inserted as Update::Set by try_load_view_mut")
+                    unreachable!(
+                        "Entry should have been inserted as Update::Set by try_load_view_mut"
+                    )
                 };
                 Ok(WriteGuardedView(
                     view.clone()

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -591,7 +591,7 @@ impl<W: View> ReentrantByteCollectionView<W::Context, W> {
             .into_iter()
             .map(|short_key| {
                 let Some(Update::Set(view)) = self.updates.get(&short_key) else {
-                    unreachable!()
+                    unreachable!("Entry should have been inserted as Update::Set by try_load_view_mut")
                 };
                 Ok(WriteGuardedView(
                     view.clone()
@@ -1065,7 +1065,7 @@ impl<W: HashableView> HashableView for ReentrantByteCollectionView<W::Context, W
             hasher.update_with_bytes(&key)?;
             let hash = if let Some(entry) = self.updates.get_mut(&key) {
                 let Update::Set(view) = entry else {
-                    unreachable!();
+                    unreachable!("Loaded entries in updates should always be Update::Set");
                 };
                 let mut view = view
                     .try_write_arc()
@@ -1096,7 +1096,7 @@ impl<W: HashableView> HashableView for ReentrantByteCollectionView<W::Context, W
             hasher.update_with_bytes(&key)?;
             let hash = if let Some(entry) = self.updates.get(&key) {
                 let Update::Set(view) = entry else {
-                    unreachable!();
+                    unreachable!("Loaded entries in updates should always be Update::Set");
                 };
                 let view = view
                     .try_read_arc()


### PR DESCRIPTION
## Motivation

The `LazyRegisterView::get_mut` could modify the state and leave it in an incorrect state if an error occurs.

## Proposal

We also add reasons for the unreachable statements.

## Test Plan

CI.

## Release Plan

It can be backported to `testnet_conway`.

## Links

None.