### PR TITLE
Linera bridge relayer runbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5456,6 +5456,7 @@ dependencies = [
  "test-case",
  "thiserror 1.0.69",
  "tokio",
+ "tower 0.4.13",
  "tower-http 0.6.6",
  "tracing",
  "tracing-subscriber 0.3.19",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5438,6 +5438,7 @@ dependencies = [
  "test-case",
  "thiserror 1.0.69",
  "tokio",
+ "tower 0.4.13",
  "tower-http 0.6.6",
  "tracing",
  "tracing-subscriber 0.3.19",

--- a/docker/README.testnet.md
+++ b/docker/README.testnet.md
@@ -3,6 +3,9 @@
 This describes how to provision and operate a `linera-bridge` relayer
 on a single VM, bridging Base Sepolia (EVM) and Testnet Conway (Linera).
 
+For the full design rationale, see [`SPEC-linera-bridge-testnet-deployment.md`](../SPEC-linera-bridge-testnet-deployment.md)
+in the repo root.
+
 ## Prerequisites
 
 - A Linux VM with Docker + docker-compose
@@ -38,7 +41,17 @@ sudo chown root:root /etc/linera-bridge/.env.secret
 
 ### 3. Provision contracts and Linera apps
 
+Run setup.sh as the `linera-bridge` user so the wallet/keystore/storage
+files are owned by the same uid that the container runs as. The
+`--relayer-env` output goes to `/etc/linera-bridge/.env` which is root-
+writable, so allow that one path to the linera-bridge user via sudo or
+write the env file to a temporary location and `sudo cp` it into place.
+The simplest path:
+
 ```bash
+# Make /etc/linera-bridge writable by linera-bridge for this one provision
+sudo chown linera-bridge:linera-bridge /etc/linera-bridge
+sudo -u linera-bridge bash <<'EOF'
 cd examples/bridge-demo
 ./setup.sh \
   --evm-rpc-url https://sepolia.base.org \
@@ -48,14 +61,25 @@ cd examples/bridge-demo
   --linera-wallet /var/lib/linera-bridge/wallet.json \
   --linera-keystore /var/lib/linera-bridge/keystore.json \
   --linera-storage rocksdb:/var/lib/linera-bridge/client.db \
+  --shared-dir /var/lib/linera-bridge/shared \
   --relayer-env /etc/linera-bridge/.env
+EOF
+# Restore tighter ownership on /etc/linera-bridge
+sudo chown root:root /etc/linera-bridge
 ```
 
 This deploys `LightClient`, `MockERC20`, `FungibleBridge` on Base
 Sepolia, claims a Linera bridge chain on Conway, publishes the
 `evm-bridge` and `wrapped-fungible` apps, cross-registers their IDs,
 and writes `/etc/linera-bridge/.env` plus the wallet/keystore/storage
-under `/var/lib/linera-bridge/`.
+under `/var/lib/linera-bridge/`. Provisioning artifacts (LightClient
+constructor args, intermediate addresses) land in
+`/var/lib/linera-bridge/shared/` for inspection.
+
+`setup.sh` will run `linera wallet init --faucet` and `linera wallet
+request-chain --faucet` automatically when the wallet doesn't yet
+exist at `--linera-wallet`, so you do NOT need to pre-procure
+`--linera-bridge-chain-id` or `--relay-owner`.
 
 ### 4. Start the relayer
 
@@ -68,10 +92,10 @@ Verify it came up healthy:
 ```bash
 docker compose -f docker/docker-compose.bridge-testnet.yml ps
 # State should be 'running (healthy)' after ~60s.
-curl -s http://localhost:3001/health
-# Expected: 200 OK with empty body.
-curl -s http://localhost:3001/metrics | head -20
-# Expected: Prometheus text format with bridge_* metrics.
+curl -sI http://localhost:3001/health | head -1
+# Expected: HTTP/1.1 200 OK
+curl -s http://localhost:3001/metrics | grep '^linera_bridge_' | head -10
+# Expected: a handful of linera_bridge_* metrics in Prometheus text format
 ```
 
 ## Routine operations
@@ -151,24 +175,26 @@ the deployed artifacts are unrecoverable as well.
 The relayer exposes Prometheus metrics on `http://127.0.0.1:3001/metrics`.
 Key metrics for testnet operations:
 
-| Metric                          | Type        | Use                                          |
-|---------------------------------|-------------|----------------------------------------------|
-| `RELAYER_EVM_BALANCE_WEI`       | Gauge       | Alert when low (e.g., `< 1e16` = 0.01 ETH)   |
-| `RELAYER_LINERA_BALANCE_ATTO`   | Gauge       | Alert when low (e.g., `< 1e18`)              |
-| `DEPOSITS_PENDING`, `BURNS_PENDING` | IntGauge | Should drain; if growing, check logs        |
-| `DEPOSITS_FAILED`, `BURNS_FAILED`   | IntGauge | Any > 0 → investigate via SQLite            |
-| `LAST_SCANNED_EVM_BLOCK`        | IntGauge    | Should track Base Sepolia head               |
-| `LAST_SCANNED_LINERA_HEIGHT`    | IntGauge    | Should track Linera bridge chain head        |
+All metrics are namespaced `linera_bridge_*`:
+
+| Metric                                                     | Type        | Use                                          |
+|------------------------------------------------------------|-------------|----------------------------------------------|
+| `linera_bridge_evm_balance_wei`                            | Gauge       | Alert when low (e.g., `< 1e16` = 0.01 ETH)   |
+| `linera_bridge_linera_balance_atto`                        | Gauge       | Alert when low (e.g., `< 1e18`)              |
+| `linera_bridge_deposits_pending`, `linera_bridge_burns_pending` | IntGauge | Should drain; if growing, check logs        |
+| `linera_bridge_deposits_failed`, `linera_bridge_burns_failed`   | IntGauge | Any > 0 → investigate via SQLite            |
+| `linera_bridge_last_scanned_evm_block`                     | IntGauge    | Should track Base Sepolia head               |
+| `linera_bridge_last_scanned_linera_height`                 | IntGauge    | Should track Linera bridge chain head        |
 
 Suggested alert rules (apply on the external Prometheus):
 
 ```yaml
 - alert: LineraBridgeGasBalanceLow
-  expr: RELAYER_EVM_BALANCE_WEI < 1e16
+  expr: linera_bridge_evm_balance_wei < 1e16
   for: 5m
 
 - alert: LineraBridgeLineraBalanceLow
-  expr: RELAYER_LINERA_BALANCE_ATTO < 1e18
+  expr: linera_bridge_linera_balance_atto < 1e18
   for: 5m
 
 - alert: LineraBridgeDown
@@ -176,16 +202,17 @@ Suggested alert rules (apply on the external Prometheus):
   for: 2m
 
 - alert: LineraBridgePendingStuck
-  expr: DEPOSITS_FAILED > 0 OR BURNS_FAILED > 0
+  expr: linera_bridge_deposits_failed > 0 or linera_bridge_burns_failed > 0
   for: 15m
 ```
 
 ## Troubleshooting
 
-| Symptom                                 | Likely cause                                   | Action                                                    |
-|-----------------------------------------|------------------------------------------------|-----------------------------------------------------------|
-| Container restart-loop                  | Missing/malformed `/etc/linera-bridge/.env`    | Check `docker compose ... logs` for clap parse errors      |
-| `/health` returns connection refused    | Relayer process exited                         | Check logs; container should auto-restart                  |
-| `RELAYER_EVM_BALANCE_WEI` reads 0       | RPC unreachable, or wrong key                  | Check `RPC_URL`, verify key with `cast wallet address`    |
-| Pending deposits/burns stuck            | EVM gas too low, or RPC errors                 | Top up gas; check logs for retry messages                  |
-| Slow startup, no metrics for minutes    | RocksDB cache rebuilding from chain history    | Wait; check `LAST_SCANNED_LINERA_HEIGHT` is climbing       |
+| Symptom                                          | Likely cause                                   | Action                                                                          |
+|--------------------------------------------------|------------------------------------------------|---------------------------------------------------------------------------------|
+| Container restart-loop                           | Missing/malformed `/etc/linera-bridge/.env`    | Check `docker compose ... logs` for clap parse errors                            |
+| `/health` returns connection refused             | Relayer process exited                         | `restart: unless-stopped` will re-launch on exit; check logs and `ps`            |
+| Container "unhealthy" but listener still open    | Process hung (deadlock, RPC wedge)             | `docker compose restart relayer`; investigate hang in logs                       |
+| `linera_bridge_evm_balance_wei` reads 0          | RPC unreachable, or wrong key                  | Check `RPC_URL`, verify key with `cast wallet address`                           |
+| Pending deposits/burns stuck                     | EVM gas too low, or RPC errors                 | Top up gas; check logs for retry messages                                        |
+| Slow startup, no metrics for minutes             | RocksDB cache rebuilding from chain history    | Wait; check `linera_bridge_last_scanned_linera_height` is climbing               |

--- a/docker/README.testnet.md
+++ b/docker/README.testnet.md
@@ -1,0 +1,191 @@
+# Linera Bridge — Testnet Deployment Runbook
+
+This describes how to provision and operate a `linera-bridge` relayer
+on a single VM, bridging Base Sepolia (EVM) and Testnet Conway (Linera).
+
+## Prerequisites
+
+- A Linux VM with Docker + docker-compose
+- Foundry (`forge`, `cast`) and a recent `linera` binary on the VM (or
+  available inside docker images)
+- Outbound network access to:
+  - Base Sepolia RPC (`https://sepolia.base.org` or operator's provider)
+  - Testnet Conway faucet (`https://faucet.testnet-conway.linera.net`)
+- A funded Base Sepolia account (private key) for contract deployment
+  and `addBlock` signing
+
+## Initial deployment (one-time)
+
+### 1. Create directories with correct ownership
+
+```bash
+sudo useradd -r linera-bridge || true
+sudo mkdir -p /var/lib/linera-bridge /etc/linera-bridge
+sudo chown -R linera-bridge:linera-bridge /var/lib/linera-bridge
+sudo chmod 750 /var/lib/linera-bridge
+sudo chmod 755 /etc/linera-bridge
+```
+
+### 2. Drop the EVM signing key
+
+```bash
+sudo tee /etc/linera-bridge/.env.secret >/dev/null <<'EOF'
+EVM_PRIVATE_KEY=0x...
+EOF
+sudo chmod 600 /etc/linera-bridge/.env.secret
+sudo chown root:root /etc/linera-bridge/.env.secret
+```
+
+### 3. Provision contracts and Linera apps
+
+```bash
+cd examples/bridge-demo
+./setup.sh \
+  --evm-rpc-url https://sepolia.base.org \
+  --evm-chain-id 84532 \
+  --evm-private-key "$EVM_PRIVATE_KEY" \
+  --faucet-url https://faucet.testnet-conway.linera.net \
+  --linera-wallet /var/lib/linera-bridge/wallet.json \
+  --linera-keystore /var/lib/linera-bridge/keystore.json \
+  --linera-storage rocksdb:/var/lib/linera-bridge/client.db \
+  --relayer-env /etc/linera-bridge/.env
+```
+
+This deploys `LightClient`, `MockERC20`, `FungibleBridge` on Base
+Sepolia, claims a Linera bridge chain on Conway, publishes the
+`evm-bridge` and `wrapped-fungible` apps, cross-registers their IDs,
+and writes `/etc/linera-bridge/.env` plus the wallet/keystore/storage
+under `/var/lib/linera-bridge/`.
+
+### 4. Start the relayer
+
+```bash
+docker compose -f docker/docker-compose.bridge-testnet.yml up -d
+```
+
+Verify it came up healthy:
+
+```bash
+docker compose -f docker/docker-compose.bridge-testnet.yml ps
+# State should be 'running (healthy)' after ~60s.
+curl -s http://localhost:3001/health
+# Expected: 200 OK with empty body.
+curl -s http://localhost:3001/metrics | head -20
+# Expected: Prometheus text format with bridge_* metrics.
+```
+
+## Routine operations
+
+### Restart (after VM reboot or image update)
+
+```bash
+docker compose -f docker/docker-compose.bridge-testnet.yml up -d
+```
+
+Idempotent. Wallet, chain IDs, contracts persist across restarts.
+
+### Image update
+
+```bash
+docker compose -f docker/docker-compose.bridge-testnet.yml pull
+docker compose -f docker/docker-compose.bridge-testnet.yml up -d
+```
+
+### Top up Base Sepolia gas
+
+The relayer signs `addBlock` transactions on Base Sepolia. When ETH
+runs low, bridging stalls. Send ETH to the relayer's address (the
+public address of `EVM_PRIVATE_KEY`) — no relayer restart required.
+
+To find the address from the secret:
+
+```bash
+sudo cast wallet address \
+  --private-key "$(grep ^EVM_PRIVATE_KEY /etc/linera-bridge/.env.secret | cut -d= -f2-)"
+```
+
+### Inspect logs
+
+```bash
+journalctl CONTAINER_TAG=linera-bridge -f
+# or
+docker compose -f docker/docker-compose.bridge-testnet.yml logs -f
+```
+
+### Inspect pending bridge requests
+
+```bash
+sudo sqlite3 /var/lib/linera-bridge/bridge_relay.sqlite3 \
+  'SELECT * FROM deposits WHERE status != "completed";'
+sudo sqlite3 /var/lib/linera-bridge/bridge_relay.sqlite3 \
+  'SELECT * FROM burns WHERE status != "completed";'
+```
+
+(Schema names are illustrative; check actual schema with `.schema`.)
+
+## Backup
+
+Critical: loss of `/var/lib/linera-bridge` means loss of the Linera
+wallet that owns the bridge chain. The bridge becomes unusable and
+**re-provisioning is the only recovery** (which means a fresh bridge,
+new contract addresses, new chain, etc. — not a real recovery).
+
+Nightly backup:
+
+```bash
+# SQLite needs the .backup pragma for a consistent snapshot
+sudo sqlite3 /var/lib/linera-bridge/bridge_relay.sqlite3 \
+  ".backup /tmp/bridge_relay.sqlite3.bak"
+sudo rsync -a --delete /var/lib/linera-bridge/ \
+  backup-host:/snapshots/linera-bridge-$(date +%F)/
+sudo rsync /tmp/bridge_relay.sqlite3.bak \
+  backup-host:/snapshots/linera-bridge-$(date +%F)/bridge_relay.sqlite3
+sudo rm /tmp/bridge_relay.sqlite3.bak
+```
+
+Also back up `/etc/linera-bridge/` (both env files). Without those
+the deployed artifacts are unrecoverable as well.
+
+## Observability
+
+The relayer exposes Prometheus metrics on `http://127.0.0.1:3001/metrics`.
+Key metrics for testnet operations:
+
+| Metric                          | Type        | Use                                          |
+|---------------------------------|-------------|----------------------------------------------|
+| `RELAYER_EVM_BALANCE_WEI`       | Gauge       | Alert when low (e.g., `< 1e16` = 0.01 ETH)   |
+| `RELAYER_LINERA_BALANCE_ATTO`   | Gauge       | Alert when low (e.g., `< 1e18`)              |
+| `DEPOSITS_PENDING`, `BURNS_PENDING` | IntGauge | Should drain; if growing, check logs        |
+| `DEPOSITS_FAILED`, `BURNS_FAILED`   | IntGauge | Any > 0 → investigate via SQLite            |
+| `LAST_SCANNED_EVM_BLOCK`        | IntGauge    | Should track Base Sepolia head               |
+| `LAST_SCANNED_LINERA_HEIGHT`    | IntGauge    | Should track Linera bridge chain head        |
+
+Suggested alert rules (apply on the external Prometheus):
+
+```yaml
+- alert: LineraBridgeGasBalanceLow
+  expr: RELAYER_EVM_BALANCE_WEI < 1e16
+  for: 5m
+
+- alert: LineraBridgeLineraBalanceLow
+  expr: RELAYER_LINERA_BALANCE_ATTO < 1e18
+  for: 5m
+
+- alert: LineraBridgeDown
+  expr: up{job="linera-bridge"} == 0
+  for: 2m
+
+- alert: LineraBridgePendingStuck
+  expr: DEPOSITS_FAILED > 0 OR BURNS_FAILED > 0
+  for: 15m
+```
+
+## Troubleshooting
+
+| Symptom                                 | Likely cause                                   | Action                                                    |
+|-----------------------------------------|------------------------------------------------|-----------------------------------------------------------|
+| Container restart-loop                  | Missing/malformed `/etc/linera-bridge/.env`    | Check `docker compose ... logs` for clap parse errors      |
+| `/health` returns connection refused    | Relayer process exited                         | Check logs; container should auto-restart                  |
+| `RELAYER_EVM_BALANCE_WEI` reads 0       | RPC unreachable, or wrong key                  | Check `RPC_URL`, verify key with `cast wallet address`    |
+| Pending deposits/burns stuck            | EVM gas too low, or RPC errors                 | Top up gas; check logs for retry messages                  |
+| Slow startup, no metrics for minutes    | RocksDB cache rebuilding from chain history    | Wait; check `LAST_SCANNED_LINERA_HEIGHT` is climbing       |

--- a/docker/README.testnet.md
+++ b/docker/README.testnet.md
@@ -133,14 +133,25 @@ docker compose -f docker/docker-compose.bridge-testnet.yml logs -f
 
 ### Inspect pending bridge requests
 
+The relay splits live work and history into separate tables: `pending_*`
+holds work the relay is currently chasing; `finished_*` holds completed
+or permanently-failed entries with a `status` column.
+
 ```bash
+# live work queue
 sudo sqlite3 /var/lib/linera-bridge/bridge_relay.sqlite3 \
-  'SELECT * FROM deposits WHERE status != "completed";'
+  'SELECT * FROM pending_deposits;'
 sudo sqlite3 /var/lib/linera-bridge/bridge_relay.sqlite3 \
-  'SELECT * FROM burns WHERE status != "completed";'
+  'SELECT * FROM pending_burns;'
+
+# permanent failures (status = 'failed' or 'completed')
+sudo sqlite3 /var/lib/linera-bridge/bridge_relay.sqlite3 \
+  "SELECT * FROM finished_deposits WHERE status = 'failed';"
+sudo sqlite3 /var/lib/linera-bridge/bridge_relay.sqlite3 \
+  "SELECT * FROM finished_burns WHERE status = 'failed';"
 ```
 
-(Schema names are illustrative; check actual schema with `.schema`.)
+(Check the actual schema with `.schema` if column lists differ.)
 
 ## Backup
 
@@ -172,14 +183,16 @@ Key metrics for testnet operations:
 
 All metrics are namespaced `linera_bridge_*`:
 
-| Metric                                                     | Type        | Use                                          |
-|------------------------------------------------------------|-------------|----------------------------------------------|
-| `linera_bridge_evm_balance_wei`                            | Gauge       | Alert when low (e.g., `< 1e16` = 0.01 ETH)   |
-| `linera_bridge_linera_balance_atto`                        | Gauge       | Alert when low (e.g., `< 1e18`)              |
-| `linera_bridge_deposits_pending`, `linera_bridge_burns_pending` | IntGauge | Should drain; if growing, check logs        |
-| `linera_bridge_deposits_failed`, `linera_bridge_burns_failed`   | IntGauge | Any > 0 → investigate via SQLite            |
-| `linera_bridge_last_scanned_evm_block`                     | IntGauge    | Should track Base Sepolia head               |
-| `linera_bridge_last_scanned_linera_height`                 | IntGauge    | Should track Linera bridge chain head        |
+| Metric                                                          | Type     | Use                                                   |
+|-----------------------------------------------------------------|----------|-------------------------------------------------------|
+| `linera_bridge_evm_balance_wei`                                 | Gauge    | Alert when low (e.g., `< 1e16` = 0.01 ETH)            |
+| `linera_bridge_linera_balance_atto`                             | Gauge    | Alert when low (e.g., `< 1e18`)                       |
+| `linera_bridge_deposits_pending`, `linera_bridge_burns_pending` | IntGauge | Should drain; if growing, check logs                  |
+| `linera_bridge_deposits_failed`, `linera_bridge_burns_failed`   | IntGauge | Any > 0 → investigate via SQLite                      |
+| `linera_bridge_deposits_detected`, `linera_bridge_burns_detected`     | Counter | Total seen by scanners (cumulative)             |
+| `linera_bridge_deposits_completed`, `linera_bridge_burns_completed`   | Counter | Total successfully processed (cumulative)       |
+| `linera_bridge_last_scanned_evm_block`                          | IntGauge | Should track Base Sepolia head                        |
+| `linera_bridge_last_scanned_linera_height`                      | IntGauge | Should track Linera bridge chain head                 |
 
 Suggested alert rules (apply on the external Prometheus):
 
@@ -196,8 +209,20 @@ Suggested alert rules (apply on the external Prometheus):
   expr: up{job="linera-bridge"} == 0
   for: 2m
 
-- alert: LineraBridgePendingStuck
+# Permanent failure: relay marked items as terminally failed.
+- alert: LineraBridgePermanentFailure
   expr: linera_bridge_deposits_failed > 0 or linera_bridge_burns_failed > 0
+  for: 15m
+
+# Throughput stall: pending work exists but nothing is being completed.
+# Catches a stuck relay even when no item has been marked permanently failed yet.
+- alert: LineraBridgePendingStuck
+  expr: |
+    (linera_bridge_deposits_pending > 0
+     and rate(linera_bridge_deposits_completed[15m]) == 0)
+    or
+    (linera_bridge_burns_pending > 0
+     and rate(linera_bridge_burns_completed[15m]) == 0)
   for: 15m
 ```
 

--- a/docker/README.testnet.md
+++ b/docker/README.testnet.md
@@ -3,9 +3,6 @@
 This describes how to provision and operate a `linera-bridge` relayer
 on a single VM, bridging Base Sepolia (EVM) and Testnet Conway (Linera).
 
-For the full design rationale, see [`SPEC-linera-bridge-testnet-deployment.md`](../SPEC-linera-bridge-testnet-deployment.md)
-in the repo root.
-
 ## Prerequisites
 
 - A Linux VM with Docker + docker-compose

--- a/docker/README.testnet.md
+++ b/docker/README.testnet.md
@@ -36,47 +36,45 @@ sudo chmod 600 /etc/linera-bridge/.env.secret
 sudo chown root:root /etc/linera-bridge/.env.secret
 ```
 
-### 3. Provision contracts and Linera apps
+### 3. Provision contracts, Linera apps, wallet, env file
 
-Run setup.sh as the `linera-bridge` user so the wallet/keystore/storage
-files are owned by the same uid that the container runs as. The
-`--relayer-env` output goes to `/etc/linera-bridge/.env` which is root-
-writable, so allow that one path to the linera-bridge user via sudo or
-write the env file to a temporary location and `sudo cp` it into place.
-The simplest path:
+Production provisioning tooling is out of scope of this runbook —
+`examples/bridge-demo/setup.sh` is for local development only and is not
+reused here. The operator must end up with:
 
-```bash
-# Make /etc/linera-bridge writable by linera-bridge for this one provision
-sudo chown linera-bridge:linera-bridge /etc/linera-bridge
-sudo -u linera-bridge bash <<'EOF'
-cd examples/bridge-demo
-./setup.sh \
-  --evm-rpc-url https://sepolia.base.org \
-  --evm-chain-id 84532 \
-  --evm-private-key "$EVM_PRIVATE_KEY" \
-  --faucet-url https://faucet.testnet-conway.linera.net \
-  --linera-wallet /var/lib/linera-bridge/wallet.json \
-  --linera-keystore /var/lib/linera-bridge/keystore.json \
-  --linera-storage rocksdb:/var/lib/linera-bridge/client.db \
-  --shared-dir /var/lib/linera-bridge/shared \
-  --relayer-env /etc/linera-bridge/.env
-EOF
-# Restore tighter ownership on /etc/linera-bridge
-sudo chown root:root /etc/linera-bridge
+- `/var/lib/linera-bridge/wallet.json`, `keystore.json`, `client.db`:
+  Linera wallet that owns the bridge chain (the relay container reads
+  these via the bind-mount at `/data`).
+- `/etc/linera-bridge/.env`: env file with the keys consumed by
+  `bridge-entrypoint.sh`. Use `/data/...` paths inside (the host bind-mount
+  exposes `/var/lib/linera-bridge` at `/data` in the container).
+
+```
+# /etc/linera-bridge/.env
+RPC_URL=https://sepolia.base.org
+FAUCET_URL=https://faucet.testnet-conway.linera.net
+EVM_BRIDGE_ADDRESS=0x...
+LINERA_BRIDGE_APP=...                 # evm-bridge app ID (64 hex)
+LINERA_FUNGIBLE_APP=...               # wrapped-fungible app ID (64 hex)
+LINERA_BRIDGE_CHAIN_ID=...            # 64 hex
+LINERA_BRIDGE_CHAIN_OWNER=0x...       # AccountOwner that owns bridge chain
+LINERA_WALLET=/data/wallet.json
+LINERA_KEYSTORE=/data/keystore.json
+LINERA_STORAGE=rocksdb:/data/client.db
+MONITOR_SCAN_INTERVAL=30
+MONITOR_START_BLOCK=...               # FungibleBridge deploy block
+MAX_RETRIES=10
+PORT=3001
 ```
 
-This deploys `LightClient`, `MockERC20`, `FungibleBridge` on Base
-Sepolia, claims a Linera bridge chain on Conway, publishes the
-`evm-bridge` and `wrapped-fungible` apps, cross-registers their IDs,
-and writes `/etc/linera-bridge/.env` plus the wallet/keystore/storage
-under `/var/lib/linera-bridge/`. Provisioning artifacts (LightClient
-constructor args, intermediate addresses) land in
-`/var/lib/linera-bridge/shared/` for inspection.
+Production EVM contracts (`LightClient`, `FungibleBridge`,
+`MockERC20`-or-real-ERC20), the bridge chain, and the two Linera apps
+(`evm-bridge`, `wrapped-fungible`) are deployed/registered out-of-band by
+the team's deployment tooling. The output artifacts populate the env file
+above.
 
-`setup.sh` will run `linera wallet init --faucet` and `linera wallet
-request-chain --faucet` automatically when the wallet doesn't yet
-exist at `--linera-wallet`, so you do NOT need to pre-procure
-`--linera-bridge-chain-id` or `--relay-owner`.
+The `linera-bridge` container will read `/etc/linera-bridge/.env` and
+`/etc/linera-bridge/.env.secret` at startup.
 
 ### 4. Start the relayer
 

--- a/docker/bridge-entrypoint.sh
+++ b/docker/bridge-entrypoint.sh
@@ -16,7 +16,7 @@ set -- linera-bridge serve \
     --linera-bridge-address="${LINERA_BRIDGE_APP:?LINERA_BRIDGE_APP is required}" \
     --linera-fungible-address="${LINERA_FUNGIBLE_APP:?LINERA_FUNGIBLE_APP is required}" \
     --evm-private-key="${EVM_PRIVATE_KEY:?EVM_PRIVATE_KEY is required}" \
-    --port="${PORT:-5001}" \
+    --port="${PORT:-3001}" \
     --monitor-scan-interval="${MONITOR_SCAN_INTERVAL:-30}" \
     --monitor-start-block="${MONITOR_START_BLOCK:-0}" \
     --max-retries="${MAX_RETRIES:-10}" \

--- a/docker/bridge-entrypoint.sh
+++ b/docker/bridge-entrypoint.sh
@@ -18,7 +18,7 @@ set -- linera-bridge serve \
     --evm-private-key="${EVM_PRIVATE_KEY:?EVM_PRIVATE_KEY is required}" \
     --linera-bridge-chain-id="${LINERA_BRIDGE_CHAIN_ID:?LINERA_BRIDGE_CHAIN_ID is required}" \
     --linera-bridge-chain-owner="${LINERA_BRIDGE_CHAIN_OWNER:?LINERA_BRIDGE_CHAIN_OWNER is required}" \
-    --port="${PORT:-5001}" \
+    --port="${PORT:-3001}" \
     --monitor-scan-interval="${MONITOR_SCAN_INTERVAL:-30}" \
     --monitor-start-block="${MONITOR_START_BLOCK:-0}" \
     --max-retries="${MAX_RETRIES:-10}" \

--- a/docker/docker-compose.bridge-testnet.yml
+++ b/docker/docker-compose.bridge-testnet.yml
@@ -22,7 +22,10 @@ services:
     volumes:
       - /var/lib/linera-bridge:/data
     healthcheck:
-      test: ["CMD", "sh", "-c", "wget -qO- http://localhost:3001/health || exit 1"]
+      # The runtime image only ships netcat (no wget/curl). A bare TCP probe
+      # is enough — the /health route exists for any axum-based liveness
+      # checks downstream collectors might run separately.
+      test: ["CMD", "nc", "-z", "localhost", "3001"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker/docker-compose.bridge-testnet.yml
+++ b/docker/docker-compose.bridge-testnet.yml
@@ -1,0 +1,33 @@
+# Long-running linera-bridge relayer for testnet deployments.
+#
+# Prerequisites (operator must do once on the VM):
+#   1. Create /var/lib/linera-bridge (data) and /etc/linera-bridge (env)
+#   2. Run examples/bridge-demo/setup.sh in direct mode with
+#      --relayer-env /etc/linera-bridge/.env to populate both directories
+#   3. Drop the EVM signing key in /etc/linera-bridge/.env.secret
+#      (mode 0600, root:root): EVM_PRIVATE_KEY=0x...
+#
+# See docker/README.testnet.md for the full procedure.
+services:
+  relayer:
+    image: linera-bridge:${BRIDGE_TAG:-testnet_conway}
+    restart: unless-stopped
+    env_file:
+      - /etc/linera-bridge/.env
+      - /etc/linera-bridge/.env.secret
+    ports:
+      # Loopback only — /metrics and /health are not public-facing.
+      # Scrape via SSH tunnel or VPN from the ops network.
+      - "127.0.0.1:3001:3001"
+    volumes:
+      - /var/lib/linera-bridge:/data
+    healthcheck:
+      test: ["CMD", "sh", "-c", "wget -qO- http://localhost:3001/health || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 60s
+    logging:
+      driver: journald
+      options:
+        tag: linera-bridge

--- a/docker/docker-compose.bridge-testnet.yml
+++ b/docker/docker-compose.bridge-testnet.yml
@@ -10,7 +10,7 @@
 # See docker/README.testnet.md for the full procedure.
 services:
   relayer:
-    image: linera-bridge:${BRIDGE_TAG:-testnet_conway}
+    image: us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-bridge:testnet_conway_internal
     restart: unless-stopped
     env_file:
       - /etc/linera-bridge/.env

--- a/docker/docker-compose.bridge-testnet.yml
+++ b/docker/docker-compose.bridge-testnet.yml
@@ -1,9 +1,17 @@
-# Long-running linera-bridge relayer for testnet deployments.
+# Long-running linera-bridge relayer.
 #
-# Prerequisites (operator must do once on the VM):
+# Defaults match the testnet host layout (env at /etc/linera-bridge,
+# data at /var/lib/linera-bridge). Override RELAYER_ENV_FILE,
+# RELAYER_ENV_SECRET, RELAYER_DATA_DIR to reuse this compose file
+# from a developer machine.
+#
+# Prerequisites (testnet operator does this once on the VM):
 #   1. Create /var/lib/linera-bridge (data) and /etc/linera-bridge (env)
-#   2. Run examples/bridge-demo/setup.sh in direct mode with
-#      --relayer-env /etc/linera-bridge/.env to populate both directories
+#   2. Populate /etc/linera-bridge/.env with the keys consumed by
+#      bridge-entrypoint.sh (RPC_URL, FAUCET_URL, EVM_BRIDGE_ADDRESS,
+#      LINERA_BRIDGE_APP, LINERA_FUNGIBLE_APP, LINERA_BRIDGE_CHAIN_ID,
+#      LINERA_BRIDGE_CHAIN_OWNER, LINERA_WALLET, LINERA_KEYSTORE,
+#      LINERA_STORAGE, MONITOR_*, MAX_RETRIES, PORT)
 #   3. Drop the EVM signing key in /etc/linera-bridge/.env.secret
 #      (mode 0600, root:root): EVM_PRIVATE_KEY=0x...
 #
@@ -13,14 +21,14 @@ services:
     image: us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-bridge:testnet_conway_internal
     restart: unless-stopped
     env_file:
-      - /etc/linera-bridge/.env
-      - /etc/linera-bridge/.env.secret
+      - ${RELAYER_ENV_FILE:-/etc/linera-bridge/.env}
+      - ${RELAYER_ENV_SECRET:-/etc/linera-bridge/.env.secret}
     ports:
       # Loopback only — /metrics and /health are not public-facing.
       # Scrape via SSH tunnel or VPN from the ops network.
       - "127.0.0.1:3001:3001"
     volumes:
-      - /var/lib/linera-bridge:/data
+      - ${RELAYER_DATA_DIR:-/var/lib/linera-bridge}:/data
     healthcheck:
       # The runtime image only ships netcat (no wget/curl). A bare TCP probe
       # is enough — the /health route exists for any axum-based liveness

--- a/docker/docker-compose.bridge-testnet.yml
+++ b/docker/docker-compose.bridge-testnet.yml
@@ -34,3 +34,11 @@ services:
       driver: journald
       options:
         tag: linera-bridge
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
+        reservations:
+          cpus: "0.25"
+          memory: 256M

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -422,6 +422,13 @@ BRIDGE_OUTPUT=$(evm_exec \
     "$TOKEN_ADDRESS")
 BRIDGE_ADDRESS=$(echo "$BRIDGE_OUTPUT" | parse_address)
 wait_for_tx "$(echo "$BRIDGE_OUTPUT" | parse_tx_hash)"
+# Capture deployment block so the relayer can start its EVM monitor scan
+# at the right place instead of scanning from genesis on every fresh deploy.
+BRIDGE_DEPLOY_TX="$(echo "$BRIDGE_OUTPUT" | parse_tx_hash)"
+BRIDGE_DEPLOY_BLOCK="$(evm_exec cast receipt --json \
+    --rpc-url "$EVM_RPC_URL" "$BRIDGE_DEPLOY_TX" \
+    | python3 -c "import json,sys; print(int(json.load(sys.stdin)['blockNumber'], 16))")"
+echo "  FungibleBridge deployed in block: $BRIDGE_DEPLOY_BLOCK"
 validate_eth_address "FungibleBridge address" "$BRIDGE_ADDRESS"
 BRIDGE_ADDR_HEX=$(echo "$BRIDGE_ADDRESS" | sed 's/^0x//')
 echo "  FungibleBridge: $BRIDGE_ADDRESS"

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -27,6 +27,7 @@ TOKEN_ADDRESS=""
 WASM_DIR=""
 CONTRACTS_DIR=""
 OUTPUT_FILE=""
+RELAYER_ENV_FILE=""
 FAUCET_URL=""
 RELAY_URL=""
 RELAY_OWNER=""
@@ -93,6 +94,10 @@ Options:
                             Docker default: /contracts
                             Direct default: ../../linera-bridge/src/solidity
   --output PATH             Output env file (default: .env.local in script dir)
+  --relayer-env PATH        Output file with the env schema consumed by
+                            docker/docker-compose.bridge-testnet.yml
+                            (different schema than --output, which writes
+                            the demo frontend env)
   --faucet-url URL          Linera faucet URL (default: http://localhost:8080)
   --relay-url URL           Relay service URL (default: http://localhost:3001)
   --relay-owner OWNER       Relay's AccountOwner (minter for wrapped-fungible)
@@ -123,6 +128,7 @@ while [[ $# -gt 0 ]]; do
         --wasm-dir)          WASM_DIR="$2"; shift 2 ;;
         --contracts-dir)     CONTRACTS_DIR="$2"; shift 2 ;;
         --output)            OUTPUT_FILE="$2"; shift 2 ;;
+        --relayer-env)       RELAYER_ENV_FILE="$2"; shift 2 ;;
         --faucet-url)        FAUCET_URL="$2"; shift 2 ;;
         --relay-url)         RELAY_URL="$2"; shift 2 ;;
         --relay-owner)       RELAY_OWNER="$2"; shift 2 ;;
@@ -583,6 +589,35 @@ LINERA_TOKEN_ADDRESS=$TOKEN_ADDRESS
 LINERA_BRIDGE_CHAIN_ID=$BRIDGE_CHAIN_ID
 LINERA_EVM_CHAIN_ID=$EVM_CHAIN_ID
 EOF
+
+# ── Relayer env file (consumed by docker-compose.bridge-testnet.yml) ──
+if [[ -n "$RELAYER_ENV_FILE" ]]; then
+    echo "Writing relayer env to $RELAYER_ENV_FILE..."
+    # Paths inside the relayer container — the host bind-mount is
+    # /var/lib/linera-bridge mounted at /data, so the relayer sees
+    # /data/wallet.json etc.
+    cat > "$RELAYER_ENV_FILE" << EOF
+# Chain endpoints
+RPC_URL=$EVM_RPC_URL
+FAUCET_URL=$FAUCET_URL
+
+# Deployed artifacts
+EVM_BRIDGE_ADDRESS=$BRIDGE_ADDRESS
+EVM_TOKEN_ADDRESS=$TOKEN_ADDRESS
+LINERA_BRIDGE_CHAIN_ID=$BRIDGE_CHAIN_ID
+LINERA_BRIDGE_CHAIN_OWNER=$RELAY_OWNER
+LINERA_BRIDGE_APP=$BRIDGE_APP_ID
+LINERA_FUNGIBLE_APP=$WRAPPED_APP_ID
+
+# Runtime
+LINERA_WALLET=/data/wallet.json
+LINERA_KEYSTORE=/data/keystore.json
+LINERA_STORAGE=rocksdb:/data/client.db
+MONITOR_START_BLOCK=$BRIDGE_DEPLOY_BLOCK
+MONITOR_SCAN_INTERVAL=30
+MAX_RETRIES=10
+EOF
+fi
 
 # Write setup-complete marker so the relay knows it's safe to start.
 if [[ -n "$COMPOSE_FILE" ]]; then

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -216,7 +216,9 @@ if [[ -n "$COMPOSE_FILE" ]]; then
 else
     echo "Mode: Direct"
     [[ -z "$EVM_PRIVATE_KEY" ]] && die "--evm-private-key is required in direct mode"
-    [[ -z "$BRIDGE_CHAIN_ID" ]] && die "--linera-bridge-chain-id is required in direct mode"
+    # BRIDGE_CHAIN_ID and RELAY_OWNER may be auto-derived later from a fresh
+    # wallet init + chain claim; their requirement is checked below after the
+    # wallet bootstrap step.
     EVM_RPC_URL="${EVM_RPC_URL:-http://localhost:8545}"
     WASM_DIR="${WASM_DIR:-$SCRIPT_DIR/../../examples/target/wasm32-unknown-unknown/release}"
     CONTRACTS_DIR="${CONTRACTS_DIR:-$SCRIPT_DIR/../../linera-bridge/src/solidity}"
@@ -277,11 +279,39 @@ if [[ -z "$COMPOSE_FILE" ]]; then
         LINERA_WALLET_PATH="$LINERA_TMP_DIR/wallet.json"
         LINERA_KEYSTORE_PATH="$LINERA_TMP_DIR/keystore.json"
         LINERA_STORAGE_PATH="rocksdb:$LINERA_TMP_DIR/client.db"
-        if [[ ! -f "$LINERA_WALLET_PATH" ]]; then
-            echo "Initializing Linera wallet from faucet..."
-            linera_exec wallet init --faucet "$FAUCET_URL"
-        else
-            echo "  Using existing wallet at $LINERA_TMP_DIR"
+    fi
+
+    # Bootstrap the wallet from the faucet if it doesn't exist yet, then
+    # claim a fresh chain to act as the bridge chain. This makes a real-network
+    # deploy work without the operator having to procure chain ID / owner
+    # out-of-band; if they pass --linera-bridge-chain-id and --relay-owner the
+    # auto-derive steps are skipped.
+    if [[ ! -f "$LINERA_WALLET_PATH" ]]; then
+        [[ -z "$FAUCET_URL" ]] && die "--faucet-url is required to initialize a new wallet at $LINERA_WALLET_PATH"
+        echo "Initializing Linera wallet from faucet at $LINERA_WALLET_PATH..."
+        linera_exec wallet init --faucet "$FAUCET_URL"
+    else
+        echo "  Using existing wallet at $LINERA_WALLET_PATH"
+    fi
+
+    if [[ -z "$BRIDGE_CHAIN_ID" || -z "$RELAY_OWNER" ]]; then
+        [[ -z "$FAUCET_URL" ]] && die "--faucet-url is required to claim a bridge chain when --linera-bridge-chain-id / --relay-owner are not provided"
+        echo "Claiming bridge chain from faucet..."
+        CHAIN_CLAIM_OUTPUT="$(linera_exec wallet request-chain --faucet "$FAUCET_URL" 2>&1)"
+        echo "$CHAIN_CLAIM_OUTPUT"
+        # request-chain prints the new chain ID (64-char hex on its own line)
+        # and the AccountOwner that received it (0x-prefixed 64-hex). The same
+        # pattern is used by docker/docker-compose.bridge-test.yml to populate
+        # /shared/{bridge-chain-id,relay-owner} for the e2e relay.
+        if [[ -z "$BRIDGE_CHAIN_ID" ]]; then
+            BRIDGE_CHAIN_ID="$(echo "$CHAIN_CLAIM_OUTPUT" | grep -oE '^[a-f0-9]{64}$' | tail -1)"
+            [[ -z "$BRIDGE_CHAIN_ID" ]] && die "Could not extract bridge chain ID from request-chain output"
+            echo "  Auto-derived bridge chain ID: $BRIDGE_CHAIN_ID"
+        fi
+        if [[ -z "$RELAY_OWNER" ]]; then
+            RELAY_OWNER="$(echo "$CHAIN_CLAIM_OUTPUT" | grep -oE '0x[a-f0-9]{64}' | tail -1)"
+            [[ -z "$RELAY_OWNER" ]] && die "Could not extract relay owner from request-chain output"
+            echo "  Auto-derived relay owner: $RELAY_OWNER"
         fi
     fi
 fi
@@ -406,7 +436,10 @@ if [[ -n "$COMPOSE_FILE" ]]; then
     done
     [[ -z "$RELAY_OWNER" ]] && die "Relay owner not found within timeout"
 else
-    [[ -z "$RELAY_OWNER" ]] && die "--relay-owner is required in direct mode"
+    # In direct mode, RELAY_OWNER is set in the wallet bootstrap step above
+    # — either passed explicitly via --relay-owner or auto-derived from the
+    # request-chain output. If it's still empty here, the bootstrap failed.
+    [[ -z "$RELAY_OWNER" ]] && die "Relay owner unset after wallet bootstrap (this is a bug; check earlier output)"
 fi
 echo "  Relay owner (minter): $RELAY_OWNER"
 
@@ -427,13 +460,15 @@ BRIDGE_OUTPUT=$(evm_exec \
     "$CHAIN_BYTES32" \
     "$TOKEN_ADDRESS")
 BRIDGE_ADDRESS=$(echo "$BRIDGE_OUTPUT" | parse_address)
-wait_for_tx "$(echo "$BRIDGE_OUTPUT" | parse_tx_hash)"
+BRIDGE_DEPLOY_TX=$(echo "$BRIDGE_OUTPUT" | parse_tx_hash)
+wait_for_tx "$BRIDGE_DEPLOY_TX"
 # Capture deployment block so the relayer can start its EVM monitor scan
 # at the right place instead of scanning from genesis on every fresh deploy.
-BRIDGE_DEPLOY_TX="$(echo "$BRIDGE_OUTPUT" | parse_tx_hash)"
+# `cast receipt --json` historically returned blockNumber as 0x-prefixed hex,
+# but newer versions sometimes emit decimal. `int(v, 0)` accepts both.
 BRIDGE_DEPLOY_BLOCK="$(evm_exec cast receipt --json \
     --rpc-url "$EVM_RPC_URL" "$BRIDGE_DEPLOY_TX" \
-    | python3 -c "import json,sys; print(int(json.load(sys.stdin)['blockNumber'], 16))")"
+    | python3 -c "import json,sys; v=json.load(sys.stdin)['blockNumber']; print(int(v,0) if isinstance(v,str) else v)")"
 echo "  FungibleBridge deployed in block: $BRIDGE_DEPLOY_BLOCK"
 validate_eth_address "FungibleBridge address" "$BRIDGE_ADDRESS"
 BRIDGE_ADDR_HEX=$(echo "$BRIDGE_ADDRESS" | sed 's/^0x//')

--- a/linera-bridge/Cargo.toml
+++ b/linera-bridge/Cargo.toml
@@ -162,3 +162,4 @@ alloy-sol-types.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
 test-case.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tower = { workspace = true, features = ["util"] }

--- a/linera-bridge/Cargo.toml
+++ b/linera-bridge/Cargo.toml
@@ -159,3 +159,4 @@ alloy-sol-types.workspace = true
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "sqlite"] }
 test-case.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tower = { workspace = true, features = ["util"] }

--- a/linera-bridge/src/monitor/db.rs
+++ b/linera-bridge/src/monitor/db.rs
@@ -6,6 +6,12 @@
 //! This is a write-through layer alongside the in-memory `MonitorState`.
 //! It persists request metadata and raw operation bytes so they can be
 //! queried and replayed without the relayer running.
+//!
+//! Pending and finished requests live in separate tables (`pending_deposits`/
+//! `finished_deposits`, `pending_burns`/`finished_burns`) so that the hot
+//! `load_pending_*` queries scan only live work and stay fast as historical
+//! volume grows. Completion or failure moves a row from the pending table to
+//! the finished table atomically.
 
 use std::path::Path;
 
@@ -54,7 +60,7 @@ impl BridgeDb {
 
     async fn create_tables(&self) -> Result<()> {
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS deposits (
+            "CREATE TABLE IF NOT EXISTS pending_deposits (
                 source_chain_id   INTEGER NOT NULL,
                 block_hash        BLOB NOT NULL,
                 tx_index          INTEGER NOT NULL,
@@ -63,55 +69,71 @@ impl BridgeDb {
                 depositor         BLOB NOT NULL,
                 amount            TEXT NOT NULL,
                 nonce             TEXT NOT NULL,
-                status            TEXT NOT NULL DEFAULT 'pending',
                 raw_operation     BLOB,
                 created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
                 PRIMARY KEY (source_chain_id, block_hash, tx_index, log_index)
             )",
         )
         .execute(&self.pool)
         .await?;
 
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_deposits_status ON deposits(status)")
-            .execute(&self.pool)
-            .await?;
-
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_deposits_depositor ON deposits(depositor)")
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS finished_deposits (
+                source_chain_id   INTEGER NOT NULL,
+                block_hash        BLOB NOT NULL,
+                tx_index          INTEGER NOT NULL,
+                log_index         INTEGER NOT NULL,
+                tx_hash           BLOB NOT NULL,
+                depositor         BLOB NOT NULL,
+                amount            TEXT NOT NULL,
+                nonce             TEXT NOT NULL,
+                raw_operation     BLOB,
+                status            TEXT NOT NULL,
+                created_at        TEXT NOT NULL,
+                finished_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                PRIMARY KEY (source_chain_id, block_hash, tx_index, log_index)
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
 
         sqlx::query(
-            "CREATE TABLE IF NOT EXISTS burns (
+            "CREATE TABLE IF NOT EXISTS pending_burns (
                 linera_height     INTEGER NOT NULL,
                 burn_index        INTEGER NOT NULL,
                 evm_recipient     TEXT NOT NULL,
                 amount            TEXT NOT NULL,
-                status            TEXT NOT NULL DEFAULT 'pending',
                 raw_cert          BLOB,
                 created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                updated_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
                 PRIMARY KEY (linera_height, burn_index)
             )",
         )
         .execute(&self.pool)
         .await?;
 
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_burns_status ON burns(status)")
-            .execute(&self.pool)
-            .await?;
-
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_burns_evm_recipient ON burns(evm_recipient)")
-            .execute(&self.pool)
-            .await?;
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS finished_burns (
+                linera_height     INTEGER NOT NULL,
+                burn_index        INTEGER NOT NULL,
+                evm_recipient     TEXT NOT NULL,
+                amount            TEXT NOT NULL,
+                raw_cert          BLOB,
+                status            TEXT NOT NULL,
+                created_at        TEXT NOT NULL,
+                finished_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+                PRIMARY KEY (linera_height, burn_index)
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
 
         Ok(())
     }
 
-    /// Inserts a new deposit. Ignores duplicates (idempotent).
+    /// Inserts a new pending deposit. Ignores duplicates (idempotent).
     pub async fn insert_deposit(&self, deposit: &PendingDeposit) -> Result<()> {
         sqlx::query(
-            "INSERT OR IGNORE INTO deposits
+            "INSERT OR IGNORE INTO pending_deposits
                 (source_chain_id, block_hash, tx_index, log_index, tx_hash, depositor, amount, nonce)
              VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
@@ -128,10 +150,23 @@ impl BridgeDb {
         Ok(())
     }
 
-    /// Updates a deposit's status and timestamp.
+    /// Atomically moves a deposit from `pending_deposits` to `finished_deposits`
+    /// with the given terminal `status` (`"completed"` or `"failed"`).
+    ///
+    /// If `finished_deposits` already has a row for this key (replay scenario),
+    /// the existing record is preserved and a warning is logged. The matching
+    /// pending row is still deleted so the deposit does not stay queued.
     pub async fn update_deposit_status(&self, key: &DepositKey, status: &str) -> Result<()> {
-        sqlx::query(
-            "UPDATE deposits SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        let mut tx = self.pool.begin().await?;
+        let inserted = sqlx::query(
+            "INSERT OR IGNORE INTO finished_deposits
+                (source_chain_id, block_hash, tx_index, log_index,
+                 tx_hash, depositor, amount, nonce, raw_operation,
+                 status, created_at)
+             SELECT source_chain_id, block_hash, tx_index, log_index,
+                    tx_hash, depositor, amount, nonce, raw_operation,
+                    ?, created_at
+             FROM pending_deposits
              WHERE source_chain_id = ? AND block_hash = ? AND tx_index = ? AND log_index = ?",
         )
         .bind(status)
@@ -139,15 +174,34 @@ impl BridgeDb {
         .bind(key.block_hash.as_slice())
         .bind(key.tx_index as i64)
         .bind(key.log_index as i64)
-        .execute(&self.pool)
-        .await?;
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+        let deleted = sqlx::query(
+            "DELETE FROM pending_deposits
+             WHERE source_chain_id = ? AND block_hash = ? AND tx_index = ? AND log_index = ?",
+        )
+        .bind(key.source_chain_id as i64)
+        .bind(key.block_hash.as_slice())
+        .bind(key.tx_index as i64)
+        .bind(key.log_index as i64)
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+        tx.commit().await?;
+        if deleted > 0 && inserted == 0 {
+            tracing::warn!(
+                ?key,
+                "Replay detected: deposit already in finished_deposits, original record kept"
+            );
+        }
         Ok(())
     }
 
-    /// Stores raw BCS-serialized operation bytes for a deposit.
+    /// Stores raw BCS-serialized operation bytes on the pending deposit row.
     pub async fn store_deposit_raw(&self, key: &DepositKey, raw: &[u8]) -> Result<()> {
         sqlx::query(
-            "UPDATE deposits SET raw_operation = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            "UPDATE pending_deposits SET raw_operation = ?
              WHERE source_chain_id = ? AND block_hash = ? AND tx_index = ? AND log_index = ?",
         )
         .bind(raw)
@@ -160,10 +214,10 @@ impl BridgeDb {
         Ok(())
     }
 
-    /// Inserts a new burn. Ignores duplicates (idempotent).
+    /// Inserts a new pending burn. Ignores duplicates (idempotent).
     pub async fn insert_burn(&self, burn: &PendingBurn) -> Result<()> {
         sqlx::query(
-            "INSERT OR IGNORE INTO burns (linera_height, burn_index, evm_recipient, amount)
+            "INSERT OR IGNORE INTO pending_burns (linera_height, burn_index, evm_recipient, amount)
              VALUES (?, ?, ?, ?)",
         )
         .bind(burn.height.0 as i64)
@@ -175,32 +229,59 @@ impl BridgeDb {
         Ok(())
     }
 
-    /// Updates a burn's status and timestamp.
+    /// Atomically moves a burn from `pending_burns` to `finished_burns` with
+    /// the given terminal `status` (`"completed"` or `"failed"`).
+    ///
+    /// If `finished_burns` already has a row for this key (replay scenario),
+    /// the existing record is preserved and a warning is logged. The matching
+    /// pending row is still deleted so the burn does not stay queued.
     pub async fn update_burn_status(
         &self,
         height: BlockHeight,
         index: usize,
         status: &str,
     ) -> Result<()> {
-        sqlx::query(
-            "UPDATE burns SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        let mut tx = self.pool.begin().await?;
+        let inserted = sqlx::query(
+            "INSERT OR IGNORE INTO finished_burns
+                (linera_height, burn_index, evm_recipient, amount, raw_cert,
+                 status, created_at)
+             SELECT linera_height, burn_index, evm_recipient, amount, raw_cert,
+                    ?, created_at
+             FROM pending_burns
              WHERE linera_height = ? AND burn_index = ?",
         )
         .bind(status)
         .bind(height.0 as i64)
         .bind(index as i64)
-        .execute(&self.pool)
-        .await?;
+        .execute(&mut *tx)
+        .await?
+        .rows_affected();
+        let deleted =
+            sqlx::query("DELETE FROM pending_burns WHERE linera_height = ? AND burn_index = ?")
+                .bind(height.0 as i64)
+                .bind(index as i64)
+                .execute(&mut *tx)
+                .await?
+                .rows_affected();
+        tx.commit().await?;
+        if deleted > 0 && inserted == 0 {
+            tracing::warn!(
+                ?height,
+                burn_index = index,
+                "Replay detected: burn already in finished_burns, original record kept"
+            );
+        }
         Ok(())
     }
 
-    /// Loads every deposit whose status is still `pending`, used at relay
-    /// startup to repopulate the in-memory `MonitorState` so that work
-    /// in flight at the time of the previous shutdown is not lost.
+    /// Loads every pending deposit, used at relay startup to repopulate the
+    /// in-memory `MonitorState` so that work in flight at the time of the
+    /// previous shutdown is not lost.
     pub async fn load_pending_deposits(&self) -> Result<Vec<PendingDeposit>> {
         let rows = sqlx::query(
             "SELECT source_chain_id, block_hash, tx_index, log_index, tx_hash, depositor, amount, nonce
-             FROM deposits WHERE status = 'pending'",
+             FROM pending_deposits",
         )
         .fetch_all(&self.pool)
         .await?;
@@ -236,12 +317,12 @@ impl BridgeDb {
         Ok(out)
     }
 
-    /// Loads every burn whose status is still `pending`, used at relay
-    /// startup to repopulate the in-memory `MonitorState`.
+    /// Loads every pending burn, used at relay startup to repopulate the
+    /// in-memory `MonitorState`.
     pub async fn load_pending_burns(&self) -> Result<Vec<PendingBurn>> {
         let rows = sqlx::query(
             "SELECT linera_height, burn_index, evm_recipient, amount
-             FROM burns WHERE status = 'pending'",
+             FROM pending_burns",
         )
         .fetch_all(&self.pool)
         .await?;
@@ -265,7 +346,23 @@ impl BridgeDb {
         Ok(out)
     }
 
-    /// Stores raw BCS-serialized certificate bytes for a burn.
+    /// Returns the number of rows currently in `pending_deposits`.
+    pub async fn pending_deposits_count(&self) -> Result<i64> {
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM pending_deposits")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count)
+    }
+
+    /// Returns the number of rows currently in `pending_burns`.
+    pub async fn pending_burns_count(&self) -> Result<i64> {
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM pending_burns")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(count)
+    }
+
+    /// Stores raw BCS-serialized certificate bytes on the pending burn row.
     pub async fn store_burn_raw(
         &self,
         height: BlockHeight,
@@ -273,7 +370,7 @@ impl BridgeDb {
         raw: &[u8],
     ) -> Result<()> {
         sqlx::query(
-            "UPDATE burns SET raw_cert = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            "UPDATE pending_burns SET raw_cert = ?
              WHERE linera_height = ? AND burn_index = ?",
         )
         .bind(raw)
@@ -297,14 +394,14 @@ mod tests {
 
     static FILE_COUNTER: AtomicU32 = AtomicU32::new(0);
 
-    async fn open_db(use_file: bool) -> BridgeDb {
+    async fn open_db(use_file: bool) -> Result<BridgeDb> {
         if use_file {
             let n = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
             let path = std::path::PathBuf::from(format!("/tmp/bridge_db_test_{n}.sqlite3"));
             std::fs::remove_file(&path).ok(); // Best-effort cleanup; NotFound is the common case.
-            BridgeDb::open(&path).await.unwrap()
+            BridgeDb::open(&path).await
         } else {
-            BridgeDb::open_in_memory().await.unwrap()
+            BridgeDb::open_in_memory().await
         }
     }
 
@@ -341,187 +438,315 @@ mod tests {
     #[test_case(false; "in_memory")]
     #[test_case(true; "file_backed")]
     #[tokio::test]
-    async fn test_insert_and_query_deposit(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_deposit(&test_deposit()).await.unwrap();
+    async fn test_insert_and_query_deposit(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_deposit(&test_deposit()).await?;
 
-        let row: (String, Vec<u8>, String) = sqlx::query_as(
-            "SELECT amount, depositor, status FROM deposits WHERE source_chain_id = 8453",
+        let row: (String, Vec<u8>) = sqlx::query_as(
+            "SELECT amount, depositor FROM pending_deposits WHERE source_chain_id = 8453",
         )
         .fetch_one(&db.pool)
-        .await
-        .unwrap();
+        .await?;
         assert_eq!(row.0, "1000000");
         assert_eq!(row.1, Address::from([0xCC; 20]).as_slice());
-        assert_eq!(row.2, "pending");
+        Ok(())
     }
 
     #[test_case(false; "in_memory")]
     #[test_case(true; "file_backed")]
     #[tokio::test]
-    async fn test_complete_deposit(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_deposit(&test_deposit()).await.unwrap();
-        db.update_deposit_status(&test_deposit_key(), "completed")
-            .await
-            .unwrap();
+    async fn test_insert_deposit_idempotent(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_deposit(&test_deposit()).await?;
+        db.insert_deposit(&test_deposit()).await?;
 
-        let (status,): (String,) =
-            sqlx::query_as("SELECT status FROM deposits WHERE source_chain_id = 8453")
-                .fetch_one(&db.pool)
-                .await
-                .unwrap();
-        assert_eq!(status, "completed");
+        assert_eq!(db.pending_deposits_count().await?, 1);
+        Ok(())
     }
 
     #[test_case(false; "in_memory")]
     #[test_case(true; "file_backed")]
     #[tokio::test]
-    async fn test_fail_deposit(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_deposit(&test_deposit()).await.unwrap();
-        db.update_deposit_status(&test_deposit_key(), "failed")
-            .await
-            .unwrap();
+    async fn test_partial_processing_splits_pending_and_finished(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
 
-        let (status,): (String,) =
-            sqlx::query_as("SELECT status FROM deposits WHERE source_chain_id = 8453")
-                .fetch_one(&db.pool)
-                .await
-                .unwrap();
-        assert_eq!(status, "failed");
-    }
+        let mut keys = Vec::new();
+        for log_index in 0..5 {
+            let mut deposit = test_deposit();
+            deposit.key.log_index = log_index;
+            db.insert_deposit(&deposit).await?;
+            keys.push(deposit.key);
+        }
+        assert_eq!(db.pending_deposits_count().await?, 5);
 
-    #[test_case(false; "in_memory")]
-    #[test_case(true; "file_backed")]
-    #[tokio::test]
-    async fn test_insert_deposit_idempotent(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_deposit(&test_deposit()).await.unwrap();
-        db.insert_deposit(&test_deposit()).await.unwrap();
+        for key in &keys[..2] {
+            db.update_deposit_status(key, "completed").await?;
+        }
 
-        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM deposits")
+        assert_eq!(db.pending_deposits_count().await?, 3);
+        let (finished_count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM finished_deposits")
             .fetch_one(&db.pool)
-            .await
-            .unwrap();
-        assert_eq!(count, 1);
+            .await?;
+        assert_eq!(finished_count, 2);
+        Ok(())
     }
 
     #[test_case(false; "in_memory")]
     #[test_case(true; "file_backed")]
     #[tokio::test]
-    async fn test_store_and_retrieve_deposit_raw(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_deposit(&test_deposit()).await.unwrap();
+    async fn test_store_and_retrieve_deposit_raw(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_deposit(&test_deposit()).await?;
 
         let raw_bytes = vec![1, 2, 3, 4, 5];
         db.store_deposit_raw(&test_deposit_key(), &raw_bytes)
-            .await
-            .unwrap();
+            .await?;
 
-        let (raw,): (Vec<u8>,) =
-            sqlx::query_as("SELECT raw_operation FROM deposits WHERE source_chain_id = 8453")
-                .fetch_one(&db.pool)
-                .await
-                .unwrap();
-        assert_eq!(raw, raw_bytes);
-    }
-
-    #[test_case(false; "in_memory")]
-    #[test_case(true; "file_backed")]
-    #[tokio::test]
-    async fn test_insert_and_query_burn(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_burn(&test_burn()).await.unwrap();
-
-        let burn = test_burn();
-        let row: (String, String, String) = sqlx::query_as(
-            "SELECT evm_recipient, amount, status FROM burns WHERE linera_height = 100",
+        let (raw,): (Vec<u8>,) = sqlx::query_as(
+            "SELECT raw_operation FROM pending_deposits WHERE source_chain_id = 8453",
         )
         .fetch_one(&db.pool)
-        .await
-        .unwrap();
+        .await?;
+        assert_eq!(raw, raw_bytes);
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_insert_and_query_burn(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_burn(&test_burn()).await?;
+
+        let burn = test_burn();
+        let row: (String, String) = sqlx::query_as(
+            "SELECT evm_recipient, amount FROM pending_burns WHERE linera_height = 100",
+        )
+        .fetch_one(&db.pool)
+        .await?;
         assert_eq!(row.0, format!("{:#x}", burn.evm_recipient));
         assert_eq!(row.1, burn.amount.to_string());
-        assert_eq!(row.2, "pending");
+        Ok(())
     }
 
     #[test_case(false; "in_memory")]
     #[test_case(true; "file_backed")]
     #[tokio::test]
-    async fn test_complete_burn(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_burn(&test_burn()).await.unwrap();
-        db.update_burn_status(BlockHeight(100), 0, "completed")
-            .await
-            .unwrap();
+    async fn test_insert_burn_idempotent(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_burn(&test_burn()).await?;
+        db.insert_burn(&test_burn()).await?;
 
-        let (status,): (String,) =
-            sqlx::query_as("SELECT status FROM burns WHERE linera_height = 100")
-                .fetch_one(&db.pool)
-                .await
-                .unwrap();
-        assert_eq!(status, "completed");
+        assert_eq!(db.pending_burns_count().await?, 1);
+        Ok(())
     }
 
     #[test_case(false; "in_memory")]
     #[test_case(true; "file_backed")]
     #[tokio::test]
-    async fn test_insert_burn_idempotent(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_burn(&test_burn()).await.unwrap();
-        db.insert_burn(&test_burn()).await.unwrap();
-
-        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM burns")
-            .fetch_one(&db.pool)
-            .await
-            .unwrap();
-        assert_eq!(count, 1);
-    }
-
-    #[test_case(false; "in_memory")]
-    #[test_case(true; "file_backed")]
-    #[tokio::test]
-    async fn test_store_and_retrieve_burn_raw(use_file: bool) {
-        let db = open_db(use_file).await;
-        db.insert_burn(&test_burn()).await.unwrap();
+    async fn test_store_and_retrieve_burn_raw(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_burn(&test_burn()).await?;
 
         let cert_bytes = vec![10, 20, 30, 40, 50];
-        db.store_burn_raw(BlockHeight(100), 0, &cert_bytes)
-            .await
-            .unwrap();
+        db.store_burn_raw(BlockHeight(100), 0, &cert_bytes).await?;
 
         let (raw,): (Vec<u8>,) =
-            sqlx::query_as("SELECT raw_cert FROM burns WHERE linera_height = 100")
+            sqlx::query_as("SELECT raw_cert FROM pending_burns WHERE linera_height = 100")
                 .fetch_one(&db.pool)
-                .await
-                .unwrap();
+                .await?;
         assert_eq!(raw, cert_bytes);
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_complete_deposit_moves_to_finished(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_deposit(&test_deposit()).await?;
+        db.update_deposit_status(&test_deposit_key(), "completed")
+            .await?;
+
+        assert_eq!(
+            db.pending_deposits_count().await?,
+            0,
+            "row should be removed from pending"
+        );
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM finished_deposits WHERE source_chain_id = 8453")
+                .fetch_one(&db.pool)
+                .await?;
+        assert_eq!(status, "completed");
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_fail_deposit_moves_to_finished(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_deposit(&test_deposit()).await?;
+        db.update_deposit_status(&test_deposit_key(), "failed")
+            .await?;
+
+        assert_eq!(db.pending_deposits_count().await?, 0);
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM finished_deposits WHERE source_chain_id = 8453")
+                .fetch_one(&db.pool)
+                .await?;
+        assert_eq!(status, "failed");
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_complete_burn_moves_to_finished(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_burn(&test_burn()).await?;
+        db.update_burn_status(BlockHeight(100), 0, "completed")
+            .await?;
+
+        assert_eq!(db.pending_burns_count().await?, 0);
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM finished_burns WHERE linera_height = 100")
+                .fetch_one(&db.pool)
+                .await?;
+        assert_eq!(status, "completed");
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_fail_burn_moves_to_finished(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_burn(&test_burn()).await?;
+        db.update_burn_status(BlockHeight(100), 0, "failed").await?;
+
+        assert_eq!(db.pending_burns_count().await?, 0);
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM finished_burns WHERE linera_height = 100")
+                .fetch_one(&db.pool)
+                .await?;
+        assert_eq!(status, "failed");
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_replay_preserves_original_finished_deposit(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_deposit(&test_deposit()).await?;
+        db.update_deposit_status(&test_deposit_key(), "completed")
+            .await?;
+
+        // Replay: re-insert the same deposit and try to mark it failed.
+        db.insert_deposit(&test_deposit()).await?;
+        db.update_deposit_status(&test_deposit_key(), "failed")
+            .await?;
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM finished_deposits WHERE source_chain_id = 8453")
+                .fetch_one(&db.pool)
+                .await?;
+        assert_eq!(
+            status, "completed",
+            "original terminal status must be preserved on replay"
+        );
+        assert_eq!(
+            db.pending_deposits_count().await?,
+            0,
+            "replayed pending row must be cleared"
+        );
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_replay_preserves_original_finished_burn(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        db.insert_burn(&test_burn()).await?;
+        db.update_burn_status(BlockHeight(100), 0, "completed")
+            .await?;
+
+        db.insert_burn(&test_burn()).await?;
+        db.update_burn_status(BlockHeight(100), 0, "failed").await?;
+
+        let (status,): (String,) =
+            sqlx::query_as("SELECT status FROM finished_burns WHERE linera_height = 100")
+                .fetch_one(&db.pool)
+                .await?;
+        assert_eq!(status, "completed");
+        assert_eq!(db.pending_burns_count().await?, 0);
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_load_pending_excludes_finished_deposits(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        let first = test_deposit();
+        let mut second = test_deposit();
+        second.key.log_index = 1;
+        db.insert_deposit(&first).await?;
+        db.insert_deposit(&second).await?;
+        db.update_deposit_status(&first.key, "completed").await?;
+
+        let pending = db.load_pending_deposits().await?;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].key.log_index, 1);
+        Ok(())
+    }
+
+    #[test_case(false; "in_memory")]
+    #[test_case(true; "file_backed")]
+    #[tokio::test]
+    async fn test_load_pending_excludes_finished_burns(use_file: bool) -> Result<()> {
+        let db = open_db(use_file).await?;
+        let mut second = test_burn();
+        second.burn_index = 1;
+        db.insert_burn(&test_burn()).await?;
+        db.insert_burn(&second).await?;
+        db.update_burn_status(BlockHeight(100), 0, "completed")
+            .await?;
+
+        let pending = db.load_pending_burns().await?;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].burn_index, 1);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_file_persistence_survives_reopen() {
+    async fn test_file_persistence_survives_reopen() -> Result<()> {
         let path = std::path::PathBuf::from("/tmp/bridge_db_test_reopen.sqlite3");
         std::fs::remove_file(&path).ok(); // Best-effort pre-cleanup; NotFound is the common case.
 
         {
-            let db = BridgeDb::open(&path).await.unwrap();
-            db.insert_deposit(&test_deposit()).await.unwrap();
+            let db = BridgeDb::open(&path).await?;
+            db.insert_deposit(&test_deposit()).await?;
             db.update_deposit_status(&test_deposit_key(), "completed")
-                .await
-                .unwrap();
+                .await?;
         }
 
         {
-            let db = BridgeDb::open(&path).await.unwrap();
+            let db = BridgeDb::open(&path).await?;
             let (status,): (String,) =
-                sqlx::query_as("SELECT status FROM deposits WHERE source_chain_id = 8453")
+                sqlx::query_as("SELECT status FROM finished_deposits WHERE source_chain_id = 8453")
                     .fetch_one(&db.pool)
-                    .await
-                    .unwrap();
+                    .await?;
             assert_eq!(status, "completed");
         }
 
         std::fs::remove_file(&path).ok(); // Best-effort post-test cleanup.
+        Ok(())
     }
 }

--- a/linera-bridge/src/relay/metrics.rs
+++ b/linera-bridge/src/relay/metrics.rs
@@ -145,6 +145,7 @@ pub(crate) fn set_relayer_linera_balance(balance_atto: f64) {
 pub(crate) fn build_router() -> Router {
     Router::new()
         .route("/metrics", get(serve_metrics))
+        .route("/health", get(|| async { StatusCode::OK }))
         .layer(CorsLayer::permissive())
 }
 
@@ -157,5 +158,27 @@ async fn serve_metrics() -> impl IntoResponse {
             format!("Failed to encode metrics: {e}"),
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::Body, http::Request};
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn health_endpoint_returns_200() {
+        let response = build_router()
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/web/@linera/client/build.bash
+++ b/web/@linera/client/build.bash
@@ -37,10 +37,14 @@ wasm-bindgen \
     --keep-debug \
     --split-linked-modules
 
-wasm-split \
-    src/wasm/index_bg.wasm \
-    --strip \
-    --debug-out src/wasm/index_bg.debug.wasm
+if command -v wasm-split >/dev/null; then
+    wasm-split \
+        src/wasm/index_bg.wasm \
+        --strip \
+        --debug-out src/wasm/index_bg.debug.wasm
+else
+    echo "wasm-split not found, skipping (debug wasm and stripping disabled)" >&2
+fi
 
 mkdir -p dist
 cp -r src/wasm dist/


### PR DESCRIPTION
## Motivation

Provision a dedicated docker-compose stack for running a long-lived
`linera-bridge` relayer on a testnet VM, plus the operational runbook
the team needs to deploy, monitor, back up, and troubleshoot it.

## Proposal

- New compose file `docker/docker-compose.bridge-testnet.yml`: single
  `relayer` service with bind-mounted `/var/lib/linera-bridge` data dir,
  `/etc/linera-bridge/.env*` env files, journald logging, loopback-only
  metrics + health, `restart: unless-stopped`, conservative CPU/memory
  limits.
- `docker/bridge-entrypoint.sh`: align the default `--port` (3001) with
  the Dockerfile and the testnet compose port mapping.
- `linera-bridge`: add a `/health` route to the relay HTTP server. The
  testnet compose healthcheck uses a bare TCP probe (only `nc` ships in
  the runtime image); the route is there for downstream collectors that
  prefer HTTP probes.
- `docker/README.testnet.md`: deployment runbook — directory layout,
  env file schema, startup, routine ops, backup, observability table
  matching the metrics emitted by `linera-bridge/src/relay/metrics.rs`,
  Prometheus alert rules (gas balance, permanent failures, throughput
  stall), and a troubleshooting matrix. SQL examples updated for the
  new `pending_*`/`finished_*` schema.

## Test Plan

- CI builds the bridge image and parses the compose file.
- Local: `make demo` still works end-to-end (this PR does not touch
  `setup.sh` or the local docker-compose).
- `docker compose -f docker/docker-compose.bridge-testnet.yml config`
  parses with both the testnet defaults (`/etc/linera-bridge/...`,
  `/var/lib/linera-bridge/...`) and operator-supplied paths via env-var
  overrides where applicable.
- Manual: bring the compose up, verify `nc -z localhost 3001` succeeds,
  `curl -sI http://localhost:3001/health` returns `HTTP/1.1 200 OK`,
  `/metrics` exposes the metrics listed in the Observability table.

## Release Plan

- Nothing to do

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)