### PR TITLE
Add optional whitelist for chain self-recovery

### DIFF
--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -52,6 +52,11 @@ pub struct ChainWorkerConfig {
     /// state is detected to be corrupted — but only if the given duration has
     /// elapsed since block 0 was last executed (to prevent reset loops).
     pub reset_on_corrupted_chain_state: Option<Duration>,
+    /// Optional whitelist restricting which chains are eligible for the
+    /// `allow_revert_confirm` and `reset_on_corrupted_chain_state` recovery
+    /// mechanisms. If `None`, every chain is eligible (subject to the
+    /// respective feature flag). If `Some`, only chains in the set are.
+    pub recovery_whitelist: Option<HashSet<ChainId>>,
 }
 
 impl ChainWorkerConfig {
@@ -64,6 +69,14 @@ impl ChainWorkerConfig {
     /// Gets a reference to the [`ValidatorSecretKey`], if available.
     pub fn key_pair(&self) -> Option<&ValidatorSecretKey> {
         self.key_pair.as_ref().map(Arc::as_ref)
+    }
+
+    /// Returns whether `chain_id` is allowed to attempt the `RevertConfirm` and
+    /// corrupted-state-reset recovery mechanisms.
+    pub(crate) fn recovery_allowed_for(&self, chain_id: &ChainId) -> bool {
+        self.recovery_whitelist
+            .as_ref()
+            .is_none_or(|set| set.contains(chain_id))
     }
 }
 
@@ -86,6 +99,7 @@ impl Default for ChainWorkerConfig {
             cross_chain_message_chunk_limit: usize::MAX,
             allow_revert_confirm: false,
             reset_on_corrupted_chain_state: None,
+            recovery_whitelist: None,
         }
     }
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1067,7 +1067,8 @@ where
         if let Some(prev) = previous_height {
             if prev >= next_height_to_receive {
                 let recipient = self.chain_id();
-                if self.config.allow_revert_confirm {
+                if self.config.allow_revert_confirm && self.config.recovery_allowed_for(&recipient)
+                {
                     warn!(
                         "Inbox gap detected for {recipient} from {origin}: \
                         sender declares previous height {prev} but we only have up to \
@@ -1269,6 +1270,9 @@ where
             return Ok(None);
         };
         let chain_id = self.chain_id();
+        if !self.config.recovery_allowed_for(&chain_id) {
+            return Ok(None);
+        }
         let local_time = self.storage.clock().current_time();
         let block_zero_time = *self.chain.block_zero_executed_at.get();
         let elapsed = local_time.duration_since(block_zero_time);

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1067,8 +1067,7 @@ where
         if let Some(prev) = previous_height {
             if prev >= next_height_to_receive {
                 let chain_id = self.chain_id();
-                if self.config.allow_revert_confirm && self.config.recovery_allowed_for(&recipient)
-                {
+                if self.config.allow_revert_confirm && self.config.recovery_allowed_for(&chain_id) {
                     warn!(
                         %chain_id,
                         "Inbox gap detected from {origin}: \

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4735,7 +4735,45 @@ where
         );
     }
 
-    // Step 5: Now create a worker WITH recovery enabled and process the same block.
+    // Step 4b: Verify that with recovery enabled but a whitelist that EXCLUDES
+    // `chain_id`, no reset happens — retrying still fails with the same error.
+    {
+        let worker_not_whitelisted = WorkerState::new(
+            storage.clone(),
+            ChainWorkerConfig {
+                nickname: "Whitelist-excludes worker".to_string(),
+                allow_inactive_chains: true,
+                allow_messages_from_deprecated_epochs: true,
+                reset_on_corrupted_chain_state: Some(Duration::from_secs(0)),
+                recovery_whitelist: Some(HashSet::from([target_id])),
+                block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
+                ..ChainWorkerConfig::default()
+            }
+            .with_key_pair(Some(
+                env.worker().chain_worker_config.key_pair().unwrap().copy(),
+            )),
+            None,
+        );
+
+        assert_matches!(
+            worker_not_whitelisted
+                .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+                .await,
+            Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
+        );
+        // Retry: without a reset there is no way to recover, so the same error repeats.
+        // The retry serializes behind the background reset task's write lock, so by the
+        // time it starts the reset task has already decided to skip.
+        assert_matches!(
+            worker_not_whitelisted
+                .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+                .await,
+            Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
+        );
+    }
+
+    // Step 5: Now create a worker WITH recovery enabled and a whitelist that
+    // includes `chain_id`, and process the same block.
     let worker_with_recovery = WorkerState::new(
         storage.clone(),
         ChainWorkerConfig {
@@ -4743,6 +4781,7 @@ where
             allow_inactive_chains: true,
             allow_messages_from_deprecated_epochs: true,
             reset_on_corrupted_chain_state: Some(Duration::from_secs(0)),
+            recovery_whitelist: Some(HashSet::from([chain_id])),
             block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
             ..ChainWorkerConfig::default()
         }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -16,6 +16,7 @@ pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\
 
 use std::{
     borrow::Cow,
+    collections::HashSet,
     num::NonZeroU16,
     path::{Path, PathBuf},
     sync::Arc,
@@ -27,6 +28,7 @@ use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt, TryFutureExt as _};
 use linera_base::{
     crypto::{CryptoRng, Ed25519SecretKey},
+    identifiers::ChainId,
     listen_for_shutdown_signals,
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
@@ -69,6 +71,7 @@ struct ServerContext {
     execution_state_cache_size: usize,
     allow_revert_confirm: bool,
     reset_on_corrupted_chain_state_mins: Option<u64>,
+    recovery_whitelist: Option<HashSet<ChainId>>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -103,6 +106,7 @@ impl ServerContext {
             reset_on_corrupted_chain_state: self
                 .reset_on_corrupted_chain_state_mins
                 .map(|m| linera_base::time::Duration::from_secs(m * 60)),
+            recovery_whitelist: self.recovery_whitelist.clone(),
             cross_chain_message_chunk_limit: self.cross_chain_message_chunk_limit,
             ..ChainWorkerConfig::default()
         };
@@ -478,6 +482,13 @@ enum ServerCommand {
         #[arg(long)]
         reset_on_corrupted_chain_state_mins: Option<u64>,
 
+        /// Optional whitelist of chain IDs allowed to use the `--allow-revert-confirm`
+        /// and `--reset-on-corrupted-chain-state-mins` recovery mechanisms. If not
+        /// specified, every chain is eligible. Values may be passed as a
+        /// comma-separated list or by repeating the flag.
+        #[arg(long, value_delimiter = ',')]
+        recovery_whitelist: Option<Vec<ChainId>>,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -612,6 +623,7 @@ async fn run(options: ServerOptions) {
             cross_chain_message_chunk_limit,
             allow_revert_confirm,
             reset_on_corrupted_chain_state_mins,
+            recovery_whitelist,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -632,6 +644,7 @@ async fn run(options: ServerOptions) {
                 execution_state_cache_size: common_storage_options.execution_state_cache_size,
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
+                recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };


### PR DESCRIPTION
## Motivation

We want to be careful with the new recovery mechanism, and not enable them for all chains.

## Proposal

Gate `allow_revert_confirm` and `reset_on_corrupted_chain_state` on an optional `recovery_whitelist`: when unset, every chain is eligible; when set, only listed chains may attempt self-repair. Exposed via a new `--recovery-whitelist` flag on `linera-server run`.

## Test Plan

The test was extended.

## Release Plan

- Possibly port to `main`?
- Hotfix validators.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
