### PR TITLE
Pin the version of `protoc` in CI.

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run the storage-service instance
       run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run benchmarks
       run: |

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -42,6 +42,7 @@ jobs:
       - name: 'Install Protoc'
         uses: arduino/setup-protoc@v3
         with:
+          version: "34.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Install mdbook linkcheck'

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
+          version: "34.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
+          version: "34.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       # TODO(#2709): Uncomment once this workflow runs in a custom runner
       # - name: Update aio-max-nr

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Compute docs
       run: |
@@ -66,6 +67,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install cargo tools
       run: |

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build example applications
       run: |

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check indexer library compiles
       run: |
@@ -57,6 +58,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run indexer integration tests
       run: |

--- a/.github/workflows/instruction-count-benchmarks.yml
+++ b/.github/workflows/instruction-count-benchmarks.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Valgrind
       run: sudo apt-get update && sudo apt-get install -y valgrind
@@ -69,6 +70,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Valgrind
       run: sudo apt-get update && sudo apt-get install -y valgrind

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -46,6 +46,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run cargo hack check (partition ${{ matrix.partition }}/6)
       run: |

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       run: |

--- a/.github/workflows/remote-kubernetes-net-test.yml
+++ b/.github/workflows/remote-kubernetes-net-test.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install helmfile
       run: |

--- a/.github/workflows/remote-net-test.yml
+++ b/.github/workflows/remote-net-test.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run the storage-service instance
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -166,6 +166,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Wasm application tests
       run: |
@@ -187,6 +188,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run linera-sdk fixtures
       run: |
@@ -210,6 +212,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Compile Wasm test modules for Witty integration tests
       run: |
@@ -234,6 +237,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check for outdated CLI.md
       run: |
@@ -279,6 +283,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install serde-generate-bin
       run: |
@@ -321,6 +326,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build example applications
       run: |
@@ -471,6 +477,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Wasm application lints
       run: |
@@ -496,6 +503,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run clippy
       run: |
@@ -522,6 +530,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run cargo doc
       run: |
@@ -539,6 +548,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Check linera-service GraphQL schema
       run: |

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build example applications
       run: |

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -44,10 +44,11 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: jetli/wasm-bindgen-action@v0.2.0
       with:
-        version: latest
+        version: 0.2.100
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -68,6 +68,7 @@ jobs:
         rustflags: ""
     - uses: arduino/setup-protoc@v3
       with:
+        version: "34.1"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - uses: nanasess/setup-chromedriver@v2
     - uses: jetli/wasm-pack-action@v0.4.0


### PR DESCRIPTION
## Motivation

The `setup-protoc` is often failing in CI.

## Proposal

Pin the version of `protoc` in the CI to the latest one. That should enable the caching.

Also pin the version of `jetli/wasm-bindgen-action` which was pinned to `latest` in one CI check and `0.2.100` in another.

## Test Plan

CI

## Release Plan

Can be backported to `testnet_conway`.

## Links

None