### PR TITLE
Rename `query-certificate` to `query-block`

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -63,7 +63,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera validator update`↴](#linera-validator-update)
 * [`linera validator list`↴](#linera-validator-list)
 * [`linera validator query`↴](#linera-validator-query)
-* [`linera validator query-certificate`↴](#linera-validator-query-certificate)
+* [`linera validator query-block`↴](#linera-validator-query-block)
 * [`linera validator remove`↴](#linera-validator-remove)
 * [`linera validator sync`↴](#linera-validator-sync)
 * [`linera storage`↴](#linera-storage)
@@ -1338,7 +1338,7 @@ Manage validators in the committee
 * `update` — Apply multiple validator changes from JSON input
 * `list` — List all validators in the committee
 * `query` — Query a single validator's state and connectivity
-* `query-certificate` — Query a single validator for a certificate at a particular chain and height
+* `query-block` — Query a single validator for a block at a particular chain and height
 * `remove` — Remove a validator from the committee
 * `sync` — Synchronize chain state to a validator
 
@@ -1436,13 +1436,13 @@ Connects to a validator at the specified network address and queries its view of
 
 
 
-## `linera validator query-certificate`
+## `linera validator query-block`
 
-Query a single validator for a certificate at a particular chain and height.
+Query a single validator for a block at a particular chain and height.
 
 Connects to a validator at the specified network address and queries its view of the blockchain.
 
-**Usage:** `linera validator query-certificate [OPTIONS] --height <HEIGHT> <ADDRESS>`
+**Usage:** `linera validator query-block [OPTIONS] --height <HEIGHT> <ADDRESS>`
 
 ###### **Arguments:**
 

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -82,7 +82,7 @@ pub enum Command {
     Update(Update),
     List(List),
     Query(Query),
-    QueryCertificate(QueryCertificate),
+    QueryBlock(QueryBlock),
     Remove(Remove),
     Sync(Sync),
 }
@@ -177,12 +177,12 @@ pub struct Query {
     public_key: Option<ValidatorPublicKey>,
 }
 
-/// Query a single validator for a certificate at a particular chain and height.
+/// Query a single validator for a block at a particular chain and height.
 ///
 /// Connects to a validator at the specified network address and queries its
 /// view of the blockchain.
 #[derive(Debug, Clone, clap::Parser)]
-pub struct QueryCertificate {
+pub struct QueryBlock {
     /// Network address of the validator (e.g., grpcs://host:port)
     address: String,
     /// Chain ID to query about (defaults to default chain)
@@ -250,7 +250,7 @@ impl Command {
             Update(command) => command.run(context).await,
             List(command) => command.run(context).await,
             Query(command) => command.run(context).await,
-            QueryCertificate(command) => command.run(context).await,
+            QueryBlock(command) => command.run(context).await,
             Remove(command) => command.run(context).await,
             Sync(command) => Box::pin(command.run(context)).await,
         }
@@ -711,7 +711,7 @@ impl Query {
     }
 }
 
-impl QueryCertificate {
+impl QueryBlock {
     async fn run(
         &self,
         context: &mut ClientContext<impl linera_core::Environment>,

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -730,8 +730,8 @@ impl QueryBlock {
 
         match result {
             Ok(certificates) => {
-                let block = certificates[0].block();
-                println!("{:#?}", block);
+                let confirmed_block = certificates[0].inner();
+                println!("{:#?}", confirmed_block);
             }
             Err(error) => {
                 tracing::error!("{}", error);


### PR DESCRIPTION
## Motivation

#6037 introduced the `query-certificate` subcommand. Since the subcommand only prints a block, and not the whole certificate, it was suggested to rename it to `query-block`.

## Proposal

Since I merged #6037 before remembering to rename the command, this PR does the rename. Also, in order to include the hash of the block in the printed information, the `ConfirmedBlock` is printed instead of just the `Block`.

## Test Plan

CI will catch regressions

## Release Plan

- These changes should be forward-ported to `main` and
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
