### PR TITLE
Fourth set of improvement to `linera-explorer`.

### DIFF
--- a/linera-explorer/src/components/App.vue
+++ b/linera-explorer/src/components/App.vue
@@ -85,7 +85,7 @@ export default {
         </div>
       </div>
     </nav>
-    <div class="container pb-5">
+    <div class="container-fluid pb-5">
       <div v-if="page=='unloaded'">
         <div class="text-center m-5 p-5">
           <span class="spinner-border">
@@ -111,7 +111,12 @@ export default {
       </div>
 
       <div v-else-if="page.blocks">
-        <Blocks :blocks="page.blocks"/>
+        <div class="card">
+          <div class="card-header">Blocks</div>
+          <div class="card-body">
+            <Blocks :blocks="page.blocks"/>
+          </div>
+        </div>
       </div>
 
       <div v-else-if="page.block">

--- a/linera-explorer/src/components/Applications.vue
+++ b/linera-explorer/src/components/Applications.vue
@@ -29,9 +29,22 @@ function safeStringify(obj: any): string {
             </a>
           </td>
           <td :title="a.link">
-            <a :href="a.link" target="_blank" class="btn btn-link btn-sm">
+            <button class="btn btn-link btn-sm" data-bs-toggle="modal" :data-bs-target="'#'+a.id+'-graphiql-modal'">
               <i class="bi bi-bounding-box-circles"></i>
-            </a>
+            </button>
+            <div :id="a.id+'-graphiql-modal'" class="modal fade">
+              <div class="modal-dialog modal-fullscreen">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h5 class="modal-title">GraphiQL</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                  </div>
+                  <div class="modal-body p-0">
+                    <iframe :src="a.link" style="width: 100%; height: 100%; border: none;"></iframe>
+                  </div>
+                </div>
+              </div>
+            </div>
           </td>
           <td>
             <button class="btn btn-link btn-sm" data-bs-toggle="modal" :data-bs-target="'#'+a.id+'-modal'" @click="json_load(a.id+'-json', a)">
@@ -42,7 +55,7 @@ function safeStringify(obj: any): string {
                 <div class="modal-content">
                   <div class="modal-header">
                     <h5 class="modal-title">Application</h5>
-                    <button type="button" class="btn-close" data-bs-digsmiss="modal"></button>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                   </div>
                   <div class="modal-body">
                     <div :id="a.id+'-json'" style="overflow-x: auto">

--- a/linera-explorer/src/components/Blocks.vue
+++ b/linera-explorer/src/components/Blocks.vue
@@ -20,6 +20,8 @@ defineProps<{blocks: ConfirmedBlock[]}>()
         <th>#InMessages</th>
         <th>#OutMessages</th>
         <th>#Operations</th>
+        <th>#Events</th>
+        <th>#OracleResponses</th>
         <th>JSON</th>
       </thead>
       <tbody>
@@ -37,6 +39,8 @@ defineProps<{blocks: ConfirmedBlock[]}>()
           <td>{{ getIncomingBundles(b.block.body.transactionMetadata).length }}</td>
           <td>{{ b.block.body.messages.length }}</td>
           <td>{{ getOperations(b.block.body.transactionMetadata).length }}</td>
+          <td>{{ b.block.body.events.flat().length }}</td>
+          <td>{{ b.block.body.oracleResponses.flat().length }}</td>
           <td>
             <button class="btn btn-link btn-sm" data-bs-toggle="modal" :data-bs-target="'#'+b.hash+'-modal'" @click="json_load(b.hash+'-json', b)">
               <i class="bi bi-braces"></i>

--- a/linera-explorer/src/components/Blocks.vue
+++ b/linera-explorer/src/components/Blocks.vue
@@ -29,7 +29,10 @@ defineProps<{blocks: ConfirmedBlock[]}>()
             <a @click="$root.route('block', [['block', b.hash]])" class="btn btn-link">{{ short_hash(b.hash) }}</a>
           </td>
           <td>{{ (new Date(Number(b.block.header.timestamp)/1000)).toLocaleString() }}</td>
-          <td :title="b.block.header.authenticatedOwner">{{ b.block.header.authenticatedOwner }}</td>
+          <td>
+            <a v-if="b.block.header.authenticatedOwner" class="btn btn-link btn-sm font-monospace" data-bs-toggle="collapse" :data-bs-target="'#signer-'+b.hash">{{ b.block.header.authenticatedOwner.slice(0, 10) }}…</a>
+            <div v-if="b.block.header.authenticatedOwner" class="collapse font-monospace small text-break" :id="'signer-'+b.hash">{{ b.block.header.authenticatedOwner }}</div>
+          </td>
           <td>{{ b.status }}</td>
           <td>{{ getIncomingBundles(b.block.body.transactionMetadata).length }}</td>
           <td>{{ b.block.body.messages.length }}</td>


### PR DESCRIPTION
## Motivation

We now address the Blocks entries.

## Proposal

Here we improve some forgotten dismiss typo and add some information to the Blocks entries.

## Test Plan

CI

Running locally, we now have the number of events and oracle responses in the block information.
We also use the full screen which reduces the whitespace lost.
<img width="1716" height="504" alt="Linera_explorer4_blocks" src="https://github.com/user-attachments/assets/2ba0ac55-2daf-458e-9774-0194a76b5971" />


## Release Plan

It can be released to `testnet_conway`.

## Links

None