### PR TITLE
[testnet_conway] Move free-tier CI jobs back to ubuntu-latest

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   benchmark:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
           mdbook test -L ../target/debug/deps/
 
   formatting:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
 
   publish-rust-docs:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     # We only publish docs for the main branch.
@@ -58,7 +58,7 @@ jobs:
         force_orphan: true
 
   test-crates-and-docrs:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -49,7 +49,7 @@ jobs:
   test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   indexer-check:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -51,7 +51,7 @@ jobs:
 
   indexer-integration-tests:
     if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/performance_summary.yml
+++ b/.github/workflows/performance_summary.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   performance-summary:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -99,7 +99,7 @@ jobs:
   execution-wasmtime-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -112,7 +112,7 @@ jobs:
   bridge-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 25
 
     steps:
@@ -167,7 +167,7 @@ jobs:
   metrics-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -180,8 +180,8 @@ jobs:
   wasm-application-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
 
     steps:
     - uses: actions/checkout@v4
@@ -201,7 +201,7 @@ jobs:
   linera-sdk-tests-fixtures:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -254,7 +254,7 @@ jobs:
   check-outdated-cli-md:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -276,7 +276,7 @@ jobs:
   benchmark-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 40
 
     steps:
@@ -300,7 +300,7 @@ jobs:
   ethereum-tests:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:
@@ -395,7 +395,7 @@ jobs:
   check-wit-files:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -406,7 +406,7 @@ jobs:
   lint-unexpected-chain-load-operations:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -418,7 +418,7 @@ jobs:
   lint-check-copyright-headers:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -435,7 +435,7 @@ jobs:
   lint-cargo-machete:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -454,7 +454,7 @@ jobs:
   lint-cargo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 2
 
     steps:
@@ -470,7 +470,7 @@ jobs:
   lint-taplo-fmt:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -484,7 +484,7 @@ jobs:
   lint-check-for-outdated-readme:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -513,7 +513,7 @@ jobs:
   lint-wasm-applications:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -538,7 +538,7 @@ jobs:
   lint-cargo-clippy:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -564,7 +564,7 @@ jobs:
   lint-cargo-doc:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
@@ -584,7 +584,7 @@ jobs:
   lint-check-linera-service-graphql-schema:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   changed-files:
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     outputs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
@@ -59,7 +59,7 @@ jobs:
   web:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Motivation

Same as the main-branch sibling PR: free-tier `ubuntu-latest` jobs should not run on the
paid self-hosted pool. PR #5542 migrated everything on `testnet_conway` to self-hosted,
including 20+ jobs originally on `ubuntu-latest`.

## Proposal

Revert `runs-on: linera-io-self-hosted-ci` → `runs-on: ubuntu-latest` for every job
originally on `ubuntu-latest` per PR #5542:

- `benchmarks.yml`, `book.yml` (×2), `docker_image.yml`, `documentation.yml` (×2),
`explorer.yml` (×2), `indexer.yml` (×2), `performance_summary.yml`, `release.yml`,
`web.yml` (×2).
- `rust.yml` — 20 jobs: `changed-files`, `execution-wasmtime-test`, `bridge-tests`,
`metrics-test`, `wasm-application-test`, `linera-sdk-tests-fixtures`,
`check-outdated-cli-md`, `benchmark-test`, `ethereum-tests`, `check-wit-files`, and 10
lints.

**Unchanged (remain on self-hosted):** `rust.yml::remote-net-test` (originally 8-cores),
`rust.yml::default-features-and-witty-integration-test` (originally 8  `rust.yml::storage-service-tests` (originally 16-cores), `bridge-e2e`, `docker-compose`,
`dynamodb`, `lint-check-all-features`, `long_faucet_chain_test`,
`remote_compatibility`, `scylladb`, `test-readmes`.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

