### PR TITLE
Iron out another bug with the MUTATIONS in "linera-explorer".

### DIFF
--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -758,18 +758,28 @@ async fn subscribe_chain(app: &JsValue, address: &str, chain: ChainId) {
         while let Some(evt) = wsio.next().await {
             match evt {
                 WsMessage::Text(message) => {
-                    let graphql_message = serde_json::from_str::<
+                    let graphql_message = match serde_json::from_str::<
                         GQuery<Response<notifications::ResponseData>>,
                     >(&message)
-                    .expect("unexpected websocket response");
+                    {
+                        Ok(msg) => msg,
+                        Err(e) => {
+                            log_str(&format!("ignoring websocket message: {}", e));
+                            continue;
+                        }
+                    };
                     if let Some(payload) = graphql_message.payload {
                         if let Some(message_data) = payload.data {
                             let data =
                                 from_value::<Data>(app.clone()).expect("cannot parse vue data");
-                            if let Reason::NewBlock { .. } = message_data.notifications.reason {
-                                if message_data.notifications.chain_id == chain {
-                                    route_aux(&app, &data, &None, &Vec::new(), false).await
-                                }
+                            let should_refresh = matches!(
+                                &message_data.notifications.reason,
+                                Reason::NewBlock { .. }
+                                    | Reason::BlockExecuted { .. }
+                                    | Reason::NewEvents { .. }
+                            );
+                            if should_refresh && message_data.notifications.chain_id == chain {
+                                route_aux(&app, &data, &None, &Vec::new(), false).await
                             }
                         }
                         if let Some(errors) = payload.errors {

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -13,11 +13,13 @@ pub type JSONObject = serde_json::Value;
 
 #[cfg(target_arch = "wasm32")]
 mod types {
-    use linera_base::data_types::Round;
+    use std::collections::BTreeSet;
+
+    use linera_base::identifiers::StreamId;
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
-    use super::{BlockHeight, ChainId, CryptoHash};
+    use super::{BlockHeight, ChainId, CryptoHash, Round};
 
     pub type ChainManager = Value;
     pub type ChainOwnership = Value;
@@ -31,26 +33,38 @@ mod types {
     pub type ApplicationDescription = Value;
     pub type OperationResult = Value;
 
+    /// Mirrors `linera_core::worker::Notification`.
+    /// Duplicated because `linera-core` doesn't compile for wasm32.
     #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
     pub struct Notification {
         pub chain_id: ChainId,
         pub reason: Reason,
     }
 
+    /// Mirrors `linera_core::worker::Reason`.
+    /// Duplicated because `linera-core` doesn't compile for wasm32.
     #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-    #[expect(clippy::enum_variant_names)]
     pub enum Reason {
         NewBlock {
             height: BlockHeight,
+            hash: CryptoHash,
+        },
+        NewEvents {
+            height: BlockHeight,
             block_hash: CryptoHash,
+            event_streams: BTreeSet<StreamId>,
         },
         NewIncomingBundle {
-            origin: Origin,
+            origin: ChainId,
             height: BlockHeight,
         },
         NewRound {
             height: BlockHeight,
             round: Round,
+        },
+        BlockExecuted {
+            height: BlockHeight,
+            hash: CryptoHash,
         },
     }
 }


### PR DESCRIPTION
## Motivation

When doing a MUTATION in applications in "linera-explorer", even if the API looks ok, we have errors
that are shown in the console.

## Proposal

Adjust the "enum Reason".

So, we still have the duplication in "enum Reason" in `linera-core/src/worker.rs` and `linera-service-graphql-client/src/service.rs`, which was the original cause of the problem. Maybe that should be moved to `linera-base`. It is difficult to use `linera-core` to compile it on `Wasm32`.

## Test Plan

CI

This was tested locally.

## Release Plan

Backport to `testnet_conway` would make sense.

## Links

None