### PR TITLE
[testnet] backport #6040 to limit the number of stream IDs per `PreviousEventBlocks` request

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -209,7 +209,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-joined-tasks <MAX_JOINED_TASKS>` — Maximum number of tasks that can are joined concurrently in the client
 
   Default value: `100`
-* `--max-stream-queries <MAX_STREAM_QUERIES>` — Maximum number of event stream IDs to include in a single `PreviousEventBlocks` request. Larger sets are split into multiple requests
+* `--max-event-stream-queries <MAX_EVENT_STREAM_QUERIES>` — Maximum number of event stream IDs to include in a single `PreviousEventBlocks` request. Larger sets are split into multiple requests
 
   Default value: `1000`
 * `--max-accepted-latency-ms <MAX_ACCEPTED_LATENCY_MS>` — Maximum expected latency in milliseconds for score normalization

--- a/CLI.md
+++ b/CLI.md
@@ -209,6 +209,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--max-joined-tasks <MAX_JOINED_TASKS>` — Maximum number of tasks that can are joined concurrently in the client
 
   Default value: `100`
+* `--max-stream-queries <MAX_STREAM_QUERIES>` — Maximum number of event stream IDs to include in a single `PreviousEventBlocks` request. Larger sets are split into multiple requests
+
+  Default value: `1000`
 * `--max-accepted-latency-ms <MAX_ACCEPTED_LATENCY_MS>` — Maximum expected latency in milliseconds for score normalization
 
   Default value: `5000`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -15,7 +15,8 @@ use linera_base::{
 use linera_core::{
     client::{
         chain_client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
-        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_MAX_EVENT_STREAM_QUERIES,
+        DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
     },
     node::CrossChainMessageDelivery,
     DEFAULT_QUORUM_GRACE_PERIOD,
@@ -237,6 +238,11 @@ pub struct Options {
     #[arg(long, default_value = "100")]
     pub max_joined_tasks: usize,
 
+    /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
+    /// request. Larger sets are split into multiple requests.
+    #[arg(long, default_value_t = DEFAULT_MAX_EVENT_STREAM_QUERIES)]
+    pub max_event_stream_queries: usize,
+
     /// Maximum expected latency in milliseconds for score normalization.
     #[arg(
         long,
@@ -343,6 +349,7 @@ impl Options {
                 .notification_circuit_breaker_initial_probe_interval,
             notification_circuit_breaker_max_probe_interval: self
                 .notification_circuit_breaker_max_probe_interval,
+            max_event_stream_queries: self.max_event_stream_queries,
         }
     }
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -127,6 +127,9 @@ pub struct Options {
     /// Maximum probe interval for the notification circuit breaker. The probe interval
     /// doubles on each failure but is capped at this value.
     pub notification_circuit_breaker_max_probe_interval: Duration,
+    /// Maximum number of event stream IDs to include in a single `PreviousEventBlocks`
+    /// request. Larger sets are split into multiple requests.
+    pub max_event_stream_queries: usize,
 }
 
 struct CircuitBreakerState {
@@ -139,7 +142,7 @@ impl Options {
     pub fn test_default() -> Self {
         use super::{
             DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE, DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
-            DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            DEFAULT_MAX_EVENT_STREAM_QUERIES, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
         };
         use crate::DEFAULT_QUORUM_GRACE_PERIOD;
 
@@ -160,6 +163,7 @@ impl Options {
             allow_fast_blocks: false,
             notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
             notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
+            max_event_stream_queries: DEFAULT_MAX_EVENT_STREAM_QUERIES,
         }
     }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -127,6 +127,7 @@ mod metrics {
 pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE: usize = 20_000;
+pub static DEFAULT_MAX_EVENT_STREAM_QUERIES: usize = 1000;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TimingType {
@@ -1520,11 +1521,14 @@ impl<Env: Environment> Client<Env> {
         remote_node: &RemoteNode<Env::ValidatorNode>,
     ) -> Result<(), chain_client::Error> {
         let stream_ids_vec: Vec<_> = stream_ids.iter().cloned().collect();
-        let previous_blocks = remote_node
-            .node
-            .previous_event_blocks(chain_id, stream_ids_vec)
-            .await?;
-        let initial_blocks = previous_blocks.values().copied().collect();
+        let mut initial_blocks = BTreeSet::new();
+        for chunk in stream_ids_vec.chunks(self.options.max_event_stream_queries) {
+            let previous_blocks = remote_node
+                .node
+                .previous_event_blocks(chain_id, chunk.to_vec())
+                .await?;
+            initial_blocks.extend(previous_blocks.values().copied());
+        }
         let local_height = match self.local_node.chain_info(chain_id).await {
             Ok(info) => info.next_block_height,
             Err(LocalNodeError::InactiveChain(_) | LocalNodeError::BlobsNotFound(_)) => {


### PR DESCRIPTION
## Motivation

Limit the number of stream IDs per `PreviousEventBlocks` request

## Proposal

backport #6040

## Test Plan

CI