### PR TITLE
Log ignored notifications at TRACE, not DEBUG

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2704,7 +2704,7 @@ impl<Env: Environment> ChainClient<Env> {
             .as_ref()
             .is_some_and(|mode| mode.is_relevant(&notification.reason));
         if !relevant {
-            debug!(
+            tracing::trace!(
                 chain_id = %notification.chain_id,
                 reason = ?notification.reason,
                 ?listening_mode,


### PR DESCRIPTION
## Motivation

Now that we don't see DEBUG notifications in CI, they have become much too verbose to use for debugging out of the box.  Particularly, in real-world scenarios, this log line is spammed many times per second.

## Proposal

Demote it to TRACE.

## Test Plan

N/A

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
