### PR TITLE
Restore chain_id to warn!/error! logs with INFO/DEBUG spans.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1040,8 +1040,10 @@ where
         // we haven't received yet, the inbox has a gap.
         if let Some(prev) = sender_previous_height {
             if prev >= next_height_to_receive {
+                let chain_id = self.chain_id();
                 if self.config.allow_revert_confirm {
                     warn!(
+                        %chain_id,
                         "Inbox gap detected from {origin}: \
                         sender declares previous height {prev} but we only have up to \
                         {next_height_to_receive}; requesting resend",
@@ -1052,7 +1054,7 @@ where
                     });
                 }
                 return Err(ChainError::InboxGapDetected {
-                    chain_id: self.chain_id(),
+                    chain_id,
                     origin,
                     expected_height: prev,
                     actual_height: bundles.first().map(|(_, b)| b.height).unwrap_or_default(),
@@ -1097,6 +1099,7 @@ where
             // now. Accordingly, do not send a confirmation, so that the
             // cross-chain update is retried later.
             warn!(
+                chain_id = %self.chain_id(),
                 "Refusing to deliver messages from {origin} \
                 at height {last_updated_height} because the recipient is still inactive",
             );
@@ -1262,6 +1265,7 @@ where
         self.knows_chain_is_active = false;
         self.save().await?;
         warn!(
+            %chain_id,
             "Cleared chain state up to height {tip_height}; \
             re-executing all blocks"
         );
@@ -2108,7 +2112,11 @@ where
     ))]
     async fn save(&mut self) -> Result<(), WorkerError> {
         if let Err(error) = self.chain.save().await {
-            tracing::error!(?error, "Chain save failed; marking worker as poisoned");
+            tracing::error!(
+                ?error,
+                chain_id = %self.chain_id(),
+                "Chain save failed; marking worker as poisoned"
+            );
             self.poisoned = true;
             return Err(WorkerError::PoisonedWorker);
         }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1171,7 +1171,7 @@ impl<Env: Environment> Client<Env> {
         let (max_epoch, committees) = match self.admin_committees().await {
             Ok(result) => result,
             Err(error) => {
-                error!(%error, "could not read admin committees");
+                error!(%error, %sender_chain_id, "could not read admin committees");
                 return;
             }
         };
@@ -1257,6 +1257,7 @@ impl<Env: Environment> Client<Env> {
                     nodes.retain(|node| !faulty_validators.contains(&node.public_key));
                     if nodes.is_empty() {
                         info!(
+                            chain_id = %sender_chain_id,
                             "could not download certificates for chain - no more correct validators left"
                         );
                         return;


### PR DESCRIPTION
Partial forward-port of https://github.com/linera-io/linera-protocol/pull/6074.

## Motivation

An `#[instrument]` span is entered only when the subscriber's max level is at or below the span's level. A default (INFO) span is therefore disabled at WARN/ERROR, and a DEBUG span is disabled at INFO and above — so `warn!`/`error!` events inside them lose the span's `chain_id` field.

That means after https://github.com/linera-io/linera-protocol/pull/6069, some chain IDs won't be shown at WARN/ERROR level.

## Proposal

For the `warn!` and `error!` calls that relied on an INFO- or DEBUG-level chain_id span, re-attach `chain_id` explicitly so it is still logged when the filter is raised.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
