### PR TITLE
Fix storage cache reads dropping Arc before use

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1312,10 +1312,7 @@ where
             .with_label_values(&[metrics::DB])
             .inc();
         match value {
-            Some(block) => {
-                self.caches.confirmed_block.insert(&hash, block);
-                Ok(self.caches.confirmed_block.get(&hash))
-            }
+            Some(block) => Ok(Some(self.caches.confirmed_block.insert(&hash, block))),
             None => Ok(None),
         }
     }
@@ -1344,10 +1341,11 @@ where
             for (miss_idx, root_key) in misses.iter().zip(root_keys) {
                 let store = self.database.open_shared(&root_key)?;
                 if let Some(block) = store.read_value::<ConfirmedBlock>(BLOCK_KEY).await? {
-                    self.caches
-                        .confirmed_block
-                        .insert(&hashes[*miss_idx], block);
-                    results[*miss_idx] = self.caches.confirmed_block.get(&hashes[*miss_idx]);
+                    results[*miss_idx] = Some(
+                        self.caches
+                            .confirmed_block
+                            .insert(&hashes[*miss_idx], block),
+                    );
                 }
             }
         }
@@ -1388,8 +1386,7 @@ where
         match maybe_blob_bytes {
             Some(blob_bytes) => {
                 let blob = Blob::new_with_id_unchecked(blob_id, blob_bytes);
-                self.caches.blob.insert(&blob_id, blob);
-                Ok(self.caches.blob.get(&blob_id))
+                Ok(Some(self.caches.blob.insert(&blob_id, blob)))
             }
             None => Ok(None),
         }
@@ -1627,10 +1624,11 @@ where
                 let store = self.database.open_shared(&root_key)?;
                 let values = store.read_multi_values_bytes(&get_block_keys()).await?;
                 if let (Some(lite), Some(block)) = (values[0].as_ref(), values[1].as_ref()) {
-                    self.caches
-                        .certificate_raw
-                        .insert(&hashes[*miss_idx], (lite.clone(), block.clone()));
-                    results[*miss_idx] = self.caches.certificate_raw.get(&hashes[*miss_idx]);
+                    results[*miss_idx] = Some(
+                        self.caches
+                            .certificate_raw
+                            .insert(&hashes[*miss_idx], (lite.clone(), block.clone())),
+                    );
                 }
             }
         }
@@ -1779,10 +1777,7 @@ where
             .with_label_values(&[metrics::DB])
             .inc();
         match event {
-            Some(event_bytes) => {
-                self.caches.event.insert(&event_id, event_bytes);
-                Ok(self.caches.event.get(&event_id))
-            }
+            Some(event_bytes) => Ok(Some(self.caches.event.insert(&event_id, event_bytes))),
             None => Ok(None),
         }
     }


### PR DESCRIPTION
## Motivation

After #5967 introduced Arc-shared caches with weak-index deduplication, several DbStorage read methods (read_confirmed_block, read_blob, read_event, etc.) used an insert-then-get pattern:

```rust
self.caches.confirmed_block.insert(&hash, block);
Ok(self.caches.confirmed_block.get(&hash))
```

The Arc returned by insert is dropped immediately. If the bounded cache (S3-FIFO) evicts the entry before get runs -- e.g., under high cache pressure or concurrent inserts -- and no other consumer holds a strong reference, the weak index entry becomes dead and get returns None. This turns a successful DB read into a spurious None, causing errors like `Missing confirmed block` in the chain listener.

## Proposal

Use the Arc returned by insert directly instead of round-tripping through get:

```rust
Ok(Some(self.caches.confirmed_block.insert(&hash, block)))
```

Fixed in 5 call sites:
- read_confirmed_block
- read_confirmed_blocks
- read_blob
- read_certificates_raw
- read_event

## Test Plan

- Existing CI tests pass
- Verified no other insert-then-get pattern exists (insert_hashed/get_hashed callers do not use this pattern)