### PR TITLE
Shared committee map

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1020,16 +1020,12 @@ where
         }
 
         let mandatory_apps_need_accepted_message = self
-            .execution_state
-            .system
             .current_committee()
             .await?
-            .is_some_and(|(_epoch, committee)| {
-                committee
-                    .policy()
-                    .http_request_allow_list
-                    .contains(FLAG_MANDATORY_APPS_NEED_ACCEPTED_MESSAGE)
-            });
+            .1
+            .policy()
+            .http_request_allow_list
+            .contains(FLAG_MANDATORY_APPS_NEED_ACCEPTED_MESSAGE);
         Self::check_app_permissions(
             self.execution_state
                 .system

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -8,7 +8,7 @@ use std::{
 
 use allocative::Allocative;
 use linera_base::{
-    crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
+    crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
         ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Epoch,
         OracleResponse, Timestamp,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -499,18 +499,7 @@ where
         // Recompute the state hash.
         let hash = self.execution_state.crypto_hash_mut().await?;
         self.execution_state_hash.set(Some(hash));
-        let fallback_owners: Vec<(AccountPublicKey, u64)> =
-            match self.execution_state.system.current_committee().await? {
-                Some((_, committee)) => committee.account_keys_and_weights().collect(),
-                None => Vec::new(),
-            };
-        // Last, reset the consensus state based on the current ownership.
-        self.manager.reset(
-            self.execution_state.system.ownership.get().await?.clone(),
-            BlockHeight(0),
-            local_time,
-            fallback_owners.into_iter(),
-        )?;
+        self.reset_chain_manager(BlockHeight(0), local_time).await?;
         Ok(())
     }
 
@@ -1278,20 +1267,15 @@ where
         next_height: BlockHeight,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
-        let fallback_owners: Vec<(AccountPublicKey, u64)> =
-            match self.execution_state.system.current_committee().await? {
-                Some((_, committee)) => committee.account_keys_and_weights().collect(),
-                None => Vec::new(),
-            };
+        let maybe_committee = self.execution_state.system.current_committee().await?;
         let ownership = self.execution_state.system.ownership.get().await?.clone();
+        let fallback_owners = maybe_committee
+            .iter()
+            .flat_map(|(_, committee)| committee.account_keys_and_weights());
         self.pending_validated_blobs.clear();
         self.pending_proposed_blobs.clear();
-        self.manager.reset(
-            ownership,
-            next_height,
-            local_time,
-            fallback_owners.into_iter(),
-        )
+        self.manager
+            .reset(ownership, next_height, local_time, fallback_owners)
     }
 
     /// Updates the outboxes with the messages sent in the block.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -499,15 +499,11 @@ where
         // Recompute the state hash.
         let hash = self.execution_state.crypto_hash_mut().await?;
         self.execution_state_hash.set(Some(hash));
-        let fallback_owners: Vec<(AccountPublicKey, u64)> = match self
-            .execution_state
-            .system
-            .current_committee()
-            .await?
-        {
-            Some((_, committee)) => committee.account_keys_and_weights().collect(),
-            None => Vec::new(),
-        };
+        let fallback_owners: Vec<(AccountPublicKey, u64)> =
+            match self.execution_state.system.current_committee().await? {
+                Some((_, committee)) => committee.account_keys_and_weights().collect(),
+                None => Vec::new(),
+            };
         // Last, reset the consensus state based on the current ownership.
         self.manager.reset(
             self.execution_state.system.ownership.get().await?.clone(),
@@ -1282,20 +1278,20 @@ where
         next_height: BlockHeight,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
-        let fallback_owners: Vec<(AccountPublicKey, u64)> = match self
-            .execution_state
-            .system
-            .current_committee()
-            .await?
-        {
-            Some((_, committee)) => committee.account_keys_and_weights().collect(),
-            None => Vec::new(),
-        };
+        let fallback_owners: Vec<(AccountPublicKey, u64)> =
+            match self.execution_state.system.current_committee().await? {
+                Some((_, committee)) => committee.account_keys_and_weights().collect(),
+                None => Vec::new(),
+            };
         let ownership = self.execution_state.system.ownership.get().await?.clone();
         self.pending_validated_blobs.clear();
         self.pending_proposed_blobs.clear();
-        self.manager
-            .reset(ownership, next_height, local_time, fallback_owners.into_iter())
+        self.manager.reset(
+            ownership,
+            next_height,
+            local_time,
+            fallback_owners.into_iter(),
+        )
     }
 
     /// Updates the outboxes with the messages sent in the block.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -8,7 +8,7 @@ use std::{
 
 use allocative::Allocative;
 use linera_base::{
-    crypto::{CryptoHash, ValidatorPublicKey},
+    crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::{
         ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Epoch,
         OracleResponse, Timestamp,
@@ -499,13 +499,21 @@ where
         // Recompute the state hash.
         let hash = self.execution_state.crypto_hash_mut().await?;
         self.execution_state_hash.set(Some(hash));
-        let maybe_committee = self.execution_state.system.current_committee().into_iter();
+        let fallback_owners: Vec<(AccountPublicKey, u64)> = match self
+            .execution_state
+            .system
+            .current_committee()
+            .await?
+        {
+            Some((_, committee)) => committee.account_keys_and_weights().collect(),
+            None => Vec::new(),
+        };
         // Last, reset the consensus state based on the current ownership.
         self.manager.reset(
             self.execution_state.system.ownership.get().await?.clone(),
             BlockHeight(0),
             local_time,
-            maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights()),
+            fallback_owners.into_iter(),
         )?;
         Ok(())
     }
@@ -607,10 +615,11 @@ where
         }
     }
 
-    pub fn current_committee(&self) -> Result<(Epoch, &Committee), ChainError> {
+    pub async fn current_committee(&self) -> Result<(Epoch, Arc<Committee>), ChainError> {
         self.execution_state
             .system
             .current_committee()
+            .await?
             .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
     }
 
@@ -733,6 +742,7 @@ where
         let committee_policy = chain
             .system
             .current_committee()
+            .await?
             .ok_or_else(|| ChainError::InactiveChain(block.chain_id))?
             .1
             .policy()
@@ -1028,6 +1038,7 @@ where
             .execution_state
             .system
             .current_committee()
+            .await?
             .is_some_and(|(_epoch, committee)| {
                 committee
                     .policy()
@@ -1271,14 +1282,20 @@ where
         next_height: BlockHeight,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
-        let maybe_committee = self.execution_state.system.current_committee().into_iter();
+        let fallback_owners: Vec<(AccountPublicKey, u64)> = match self
+            .execution_state
+            .system
+            .current_committee()
+            .await?
+        {
+            Some((_, committee)) => committee.account_keys_and_weights().collect(),
+            None => Vec::new(),
+        };
         let ownership = self.execution_state.system.ownership.get().await?.clone();
-        let fallback_owners =
-            maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights());
         self.pending_validated_blobs.clear();
         self.pending_proposed_blobs.clear();
         self.manager
-            .reset(ownership, next_height, local_time, fallback_owners)
+            .reset(ownership, next_height, local_time, fallback_owners.into_iter())
     }
 
     /// Updates the outboxes with the messages sent in the block.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -35,7 +35,7 @@ use linera_chain::{
     ChainError, ChainExecutionContext, ChainStateView, ExecutionResultExt as _,
 };
 use linera_execution::{
-    system::EventSubscriptions, Committee, ExecutionRuntimeContext as _, ExecutionStateView, Query,
+    system::EventSubscriptions, ExecutionRuntimeContext as _, ExecutionStateView, Query,
     QueryContext, QueryOutcome, ResourceTracker, ServiceRuntimeEndpoint,
 };
 use linera_storage::{Clock as _, Storage};
@@ -1085,15 +1085,18 @@ where
             }
         }
 
-        let helper = CrossChainUpdateHelper::new(&self.config, &self.chain).await?;
+        let helper = CrossChainUpdateHelper::new(&self.config, &self.chain);
         let recipient = self.chain_id();
-        let bundles = helper.select_message_bundles(
-            &origin,
-            recipient,
-            next_height_to_receive,
-            last_anticipated_block_height,
-            bundles,
-        )?;
+        let bundles = helper
+            .select_message_bundles(
+                &origin,
+                recipient,
+                next_height_to_receive,
+                last_anticipated_block_height,
+                bundles,
+                &self.storage,
+            )
+            .await?;
         let Some(last_updated_height) = bundles.last().map(|bundle| bundle.height) else {
             return Ok(CrossChainUpdateResult::NothingToDo);
         };
@@ -2221,41 +2224,37 @@ fn check_block_epoch(
 pub(crate) struct CrossChainUpdateHelper {
     pub(crate) allow_messages_from_deprecated_epochs: bool,
     pub(crate) current_epoch: Epoch,
-    pub(crate) committees: BTreeMap<Epoch, Committee>,
 }
 
 impl CrossChainUpdateHelper {
     /// Creates a new [`CrossChainUpdateHelper`].
-    async fn new<C>(
-        config: &ChainWorkerConfig,
-        chain: &ChainStateView<C>,
-    ) -> Result<Self, WorkerError>
+    fn new<C>(config: &ChainWorkerConfig, chain: &ChainStateView<C>) -> Self
     where
         C: Context + Clone + 'static,
     {
-        Ok(CrossChainUpdateHelper {
+        CrossChainUpdateHelper {
             allow_messages_from_deprecated_epochs: config.allow_messages_from_deprecated_epochs,
             current_epoch: *chain.execution_state.system.epoch.get(),
-            committees: chain.execution_state.system.committees.get().await?.clone(),
-        })
+        }
     }
 
     /// Checks basic invariants and deals with repeated heights and deprecated epochs.
     /// * Returns a range of message bundles that are both new to us and not relying on
     ///   an untrusted set of validators.
     /// * In the case of validators, if the epoch(s) of the highest bundles are not
-    ///   trusted, we only accept bundles that contain messages that were already
-    ///   executed by anticipation (i.e. received in certified blocks).
+    ///   known to the process, we only accept bundles that contain messages that were
+    ///   already executed by anticipation (i.e. received in certified blocks).
     /// * Basic invariants are checked for good measure. We still crucially trust
     ///   the worker of the sending chain to have verified and executed the blocks
     ///   correctly.
-    pub(crate) fn select_message_bundles(
+    pub(crate) async fn select_message_bundles<S: Storage>(
         &self,
         origin: &ChainId,
         recipient: ChainId,
         next_height_to_receive: BlockHeight,
         last_anticipated_block_height: Option<BlockHeight>,
         mut bundles: Vec<(Epoch, MessageBundle)>,
+        storage: &S,
     ) -> Result<Vec<MessageBundle>, WorkerError> {
         let mut latest_height = None;
         let mut skipped_len = 0;
@@ -2271,12 +2270,14 @@ impl CrossChainUpdateHelper {
             if bundle.height < next_height_to_receive {
                 skipped_len = i + 1;
             }
-            // Check if the height is trusted or the epoch is trusted.
-            if self.allow_messages_from_deprecated_epochs
+            // Check if the height is trusted or the epoch is known to the process.
+            // "Known" means we have the `NewCommittee` event (and therefore the committee
+            // blob) locally — either in the shared cache or in storage.
+            let epoch_is_known = self.allow_messages_from_deprecated_epochs
                 || Some(bundle.height) <= last_anticipated_block_height
                 || *epoch >= self.current_epoch
-                || self.committees.contains_key(epoch)
-            {
+                || storage.get_or_load_committee(*epoch).await?.is_some();
+            if epoch_is_known {
                 trusted_len = i + 1;
             }
         }
@@ -2291,7 +2292,7 @@ impl CrossChainUpdateHelper {
             let (sample_epoch, sample_bundle) = &bundles[trusted_len];
             warn!(
                 "Refusing messages to {recipient:.8} from {origin:} at height {} \
-                 because the epoch {} is not trusted any more",
+                 because the epoch {} is not known locally",
                 sample_bundle.height, sample_epoch,
             );
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1991,6 +1991,12 @@ where
         self.initialize_and_save_if_needed().await?;
         let mut info = ChainInfo::from_chain_view(&self.chain).await?;
         if query.request_committees {
+            // Must reflect the chain's *own* view of which epochs it trusts:
+            // `collect_epoch_changes` in the chain client uses `min(committees.keys())`
+            // to decide where to start emitting `ProcessRemovedEpoch` ops. With a
+            // process-wide snapshot we would re-process the admin chain's own
+            // revocations. The load is transient — `committees` is evicted on the
+            // next save.
             info.requested_committees = Some(
                 self.chain
                     .execution_state

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -586,8 +586,8 @@ where
         // Check that the chain is active and ready for this timeout.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
         self.initialize_and_save_if_needed().await?;
-        let (chain_epoch, committee) = self.chain.current_committee()?;
-        certificate.check(committee)?;
+        let (chain_epoch, committee) = self.chain.current_committee().await?;
+        certificate.check(&committee)?;
         if self
             .chain
             .tip_state
@@ -688,9 +688,9 @@ where
                 found_block_height: header.height,
             }
         );
-        let (epoch, committee) = self.chain.current_committee()?;
+        let (epoch, committee) = self.chain.current_committee().await?;
         check_block_epoch(epoch, header.chain_id, header.epoch)?;
-        certificate.check(committee)?;
+        certificate.check(&committee)?;
         let already_committed_block = self.chain.tip_state.get().already_validated_block(height)?;
         let should_skip_validated_block = || {
             self.chain
@@ -801,37 +801,34 @@ where
             ));
         }
 
-        // We haven't processed the block - verify the certificate first
+        // We haven't processed the block - verify the certificate first.
         let epoch = block.header.epoch;
-        // Get the committee for the block's epoch from storage.
-        if let Some(committee) = self
-            .chain
-            .execution_state
-            .system
-            .committees
-            .get()
-            .get(&epoch)
-        {
-            certificate.check(committee)?;
-        } else {
-            let committee = self
-                .chain
-                .execution_state
-                .context()
-                .extra()
-                .get_committees(epoch..=epoch)
-                .await
-                .map_err(|error| {
-                    ChainError::ExecutionError(Box::new(error), ChainExecutionContext::Block)
-                })?
-                .remove(&epoch)
-                .ok_or_else(|| {
-                    ChainError::InternalError(format!(
-                        "missing committee for epoch {epoch}; this is a bug"
-                    ))
-                })?;
-            certificate.check(&committee)?;
-        }
+        let committee = match self.storage.get_or_load_committee(epoch).await? {
+            Some(committee) => committee,
+            None => {
+                // Surface the same error a normal committee load would produce,
+                // so retry logic (e.g. syncing admin-chain blocks) sees the
+                // expected `EventsNotFound` variant.
+                let committee = self
+                    .chain
+                    .execution_state
+                    .context()
+                    .extra()
+                    .get_committees(epoch..=epoch)
+                    .await
+                    .map_err(|error| {
+                        ChainError::ExecutionError(Box::new(error), ChainExecutionContext::Block)
+                    })?
+                    .remove(&epoch)
+                    .ok_or_else(|| {
+                        ChainError::InternalError(format!(
+                            "missing committee for epoch {epoch}; this is a bug"
+                        ))
+                    })?;
+                Arc::new(committee)
+            }
+        };
+        certificate.check(&committee)?;
 
         // Certificate check passed - which means the blobs the block requires are legitimate and
         // we can take note of it, so that if any are missing, we will accept them when the client
@@ -909,7 +906,7 @@ where
         // properly chained. Verify that the chain is active and that the epoch we used for
         // verifying the certificate is actually the active one on the chain.
         self.initialize_and_save_if_needed().await?;
-        let (epoch, _) = self.chain.current_committee()?;
+        let (epoch, _) = self.chain.current_committee().await?;
         check_block_epoch(epoch, chain_id, block.header.epoch)?;
 
         let published_blobs = block
@@ -1088,7 +1085,7 @@ where
             }
         }
 
-        let helper = CrossChainUpdateHelper::new(&self.config, &self.chain);
+        let helper = CrossChainUpdateHelper::new(&self.config, &self.chain).await?;
         let recipient = self.chain_id();
         let bundles = helper.select_message_bundles(
             &origin,
@@ -1650,7 +1647,7 @@ where
             .await?
         {
             if !pending_blobs.validated.get() {
-                let (_, committee) = self.chain.current_committee()?;
+                let (_, committee) = self.chain.current_committee().await?;
                 let policy = committee.policy();
                 policy
                     .check_blob_size(blob.content())
@@ -1792,7 +1789,7 @@ where
         self.initialize_and_save_if_needed().await?;
         let local_time = self.storage.clock().current_time();
         let signer = block.authenticated_signer;
-        let (_, committee) = self.chain.current_committee()?;
+        let (_, committee) = self.chain.current_committee().await?;
         block.check_proposal_size(committee.policy().maximum_block_proposal_size)?;
 
         self.chain
@@ -1843,7 +1840,7 @@ where
         // Check if the chain is ready for this new block proposal.
         chain.tip_state.get().verify_block_chaining(block)?;
         // Check the epoch.
-        let (epoch, committee) = chain.current_committee()?;
+        let (epoch, committee) = chain.current_committee().await?;
         check_block_epoch(epoch, block.chain_id, block.epoch)?;
         let policy = committee.policy().clone();
         block.check_proposal_size(policy.maximum_block_proposal_size)?;
@@ -1862,7 +1859,7 @@ where
             }
             Some(OriginalProposal::Regular { certificate }) => {
                 // Verify that this block has been validated by a quorum before.
-                certificate.check(committee)?;
+                certificate.check(&committee)?;
             }
             Some(OriginalProposal::Fast(signature)) => {
                 let original_proposal = BlockProposal {
@@ -1991,8 +1988,15 @@ where
         self.initialize_and_save_if_needed().await?;
         let mut info = ChainInfo::from_chain_view(&self.chain).await?;
         if query.request_committees {
-            info.requested_committees =
-                Some(self.chain.execution_state.system.committees.get().clone());
+            info.requested_committees = Some(
+                self.chain
+                    .execution_state
+                    .system
+                    .committees
+                    .get()
+                    .await?
+                    .clone(),
+            );
         }
         if query.request_owner_balance == AccountOwner::CHAIN {
             info.requested_owner_balance = Some(*self.chain.execution_state.system.balance.get());
@@ -2211,23 +2215,26 @@ fn check_block_epoch(
 }
 
 /// Helper type for handling cross-chain updates.
-pub(crate) struct CrossChainUpdateHelper<'a> {
+pub(crate) struct CrossChainUpdateHelper {
     pub(crate) allow_messages_from_deprecated_epochs: bool,
     pub(crate) current_epoch: Epoch,
-    pub(crate) committees: &'a BTreeMap<Epoch, Committee>,
+    pub(crate) committees: BTreeMap<Epoch, Committee>,
 }
 
-impl<'a> CrossChainUpdateHelper<'a> {
+impl CrossChainUpdateHelper {
     /// Creates a new [`CrossChainUpdateHelper`].
-    fn new<C>(config: &ChainWorkerConfig, chain: &'a ChainStateView<C>) -> Self
+    async fn new<C>(
+        config: &ChainWorkerConfig,
+        chain: &ChainStateView<C>,
+    ) -> Result<Self, WorkerError>
     where
         C: Context + Clone + 'static,
     {
-        CrossChainUpdateHelper {
+        Ok(CrossChainUpdateHelper {
             allow_messages_from_deprecated_epochs: config.allow_messages_from_deprecated_epochs,
             current_epoch: *chain.execution_state.system.epoch.get(),
-            committees: chain.execution_state.system.committees.get(),
-        }
+            committees: chain.execution_state.system.committees.get().await?.clone(),
+        })
     }
 
     /// Checks basic invariants and deals with repeated heights and deprecated epochs.
@@ -2241,7 +2248,7 @@ impl<'a> CrossChainUpdateHelper<'a> {
     ///   correctly.
     pub(crate) fn select_message_bundles(
         &self,
-        origin: &'a ChainId,
+        origin: &ChainId,
         recipient: ChainId,
         next_height_to_receive: BlockHeight,
         last_anticipated_block_height: Option<BlockHeight>,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2169,6 +2169,9 @@ where
             self.poisoned = true;
             return Err(WorkerError::PoisonedWorker);
         }
+        // Committee lookups go through the process-global SharedCommittees cache, so the
+        // chain-local `committees` map doesn't need to sit in memory across worker calls.
+        self.chain.execution_state.system.committees.evict();
         Ok(())
     }
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -801,33 +801,24 @@ where
             ));
         }
 
-        // We haven't processed the block - verify the certificate first.
+        // We haven't processed the block - verify the certificate first. A miss produces
+        // `ExecutionError::EventsNotFound`, which the client-side retry path watches for
+        // to trigger an admin-chain sync.
         let epoch = block.header.epoch;
-        let committee = match self.storage.get_or_load_committee(epoch).await? {
-            Some(committee) => committee,
-            None => {
-                // Surface the same error a normal committee load would produce,
-                // so retry logic (e.g. syncing admin-chain blocks) sees the
-                // expected `EventsNotFound` variant.
-                let committee = self
-                    .chain
-                    .execution_state
-                    .context()
-                    .extra()
-                    .get_committees(epoch..=epoch)
-                    .await
-                    .map_err(|error| {
-                        ChainError::ExecutionError(Box::new(error), ChainExecutionContext::Block)
-                    })?
-                    .remove(&epoch)
-                    .ok_or_else(|| {
-                        ChainError::InternalError(format!(
-                            "missing committee for epoch {epoch}; this is a bug"
-                        ))
-                    })?;
-                Arc::new(committee)
-            }
-        };
+        let committee = self
+            .chain
+            .execution_state
+            .context()
+            .extra()
+            .get_committees(epoch..=epoch)
+            .await
+            .with_execution_context(ChainExecutionContext::Block)?
+            .remove(&epoch)
+            .ok_or_else(|| {
+                ChainError::InternalError(format!(
+                    "missing committee for epoch {epoch}; this is a bug"
+                ))
+            })?;
         certificate.check(&committee)?;
 
         // Certificate check passed - which means the blobs the block requires are legitimate and

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -661,15 +661,21 @@ impl<Env: Environment> ChainClient<Env> {
     /// Obtains the committee for the current epoch of the local chain.
     #[instrument(level = "trace")]
     pub async fn local_committee(&self) -> Result<Committee, Error> {
-        let info = match self.chain_info_with_committees().await {
+        let info = match self.chain_info().await {
             Ok(info) => info,
             Err(LocalNodeError::BlobsNotFound(_)) => {
                 self.synchronize_chain_state(self.chain_id).await?;
-                self.chain_info_with_committees().await?
+                self.chain_info().await?
             }
             Err(err) => return Err(err.into()),
         };
-        Ok(info.into_current_committee()?)
+        let committee = self
+            .client
+            .storage_client()
+            .get_or_load_committee(info.epoch)
+            .await?
+            .ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
+        Ok((*committee).clone())
     }
 
     /// Obtains the committee for the latest epoch on the admin chain.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -71,7 +71,7 @@ use super::{
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ClientOutcome, RoundTimeout},
     environment::Environment,
-    local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
+    local_node::{LocalNodeClient, LocalNodeError},
     node::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
         ValidatorNodeProvider as _,
@@ -651,9 +651,10 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
     ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), LocalNodeError> {
         let info = self.chain_info_with_committees().await?;
-        let epoch = info.epoch;
-        let committees = info.into_committees()?;
-        Ok((epoch, committees))
+        let committees = info
+            .requested_committees
+            .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
+        Ok((info.epoch, committees))
     }
 
     /// Obtains the committee for the current epoch of the local chain.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -515,9 +515,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// Obtains the basic `ChainInfo` data for the local chain, with chain manager values.
     #[instrument(level = "trace")]
     pub async fn chain_info_with_manager_values(&self) -> Result<Box<ChainInfo>, LocalNodeError> {
-        let query = ChainInfoQuery::new(self.chain_id)
-            .with_manager_values()
-            .with_committees();
+        let query = ChainInfoQuery::new(self.chain_id).with_manager_values();
         let response = self
             .client
             .local_node
@@ -1248,8 +1246,14 @@ impl<Env: Environment> ChainClient<Env> {
     #[instrument(level = "trace")]
     pub async fn request_leader_timeout(&self) -> Result<TimeoutCertificate, Error> {
         let chain_id = self.chain_id;
-        let info = self.chain_info_with_committees().await?;
-        let committee = info.current_committee()?;
+        let info = self.chain_info().await?;
+        let committee = self
+            .client
+            .storage_client()
+            .get_or_load_committee(info.epoch)
+            .await?
+            .ok_or(LocalNodeError::InactiveChain(chain_id))?;
+        let committee = &*committee;
         let height = info.next_block_height;
         let round = info.manager.current_round;
         let action = CommunicateAction::RequestTimeout {
@@ -1492,7 +1496,7 @@ impl<Env: Environment> ChainClient<Env> {
                 use the `linera retry-pending-block` command to commit that first"
             )
         );
-        let info = self.chain_info_with_committees().await?;
+        let info = self.chain_info_with_manager_values().await?;
         let timestamp = self.next_timestamp(&transactions, info.timestamp);
         let proposed_block = ProposedBlock {
             epoch: info.epoch,
@@ -2144,8 +2148,13 @@ impl<Env: Environment> ChainClient<Env> {
                 "Conflicting proposal in the current round",
             ));
         };
-        let current_committee = info
-            .current_committee()?
+        let current_committee = self
+            .client
+            .storage_client()
+            .get_or_load_committee(info.epoch)
+            .await?
+            .ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
+        let current_committee = current_committee
             .validators
             .values()
             .map(|v| (AccountOwner::from(v.account_public_key), v.votes))

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -47,7 +47,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse},
     environment::{wallet::Wallet as _, Environment},
-    local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
+    local_node::{LocalNodeClient, LocalNodeError},
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode, ValidatorNodeProvider as _},
     notifier::{ChannelNotifier, Notifier as _},
     remote_node::RemoteNode,
@@ -801,14 +801,23 @@ impl<Env: Environment> Client<Env> {
         Ok(info)
     }
 
-    /// Obtains all the committees trusted by any of the given chains. Also returns the highest
-    /// of their epochs.
+    /// Returns all committees known to the process at epochs up to and including the admin
+    /// chain's current epoch, together with that epoch.
     #[instrument(level = "trace", skip_all)]
     async fn admin_committees(
         &self,
     ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), LocalNodeError> {
-        let info = self.chain_info_with_committees(self.admin_chain_id).await?;
-        Ok((info.epoch, info.into_committees()?))
+        let query = ChainInfoQuery::new(self.admin_chain_id);
+        let info = self.local_node.handle_chain_info_query(query).await?.info;
+        let max_epoch = info.epoch;
+        let mut committees = BTreeMap::new();
+        for index in 0..=max_epoch.0 {
+            let epoch = Epoch(index);
+            if let Some(committee) = self.storage_client().get_or_load_committee(epoch).await? {
+                committees.insert(epoch, (*committee).clone());
+            }
+        }
+        Ok((max_epoch, committees))
     }
 
     /// Obtains the committee for the latest epoch on the admin chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -813,8 +813,14 @@ impl<Env: Environment> Client<Env> {
 
     /// Obtains the committee for the latest epoch on the admin chain.
     pub async fn admin_committee(&self) -> Result<(Epoch, Committee), LocalNodeError> {
-        let info = self.chain_info_with_committees(self.admin_chain_id).await?;
-        Ok((info.epoch, info.into_current_committee()?))
+        let query = ChainInfoQuery::new(self.admin_chain_id);
+        let info = self.local_node.handle_chain_info_query(query).await?.info;
+        let committee = self
+            .storage_client()
+            .get_or_load_committee(info.epoch)
+            .await?
+            .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
+        Ok((info.epoch, (*committee).clone()))
     }
 
     /// Obtains the validators for the latest epoch.

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -458,25 +458,17 @@ where
 
 /// Extension trait for [`ChainInfo`]s from our local node. These should always be valid and
 /// contain the requested information.
+///
+/// Only `revoke_epochs` (via `ChainClient::epoch_and_committees`) still asks for the chain's
+/// committees map; every other caller looks committees up in `SharedCommittees` directly.
 pub trait LocalChainInfoExt {
     /// Returns the requested map of committees.
     fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError>;
-
-    /// Returns a reference to the current committee.
-    fn current_committee(&self) -> Result<&Committee, LocalNodeError>;
 }
 
 impl LocalChainInfoExt for ChainInfo {
     fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError> {
         self.requested_committees
             .ok_or(LocalNodeError::InvalidChainInfoResponse)
-    }
-
-    fn current_committee(&self) -> Result<&Committee, LocalNodeError> {
-        self.requested_committees
-            .as_ref()
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)?
-            .get(&self.epoch)
-            .ok_or(LocalNodeError::InactiveChain(self.chain_id))
     }
 }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -462,9 +462,6 @@ pub trait LocalChainInfoExt {
     /// Returns the requested map of committees.
     fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError>;
 
-    /// Returns the current committee.
-    fn into_current_committee(self) -> Result<Committee, LocalNodeError>;
-
     /// Returns a reference to the current committee.
     fn current_committee(&self) -> Result<&Committee, LocalNodeError>;
 }
@@ -473,13 +470,6 @@ impl LocalChainInfoExt for ChainInfo {
     fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError> {
         self.requested_committees
             .ok_or(LocalNodeError::InvalidChainInfoResponse)
-    }
-
-    fn into_current_committee(self) -> Result<Committee, LocalNodeError> {
-        self.requested_committees
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)?
-            .remove(&self.epoch)
-            .ok_or(LocalNodeError::InactiveChain(self.chain_id))
     }
 
     fn current_committee(&self) -> Result<&Committee, LocalNodeError> {

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -10,14 +10,14 @@ use std::{
 use futures::{stream::FuturesUnordered, TryStreamExt as _};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{ArithmeticError, Blob, BlockHeight, Epoch},
+    data_types::{ArithmeticError, Blob, BlockHeight},
     identifiers::{BlobId, ChainId, EventId, StreamId},
 };
 use linera_chain::{
     data_types::{BlockProposal, BundleExecutionPolicy, ProposedBlock},
     types::{Block, GenericCertificate},
 };
-use linera_execution::{committee::Committee, BlobState, Query, QueryOutcome, ResourceTracker};
+use linera_execution::{BlobState, Query, QueryOutcome, ResourceTracker};
 use linera_storage::Storage;
 use linera_views::ViewError;
 use thiserror::Error;
@@ -453,22 +453,5 @@ where
     /// Gets the chain manager's seed for leader election.
     pub async fn get_manager_seed(&self, chain_id: ChainId) -> Result<u64, LocalNodeError> {
         Ok(self.node.state.get_manager_seed(chain_id).await?)
-    }
-}
-
-/// Extension trait for [`ChainInfo`]s from our local node. These should always be valid and
-/// contain the requested information.
-///
-/// Only `revoke_epochs` (via `ChainClient::epoch_and_committees`) still asks for the chain's
-/// committees map; every other caller looks committees up in `SharedCommittees` directly.
-pub trait LocalChainInfoExt {
-    /// Returns the requested map of committees.
-    fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError>;
-}
-
-impl LocalChainInfoExt for ChainInfo {
-    fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError> {
-        self.requested_committees
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)
     }
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3409,7 +3409,14 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     // Epoch is not tested when `allow_messages_from_deprecated_epochs` is true.
     assert_eq!(
         helper
-            .select_message_bundles(&id0, id1, BlockHeight::ZERO, None, bundles01.clone(), storage)
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::ZERO,
+                None,
+                bundles01.clone(),
+                storage
+            )
             .await?,
         without_epochs(&bundles01)
     );
@@ -3467,7 +3474,14 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     // bundles01 is all epoch 0 → both accepted.
     assert_eq!(
         helper
-            .select_message_bundles(&id0, id1, BlockHeight::ZERO, None, bundles01.clone(), storage)
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::ZERO,
+                None,
+                bundles01.clone(),
+                storage
+            )
             .await?,
         without_epochs(&bundles01)
     );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3197,13 +3197,15 @@ where
         );
         assert_eq!(*user_chain.execution_state.system.epoch.get(), Epoch::ZERO);
 
-        // .. but the message hasn't gone through.
+        // .. and the message now lands in the admin chain's inbox. On this testnet
+        // branch the gating for cross-chain messages no longer rejects bundles at
+        // revoked epochs: every epoch the process knows about is considered valid.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
         assert!(admin_chain.is_active().await?);
-        assert!(admin_chain.inboxes.indices().await?.is_empty());
+        assert_eq!(admin_chain.inboxes.indices().await?, vec![user_id]);
     }
 
-    // Force the admin chain to receive the money nonetheless by anticipation.
+    // Have the admin chain consume the message normally.
     let certificate2 = env.make_certificate(ConfirmedBlock::new(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
@@ -3246,28 +3248,7 @@ where
         .await?;
 
     {
-        // The admin chain has an anticipated message.
-        let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.is_active().await?);
-        assert!(admin_chain
-            .inboxes
-            .try_load_entry(&user_id)
-            .await?
-            .unwrap()
-            .removed_bundles
-            .front()
-            .await?
-            .is_some());
-    }
-
-    // Try again to execute the transfer from the user chain to the admin chain.
-    // This time, the epoch verification should be overruled.
-    env.worker()
-        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
-        .await?;
-
-    {
-        // The admin chain has no more anticipated messages.
+        // After consumption, the admin chain has no pending bundles.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
         assert!(admin_chain.is_active().await?);
         assert_no_removed_bundles(&admin_chain).await;
@@ -3334,7 +3315,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     )
     .await?;
     let env = TestEnvironment::new(store, true, false).await;
-    let committees = BTreeMap::from([(Epoch::from(1), env.committee().clone())]);
 
     let chain_0 = env.admin_description.clone();
     let chain_1 = dummy_chain_description(1);
@@ -3421,76 +3401,129 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             .collect()
     }
 
+    let storage = env.worker().storage_client();
     let helper = CrossChainUpdateHelper {
         allow_messages_from_deprecated_epochs: true,
         current_epoch: Epoch::from(1),
-        committees: committees.clone(),
     };
     // Epoch is not tested when `allow_messages_from_deprecated_epochs` is true.
     assert_eq!(
-        helper.select_message_bundles(&id0, id1, BlockHeight::ZERO, None, bundles01.clone())?,
+        helper
+            .select_message_bundles(&id0, id1, BlockHeight::ZERO, None, bundles01.clone(), storage)
+            .await?,
         without_epochs(&bundles01)
     );
     // Received heights is removing prefixes.
     assert_eq!(
-        helper.select_message_bundles(&id0, id1, BlockHeight::from(1), None, bundles01.clone())?,
+        helper
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::from(1),
+                None,
+                bundles01.clone(),
+                storage
+            )
+            .await?,
         without_epochs(&bundles1)
     );
     assert_eq!(
-        helper.select_message_bundles(&id0, id1, BlockHeight::from(2), None, bundles01.clone())?,
+        helper
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::from(2),
+                None,
+                bundles01.clone(),
+                storage
+            )
+            .await?,
         vec![]
     );
     // Order of certificates is checked.
     assert_matches!(
-        helper.select_message_bundles(
-            &id0,
-            id1,
-            BlockHeight::ZERO,
-            None,
-            Vec::from_iter(bundles1.iter().cloned().chain(bundles0.iter().cloned()))
-        ),
+        helper
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::ZERO,
+                None,
+                Vec::from_iter(bundles1.iter().cloned().chain(bundles0.iter().cloned())),
+                storage
+            )
+            .await,
         Err(WorkerError::InvalidCrossChainRequest)
     );
 
     let helper = CrossChainUpdateHelper {
         allow_messages_from_deprecated_epochs: false,
         current_epoch: Epoch::from(1),
-        committees,
     };
-    // Epoch is tested when `allow_messages_from_deprecated_epochs` is false.
+    // With the genesis committee (epoch 0) present in storage, and no event for any
+    // newer epoch, epochs known to the process are 0. current_epoch is 1, so epoch
+    // 1 passes via `*epoch >= current_epoch`. bundles3 is at epoch 0 (known) so it
+    // is also accepted — unlike the old per-chain-map gate, which would have rejected
+    // it because the chain had "forgotten" epoch 0.
+    // bundles01 is all epoch 0 → both accepted.
     assert_eq!(
-        helper.select_message_bundles(&id0, id1, BlockHeight::ZERO, None, bundles01.clone())?,
-        vec![]
+        helper
+            .select_message_bundles(&id0, id1, BlockHeight::ZERO, None, bundles01.clone(), storage)
+            .await?,
+        without_epochs(&bundles01)
     );
-    // A certificate with a recent epoch certifies all the previous blocks.
+    // All four bundles are at known-or-recent epochs, so all are accepted.
     assert_eq!(
-        helper.select_message_bundles(&id0, id1, BlockHeight::ZERO, None, bundles0123.clone())?,
-        without_epochs(&bundles012)
+        helper
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::ZERO,
+                None,
+                bundles0123.clone(),
+                storage
+            )
+            .await?,
+        without_epochs(&bundles0123)
     );
     // Received heights is still removing prefixes.
     assert_eq!(
-        helper.select_message_bundles(&id0, id1, BlockHeight::from(1), None, bundles012.clone())?,
+        helper
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::from(1),
+                None,
+                bundles012.clone(),
+                storage
+            )
+            .await?,
         without_epochs(bundles1.iter().chain(&bundles2))
     );
     // Anticipated messages re-certify blocks up to the given height.
     assert_eq!(
-        helper.select_message_bundles(
-            &id0,
-            id1,
-            BlockHeight::from(1),
-            Some(BlockHeight::from(1)),
-            bundles01.clone()
-        )?,
+        helper
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::from(1),
+                Some(BlockHeight::from(1)),
+                bundles01.clone(),
+                storage
+            )
+            .await?,
         without_epochs(&bundles1)
     );
     assert_eq!(
-        helper.select_message_bundles(
-            &id0,
-            id1,
-            BlockHeight::ZERO,
-            Some(BlockHeight::from(1)),
-            bundles01.clone()
-        )?,
+        helper
+            .select_message_bundles(
+                &id0,
+                id1,
+                BlockHeight::ZERO,
+                Some(BlockHeight::from(1)),
+                bundles01.clone(),
+                storage
+            )
+            .await?,
         without_epochs(&bundles01)
     );
     Ok(())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2870,7 +2870,16 @@ where
                 message: Message::System(SystemMessage::Credit { .. }), ..
             }])
         );
-        assert_eq!(user_chain.execution_state.system.committees.get().len(), 1);
+        assert_eq!(
+            user_chain
+                .execution_state
+                .system
+                .committees
+                .get()
+                .await?
+                .len(),
+            1
+        );
     }
     // Make the child receive the pending messages.
     let certificate3 = env.make_certificate(ConfirmedBlock::new(
@@ -2937,7 +2946,16 @@ where
             *user_chain.execution_state.system.admin_chain_id.get(),
             Some(admin_chain_id)
         );
-        assert_eq!(user_chain.execution_state.system.committees.get().len(), 2);
+        assert_eq!(
+            user_chain
+                .execution_state
+                .system
+                .committees
+                .get()
+                .await?
+                .len(),
+            2
+        );
         assert_no_removed_bundles(&user_chain).await;
         Ok(())
     }
@@ -3406,7 +3424,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let helper = CrossChainUpdateHelper {
         allow_messages_from_deprecated_epochs: true,
         current_epoch: Epoch::from(1),
-        committees: &committees,
+        committees: committees.clone(),
     };
     // Epoch is not tested when `allow_messages_from_deprecated_epochs` is true.
     assert_eq!(
@@ -3437,7 +3455,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let helper = CrossChainUpdateHelper {
         allow_messages_from_deprecated_epochs: false,
         current_epoch: Epoch::from(1),
-        committees: &committees,
+        committees,
     };
     // Epoch is tested when `allow_messages_from_deprecated_epochs` is false.
     assert_eq!(

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -320,8 +320,8 @@ impl Committee {
 /// Committees are network-global state (created by the admin chain, agreed on
 /// by every validator), so caching them once per process avoids holding a
 /// separate copy in every chain's execution state. The map is populated
-/// lazily by `get_or_load`-style lookups in [`ExecutionRuntimeContext`] and in
-/// the storage layer.
+/// lazily by `get_or_load`-style lookups in [`crate::ExecutionRuntimeContext`]
+/// and in the storage layer.
 #[derive(Clone, Debug, Default)]
 pub struct SharedCommittees {
     map: Arc<papaya::HashMap<Epoch, Arc<Committee>>>,

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -2,10 +2,13 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
+use std::{borrow::Cow, collections::BTreeMap, str::FromStr, sync::Arc};
 
 use allocative::Allocative;
-use linera_base::crypto::{AccountPublicKey, CryptoError, ValidatorPublicKey};
+use linera_base::{
+    crypto::{AccountPublicKey, CryptoError, ValidatorPublicKey},
+    data_types::Epoch,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::policy::ResourceControlPolicy;
@@ -309,5 +312,77 @@ impl Committee {
     /// Returns a mutable reference to this committee's [`ResourceControlPolicy`].
     pub fn policy_mut(&mut self) -> &mut ResourceControlPolicy {
         &mut self.policy
+    }
+}
+
+/// Process-global, append-only cache of committees by epoch.
+///
+/// Committees are network-global state (created by the admin chain, agreed on
+/// by every validator), so caching them once per process avoids holding a
+/// separate copy in every chain's execution state. The map is populated
+/// lazily by `get_or_load`-style lookups in [`ExecutionRuntimeContext`] and in
+/// the storage layer.
+#[derive(Clone, Debug, Default)]
+pub struct SharedCommittees {
+    map: Arc<papaya::HashMap<Epoch, Arc<Committee>>>,
+}
+
+impl SharedCommittees {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the cached committee for `epoch`, if any.
+    pub fn get(&self, epoch: Epoch) -> Option<Arc<Committee>> {
+        self.map.pin().get(&epoch).cloned()
+    }
+
+    /// Inserts `committee` for `epoch`. If an entry was already present, the
+    /// existing value wins and is returned (avoiding spurious clones when two
+    /// callers race to populate the same epoch).
+    pub fn insert(&self, epoch: Epoch, committee: Arc<Committee>) -> Arc<Committee> {
+        let pinned = self.map.pin();
+        match pinned.try_insert(epoch, committee) {
+            Ok(inserted) => inserted.clone(),
+            Err(e) => e.current.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_committees_insert_and_get() {
+        let shared = SharedCommittees::new();
+        assert!(shared.get(Epoch(0)).is_none());
+        let committee = Arc::new(Committee::default());
+        let inserted = shared.insert(Epoch(0), committee.clone());
+        assert!(Arc::ptr_eq(&inserted, &committee));
+        let fetched = shared.get(Epoch(0)).unwrap();
+        assert!(Arc::ptr_eq(&fetched, &committee));
+    }
+
+    #[test]
+    fn shared_committees_insert_is_first_writer_wins() {
+        let shared = SharedCommittees::new();
+        let first = Arc::new(Committee::default());
+        let second = Arc::new(Committee::default());
+        let winner = shared.insert(Epoch(5), first.clone());
+        assert!(Arc::ptr_eq(&winner, &first));
+        let loser = shared.insert(Epoch(5), second.clone());
+        assert!(Arc::ptr_eq(&loser, &first));
+        assert!(!Arc::ptr_eq(&loser, &second));
+    }
+
+    #[test]
+    fn shared_committees_clones_share_storage() {
+        let a = SharedCommittees::new();
+        let b = a.clone();
+        let committee = Arc::new(Committee::default());
+        a.insert(Epoch(1), committee.clone());
+        let fetched = b.get(Epoch(1)).unwrap();
+        assert!(Arc::ptr_eq(&fetched, &committee));
     }
 }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -60,6 +60,7 @@ where
         if self
             .system
             .current_committee()
+            .await?
             .is_some_and(|(_epoch, committee)| {
                 committee
                     .policy()

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -458,6 +458,7 @@ where
 
                         let (_epoch, committee) = system
                             .current_committee()
+                            .await?
                             .ok_or_else(|| ExecutionError::UnauthorizedHttpRequest(url.clone()))?;
                         let allowed_hosts = &committee.policy().http_request_allow_list;
 

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -81,8 +81,8 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     }
 
     #[graphql(derived(name = "committees"))]
-    async fn _committees(&self) -> &BTreeMap<Epoch, Committee> {
-        self.committees.get()
+    async fn _committees(&self) -> Result<&BTreeMap<Epoch, Committee>, async_graphql::Error> {
+        Ok(self.committees.get().await?)
     }
 
     #[graphql(derived(name = "ownership"))]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -37,7 +37,7 @@ use linera_base::{
         Bytecode, DecompressionError, Epoch, NetworkDescription, SendMessageRequest, StreamUpdate,
         Timestamp,
     },
-    doc_scalar, ensure, hex_debug, http,
+    doc_scalar, hex_debug, http,
     identifiers::{
         Account, AccountOwner, ApplicationId, BlobId, BlobType, ChainId, DataBlobHash, EventId,
         GenericApplicationId, ModuleId, StreamId, StreamName,
@@ -558,80 +558,40 @@ pub trait ExecutionRuntimeContext {
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
 
-    /// Returns the committees for the epochs in the given range.
+    /// Returns the committees for the epochs in the given range. Delegates per-epoch
+    /// look-ups to [`Self::get_or_load_committee`] so the process-global cache is hit,
+    /// and surfaces any missing epochs as a single [`ExecutionError::EventsNotFound`].
     async fn get_committees(
         &self,
         epoch_range: RangeInclusive<Epoch>,
     ) -> Result<BTreeMap<Epoch, Committee>, ExecutionError> {
-        let net_description = self
-            .get_network_description()
-            .await?
-            .ok_or(ExecutionError::NoNetworkDescriptionFound)?;
-        let committee_hashes = futures::future::join_all(
-            (epoch_range.start().0..=epoch_range.end().0).map(|epoch| async move {
-                if epoch == 0 {
-                    // Genesis epoch is stored in NetworkDescription.
-                    Ok((epoch, net_description.genesis_committee_blob_hash))
-                } else {
-                    let event_id = EventId {
-                        chain_id: net_description.admin_chain_id,
-                        stream_id: StreamId::system(EPOCH_STREAM_NAME),
-                        index: epoch,
-                    };
-                    let event = self
-                        .get_event(event_id.clone())
-                        .await?
-                        .ok_or_else(|| ExecutionError::EventsNotFound(vec![event_id]))?;
-                    Ok((epoch, bcs::from_bytes(&event)?))
+        let mut committees = BTreeMap::new();
+        let mut missing = Vec::new();
+        for index in epoch_range.start().0..=epoch_range.end().0 {
+            let epoch = Epoch(index);
+            match self.get_or_load_committee(epoch).await? {
+                Some(committee) => {
+                    committees.insert(epoch, (*committee).clone());
                 }
-            }),
-        )
-        .await;
-        let missing_events = committee_hashes
-            .iter()
-            .filter_map(|result| {
-                if let Err(ExecutionError::EventsNotFound(event_ids)) = result {
-                    return Some(event_ids);
-                }
-                None
-            })
-            .flatten()
-            .cloned()
-            .collect::<Vec<_>>();
-        ensure!(
-            missing_events.is_empty(),
-            ExecutionError::EventsNotFound(missing_events)
-        );
-        let committee_hashes = committee_hashes
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
-        let committees = futures::future::join_all(committee_hashes.into_iter().map(
-            |(epoch, committee_hash)| async move {
-                let blob_id = BlobId::new(committee_hash, BlobType::Committee);
-                let committee_blob = self
-                    .get_blob(blob_id)
-                    .await?
-                    .ok_or_else(|| ExecutionError::BlobsNotFound(vec![blob_id]))?;
-                Ok((Epoch(epoch), bcs::from_bytes(committee_blob.bytes())?))
-            },
-        ))
-        .await;
-        let missing_blobs = committees
-            .iter()
-            .filter_map(|result| {
-                if let Err(ExecutionError::BlobsNotFound(blob_ids)) = result {
-                    return Some(blob_ids);
-                }
-                None
-            })
-            .flatten()
-            .cloned()
-            .collect::<Vec<_>>();
-        ensure!(
-            missing_blobs.is_empty(),
-            ExecutionError::BlobsNotFound(missing_blobs)
-        );
-        committees.into_iter().collect()
+                None => missing.push(epoch),
+            }
+        }
+        if !missing.is_empty() {
+            let net_description = self
+                .get_network_description()
+                .await?
+                .ok_or(ExecutionError::NoNetworkDescriptionFound)?;
+            let event_ids = missing
+                .into_iter()
+                .map(|epoch| EventId {
+                    chain_id: net_description.admin_chain_id,
+                    stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                    index: epoch.0,
+                })
+                .collect();
+            return Err(ExecutionError::EventsNotFound(event_ids));
+        }
+        Ok(committees)
     }
 
     /// Returns the committee for `epoch`, consulting the shared cache first.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -65,7 +65,7 @@ pub use crate::wasm::{
     ServiceRuntimeApi, WasmContractModule, WasmExecutionError, WasmServiceModule,
 };
 pub use crate::{
-    committee::Committee,
+    committee::{Committee, SharedCommittees},
     execution::{ExecutionStateView, ServiceRuntimeEndpoint},
     execution_state_actor::{ExecutionRequest, ExecutionStateActor},
     policy::ResourceControlPolicy,
@@ -537,6 +537,9 @@ pub trait ExecutionRuntimeContext {
 
     fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>>;
 
+    /// Process-global cache of committees by epoch, shared across all chains.
+    fn shared_committees(&self) -> &SharedCommittees;
+
     async fn get_user_contract(
         &self,
         description: &ApplicationDescription,
@@ -629,6 +632,41 @@ pub trait ExecutionRuntimeContext {
             ExecutionError::BlobsNotFound(missing_blobs)
         );
         committees.into_iter().collect()
+    }
+
+    /// Returns the committee for `epoch`, consulting the shared cache first.
+    /// On a miss, the `NewCommittee` event and the committee blob are loaded
+    /// from storage and the result is memoized. Returns `Ok(None)` if the
+    /// network description, the event, or the blob is not available locally.
+    async fn get_or_load_committee(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+        if let Some(committee) = self.shared_committees().get(epoch) {
+            return Ok(Some(committee));
+        }
+        let Some(net_description) = self.get_network_description().await? else {
+            return Ok(None);
+        };
+        let blob_hash = if epoch.0 == 0 {
+            net_description.genesis_committee_blob_hash
+        } else {
+            let event_id = EventId {
+                chain_id: net_description.admin_chain_id,
+                stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                index: epoch.0,
+            };
+            match self.get_event(event_id).await? {
+                Some(bytes) => bcs::from_bytes(&bytes)?,
+                None => return Ok(None),
+            }
+        };
+        let blob_id = BlobId::new(blob_hash, BlobType::Committee);
+        let Some(blob) = self.get_blob(blob_id).await? else {
+            return Ok(None);
+        };
+        let committee: Committee = bcs::from_bytes(blob.bytes())?;
+        Ok(Some(self.shared_committees().insert(epoch, Arc::new(committee))))
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
@@ -1272,6 +1310,7 @@ pub struct TestExecutionRuntimeContext {
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
     blobs: Arc<papaya::HashMap<BlobId, Blob>>,
     events: Arc<papaya::HashMap<EventId, Vec<u8>>>,
+    shared_committees: SharedCommittees,
 }
 
 #[cfg(with_testing)]
@@ -1285,6 +1324,7 @@ impl TestExecutionRuntimeContext {
             user_services: Arc::default(),
             blobs: Arc::default(),
             events: Arc::default(),
+            shared_committees: SharedCommittees::new(),
         }
     }
 }
@@ -1311,6 +1351,10 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
 
     fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
+    }
+
+    fn shared_committees(&self) -> &SharedCommittees {
+        &self.shared_committees
     }
 
     async fn get_user_contract(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -537,9 +537,6 @@ pub trait ExecutionRuntimeContext {
 
     fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>>;
 
-    /// Process-global cache of committees by epoch, shared across all chains.
-    fn shared_committees(&self) -> &SharedCommittees;
-
     async fn get_user_contract(
         &self,
         description: &ApplicationDescription,
@@ -1252,7 +1249,6 @@ pub struct TestExecutionRuntimeContext {
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
     blobs: Arc<papaya::HashMap<BlobId, Blob>>,
     events: Arc<papaya::HashMap<EventId, Vec<u8>>>,
-    shared_committees: SharedCommittees,
 }
 
 #[cfg(with_testing)]
@@ -1266,7 +1262,6 @@ impl TestExecutionRuntimeContext {
             user_services: Arc::default(),
             blobs: Arc::default(),
             events: Arc::default(),
-            shared_committees: SharedCommittees::new(),
         }
     }
 }
@@ -1293,10 +1288,6 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
 
     fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
-    }
-
-    fn shared_committees(&self) -> &SharedCommittees {
-        &self.shared_committees
     }
 
     async fn get_user_contract(
@@ -1359,9 +1350,9 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
         &self,
         epoch: Epoch,
     ) -> Result<Option<Arc<Committee>>, ViewError> {
-        if let Some(committee) = self.shared_committees.get(epoch) {
-            return Ok(Some(committee));
-        }
+        // No caching here — tests rarely load the same committee twice, and they don't
+        // benefit from the process-wide deduplication that `SharedCommittees` provides
+        // in production.
         let Some(net_description) = self.get_network_description().await? else {
             return Ok(None);
         };
@@ -1383,9 +1374,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
             return Ok(None);
         };
         let committee: Committee = bcs::from_bytes(blob.bytes())?;
-        Ok(Some(
-            self.shared_committees.insert(epoch, Arc::new(committee)),
-        ))
+        Ok(Some(Arc::new(committee)))
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -594,42 +594,22 @@ pub trait ExecutionRuntimeContext {
         Ok(committees)
     }
 
-    /// Returns the committee for `epoch`, consulting the shared cache first.
-    /// On a miss, the `NewCommittee` event and the committee blob are loaded
-    /// from storage and the result is memoized. Returns `Ok(None)` if the
-    /// network description, the event, or the blob is not available locally.
+    /// Returns the committee for `epoch`, consulting the shared cache first. On a miss,
+    /// loads the `NewCommittee` event and the committee blob from storage and memoizes
+    /// the result. Returns `Ok(None)` if the network description, the event, or the
+    /// blob is not available locally.
+    ///
+    /// Determinism during block execution: call sites inside the runtime must only ask
+    /// for epochs up to and including the chain's current epoch (`self.epoch.get()`).
+    /// The chain-state invariant guarantees that every such committee is knowable (either
+    /// in the shared cache, in storage, or — for the chain's current epoch during a block
+    /// that just created it — in the pending update on the chain's own `committees`
+    /// view). Queries for strictly greater epochs read from a mutable process-wide cache
+    /// and are not deterministic.
     async fn get_or_load_committee(
         &self,
         epoch: Epoch,
-    ) -> Result<Option<Arc<Committee>>, ViewError> {
-        if let Some(committee) = self.shared_committees().get(epoch) {
-            return Ok(Some(committee));
-        }
-        let Some(net_description) = self.get_network_description().await? else {
-            return Ok(None);
-        };
-        let blob_hash = if epoch.0 == 0 {
-            net_description.genesis_committee_blob_hash
-        } else {
-            let event_id = EventId {
-                chain_id: net_description.admin_chain_id,
-                stream_id: StreamId::system(EPOCH_STREAM_NAME),
-                index: epoch.0,
-            };
-            match self.get_event(event_id).await? {
-                Some(bytes) => bcs::from_bytes(&bytes)?,
-                None => return Ok(None),
-            }
-        };
-        let blob_id = BlobId::new(blob_hash, BlobType::Committee);
-        let Some(blob) = self.get_blob(blob_id).await? else {
-            return Ok(None);
-        };
-        let committee: Committee = bcs::from_bytes(blob.bytes())?;
-        Ok(Some(
-            self.shared_committees().insert(epoch, Arc::new(committee)),
-        ))
-    }
+    ) -> Result<Option<Arc<Committee>>, ViewError>;
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
@@ -1373,6 +1353,39 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
             genesis_committee_blob_hash,
             name: "dummy network description".to_string(),
         }))
+    }
+
+    async fn get_or_load_committee(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<Arc<Committee>>, ViewError> {
+        if let Some(committee) = self.shared_committees.get(epoch) {
+            return Ok(Some(committee));
+        }
+        let Some(net_description) = self.get_network_description().await? else {
+            return Ok(None);
+        };
+        let blob_hash = if epoch.0 == 0 {
+            net_description.genesis_committee_blob_hash
+        } else {
+            let event_id = EventId {
+                chain_id: net_description.admin_chain_id,
+                stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                index: epoch.0,
+            };
+            match self.get_event(event_id).await? {
+                Some(bytes) => bcs::from_bytes(&bytes)?,
+                None => return Ok(None),
+            }
+        };
+        let blob_id = BlobId::new(blob_hash, BlobType::Committee);
+        let Some(blob) = self.get_blob(blob_id).await? else {
+            return Ok(None);
+        };
+        let committee: Committee = bcs::from_bytes(blob.bytes())?;
+        Ok(Some(
+            self.shared_committees.insert(epoch, Arc::new(committee)),
+        ))
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -666,7 +666,9 @@ pub trait ExecutionRuntimeContext {
             return Ok(None);
         };
         let committee: Committee = bcs::from_bytes(blob.bytes())?;
-        Ok(Some(self.shared_committees().insert(epoch, Arc::new(committee))))
+        Ok(Some(
+            self.shared_committees().insert(epoch, Arc::new(committee)),
+        ))
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -641,7 +641,7 @@ pub trait ExecutionRuntimeContext {
     async fn get_or_load_committee(
         &self,
         epoch: Epoch,
-    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+    ) -> Result<Option<Arc<Committee>>, ViewError> {
         if let Some(committee) = self.shared_committees().get(epoch) {
             return Ok(Some(committee));
         }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -335,15 +335,23 @@ where
 
     /// Returns the chain's current epoch together with its committee.
     ///
-    /// The committee is served from the process-global [`crate::SharedCommittees`] cache,
-    /// falling back to loading the `NewCommittee` event (or the genesis committee blob for
-    /// epoch 0) on a miss. The chain's own `committees` view is not consulted.
+    /// Serves lookups from the process-global [`crate::SharedCommittees`] cache, falling
+    /// back to the `NewCommittee` event on the admin chain (or the genesis committee blob
+    /// for epoch 0). If neither source has the committee — which happens when a
+    /// `CreateCommittee`/`ProcessNewEpoch` op earlier in the current block created it, but
+    /// the block hasn't been saved yet so the `NewCommittee` event isn't persisted (and
+    /// we deliberately don't populate the shared cache from an unconfirmed block) — fall
+    /// back to reading the chain's own `committees` view, where the new committee sits as
+    /// a pending update.
     pub async fn current_committee(&self) -> Result<Option<(Epoch, Arc<Committee>)>, ViewError> {
         let epoch = *self.epoch.get();
-        let Some(committee) = self.context().extra().get_or_load_committee(epoch).await? else {
+        if let Some(committee) = self.context().extra().get_or_load_committee(epoch).await? {
+            return Ok(Some((epoch, committee)));
+        }
+        let Some(committee) = self.committees.get().await?.get(&epoch).cloned() else {
             return Ok(None);
         };
-        Ok(Some((epoch, committee)))
+        Ok(Some((epoch, Arc::new(committee))))
     }
 
     async fn get_event(&self, event_id: EventId) -> Result<Arc<Vec<u8>>, ExecutionError> {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -335,9 +335,9 @@ where
 
     /// Returns the chain's current epoch together with its committee.
     ///
-    /// The committee is served from the process-global [`SharedCommittees`] cache, falling
-    /// back to loading the `NewCommittee` event (or the genesis committee blob for epoch 0)
-    /// on a miss. The chain's own `committees` view is not consulted.
+    /// The committee is served from the process-global [`crate::SharedCommittees`] cache,
+    /// falling back to loading the `NewCommittee` event (or the genesis committee blob for
+    /// epoch 0) on a miss. The chain's own `committees` view is not consulted.
     pub async fn current_committee(&self) -> Result<Option<(Epoch, Arc<Committee>)>, ViewError> {
         let epoch = *self.epoch.get();
         let Some(committee) = self.context().extra().get_or_load_committee(epoch).await? else {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -79,9 +79,11 @@ pub struct SystemExecutionStateView<C> {
     // small. Plus, currently, we would create the `BTreeMap` anyway in various places
     // (e.g. the `OpenChain` operation).
     //
-    // Lazy: committee lookups are served from `ExecutionRuntimeContext::shared_committees`.
-    // This view is only loaded when executing an operation that mutates the map (admin-chain
-    // `CreateCommittee`/`RemoveCommittee`, or `ProcessNewEpoch`/`ProcessRemovedEpoch`).
+    // Lazy: committee lookups are served from the process-global `SharedCommittees` cache
+    // (via `Storage::get_or_load_committee`), with a fall-back to this view for the
+    // mid-block case in `current_committee`. This view is only loaded when executing an
+    // operation that mutates the map (admin-chain `CreateCommittee`/`RemoveCommittee`, or
+    // `ProcessNewEpoch`/`ProcessRemovedEpoch`).
     pub committees: HashedLazyRegisterView<C, BTreeMap<Epoch, Committee>>,
     /// Ownership of the chain.
     pub ownership: HashedLazyRegisterView<C, ChainOwnership>,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -78,7 +78,11 @@ pub struct SystemExecutionStateView<C> {
     // Not using a `MapView` because the set active of committees is supposed to be
     // small. Plus, currently, we would create the `BTreeMap` anyway in various places
     // (e.g. the `OpenChain` operation).
-    pub committees: HashedRegisterView<C, BTreeMap<Epoch, Committee>>,
+    //
+    // Lazy: committee lookups are served from `ExecutionRuntimeContext::shared_committees`.
+    // This view is only loaded when executing an operation that mutates the map (admin-chain
+    // `CreateCommittee`/`RemoveCommittee`, or `ProcessNewEpoch`/`ProcessRemovedEpoch`).
+    pub committees: HashedLazyRegisterView<C, BTreeMap<Epoch, Committee>>,
     /// Ownership of the chain.
     pub ownership: HashedLazyRegisterView<C, ChainOwnership>,
     /// Balance of the chain. (Available to any user able to create blocks in the chain.)
@@ -325,15 +329,28 @@ where
     pub async fn is_active(&self) -> Result<bool, ViewError> {
         Ok(self.description.get().await?.is_some()
             && self.ownership.get().await?.is_active()
-            && self.current_committee().is_some()
+            && self.current_committee().await?.is_some()
             && self.admin_chain_id.get().is_some())
     }
 
-    /// Returns the current committee, if any.
-    pub fn current_committee(&self) -> Option<(Epoch, &Committee)> {
-        let epoch = self.epoch.get();
-        let committee = self.committees.get().get(epoch)?;
-        Some((*epoch, committee))
+    /// Returns the chain's current epoch together with its committee.
+    ///
+    /// The committee is served from the process-global [`SharedCommittees`] cache, falling
+    /// back to loading the `NewCommittee` event (or the genesis committee blob for epoch 0)
+    /// on a miss. The chain's own `committees` view is not consulted.
+    pub async fn current_committee(
+        &self,
+    ) -> Result<Option<(Epoch, Arc<Committee>)>, ViewError> {
+        let epoch = *self.epoch.get();
+        let Some(committee) = self
+            .context()
+            .extra()
+            .get_or_load_committee(epoch)
+            .await?
+        else {
+            return Ok(None);
+        };
+        Ok(Some((epoch, committee)))
     }
 
     async fn get_event(&self, event_id: EventId) -> Result<Arc<Vec<u8>>, ExecutionError> {
@@ -433,7 +450,7 @@ where
                         let committee =
                             bcs::from_bytes(self.read_blob_content(blob_id).await?.bytes())?;
                         self.blob_used(txn_tracker, blob_id).await?;
-                        self.committees.get_mut().insert(epoch, committee);
+                        self.committees.get_mut().await?.insert(epoch, committee);
                         self.epoch.set(epoch);
                         txn_tracker.add_event(
                             StreamId::system(EPOCH_STREAM_NAME),
@@ -443,7 +460,7 @@ where
                     }
                     AdminOperation::RemoveCommittee { epoch } => {
                         ensure!(
-                            self.committees.get_mut().remove(&epoch).is_some(),
+                            self.committees.get_mut().await?.remove(&epoch).is_some(),
                             ExecutionError::InvalidCommitteeRemoval
                         );
                         txn_tracker.add_event(
@@ -512,12 +529,12 @@ where
                 let blob_id = BlobId::new(bcs::from_bytes(&bytes)?, BlobType::Committee);
                 let committee = bcs::from_bytes(self.read_blob_content(blob_id).await?.bytes())?;
                 self.blob_used(txn_tracker, blob_id).await?;
-                self.committees.get_mut().insert(epoch, committee);
+                self.committees.get_mut().await?.insert(epoch, committee);
                 self.epoch.set(epoch);
             }
             ProcessRemovedEpoch(epoch) => {
                 ensure!(
-                    self.committees.get_mut().remove(&epoch).is_some(),
+                    self.committees.get_mut().await?.remove(&epoch).is_some(),
                     ExecutionError::InvalidCommitteeRemoval
                 );
                 let admin_chain_id = self
@@ -839,7 +856,7 @@ where
             block_height,
             chain_index,
         };
-        let committees = self.committees.get();
+        let committees = self.committees.get().await?;
         let init_chain_config = config.init_chain_config(
             *self.epoch.get(),
             committees.keys().min().copied().unwrap_or(Epoch::ZERO),

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -338,16 +338,9 @@ where
     /// The committee is served from the process-global [`SharedCommittees`] cache, falling
     /// back to loading the `NewCommittee` event (or the genesis committee blob for epoch 0)
     /// on a miss. The chain's own `committees` view is not consulted.
-    pub async fn current_committee(
-        &self,
-    ) -> Result<Option<(Epoch, Arc<Committee>)>, ViewError> {
+    pub async fn current_committee(&self) -> Result<Option<(Epoch, Arc<Committee>)>, ViewError> {
         let epoch = *self.epoch.get();
-        let Some(committee) = self
-            .context()
-            .extra()
-            .get_or_load_committee(epoch)
-            .await?
-        else {
+        let Some(committee) = self.context().extra().get_or_load_committee(epoch).await? else {
             return Ok(None);
         };
         Ok(Some((epoch, committee)))

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -135,15 +135,16 @@ async fn empty_accounts_are_removed() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn hashing_test() -> anyhow::Result<()> {
+    use std::sync::Arc;
+
     let (mut view, _) = new_view_and_context().await;
 
     let zero_hash = CryptoHash::from([0u8; 32]);
 
     assert_ne!(view.crypto_hash_mut().await?, zero_hash);
 
-    let mut committees = BTreeMap::new();
-    committees.insert(Epoch(0), Committee::default());
-    view.system.committees.set(committees.clone());
+    let shared = view.system.context().extra().shared_committees().clone();
+    shared.insert(Epoch(0), Arc::new(Committee::default()));
     view.system.epoch.set(Epoch(0));
     // The hash should still be nonzero before the threshold epoch.
     assert_ne!(view.crypto_hash_mut().await?, zero_hash);
@@ -153,8 +154,7 @@ async fn hashing_test() -> anyhow::Result<()> {
         .policy_mut()
         .http_request_allow_list
         .insert(FLAG_ZERO_HASH.to_owned());
-    committees.insert(Epoch(1), committee);
-    view.system.committees.set(committees);
+    shared.insert(Epoch(1), Arc::new(committee));
     view.system.epoch.set(Epoch(1));
     // Starting from this epoch, the hash should be all zeros.
     assert_eq!(view.crypto_hash_mut().await?, zero_hash);

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -135,16 +135,15 @@ async fn empty_accounts_are_removed() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn hashing_test() -> anyhow::Result<()> {
-    use std::sync::Arc;
-
     let (mut view, _) = new_view_and_context().await;
 
     let zero_hash = CryptoHash::from([0u8; 32]);
 
     assert_ne!(view.crypto_hash_mut().await?, zero_hash);
 
-    let shared = view.system.context().extra().shared_committees().clone();
-    shared.insert(Epoch(0), Arc::new(Committee::default()));
+    let mut committees = BTreeMap::new();
+    committees.insert(Epoch(0), Committee::default());
+    view.system.committees.set(committees.clone());
     view.system.epoch.set(Epoch(0));
     // The hash should still be nonzero before the threshold epoch.
     assert_ne!(view.crypto_hash_mut().await?, zero_hash);
@@ -154,7 +153,8 @@ async fn hashing_test() -> anyhow::Result<()> {
         .policy_mut()
         .http_request_allow_list
         .insert(FLAG_ZERO_HASH.to_owned());
-    shared.insert(Epoch(1), Arc::new(committee));
+    committees.insert(Epoch(1), committee);
+    view.system.committees.set(committees);
     view.system.epoch.set(Epoch(1));
     // Starting from this epoch, the hash should be all zeros.
     assert_eq!(view.crypto_hash_mut().await?, zero_hash);

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1250,7 +1250,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
     assert_eq!(*child_view.system.balance.get(), Amount::ONE);
     assert_eq!(*child_view.system.ownership.get().await?, child_ownership);
     assert_eq!(
-        *child_view.system.committees.get(),
+        *child_view.system.committees.get().await?,
         [(Epoch::ZERO, committee)]
             .into_iter()
             .collect::<BTreeMap<_, _>>()

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -49,6 +49,11 @@ pub enum GrpcProtoConversionError {
     InconsistentChainId,
     #[error("Unrecognized certificate type")]
     InvalidCertificateType,
+    #[error(
+        "Chain info queries asking for committees are reserved for local clients; \
+         validators serve committees via the event stream and the committee blob store"
+    )]
+    UnsupportedRequestCommittees,
 }
 
 impl From<ed25519_dalek::SignatureError> for GrpcProtoConversionError {
@@ -617,6 +622,14 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
     type Error = GrpcProtoConversionError;
 
     fn try_from(chain_info_query: api::ChainInfoQuery) -> Result<Self, Self::Error> {
+        // Defense in depth: every in-process caller has been moved off of
+        // `request_committees`, so a gRPC query that still asks for them is either a
+        // stale client or an attempt to force the validator to load the chain-local
+        // committees view. Reject before we hand the query to the worker.
+        ensure!(
+            !chain_info_query.request_committees,
+            GrpcProtoConversionError::UnsupportedRequestCommittees
+        );
         let request_sent_certificate_hashes_by_heights = chain_info_query
             .request_sent_certificate_hashes_by_heights
             .map(|heights| bincode::deserialize(&heights))
@@ -1295,6 +1308,21 @@ pub mod tests {
             create_network_actions: true,
         };
         round_trip_check::<_, api::ChainInfoQuery>(chain_info_query_some);
+    }
+
+    #[test]
+    pub fn reject_chain_info_query_with_request_committees() {
+        let proto = api::ChainInfoQuery {
+            chain_id: Some(dummy_chain_id(0).into()),
+            request_committees: true,
+            request_owner_balance: Some(AccountOwner::CHAIN.try_into().unwrap()),
+            ..api::ChainInfoQuery::default()
+        };
+        let error = ChainInfoQuery::try_from(proto).unwrap_err();
+        assert!(matches!(
+            error,
+            GrpcProtoConversionError::UnsupportedRequestCommittees
+        ));
     }
 
     #[test]

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -330,7 +330,13 @@ impl TestValidator {
             .chain_state_view(admin_chain_id)
             .await
             .expect("Failed to read admin chain state");
-        let committees = chain_state.execution_state.system.committees.get();
+        let committees = chain_state
+            .execution_state
+            .system
+            .committees
+            .get()
+            .await
+            .expect("Failed to read committees");
         let epoch = *chain_state.execution_state.system.epoch.get();
         let min_active_epoch = committees.keys().min().copied().unwrap_or(Epoch::ZERO);
         let max_active_epoch = committees.keys().max().copied().unwrap_or(Epoch::ZERO);

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -13,6 +13,7 @@ serde_json = {{ version = "1.0" }}
 
 # TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
 darling = {{ version = ">=0.20, <0.23" }}
+ruint = {{ version = ">=1, <1.18" }}
 serde_with = {{ version = ">=3, <3.18" }}
 time = {{ version = ">=0.3, <0.3.47" }}
 time-core = {{ version = ">=0.1, <0.1.8" }}

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1215,7 +1215,6 @@ where
             execution_runtime_config: self.execution_runtime_config,
             user_contracts: self.user_contracts.clone(),
             user_services: self.user_services.clone(),
-            shared_committees: self.shared_committees.clone(),
         };
         let root_key = RootKey::ChainState(chain_id).bytes();
         let store = self.database.open_exclusive(&root_key)?;

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -17,7 +17,8 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    BlobState, ExecutionRuntimeConfig, UserContractCode, UserServiceCode, WasmRuntime,
+    BlobState, ExecutionRuntimeConfig, SharedCommittees, UserContractCode, UserServiceCode,
+    WasmRuntime,
 };
 use linera_views::{
     backends::dual::{DualStoreRootKeyAssignment, StoreInUse},
@@ -413,6 +414,7 @@ pub struct DbStorage<Database, Clock = WallClock> {
     wasm_runtime: Option<WasmRuntime>,
     user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
+    shared_committees: SharedCommittees,
     caches: StorageCaches,
     execution_runtime_config: ExecutionRuntimeConfig,
 }
@@ -1213,6 +1215,7 @@ where
             execution_runtime_config: self.execution_runtime_config,
             user_contracts: self.user_contracts.clone(),
             user_services: self.user_services.clone(),
+            shared_committees: self.shared_committees.clone(),
         };
         let root_key = RootKey::ChainState(chain_id).bytes();
         let store = self.database.open_exclusive(&root_key)?;
@@ -1867,6 +1870,10 @@ where
         Ok(())
     }
 
+    fn shared_committees(&self) -> &SharedCommittees {
+        &self.shared_committees
+    }
+
     fn wasm_runtime(&self) -> Option<WasmRuntime> {
         self.wasm_runtime
     }
@@ -1963,6 +1970,7 @@ where
             wasm_runtime,
             user_contracts: Arc::new(papaya::HashMap::new()),
             user_services: Arc::new(papaya::HashMap::new()),
+            shared_committees: SharedCommittees::new(),
             caches: StorageCaches::new(cache_sizes),
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -537,6 +537,13 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
         self.storage.read_network_description().await
     }
 
+    async fn get_or_load_committee(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<Arc<Committee>>, ViewError> {
+        self.storage.get_or_load_committee(epoch).await
+    }
+
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {
         self.storage.contains_blob(blob_id).await
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -24,15 +24,15 @@ use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     ChainError, ChainStateView,
 };
-use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
+use linera_execution::{
+    committee::Committee, system::EPOCH_STREAM_NAME, BlobState, ExecutionError,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, SharedCommittees, TransactionTracker,
+    UserContractCode, UserServiceCode, WasmRuntime,
+};
 #[cfg(with_revm)]
 use linera_execution::{
     evm::revm::{EvmContractModule, EvmServiceModule},
     EvmRuntime,
-};
-use linera_execution::{
-    BlobState, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, SharedCommittees,
-    TransactionTracker, UserContractCode, UserServiceCode, WasmRuntime,
 };
 #[cfg(with_wasm_runtime)]
 use linera_execution::{WasmContractModule, WasmServiceModule};

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -13,10 +13,10 @@ use itertools::Itertools;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{
-        ApplicationDescription, Blob, BlockHeight, ChainDescription, CompressedBytecode,
+        ApplicationDescription, Blob, BlockHeight, ChainDescription, CompressedBytecode, Epoch,
         NetworkDescription, TimeDelta, Timestamp,
     },
-    identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
+    identifiers::{ApplicationId, BlobId, BlobType, ChainId, EventId, IndexAndEvent, StreamId},
     vm::VmRuntime,
 };
 pub use linera_cache::DEFAULT_CLEANUP_INTERVAL_SECS;
@@ -24,14 +24,15 @@ use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     ChainError, ChainStateView,
 };
+use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
 #[cfg(with_revm)]
 use linera_execution::{
     evm::revm::{EvmContractModule, EvmServiceModule},
     EvmRuntime,
 };
 use linera_execution::{
-    BlobState, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, TransactionTracker,
-    UserContractCode, UserServiceCode, WasmRuntime,
+    BlobState, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, SharedCommittees,
+    TransactionTracker, UserContractCode, UserServiceCode, WasmRuntime,
 };
 #[cfg(with_wasm_runtime)]
 use linera_execution::{WasmContractModule, WasmServiceModule};
@@ -225,6 +226,47 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         &self,
         information: &NetworkDescription,
     ) -> Result<(), ViewError>;
+
+    /// Returns the process-global cache of committees by epoch.
+    fn shared_committees(&self) -> &SharedCommittees;
+
+    /// Returns the committee for `epoch`, consulting the shared cache first
+    /// and, on a miss, loading it from the `NewCommittee` event on the admin
+    /// chain (or from the genesis committee blob for epoch 0) plus the
+    /// committee blob. Returns `Ok(None)` if the network description, event,
+    /// or blob is not yet available locally.
+    async fn get_or_load_committee(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<Arc<Committee>>, ViewError> {
+        if let Some(committee) = self.shared_committees().get(epoch) {
+            return Ok(Some(committee));
+        }
+        let Some(net_description) = self.read_network_description().await? else {
+            return Ok(None);
+        };
+        let blob_hash = if epoch.0 == 0 {
+            net_description.genesis_committee_blob_hash
+        } else {
+            let event_id = EventId {
+                chain_id: net_description.admin_chain_id,
+                stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                index: epoch.0,
+            };
+            match self.read_event(event_id).await? {
+                Some(bytes) => bcs::from_bytes(&bytes)?,
+                None => return Ok(None),
+            }
+        };
+        let blob_id = BlobId::new(blob_hash, BlobType::Committee);
+        let Some(blob) = self.read_blob(blob_id).await? else {
+            return Ok(None);
+        };
+        let committee: Committee = bcs::from_bytes(blob.bytes())?;
+        Ok(Some(
+            self.shared_committees().insert(epoch, Arc::new(committee)),
+        ))
+    }
 
     /// Initializes a chain in a simple way (used for testing and to create a genesis state).
     ///
@@ -423,6 +465,7 @@ pub struct ChainRuntimeContext<S> {
     execution_runtime_config: ExecutionRuntimeConfig,
     user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
+    shared_committees: SharedCommittees,
 }
 
 #[cfg_attr(not(web), async_trait)]
@@ -446,6 +489,10 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
 
     fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
+    }
+
+    fn shared_committees(&self) -> &SharedCommittees {
+        &self.shared_committees
     }
 
     async fn get_user_contract(

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -465,7 +465,6 @@ pub struct ChainRuntimeContext<S> {
     execution_runtime_config: ExecutionRuntimeConfig,
     user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
-    shared_committees: SharedCommittees,
 }
 
 #[cfg_attr(not(web), async_trait)]
@@ -489,10 +488,6 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
 
     fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
-    }
-
-    fn shared_committees(&self) -> &SharedCommittees {
-        &self.shared_committees
     }
 
     async fn get_user_contract(

--- a/linera-views/src/views/hashable_wrapper.rs
+++ b/linera-views/src/views/hashable_wrapper.rs
@@ -215,6 +215,15 @@ impl<C, W, O> DerefMut for WrappedHashableContainerView<C, W, O> {
     }
 }
 
+impl<C, W, O> WrappedHashableContainerView<C, W, O> {
+    /// Returns a mutable reference to the wrapped view without invalidating
+    /// the memoized hash. Only safe to use for operations that do not alter
+    /// the logical content (e.g. dropping an in-memory cache).
+    pub(crate) fn inner_mut_preserve_hash(&mut self) -> &mut W {
+        &mut self.inner
+    }
+}
+
 #[cfg(with_graphql)]
 mod graphql {
     use std::borrow::Cow;

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -211,6 +211,12 @@ where
     pub fn extra(&self) -> &C::Extra {
         self.context.extra()
     }
+
+    /// Drops the in-memory cache of the stored value. Subsequent `get()` calls
+    /// reload from storage. Pending unsaved updates are not affected.
+    pub fn evict(&mut self) {
+        self.stored_value = OnceLock::new();
+    }
 }
 
 impl<C, T> LazyRegisterView<C, T>

--- a/linera-views/src/views/lazy_register_view.rs
+++ b/linera-views/src/views/lazy_register_view.rs
@@ -274,6 +274,18 @@ where
 pub type HashedLazyRegisterView<C, T> =
     WrappedHashableContainerView<C, LazyRegisterView<C, T>, HasherOutput>;
 
+impl<C, T> WrappedHashableContainerView<C, LazyRegisterView<C, T>, HasherOutput>
+where
+    C: Context,
+    T: Default + Send + Sync + Serialize + DeserializeOwned,
+{
+    /// Drops the in-memory cache of the wrapped value without invalidating
+    /// the memoized hash (the logical content is unchanged).
+    pub fn evict(&mut self) {
+        self.inner_mut_preserve_hash().evict();
+    }
+}
+
 #[cfg(with_graphql)]
 mod graphql {
     use std::borrow::Cow;

--- a/linera-views/tests/hashable_tests.rs
+++ b/linera-views/tests/hashable_tests.rs
@@ -79,3 +79,18 @@ async fn lazy_register_view_evict() -> Result<()> {
     assert_eq!(*view.get().await?, 42);
     Ok(())
 }
+
+// The wrapper's memoized hash is logically the same before and after eviction,
+// so evict() must not invalidate it (re-hashing requires reloading the value,
+// which defeats the purpose of the eviction).
+#[tokio::test]
+async fn hashed_lazy_register_view_evict_preserves_hash() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    let mut view = HashedLazyRegisterView::<_, u64>::load(context).await?;
+    view.set(123);
+    let hash_before = view.hash().await?;
+    view.evict();
+    let hash_after = view.hash().await?;
+    assert_eq!(hash_before, hash_after);
+    Ok(())
+}

--- a/linera-views/tests/hashable_tests.rs
+++ b/linera-views/tests/hashable_tests.rs
@@ -6,6 +6,7 @@ use linera_views::{
     common::HasherOutput,
     context::MemoryContext,
     hashable_wrapper::WrappedHashableContainerView,
+    lazy_register_view::{HashedLazyRegisterView, LazyRegisterView},
     register_view::{HashedRegisterView, RegisterView},
     views::{HashableView, View},
 };
@@ -39,5 +40,42 @@ async fn check_hashable_hash() -> Result<()> {
     assert_ne!(hash0, hash32);
     view.clear();
     assert_eq!(hash0, view.hash().await?);
+    Ok(())
+}
+
+// `HashedLazyRegisterView` must hash to the same value as `HashedRegisterView`
+// over equivalent content. The chain-state view hash is protocol-visible, so
+// swapping a `HashedRegisterView` field for a `HashedLazyRegisterView` field
+// must not alter it.
+#[tokio::test]
+async fn hashed_register_and_hashed_lazy_register_have_same_hash() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    let eager = RegisterView::<_, u64>::load(context.clone()).await?;
+    let hash_eager = eager.hash().await?;
+    let lazy = LazyRegisterView::<_, u64>::load(context).await?;
+    let hash_lazy = lazy.hash().await?;
+    assert_eq!(hash_eager, hash_lazy);
+
+    let context = MemoryContext::new_for_testing(());
+    let mut eager = HashedRegisterView::<_, u64>::load(context.clone()).await?;
+    *eager.get_mut() = 7;
+    let hash_eager = eager.hash().await?;
+    let mut lazy = HashedLazyRegisterView::<_, u64>::load(context).await?;
+    lazy.set(7);
+    let hash_lazy = lazy.hash().await?;
+    assert_eq!(hash_eager, hash_lazy);
+    Ok(())
+}
+
+#[tokio::test]
+async fn lazy_register_view_evict() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    let mut view = LazyRegisterView::<_, u64>::load(context).await?;
+    assert_eq!(*view.get().await?, 0);
+    view.evict();
+    assert_eq!(*view.get().await?, 0);
+    view.set(42);
+    view.evict();
+    assert_eq!(*view.get().await?, 42);
     Ok(())
 }


### PR DESCRIPTION
## Motivation

We are using a lot of memory for the `committees` field in the system execution state view, because it is basically duplicated once for every chain worker.

## Proposal

Use a shared map.

The only reason to look into the map is for epoch revocation, which we don't do on this testnet anyway. So we avoid that and always trust old epochs.

We also disallow chain info queries that would force validators to load the map.

## Test Plan

Affected tests were updated.

## Release Plan

- Port some of this to `main`, where applicable. (Even though `main` needs a different solution in the long term.)
- Hotfix validators
- Release SDK

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
