### PR TITLE
Use `hex_debug` for `Vec<u8>` in `linera-views`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6280,6 +6280,7 @@ dependencies = [
  "cfg_aliases",
  "convert_case",
  "criterion",
+ "custom_debug_derive",
  "derive_more 1.0.0",
  "futures",
  "generic-array",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4120,6 +4120,7 @@ dependencies = [
  "bcs",
  "cfg_aliases",
  "convert_case",
+ "custom_debug_derive",
  "derive_more 1.0.0",
  "futures",
  "generic-array",

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2478,6 +2478,7 @@ dependencies = [
  "bcs",
  "cfg_aliases",
  "convert_case",
+ "custom_debug_derive",
  "derive_more 1.0.0",
  "futures",
  "generic-array",

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -41,6 +41,7 @@ aws-sdk-dynamodb = { workspace = true, optional = true }
 aws-smithy-types = { workspace = true, optional = true }
 bcs.workspace = true
 convert_case.workspace = true
+custom_debug_derive.workspace = true
 derive_more = { workspace = true, features = ["from"] }
 futures.workspace = true
 generic-array.workspace = true

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -17,13 +17,15 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
-    fmt::Debug,
+    fmt,
     iter::Peekable,
     ops::Bound,
     vec::IntoIter,
 };
 
 use bcs::serialized_size;
+use custom_debug_derive::Debug;
+use linera_base::hex_debug;
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 
@@ -42,18 +44,22 @@ pub enum WriteOperation {
     /// Delete the given key.
     Delete {
         /// The key that will be deleted.
+        #[debug(with = "hex_debug")]
         key: Vec<u8>,
     },
     /// Delete all the keys matching the given prefix.
     DeletePrefix {
         /// The prefix of the keys to be deleted.
+        #[debug(with = "hex_debug")]
         key_prefix: Vec<u8>,
     },
     /// Set or replace the value of a given key.
     Put {
         /// The key to be inserted or replaced.
+        #[debug(with = "hex_debug")]
         key: Vec<u8>,
         /// The value to be inserted on the key.
+        #[debug(with = "hex_debug")]
         value: Vec<u8>,
     },
 }
@@ -370,7 +376,7 @@ impl Batch {
 #[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait DeletePrefixExpander {
     /// The error type that can happen when expanding the key prefix.
-    type Error: Debug;
+    type Error: fmt::Debug;
 
     /// Returns the list of keys to be appended to the list.
     async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use custom_debug_derive::Debug;
+use linera_base::hex_debug;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
@@ -15,6 +17,7 @@ use crate::{
 pub struct BaseKey {
     /// The byte value of the key prefix.
     #[from]
+    #[debug(with = "hex_debug")]
     pub bytes: Vec<u8>,
 }
 


### PR DESCRIPTION
## Motivation

`Vec<u8>` is printed in slice syntax by default, which is very verbose.

## Proposal

Use `hex_debug` to print it in hexadecimal and elide if too long.

## Test Plan

(We're already using `hex_debug` in other crates.)

## Release Plan

- Backport to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
