### PR TITLE
Update the `get_mut` function of `LazyRegisterView`.

### DIFF
--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -231,11 +231,11 @@ where
     /// # })
     /// ```
     pub async fn get_mut(&mut self) -> Result<&mut T, ViewError> {
-        self.delete_storage_first = false;
         if self.update.is_none() {
             let update = self.get().await?.clone();
             self.update = Some(Box::new(update));
         }
+        self.delete_storage_first = false;
         Ok(self.update.as_mut().unwrap())
     }
 


### PR DESCRIPTION
## Motivation

If an error occurs in `get_mut`, then we want the view to remain in a valid state.

## Proposal

Revert the position of `self.delete_storage_first = false`.

## Test Plan

CI

## Release Plan

This is the backport.

## Links

None.