### PR TITLE
Remove redundant admin chain sync from synchronize_publisher_chains

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -849,12 +849,8 @@ impl<Env: Environment> ChainClient<Env> {
                     .insert(stream_id.clone());
             }
         }
-        // Always fully sync the admin chain for epoch changes.
-        let admin_chain_id = self.client.admin_chain_id;
-        if admin_chain_id != self.chain_id {
-            self.client.synchronize_chain_state(admin_chain_id).await?;
-        }
         // For event publisher chains, do a partial sync using previous_event_blocks.
+        let admin_chain_id = self.client.admin_chain_id;
         let (_, committee) = self.admin_committee().await?;
         let nodes = self.client.make_nodes(&committee)?;
         let tasks = streams_by_chain


### PR DESCRIPTION
## Motivation

`synchronize_publisher_chains` unconditionally calls `synchronize_chain_state(admin_chain_id)` every time it runs. Its only caller, `synchronize_from_validators`, always runs `prepare_chain` first — which already detects epoch mismatches and syncs the admin chain when needed. The unconditional sync is redundant and causes unnecessary quorum-wide validator queries when multiple chains are processed in sequence.

## Proposal

Remove the unconditional admin chain sync from `synchronize_publisher_chains`. The `admin_chain_id` local variable is kept for the publisher chain filter.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Related: #5989