### PR TITLE
Extend the range of possible return reasons.

### DIFF
--- a/linera-execution/src/evm/mod.rs
+++ b/linera-execution/src/evm/mod.rs
@@ -13,8 +13,8 @@ pub mod inputs;
 pub mod revm;
 
 use linera_base::data_types::AmountConversionError;
-use revm_context::result::{HaltReason, Output, SuccessReason};
-use revm_primitives::{Address, Log, U256};
+use revm_context::result::HaltReason;
+use revm_primitives::{Address, U256};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -62,13 +62,4 @@ pub enum EvmExecutionError {
     },
     #[error("The operation was halted with {gas_used} gas used due to {reason:?}")]
     Halt { gas_used: u64, reason: HaltReason },
-    #[error("The interpreter did not return, reason={:?}, gas_used={}, gas_refunded={}, logs={:?}, output={:?}",
-            reason, gas_used, gas_refunded, logs, output)]
-    NoReturnInterpreter {
-        reason: SuccessReason,
-        gas_used: u64,
-        gas_refunded: u64,
-        logs: Vec<Log>,
-        output: Output,
-    },
 }

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -50,7 +50,7 @@ use linera_base::{
 };
 use revm::{primitives::Bytes, InspectCommitEvm, InspectEvm, Inspector};
 use revm_context::{
-    result::{ExecutionResult, Output, SuccessReason},
+    result::{ExecutionResult, Output},
     BlockEnv, Cfg, ContextTr, Evm, Journal, JournalTr, LocalContextTr as _, TxEnv,
 };
 use revm_database::WrapDatabaseRef;
@@ -1335,31 +1335,24 @@ fn process_execution_result(
 ) -> Result<ExecutionResultSuccess, EvmExecutionError> {
     match result {
         ExecutionResult::Success {
-            reason,
             gas_used,
             gas_refunded,
             logs,
             output,
+            ..
         } => {
+            // All SuccessReason variants (Return, Stop, SelfDestruct,
+            // EofReturnContract) are valid successful EVM terminations.
+            // Reverts and halts are handled by separate arms.
             // Apply EIP-3529 refund cap (London fork)
             let max_refund = gas_used / 5;
             let actual_refund = gas_refunded.min(max_refund);
             let gas_final = gas_used - actual_refund;
-            if !matches!(reason, SuccessReason::Return) {
-                Err(EvmExecutionError::NoReturnInterpreter {
-                    reason,
-                    gas_used,
-                    gas_refunded,
-                    logs,
-                    output,
-                })
-            } else {
-                Ok(ExecutionResultSuccess {
-                    gas_final,
-                    logs,
-                    output,
-                })
-            }
+            Ok(ExecutionResultSuccess {
+                gas_final,
+                logs,
+                output,
+            })
         }
         ExecutionResult::Revert { gas_used, output } => {
             Err(EvmExecutionError::Revert { gas_used, output })


### PR DESCRIPTION
## Motivation

The instruction `STOP` in EVM was incorrectly thought to mean that the execution failed.

Fixes https://github.com/linera-io/linera-protocol/issues/6077

## Proposal

Simply accept all reasons.

## Test Plan

CI.

## Release Plan

Can be backported if deemed useful.

## Links

None.