### PR TITLE
Log each chain ID exactly once.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -503,7 +503,7 @@ where
         assert!(!bundle.messages.is_empty());
         let chain_id = self.chain_id();
         tracing::trace!(
-            "Processing new messages to {chain_id:.8} from {origin} at height {}",
+            "Processing new messages from {origin} at height {}",
             bundle.height,
         );
         let chain_and_height = ChainAndHeight {
@@ -609,7 +609,7 @@ where
         let inboxes = self.inboxes.try_load_entries_mut(&origins).await?;
         for ((origin, bundles), mut inbox) in bundles_by_origin.into_iter().zip(inboxes) {
             tracing::trace!(
-                "Removing [{}] from {chain_id:.8}'s inbox for {origin:}",
+                "Removing [{}] from inbox for {origin}",
                 bundles
                     .iter()
                     .map(|bundle| bundle.height.to_string())

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -503,7 +503,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         context: Arc<Mutex<C>>,
         chain_id: ChainId,
     ) -> Result<(), Error> {
-        info!("Starting background certificate sync for chain {chain_id}");
+        info!("Starting background certificate sync");
         let client = context.lock().await.make_chain_client(chain_id).await?;
 
         Ok(client.find_received_certificates().await?)

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -850,7 +850,7 @@ where
                     },
                 });
             }
-            trace!("Preprocessed confirmed block {height} on chain {chain_id:.8}");
+            trace!("Preprocessed confirmed block {height}");
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
                 .await;
             return Ok((
@@ -930,7 +930,7 @@ where
                     let elapsed = local_time.duration_since(block_zero_time);
                     if elapsed >= min_duration {
                         warn!(
-                            "IncorrectOutcome for block {height} on chain {chain_id}; \
+                            "IncorrectOutcome for block {height}; \
                             resetting chain state and re-executing"
                         );
                         return self
@@ -942,7 +942,7 @@ where
                             .await;
                     }
                     warn!(
-                        "IncorrectOutcome for block {height} on chain {chain_id}; \
+                        "IncorrectOutcome for block {height}; \
                         not resetting because only {elapsed:?} elapsed since last \
                         block 0 execution (minimum: {min_duration:?})"
                     );
@@ -960,7 +960,7 @@ where
             .apply_confirmed_block(&confirmed_block, local_time)
             .await?;
         let mut actions = self.create_network_actions(None).await?;
-        trace!("Processed confirmed block {height} on chain {chain_id:.8}");
+        trace!("Processed confirmed block {height}");
         actions.notifications.push(Notification {
             chain_id,
             reason: Reason::NewBlock {
@@ -1021,7 +1021,7 @@ where
     }
 
     /// Updates the chain's inboxes, receiving messages from a cross-chain update.
-    #[instrument(level = "trace", skip(self, bundles))]
+    #[instrument(level = "debug", skip(self, bundles), fields(chain_id = %self.chain_id()))]
     pub(crate) async fn process_cross_chain_update(
         &mut self,
         origin: ChainId,
@@ -1040,10 +1040,9 @@ where
         // we haven't received yet, the inbox has a gap.
         if let Some(prev) = sender_previous_height {
             if prev >= next_height_to_receive {
-                let recipient = self.chain_id();
                 if self.config.allow_revert_confirm {
                     warn!(
-                        "Inbox gap detected for {recipient} from {origin}: \
+                        "Inbox gap detected from {origin}: \
                         sender declares previous height {prev} but we only have up to \
                         {next_height_to_receive}; requesting resend",
                     );
@@ -1053,7 +1052,7 @@ where
                     });
                 }
                 return Err(ChainError::InboxGapDetected {
-                    chain_id: recipient,
+                    chain_id: self.chain_id(),
                     origin,
                     expected_height: prev,
                     actual_height: bundles.first().map(|(_, b)| b.height).unwrap_or_default(),
@@ -1098,7 +1097,7 @@ where
             // now. Accordingly, do not send a confirmation, so that the
             // cross-chain update is retried later.
             warn!(
-                "Refusing to deliver messages to {recipient} from {origin} \
+                "Refusing to deliver messages from {origin} \
                 at height {last_updated_height} because the recipient is still inactive",
             );
             return Ok(CrossChainUpdateResult::NothingToDo);
@@ -1263,7 +1262,7 @@ where
         self.knows_chain_is_active = false;
         self.save().await?;
         warn!(
-            "Cleared chain state for {chain_id} up to height {tip_height}; \
+            "Cleared chain state up to height {tip_height}; \
             re-executing all blocks"
         );
 
@@ -1317,7 +1316,7 @@ where
         }
 
         warn!(
-            "Chain {chain_id} reset and re-executed up to height {}; \
+            "Chain reset and re-executed up to height {}; \
             sent RevertConfirm to {} senders",
             self.chain.tip_state.get().next_block_height,
             actions
@@ -2112,7 +2111,6 @@ where
             if error.must_reload_view() {
                 tracing::error!(
                     ?error,
-                    chain_id = %self.chain_id(),
                     "Journal resolution failed; marking worker as poisoned"
                 );
                 self.poisoned = true;

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -908,9 +908,9 @@ impl<Env: Environment> ChainClient<Env> {
     ///
     /// However, this should be the case whenever a sender's chain is still in use and
     /// is regularly upgraded to new committees.
-    #[instrument(level = "trace")]
+    #[instrument(level = "debug", skip(self), fields(chain_id = %self.chain_id))]
     pub async fn find_received_certificates(&self) -> Result<(), Error> {
-        debug!(chain_id = %self.chain_id, "starting find_received_certificates");
+        debug!("starting find_received_certificates");
         #[cfg(with_metrics)]
         let _latency = super::metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
         // Use network information from the local chain.
@@ -1013,7 +1013,7 @@ impl<Env: Environment> ChainClient<Env> {
             error!(
                 chain_id = %self.chain_id,
                 %error,
-                "Failed to update the certificate trackers for chain",
+                "Failed to update the certificate trackers",
             );
         }
     }
@@ -1293,8 +1293,8 @@ impl<Env: Environment> ChainClient<Env> {
                     },
                 ))) if expected_block_height > found_block_height => {
                     tracing::info!(
-                        "Local state is outdated; synchronizing chain {:.8}",
-                        self.chain_id
+                        chain_id = %self.chain_id,
+                        "Local state is outdated; synchronizing chain"
                     );
                     self.synchronize_chain_state(self.chain_id).await?;
                 }
@@ -1332,6 +1332,7 @@ impl<Env: Environment> ChainClient<Env> {
         let lock_start = linera_base::time::Instant::now();
         let mut proposal_guard = mutex.lock_owned().await;
         tracing::debug!(
+            chain_id = %self.chain_id,
             lock_wait_ms = lock_start.elapsed().as_millis(),
             "acquired proposal_mutex in execute_block"
         );
@@ -1822,7 +1823,7 @@ impl<Env: Environment> ChainClient<Env> {
     ///
     /// The caller must hold the proposal mutex via `proposal_guard`. The pending proposal
     /// is read from and cleared through the guard, ensuring synchronization.
-    #[instrument(level = "trace", skip(proposal_guard))]
+    #[instrument(level = "debug", skip(self, proposal_guard), fields(chain_id = %self.chain_id))]
     async fn process_pending_block_without_prepare(
         &self,
         proposal_guard: &mut Option<PendingProposal>,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1159,7 +1159,7 @@ impl<Env: Environment> Client<Env> {
     }
 
     /// Downloads and processes certificates for sender chain blocks.
-    #[instrument(level = "trace", skip_all)]
+    #[instrument(level = "debug", skip_all, fields(chain_id = %sender_chain_id))]
     async fn download_and_process_sender_chain(
         &self,
         sender_chain_id: ChainId,
@@ -1171,7 +1171,7 @@ impl<Env: Environment> Client<Env> {
         let (max_epoch, committees) = match self.admin_committees().await {
             Ok(result) => result,
             Err(error) => {
-                error!(%error, %sender_chain_id, "could not read admin committees");
+                error!(%error, "could not read admin committees");
                 return;
             }
         };
@@ -1257,7 +1257,6 @@ impl<Env: Environment> Client<Env> {
                     nodes.retain(|node| !faulty_validators.contains(&node.public_key));
                     if nodes.is_empty() {
                         info!(
-                            chain_id = %sender_chain_id,
                             "could not download certificates for chain - no more correct validators left"
                         );
                         return;
@@ -1267,7 +1266,6 @@ impl<Env: Environment> Client<Env> {
             };
 
             trace!(
-                chain_id = %sender_chain_id,
                 num_certificates = %certificates.len(),
                 "received certificates",
             );
@@ -1307,10 +1305,7 @@ impl<Env: Environment> Client<Env> {
 
             remote_heights.retain(|height| !to_remove_from_queue.contains(height));
         }
-        trace!(
-            chain_id = %sender_chain_id,
-            "find_received_certificates: finished processing chain",
-        );
+        trace!("find_received_certificates: finished processing chain");
     }
 
     /// Downloads the log of received messages for a chain from a validator.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -434,14 +434,14 @@ where
                 )
                 .await?;
             }
-            NodeError::InactiveChain(chain_id) => {
+            NodeError::InactiveChain(inactive_chain_id) => {
                 tracing::debug!(
                     address,
-                    %chain_id,
+                    chain_id = %inactive_chain_id,
                     "Validator has inactive chain; sending chain info.",
                 );
                 self.send_chain_information(
-                    *chain_id,
+                    *inactive_chain_id,
                     height,
                     CrossChainMessageDelivery::NonBlocking,
                     None,
@@ -674,7 +674,7 @@ where
     /// # Returns
     /// - `Ok(())` if synchronization completed successfully or the validator is already up to date
     /// - `Err` if there was a communication or storage error
-    #[instrument(level = "trace", skip_all)]
+    #[instrument(level = "debug", skip_all, fields(%chain_id))]
     pub async fn send_chain_information(
         &mut self,
         chain_id: ChainId,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1206,7 +1206,10 @@ where
 
     /// Processes a certificate, e.g. to extend a chain with a confirmed block.
     // Other fields will be included in the caller's span.
-    #[instrument(skip_all, fields(hash = %certificate.value.value_hash))]
+    #[instrument(skip_all, fields(
+        chain_id = %certificate.value.chain_id,
+        hash = %certificate.value.value_hash,
+    ))]
     pub async fn handle_lite_certificate(
         &self,
         certificate: LiteCertificate<'_>,
@@ -1335,10 +1338,7 @@ where
         chain_id: ChainId,
         blob_id: BlobId,
     ) -> Result<Blob, WorkerError> {
-        trace!(
-            "{} <-- download_pending_blob({chain_id:8}, {blob_id:8})",
-            self.nickname()
-        );
+        trace!("{} <-- download_pending_blob({blob_id:8})", self.nickname());
         let result = self
             .chain_read(chain_id, |guard| async move {
                 guard.download_pending_blob(blob_id).await
@@ -1362,10 +1362,7 @@ where
         blob: Blob,
     ) -> Result<ChainInfoResponse, WorkerError> {
         let blob_id = blob.id();
-        trace!(
-            "{} <-- handle_pending_blob({chain_id:8}, {blob_id:8})",
-            self.nickname()
-        );
+        trace!("{} <-- handle_pending_blob({blob_id:8})", self.nickname());
         let result = self
             .chain_write(chain_id, |mut guard| async move {
                 guard.handle_pending_blob(blob).await

--- a/linera-rpc/src/cross_chain_message_queue.rs
+++ b/linera-rpc/src/cross_chain_message_queue.rs
@@ -84,6 +84,7 @@ pub(crate) async fn forward_cross_chain_queries<F, G>(
             queue,
             match action {
                 Action::Proceed { .. } => {
+                    let target_chain_id = state.task.request.target_chain_id();
                     if let Err(error) = run_task(state.task).await {
                         warn!(
                             nickname = state.nickname,
@@ -91,6 +92,7 @@ pub(crate) async fn forward_cross_chain_queries<F, G>(
                             retry = state.retries,
                             from_shard = this_shard,
                             to_shard,
+                            chain_id = %target_chain_id,
                             "Failed to send cross-chain query",
                         );
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -932,7 +932,7 @@ where
     ) -> Result<Response<PendingBlobResult>, Status> {
         let traffic_type = Self::get_traffic_type(&request);
         let (chain_id, blob_id) = request.into_inner().try_into()?;
-        trace!(?chain_id, ?blob_id, "Download pending blob");
+        trace!(?blob_id, "Download pending blob");
         match self
             .state
             .clone()
@@ -968,7 +968,7 @@ where
         let (chain_id, blob_content) = request.into_inner().try_into()?;
         let blob = Blob::new(blob_content);
         let blob_id = blob.id();
-        trace!(?chain_id, ?blob_id, "Handle pending blob");
+        trace!(?blob_id, "Handle pending blob");
         match self.state.clone().handle_pending_blob(chain_id, blob).await {
             Ok(info) => {
                 Self::log_request_success("handle_pending_blob", traffic_type);


### PR DESCRIPTION
## Motivation

Some logs related to a particular chain don't contain the chain ID; others contain it multiple times, due to spans.

## Proposal

Remove chain IDs from log messages when they are already in the span, add them to chain-scoped logs that were missing context, and raise the span level from trace to debug on several chain-scoped functions so their chain_id field is visible in DEBUG/INFO logs.

## Test Plan

Maybe it's easiest to just take a look at the CI logs, how they look now.

## Release Plan

- Backport to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
