### PR TITLE
Run lint-check-all-features on ubuntu-latest instead of self-hosted

### DIFF
--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   check-all-features-partition:
     if: github.event_name != 'pull_request'
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -54,7 +54,7 @@ jobs:
 
   lint-check-all-features:
     needs: check-all-features-partition
-    runs-on: linera-io-self-hosted-ci
+    runs-on: ubuntu-latest
     if: always()
     steps:
     - run: |


### PR DESCRIPTION
## Motivation

The `lint-check-all-features` workflow has 6 `cargo hack check --each-feature` partitions that currently run on our paid self-hosted OVH runners. We are tight on CI spend and want to shift anything that can safely run on free `ubuntu-latest` away from the self-hosted pool.

## Proposal

Change `runs-on` from `linera-io-self-hosted-ci` to `ubuntu-latest` on both jobs in `.github/workflows/lint-check-all-features.yml`: the 6-way matrix job and its summary gate.

Hard data backing the move:

- The 6 partitions run in parallel, so wall-time is bounded by the longest shard, not the sum.
- Recent merge_group runs on self-hosted show the longest shard at ~16m.
- Measured self-hosted / ubuntu-latest slowdown for comparable Rust check jobs in this repo is roughly 1.8x.
- Projected longest shard on `ubuntu-latest`: ~29m, which ties (does not exceed) the existing critical-path job `remote-net-test` at ~29m. So no new wall-time bottleneck.
- Frees ~74 self-hosted minutes per merge_group run.

If a partition turns out to be memory-bound on `ubuntu-latest` (7 GB RAM), the mitigation is cheap: bump partition count from 6 to 8 or 12.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)