### PR TITLE
Limit the number of stream IDs per `PreviousEventBlocks` request.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -208,7 +208,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-joined-tasks <MAX_JOINED_TASKS>` — Maximum number of tasks that can are joined concurrently in the client
 
   Default value: `100`
-* `--max-stream-queries <MAX_STREAM_QUERIES>` — Maximum number of event stream IDs to include in a single `PreviousEventBlocks` request. Larger sets are split into multiple requests
+* `--max-event-stream-queries <MAX_EVENT_STREAM_QUERIES>` — Maximum number of event stream IDs to include in a single `PreviousEventBlocks` request. Larger sets are split into multiple requests
 
   Default value: `1000`
 * `--max-accepted-latency-ms <MAX_ACCEPTED_LATENCY_MS>` — Maximum expected latency in milliseconds for score normalization

--- a/CLI.md
+++ b/CLI.md
@@ -208,6 +208,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-joined-tasks <MAX_JOINED_TASKS>` — Maximum number of tasks that can are joined concurrently in the client
 
   Default value: `100`
+* `--max-stream-queries <MAX_STREAM_QUERIES>` — Maximum number of event stream IDs to include in a single `PreviousEventBlocks` request. Larger sets are split into multiple requests
+
+  Default value: `1000`
 * `--max-accepted-latency-ms <MAX_ACCEPTED_LATENCY_MS>` — Maximum expected latency in milliseconds for score normalization
 
   Default value: `5000`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -15,7 +15,8 @@ use linera_base::{
 use linera_core::{
     client::{
         chain_client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
-        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_MAX_STREAM_QUERIES,
+        DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
     },
     node::CrossChainMessageDelivery,
     DEFAULT_QUORUM_GRACE_PERIOD,
@@ -230,6 +231,11 @@ pub struct Options {
     #[arg(long, default_value = "100")]
     pub max_joined_tasks: usize,
 
+    /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
+    /// request. Larger sets are split into multiple requests.
+    #[arg(long, default_value_t = DEFAULT_MAX_STREAM_QUERIES)]
+    pub max_stream_queries: usize,
+
     /// Maximum expected latency in milliseconds for score normalization.
     #[arg(
         long,
@@ -335,6 +341,7 @@ impl Options {
                 .notification_circuit_breaker_initial_probe_interval,
             notification_circuit_breaker_max_probe_interval: self
                 .notification_circuit_breaker_max_probe_interval,
+            max_stream_queries: self.max_stream_queries,
         }
     }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -15,7 +15,7 @@ use linera_base::{
 use linera_core::{
     client::{
         chain_client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
-        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_MAX_STREAM_QUERIES,
+        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_MAX_EVENT_STREAM_QUERIES,
         DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
     },
     node::CrossChainMessageDelivery,
@@ -233,8 +233,8 @@ pub struct Options {
 
     /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
     /// request. Larger sets are split into multiple requests.
-    #[arg(long, default_value_t = DEFAULT_MAX_STREAM_QUERIES)]
-    pub max_stream_queries: usize,
+    #[arg(long, default_value_t = DEFAULT_MAX_EVENT_STREAM_QUERIES)]
+    pub max_event_stream_queries: usize,
 
     /// Maximum expected latency in milliseconds for score normalization.
     #[arg(
@@ -341,7 +341,7 @@ impl Options {
                 .notification_circuit_breaker_initial_probe_interval,
             notification_circuit_breaker_max_probe_interval: self
                 .notification_circuit_breaker_max_probe_interval,
-            max_stream_queries: self.max_stream_queries,
+            max_event_stream_queries: self.max_event_stream_queries,
         }
     }
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -123,6 +123,9 @@ pub struct Options {
     /// Maximum probe interval for the notification circuit breaker. The probe interval
     /// doubles on each failure but is capped at this value.
     pub notification_circuit_breaker_max_probe_interval: Duration,
+    /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
+    /// request. Larger sets are split into multiple requests.
+    pub max_stream_queries: usize,
 }
 
 struct CircuitBreakerState {
@@ -135,7 +138,7 @@ impl Options {
     pub fn test_default() -> Self {
         use super::{
             DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE, DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
-            DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            DEFAULT_MAX_STREAM_QUERIES, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
         };
         use crate::DEFAULT_QUORUM_GRACE_PERIOD;
 
@@ -155,6 +158,7 @@ impl Options {
             allow_fast_blocks: false,
             notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
             notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
+            max_stream_queries: DEFAULT_MAX_STREAM_QUERIES,
         }
     }
 }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -125,7 +125,7 @@ pub struct Options {
     pub notification_circuit_breaker_max_probe_interval: Duration,
     /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
     /// request. Larger sets are split into multiple requests.
-    pub max_stream_queries: usize,
+    pub max_event_stream_queries: usize,
 }
 
 struct CircuitBreakerState {
@@ -138,7 +138,7 @@ impl Options {
     pub fn test_default() -> Self {
         use super::{
             DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE, DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
-            DEFAULT_MAX_STREAM_QUERIES, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            DEFAULT_MAX_EVENT_STREAM_QUERIES, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
         };
         use crate::DEFAULT_QUORUM_GRACE_PERIOD;
 
@@ -158,7 +158,7 @@ impl Options {
             allow_fast_blocks: false,
             notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
             notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
-            max_stream_queries: DEFAULT_MAX_STREAM_QUERIES,
+            max_event_stream_queries: DEFAULT_MAX_EVENT_STREAM_QUERIES,
         }
     }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -127,6 +127,7 @@ mod metrics {
 pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE: usize = 20_000;
+pub static DEFAULT_MAX_STREAM_QUERIES: usize = 1000;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TimingType {
@@ -1557,13 +1558,12 @@ impl<Env: Environment> Client<Env> {
         remote_node: &RemoteNode<Env::ValidatorNode>,
     ) -> Result<(), chain_client::Error> {
         let stream_ids_vec: Vec<_> = stream_ids.iter().cloned().collect();
-        let query = ChainInfoQuery::new(chain_id).with_previous_event_blocks(stream_ids_vec);
-        let info = remote_node.handle_chain_info_query(query).await?;
-        let initial_blocks = info
-            .requested_previous_event_blocks
-            .values()
-            .copied()
-            .collect();
+        let mut initial_blocks = BTreeSet::new();
+        for chunk in stream_ids_vec.chunks(self.options.max_stream_queries) {
+            let query = ChainInfoQuery::new(chain_id).with_previous_event_blocks(chunk.to_vec());
+            let info = remote_node.handle_chain_info_query(query).await?;
+            initial_blocks.extend(info.requested_previous_event_blocks.values().copied());
+        }
         let local_height = match self.local_node.chain_info(chain_id).await {
             Ok(info) => info.next_block_height,
             Err(LocalNodeError::InactiveChain(_) | LocalNodeError::BlobsNotFound(_)) => {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -127,7 +127,7 @@ mod metrics {
 pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE: usize = 20_000;
-pub static DEFAULT_MAX_STREAM_QUERIES: usize = 1000;
+pub static DEFAULT_MAX_EVENT_STREAM_QUERIES: usize = 1000;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TimingType {
@@ -1559,7 +1559,7 @@ impl<Env: Environment> Client<Env> {
     ) -> Result<(), chain_client::Error> {
         let stream_ids_vec: Vec<_> = stream_ids.iter().cloned().collect();
         let mut initial_blocks = BTreeSet::new();
-        for chunk in stream_ids_vec.chunks(self.options.max_stream_queries) {
+        for chunk in stream_ids_vec.chunks(self.options.max_event_stream_queries) {
             let query = ChainInfoQuery::new(chain_id).with_previous_event_blocks(chunk.to_vec());
             let info = remote_node.handle_chain_info_query(query).await?;
             initial_blocks.extend(info.requested_previous_event_blocks.values().copied());


### PR DESCRIPTION
## Motivation

`PreviousEventBlocks` requests often time out.

## Proposal

Add a configurable `--max-event-stream-queries` option (default 1000) that chunks large `PreviousEventBlocks` queries into multiple smaller requests to avoid timeouts on the server side.

## Test Plan

CI
(The added logic is trivial.)

## Release Plan

- Backport to `testnet_conway`.
- Release SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
