### PR TITLE
fix CI host in bridge-e2e.yml

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   bridge-e2e:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: linera-io-self-hosted-ci
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
## Motivation

Use OVH hosts for long-running jobs

## Proposal

* fix CI host in bridge-e2e.yml

## Test Plan

CI