### PR TITLE
[testnet] Backport the third set of changes to `linera-explorer`.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -557,8 +557,6 @@ impl std::str::FromStr for StreamName {
     Ord,
     PartialEq,
     PartialOrd,
-    Serialize,
-    Deserialize,
     WitLoad,
     WitStore,
     WitType,
@@ -572,6 +570,47 @@ pub struct StreamId {
     pub application_id: GenericApplicationId,
     /// The name of this stream: an application can have multiple streams with different names.
     pub stream_name: StreamName,
+}
+
+impl serde::Serialize for StreamId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_string())
+        } else {
+            use serde::ser::SerializeStruct;
+            let mut state = serializer.serialize_struct("StreamId", 2)?;
+            state.serialize_field("application_id", &self.application_id)?;
+            state.serialize_field("stream_name", &self.stream_name)?;
+            state.end()
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            Self::from_str(&s).map_err(serde::de::Error::custom)
+        } else {
+            #[derive(serde::Deserialize)]
+            #[serde(rename = "StreamId")]
+            struct StreamIdHelper {
+                application_id: GenericApplicationId,
+                stream_name: StreamName,
+            }
+            let helper = StreamIdHelper::deserialize(deserializer)?;
+            Ok(StreamId {
+                application_id: helper.application_id,
+                stream_name: helper.stream_name,
+            })
+        }
+    }
 }
 
 impl StreamId {

--- a/linera-explorer/src/components/Entrypoint.vue
+++ b/linera-explorer/src/components/Entrypoint.vue
@@ -7,6 +7,7 @@ import InputType from './InputType.vue'
 import OutputType from './OutputType.vue'
 
 export default defineComponent({
+  components: { Json, InputType, OutputType },
   props: {
     entry: {type: Object as PropType<IntrospectionField>, required: true},
     link: {type: String, required: true},

--- a/linera-explorer/src/components/Json.vue
+++ b/linera-explorer/src/components/Json.vue
@@ -1,14 +1,30 @@
 <script setup lang="ts" >
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch, toRaw } from 'vue'
 import JSONFormatter from 'json-formatter-js'
 
 const props = defineProps<{data: any}>()
 const container : any = ref(null)
 
-onMounted(() => {
-  let formatter = new JSONFormatter(props.data, Infinity)
-  container.value!.appendChild(formatter.render())
-})
+function safeStringify(obj: any): string {
+  return JSON.stringify(obj, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value
+  )
+}
+
+function render() {
+  if (!container.value) return
+  container.value.innerHTML = ''
+  const raw = toRaw(props.data)
+  if (raw === undefined || raw === null) return
+  // Convert reactive proxy to plain object for JSONFormatter
+  // Use BigInt-safe stringify since WASM serializer produces BigInt for u64/i64
+  const plain = JSON.parse(safeStringify(raw))
+  let formatter = new JSONFormatter(plain, Infinity)
+  container.value.appendChild(formatter.render())
+}
+
+onMounted(render)
+watch(() => props.data, render, { deep: true })
 </script>
 
 <template>

--- a/linera-explorer/src/entrypoint.rs
+++ b/linera-explorer/src/entrypoint.rs
@@ -131,7 +131,13 @@ pub async fn query(app: JsValue, query: JsValue, kind: String) {
     let body =
         serde_json::json!({ "query": format!("{} {{{} {}}}", kind, input, response) }).to_string();
     let client = reqwest_client();
-    match client.post(&link).body(body).send().await {
+    match client
+        .post(&link)
+        .header("Content-Type", "application/json")
+        .body(body)
+        .send()
+        .await
+    {
         Err(e) => setf(&app, "errors", &JsValue::from_str(&e.to_string())),
         Ok(response) => match response.text().await {
             Err(e) => setf(&app, "errors", &JsValue::from_str(&e.to_string())),


### PR DESCRIPTION
## Motivation

The changes to Applications and Operations can be backported to testnet_conway.

## Proposal

Same as https://github.com/linera-io/linera-protocol/pull/6058 and https://github.com/linera-io/linera-protocol/pull/6059.

See https://github.com/linera-io/linera-protocol/pull/6058 for the result of those changes.

## Test Plan

CI

## Release Plan

Changes to `testnet_conway`.

## Links

None.