### PR TITLE
Increase the timeout for linera-indexer.

### DIFF
--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   indexer-check:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

The `indexer-check` CI checks is sometimes failing due to runtime error.

## Proposal

Switch from 10 minutes to 15 minutes.

## Test Plan

CI

## Release Plan

This is to `testnet_conway`.

## Links

None