### PR TITLE
Skip certificate-created blobs during pre-fetch

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -781,9 +781,18 @@ impl<Env: Environment> Client<Env> {
         until_block_time: Option<Timestamp>,
     ) -> Result<Option<Box<ChainInfo>>, chain_client::Error> {
         let mut info = None;
+        // Blobs created by these certs are already embedded in the downloaded
+        // block bodies, so they don't need to be fetched from a validator. The
+        // chain worker resolves them from `Block::created_blobs()` during
+        // `handle_certificate`.
+        let created_blob_ids: BTreeSet<BlobId> = certificates
+            .iter()
+            .flat_map(|certificate| certificate.value().block().created_blob_ids())
+            .collect();
         let required_blob_ids: Vec<_> = certificates
             .iter()
             .flat_map(|certificate| certificate.value().required_blob_ids())
+            .filter(|blob_id| !created_blob_ids.contains(blob_id))
             .collect();
 
         match self


### PR DESCRIPTION
## Motivation

During catch-up, `process_certificates` pre-fetches every blob referenced
by the downloaded certificates, including blobs the certificates
themselves create. Those blobs are already embedded in the block body
(bound via `BlockHeader::blobs_hash`), so fetching them from storage or a
validator is redundant.

## Proposal

Filter blobs in `Block::created_blob_ids()` out of the pre-fetch set in
`Client::process_certificates`. The chain-worker path that follows is
unaffected: `maybe_get_required_blobs`
(`linera-core/src/chain_worker/state.rs`) populates the `created_blobs`
hint before consulting the chain manager or storage, so created blobs
are resolved directly from the cert body without any extra read.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch.
