### PR TITLE
[testnet] Fix cancellation safety of LruCachingStore::write_batch (using task::spawn)

### DIFF
--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -347,30 +347,55 @@ where
 
 impl<K> WritableKeyValueStore for LruCachingStore<K>
 where
-    K: WritableKeyValueStore,
+    K: WritableKeyValueStore + Clone + Send + 'static,
+    K::Error: Send,
 {
     // The LRU cache does not change the underlying store's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), Self::Error> {
-        self.store.write_batch(batch.clone()).await?;
-        if let Some(cache) = &self.cache {
-            let mut cache = cache.lock().unwrap();
-            for operation in &batch.operations {
-                match operation {
-                    WriteOperation::Put { key, value } => {
-                        cache.put_key_value(key, value);
-                    }
-                    WriteOperation::Delete { key } => {
-                        cache.delete_key(key);
-                    }
-                    WriteOperation::DeletePrefix { key_prefix } => {
-                        cache.delete_prefix(key_prefix);
+        // Spawn a task to ensure the DB write and cache update run to
+        // completion atomically, even if the caller's future is cancelled
+        // (e.g. by RollbackGuard). Without this, a cancellation between
+        // the DB write and cache update leaves the cache stale, causing
+        // data loss on the next save.
+        //
+        // We use `tokio::task::spawn` (not `linera_base::Task::spawn`)
+        // because the latter cancels on drop via `RemoteHandle`.
+        let store = self.store.clone();
+        let cache = self.cache.clone();
+        let task = async move {
+            store.write_batch(batch.clone()).await?;
+            if let Some(cache) = &cache {
+                let mut cache = cache.lock().unwrap();
+                for operation in &batch.operations {
+                    match operation {
+                        WriteOperation::Put { key, value } => {
+                            cache.put_key_value(key, value);
+                        }
+                        WriteOperation::Delete { key } => {
+                            cache.delete_key(key);
+                        }
+                        WriteOperation::DeletePrefix { key_prefix } => {
+                            cache.delete_prefix(key_prefix);
+                        }
                     }
                 }
             }
+            Ok(())
+        };
+        // On native, spawn a task that runs to completion even if the
+        // caller is cancelled. On web, cancellation safety is not a
+        // concern (no RollbackGuard / concurrent chain workers).
+        #[cfg(not(web))]
+        match tokio::task::spawn(task).await {
+            Ok(result) => result,
+            Err(join_error) => std::panic::resume_unwind(join_error.into_panic()),
         }
-        Ok(())
+        #[cfg(web)]
+        {
+            task.await
+        }
     }
 
     async fn clear_journal(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
## Motivation

The `LruCachingStore::write_batch` method was not cancellation-safe. It wrote to the DB first, then updated the LRU cache. If the caller's future was cancelled between the two steps (e.g. by a gRPC timeout or runtime shutdown), the DB would have the new data but the cache would retain stale entries. The subsequent `RollbackGuard` would then reset the in-memory view state, and the next `save()` would overwrite the DB with old data -- causing silent data loss.

This was identified as the likely root cause of the missing outbox bucket data on validator 4 (`The front bucket is always loaded` panic).

## Proposal

Wrap the DB write and cache update in a `tokio::task::spawn` so they run to completion even if the caller's future is cancelled. On web targets, the task runs inline since cancellation safety is not a concern there (no `RollbackGuard` / concurrent chain workers).

Adds `Clone + Send + 'static` bounds on the inner store type parameter, which are already satisfied by all stores in the chain (ScyllaDB, RocksDB, journaling, value-splitting).

## Test Plan

CI

## Links

- Alternative to #6051 (invalidate-first approach)
- Related: #5790 (Remove chain actors -- introduced `RollbackGuard`)
- Related: #6015 (Fix `BucketQueueView::delete_front` load failure handling)
- Related: #6046 (Fix storage cache reads dropping Arc before use)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)