### PR TITLE
Sleep before cleaning up in linera net helper; re-enable readme tests

### DIFF
--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull requests
@@ -33,7 +34,7 @@ permissions:
 
 jobs:
   test-readme-scripts:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 40
     steps:

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -10,7 +10,7 @@ function linera_spawn_and_read_wallet_variables() {
     # When the shell exits, we will clean up the top-level jobs (if any), the temporary
     # directory, and the main process. Handling future top-level jobs here is useful
     # because calling `trap` again will be replace this handler.
-    trap 'jobs -p | xargs -r kill; rm -rf "$LINERA_TMP_DIR"' EXIT
+    trap 'jobs -p | xargs -r kill; sleep 1; rm -rf "$LINERA_TMP_DIR"' EXIT
 
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"
@@ -38,7 +38,7 @@ function linera_spawn_and_read_wallet_variables() {
 function linera_spawn() {
     LINERA_TMP_DIR=$(mktemp -d) || exit 1
 
-    trap 'jobs -p | xargs -r kill || true; rm -rf "$LINERA_TMP_DIR"' EXIT
+    trap 'jobs -p | xargs -r kill || true; sleep 1; rm -rf "$LINERA_TMP_DIR"' EXIT
 
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"


### PR DESCRIPTION
## Motivation

Readme tests were disabled in the merge queue due to their flakiness.

## Proposal

The flakiness seems to have been due to a race condition between shutting down `linera` processes and a cleanup `rm` call. Delay the call a bit to reduce the chances of this race condition happening.

## Test Plan

Hard to test directly due to inherent non-determinism in test flakiness.
Future CI runs will show if the problem persists.

## Release Plan

- Nothing to do.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
