### PR TITLE
Route corruption-recovery `RevertConfirms` to correct shard

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -604,7 +604,17 @@ pub struct WorkerState<StorageClient: Storage> {
     /// manages its own lifetime via a keep-alive task. A background sweep
     /// periodically removes dead entries.
     chain_workers: ChainWorkerMap<StorageClient>,
+    /// Shard-routing dispatcher for outbound cross-chain requests. Used when we need
+    /// to send cross-chain requests outside of the normal `NetworkActions` return
+    /// path — in particular, the `RevertConfirm`s emitted after resetting a
+    /// corrupted chain. The RPC server layer installs this; without it, we fall
+    /// back to dispatching locally through `handle_cross_chain_request`.
+    outbound_cross_chain_sender: Option<OutboundCrossChainSender>,
 }
+
+/// Dispatcher for outbound cross-chain requests that handles the source-shard-to-
+/// target-shard routing that the worker itself is not aware of.
+pub type OutboundCrossChainSender = Arc<dyn Fn(CrossChainRequest) + Send + Sync>;
 
 impl<StorageClient> Clone for WorkerState<StorageClient>
 where
@@ -619,6 +629,7 @@ where
             chain_modes: self.chain_modes.clone(),
             delivery_notifiers: self.delivery_notifiers.clone(),
             chain_workers: self.chain_workers.clone(),
+            outbound_cross_chain_sender: self.outbound_cross_chain_sender.clone(),
         }
     }
 }
@@ -762,7 +773,17 @@ where
             chain_modes,
             delivery_notifiers: Arc::default(),
             chain_workers,
+            outbound_cross_chain_sender: None,
         }
+    }
+
+    /// Installs a shard-routing dispatcher used for outbound cross-chain requests
+    /// generated outside the normal response path (specifically, after resetting a
+    /// corrupted chain). Without it, such requests are dispatched locally in a
+    /// loop via `handle_cross_chain_request`.
+    pub fn with_outbound_cross_chain_sender(mut self, sender: OutboundCrossChainSender) -> Self {
+        self.outbound_cross_chain_sender = Some(sender);
+        self
     }
 
     #[instrument(level = "trace", skip(self, certificate, notifier))]
@@ -850,9 +871,11 @@ where
     /// task ensures it survives cancellation of the originating request: if the
     /// caller's future is dropped mid-way through re-execution, the chain would
     /// otherwise be left at a partial tip and our safety snapshot would be lost.
-    /// Generated `RevertConfirm` requests are dispatched through the normal
-    /// cross-chain pipeline. Errors are logged; the caller already has the
-    /// original error to propagate.
+    /// Generated `RevertConfirm` requests are dispatched via the installed
+    /// shard-routing sender when present (sharded validators), or locally
+    /// through `handle_cross_chain_request` otherwise (client nodes and tests).
+    /// Errors are logged; the caller already has the original error to
+    /// propagate.
     fn spawn_reset_corrupted_chain_state(
         &self,
         chain_id: ChainId,
@@ -875,16 +898,27 @@ where
                     }
                 }
             };
-            let mut queue = VecDeque::from(requests);
-            while let Some(request) = queue.pop_front() {
-                match this.handle_cross_chain_request(request).await {
-                    Ok(actions) => queue.extend(actions.cross_chain_requests),
-                    Err(error) => {
-                        tracing::warn!(
-                            %chain_id, %error,
-                            "Failed to dispatch cross-chain request after \
-                            resetting corrupted chain state"
-                        );
+            if let Some(sender) = &this.outbound_cross_chain_sender {
+                // Sharded validator path: let the RPC layer route each request to
+                // the shard that owns the target chain.
+                for request in requests {
+                    sender(request);
+                }
+            } else {
+                // No routing dispatcher is installed (client node or test), so all
+                // involved chains are co-located on this worker. Dispatch locally
+                // in a loop, following any cascading cross-chain requests.
+                let mut queue = VecDeque::from(requests);
+                while let Some(request) = queue.pop_front() {
+                    match this.handle_cross_chain_request(request).await {
+                        Ok(actions) => queue.extend(actions.cross_chain_requests),
+                        Err(error) => {
+                            warn!(
+                                %chain_id, %error,
+                                "Failed to dispatch cross-chain request after \
+                                resetting corrupted chain state"
+                            );
+                        }
                     }
                 }
             }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -370,6 +370,20 @@ where
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(cross_chain_config.queue_size);
 
+        // Give the worker a shard-routing sender for cross-chain requests generated
+        // outside the normal `NetworkActions` return path (specifically, the
+        // `RevertConfirm`s emitted after resetting a corrupted chain).
+        let state = {
+            let routing_network = internal_network.clone();
+            let routing_sender = cross_chain_sender.clone();
+            state.with_outbound_cross_chain_sender(std::sync::Arc::new(move |request| {
+                let shard_id = routing_network.get_shard_id(request.target_chain_id());
+                if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
+                    error!(%error, "dropping cross-chain request");
+                }
+            }))
+        };
+
         let (notification_sender, _) =
             tokio::sync::broadcast::channel(notification_config.notification_queue_size);
 

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -123,7 +123,7 @@ where
     }
 
     pub fn spawn(
-        self,
+        mut self,
         shutdown_signal: CancellationToken,
         join_set: &mut JoinSet<()>,
     ) -> ServerHandle {
@@ -135,6 +135,22 @@ where
 
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(self.cross_chain_config.queue_size);
+
+        // Give the worker a shard-routing sender for cross-chain requests generated
+        // outside the normal `NetworkActions` return path (specifically, the
+        // `RevertConfirm`s emitted after resetting a corrupted chain).
+        {
+            let routing_network = self.network.clone();
+            let routing_sender = cross_chain_sender.clone();
+            self.state = self.state.clone().with_outbound_cross_chain_sender(Arc::new(
+                move |request| {
+                    let shard_id = routing_network.get_shard_id(request.target_chain_id());
+                    if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
+                        tracing::error!(%error, "dropping cross-chain request");
+                    }
+                },
+            ));
+        }
 
         join_set.spawn_task(Self::forward_cross_chain_queries(
             self.state.nickname().to_string(),

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -142,14 +142,15 @@ where
         {
             let routing_network = self.network.clone();
             let routing_sender = cross_chain_sender.clone();
-            self.state = self.state.clone().with_outbound_cross_chain_sender(Arc::new(
-                move |request| {
+            self.state = self
+                .state
+                .clone()
+                .with_outbound_cross_chain_sender(Arc::new(move |request| {
                     let shard_id = routing_network.get_shard_id(request.target_chain_id());
                     if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
                         tracing::error!(%error, "dropping cross-chain request");
                     }
-                },
-            ));
+                }));
         }
 
         join_set.spawn_task(Self::forward_cross_chain_queries(


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/6063 introduced a bug, that was only found in the review of the `testnet_conway_debug` port https://github.com/linera-io/linera-protocol/pull/6071:

Calling `handle_cross_chain_request` in a loop on the worker only works for single-shard configurations; in sharded validators the target sender chain may live on a different shard. 

## Proposal

Add an `OutboundCrossChainSender` that the RPC server layer (gRPC and simple) installs on `WorkerState`, closing over the shard-routing network config and the cross-chain `mpsc` sender. `spawn_reset_corrupted_chain_state` now dispatches each `RevertConfirm` through that sender so `forward_cross_chain_queries` can route it to the correct shard. When no dispatcher is installed (client nodes, tests) we keep the existing local loop, which is correct because all involved chains are co-located on the same worker.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
