### PR TITLE
[testnet] Second set of corrections to the `linera-explorer`.

### DIFF
--- a/linera-explorer/src/components/Applications.vue
+++ b/linera-explorer/src/components/Applications.vue
@@ -2,6 +2,12 @@
 import { ApplicationOverview } from '../../gql/service'
 
 defineProps<{apps: ApplicationOverview[]}>()
+
+function safeStringify(obj: any): string {
+  return JSON.stringify(obj, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value
+  )
+}
 </script>
 
 <template>
@@ -18,7 +24,7 @@ defineProps<{apps: ApplicationOverview[]}>()
       <tbody>
         <tr v-for="a in apps" :key="'application-'+a.id">
           <td :title="a.id">
-            <a target="_blank" class="btn btn-link btn-sm" @click="$root.route('application', [['app', JSON.stringify(a)]])">
+            <a target="_blank" class="btn btn-link btn-sm" @click="$root.route('application', [['app', safeStringify(a)]])">
               {{ short_app_id(a.id) }}
             </a>
           </td>

--- a/linera-explorer/src/components/Block.vue
+++ b/linera-explorer/src/components/Block.vue
@@ -134,64 +134,100 @@ const transactions = computed(() => props.block.block.body.transactionMetadata |
             </li>
           </ul>
         </div>
-        <li v-if="block.block.body.oracleResponses.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#oracle-responses-collapse-'+block.hash">
-          <span><strong>Oracle Responses</strong> ({{ block.block.body.oracleResponses.length }})</span>
+        <li v-if="block.block.body.oracleResponses.flat().length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#oracle-responses-collapse-'+block.hash">
+          <span><strong>Oracle Responses</strong> ({{ block.block.body.oracleResponses.flat().length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Oracle Responses</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.block.body.oracleResponses.length!==0" class="collapse" :id="'oracle-responses-collapse-'+block.hash">
+        <div v-if="block.block.body.oracleResponses.flat().length!==0" class="collapse" :id="'oracle-responses-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.block.body.oracleResponses" class="list-group-item p-0" key="block.hash+'-oracleresponse-'+i">
-              <div class="card">
-                <div class="card-header">Oracle Response {{ i+1 }}</div>
-                <div class="card-body">
-                  <Json :data="m"/>
+            <template v-for="(txOracles, ti) in block.block.body.oracleResponses" :key="block.hash+'-oracles-tx-'+ti">
+              <li v-for="(oracle, oi) in txOracles" class="list-group-item" :key="block.hash+'-oracle-'+ti+'-'+oi">
+                <div class="d-flex justify-content-between align-items-center" data-bs-toggle="collapse" :data-bs-target="'#oracle-'+block.hash+'-'+ti+'-'+oi" role="button">
+                  <span>
+                    <strong>Oracle Response {{ oi+1 }}</strong>
+                    <span v-if="Array.isArray(oracle)" class="ms-2 font-monospace small">{{ oracle.map((b: number) => b.toString(16).padStart(2, '0')).join('').substring(0, 16) + (oracle.length > 8 ? '..' : '') }}</span>
+                    <span v-else-if="typeof oracle === 'string'" class="ms-2 font-monospace small">{{ oracle.length > 16 ? oracle.substring(0, 8) + '..' + oracle.substring(oracle.length - 8) : oracle }}</span>
+                    <span class="ms-2 text-muted small">({{ Array.isArray(oracle) ? oracle.length : typeof oracle === 'string' ? oracle.length / 2 : '?' }} bytes)</span>
+                  </span>
+                  <i class="bi bi-caret-down-fill"></i>
                 </div>
-              </div>
-            </li>
+                <div class="collapse" :id="'oracle-'+block.hash+'-'+ti+'-'+oi">
+                  <div class="p-2 small font-monospace" style="word-break:break-all">
+                    <span v-if="Array.isArray(oracle)">{{ oracle.map((b: number) => b.toString(16).padStart(2, '0')).join('') }}</span>
+                    <span v-else-if="typeof oracle === 'string'">{{ oracle }}</span>
+                    <Json v-else :data="oracle"/>
+                  </div>
+                </div>
+              </li>
+            </template>
           </ul>
         </div>
-        <li v-if="block.block.body.events.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#events-collapse-'+block.hash">
-          <span><strong>Events</strong> ({{ block.block.body.events.length }})</span>
+        <li v-if="block.block.body.events.flat().length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#events-collapse-'+block.hash">
+          <span><strong>Events</strong> ({{ block.block.body.events.flat().length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Events</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.block.body.events.length!==0" class="collapse" :id="'events-collapse-'+block.hash">
+        <div v-if="block.block.body.events.flat().length!==0" class="collapse" :id="'events-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.block.body.events" class="list-group-item p-0" key="block.hash+'-event-'+i">
-              <div class="card">
-                <div class="card-header">Event {{ i+1 }}</div>
-                <div class="card-body">
-                  <Json :data="m"/>
+            <template v-for="(txEvents, ti) in block.block.body.events" :key="block.hash+'-events-tx-'+ti">
+              <li v-for="(evt, ei) in txEvents" class="list-group-item" :key="block.hash+'-event-'+ti+'-'+ei">
+                <div class="d-flex justify-content-between align-items-center" data-bs-toggle="collapse" :data-bs-target="'#event-'+block.hash+'-'+ti+'-'+ei" role="button">
+                  <span>
+                    <strong>Event</strong>
+                    <span v-if="evt.streamId" class="ms-2 small">
+                      <span v-if="evt.streamId.applicationId" class="font-monospace">{{ typeof evt.streamId.applicationId === 'string' ? short_app_id(evt.streamId.applicationId) : evt.streamId.applicationId.User ? short_app_id(evt.streamId.applicationId.User) : '' }}</span>
+                      <span v-if="evt.streamId.streamName">/{{ Array.isArray(evt.streamId.streamName) ? String.fromCharCode(...evt.streamId.streamName) : evt.streamId.streamName }}</span>
+                    </span>
+                    <span v-if="evt.index != null" class="ms-2 badge bg-secondary">index: {{ evt.index }}</span>
+                    <span v-if="evt.value && evt.value.length > 0" class="ms-2 text-muted small">({{ evt.value.length }} bytes)</span>
+                  </span>
+                  <i class="bi bi-caret-down-fill"></i>
                 </div>
-              </div>
-            </li>
+                <div class="collapse" :id="'event-'+block.hash+'-'+ti+'-'+ei">
+                  <div v-if="evt.value && evt.value.length > 0" class="p-2 small font-monospace" style="word-break:break-all">
+                    {{ evt.value.map((b: number) => b.toString(16).padStart(2, '0')).join('') }}
+                  </div>
+                </div>
+              </li>
+            </template>
           </ul>
         </div>
-        <li v-if="block.block.body.blobs.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#blobs-collapse-'+block.hash">
-          <span><strong>Blobs</strong> ({{ block.block.body.blobs.length }})</span>
+        <li v-if="block.block.body.blobs.flat().length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#blobs-collapse-'+block.hash">
+          <span><strong>Blobs</strong> ({{ block.block.body.blobs.flat().length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Blobs</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.block.body.blobs.length!==0" class="collapse" :id="'blobs-collapse-'+block.hash">
+        <div v-if="block.block.body.blobs.flat().length!==0" class="collapse" :id="'blobs-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.block.body.blobs" class="list-group-item p-0" key="block.hash+'-blob-'+i">
-              <div class="card">
-                <div class="card-header">Blob {{ i+1 }}</div>
-                <div class="card-body">
-                  <Json :data="m"/>
+            <template v-for="(txBlobs, ti) in block.block.body.blobs" :key="block.hash+'-blobs-tx-'+ti">
+              <li v-for="(blob, bi) in txBlobs" class="list-group-item" :key="block.hash+'-blob-'+ti+'-'+bi">
+                <div class="d-flex justify-content-between align-items-center" data-bs-toggle="collapse" :data-bs-target="'#blob-'+block.hash+'-'+ti+'-'+bi" role="button">
+                  <span>
+                    <strong>Blob {{ bi+1 }}</strong>
+                    <span v-if="typeof blob === 'string'" class="ms-2 font-monospace small">{{ blob.length > 16 ? blob.substring(0, 8) + '..' + blob.substring(blob.length - 8) : blob }}</span>
+                    <span v-else-if="Array.isArray(blob)" class="ms-2 font-monospace small">{{ blob.map((b: number) => b.toString(16).padStart(2, '0')).join('').substring(0, 8) + '..' }}</span>
+                    <span class="ms-2 text-muted small">({{ typeof blob === 'string' ? blob.length / 2 : Array.isArray(blob) ? blob.length : '?' }} bytes)</span>
+                  </span>
+                  <i class="bi bi-caret-down-fill"></i>
                 </div>
-              </div>
-            </li>
+                <div class="collapse" :id="'blob-'+block.hash+'-'+ti+'-'+bi">
+                  <div class="p-2 small font-monospace" style="word-break:break-all">
+                    <span v-if="typeof blob === 'string'">{{ blob }}</span>
+                    <span v-else-if="Array.isArray(blob)">{{ blob.map((b: number) => b.toString(16).padStart(2, '0')).join('') }}</span>
+                  </div>
+                </div>
+              </li>
+            </template>
           </ul>
         </div>
         <li v-if="block.block.body.operationResults.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#operation-results-collapse-'+block.hash">
@@ -204,11 +240,21 @@ const transactions = computed(() => props.block.block.body.transactionMetadata |
         </li>
         <div v-if="block.block.body.operationResults.length!==0" class="collapse" :id="'operation-results-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.block.body.operationResults" class="list-group-item p-0" key="block.hash+'-operationresult-'+i">
-              <div class="card">
-                <div class="card-header">Operation Result {{ i+1 }}</div>
-                <div class="card-body">
-                  <Json :data="m"/>
+            <li v-for="(m, i) in block.block.body.operationResults" class="list-group-item" :key="block.hash+'-operationresult-'+i">
+              <div class="d-flex justify-content-between align-items-center" data-bs-toggle="collapse" :data-bs-target="'#opresult-'+block.hash+'-'+i" role="button">
+                <span>
+                  <strong>Operation Result {{ i+1 }}</strong>
+                  <span v-if="Array.isArray(m)" class="ms-2 font-monospace small">{{ m.map((b: number) => b.toString(16).padStart(2, '0')).join('').substring(0, 16) + (m.length > 8 ? '..' : '') }}</span>
+                  <span v-else-if="typeof m === 'string'" class="ms-2 font-monospace small">{{ m.length > 16 ? m.substring(0, 8) + '..' + m.substring(m.length - 8) : m }}</span>
+                  <span class="ms-2 text-muted small">({{ Array.isArray(m) ? m.length : typeof m === 'string' ? m.length / 2 : '?' }} bytes)</span>
+                </span>
+                <i class="bi bi-caret-down-fill"></i>
+              </div>
+              <div class="collapse" :id="'opresult-'+block.hash+'-'+i">
+                <div class="p-2 small font-monospace" style="word-break:break-all">
+                  <span v-if="Array.isArray(m)">{{ m.map((b: number) => b.toString(16).padStart(2, '0')).join('') }}</span>
+                  <span v-else-if="typeof m === 'string'">{{ m }}</span>
+                  <Json v-else :data="m"/>
                 </div>
               </div>
             </li>

--- a/linera-explorer/src/components/Chain.vue
+++ b/linera-explorer/src/components/Chain.vue
@@ -27,11 +27,44 @@ defineProps<{title: string, chain: ChainStateExtendedView}>()
         </li>
         <div v-if="chain.inboxes.entries.length!==0" class="collapse" :id="'chain-'+chain.chainId+'-inboxes-collapse'">
           <ul class="list-group">
-            <li v-for="(inbox, i) in chain.inboxes.entries" class="list-group-item p-0" key="'chain-'+chain.chainId+'-inbox-'+i">
-              <div class="card">
-                <div class="card-header">Inbox {{ i+1 }}</div>
+            <li v-for="(inbox, i) in chain.inboxes.entries" class="list-group-item p-0" :key="'chain-'+chain.chainId+'-inbox-'+i">
+              <div class="card border-0">
+                <div class="card-header">
+                  <strong>From</strong>
+                  <a @click="$root.route(undefined, [['chain', inbox.key]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(inbox.key) }}</a>
+                </div>
                 <div class="card-body">
-                  <Json :data="inbox.value"/>
+                  <div class="row mb-2 small">
+                    <div class="col-md-6">
+                      <strong>Next cursor to add:</strong>
+                      <span v-if="inbox.value.nextCursorToAdd" class="ms-1">h={{ inbox.value.nextCursorToAdd.height }}, i={{ inbox.value.nextCursorToAdd.index }}</span>
+                    </div>
+                    <div class="col-md-6">
+                      <strong>Next cursor to remove:</strong>
+                      <span v-if="inbox.value.nextCursorToRemove" class="ms-1">h={{ inbox.value.nextCursorToRemove.height }}, i={{ inbox.value.nextCursorToRemove.index }}</span>
+                    </div>
+                  </div>
+                  <div v-if="inbox.value.addedBundles?.entries?.length" class="mb-2">
+                    <details>
+                      <summary class="small"><strong>Added Bundles</strong> ({{ inbox.value.addedBundles.entries.length }})</summary>
+                      <div v-for="(bundle, bi) in inbox.value.addedBundles.entries" :key="bi" class="border rounded p-2 mb-1 mt-1 small">
+                        <strong>Height:</strong> {{ bundle.height }}
+                        <strong class="ms-2">Tx:</strong> {{ bundle.transactionIndex }}
+                        <strong class="ms-2">Cert:</strong>
+                        <a @click="$root.route('block', [['block', bundle.certificateHash]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(bundle.certificateHash) }}</a>
+                        <span v-if="bundle.messages?.length" class="text-muted ms-2">({{ bundle.messages.length }} msg{{ bundle.messages.length !== 1 ? 's' : '' }})</span>
+                      </div>
+                    </details>
+                  </div>
+                  <div v-if="inbox.value.removedBundles?.entries?.length">
+                    <details>
+                      <summary class="small"><strong>Removed Bundles</strong> ({{ inbox.value.removedBundles.entries.length }})</summary>
+                      <div v-for="(bundle, bi) in inbox.value.removedBundles.entries" :key="bi" class="border rounded p-2 mb-1 mt-1 small">
+                        <strong>Height:</strong> {{ bundle.height }}
+                        <strong class="ms-2">Tx:</strong> {{ bundle.transactionIndex }}
+                      </div>
+                    </details>
+                  </div>
                 </div>
               </div>
             </li>
@@ -48,11 +81,23 @@ defineProps<{title: string, chain: ChainStateExtendedView}>()
         </li>
         <div v-if="chain.outboxes.entries.length!==0" class="collapse" :id="'chain-'+chain.chainId+'-outboxes-collapse'">
           <ul class="list-group">
-            <li v-for="(outbox, i) in chain.outboxes.entries" class="list-group-item p-0" key="'chain-'+chain.chainId+'-outbox-'+i">
-              <div class="card">
-                <div class="card-header">Outbox {{ i+1 }}</div>
-                <div class="card-body">
-                  <Json :data="outbox.value"/>
+            <li v-for="(outbox, i) in chain.outboxes.entries" class="list-group-item p-0" :key="'chain-'+chain.chainId+'-outbox-'+i">
+              <div class="card border-0">
+                <div class="card-header">
+                  <strong>To</strong>
+                  <a @click="$root.route(undefined, [['chain', outbox.key]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(outbox.key) }}</a>
+                </div>
+                <div class="card-body small">
+                  <div class="mb-2">
+                    <strong>Next height to schedule:</strong>
+                    <span class="ms-1">{{ outbox.value.nextHeightToSchedule }}</span>
+                  </div>
+                  <div v-if="outbox.value.queue?.entries?.length">
+                    <details>
+                      <summary><strong>Queue</strong> ({{ outbox.value.queue.entries.length }})</summary>
+                      <Json :data="outbox.value.queue.entries"/>
+                    </details>
+                  </div>
                 </div>
               </div>
             </li>

--- a/linera-explorer/src/components/OutgoingMessages.vue
+++ b/linera-explorer/src/components/OutgoingMessages.vue
@@ -104,7 +104,7 @@ function getMessageMetadata(msg: any) {
 
           <div class="mb-2 small">
             <strong>Destination:</strong>
-            <span class="font-monospace" v-if="typeof msg.destination === 'string'">{{ short_hash(msg.destination) }}</span>
+            <a v-if="typeof msg.destination === 'string'" @click="$root.route(undefined, [['chain', msg.destination]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(msg.destination) }}</a>
             <span v-else>{{ JSON.stringify(msg.destination) }}</span>
           </div>
 

--- a/linera-explorer/src/components/Transaction.vue
+++ b/linera-explorer/src/components/Transaction.vue
@@ -40,7 +40,7 @@ defineProps<{
             <div class="row">
               <div class="col-md-6">
                 <strong>Origin:</strong>
-                <span class="font-monospace">{{ short_hash(transaction.incomingBundle.origin.sender || transaction.incomingBundle.origin) }}</span>
+                <a @click="$root.route(undefined, [['chain', transaction.incomingBundle.origin.sender || transaction.incomingBundle.origin]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(transaction.incomingBundle.origin.sender || transaction.incomingBundle.origin) }}</a>
               </div>
               <div class="col-md-6">
                 <strong>Action:</strong>
@@ -59,7 +59,7 @@ defineProps<{
               </div>
               <div class="col-md-4">
                 <strong>Certificate Hash:</strong>
-                <span class="font-monospace small">{{ short_hash(transaction.incomingBundle.bundle.certificateHash) }}</span>
+                <a @click="$root.route('block', [['block', transaction.incomingBundle.bundle.certificateHash]])" class="btn btn-link btn-sm p-0 font-monospace small">{{ short_hash(transaction.incomingBundle.bundle.certificateHash) }}</a>
               </div>
             </div>
 

--- a/linera-explorer/src/graphql.rs
+++ b/linera-explorer/src/graphql.rs
@@ -36,6 +36,7 @@ pub async fn introspection(url: &str) -> Result<Value> {
            ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType { kind name ofType {kind name} } } } } } } }";
     let res = client
         .post(url)
+        .header("Content-Type", "application/json")
         .body(format!("{{\"query\":\"{}\"}}", graphql_query))
         .send()
         .await?

--- a/linera-explorer/src/js_utils.rs
+++ b/linera-explorer/src/js_utils.rs
@@ -6,8 +6,9 @@ use serde_wasm_bindgen::Serializer;
 use wasm_bindgen::prelude::*;
 
 /// JS special serializer
-pub(crate) const SER: Serializer =
-    serde_wasm_bindgen::Serializer::new().serialize_large_number_types_as_bigints(true);
+pub(crate) const SER: Serializer = serde_wasm_bindgen::Serializer::new()
+    .serialize_large_number_types_as_bigints(true)
+    .serialize_maps_as_objects(true);
 
 pub fn setf(target: &JsValue, field: &str, value: &JsValue) {
     js_sys::Reflect::set(target, &JsValue::from_str(field), value)

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -493,35 +493,48 @@ async fn plugin(plugin: &str, indexer: &str) -> Result<(Page, String)> {
 }
 
 fn format_bytes(value: &JsValue) -> JsValue {
-    let modified_value = value.clone();
-    if let Some(object) = js_sys::Object::try_from(value) {
-        js_sys::Object::keys(object)
-            .iter()
-            .for_each(|k: JsValue| match k.as_string() {
-                None => (),
-                Some(key_str) => {
-                    if &key_str == "bytes" {
-                        let array: Vec<u8> =
-                            js_sys::Uint8Array::from(getf(&modified_value, "bytes")).to_vec();
-                        let array_hex = hex::encode(array);
-                        let hex_len = array_hex.len();
-                        let hex_elided = if hex_len > 128 {
-                            // don't show all hex digits if the bytes array is too long
-                            format!("{}..{}", &array_hex[0..4], &array_hex[hex_len - 4..])
-                        } else {
-                            array_hex
-                        };
-                        setf(&modified_value, "bytes", &JsValue::from_str(&hex_elided))
-                    } else {
-                        setf(
-                            &modified_value,
-                            &key_str,
-                            &format_bytes(&getf(&modified_value, &key_str)),
-                        )
-                    }
-                }
-            });
+    // Skip non-object types (primitives, null, undefined, BigInt, etc.)
+    let object = match js_sys::Object::try_from(value) {
+        Some(obj) => obj,
+        None => return value.clone(),
     };
+    let modified_value = value.clone();
+    for k in js_sys::Object::keys(object).iter() {
+        let key_str = match k.as_string() {
+            Some(s) => s,
+            None => continue,
+        };
+        let child = match js_sys::Reflect::get(&modified_value, &k) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if key_str == "bytes" && js_sys::Array::is_array(&child) {
+            let js_arr = js_sys::Array::from(&child);
+            let mut valid = true;
+            let mut array = Vec::with_capacity(js_arr.length() as usize);
+            for v in js_arr.iter() {
+                if let Some(f) = v.as_f64() {
+                    array.push(f as u8);
+                } else {
+                    valid = false;
+                    break;
+                }
+            }
+            if valid {
+                let array_hex = hex::encode(array);
+                let hex_len = array_hex.len();
+                let hex_elided = if hex_len > 128 {
+                    format!("{}..{}", &array_hex[0..4], &array_hex[hex_len - 4..])
+                } else {
+                    array_hex
+                };
+                setf(&modified_value, "bytes", &JsValue::from_str(&hex_elided));
+            }
+        } else {
+            let formatted = format_bytes(&child);
+            let _ = js_sys::Reflect::set(&modified_value, &k, &formatted);
+        }
+    }
     modified_value
 }
 
@@ -667,12 +680,19 @@ async fn route_aux(
     let (page, new_path) = result.unwrap_or_else(|e| error(&e));
     let page_js = format_bytes(&page.serialize(&SER).unwrap());
     setf(app, "page", &page_js);
-    web_sys::window()
+    let history = web_sys::window()
         .expect("window object not found")
         .history()
-        .expect("history object not found")
-        .push_state_with_url(&page_js, &new_path, Some(&new_path))
-        .expect("push_state failed");
+        .expect("history object not found");
+    if init {
+        history
+            .replace_state_with_url(&page_js, &new_path, Some(&new_path))
+            .expect("replace_state failed");
+    } else {
+        history
+            .push_state_with_url(&page_js, &new_path, Some(&new_path))
+            .expect("push_state failed");
+    }
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Motivation

It appeared that there were still issues with the `linera-explorer`.
We correct here the next block of errors.

Backport of #6054 

## Proposal

The following bugs were identified:
* Clicking on the application hash did not lead to the screen of the application.
* Clicking on operations did not lead to operations.
* Some entries were marked as "Oracle responses", "Events", and so on when none could exist.
* The Operation results were presented as single vectors.

The following decisions were made:
* The application now show the queries and mutations. They were not tested though. This is for the next round.
* Now for "Operation results", "Blobs", "Events" and "Oracle responses" we present the result as hexadecimal string. The short one is presented and when clicking we can get the full entry.

The BlobId were not shown as they are not available.


## Test Plan

CI

## Release Plan

This is the backport to `testnet_conway`.

## Links

None