### PR TITLE
ci: wait for docker daemon before docker steps

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -42,6 +42,23 @@ jobs:
           version: "34.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Self-hosted runners occasionally expose an unhealthy
+      # docker socket at job start despite
+      # RUNNER_WAIT_FOR_DOCKER_IN_SECONDS. Probe + retry so
+      # we do not fail the whole run on a startup race.
+      - name: Wait for docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if docker info >/dev/null 2>&1; then
+              echo "Docker ready after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Waiting for docker daemon ($i/60)..."
+            sleep 2
+          done
+          echo "Docker daemon did not become ready in 120s"
+          exit 1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -29,6 +29,23 @@ jobs:
       - name: Configure Docker to push to Artifact Registry
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
+      # Self-hosted builder occasionally exposes an unhealthy
+      # docker socket at job start despite
+      # RUNNER_WAIT_FOR_DOCKER_IN_SECONDS. Probe + retry so
+      # we do not fail the whole run on a startup race.
+      - name: Wait for docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if docker info >/dev/null 2>&1; then
+              echo "Docker ready after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Waiting for docker daemon ($i/60)..."
+            sleep 2
+          done
+          echo "Docker daemon did not become ready in 120s"
+          exit 1
+
       - name: Set env variables
         env:
           HEAD_REF: ${{ github.head_ref }}


### PR DESCRIPTION
## Motivation

Bridge E2E and Docker Image workflows have intermittently failed at the very first docker-using step with `dial unix /var/run/docker.sock: connect: no such file or directory` (e.g. runs 24424265616 and 24424265605, both at 21:49 UTC on 98624d29). Despite `RUNNER_WAIT_FOR_DOCKER_IN_SECONDS=120` on the self-hosted runner pods, the docker socket can be momentarily unavailable when the job step runs.

## Proposal

Add a short `Wait for docker daemon` step (probe `docker info`, retry up to 60 times at 2s intervals = 120s cap) before the first docker-using step in both workflows. If the daemon is healthy, the loop exits on the first iteration with negligible cost; if it is briefly down at job start, the run survives instead of failing immediately.

This is a mitigation. The underlying dind instability is being investigated separately.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `testnet` branch.

## Links

- Example failures: https://github.com/linera-io/linera-protocol/actions/runs/24424265616/job/71354338011 and https://github.com/linera-io/linera-protocol/actions/runs/24424265605/job/71354337823