### PR TITLE
Storage atomicity and cancel safety fixes. (#6056, #6046, #6053)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2109,15 +2109,13 @@ where
     ))]
     async fn save(&mut self) -> Result<(), WorkerError> {
         if let Err(error) = self.chain.save().await {
-            if error.must_reload_view() {
-                tracing::error!(
-                    ?error,
-                    chain_id = %self.chain_id(),
-                    "Journal resolution failed; marking worker as poisoned"
-                );
-                self.poisoned = true;
-            }
-            return Err(error.into());
+            tracing::error!(
+                ?error,
+                chain_id = %self.chain_id(),
+                "Chain save failed; marking worker as poisoned"
+            );
+            self.poisoned = true;
+            return Err(WorkerError::PoisonedWorker);
         }
         Ok(())
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -775,10 +775,7 @@ where
             .with_label_values(&[metrics::DB])
             .inc();
         match value {
-            Some(block) => {
-                self.caches.confirmed_block.insert(&hash, block);
-                Ok(self.caches.confirmed_block.get(&hash))
-            }
+            Some(block) => Ok(Some(self.caches.confirmed_block.insert(&hash, block))),
             None => Ok(None),
         }
     }
@@ -807,10 +804,11 @@ where
             for (miss_idx, root_key) in misses.iter().zip(root_keys) {
                 let store = self.database.open_shared(&root_key)?;
                 if let Some(block) = store.read_value::<ConfirmedBlock>(BLOCK_KEY).await? {
-                    self.caches
-                        .confirmed_block
-                        .insert(&hashes[*miss_idx], block);
-                    results[*miss_idx] = self.caches.confirmed_block.get(&hashes[*miss_idx]);
+                    results[*miss_idx] = Some(
+                        self.caches
+                            .confirmed_block
+                            .insert(&hashes[*miss_idx], block),
+                    );
                 }
             }
         }
@@ -851,8 +849,7 @@ where
         match maybe_blob_bytes {
             Some(blob_bytes) => {
                 let blob = Blob::new_with_id_unchecked(blob_id, blob_bytes);
-                self.caches.blob.insert(&blob_id, blob);
-                Ok(self.caches.blob.get(&blob_id))
+                Ok(Some(self.caches.blob.insert(&blob_id, blob)))
             }
             None => Ok(None),
         }
@@ -1090,10 +1087,11 @@ where
                 let store = self.database.open_shared(&root_key)?;
                 let values = store.read_multi_values_bytes(&get_block_keys()).await?;
                 if let (Some(lite), Some(block)) = (values[0].as_ref(), values[1].as_ref()) {
-                    self.caches
-                        .certificate_raw
-                        .insert(&hashes[*miss_idx], (lite.clone(), block.clone()));
-                    results[*miss_idx] = self.caches.certificate_raw.get(&hashes[*miss_idx]);
+                    results[*miss_idx] = Some(
+                        self.caches
+                            .certificate_raw
+                            .insert(&hashes[*miss_idx], (lite.clone(), block.clone())),
+                    );
                 }
             }
         }
@@ -1248,10 +1246,7 @@ where
             .with_label_values(&[metrics::DB])
             .inc();
         match event {
-            Some(event_bytes) => {
-                self.caches.event.insert(&event_id, event_bytes);
-                Ok(self.caches.event.get(&event_id))
-            }
+            Some(event_bytes) => Ok(Some(self.caches.event.insert(&event_id, event_bytes))),
             None => Ok(None),
         }
     }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -347,30 +347,55 @@ where
 
 impl<K> WritableKeyValueStore for LruCachingStore<K>
 where
-    K: WritableKeyValueStore,
+    K: WritableKeyValueStore + Clone + Send + 'static,
+    K::Error: Send,
 {
     // The LRU cache does not change the underlying store's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), Self::Error> {
-        self.store.write_batch(batch.clone()).await?;
-        if let Some(cache) = &self.cache {
-            let mut cache = cache.lock().unwrap();
-            for operation in &batch.operations {
-                match operation {
-                    WriteOperation::Put { key, value } => {
-                        cache.put_key_value(key, value);
-                    }
-                    WriteOperation::Delete { key } => {
-                        cache.delete_key(key);
-                    }
-                    WriteOperation::DeletePrefix { key_prefix } => {
-                        cache.delete_prefix(key_prefix);
+        // Spawn a task to ensure the DB write and cache update run to
+        // completion atomically, even if the caller's future is cancelled
+        // (e.g. by RollbackGuard). Without this, a cancellation between
+        // the DB write and cache update leaves the cache stale, causing
+        // data loss on the next save.
+        //
+        // We use `tokio::task::spawn` (not `linera_base::Task::spawn`)
+        // because the latter cancels on drop via `RemoteHandle`.
+        let store = self.store.clone();
+        let cache = self.cache.clone();
+        let task = async move {
+            store.write_batch(batch.clone()).await?;
+            if let Some(cache) = &cache {
+                let mut cache = cache.lock().unwrap();
+                for operation in &batch.operations {
+                    match operation {
+                        WriteOperation::Put { key, value } => {
+                            cache.put_key_value(key, value);
+                        }
+                        WriteOperation::Delete { key } => {
+                            cache.delete_key(key);
+                        }
+                        WriteOperation::DeletePrefix { key_prefix } => {
+                            cache.delete_prefix(key_prefix);
+                        }
                     }
                 }
             }
+            Ok(())
+        };
+        // On native, spawn a task that runs to completion even if the
+        // caller is cancelled. On web, cancellation safety is not a
+        // concern (no RollbackGuard / concurrent chain workers).
+        #[cfg(not(web))]
+        match tokio::task::spawn(task).await {
+            Ok(result) => result,
+            Err(join_error) => std::panic::resume_unwind(join_error.into_panic()),
         }
-        Ok(())
+        #[cfg(web)]
+        {
+            task.await
+        }
     }
 
     async fn clear_journal(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
Ports of #6056, #6046 and #6053.

## Motivation

* The LRU cache is not cancel-safe: If the task is canceled, new values could have been written to the store, with the old values still in the cache.
* The block cache uses `Weak` pointers, so inserting and then getting doesn't work: After inserting there is no strong reference so the weak one becomes invalid.
* We currently reload the chain state only on specific journaling errors. But it's not clear that's the only error that can cause the view to become inconsistent.

## Proposal

* `spawn` the task that updates the LRU cache and writes to the underlying storage.
* Use the `Arc` returned from `insert` instead of dropping it.
* Reload the chain state on all `save()` errors.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- `testnet_conway` versions: #6056, #6046, #6053
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
