### PR TITLE
Move free-tier CI jobs back to ubuntu-latest

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   benchmark-test:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
 
   publish-docs:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     # We only publish docs for the main branch.

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -47,7 +47,7 @@ jobs:
   test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   indexer-check:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   indexer-integration-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/instruction-count-benchmarks.yml
+++ b/.github/workflows/instruction-count-benchmarks.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   save-baseline:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   compare:
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   performance-summary:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -55,7 +55,7 @@ jobs:
               - '!CONTRIBUTING.md'
               - '!INSTALL.md'
   changed-files-kubernetes:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -73,7 +73,7 @@ jobs:
   execution-wasmtime-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -141,7 +141,7 @@ jobs:
   metrics-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -154,8 +154,8 @@ jobs:
   wasm-application-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
     - uses: actions/checkout@v4
@@ -175,7 +175,7 @@ jobs:
   linera-sdk-tests-fixtures:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -225,7 +225,7 @@ jobs:
   check-outdated-cli-md:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -247,7 +247,7 @@ jobs:
   ethereum-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true' && github.event_name != 'merge_group'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -341,7 +341,7 @@ jobs:
   check-wit-files:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -352,7 +352,7 @@ jobs:
   lint-unexpected-chain-load-operations:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -364,7 +364,7 @@ jobs:
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -381,7 +381,7 @@ jobs:
   lint-cargo-machete:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -400,7 +400,7 @@ jobs:
   lint-cargo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -416,7 +416,7 @@ jobs:
   lint-taplo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -430,7 +430,7 @@ jobs:
   lint-check-for-outdated-readme:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -459,7 +459,7 @@ jobs:
   lint-wasm-applications:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -484,7 +484,7 @@ jobs:
   lint-cargo-clippy:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -510,7 +510,7 @@ jobs:
   lint-cargo-doc:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 25
 
     steps:
@@ -530,7 +530,7 @@ jobs:
   lint-check-linera-service-graphql-schema:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -57,7 +57,7 @@ jobs:
   web:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Motivation

GitHub-hosted `ubuntu-latest` runners are free (within plan minutes). Self-hosted OVH
runners (`linera-io-self-hosted-ci`) cost money. PR #5452 migrated every CI job —
including 19 lightweight jobs that had been on the free `ubuntu-latest` tier — to the
self-hosted pool.

`ubuntu-latest-8-cores` and `ubuntu-latest-16-cores` jobs are NOT touched: self-hosted
is cheaper than those paid GitHub-hosted tiers.

## Proposal

Revert `runs-on: linera-io-self-hosted-ci` → `runs-on: ubuntu-latest` for every job that
was originally on `ubuntu-latest` per PR #5452:

- `benchmark-test.yml`, `benchmarks.yml`, `docker_image.yml`, `explorer.yml` (×2),
`indexer.yml` (×2), `performance_summary.yml`, `release.yml`, `web.yml` (×2),
`documentation.yml::publish-docs`.
- `rust.yml` — 19 jobs: `changed-files`, `changed-files-kubernetes`,
`execution-wasmtime-test`, `metrics-test`, `wasm-application-test`,
`linera-sdk-tests-fixtures`, `check-outdated-cli-md`, `ethereum-tests`,
`check-wit-files`, and 10 lints.
- `instruction-count-benchmarks.yml` (×2) — light enough for `ubuntu-latest`.
- `docker_image.yml` was on `linera-io-self-hosted-builder` (the #5984 Cloud Build
replacement); reverted since it was originally `ubuntu-latest`.

**Unchanged (remain on self-hosted):** `default-features-and-witty-integration-test`
(originally 8-cores), `storage-service-tests` (originally 16-cores), `docker-compose`,
`dynamodb`, `lint-check-all-features`, `long_faucet_chain_test`,
`remote-kubernetes-net-test`, `remote-net-test`, `scylladb`, `test-readmes`,
`documentation::test-crates-and-docrs`, `build_image.yml` (heavy Docker builder pool).

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

