### PR TITLE
Fwd-port: Add a command to query a validator for a block (#6037, #6087)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -64,6 +64,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera validator update`↴](#linera-validator-update)
 * [`linera validator list`↴](#linera-validator-list)
 * [`linera validator query`↴](#linera-validator-query)
+* [`linera validator query-block`↴](#linera-validator-query-block)
 * [`linera validator remove`↴](#linera-validator-remove)
 * [`linera validator sync`↴](#linera-validator-sync)
 * [`linera storage`↴](#linera-storage)
@@ -1344,6 +1345,7 @@ Manage validators in the committee
 * `update` — Apply multiple validator changes from JSON input
 * `list` — List all validators in the committee
 * `query` — Query a single validator's state and connectivity
+* `query-block` — Query a single validator for a block at a particular chain and height
 * `remove` — Remove a validator from the committee
 * `sync` — Synchronize chain state to a validator
 
@@ -1438,6 +1440,26 @@ Connects to a validator at the specified network address and queries its view of
 
 * `--chain-id <CHAIN_ID>` — Chain ID to query about (defaults to default chain)
 * `--public-key <PUBLIC_KEY>` — Expected public key of the validator (for verification)
+
+
+
+## `linera validator query-block`
+
+Query a single validator for a block at a particular chain and height.
+
+Connects to a validator at the specified network address and queries its view of the blockchain.
+
+**Usage:** `linera validator query-block [OPTIONS] --height <HEIGHT> <ADDRESS>`
+
+###### **Arguments:**
+
+* `<ADDRESS>` — Network address of the validator (e.g., grpcs://host:port)
+
+###### **Options:**
+
+* `--chain-id <CHAIN_ID>` — Chain ID to query about (defaults to default chain)
+* `--public-key <PUBLIC_KEY>` — Expected public key of the validator (for verification)
+* `--height <HEIGHT>` — Block height to query about
 
 
 

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -714,7 +714,7 @@ impl Query {
 impl QueryBlock {
     async fn run(
         &self,
-        context: &mut ClientContext<impl linera_core::Environment>,
+        context: &ClientContext<impl linera_core::Environment>,
     ) -> anyhow::Result<()> {
         let node = context.make_node_provider().make_node(&self.address)?;
         let chain_id = self.chain_id.unwrap_or_else(|| context.default_chain());

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -9,10 +9,15 @@ use anyhow::Context as _;
 use futures::stream::TryStreamExt as _;
 use linera_base::{
     crypto::{AccountPublicKey, ValidatorPublicKey},
+    data_types::BlockHeight,
     identifiers::ChainId,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
-use linera_core::{data_types::ClientOutcome, node::ValidatorNodeProvider, Wallet as _};
+use linera_core::{
+    data_types::ClientOutcome,
+    node::{ValidatorNode, ValidatorNodeProvider},
+    Wallet as _,
+};
 use linera_execution::committee::{Committee, ValidatorState};
 use serde::{Deserialize, Serialize};
 
@@ -77,6 +82,7 @@ pub enum Command {
     Update(Update),
     List(List),
     Query(Query),
+    QueryBlock(QueryBlock),
     Remove(Remove),
     Sync(Sync),
 }
@@ -171,6 +177,25 @@ pub struct Query {
     public_key: Option<ValidatorPublicKey>,
 }
 
+/// Query a single validator for a block at a particular chain and height.
+///
+/// Connects to a validator at the specified network address and queries its
+/// view of the blockchain.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct QueryBlock {
+    /// Network address of the validator (e.g., grpcs://host:port)
+    address: String,
+    /// Chain ID to query about (defaults to default chain)
+    #[arg(long)]
+    chain_id: Option<ChainId>,
+    /// Expected public key of the validator (for verification)
+    #[arg(long)]
+    public_key: Option<ValidatorPublicKey>,
+    /// Block height to query about
+    #[arg(long)]
+    height: BlockHeight,
+}
+
 /// Remove a validator from the committee.
 ///
 /// Removes the validator with the specified public key from the committee.
@@ -225,6 +250,7 @@ impl Command {
             Update(command) => command.run(context).await,
             List(command) => command.run(context).await,
             Query(command) => command.run(context).await,
+            QueryBlock(command) => command.run(context).await,
             Remove(command) => command.run(context).await,
             Sync(command) => Box::pin(command.run(context)).await,
         }
@@ -679,6 +705,37 @@ impl Query {
                 "Found one or several issue(s) while querying validator {}",
                 self.address
             );
+        }
+
+        Ok(())
+    }
+}
+
+impl QueryBlock {
+    async fn run(
+        &self,
+        context: &mut ClientContext<impl linera_core::Environment>,
+    ) -> anyhow::Result<()> {
+        let node = context.make_node_provider().make_node(&self.address)?;
+        let chain_id = self.chain_id.unwrap_or_else(|| context.default_chain());
+        let height = self.height;
+        println!(
+            "Querying validator about the certificate for height {height} on the chain \
+            {chain_id}.\n"
+        );
+
+        let result = node
+            .download_certificates_by_heights(chain_id, vec![height])
+            .await;
+
+        match result {
+            Ok(certificates) => {
+                let confirmed_block = certificates[0].inner();
+                println!("{:#?}", confirmed_block);
+            }
+            Err(error) => {
+                tracing::error!("{}", error);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Motivation

We could use a way of inspecting blocks without downloading whole chains from validators.

## Proposal

Add a command to the client which uses `download_certificates_by_height` to download a single certificate from a given validator and display the block.

## Test Plan

CI will catch possible regressions.
The command has been succesfully used manually.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6037 
- #6087 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
