### PR TITLE
Make chain worker writes cancel-safe

### DIFF
--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -33,7 +33,7 @@ pub mod port;
 #[cfg(with_metrics)]
 pub mod prometheus_util;
 #[cfg(not(chain))]
-mod task;
+pub mod task;
 #[cfg(not(chain))]
 pub use task::Task;
 pub mod task_processor;

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -7,6 +7,40 @@ Abstractions over tasks that can be used natively or on the Web.
 
 use futures::{future, Future, FutureExt as _};
 
+/// Spawns `future` on the runtime and awaits its completion.
+///
+/// Unlike [`Task::spawn`], dropping the returned future does *not* cancel the
+/// spawned task — it runs to completion in the background. Use this when the
+/// spawned work (e.g. a storage write paired with its in-memory finalization)
+/// must not be torn apart mid-flight by caller cancellation.
+#[cfg(not(web))]
+pub async fn run_detached<F, R>(future: F) -> R
+where
+    F: Future<Output = R> + Send + 'static,
+    R: Send + 'static,
+{
+    tokio::task::spawn(future)
+        .await
+        .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
+}
+
+/// Web variant: runs `future` on the event loop via
+/// [`wasm_bindgen_futures::spawn_local`], delivering the output via a oneshot.
+/// The spawned task is inherently detached from any handle on web.
+#[cfg(web)]
+pub async fn run_detached<F, R>(future: F) -> R
+where
+    F: Future<Output = R> + 'static,
+    R: 'static,
+{
+    let (tx, rx) = futures::channel::oneshot::channel();
+    wasm_bindgen_futures::spawn_local(async move {
+        let _ = tx.send(future.await);
+    });
+    rx.await
+        .expect("spawned task dropped without sending its result")
+}
+
 /// The type of a future awaiting another task.
 ///
 /// On drop, the remote task will be asynchronously cancelled, but will remain

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -25,34 +25,20 @@ impl<T> MaybeSend for T {}
 
 /// Spawns `future` on the runtime and awaits its completion.
 ///
-/// Unlike [`Task::spawn`], dropping the returned future does *not* cancel the
-/// spawned task — it runs to completion in the background. Use this when the
-/// spawned work (e.g. a storage write paired with its in-memory finalization)
-/// must not be torn apart mid-flight by caller cancellation.
-#[cfg(not(web))]
-pub async fn run_detached<F, R>(future: F) -> R
-where
-    F: Future<Output = R> + MaybeSend + 'static,
-    R: MaybeSend + 'static,
-{
-    tokio::task::spawn(future)
-        .await
-        .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
-}
-
-/// Web variant: runs `future` on the event loop via
-/// [`wasm_bindgen_futures::spawn_local`], delivering the output via a oneshot.
-/// The spawned task is inherently detached from any handle on web.
-#[cfg(web)]
+/// Unlike [`Task::spawn`] on its own, dropping the returned future does *not*
+/// cancel the spawned task — it runs to completion in the background. Use this
+/// when the spawned work (e.g. a storage write paired with its in-memory
+/// finalization) must not be torn apart mid-flight by caller cancellation.
 pub async fn run_detached<F, R>(future: F) -> R
 where
     F: Future<Output = R> + MaybeSend + 'static,
     R: MaybeSend + 'static,
 {
     let (tx, rx) = futures::channel::oneshot::channel();
-    wasm_bindgen_futures::spawn_local(async move {
+    Task::spawn(async move {
         let _ = tx.send(future.await);
-    });
+    })
+    .forget();
     rx.await
         .expect("spawned task dropped without sending its result")
 }

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -7,6 +7,22 @@ Abstractions over tasks that can be used natively or on the Web.
 
 use futures::{future, Future, FutureExt as _};
 
+/// `Send` on native targets; no bound on web (where there's only one thread).
+///
+/// Use this in generic bounds that need `Send` on native but should compile on
+/// web without the bound. Combined with [`run_detached`], this lets a single
+/// function body support both targets.
+#[cfg(not(web))]
+pub trait MaybeSend: Send {}
+#[cfg(not(web))]
+impl<T: Send> MaybeSend for T {}
+
+/// `Send` on native targets; no bound on web (where there's only one thread).
+#[cfg(web)]
+pub trait MaybeSend {}
+#[cfg(web)]
+impl<T> MaybeSend for T {}
+
 /// Spawns `future` on the runtime and awaits its completion.
 ///
 /// Unlike [`Task::spawn`], dropping the returned future does *not* cancel the
@@ -16,8 +32,8 @@ use futures::{future, Future, FutureExt as _};
 #[cfg(not(web))]
 pub async fn run_detached<F, R>(future: F) -> R
 where
-    F: Future<Output = R> + Send + 'static,
-    R: Send + 'static,
+    F: Future<Output = R> + MaybeSend + 'static,
+    R: MaybeSend + 'static,
 {
     tokio::task::spawn(future)
         .await
@@ -30,8 +46,8 @@ where
 #[cfg(web)]
 pub async fn run_detached<F, R>(future: F) -> R
 where
-    F: Future<Output = R> + 'static,
-    R: 'static,
+    F: Future<Output = R> + MaybeSend + 'static,
+    R: MaybeSend + 'static,
 {
     let (tx, rx) = futures::channel::oneshot::channel();
     wasm_bindgen_futures::spawn_local(async move {

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -61,7 +61,9 @@ where
 {
     let (tx, rx) = futures::channel::oneshot::channel();
     wasm_bindgen_futures::spawn_local(async move {
-        let _ = tx.send(future.await);
+        if tx.send(future.await).is_err() {
+            tracing::debug!("run_detached: receiver dropped before result was delivered");
+        }
     });
     rx.await
         .expect("spawned task dropped without sending its result")

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -48,9 +48,7 @@ where
         let (tx, rx) = futures::channel::oneshot::channel();
         wasm_bindgen_futures::spawn_local(async move {
             if tx.send(future.await).is_err() {
-                tracing::debug!(
-                    "run_detached: receiver dropped before result was delivered"
-                );
+                tracing::debug!("run_detached: receiver dropped before result was delivered");
             }
         });
         rx.await

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -29,44 +29,33 @@ impl<T> MaybeSend for T {}
 /// to completion in the background. Use this when the spawned work (e.g. a
 /// storage write paired with its in-memory finalization) must not be torn
 /// apart mid-flight by caller cancellation.
-///
-/// On native, this is just `tokio::task::spawn(future).await`, which already
-/// detaches on drop. On web, `wasm_bindgen_futures::spawn_local` is
-/// fire-and-forget, so we deliver the output through a oneshot channel.
-#[cfg(not(web))]
 pub async fn run_detached<F, R>(future: F) -> R
 where
     F: Future<Output = R> + MaybeSend + 'static,
     R: MaybeSend + 'static,
 {
-    tokio::task::spawn(future)
-        .await
-        .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
-}
-
-/// Spawns `future` on the runtime and awaits its completion.
-///
-/// Dropping the returned future does *not* cancel the spawned task — it runs
-/// to completion in the background. Use this when the spawned work (e.g. a
-/// storage write paired with its in-memory finalization) must not be torn
-/// apart mid-flight by caller cancellation.
-///
-/// On web, `wasm_bindgen_futures::spawn_local` is fire-and-forget, so we
-/// deliver the output through a oneshot channel.
-#[cfg(web)]
-pub async fn run_detached<F, R>(future: F) -> R
-where
-    F: Future<Output = R> + MaybeSend + 'static,
-    R: MaybeSend + 'static,
-{
-    let (tx, rx) = futures::channel::oneshot::channel();
-    wasm_bindgen_futures::spawn_local(async move {
-        if tx.send(future.await).is_err() {
-            tracing::debug!("run_detached: receiver dropped before result was delivered");
-        }
-    });
-    rx.await
-        .expect("spawned task dropped without sending its result")
+    // On native, `tokio::task::spawn` returns a `JoinHandle` that already
+    // detaches on drop. On web, `wasm_bindgen_futures::spawn_local` is
+    // fire-and-forget, so we deliver the output through a oneshot channel.
+    #[cfg(not(web))]
+    {
+        tokio::task::spawn(future)
+            .await
+            .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
+    }
+    #[cfg(web)]
+    {
+        let (tx, rx) = futures::channel::oneshot::channel();
+        wasm_bindgen_futures::spawn_local(async move {
+            if tx.send(future.await).is_err() {
+                tracing::debug!(
+                    "run_detached: receiver dropped before result was delivered"
+                );
+            }
+        });
+        rx.await
+            .expect("spawned task dropped without sending its result")
+    }
 }
 
 /// The type of a future awaiting another task.

--- a/linera-base/src/task.rs
+++ b/linera-base/src/task.rs
@@ -25,20 +25,44 @@ impl<T> MaybeSend for T {}
 
 /// Spawns `future` on the runtime and awaits its completion.
 ///
-/// Unlike [`Task::spawn`] on its own, dropping the returned future does *not*
-/// cancel the spawned task — it runs to completion in the background. Use this
-/// when the spawned work (e.g. a storage write paired with its in-memory
-/// finalization) must not be torn apart mid-flight by caller cancellation.
+/// Dropping the returned future does *not* cancel the spawned task — it runs
+/// to completion in the background. Use this when the spawned work (e.g. a
+/// storage write paired with its in-memory finalization) must not be torn
+/// apart mid-flight by caller cancellation.
+///
+/// On native, this is just `tokio::task::spawn(future).await`, which already
+/// detaches on drop. On web, `wasm_bindgen_futures::spawn_local` is
+/// fire-and-forget, so we deliver the output through a oneshot channel.
+#[cfg(not(web))]
+pub async fn run_detached<F, R>(future: F) -> R
+where
+    F: Future<Output = R> + MaybeSend + 'static,
+    R: MaybeSend + 'static,
+{
+    tokio::task::spawn(future)
+        .await
+        .unwrap_or_else(|e| std::panic::resume_unwind(e.into_panic()))
+}
+
+/// Spawns `future` on the runtime and awaits its completion.
+///
+/// Dropping the returned future does *not* cancel the spawned task — it runs
+/// to completion in the background. Use this when the spawned work (e.g. a
+/// storage write paired with its in-memory finalization) must not be torn
+/// apart mid-flight by caller cancellation.
+///
+/// On web, `wasm_bindgen_futures::spawn_local` is fire-and-forget, so we
+/// deliver the output through a oneshot channel.
+#[cfg(web)]
 pub async fn run_detached<F, R>(future: F) -> R
 where
     F: Future<Output = R> + MaybeSend + 'static,
     R: MaybeSend + 'static,
 {
     let (tx, rx) = futures::channel::oneshot::channel();
-    Task::spawn(async move {
+    wasm_bindgen_futures::spawn_local(async move {
         let _ = tx.send(future.await);
-    })
-    .forget();
+    });
     rx.await
         .expect("spawned task dropped without sending its result")
 }

--- a/linera-core/src/chain_worker/handle.rs
+++ b/linera-core/src/chain_worker/handle.rs
@@ -159,8 +159,9 @@ pub(crate) async fn read_lock<S: Storage + Clone + 'static>(
 /// Acquires a read lock, initializing the chain if needed.
 ///
 /// First acquires a read lock and checks if the chain is already known to be active.
-/// If not, drops the read lock, acquires a write lock to initialize the chain,
-/// then re-acquires the read lock.
+/// If not, drops the read lock, runs the initializing write phase on a detached task
+/// (so caller cancellation cannot tear the save halfway), then re-acquires the read
+/// lock.
 pub(crate) async fn read_lock_initialized<S: Storage + Clone + 'static>(
     state: &Arc<RwLock<ChainWorkerState<S>>>,
 ) -> Result<OwnedRwLockReadGuard<ChainWorkerState<S>>, crate::worker::WorkerError> {
@@ -170,10 +171,12 @@ pub(crate) async fn read_lock_initialized<S: Storage + Clone + 'static>(
             return Ok(guard);
         }
     }
-    {
-        let mut guard = write_lock(state).await;
-        guard.initialize_and_save_if_needed().await?;
-    }
+    let state_for_task = state.clone();
+    linera_base::task::run_detached(async move {
+        let mut guard = write_lock(&state_for_task).await;
+        guard.initialize_and_save_if_needed().await
+    })
+    .await?;
     Ok(read_lock(state).await)
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -832,9 +832,38 @@ where
 
     /// Acquires a write lock on the chain worker and executes the given closure.
     ///
-    /// The [`RollbackGuard`] automatically rolls back uncommitted chain state changes
-    /// when dropped, ensuring cancellation safety. The future is boxed to keep deeply
-    /// nested types off the stack.
+    /// On native targets, the write work runs on a detached task (via
+    /// [`linera_base::task::run_detached`]) so that caller cancellation does
+    /// not unwind the task mid-save. The [`RollbackGuard`] lives inside the
+    /// detached task, so the write lock is held until the DB round-trip and
+    /// `post_save` have fully completed — subsequent readers, including a
+    /// freshly-loaded replacement worker, only see the committed state.
+    #[cfg(not(web))]
+    async fn chain_write<R, F, Fut>(&self, chain_id: ChainId, f: F) -> Result<R, WorkerError>
+    where
+        F: FnOnce(handle::RollbackGuard<StorageClient>) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<R, WorkerError>> + Send,
+        R: Send + 'static,
+    {
+        let state = self.get_or_create_chain_worker(chain_id).await?;
+        let state_for_task = state.clone();
+        let result = Box::pin(wrap_future(linera_base::task::run_detached(async move {
+            let guard = handle::write_lock(&state_for_task).await;
+            guard.check_not_poisoned()?;
+            f(guard).await
+        })))
+        .await;
+        if let Err(error) = &result {
+            if error.must_reload_view() {
+                self.evict_poisoned_worker(chain_id, &state);
+            }
+        }
+        result
+    }
+
+    /// Web variant: `ChainWorkerState` isn't `Send` on wasm and there's no
+    /// cross-task cancellation to worry about, so skip the detach.
+    #[cfg(web)]
     async fn chain_write<R, F, Fut>(&self, chain_id: ChainId, f: F) -> Result<R, WorkerError>
     where
         F: FnOnce(handle::RollbackGuard<StorageClient>) -> Fut,
@@ -1009,7 +1038,7 @@ where
         policy: BundleExecutionPolicy,
     ) -> Result<(ProposedBlock, Block, ChainInfoResponse, ResourceTracker), WorkerError> {
         let chain_id = block.chain_id;
-        self.chain_write(chain_id, |mut guard| async move {
+        self.chain_write(chain_id, move |mut guard| async move {
             guard
                 .stage_block_execution(block, round, &published_blobs, policy)
                 .await
@@ -1028,7 +1057,7 @@ where
         query: Query,
         block_hash: Option<CryptoHash>,
     ) -> Result<(QueryOutcome, BlockHeight), WorkerError> {
-        self.chain_write(chain_id, |mut guard| async move {
+        self.chain_write(chain_id, move |mut guard| async move {
             guard.query_application(query, block_hash).await
         })
         .await
@@ -1065,7 +1094,7 @@ where
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
         let chain_id = certificate.block().header.chain_id;
-        self.chain_write(chain_id, |mut guard| async move {
+        self.chain_write(chain_id, move |mut guard| async move {
             guard
                 .process_confirmed_block(certificate, notify_when_messages_are_delivered)
                 .await
@@ -1084,7 +1113,7 @@ where
         certificate: ValidatedBlockCertificate,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
         let chain_id = certificate.block().header.chain_id;
-        self.chain_write(chain_id, |mut guard| async move {
+        self.chain_write(chain_id, move |mut guard| async move {
             guard.process_validated_block(certificate).await
         })
         .await
@@ -1101,7 +1130,7 @@ where
         certificate: TimeoutCertificate,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let chain_id = certificate.value().chain_id();
-        self.chain_write(chain_id, |mut guard| async move {
+        self.chain_write(chain_id, move |mut guard| async move {
             guard.process_timeout(certificate).await
         })
         .await
@@ -1120,7 +1149,7 @@ where
         bundles: Vec<(Epoch, MessageBundle)>,
         previous_height: Option<BlockHeight>,
     ) -> Result<CrossChainUpdateResult, WorkerError> {
-        self.chain_write(recipient, |mut guard| async move {
+        self.chain_write(recipient, move |mut guard| async move {
             guard
                 .process_cross_chain_update(origin, bundles, previous_height)
                 .await
@@ -1193,7 +1222,7 @@ where
         }
 
         let response = self
-            .chain_write(chain_id, |mut guard| async move {
+            .chain_write(chain_id, move |mut guard| async move {
                 guard.handle_block_proposal(proposal).await
             })
             .await?;
@@ -1321,7 +1350,7 @@ where
         metrics::CHAIN_INFO_QUERIES.inc();
         let chain_id = query.chain_id;
         let result = self
-            .chain_write(chain_id, |mut guard| async move {
+            .chain_write(chain_id, move |mut guard| async move {
                 guard.handle_chain_info_query(query).await
             })
             .await;
@@ -1364,7 +1393,7 @@ where
         let blob_id = blob.id();
         trace!("{} <-- handle_pending_blob({blob_id:8})", self.nickname());
         let result = self
-            .chain_write(chain_id, |mut guard| async move {
+            .chain_write(chain_id, move |mut guard| async move {
                 guard.handle_pending_blob(blob).await
             })
             .await;
@@ -1433,7 +1462,7 @@ where
                 latest_height,
             } => {
                 let actions = self
-                    .chain_write(sender, |mut guard| async move {
+                    .chain_write(sender, move |mut guard| async move {
                         guard
                             .confirm_updated_recipient(recipient, latest_height)
                             .await
@@ -1446,7 +1475,7 @@ where
                 recipient,
                 retransmit_from,
             } => {
-                self.chain_write(sender, |mut guard| async move {
+                self.chain_write(sender, move |mut guard| async move {
                     guard
                         .handle_revert_confirm(recipient, retransmit_from)
                         .await
@@ -1467,7 +1496,7 @@ where
         chain_id: ChainId,
         new_trackers: BTreeMap<ValidatorPublicKey, u64>,
     ) -> Result<(), WorkerError> {
-        self.chain_write(chain_id, |mut guard| async move {
+        self.chain_write(chain_id, move |mut guard| async move {
             guard
                 .update_received_certificate_trackers(new_trackers)
                 .await

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -832,18 +832,19 @@ where
 
     /// Acquires a write lock on the chain worker and executes the given closure.
     ///
-    /// On native targets, the write work runs on a detached task (via
-    /// [`linera_base::task::run_detached`]) so that caller cancellation does
-    /// not unwind the task mid-save. The [`RollbackGuard`] lives inside the
-    /// detached task, so the write lock is held until the DB round-trip and
-    /// `post_save` have fully completed — subsequent readers, including a
-    /// freshly-loaded replacement worker, only see the committed state.
-    #[cfg(not(web))]
+    /// The write work runs on a detached task (via [`linera_base::task::run_detached`])
+    /// so that caller cancellation does not unwind the task mid-save. The
+    /// [`RollbackGuard`] lives inside the detached task, so the write lock is held
+    /// until the DB round-trip and `post_save` have fully completed — subsequent
+    /// readers, including a freshly-loaded replacement worker, only see the
+    /// committed state.
     async fn chain_write<R, F, Fut>(&self, chain_id: ChainId, f: F) -> Result<R, WorkerError>
     where
-        F: FnOnce(handle::RollbackGuard<StorageClient>) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = Result<R, WorkerError>> + Send,
-        R: Send + 'static,
+        F: FnOnce(handle::RollbackGuard<StorageClient>) -> Fut
+            + linera_base::task::MaybeSend
+            + 'static,
+        Fut: std::future::Future<Output = Result<R, WorkerError>> + linera_base::task::MaybeSend,
+        R: linera_base::task::MaybeSend + 'static,
     {
         let state = self.get_or_create_chain_worker(chain_id).await?;
         let state_for_task = state.clone();
@@ -852,30 +853,6 @@ where
             guard.check_not_poisoned()?;
             f(guard).await
         })))
-        .await;
-        if let Err(error) = &result {
-            if error.must_reload_view() {
-                self.evict_poisoned_worker(chain_id, &state);
-            }
-        }
-        result
-    }
-
-    /// Web variant: `ChainWorkerState` isn't `Send` on wasm and there's no
-    /// cross-task cancellation to worry about, so skip the detach.
-    #[cfg(web)]
-    async fn chain_write<R, F, Fut>(&self, chain_id: ChainId, f: F) -> Result<R, WorkerError>
-    where
-        F: FnOnce(handle::RollbackGuard<StorageClient>) -> Fut,
-        Fut: std::future::Future<Output = Result<R, WorkerError>>,
-    {
-        let state = self.get_or_create_chain_worker(chain_id).await?;
-        let state_ref = &state;
-        let result = Box::pin(wrap_future(async move {
-            let guard = handle::write_lock(state_ref).await;
-            guard.check_not_poisoned()?;
-            f(guard).await
-        }))
         .await;
         if let Err(error) = &result {
             if error.must_reload_view() {

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 
 //! The server component of the Linera faucet.
 

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -347,55 +347,30 @@ where
 
 impl<K> WritableKeyValueStore for LruCachingStore<K>
 where
-    K: WritableKeyValueStore + Clone + Send + 'static,
-    K::Error: Send,
+    K: WritableKeyValueStore,
 {
     // The LRU cache does not change the underlying store's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), Self::Error> {
-        // Spawn a task to ensure the DB write and cache update run to
-        // completion atomically, even if the caller's future is cancelled
-        // (e.g. by RollbackGuard). Without this, a cancellation between
-        // the DB write and cache update leaves the cache stale, causing
-        // data loss on the next save.
-        //
-        // We use `tokio::task::spawn` (not `linera_base::Task::spawn`)
-        // because the latter cancels on drop via `RemoteHandle`.
-        let store = self.store.clone();
-        let cache = self.cache.clone();
-        let task = async move {
-            store.write_batch(batch.clone()).await?;
-            if let Some(cache) = &cache {
-                let mut cache = cache.lock().unwrap();
-                for operation in &batch.operations {
-                    match operation {
-                        WriteOperation::Put { key, value } => {
-                            cache.put_key_value(key, value);
-                        }
-                        WriteOperation::Delete { key } => {
-                            cache.delete_key(key);
-                        }
-                        WriteOperation::DeletePrefix { key_prefix } => {
-                            cache.delete_prefix(key_prefix);
-                        }
+        self.store.write_batch(batch.clone()).await?;
+        if let Some(cache) = &self.cache {
+            let mut cache = cache.lock().unwrap();
+            for operation in &batch.operations {
+                match operation {
+                    WriteOperation::Put { key, value } => {
+                        cache.put_key_value(key, value);
+                    }
+                    WriteOperation::Delete { key } => {
+                        cache.delete_key(key);
+                    }
+                    WriteOperation::DeletePrefix { key_prefix } => {
+                        cache.delete_prefix(key_prefix);
                     }
                 }
             }
-            Ok(())
-        };
-        // On native, spawn a task that runs to completion even if the
-        // caller is cancelled. On web, cancellation safety is not a
-        // concern (no RollbackGuard / concurrent chain workers).
-        #[cfg(not(web))]
-        match tokio::task::spawn(task).await {
-            Ok(result) => result,
-            Err(join_error) => std::panic::resume_unwind(join_error.into_panic()),
         }
-        #[cfg(web)]
-        {
-            task.await
-        }
+        Ok(())
     }
 
     async fn clear_journal(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
## Motivation

Caller cancellation can land between `write_batch` and `post_save`: the storage write completes while in-memory views go unrefreshed, leaving them out of sync.

## Proposal

Run the write work on a detached task so the `RollbackGuard` lives inside the spawn and the lock is held until the DB round-trip and `post_save` have both finished. Other tasks — including a freshly loaded replacement worker — only observe the committed state.

Also:
- Add `linera_base::task::run_detached` abstracting `tokio::task::spawn` on native and `wasm_bindgen_futures::spawn_local` on web.
- Apply the same treatment to `read_lock_initialized`.
- Drop the narrower LRU cache spawn from https://github.com/linera-io/linera-protocol/pull/6056, which is subsumed.
- Bump `linera-faucet-server` recursion_limit to fit the deeper trait  resolution introduced by the new `Send` bounds on `chain_write`.

## Test Plan

CI

The ScyllaDB tests should now not be flaky anymore.

## Release Plan

- Backport to `testnet_conway`
- Release SDK
- Hotfix validators

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
