### PR TITLE
Pin ruint in the project template to work with Rust 1.86.0

### DIFF
--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -13,6 +13,7 @@ serde_json = {{ version = "1.0" }}
 
 # TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
 darling = {{ version = ">=0.20, <0.23" }}
+ruint = {{ version = ">=1, <1.18" }}
 serde_with = {{ version = ">=3, <3.18" }}
 time = {{ version = ">=0.3, <0.3.47" }}
 time-core = {{ version = ">=0.1, <0.1.8" }}


### PR DESCRIPTION
## Motivation

`ruint` 1.18.0 bumped its MSRV to Rust 1.90. `linera project new` generates a fresh cargo project with no lockfile; the resolver then picks whatever's newest, so on CI (which runs rustc 1.86.0) this breaks `test_project_new` and `test_project_publish` with:

  error: rustc 1.86.0 is not supported by the following package:
    ruint@1.18.0 requires rustc 1.90

## Proposal

Pin to `>=1, <1.18` in the template's existing MSRV-pinning block (the one tracked by #4742), alongside darling, serde_with, time, etc. The workspace itself is already pinned via Cargo.lock.

## Test Plan

CI

## Release Plan

- Included in https://github.com/linera-io/linera-protocol/pull/6089 on testnet, but could also be a separate backport.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
