### PR TITLE
[testnet] Add Validator → Scylla Cluster UUID reference panel to ScyllaDB dashboard

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
@@ -2671,7 +2671,7 @@
               }
             ]
           },
-          "unit": "\u00b5s"
+          "unit": "µs"
         },
         "overrides": []
       },
@@ -2713,6 +2713,145 @@
       ],
       "title": "I/O Delay",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Maps each Conway validator (GKE cluster) to its ScyllaDB cluster UUID used in scylla-manager backups. Joins scylla_manager_backup_files_size_bytes (UUID + manager pod) with kube_pod_info (manager pod -> GKE cluster). Only actively-backed-up clusters appear; stale scylla-manager registrations are filtered out.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "left",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "filterable": false
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 20,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "group by (cluster, instance) (scylla_manager_backup_files_size_bytes)",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "group by (cluster, pod) (kube_pod_info{pod=~\"scylla-manager-[^-]+-[^-]+\"})",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        }
+      ],
+      "title": "Validator → Scylla Cluster UUID",
+      "transformations": [
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "A"
+          },
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true,
+              "name": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "cluster": "scylla_cluster_uuid",
+              "instance": "manager_pod"
+            }
+          }
+        },
+        {
+          "filter": {
+            "id": "byRefId",
+            "options": "B"
+          },
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "created_by_kind": true,
+              "created_by_name": true,
+              "exported_namespace": true,
+              "host_ip": true,
+              "host_network": true,
+              "job": true,
+              "namespace": true,
+              "node": true,
+              "pod_ip": true,
+              "uid": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "cluster": "validator_gke_cluster",
+              "pod": "manager_pod"
+            }
+          }
+        },
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "manager_pod",
+            "mode": "inner"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "manager_pod": 2,
+              "scylla_cluster_uuid": 1,
+              "validator_gke_cluster": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "tags": [


### PR DESCRIPTION
## Motivation

Backport of #6030 to `testnet_conway`. Maps Conway validators (V1–V4) to their Scylla-Manager cluster UUIDs directly from a Grafana panel. Previously this required ad-hoc Prometheus / GCS cross-referencing. Useful whenever we need to find a specific validator backup folder in `gs://linera-io-dev-scylla-backups/` — especially during disaster recovery (e.g. the V4 TTL-fix state-corruption incident on 2026-04-14).

## Proposal

Append one `table` panel to the `ScyllaDB` Linera dashboard (`kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json`, UID `linera-scylladb`). The panel joins:

- `scylla_manager_backup_files_size_bytes` — gives the Scylla cluster UUID (in the `cluster` label) and the scylla-manager pod (in `instance`), **only for clusters that have actually run backups**. This filters out stale scylla-manager registrations from prior rebuilds.
- `kube_pod_info{pod=~"scylla-manager-[^-]+-[^-]+"}` — maps the scylla-manager pod to its GKE cluster (which is named after the validator). The regex excludes `scylla-manager-controller-*` pods (they have an extra `-` in the name) and is immune to ReplicaSet-hash churn.

Joined on `manager_pod`, the output is a 4-row table:

| validator_gke_cluster | scylla_cluster_uuid | manager_pod |
| - | - | - |
| gke-testnet-conway-validator-1 | `0c6d3381-…` | `scylla-manager-…-29t52` |
| gke-testnet-conway-validator-2 | `1812c7ba-…` | `scylla-manager-…-hh44r` |
| gke-testnet-conway-validator-3 | `7dff25c8-…` | `scylla-manager-…-2hh7g` |
| gke-testnet-conway-validator-4 | `9ea4adb5-…` | `scylla-manager-…-wqphb` |

Identical file change as the main PR #6030 — `main` and `testnet_conway` had identical `scylladb.json` before this change.

## Test Plan

- `jq empty kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json` passes (valid JSON).
- Panel is already deployed to central monitoring (`monitoring.infra.linera.net/d/linera-scylladb/scylladb`) via the Grafana API; live rendering shows exactly 4 rows (V1–V4), no duplicates, no stale UUIDs, no controller pods.
- `jq -S` sorted-key comparison of the panel JSON in this PR vs. the live central-monitoring panel is byte-identical.
- CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.