### PR TITLE
Backport: Sleep before cleaning up in linera net helper (#6072)

### DIFF
--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -10,7 +10,7 @@ function linera_spawn_and_read_wallet_variables() {
     # When the shell exits, we will clean up the top-level jobs (if any), the temporary
     # directory, and the main process. Handling future top-level jobs here is useful
     # because calling `trap` again will be replace this handler.
-    trap 'jobs -p | xargs -r kill; rm -rf "$LINERA_TMP_DIR"' EXIT
+    trap 'jobs -p | xargs -r kill; sleep 1; rm -rf "$LINERA_TMP_DIR"' EXIT
 
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"
@@ -38,7 +38,7 @@ function linera_spawn_and_read_wallet_variables() {
 function linera_spawn() {
     LINERA_TMP_DIR=$(mktemp -d) || exit 1
 
-    trap 'jobs -p | xargs -r kill || true; rm -rf "$LINERA_TMP_DIR"' EXIT
+    trap 'jobs -p | xargs -r kill || true; sleep 1; rm -rf "$LINERA_TMP_DIR"' EXIT
 
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"


### PR DESCRIPTION
## Motivation

Readme tests were disabled in the merge queue due to their flakiness.

## Proposal

The flakiness seems to have been due to a race condition between shutting down `linera` processes and a cleanup `rm` call. Delay the call a bit to reduce the chances of this race condition happening.

We do not use the merge queue on the testnet branch, but it may be better to have this ported here just in case.

## Test Plan

Watch for flakiness in merge queues on `main`

## Release Plan

- Nothing to do

## Links

- Backport of #6072 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
