### PR TITLE
Fix & re-enable `test_evm_erc20_shared`.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -246,7 +246,7 @@ jobs:
 
   ethereum-tests:
     needs: changed-files
-    if: needs.changed-files.outputs.should-run == 'true' && github.event_name != 'merge_group'
+    if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2138,7 +2138,7 @@ async fn test_wasm_end_to_end_counter_subscription_ttl(config: impl LineraNetCon
 async fn test_evm_erc20_shared(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::time::Instant;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
-    let num_operations = 500;
+    let num_operations = 100;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;


### PR DESCRIPTION
## Motivation

The 500 operations sometimes exceeded timeout. The test would then retry, but the original block was already started, so there would be a "conflicting block".

## Proposal

Reduce `num_operations` from 500 to 100 to avoid exceeding the 60s reqwest timeout, which caused a non-idempotent retry and a block conflict error.

## Test Plan

The tests are now re-enabled in the merge queue. Let's see if they are still flaky.

## Release Plan

- Nothing to do.

## Links

- Fixes half of https://github.com/linera-io/linera-protocol/issues/5910.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
