### PR TITLE
Reset chains on more errors; restore votes

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -441,7 +441,9 @@ where
                 .get_mut()
                 .get_mut(&update)
                 .ok_or_else(|| {
-                    ChainError::InternalError("message counter should be present".into())
+                    ChainError::CorruptedChainState(
+                        "message counter should be present".into(),
+                    )
                 })?;
             *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
             if *counter == 0 {
@@ -570,7 +572,7 @@ where
             .await
             .map_err(|error| match error {
                 InboxError::ViewError(error) => ChainError::ViewError(error),
-                error => ChainError::InternalError(format!(
+                error => ChainError::CorruptedChainState(format!(
                     "while processing messages in certified block: {error}"
                 )),
             })?;
@@ -696,7 +698,7 @@ where
     ) -> Result<Vec<ReadGuardedView<OutboxStateView<C>>>, ChainError> {
         let vec_of_options = self.outboxes.try_load_entries(targets).await?;
         let optional_vec = vec_of_options.into_iter().collect::<Option<Vec<_>>>();
-        optional_vec.ok_or_else(|| ChainError::InternalError("Missing outboxes".into()))
+        optional_vec.ok_or_else(|| ChainError::CorruptedChainState("Missing outboxes".into()))
     }
 
     /// Executes a block with a specified policy for handling bundle failures.
@@ -903,7 +905,7 @@ where
         let mut previous_message_blocks = BTreeMap::new();
         for (hash, (recipient, height)) in hashes.into_iter().zip(recipient_heights) {
             let hash = hash.ok_or_else(|| {
-                ChainError::InternalError("missing entry in confirmed_log".into())
+                ChainError::CorruptedChainState("missing entry in confirmed_log".into())
             })?;
             previous_message_blocks.insert(recipient, (hash, height));
         }
@@ -923,7 +925,7 @@ where
         let mut previous_event_blocks = BTreeMap::new();
         for (hash, (stream, height)) in hashes.into_iter().zip(stream_heights) {
             let hash = hash.ok_or_else(|| {
-                ChainError::InternalError("missing entry in confirmed_log".into())
+                ChainError::CorruptedChainState("missing entry in confirmed_log".into())
             })?;
             previous_event_blocks.insert(stream, (hash, height));
         }
@@ -1318,13 +1320,19 @@ where
                         let index =
                             usize::try_from(height.0).map_err(|_| ArithmeticError::Overflow)?;
                         Some(self.confirmed_log.get(index).await?.ok_or_else(|| {
-                            ChainError::InternalError("missing entry in confirmed_log".into())
+                            ChainError::CorruptedChainState(
+                                "missing entry in confirmed_log".into(),
+                            )
                         })?)
                     }
                     // The block with last added message has not been executed yet. If we have it,
                     // it's in preprocessed_blocks.
                     Some(height) => Some(self.preprocessed_blocks.get(&height).await?.ok_or_else(
-                        || ChainError::InternalError("missing entry in preprocessed_blocks".into()),
+                        || {
+                            ChainError::CorruptedChainState(
+                                "missing entry in preprocessed_blocks".into(),
+                            )
+                        },
                     )?),
                     None => None, // No message to that sender was added yet.
                 };
@@ -1340,7 +1348,7 @@ where
                     (Some(_), None) => {
                         // Outbox indicates there was a previous message block, but
                         // previous_message_blocks has no idea about it - possible bug
-                        return Err(ChainError::InternalError(
+                        return Err(ChainError::CorruptedChainState(
                             "block indicates no previous message block,\
                             but we have one in the outbox"
                                 .into(),

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -441,9 +441,7 @@ where
                 .get_mut()
                 .get_mut(&update)
                 .ok_or_else(|| {
-                    ChainError::CorruptedChainState(
-                        "message counter should be present".into(),
-                    )
+                    ChainError::CorruptedChainState("message counter should be present".into())
                 })?;
             *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
             if *counter == 0 {
@@ -1320,9 +1318,7 @@ where
                         let index =
                             usize::try_from(height.0).map_err(|_| ArithmeticError::Overflow)?;
                         Some(self.confirmed_log.get(index).await?.ok_or_else(|| {
-                            ChainError::CorruptedChainState(
-                                "missing entry in confirmed_log".into(),
-                            )
+                            ChainError::CorruptedChainState("missing entry in confirmed_log".into())
                         })?)
                     }
                     // The block with last added message has not been executed yet. If we have it,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -149,6 +149,8 @@ pub enum ChainError {
     },
     #[error("Internal error {0}")]
     InternalError(String),
+    #[error("Corrupted chain state: {0}")]
+    CorruptedChainState(String),
     #[error("Block proposal has size {0} which is too large")]
     BlockProposalTooLarge(usize),
     #[error(transparent)]
@@ -209,6 +211,7 @@ impl ChainError {
             | ChainError::UnexpectedMessage { .. }
             | ChainError::InboxGapDetected { .. }
             | ChainError::InternalError(_)
+            | ChainError::CorruptedChainState(_)
             | ChainError::BcsError(_) => true,
             ChainError::ExecutionError(execution_error, _) => execution_error.is_local(),
         }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -798,7 +798,7 @@ impl ManagerSafetySnapshot {
     /// Reads the safety-critical fields from the given `manager`.
     pub async fn capture<C>(manager: &ChainManager<C>) -> Result<Self, ViewError>
     where
-        C: Context + Clone + Send + Sync + 'static,
+        C: Context + Clone + 'static,
     {
         Ok(Self {
             confirmed_vote: manager.confirmed_vote.get().clone(),
@@ -815,7 +815,7 @@ impl ManagerSafetySnapshot {
     /// upper bound on what this validator has already committed to.
     pub fn restore<C>(self, manager: &mut ChainManager<C>) -> Result<(), ViewError>
     where
-        C: Context + Clone + Send + Sync + 'static,
+        C: Context + Clone + 'static,
     {
         manager.confirmed_vote.set(self.confirmed_vote);
         manager.validated_vote.set(self.validated_vote);

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -781,6 +781,55 @@ where
     }
 }
 
+/// The safety-critical fields of a [`ChainManager`]: previously cast votes and the
+/// locking block. Re-applying these after a chain reset prevents a validator from
+/// being tricked into double-signing at a height/round it has already voted on.
+#[derive(Debug, Default)]
+pub struct ManagerSafetySnapshot {
+    confirmed_vote: Option<Vote<ConfirmedBlock>>,
+    validated_vote: Option<Vote<ValidatedBlock>>,
+    timeout_vote: Option<Vote<Timeout>>,
+    fallback_vote: Option<Vote<Timeout>>,
+    locking_block: Option<LockingBlock>,
+    locking_blobs: Vec<(BlobId, Blob)>,
+}
+
+impl ManagerSafetySnapshot {
+    /// Reads the safety-critical fields from the given `manager`.
+    pub async fn capture<C>(manager: &ChainManager<C>) -> Result<Self, ViewError>
+    where
+        C: Context + Clone + Send + Sync + 'static,
+    {
+        Ok(Self {
+            confirmed_vote: manager.confirmed_vote.get().clone(),
+            validated_vote: manager.validated_vote.get().clone(),
+            timeout_vote: manager.timeout_vote.get().clone(),
+            fallback_vote: manager.fallback_vote.get().clone(),
+            locking_block: manager.locking_block.get().clone(),
+            locking_blobs: manager.locking_blobs.index_values().await?,
+        })
+    }
+
+    /// Writes the captured fields back into `manager`, overriding anything that
+    /// may have been produced by re-execution. The restored state is the safe
+    /// upper bound on what this validator has already committed to.
+    pub fn restore<C>(self, manager: &mut ChainManager<C>) -> Result<(), ViewError>
+    where
+        C: Context + Clone + Send + Sync + 'static,
+    {
+        manager.confirmed_vote.set(self.confirmed_vote);
+        manager.validated_vote.set(self.validated_vote);
+        manager.timeout_vote.set(self.timeout_vote);
+        manager.fallback_vote.set(self.fallback_vote);
+        manager.locking_block.set(self.locking_block);
+        manager.locking_blobs.clear();
+        for (blob_id, blob) in self.locking_blobs {
+            manager.locking_blobs.insert(&blob_id, blob)?;
+        }
+        Ok(())
+    }
+}
+
 /// Chain manager information that is included in `ChainInfo` sent to clients.
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -48,10 +48,10 @@ pub struct ChainWorkerConfig {
     pub cross_chain_message_chunk_limit: usize,
     /// Whether to attempt recovery via `RevertConfirm` when an inbox gap is detected.
     pub allow_revert_confirm: bool,
-    /// If set, reset the chain state and re-execute all blocks when an
-    /// `IncorrectOutcome` error is encountered — but only if the given duration has
+    /// If set, reset the chain state and re-execute all blocks when the chain
+    /// state is detected to be corrupted — but only if the given duration has
     /// elapsed since block 0 was last executed (to prevent reset loops).
-    pub reset_on_incorrect_outcome: Option<Duration>,
+    pub reset_on_corrupted_chain_state: Option<Duration>,
 }
 
 impl ChainWorkerConfig {
@@ -85,7 +85,7 @@ impl Default for ChainWorkerConfig {
             ignored_bundle_origins: HashSet::new(),
             cross_chain_message_chunk_limit: usize::MAX,
             allow_revert_confirm: false,
-            reset_on_incorrect_outcome: None,
+            reset_on_corrupted_chain_state: None,
         }
     }
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -969,27 +969,6 @@ where
                 .await?;
             // We should always agree on the messages and state hash.
             if outcome != verified {
-                if let Some(min_duration) = self.config.reset_on_incorrect_outcome {
-                    let block_zero_time = *self.chain.block_zero_executed_at.get();
-                    let elapsed = local_time.duration_since(block_zero_time);
-                    if elapsed >= min_duration {
-                        warn!(
-                            "IncorrectOutcome for block {height} on chain {chain_id}; \
-                            resetting chain state and re-executing"
-                        );
-                        return self
-                            .reset_and_reexecute_chain(
-                                certificate,
-                                notify_when_messages_are_delivered,
-                            )
-                            .await;
-                    }
-                    warn!(
-                        "IncorrectOutcome for block {height} on chain {chain_id}; \
-                        not resetting because only {elapsed:?} elapsed since last \
-                        block 0 execution (minimum: {min_duration:?})"
-                    );
-                }
                 return Err(WorkerError::IncorrectOutcome {
                     submitted: Box::new(outcome),
                     computed: Box::new(verified),
@@ -1278,16 +1257,39 @@ where
         Ok(actions)
     }
 
+    /// If the config enables corruption recovery and the min-duration guard is
+    /// satisfied, resets the chain state and re-executes all confirmed blocks.
+    /// Returns `RevertConfirm` requests to dispatch, or `None` if no reset happened.
+    pub(crate) async fn maybe_reset_corrupted_chain_state(
+        &mut self,
+    ) -> Result<Option<Vec<CrossChainRequest>>, WorkerError> {
+        let Some(min_duration) = self.config.reset_on_corrupted_chain_state else {
+            return Ok(None);
+        };
+        let chain_id = self.chain_id();
+        let local_time = self.storage.clock().current_time();
+        let block_zero_time = *self.chain.block_zero_executed_at.get();
+        let elapsed = local_time.duration_since(block_zero_time);
+        if elapsed < min_duration {
+            warn!(
+                "Not resetting corrupted chain state for {chain_id} because only \
+                {elapsed:?} elapsed since last block 0 execution (minimum: {min_duration:?})"
+            );
+            return Ok(None);
+        }
+        warn!("Corrupted chain state detected for {chain_id}; resetting and re-executing");
+        Ok(Some(self.reset_and_reexecute_chain().await?))
+    }
+
     /// Resets the chain state completely and re-executes all confirmed blocks from storage.
-    /// Sends `RevertConfirm` to all known senders so they resend cross-chain messages.
+    /// Returns a `RevertConfirm` request for every known sender so they resend cross-chain
+    /// messages that may have been lost during the reset.
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
     ))]
-    async fn reset_and_reexecute_chain(
+    pub(crate) async fn reset_and_reexecute_chain(
         &mut self,
-        failed_certificate: ConfirmedBlockCertificate,
-        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
-    ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+    ) -> Result<Vec<CrossChainRequest>, WorkerError> {
         let chain_id = self.chain_id();
         let tip_height = self.chain.tip_state.get().next_block_height;
 
@@ -1326,37 +1328,25 @@ where
             Box::pin(self.process_confirmed_block(cert, None)).await?;
         }
 
-        // 4. Now process the original certificate that triggered the error.
-        let result = Box::pin(
-            self.process_confirmed_block(failed_certificate, notify_when_messages_are_delivered),
-        )
-        .await?;
-
-        // 5. Send RevertConfirm to all senders so they resend messages we may
+        // 4. Build RevertConfirm requests so each sender resends messages we may
         //    have lost during the reset.
-        let (info, mut actions, outcome) = result;
-        for sender_id in sender_ids {
-            actions
-                .cross_chain_requests
-                .push(CrossChainRequest::RevertConfirm {
-                    sender: sender_id,
-                    recipient: chain_id,
-                    retransmit_from: BlockHeight::ZERO,
-                });
-        }
+        let revert_requests = sender_ids
+            .into_iter()
+            .map(|sender| CrossChainRequest::RevertConfirm {
+                sender,
+                recipient: chain_id,
+                retransmit_from: BlockHeight::ZERO,
+            })
+            .collect::<Vec<_>>();
 
         warn!(
             "Chain {chain_id} reset and re-executed up to height {}; \
-            sent RevertConfirm to {} senders",
+            sending RevertConfirm to {} senders",
             self.chain.tip_state.get().next_block_height,
-            actions
-                .cross_chain_requests
-                .iter()
-                .filter(|r| matches!(r, CrossChainRequest::RevertConfirm { .. }))
-                .count(),
+            revert_requests.len(),
         );
 
-        Ok((info, actions, outcome))
+        Ok(revert_requests)
     }
 
     #[instrument(skip_all, fields(

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -27,7 +27,7 @@ use linera_chain::{
         BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
         OriginalProposal, ProposalContent, ProposedBlock,
     },
-    manager,
+    manager::{self, ManagerSafetySnapshot},
     types::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
         ValidatedBlockCertificate,
@@ -1300,7 +1300,11 @@ where
         let hashes = self.chain.confirmed_log.read(..).await?;
         let preprocessed = self.chain.preprocessed_blocks.index_values().await?;
 
-        // 2. Clear the chain state entirely and save.
+        // 2. Snapshot safety-critical manager state so that we cannot be tricked
+        //    into double-signing if the reset wipes votes we already cast.
+        let manager_snapshot = ManagerSafetySnapshot::capture(&self.chain.manager).await?;
+
+        // 3. Clear the chain state entirely and save.
         self.chain.clear();
         self.knows_chain_is_active = false;
         self.save().await?;
@@ -1309,7 +1313,7 @@ where
             re-executing all blocks"
         );
 
-        // 3. Re-load certificates one at a time by hash and re-process them.
+        // 4. Re-load certificates one at a time by hash and re-process them.
         for (index, hash) in hashes.into_iter().enumerate() {
             let height = BlockHeight(index as u64);
             let cert = self
@@ -1330,7 +1334,12 @@ where
             Box::pin(self.process_confirmed_block(cert, None)).await?;
         }
 
-        // 4. Build RevertConfirm requests so each sender resends messages we may
+        // 5. Restore any previously cast votes and locking block so we cannot be
+        //    asked to sign a conflicting statement at the same height/round.
+        manager_snapshot.restore(&mut self.chain.manager)?;
+        self.save().await?;
+
+        // 6. Build RevertConfirm requests so each sender resends messages we may
         //    have lost during the reset.
         let revert_requests = sender_ids
             .into_iter()

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1274,12 +1274,13 @@ where
         let elapsed = local_time.duration_since(block_zero_time);
         if elapsed < min_duration {
             warn!(
-                "Not resetting corrupted chain state for {chain_id} because only \
-                {elapsed:?} elapsed since last block 0 execution (minimum: {min_duration:?})"
+                %chain_id, ?elapsed, ?min_duration,
+                "Not resetting corrupted chain state; not enough time elapsed \
+                since last block 0 execution"
             );
             return Ok(None);
         }
-        warn!("Corrupted chain state detected for {chain_id}; resetting and re-executing");
+        warn!(%chain_id, "Corrupted chain state detected; resetting and re-executing");
         Ok(Some(self.reset_and_reexecute_chain().await?))
     }
 
@@ -1347,8 +1348,8 @@ where
             self.save().await?;
         } else {
             warn!(
-                "Dropping manager snapshot for {chain_id}: pre-reset tip {tip_height} \
-                differs from post-reset tip {new_tip_height}"
+                %tip_height, %new_tip_height,
+                "Dropping manager snapshot: pre-reset tip differs from post-reset tip"
             );
         }
 
@@ -1364,10 +1365,9 @@ where
             .collect::<Vec<_>>();
 
         warn!(
-            "Chain {chain_id} reset and re-executed up to height {}; \
-            sending RevertConfirm to {} senders",
-            self.chain.tip_state.get().next_block_height,
-            revert_requests.len(),
+            tip_height = %self.chain.tip_state.get().next_block_height,
+            num_revert_confirms = revert_requests.len(),
+            "Chain reset and re-executed; sending RevertConfirm to senders"
         );
 
         Ok(revert_requests)

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -969,10 +969,12 @@ where
                 .await?;
             // We should always agree on the messages and state hash.
             if outcome != verified {
-                return Err(WorkerError::IncorrectOutcome {
-                    submitted: Box::new(outcome),
-                    computed: Box::new(verified),
-                });
+                return Err(ChainError::CorruptedChainState(format!(
+                    "computed block outcome differs from the certificate.\n\
+                    Computed: {verified:#?}\n\
+                    Submitted: {outcome:#?}"
+                ))
+                .into());
             }
             ConfirmedBlock::new(Block::new(proposed_block, verified))
         };

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1335,9 +1335,22 @@ where
         }
 
         // 5. Restore any previously cast votes and locking block so we cannot be
-        //    asked to sign a conflicting statement at the same height/round.
-        manager_snapshot.restore(&mut self.chain.manager)?;
-        self.save().await?;
+        //    asked to sign a conflicting statement at the same height/round. Votes
+        //    in the manager always belong to the pending height (one past the tip),
+        //    so restoring is only meaningful if re-execution landed at the same
+        //    tip. Otherwise the restored state would refer to a stale pending
+        //    height and could only break the manager's invariants without any
+        //    safety benefit — so we drop the snapshot in that case.
+        let new_tip_height = self.chain.tip_state.get().next_block_height;
+        if new_tip_height == tip_height {
+            manager_snapshot.restore(&mut self.chain.manager)?;
+            self.save().await?;
+        } else {
+            warn!(
+                "Dropping manager snapshot for {chain_id}: pre-reset tip {tip_height} \
+                differs from post-reset tip {new_tip_height}"
+            );
+        }
 
         // 6. Build RevertConfirm requests so each sender resends messages we may
         //    have lost during the reset.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1811,7 +1811,7 @@ where
         env.worker()
             .fully_handle_certificate_with_notifications(certificate, &())
             .await,
-        Err(WorkerError::IncorrectOutcome { .. })
+        Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
     );
     Ok(())
 }
@@ -4626,7 +4626,7 @@ where
 ///
 /// Corrupts a chain's `previous_message_blocks` in storage so that re-executing the
 /// next block produces a different `BlockExecutionOutcome`. First verifies that the
-/// corruption causes `IncorrectOutcome` without the recovery flag, then enables the
+/// corruption causes `CorruptedChainState` without the recovery flag, then enables the
 /// flag and verifies that the chain is reset and re-executed successfully.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
@@ -4699,7 +4699,7 @@ where
         )
         .await;
 
-    // Step 4: Verify that WITHOUT recovery, processing fails with IncorrectOutcome.
+    // Step 4: Verify that WITHOUT recovery, processing fails with CorruptedChainState.
     {
         let worker_no_recovery = WorkerState::new(
             storage.clone(),
@@ -4720,7 +4720,7 @@ where
             worker_no_recovery
                 .fully_handle_certificate_with_notifications(cert_1.clone(), &())
                 .await,
-            Err(WorkerError::IncorrectOutcome { .. })
+            Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
         );
     }
 
@@ -4747,7 +4747,7 @@ where
         worker_with_recovery
             .fully_handle_certificate_with_notifications(cert_1.clone(), &())
             .await,
-        Err(WorkerError::IncorrectOutcome { .. })
+        Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
     );
     // After the reset, retrying the certificate should succeed.
     worker_with_recovery

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -28,7 +28,7 @@ use linera_chain::{
     data_types::{
         BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, ChainAndHeight,
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
-        PostedMessage, SignatureAggregator, Transaction,
+        PostedMessage, SignatureAggregator, Transaction, Vote,
     },
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -4674,7 +4674,18 @@ where
         );
     }
 
-    // Step 2: Corrupt `previous_message_blocks` in storage. This directly affects
+    // Step 2: Plant a confirmed vote in the chain manager. After the reset, it must
+    // still be present — otherwise the validator could be tricked into double-signing.
+    let planted_vote = {
+        let key_pair = env.worker().chain_worker_config.key_pair().unwrap().copy();
+        let mut chain = storage.load_chain(chain_id).await?;
+        let vote = Vote::new(cert_0.value().clone(), Round::Fast, &key_pair);
+        chain.manager.confirmed_vote.set(Some(vote.clone()));
+        chain.save().await?;
+        vote
+    };
+
+    // Step 3: Corrupt `previous_message_blocks` in storage. This directly affects
     // the BlockExecutionOutcome (it's a field in the outcome struct), so the next
     // block's computed outcome will differ from the certificate's.
     {
@@ -4749,6 +4760,19 @@ where
             .await,
         Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
     );
+    // The previously cast confirmed vote must have survived the reset, or the
+    // validator could be tricked into double-signing. We check this before the
+    // retry because `apply_confirmed_block` for cert_1 would otherwise wipe the
+    // manager during the course of the retry.
+    {
+        let chain = worker_with_recovery.chain_state_view(chain_id).await?;
+        let restored_vote = chain.manager.confirmed_vote.get().as_ref();
+        assert_eq!(
+            restored_vote.map(|v| v.signature),
+            Some(planted_vote.signature),
+            "confirmed_vote should be restored after reset-and-reexecute"
+        );
+    }
     // After the reset, retrying the certificate should succeed.
     worker_with_recovery
         .fully_handle_certificate_with_notifications(cert_1.clone(), &())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4622,7 +4622,7 @@ where
     Ok(())
 }
 
-/// Tests the reset-on-incorrect-outcome recovery mechanism.
+/// Tests the reset-on-corrupted-chain-state recovery mechanism.
 ///
 /// Corrupts a chain's `previous_message_blocks` in storage so that re-executing the
 /// next block produces a different `BlockExecutionOutcome`. First verifies that the
@@ -4633,7 +4633,7 @@ where
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
-async fn test_reset_on_incorrect_outcome<B>(mut storage_builder: B) -> anyhow::Result<()>
+async fn test_reset_on_corrupted_chain_state<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
 {
@@ -4731,7 +4731,7 @@ where
             nickname: "Recovery worker".to_string(),
             allow_inactive_chains: true,
             allow_messages_from_deprecated_epochs: true,
-            reset_on_incorrect_outcome: Some(Duration::from_secs(0)),
+            reset_on_corrupted_chain_state: Some(Duration::from_secs(0)),
             block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
             ..ChainWorkerConfig::default()
         }
@@ -4741,6 +4741,15 @@ where
         None,
     );
 
+    // The first call returns the original error but triggers a background reset that
+    // re-executes prior blocks and fixes the corruption.
+    assert_matches!(
+        worker_with_recovery
+            .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+            .await,
+        Err(WorkerError::IncorrectOutcome { .. })
+    );
+    // After the reset, retrying the certificate should succeed.
     worker_with_recovery
         .fully_handle_certificate_with_notifications(cert_1.clone(), &())
         .await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -839,7 +839,7 @@ where
             if error.must_reload_view() {
                 self.evict_poisoned_worker(chain_id, &state);
             } else if error.indicates_corrupted_chain_state() {
-                Box::pin(self.reset_corrupted_chain_state(chain_id, &state)).await;
+                Box::pin(wrap_future(self.reset_corrupted_chain_state(chain_id, &state))).await;
             }
         }
         result

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -839,48 +839,57 @@ where
             if error.must_reload_view() {
                 self.evict_poisoned_worker(chain_id, &state);
             } else if error.indicates_corrupted_chain_state() {
-                Box::pin(wrap_future(
-                    self.reset_corrupted_chain_state(chain_id, &state),
-                ))
-                .await;
+                self.spawn_reset_corrupted_chain_state(chain_id, state);
             }
         }
         result
     }
 
-    /// Re-acquires a write lock and asks the chain worker to recover from a detected
-    /// state corruption. Generated `RevertConfirm` requests are dispatched through the
-    /// normal cross-chain pipeline. Any error along the way is logged but not returned:
-    /// the caller already has the original error to propagate.
-    async fn reset_corrupted_chain_state(
+    /// Spawns a detached task that re-acquires the write lock and recovers the
+    /// chain from a detected state corruption. Running the recovery in a separate
+    /// task ensures it survives cancellation of the originating request: if the
+    /// caller's future is dropped mid-way through re-execution, the chain would
+    /// otherwise be left at a partial tip and our safety snapshot would be lost.
+    /// Generated `RevertConfirm` requests are dispatched through the normal
+    /// cross-chain pipeline. Errors are logged; the caller already has the
+    /// original error to propagate.
+    fn spawn_reset_corrupted_chain_state(
         &self,
         chain_id: ChainId,
-        state: &ChainWorkerArc<StorageClient>,
-    ) {
-        let requests = {
-            let mut guard = handle::write_lock(state).await;
-            match guard.maybe_reset_corrupted_chain_state().await {
-                Ok(Some(requests)) => requests,
-                Ok(None) => return,
-                Err(error) => {
-                    tracing::error!(%chain_id, %error, "Failed to reset corrupted chain state");
-                    return;
+        state: ChainWorkerArc<StorageClient>,
+    ) where
+        StorageClient: Clone,
+    {
+        let this = self.clone();
+        linera_base::Task::spawn(async move {
+            let requests = {
+                let mut guard = handle::write_lock(&state).await;
+                match guard.maybe_reset_corrupted_chain_state().await {
+                    Ok(Some(requests)) => requests,
+                    Ok(None) => return,
+                    Err(error) => {
+                        tracing::error!(
+                            %chain_id, %error, "Failed to reset corrupted chain state"
+                        );
+                        return;
+                    }
+                }
+            };
+            let mut queue = VecDeque::from(requests);
+            while let Some(request) = queue.pop_front() {
+                match this.handle_cross_chain_request(request).await {
+                    Ok(actions) => queue.extend(actions.cross_chain_requests),
+                    Err(error) => {
+                        tracing::warn!(
+                            %chain_id, %error,
+                            "Failed to dispatch cross-chain request after \
+                            resetting corrupted chain state"
+                        );
+                    }
                 }
             }
-        };
-        let mut queue = VecDeque::from(requests);
-        while let Some(request) = queue.pop_front() {
-            match self.handle_cross_chain_request(request).await {
-                Ok(actions) => queue.extend(actions.cross_chain_requests),
-                Err(error) => {
-                    tracing::warn!(
-                        %chain_id, %error,
-                        "Failed to dispatch cross-chain request after \
-                        resetting corrupted chain state"
-                    );
-                }
-            }
-        }
+        })
+        .forget();
     }
 
     /// Evicts a poisoned chain worker from the cache, but only if the entry still

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -502,6 +502,19 @@ impl WorkerError {
                 })
         )
     }
+
+    /// Returns `true` if this error indicates that the chain's persisted state is
+    /// internally inconsistent, so the worker should consider resetting and
+    /// re-executing it from storage.
+    fn indicates_corrupted_chain_state(&self) -> bool {
+        match self {
+            WorkerError::IncorrectOutcome { .. } => true,
+            WorkerError::ChainError(chain_error) => {
+                matches!(chain_error.as_ref(), ChainError::CorruptedChainState(_))
+            }
+            _ => false,
+        }
+    }
 }
 
 impl From<ChainError> for WorkerError {
@@ -839,9 +852,46 @@ where
         if let Err(error) = &result {
             if error.must_reload_view() {
                 self.evict_poisoned_worker(chain_id, &state);
+            } else if error.indicates_corrupted_chain_state() {
+                Box::pin(self.reset_corrupted_chain_state(chain_id, &state)).await;
             }
         }
         result
+    }
+
+    /// Re-acquires a write lock and asks the chain worker to recover from a detected
+    /// state corruption. Generated `RevertConfirm` requests are dispatched through the
+    /// normal cross-chain pipeline. Any error along the way is logged but not returned:
+    /// the caller already has the original error to propagate.
+    async fn reset_corrupted_chain_state(
+        &self,
+        chain_id: ChainId,
+        state: &ChainWorkerArc<StorageClient>,
+    ) {
+        let requests = {
+            let mut guard = handle::write_lock(state).await;
+            match guard.maybe_reset_corrupted_chain_state().await {
+                Ok(Some(requests)) => requests,
+                Ok(None) => return,
+                Err(error) => {
+                    tracing::error!(%chain_id, %error, "Failed to reset corrupted chain state");
+                    return;
+                }
+            }
+        };
+        let mut queue = VecDeque::from(requests);
+        while let Some(request) = queue.pop_front() {
+            match self.handle_cross_chain_request(request).await {
+                Ok(actions) => queue.extend(actions.cross_chain_requests),
+                Err(error) => {
+                    tracing::warn!(
+                        %chain_id, %error,
+                        "Failed to dispatch cross-chain request after \
+                        resetting corrupted chain state"
+                    );
+                }
+            }
+        }
     }
 
     /// Evicts a poisoned chain worker from the cache, but only if the entry still

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -839,7 +839,10 @@ where
             if error.must_reload_view() {
                 self.evict_poisoned_worker(chain_id, &state);
             } else if error.indicates_corrupted_chain_state() {
-                Box::pin(wrap_future(self.reset_corrupted_chain_state(chain_id, &state))).await;
+                Box::pin(wrap_future(
+                    self.reset_corrupted_chain_state(chain_id, &state),
+                ))
+                .await;
             }
         }
         result

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -26,9 +26,7 @@ use linera_cache::{UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
 #[cfg(with_testing)]
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
-    data_types::{
-        BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock,
-    },
+    data_types::{BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock},
     types::{
         Block, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
@@ -380,15 +378,6 @@ pub enum WorkerError {
     #[error("The block does not contain the hash that we expected for the previous block")]
     InvalidBlockChaining,
     #[error(
-        "The given outcome is not what we computed after executing the block.\n\
-        Computed: {computed:#?}\n\
-        Submitted: {submitted:#?}"
-    )]
-    IncorrectOutcome {
-        computed: Box<BlockExecutionOutcome>,
-        submitted: Box<BlockExecutionOutcome>,
-    },
-    #[error(
         "Block timestamp ({block_timestamp}) is further in the future from local time \
         ({local_time}) than block time grace period ({block_time_grace_period:?}) \
         [us:{block_timestamp_us}:{local_time_us}]",
@@ -469,7 +458,6 @@ impl WorkerError {
             | WorkerError::MissingNetworkDescription
             | WorkerError::Thread(_)
             | WorkerError::ReadCertificatesError(_)
-            | WorkerError::IncorrectOutcome { .. }
             | WorkerError::PoisonedWorker => true,
             WorkerError::ChainError(chain_error) => chain_error.is_local(),
         }
@@ -507,13 +495,11 @@ impl WorkerError {
     /// internally inconsistent, so the worker should consider resetting and
     /// re-executing it from storage.
     fn indicates_corrupted_chain_state(&self) -> bool {
-        match self {
-            WorkerError::IncorrectOutcome { .. } => true,
-            WorkerError::ChainError(chain_error) => {
-                matches!(chain_error.as_ref(), ChainError::CorruptedChainState(_))
-            }
-            _ => false,
-        }
+        matches!(
+            self,
+            WorkerError::ChainError(chain_error)
+                if matches!(chain_error.as_ref(), ChainError::CorruptedChainState(_))
+        )
     }
 }
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -68,7 +68,7 @@ struct ServerContext {
     block_cache_size: usize,
     execution_state_cache_size: usize,
     allow_revert_confirm: bool,
-    reset_on_incorrect_outcome_mins: Option<u64>,
+    reset_on_corrupted_chain_state_mins: Option<u64>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -100,8 +100,8 @@ impl ServerContext {
             block_cache_size: self.block_cache_size,
             execution_state_cache_size: self.execution_state_cache_size,
             allow_revert_confirm: self.allow_revert_confirm,
-            reset_on_incorrect_outcome: self
-                .reset_on_incorrect_outcome_mins
+            reset_on_corrupted_chain_state: self
+                .reset_on_corrupted_chain_state_mins
                 .map(|m| linera_base::time::Duration::from_secs(m * 60)),
             cross_chain_message_chunk_limit: self.cross_chain_message_chunk_limit,
             ..ChainWorkerConfig::default()
@@ -471,12 +471,12 @@ enum ServerCommand {
         #[arg(long, default_value_t = false)]
         allow_revert_confirm: bool,
 
-        /// On IncorrectOutcome errors, reset the chain state and re-execute all
-        /// blocks from scratch. Sends RevertConfirm to all known senders. The
+        /// On detection of corrupted chain state, reset the chain state and re-execute
+        /// all blocks from scratch. Sends RevertConfirm to all known senders. The
         /// value is the minimum number of minutes since the last reset before
         /// another reset is allowed (to prevent loops).
         #[arg(long)]
-        reset_on_incorrect_outcome_mins: Option<u64>,
+        reset_on_corrupted_chain_state_mins: Option<u64>,
 
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
@@ -611,7 +611,7 @@ async fn run(options: ServerOptions) {
             chain_info_max_received_log_entries,
             cross_chain_message_chunk_limit,
             allow_revert_confirm,
-            reset_on_incorrect_outcome_mins,
+            reset_on_corrupted_chain_state_mins,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -631,7 +631,7 @@ async fn run(options: ServerOptions) {
                 block_cache_size: common_storage_options.block_cache_size,
                 execution_state_cache_size: common_storage_options.execution_state_cache_size,
                 allow_revert_confirm,
-                reset_on_incorrect_outcome_mins,
+                reset_on_corrupted_chain_state_mins,
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/5907 we added options to recover from DB failures, specifically from corrupted chain states that would result in `IncorrectOutcome` errors.

However, corrupted chain states can cause all kinds of errors, most of which are currently the `InternalError` variant.

## Proposal

Split `InternalError`: Use `CorruptedChainState` for those errors that could be caused by such DB issues.

Rename `--reset-on-incorrect-outcome-mins` to `--reset-on-corrupted-chain-state-mins` and, if set, reset the chain state on every `CorruptedChainState` error.

Also, restore the votes after re-executing the chain, to prevent double-signing.

## Test Plan

The test was extended.

But we will have to see if this fixes the remaining issues we see in `testnet_conway`, particularly validator 4.

## Release Plan

- Possibly port to `main`?

## Links

- The first version of the recovery mechanisms: #5907
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
