### PR TITLE
[testnet] backport #6095: `web`: clone full client instead of just `ClientContext`

### DIFF
--- a/web/@linera/client/src/chain/application.rs
+++ b/web/@linera/client/src/chain/application.rs
@@ -10,7 +10,7 @@ use crate::{Environment, JsResult};
 
 #[wasm_bindgen]
 pub struct Application {
-    pub(crate) client_context: crate::ClientContext,
+    pub(crate) client: crate::Client,
     pub(crate) chain_client: ChainClient<Environment>,
     pub(crate) id: ApplicationId,
 }
@@ -70,7 +70,8 @@ impl Application {
 
         if !operations.is_empty() {
             let _hash = self
-                .client_context
+                .client
+                .context
                 .lock()
                 .await
                 .apply_client_command(&chain_client, |_chain_client| {

--- a/web/@linera/client/src/chain/mod.rs
+++ b/web/@linera/client/src/chain/mod.rs
@@ -14,14 +14,14 @@ use serde::ser::Serialize as _;
 use wasm_bindgen::prelude::*;
 use web_sys::{js_sys, wasm_bindgen};
 
-use crate::{ClientContext, Environment, JsResult};
+use crate::{Environment, JsResult};
 
 pub mod application;
 pub use application::Application;
 
 #[wasm_bindgen]
 pub struct Chain {
-    pub(crate) client_context: ClientContext,
+    pub(crate) client: crate::Client,
     pub(crate) chain_client: ChainClient<Environment>,
 }
 
@@ -80,7 +80,8 @@ impl Chain {
     #[wasm_bindgen]
     pub async fn transfer(&self, params: TransferParams) -> JsResult<()> {
         let _hash = self
-            .client_context
+            .client
+            .context
             .lock()
             .await
             .apply_client_command(&self.chain_client, |_chain_client| {
@@ -123,7 +124,8 @@ impl Chain {
         options: Option<AddOwnerOptions>,
     ) -> JsResult<()> {
         let AddOwnerOptions { weight } = options.unwrap_or_default();
-        self.client_context
+        self.client
+            .context
             .lock()
             .await
             .apply_client_command(&self.chain_client, |_chain_client| {
@@ -141,7 +143,7 @@ impl Chain {
     pub async fn validator_version_info(&self) -> JsResult<JsValue> {
         self.chain_client.synchronize_from_validators().await?;
         let result = self.chain_client.local_committee().await;
-        let mut client = self.client_context.lock().await;
+        let mut client = self.client.context.lock().await;
         client.update_wallet(&self.chain_client).await?;
         let committee = result?;
         let node_provider = client.make_node_provider();
@@ -185,7 +187,7 @@ impl Chain {
     pub async fn application(&self, id: &str) -> JsResult<Application> {
         web_sys::console::debug_1(&format!("connecting to Linera application {id}").into());
         Ok(Application {
-            client_context: self.client_context.clone(),
+            client: self.client.clone(),
             chain_client: self.chain_client.clone(),
             id: id.parse()?,
         })

--- a/web/@linera/client/src/client.rs
+++ b/web/@linera/client/src/client.rs
@@ -22,6 +22,7 @@ use crate::{
 /// to this API can be trusted to have originated from the user's
 /// request.
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct Client {
     // This use of `futures::lock::Mutex` is safe because we only
     // expose concurrency to the browser, which must always run all
@@ -30,8 +31,8 @@ pub struct Client {
     // hard-coded by `ChainListener`.
     pub(crate) context: ClientContext,
     listener: Arc<AsyncMutex<Option<Listener>>>,
-    chain_listener_config: linera_client::chain_listener::ChainListenerConfig,
-    storage: Storage,
+    pub(crate) chain_listener_config: linera_client::chain_listener::ChainListenerConfig,
+    pub(crate) storage: Storage,
 }
 
 #[derive(Default, serde::Deserialize, tsify::Tsify)]
@@ -100,14 +101,7 @@ impl Client {
     pub async fn start(&self) -> Result<()> {
         let mut guard = self.listener.lock().await;
         if guard.is_none() {
-            *guard = Some(
-                Listener::start(
-                    self.context.clone(),
-                    self.chain_listener_config.clone(),
-                    self.storage.clone(),
-                )
-                .await?,
-            );
+            *guard = Some(Listener::start(self.clone()).await?);
         }
         Ok(())
     }
@@ -142,7 +136,7 @@ impl Client {
 
         Ok(Chain {
             chain_client,
-            client_context: self.context.clone(),
+            client: self.clone(),
         })
     }
 

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -105,3 +105,8 @@ pub fn initialize(options: Option<InitializeOptions>) {
         )
         .init();
 }
+
+#[wasm_bindgen]
+pub fn panic() {
+    panic!("oh no!");
+}

--- a/web/@linera/client/src/listener.rs
+++ b/web/@linera/client/src/listener.rs
@@ -5,7 +5,7 @@ use futures::future::{self, FutureExt as _};
 use linera_client::chain_listener::ChainListener;
 use tokio_util::sync::CancellationToken;
 
-use crate::{ClientContext, Result, Storage};
+use crate::Result;
 
 pub struct Listener {
     cancellation_token: CancellationToken,
@@ -13,16 +13,12 @@ pub struct Listener {
 }
 
 impl Listener {
-    pub(crate) async fn start(
-        context: ClientContext,
-        config: linera_client::chain_listener::ChainListenerConfig,
-        storage: Storage,
-    ) -> Result<Self> {
+    pub(crate) async fn start(client: crate::Client) -> Result<Self> {
         let cancellation_token = CancellationToken::new();
         let chain_listener = ChainListener::new(
-            config,
-            context,
-            storage,
+            client.chain_listener_config,
+            client.context,
+            client.storage,
             cancellation_token.clone(),
             tokio::sync::mpsc::unbounded_channel().1,
             true, // Enable background sync


### PR DESCRIPTION
## Motivation

see #6095

## Proposal

backport #6095

## Test Plan

CI
