### PR TITLE
[testnet] Poison chain worker on cancelled save. (#6085)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2151,20 +2151,25 @@ where
 
     /// Stores the chain state in persistent storage.
     ///
-    /// If the save fails, the worker is marked as poisoned and must be reloaded.
+    /// Poisons the worker up front and clears the flag only after the underlying
+    /// `save()` has fully returned. This makes the poison sticky on both error
+    /// and cancellation: if the caller's future is dropped between the storage
+    /// write landing and `post_save()` refreshing the in-memory views, the flag
+    /// stays set and the next access will evict and reload from storage.
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id()
     ))]
     async fn save(&mut self) -> Result<(), WorkerError> {
-        if let Err(error) = self.chain.save().await {
+        self.poisoned = true;
+        self.chain.save().await.map_err(|error| {
             tracing::error!(
                 ?error,
                 chain_id = %self.chain_id(),
                 "Chain save failed; marking worker as poisoned"
             );
-            self.poisoned = true;
-            return Err(WorkerError::PoisonedWorker);
-        }
+            WorkerError::PoisonedWorker
+        })?;
+        self.poisoned = false;
         Ok(())
     }
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -195,8 +195,9 @@ where
         self.chain.rollback();
     }
 
-    /// Returns `WorkerError::PoisonedWorker` if the worker is poisoned due to a journal
-    /// resolution failure.
+    /// Returns `WorkerError::PoisonedWorker` if the in-memory state is known to be
+    /// stale relative to storage (e.g. because a save failed or was cancelled
+    /// mid-flight) and the worker must be evicted and reloaded.
     pub(crate) fn check_not_poisoned(&self) -> Result<(), WorkerError> {
         ensure!(!self.poisoned, WorkerError::PoisonedWorker);
         Ok(())

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -422,7 +422,7 @@ pub enum WorkerError {
 
     #[error("Fallback mode is not available on this network")]
     NoFallbackMode,
-    #[error("Chain worker was poisoned by a journal resolution failure")]
+    #[error("Chain worker in-memory state is stale and must be reloaded from storage")]
     PoisonedWorker,
 }
 


### PR DESCRIPTION
Backport of #6085.

## Motivation

If the caller's future is dropped between `write_batch` landing in storage and `post_save` refreshing the in-memory register views, the views (e.g. `stored_value`) goes stale while storage has advanced.

## Proposal

Set the poison flag up front and clear it only after `save`.

That way, if a request was cancelled while `save` was in progress, the chain worker is reloaded for the next request.

## Test Plan

CI

I will also run a few more tests on https://github.com/linera-io/linera-protocol/pull/6070.

## Release Plan

- Hotfix validators.

## Links

- PR to `main`: #6085
- Draft PR for experimenting with this: #6070 (easier to reproduce in CI)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
