### PR TITLE
Resolve some bugs with the "linera-explorer".

### DIFF
--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -342,8 +342,7 @@ impl From<&SystemOperation> for SystemOperationMetadata {
                 required_application_ids,
             } => SystemOperationMetadata {
                 create_application: Some(CreateApplicationOperationMetadata {
-                    module_id: serde_json::to_string(module_id)
-                        .unwrap_or_else(|_| format!("{:?}", module_id)),
+                    module_id: module_id.to_string(),
                     parameters_hex: hex::encode(parameters),
                     instantiation_argument_hex: hex::encode(instantiation_argument),
                     required_application_ids: required_application_ids.clone(),
@@ -364,8 +363,7 @@ impl From<&SystemOperation> for SystemOperationMetadata {
             },
             SystemOperation::PublishModule { module_id } => SystemOperationMetadata {
                 publish_module: Some(PublishModuleMetadata {
-                    module_id: serde_json::to_string(module_id)
-                        .unwrap_or_else(|_| format!("{:?}", module_id)),
+                    module_id: module_id.to_string(),
                 }),
                 ..SystemOperationMetadata::new("PublishModule")
             },

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -691,7 +691,10 @@ pub fn short_crypto_hash(s: &str) -> String {
 
 #[wasm_bindgen]
 pub fn short_app_id(s: &str) -> String {
-    format!("{}..{}..{}..", &s[..4], &s[64..68], &s[152..156])
+    if s.len() <= 12 {
+        return s.to_string();
+    }
+    format!("{}..{}", &s[..4], &s[s.len() - 4..])
 }
 
 fn set_onpopstate(app: JsValue) {

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -313,10 +313,10 @@ mod from {
                     )
                 })?;
 
-                let module_id: ModuleId = publish_module.module_id.parse().map_err(|_| {
-                    ConversionError::UnexpectedCertificateType(
-                        "Invalid module_id format".to_string(),
-                    )
+                let module_id: ModuleId = publish_module.module_id.parse().map_err(|e| {
+                    ConversionError::UnexpectedCertificateType(format!(
+                        "Invalid module_id format: {e}"
+                    ))
                 })?;
 
                 Ok(SystemOperation::PublishModule { module_id })
@@ -349,10 +349,10 @@ mod from {
                     )
                 })?;
 
-                let module_id: ModuleId = create_application.module_id.parse().map_err(|_| {
-                    ConversionError::UnexpectedCertificateType(
-                        "Invalid module_id format".to_string(),
-                    )
+                let module_id: ModuleId = create_application.module_id.parse().map_err(|e| {
+                    ConversionError::UnexpectedCertificateType(format!(
+                        "Invalid module_id format: {e}"
+                    ))
                 })?;
 
                 let parameters = hex::decode(create_application.parameters_hex).map_err(|_| {


### PR DESCRIPTION
## Motivation

The `linera-explorer` API had diverged from the use case of running on `linera-protocol`.

## Proposal

Address the following bugs:
* serde_json::to_string(module_id) double-quoted the value ("\"484a...\"") because JSON-serializing a string wraps it in quotes. Changed to module_id.to_string() (plain hex via Display), consistent with how blob_id and stream_id are already handled on adjacent lines. This was crashing the indexer on any block containing PublishModule or CreateApplication.
* short_app_id indexed into positions 64..68 and 152..156, but ApplicationId is now a single CryptoHash (64 hex chars). Index out of bounds → WASM panic → blank page whenever applications exist.

Another helpful change for finding bugs was done: Changed |_| to |e| so parse errors surface the real cause instead of a generic "Invalid module_id format

## Test Plan

CI

Local tests were done and it works!

## Release Plan

Could be backported to `testnet_conway`.

## Links

None.