### PR TITLE
Poison and evict chain worker on any save failure

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2143,15 +2143,13 @@ where
     ))]
     async fn save(&mut self) -> Result<(), WorkerError> {
         if let Err(error) = self.chain.save().await {
-            if error.must_reload_view() {
-                tracing::error!(
-                    ?error,
-                    chain_id = %self.chain_id(),
-                    "Journal resolution failed; marking worker as poisoned"
-                );
-                self.poisoned = true;
-            }
-            return Err(error.into());
+            tracing::error!(
+                ?error,
+                chain_id = %self.chain_id(),
+                "Chain save failed; marking worker as poisoned"
+            );
+            self.poisoned = true;
+            return Err(WorkerError::PoisonedWorker);
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation

Fixes #6052.

Previously only journal resolution failures poisoned the chain worker. Other write errors (e.g. possible ScyllaDB timeouts) left the worker loaded with potentially stale state.

Stacked on #6051.

## Proposal

- **Poison on any save failure**: `ChainWorkerState::save()` now always sets `poisoned = true` and returns `WorkerError::PoisonedWorker` on any error, triggering immediate eviction and a fresh reload on the next request.

- **Keep `must_reload_view`** for metrics and as way to document that journaling really requires a notion of view poisoning.

## Test Plan

CI

## Links

- Fixes #6052
- Stacked on #6051
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)