### PR TITLE
Make `linera-explorer` work correctly with `counter` application. Also make operations work.

### DIFF
--- a/linera-explorer/src/components/Entrypoint.vue
+++ b/linera-explorer/src/components/Entrypoint.vue
@@ -7,6 +7,7 @@ import InputType from './InputType.vue'
 import OutputType from './OutputType.vue'
 
 export default defineComponent({
+  components: { Json, InputType, OutputType },
   props: {
     entry: {type: Object as PropType<IntrospectionField>, required: true},
     link: {type: String, required: true},

--- a/linera-explorer/src/components/Json.vue
+++ b/linera-explorer/src/components/Json.vue
@@ -1,14 +1,30 @@
 <script setup lang="ts" >
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch, toRaw } from 'vue'
 import JSONFormatter from 'json-formatter-js'
 
 const props = defineProps<{data: any}>()
 const container : any = ref(null)
 
-onMounted(() => {
-  let formatter = new JSONFormatter(props.data, Infinity)
-  container.value!.appendChild(formatter.render())
-})
+function safeStringify(obj: any): string {
+  return JSON.stringify(obj, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value
+  )
+}
+
+function render() {
+  if (!container.value) return
+  container.value.innerHTML = ''
+  const raw = toRaw(props.data)
+  if (raw === undefined || raw === null) return
+  // Convert reactive proxy to plain object for JSONFormatter
+  // Use BigInt-safe stringify since WASM serializer produces BigInt for u64/i64
+  const plain = JSON.parse(safeStringify(raw))
+  let formatter = new JSONFormatter(plain, Infinity)
+  container.value.appendChild(formatter.render())
+}
+
+onMounted(render)
+watch(() => props.data, render, { deep: true })
 </script>
 
 <template>

--- a/linera-explorer/src/entrypoint.rs
+++ b/linera-explorer/src/entrypoint.rs
@@ -131,7 +131,13 @@ pub async fn query(app: JsValue, query: JsValue, kind: String) {
     let body =
         serde_json::json!({ "query": format!("{} {{{} {}}}", kind, input, response) }).to_string();
     let client = reqwest_client();
-    match client.post(&link).body(body).send().await {
+    match client
+        .post(&link)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .send()
+        .await
+    {
         Err(e) => setf(&app, "errors", &JsValue::from_str(&e.to_string())),
         Ok(response) => match response.text().await {
             Err(e) => setf(&app, "errors", &JsValue::from_str(&e.to_string())),


### PR DESCRIPTION
## Motivation

The `linera-explorer` has some applications but we could not access to the GraphQL queries and operations.

## Proposal

The entries are corrected.

The serialization of `StreamId` is controversially changed.

## Test Plan

CI

Local tests show the functionality working.

Application page:
<img width="1051" height="563" alt="Linera_explorer3_application" src="https://github.com/user-attachments/assets/07423158-2271-4e31-83fc-de04170e416d" />

The operations page:
<img width="871" height="750" alt="Linera_explorer3_operations" src="https://github.com/user-attachments/assets/4b04a391-9f57-418d-a7ca-c420d76953c9" />

## Release Plan

Can be backported to `testnet_conway`.

## Links

None