### PR TITLE
[testnet dbg] Reset chains on more errors; restore votes (#6063)

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -441,7 +441,7 @@ where
                 .get_mut()
                 .get_mut(&update)
                 .ok_or_else(|| {
-                    ChainError::InternalError("message counter should be present".into())
+                    ChainError::CorruptedChainState("message counter should be present".into())
                 })?;
             *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
             if *counter == 0 {
@@ -579,7 +579,7 @@ where
                     expected_height,
                     actual_height,
                 },
-                error => ChainError::InternalError(format!(
+                error => ChainError::CorruptedChainState(format!(
                     "while processing messages in certified block: {error}"
                 )),
             })?;
@@ -705,7 +705,7 @@ where
     ) -> Result<Vec<ReadGuardedView<OutboxStateView<C>>>, ChainError> {
         let vec_of_options = self.outboxes.try_load_entries(targets).await?;
         let optional_vec = vec_of_options.into_iter().collect::<Option<Vec<_>>>();
-        optional_vec.ok_or_else(|| ChainError::InternalError("Missing outboxes".into()))
+        optional_vec.ok_or_else(|| ChainError::CorruptedChainState("Missing outboxes".into()))
     }
 
     /// Executes a block with a specified policy for handling bundle failures.
@@ -912,7 +912,7 @@ where
         let mut previous_message_blocks = BTreeMap::new();
         for (hash, (recipient, height)) in hashes.into_iter().zip(recipient_heights) {
             let hash = hash.ok_or_else(|| {
-                ChainError::InternalError("missing entry in confirmed_log".into())
+                ChainError::CorruptedChainState("missing entry in confirmed_log".into())
             })?;
             previous_message_blocks.insert(recipient, (hash, height));
         }
@@ -932,7 +932,7 @@ where
         let mut previous_event_blocks = BTreeMap::new();
         for (hash, (stream, height)) in hashes.into_iter().zip(stream_heights) {
             let hash = hash.ok_or_else(|| {
-                ChainError::InternalError("missing entry in confirmed_log".into())
+                ChainError::CorruptedChainState("missing entry in confirmed_log".into())
             })?;
             previous_event_blocks.insert(stream, (hash, height));
         }
@@ -1321,13 +1321,17 @@ where
                         let index =
                             usize::try_from(height.0).map_err(|_| ArithmeticError::Overflow)?;
                         Some(self.confirmed_log.get(index).await?.ok_or_else(|| {
-                            ChainError::InternalError("missing entry in confirmed_log".into())
+                            ChainError::CorruptedChainState("missing entry in confirmed_log".into())
                         })?)
                     }
                     // The block with last added message has not been executed yet. If we have it,
                     // it's in preprocessed_blocks.
                     Some(height) => Some(self.preprocessed_blocks.get(&height).await?.ok_or_else(
-                        || ChainError::InternalError("missing entry in preprocessed_blocks".into()),
+                        || {
+                            ChainError::CorruptedChainState(
+                                "missing entry in preprocessed_blocks".into(),
+                            )
+                        },
                     )?),
                     None => None, // No message to that sender was added yet.
                 };
@@ -1343,7 +1347,7 @@ where
                     (Some(_), None) => {
                         // Outbox indicates there was a previous message block, but
                         // previous_message_blocks has no idea about it - possible bug
-                        return Err(ChainError::InternalError(
+                        return Err(ChainError::CorruptedChainState(
                             "block indicates no previous message block,\
                             but we have one in the outbox"
                                 .into(),

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -149,6 +149,8 @@ pub enum ChainError {
     },
     #[error("Internal error {0}")]
     InternalError(String),
+    #[error("Corrupted chain state: {0}")]
+    CorruptedChainState(String),
     #[error("Block proposal has size {0} which is too large")]
     BlockProposalTooLarge(usize),
     #[error(transparent)]
@@ -209,6 +211,7 @@ impl ChainError {
             | ChainError::UnexpectedMessage { .. }
             | ChainError::InboxGapDetected { .. }
             | ChainError::InternalError(_)
+            | ChainError::CorruptedChainState(_)
             | ChainError::BcsError(_) => true,
             ChainError::ExecutionError(execution_error, _) => execution_error.is_local(),
         }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -763,6 +763,55 @@ where
     }
 }
 
+/// The safety-critical fields of a [`ChainManager`]: previously cast votes and the
+/// locking block. Re-applying these after a chain reset prevents a validator from
+/// being tricked into double-signing at a height/round it has already voted on.
+#[derive(Debug, Default)]
+pub struct ManagerSafetySnapshot {
+    confirmed_vote: Option<Vote<ConfirmedBlock>>,
+    validated_vote: Option<Vote<ValidatedBlock>>,
+    timeout_vote: Option<Vote<Timeout>>,
+    fallback_vote: Option<Vote<Timeout>>,
+    locking_block: Option<LockingBlock>,
+    locking_blobs: Vec<(BlobId, Blob)>,
+}
+
+impl ManagerSafetySnapshot {
+    /// Reads the safety-critical fields from the given `manager`.
+    pub async fn capture<C>(manager: &ChainManager<C>) -> Result<Self, ViewError>
+    where
+        C: Context + Clone + 'static,
+    {
+        Ok(Self {
+            confirmed_vote: manager.confirmed_vote.get().clone(),
+            validated_vote: manager.validated_vote.get().clone(),
+            timeout_vote: manager.timeout_vote.get().clone(),
+            fallback_vote: manager.fallback_vote.get().clone(),
+            locking_block: manager.locking_block.get().clone(),
+            locking_blobs: manager.locking_blobs.index_values().await?,
+        })
+    }
+
+    /// Writes the captured fields back into `manager`, overriding anything that
+    /// may have been produced by re-execution. The restored state is the safe
+    /// upper bound on what this validator has already committed to.
+    pub fn restore<C>(self, manager: &mut ChainManager<C>) -> Result<(), ViewError>
+    where
+        C: Context + Clone + 'static,
+    {
+        manager.confirmed_vote.set(self.confirmed_vote);
+        manager.validated_vote.set(self.validated_vote);
+        manager.timeout_vote.set(self.timeout_vote);
+        manager.fallback_vote.set(self.fallback_vote);
+        manager.locking_block.set(self.locking_block);
+        manager.locking_blobs.clear();
+        for (blob_id, blob) in self.locking_blobs {
+            manager.locking_blobs.insert(&blob_id, blob)?;
+        }
+        Ok(())
+    }
+}
+
 /// Chain manager information that is included in `ChainInfo` sent to clients.
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -41,7 +41,7 @@ use super::{
 use crate::{
     chain_worker::BlockOutcome,
     client::ListeningMode,
-    data_types::{ChainInfoQuery, ChainInfoResponse},
+    data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     worker::{NetworkActions, WorkerError},
 };
 
@@ -304,6 +304,15 @@ where
         #[allow(clippy::type_complexity)]
         callback:
             oneshot::Sender<Result<BTreeMap<StreamId, (BlockHeight, CryptoHash)>, WorkerError>>,
+    },
+
+    /// If the config enables corruption recovery and the min-duration guard is
+    /// satisfied, reset the chain state and re-execute all confirmed blocks.
+    /// Returns the list of `RevertConfirm` requests to dispatch, or `None` if no
+    /// reset happened.
+    ResetCorruptedChainState {
+        #[debug(skip)]
+        callback: oneshot::Sender<Result<Option<Vec<CrossChainRequest>>, WorkerError>>,
     },
 }
 

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -41,10 +41,10 @@ pub struct ChainWorkerConfig {
     pub cross_chain_message_chunk_limit: usize,
     /// Whether to attempt recovery via `RevertConfirm` when an inbox gap is detected.
     pub allow_revert_confirm: bool,
-    /// If set, reset the chain state and re-execute all blocks when an
-    /// `IncorrectOutcome` error is encountered — but only if the given duration has
+    /// If set, reset the chain state and re-execute all blocks when the chain
+    /// state is detected to be corrupted — but only if the given duration has
     /// elapsed since block 0 was last executed (to prevent reset loops).
-    pub reset_on_incorrect_outcome: Option<Duration>,
+    pub reset_on_corrupted_chain_state: Option<Duration>,
 }
 
 impl ChainWorkerConfig {
@@ -75,7 +75,7 @@ impl Default for ChainWorkerConfig {
             ignored_bundle_origins: HashSet::new(),
             cross_chain_message_chunk_limit: usize::MAX,
             allow_revert_confirm: false,
-            reset_on_incorrect_outcome: None,
+            reset_on_corrupted_chain_state: None,
         }
     }
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -27,7 +27,7 @@ use linera_chain::{
         BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
         OriginalProposal, ProposalContent, ProposedBlock,
     },
-    manager,
+    manager::{self, ManagerSafetySnapshot},
     types::{Block, ConfirmedBlockCertificate, TimeoutCertificate, ValidatedBlockCertificate},
     ChainError, ChainExecutionContext, ChainStateView, ExecutionResultExt as _,
 };
@@ -331,6 +331,9 @@ where
                 callback,
             } => callback
                 .send(self.get_previous_event_blocks(stream_ids).await)
+                .is_ok(),
+            ChainWorkerRequest::ResetCorruptedChainState { callback } => callback
+                .send(self.maybe_reset_corrupted_chain_state().await)
                 .is_ok(),
         };
 
@@ -1107,28 +1110,12 @@ where
         };
         // We should always agree on the messages and state hash.
         if outcome != verified_outcome {
-            if let Some(min_duration) = self.config.reset_on_incorrect_outcome {
-                let block_zero_time = *self.chain.block_zero_executed_at.get();
-                let elapsed = local_time.duration_since(block_zero_time);
-                if elapsed >= min_duration {
-                    warn!(
-                        "IncorrectOutcome for block {height} on chain {chain_id}; \
-                        resetting chain state and re-executing"
-                    );
-                    return self
-                        .reset_and_reexecute_chain(certificate, notify_when_messages_are_delivered)
-                        .await;
-                }
-                warn!(
-                    "IncorrectOutcome for block {height} on chain {chain_id}; \
-                    not resetting because only {elapsed:?} elapsed since last \
-                    block 0 execution (minimum: {min_duration:?})"
-                );
-            }
-            return Err(WorkerError::IncorrectOutcome {
-                submitted: Box::new(outcome),
-                computed: Box::new(verified_outcome),
-            });
+            return Err(ChainError::CorruptedChainState(format!(
+                "computed block outcome differs from the certificate.\n\
+                Computed: {verified_outcome:#?}\n\
+                Submitted: {outcome:#?}"
+            ))
+            .into());
         }
 
         // Update the rest of the chain state.
@@ -1425,16 +1412,40 @@ where
         Ok(actions)
     }
 
+    /// If the config enables corruption recovery and the min-duration guard is
+    /// satisfied, resets the chain state and re-executes all confirmed blocks.
+    /// Returns `RevertConfirm` requests to dispatch, or `None` if no reset happened.
+    pub(crate) async fn maybe_reset_corrupted_chain_state(
+        &mut self,
+    ) -> Result<Option<Vec<CrossChainRequest>>, WorkerError> {
+        let Some(min_duration) = self.config.reset_on_corrupted_chain_state else {
+            return Ok(None);
+        };
+        let chain_id = self.chain_id();
+        let local_time = self.storage.clock().current_time();
+        let block_zero_time = *self.chain.block_zero_executed_at.get();
+        let elapsed = local_time.duration_since(block_zero_time);
+        if elapsed < min_duration {
+            warn!(
+                %chain_id, ?elapsed, ?min_duration,
+                "Not resetting corrupted chain state; not enough time elapsed \
+                since last block 0 execution"
+            );
+            return Ok(None);
+        }
+        warn!(%chain_id, "Corrupted chain state detected; resetting and re-executing");
+        Ok(Some(self.reset_and_reexecute_chain().await?))
+    }
+
     /// Resets the chain state completely and re-executes all confirmed blocks from storage.
-    /// Sends `RevertConfirm` to all known senders so they resend cross-chain messages.
+    /// Returns a `RevertConfirm` request for every known sender so they resend cross-chain
+    /// messages that may have been lost during the reset.
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
     ))]
-    async fn reset_and_reexecute_chain(
+    pub(crate) async fn reset_and_reexecute_chain(
         &mut self,
-        failed_certificate: ConfirmedBlockCertificate,
-        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
-    ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+    ) -> Result<Vec<CrossChainRequest>, WorkerError> {
         let chain_id = self.chain_id();
         let tip_height = self.chain.tip_state.get().next_block_height;
 
@@ -1443,7 +1454,11 @@ where
         let hashes = self.chain.confirmed_log.read(..).await?;
         let preprocessed = self.chain.preprocessed_blocks.index_values().await?;
 
-        // 2. Clear the chain state entirely and save.
+        // 2. Snapshot safety-critical manager state so that we cannot be tricked
+        //    into double-signing if the reset wipes votes we already cast.
+        let manager_snapshot = ManagerSafetySnapshot::capture(&self.chain.manager).await?;
+
+        // 3. Clear the chain state entirely and save.
         self.chain.clear();
         self.knows_chain_is_active = false;
         self.save().await?;
@@ -1452,7 +1467,7 @@ where
             re-executing all blocks"
         );
 
-        // 3. Re-load certificates one at a time by hash and re-process them.
+        // 4. Re-load certificates one at a time by hash and re-process them.
         for (index, hash) in hashes.into_iter().enumerate() {
             let height = BlockHeight(index as u64);
             let cert = self
@@ -1471,37 +1486,42 @@ where
             Box::pin(self.process_confirmed_block(cert, None)).await?;
         }
 
-        // 4. Now process the original certificate that triggered the error.
-        let result = Box::pin(
-            self.process_confirmed_block(failed_certificate, notify_when_messages_are_delivered),
-        )
-        .await?;
-
-        // 5. Send RevertConfirm to all senders so they resend messages we may
-        //    have lost during the reset.
-        let (info, mut actions, outcome) = result;
-        for sender_id in sender_ids {
-            actions
-                .cross_chain_requests
-                .push(CrossChainRequest::RevertConfirm {
-                    sender: sender_id,
-                    recipient: chain_id,
-                    missing_height: BlockHeight::ZERO,
-                });
+        // 5. Restore any previously cast votes and locking block so we cannot be
+        //    asked to sign a conflicting statement at the same height/round. Votes
+        //    in the manager always belong to the pending height (one past the tip),
+        //    so restoring is only meaningful if re-execution landed at the same
+        //    tip. Otherwise the restored state would refer to a stale pending
+        //    height and could only break the manager's invariants without any
+        //    safety benefit — so we drop the snapshot in that case.
+        let new_tip_height = self.chain.tip_state.get().next_block_height;
+        if new_tip_height == tip_height {
+            manager_snapshot.restore(&mut self.chain.manager)?;
+            self.save().await?;
+        } else {
+            warn!(
+                %tip_height, %new_tip_height,
+                "Dropping manager snapshot: pre-reset tip differs from post-reset tip"
+            );
         }
 
+        // 6. Build RevertConfirm requests so each sender resends messages we may
+        //    have lost during the reset.
+        let revert_requests = sender_ids
+            .into_iter()
+            .map(|sender| CrossChainRequest::RevertConfirm {
+                sender,
+                recipient: chain_id,
+                missing_height: BlockHeight::ZERO,
+            })
+            .collect::<Vec<_>>();
+
         warn!(
-            "Chain {chain_id} reset and re-executed up to height {}; \
-            sent RevertConfirm to {} senders",
-            self.chain.tip_state.get().next_block_height,
-            actions
-                .cross_chain_requests
-                .iter()
-                .filter(|r| matches!(r, CrossChainRequest::RevertConfirm { .. }))
-                .count(),
+            tip_height = %self.chain.tip_state.get().next_block_height,
+            num_revert_confirms = revert_requests.len(),
+            "Chain reset and re-executed; sending RevertConfirm to senders"
         );
 
-        Ok((info, actions, outcome))
+        Ok(revert_requests)
     }
 
     #[instrument(skip_all, fields(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -28,7 +28,7 @@ use linera_chain::{
     data_types::{
         BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, ChainAndHeight,
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
-        PostedMessage, SignatureAggregator, Transaction,
+        PostedMessage, SignatureAggregator, Transaction, Vote,
     },
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -1810,7 +1810,7 @@ where
         env.worker()
             .fully_handle_certificate_with_notifications(certificate, &())
             .await,
-        Err(WorkerError::IncorrectOutcome { .. })
+        Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
     );
     Ok(())
 }
@@ -4621,18 +4621,18 @@ where
     Ok(())
 }
 
-/// Tests the reset-on-incorrect-outcome recovery mechanism.
+/// Tests the reset-on-corrupted-chain-state recovery mechanism.
 ///
 /// Corrupts a chain's `previous_message_blocks` in storage so that re-executing the
 /// next block produces a different `BlockExecutionOutcome`. First verifies that the
-/// corruption causes `IncorrectOutcome` without the recovery flag, then enables the
+/// corruption causes `CorruptedChainState` without the recovery flag, then enables the
 /// flag and verifies that the chain is reset and re-executed successfully.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
-async fn test_reset_on_incorrect_outcome<B>(mut storage_builder: B) -> anyhow::Result<()>
+async fn test_reset_on_corrupted_chain_state<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
 {
@@ -4673,7 +4673,18 @@ where
         );
     }
 
-    // Step 2: Corrupt `previous_message_blocks` in storage. This directly affects
+    // Step 2: Plant a confirmed vote in the chain manager. After the reset, it must
+    // still be present — otherwise the validator could be tricked into double-signing.
+    let planted_vote = {
+        let key_pair = env.worker().chain_worker_config.key_pair().unwrap().copy();
+        let mut chain = storage.load_chain(chain_id).await?;
+        let vote = Vote::new(cert_0.value().clone(), Round::Fast, &key_pair);
+        chain.manager.confirmed_vote.set(Some(vote.clone()));
+        chain.save().await?;
+        vote
+    };
+
+    // Step 3: Corrupt `previous_message_blocks` in storage. This directly affects
     // the BlockExecutionOutcome (it's a field in the outcome struct), so the next
     // block's computed outcome will differ from the certificate's.
     {
@@ -4698,7 +4709,7 @@ where
         )
         .await;
 
-    // Step 4: Verify that WITHOUT recovery, processing fails with IncorrectOutcome.
+    // Step 4: Verify that WITHOUT recovery, processing fails with CorruptedChainState.
     {
         let worker_no_recovery = WorkerState::new(
             "No-recovery worker".to_string(),
@@ -4715,7 +4726,7 @@ where
             worker_no_recovery
                 .fully_handle_certificate_with_notifications(cert_1.clone(), &())
                 .await,
-            Err(WorkerError::IncorrectOutcome { .. })
+            Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
         );
     }
 
@@ -4729,9 +4740,31 @@ where
     )
     .with_allow_inactive_chains(true)
     .with_allow_messages_from_deprecated_epochs(true)
-    .with_reset_on_incorrect_outcome(Some(0))
+    .with_reset_on_corrupted_chain_state(Some(0))
     .with_block_time_grace_period(Duration::from_micros(TEST_GRACE_PERIOD_MICROS));
 
+    // The first call returns the original error but triggers a background reset that
+    // re-executes prior blocks and fixes the corruption.
+    assert_matches!(
+        worker_with_recovery
+            .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+            .await,
+        Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
+    );
+    // The previously cast confirmed vote must have survived the reset, or the
+    // validator could be tricked into double-signing. We check this before the
+    // retry because `apply_confirmed_block` for cert_1 would otherwise wipe the
+    // manager during the course of the retry.
+    {
+        let chain = worker_with_recovery.chain_state_view(chain_id).await?;
+        let restored_vote = chain.manager.confirmed_vote.get().as_ref();
+        assert_eq!(
+            restored_vote.map(|v| v.signature),
+            Some(planted_vote.signature),
+            "confirmed_vote should be restored after reset-and-reexecute"
+        );
+    }
+    // After the reset, retrying the certificate should succeed.
     worker_with_recovery
         .fully_handle_certificate_with_notifications(cert_1.clone(), &())
         .await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1146,18 +1146,29 @@ where
                     return;
                 }
             };
-            let Some(sender) = &this.outbound_cross_chain_sender else {
-                if !requests.is_empty() {
-                    warn!(
-                        %chain_id, dropped = requests.len(),
-                        "No outbound cross-chain sender installed; \
-                        RevertConfirms after corruption reset are dropped"
-                    );
+            if let Some(sender) = &this.outbound_cross_chain_sender {
+                // Sharded validator path: let the RPC layer route each request to
+                // the shard that owns the target chain.
+                for request in requests {
+                    sender(request);
                 }
-                return;
-            };
-            for request in requests {
-                sender(request);
+            } else {
+                // No routing dispatcher is installed (client node or test), so all
+                // involved chains are co-located on this worker. Dispatch locally
+                // in a loop, following any cascading cross-chain requests.
+                let mut queue = VecDeque::from(requests);
+                while let Some(request) = queue.pop_front() {
+                    match this.handle_cross_chain_request(request).await {
+                        Ok(actions) => queue.extend(actions.cross_chain_requests),
+                        Err(error) => {
+                            warn!(
+                                %chain_id, %error,
+                                "Failed to dispatch cross-chain request after \
+                                resetting corrupted chain state"
+                            );
+                        }
+                    }
+                }
             }
         })
         .forget();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -517,7 +517,17 @@ where
     chain_worker_tasks: Arc<Mutex<JoinSet>>,
     /// The cache of running [`ChainWorkerActor`]s.
     chain_workers: Arc<Mutex<BTreeMap<ChainId, ChainActorEndpoint<StorageClient>>>>,
+    /// Shard-routing dispatcher for outbound cross-chain requests. Used when we need
+    /// to send cross-chain requests outside of the normal `NetworkActions` return
+    /// path — in particular, the `RevertConfirm`s emitted after resetting a
+    /// corrupted chain. The RPC server layer installs this; without it, those
+    /// requests are dropped with a warning.
+    outbound_cross_chain_sender: Option<OutboundCrossChainSender>,
 }
+
+/// Dispatcher for outbound cross-chain requests that handles the source-shard-to-
+/// target-shard routing that the worker itself is not aware of.
+pub type OutboundCrossChainSender = Arc<dyn Fn(CrossChainRequest) + Send + Sync>;
 
 impl<StorageClient> Clone for WorkerState<StorageClient>
 where
@@ -534,6 +544,7 @@ where
             delivery_notifiers: self.delivery_notifiers.clone(),
             chain_worker_tasks: self.chain_worker_tasks.clone(),
             chain_workers: self.chain_workers.clone(),
+            outbound_cross_chain_sender: self.outbound_cross_chain_sender.clone(),
         }
     }
 }
@@ -570,6 +581,7 @@ where
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
             chain_workers: Arc::new(Mutex::new(BTreeMap::new())),
+            outbound_cross_chain_sender: None,
         }
     }
 
@@ -592,7 +604,16 @@ where
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
             chain_workers: Arc::new(Mutex::new(BTreeMap::new())),
+            outbound_cross_chain_sender: None,
         }
+    }
+
+    /// Installs a shard-routing dispatcher used for outbound cross-chain requests
+    /// generated outside the normal response path (specifically, after resetting a
+    /// corrupted chain). Without it, such requests are dropped.
+    pub fn with_outbound_cross_chain_sender(mut self, sender: OutboundCrossChainSender) -> Self {
+        self.outbound_cross_chain_sender = Some(sender);
+        self
     }
 
     #[instrument(level = "trace", skip(self, value))]
@@ -1096,8 +1117,8 @@ where
 
     /// Spawns a detached task that asks the chain worker actor to recover the chain
     /// from a detected state corruption and dispatches any generated `RevertConfirm`
-    /// requests. Errors are logged; the originating caller already has an error
-    /// to propagate.
+    /// requests via the installed shard-routing sender. Errors are logged; the
+    /// originating caller already has an error to propagate.
     fn spawn_reset_corrupted_chain_state(&self, chain_id: ChainId) {
         let this = self.clone();
         linera_base::Task::spawn(async move {
@@ -1125,18 +1146,18 @@ where
                     return;
                 }
             };
-            let mut queue = VecDeque::from(requests);
-            while let Some(request) = queue.pop_front() {
-                match this.handle_cross_chain_request(request).await {
-                    Ok(actions) => queue.extend(actions.cross_chain_requests),
-                    Err(error) => {
-                        warn!(
-                            %chain_id, %error,
-                            "Failed to dispatch cross-chain request after \
-                            resetting corrupted chain state"
-                        );
-                    }
+            let Some(sender) = &this.outbound_cross_chain_sender else {
+                if !requests.is_empty() {
+                    warn!(
+                        %chain_id, dropped = requests.len(),
+                        "No outbound cross-chain sender installed; \
+                        RevertConfirms after corruption reset are dropped"
+                    );
                 }
+                return;
+            };
+            for request in requests {
+                sender(request);
             }
         })
         .forget();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -23,9 +23,7 @@ use linera_cache::{UniqueValueCache, ValueCache};
 #[cfg(with_testing)]
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
-    data_types::{
-        BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock,
-    },
+    data_types::{BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock},
     types::{
         Block, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
@@ -344,15 +342,6 @@ pub enum WorkerError {
     #[error("The block does not contain the hash that we expected for the previous block")]
     InvalidBlockChaining,
     #[error(
-        "The given outcome is not what we computed after executing the block.\n\
-        Computed: {computed:#?}\n\
-        Submitted: {submitted:#?}"
-    )]
-    IncorrectOutcome {
-        computed: Box<BlockExecutionOutcome>,
-        submitted: Box<BlockExecutionOutcome>,
-    },
-    #[error(
         "Block timestamp ({block_timestamp}) is further in the future from local time \
         ({local_time}) than block time grace period ({block_time_grace_period:?}) \
         [us:{block_timestamp_us}:{local_time_us}]",
@@ -443,8 +432,7 @@ impl WorkerError {
             | WorkerError::ChainActorSendError { .. }
             | WorkerError::ChainActorRecvError { .. }
             | WorkerError::Thread(_)
-            | WorkerError::ReadCertificatesError(_)
-            | WorkerError::IncorrectOutcome { .. } => true,
+            | WorkerError::ReadCertificatesError(_) => true,
             WorkerError::ChainError(chain_error) => chain_error.is_local(),
         }
     }
@@ -453,6 +441,17 @@ impl WorkerError {
     /// which may leave storage in an inconsistent state requiring a view reload.
     pub fn must_reload_view(&self) -> bool {
         matches!(self, WorkerError::ViewError(e) if e.must_reload_view())
+    }
+
+    /// Returns `true` if this error indicates that the chain's persisted state is
+    /// internally inconsistent, so the worker should consider resetting and
+    /// re-executing it from storage.
+    fn indicates_corrupted_chain_state(&self) -> bool {
+        matches!(
+            self,
+            WorkerError::ChainError(chain_error)
+                if matches!(chain_error.as_ref(), ChainError::CorruptedChainState(_))
+        )
     }
 }
 
@@ -622,8 +621,8 @@ where
     }
 
     #[instrument(level = "trace", skip(self))]
-    pub fn with_reset_on_incorrect_outcome(mut self, minutes: Option<u64>) -> Self {
-        self.chain_worker_config.reset_on_incorrect_outcome =
+    pub fn with_reset_on_corrupted_chain_state(mut self, minutes: Option<u64>) -> Self {
+        self.chain_worker_config.reset_on_corrupted_chain_state =
             minutes.map(|m| Duration::from_secs(m * 60));
         self
     }
@@ -1071,7 +1070,7 @@ where
         }
 
         // Finally, wait a response.
-        match response.await {
+        let result = match response.await {
             Err(e) => {
                 // The actor endpoint was dropped. Better luck next time!
                 Err(WorkerError::ChainActorRecvError {
@@ -1080,7 +1079,67 @@ where
                 })
             }
             Ok(response) => response,
+        };
+        // If the operation failed with a corruption signal, detach a task to reset
+        // the chain state and re-execute all blocks. Running the recovery in a
+        // separate task ensures it survives cancellation of the originating
+        // request: if the caller's future is dropped mid-way through re-execution,
+        // the chain would otherwise be left at a partial tip and our safety
+        // snapshot would be lost.
+        if let Err(error) = &result {
+            if error.indicates_corrupted_chain_state() {
+                self.spawn_reset_corrupted_chain_state(chain_id);
+            }
         }
+        result
+    }
+
+    /// Spawns a detached task that asks the chain worker actor to recover the chain
+    /// from a detected state corruption and dispatches any generated `RevertConfirm`
+    /// requests. Errors are logged; the originating caller already has an error
+    /// to propagate.
+    fn spawn_reset_corrupted_chain_state(&self, chain_id: ChainId) {
+        let this = self.clone();
+        linera_base::Task::spawn(async move {
+            let (callback, response) = oneshot::channel();
+            let request = ChainWorkerRequest::ResetCorruptedChainState { callback };
+            if this
+                .call_and_maybe_create_chain_worker_endpoint(chain_id, request)
+                .is_err()
+            {
+                warn!(%chain_id, "Failed to send reset-corrupted-chain-state request");
+                return;
+            }
+            let requests = match response.await {
+                Ok(Ok(Some(requests))) => requests,
+                Ok(Ok(None)) => return,
+                Ok(Err(error)) => {
+                    error!(%chain_id, %error, "Failed to reset corrupted chain state");
+                    return;
+                }
+                Err(error) => {
+                    error!(
+                        %chain_id, %error,
+                        "Chain worker actor dropped the reset request"
+                    );
+                    return;
+                }
+            };
+            let mut queue = VecDeque::from(requests);
+            while let Some(request) = queue.pop_front() {
+                match this.handle_cross_chain_request(request).await {
+                    Ok(actions) => queue.extend(actions.cross_chain_requests),
+                    Err(error) => {
+                        warn!(
+                            %chain_id, %error,
+                            "Failed to dispatch cross-chain request after \
+                            resetting corrupted chain state"
+                        );
+                    }
+                }
+            }
+        })
+        .forget();
     }
 
     /// Find an endpoint and call it. Create the endpoint if necessary.

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -370,6 +370,20 @@ where
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(cross_chain_config.queue_size);
 
+        // Give the worker a shard-routing sender for cross-chain requests generated
+        // outside the normal `NetworkActions` return path (specifically, the
+        // `RevertConfirm`s emitted after resetting a corrupted chain).
+        let state = {
+            let routing_network = internal_network.clone();
+            let routing_sender = cross_chain_sender.clone();
+            state.with_outbound_cross_chain_sender(std::sync::Arc::new(move |request| {
+                let shard_id = routing_network.get_shard_id(request.target_chain_id());
+                if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
+                    error!(%error, "dropping cross-chain request");
+                }
+            }))
+        };
+
         let (notification_sender, _) =
             tokio::sync::broadcast::channel(notification_config.notification_queue_size);
 

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -123,7 +123,7 @@ where
     }
 
     pub fn spawn(
-        self,
+        mut self,
         shutdown_signal: CancellationToken,
         join_set: &mut JoinSet<()>,
     ) -> ServerHandle {
@@ -135,6 +135,22 @@ where
 
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(self.cross_chain_config.queue_size);
+
+        // Give the worker a shard-routing sender for cross-chain requests generated
+        // outside the normal `NetworkActions` return path (specifically, the
+        // `RevertConfirm`s emitted after resetting a corrupted chain).
+        {
+            let routing_network = self.network.clone();
+            let routing_sender = cross_chain_sender.clone();
+            self.state = self.state.clone().with_outbound_cross_chain_sender(Arc::new(
+                move |request| {
+                    let shard_id = routing_network.get_shard_id(request.target_chain_id());
+                    if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
+                        tracing::error!(%error, "dropping cross-chain request");
+                    }
+                },
+            ));
+        }
 
         join_set.spawn_task(Self::forward_cross_chain_queries(
             self.state.nickname().to_string(),

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -142,14 +142,15 @@ where
         {
             let routing_network = self.network.clone();
             let routing_sender = cross_chain_sender.clone();
-            self.state = self.state.clone().with_outbound_cross_chain_sender(Arc::new(
-                move |request| {
+            self.state = self
+                .state
+                .clone()
+                .with_outbound_cross_chain_sender(Arc::new(move |request| {
                     let shard_id = routing_network.get_shard_id(request.target_chain_id());
                     if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
                         tracing::error!(%error, "dropping cross-chain request");
                     }
-                },
-            ));
+                }));
         }
 
         join_set.spawn_task(Self::forward_cross_chain_queries(

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -65,7 +65,7 @@ struct ServerContext {
     block_cache_size: usize,
     execution_state_cache_size: usize,
     allow_revert_confirm: bool,
-    reset_on_incorrect_outcome_mins: Option<u64>,
+    reset_on_corrupted_chain_state_mins: Option<u64>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -96,7 +96,7 @@ impl ServerContext {
         .with_allow_inactive_chains(false)
         .with_allow_messages_from_deprecated_epochs(false)
         .with_allow_revert_confirm(self.allow_revert_confirm)
-        .with_reset_on_incorrect_outcome(self.reset_on_incorrect_outcome_mins)
+        .with_reset_on_corrupted_chain_state(self.reset_on_corrupted_chain_state_mins)
         .with_block_time_grace_period(self.block_time_grace_period)
         .with_chain_worker_ttl(self.chain_worker_ttl)
         .with_chain_info_max_received_log_entries(self.chain_info_max_received_log_entries)
@@ -465,12 +465,12 @@ enum ServerCommand {
         #[arg(long, default_value_t = false)]
         allow_revert_confirm: bool,
 
-        /// On IncorrectOutcome errors, reset the chain state and re-execute all
-        /// blocks from scratch. Sends RevertConfirm to all known senders. The
+        /// On detection of corrupted chain state, reset the chain state and re-execute
+        /// all blocks from scratch. Sends RevertConfirm to all known senders. The
         /// value is the minimum number of minutes since the last reset before
         /// another reset is allowed (to prevent loops).
         #[arg(long)]
-        reset_on_incorrect_outcome_mins: Option<u64>,
+        reset_on_corrupted_chain_state_mins: Option<u64>,
 
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
@@ -605,7 +605,7 @@ async fn run(options: ServerOptions) {
             chain_info_max_received_log_entries,
             cross_chain_message_chunk_limit,
             allow_revert_confirm,
-            reset_on_incorrect_outcome_mins,
+            reset_on_corrupted_chain_state_mins,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -625,7 +625,7 @@ async fn run(options: ServerOptions) {
                 block_cache_size: common_storage_options.block_cache_size,
                 execution_state_cache_size: common_storage_options.execution_state_cache_size,
                 allow_revert_confirm,
-                reset_on_incorrect_outcome_mins,
+                reset_on_corrupted_chain_state_mins,
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };


### PR DESCRIPTION
Backport of https://github.com/linera-io/linera-protocol/pull/6063.

## Motivation

In https://github.com/linera-io/linera-protocol/pull/5907 we added options to recover from DB failures, specifically from corrupted chain states that would result in `IncorrectOutcome` errors.

However, corrupted chain states can cause all kinds of errors, most of which are currently the `InternalError` variant.

## Proposal

Split `InternalError`: Use `CorruptedChainState` for those errors that could be caused by such DB issues.

Rename `--reset-on-incorrect-outcome-mins` to `--reset-on-corrupted-chain-state-mins` and, if set, reset the chain state on every `CorruptedChainState` error.

Also, restore the votes after re-executing the chain, to prevent double-signing.

## Test Plan

The test was extended.

But we will have to see if this fixes the remaining issues we see in `testnet_conway`, particularly validator 4.

## Release Plan

- Possibly port to `main`?

## Links

- `testnet_conway` version: https://github.com/linera-io/linera-protocol/pull/6063
- The first version of the recovery mechanisms: #5907
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)