### PR TITLE
Shared committee map; remove committees from chain state

### DIFF
--- a/linera-bridge/src/relay.rs
+++ b/linera-bridge/src/relay.rs
@@ -372,7 +372,7 @@ pub async fn run(
     );
     let admin_client = ctx.make_chain_client(admin_chain_id).await?;
     admin_client
-        .synchronize_chain_state_from_committee(committee)
+        .synchronize_chain_state_from_committee(Arc::new(committee))
         .await?;
     tracing::info!("Admin chain synced");
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -460,13 +460,20 @@ where
         // Recompute the state hash.
         let hash = self.execution_state.crypto_hash_mut().await?;
         self.execution_state_hash.set(Some(hash));
-        let maybe_committee = self.execution_state.system.current_committee().into_iter();
+        let maybe_committee = self
+            .execution_state
+            .system
+            .current_committee()
+            .await
+            .with_execution_context(ChainExecutionContext::Block)?;
         // Last, reset the consensus state based on the current ownership.
         self.manager.reset(
             self.execution_state.system.ownership.get().await?.clone(),
             BlockHeight(0),
             local_time,
-            maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights()),
+            maybe_committee
+                .iter()
+                .flat_map(|(_, committee)| committee.account_keys_and_weights()),
         )?;
         Ok(())
     }
@@ -566,11 +573,14 @@ where
         }
     }
 
-    pub fn current_committee(&self) -> Result<(Epoch, &Committee), ChainError> {
+    pub async fn current_committee(&self) -> Result<(Epoch, Arc<Committee>), ChainError> {
+        let chain_id = self.chain_id();
         self.execution_state
             .system
             .current_committee()
-            .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
+            .await
+            .with_execution_context(ChainExecutionContext::Block)?
+            .ok_or(ChainError::InactiveChain(chain_id))
     }
 
     pub async fn ownership(&self) -> Result<&ChainOwnership, ChainError> {
@@ -688,6 +698,8 @@ where
         let committee_policy = chain
             .system
             .current_committee()
+            .await
+            .with_execution_context(ChainExecutionContext::Block)?
             .ok_or_else(|| ChainError::InactiveChain(block.chain_id))?
             .1
             .policy()
@@ -1153,10 +1165,16 @@ where
         next_height: BlockHeight,
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
-        let maybe_committee = self.execution_state.system.current_committee().into_iter();
+        let maybe_committee = self
+            .execution_state
+            .system
+            .current_committee()
+            .await
+            .with_execution_context(ChainExecutionContext::Block)?;
         let ownership = self.execution_state.system.ownership.get().await?.clone();
-        let fallback_owners =
-            maybe_committee.flat_map(|(_, committee)| committee.account_keys_and_weights());
+        let fallback_owners = maybe_committee
+            .iter()
+            .flat_map(|(_, committee)| committee.account_keys_and_weights());
         self.pending_validated_blobs.clear();
         self.pending_proposed_blobs.clear();
         self.manager

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -36,7 +36,7 @@ use linera_chain::{
 };
 use linera_execution::{
     system::{EpochEventData, EventSubscriptions, EPOCH_STREAM_NAME},
-    Committee, ExecutionRuntimeContext as _, ExecutionStateView, Query, QueryContext, QueryOutcome,
+    ExecutionRuntimeContext as _, ExecutionStateView, Query, QueryContext, QueryOutcome,
     ResourceTracker, ServiceRuntimeEndpoint,
 };
 use linera_storage::{Clock as _, Storage};
@@ -582,8 +582,8 @@ where
         // Check that the chain is active and ready for this timeout.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
         self.initialize_and_save_if_needed().await?;
-        let (chain_epoch, committee) = self.chain.current_committee()?;
-        certificate.check(committee)?;
+        let (chain_epoch, committee) = self.chain.current_committee().await?;
+        certificate.check(&committee)?;
         if self
             .chain
             .tip_state
@@ -684,9 +684,9 @@ where
                 found_block_height: header.height,
             }
         );
-        let (epoch, committee) = self.chain.current_committee()?;
+        let (epoch, committee) = self.chain.current_committee().await?;
         check_block_epoch(epoch, header.chain_id, header.epoch)?;
-        certificate.check(committee)?;
+        certificate.check(&committee)?;
         let already_committed_block = self.chain.tip_state.get().already_validated_block(height)?;
         let should_skip_validated_block = || {
             self.chain
@@ -766,37 +766,43 @@ where
             ));
         }
 
-        // We haven't processed the block - verify the certificate first
+        // We haven't processed the block - verify the certificate first.
+        // Resolve the committee hash from the admin chain's epoch event stream; the
+        // chain-local `committees` map is just a cache of the same hashes for trusted
+        // epochs, so we can skip it and always hit the event stream.
         let epoch = block.header.epoch;
-        // Get the committee for the block's epoch from storage.
-        if let Some(committee) = self
+        let hash = self
             .chain
             .execution_state
-            .system
-            .committees
-            .get()
-            .get(&epoch)
-        {
-            certificate.check(committee)?;
-        } else {
-            let committee = self
-                .chain
-                .execution_state
-                .context()
-                .extra()
-                .get_committees(epoch..=epoch)
-                .await
-                .map_err(|error| {
-                    ChainError::ExecutionError(Box::new(error), ChainExecutionContext::Block)
-                })?
-                .remove(&epoch)
-                .ok_or_else(|| {
-                    ChainError::InternalError(format!(
-                        "missing committee for epoch {epoch}; this is a bug"
-                    ))
-                })?;
-            certificate.check(&committee)?;
-        }
+            .context()
+            .extra()
+            .get_committee_hashes(epoch..=epoch)
+            .await
+            .map_err(|error| {
+                ChainError::ExecutionError(Box::new(error), ChainExecutionContext::Block)
+            })?
+            .remove(&epoch)
+            .ok_or_else(|| {
+                ChainError::InternalError(format!(
+                    "missing committee for epoch {epoch}; this is a bug"
+                ))
+            })?;
+        let committee = self
+            .chain
+            .execution_state
+            .context()
+            .extra()
+            .get_or_load_committee_by_hash(hash)
+            .await
+            .map_err(|error| {
+                ChainError::ExecutionError(Box::new(error), ChainExecutionContext::Block)
+            })?
+            .ok_or_else(|| {
+                ChainError::InternalError(format!(
+                    "committee blob for epoch {epoch} missing; this is a bug"
+                ))
+            })?;
+        certificate.check(&committee)?;
 
         // Certificate check passed - which means the blobs the block requires are legitimate and
         // we can take note of it, so that if any are missing, we will accept them when the client
@@ -870,7 +876,7 @@ where
         // properly chained. Verify that the chain is active and that the epoch we used for
         // verifying the certificate is actually the active one on the chain.
         self.initialize_and_save_if_needed().await?;
-        let (epoch, _) = self.chain.current_committee()?;
+        let (epoch, _) = self.chain.current_committee().await?;
         check_block_epoch(epoch, chain_id, block.header.epoch)?;
 
         let published_blobs = block
@@ -1600,7 +1606,7 @@ where
             .await?
         {
             if !pending_blobs.validated.get() {
-                let (_, committee) = self.chain.current_committee()?;
+                let (_, committee) = self.chain.current_committee().await?;
                 let policy = committee.policy();
                 policy
                     .check_blob_size(blob.content())
@@ -1743,7 +1749,7 @@ where
     ) -> Result<(ProposedBlock, Block, ChainInfoResponse, ResourceTracker), WorkerError> {
         self.initialize_and_save_if_needed().await?;
         let local_time = self.storage.clock().current_time();
-        let (_, committee) = self.chain.current_committee()?;
+        let (_, committee) = self.chain.current_committee().await?;
         block.check_proposal_size(committee.policy().maximum_block_proposal_size)?;
 
         self.chain
@@ -1794,7 +1800,7 @@ where
         // Check if the chain is ready for this new block proposal.
         chain.tip_state.get().verify_block_chaining(block)?;
         // Check the epoch.
-        let (epoch, committee) = chain.current_committee()?;
+        let (epoch, committee) = chain.current_committee().await?;
         check_block_epoch(epoch, block.chain_id, block.epoch)?;
         let policy = committee.policy().clone();
         block.check_proposal_size(policy.maximum_block_proposal_size)?;
@@ -1813,7 +1819,7 @@ where
             }
             Some(OriginalProposal::Regular { certificate }) => {
                 // Verify that this block has been validated by a quorum before.
-                certificate.check(committee)?;
+                certificate.check(&committee)?;
             }
             Some(OriginalProposal::Fast(signature)) => {
                 let original_proposal = BlockProposal {
@@ -2169,7 +2175,7 @@ fn check_block_epoch(
 pub(crate) struct CrossChainUpdateHelper<'a> {
     pub(crate) allow_messages_from_deprecated_epochs: bool,
     pub(crate) current_epoch: Epoch,
-    pub(crate) committees: &'a BTreeMap<Epoch, Committee>,
+    pub(crate) committees: &'a BTreeMap<Epoch, CryptoHash>,
 }
 
 impl<'a> CrossChainUpdateHelper<'a> {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -796,11 +796,6 @@ where
             .await
             .map_err(|error| {
                 ChainError::ExecutionError(Box::new(error), ChainExecutionContext::Block)
-            })?
-            .ok_or_else(|| {
-                ChainError::InternalError(format!(
-                    "committee blob for epoch {epoch} missing; this is a bug"
-                ))
             })?;
         certificate.check(&committee)?;
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -69,7 +69,7 @@ use super::{
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ClientOutcome, RoundTimeout},
     environment::Environment,
-    local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
+    local_node::{LocalNodeClient, LocalNodeError},
     node::{
         CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
         ValidatorNodeProvider as _,
@@ -624,16 +624,18 @@ impl<Env: Environment> ChainClient<Env> {
     #[instrument(level = "trace")]
     async fn epoch_and_committees(
         &self,
-    ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), LocalNodeError> {
+    ) -> Result<(Epoch, BTreeMap<Epoch, CryptoHash>), LocalNodeError> {
         let info = self.chain_info_with_committees().await?;
         let epoch = info.epoch;
-        let committees = info.into_committees()?;
+        let committees = info
+            .requested_committees
+            .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
         Ok((epoch, committees))
     }
 
     /// Obtains the committee for the current epoch of the local chain.
     #[instrument(level = "trace")]
-    pub async fn local_committee(&self) -> Result<Committee, Error> {
+    pub async fn local_committee(&self) -> Result<Arc<Committee>, Error> {
         let info = match self.chain_info_with_committees().await {
             Ok(info) => info,
             Err(LocalNodeError::BlobsNotFound(_)) => {
@@ -642,12 +644,23 @@ impl<Env: Environment> ChainClient<Env> {
             }
             Err(err) => return Err(err.into()),
         };
-        Ok(info.into_current_committee()?)
+        let hash = info
+            .requested_committees
+            .as_ref()
+            .ok_or(LocalNodeError::InvalidChainInfoResponse)?
+            .get(&info.epoch)
+            .copied()
+            .ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
+        self.storage_client()
+            .get_or_load_committee_by_hash(hash)
+            .await
+            .map_err(LocalNodeError::from)?
+            .ok_or_else(|| LocalNodeError::InactiveChain(self.chain_id).into())
     }
 
     /// Obtains the committee for the latest epoch on the admin chain.
     #[instrument(level = "trace")]
-    pub async fn admin_committee(&self) -> Result<(Epoch, Committee), LocalNodeError> {
+    pub async fn admin_committee(&self) -> Result<(Epoch, Arc<Committee>), LocalNodeError> {
         self.client.admin_committee().await
     }
 
@@ -797,7 +810,7 @@ impl<Env: Environment> ChainClient<Env> {
                 .await?
         };
         if let Ok(new_committee) = self.local_committee().await {
-            if Some(&new_committee) != old_committee {
+            if old_committee.is_none_or(|old| *new_committee != *old) {
                 // If the configuration just changed, communicate to the new committee as well.
                 // (This is actually more important that updating the previous committee.)
                 self.communicate_chain_updates(&new_committee, latest_certificate)
@@ -1209,8 +1222,8 @@ impl<Env: Environment> ChainClient<Env> {
     #[instrument(level = "trace")]
     pub async fn request_leader_timeout(&self) -> Result<TimeoutCertificate, Error> {
         let chain_id = self.chain_id;
-        let info = self.chain_info_with_committees().await?;
-        let committee = info.current_committee()?;
+        let info = self.chain_info().await?;
+        let committee = self.local_committee().await?;
         let height = info.next_block_height;
         let round = info.manager.current_round;
         let action = CommunicateAction::RequestTimeout {
@@ -1221,14 +1234,14 @@ impl<Env: Environment> ChainClient<Env> {
         let value = Timeout::new(chain_id, height, info.epoch);
         let certificate = Box::new(
             self.client
-                .communicate_chain_action(committee, action, value)
+                .communicate_chain_action(&committee, action, value)
                 .await?,
         );
         self.client.handle_certificate(*certificate.clone()).await?;
         // The block height didn't increase, but this will communicate the timeout as well.
         self.client
             .communicate_chain_updates(
-                committee,
+                &committee,
                 chain_id,
                 height,
                 CrossChainMessageDelivery::NonBlocking,
@@ -1252,7 +1265,7 @@ impl<Env: Environment> ChainClient<Env> {
     #[instrument(level = "trace", skip_all)]
     pub async fn synchronize_chain_state_from_committee(
         &self,
-        committee: Committee,
+        committee: Arc<Committee>,
     ) -> Result<Box<ChainInfo>, Error> {
         self.client
             .synchronize_chain_from_committee(self.chain_id, committee)
@@ -2094,8 +2107,9 @@ impl<Env: Environment> ChainClient<Env> {
                 "Conflicting proposal in the current round",
             ));
         };
-        let current_committee = info
-            .current_committee()?
+        let current_committee = self
+            .local_committee()
+            .await?
             .validators
             .values()
             .map(|v| (AccountOwner::from(v.account_public_key), v.votes))

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -651,11 +651,11 @@ impl<Env: Environment> ChainClient<Env> {
             .get(&info.epoch)
             .copied()
             .ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
-        self.storage_client()
+        Ok(self
+            .storage_client()
             .get_or_load_committee_by_hash(hash)
             .await
-            .map_err(LocalNodeError::from)?
-            .ok_or_else(|| LocalNodeError::InactiveChain(self.chain_id).into())
+            .map_err(LocalNodeError::from)?)
     }
 
     /// Obtains the committee for the latest epoch on the admin chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -859,7 +859,10 @@ impl<Env: Environment> Client<Env> {
             .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
         let committees =
             futures::future::try_join_all(hashes.into_iter().map(|(epoch, hash)| async move {
-                let committee = self.storage_client().get_or_load_committee_by_hash(hash).await?;
+                let committee = self
+                    .storage_client()
+                    .get_or_load_committee_by_hash(hash)
+                    .await?;
                 Ok::<_, LocalNodeError>((epoch, committee))
             }))
             .await?

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -47,7 +47,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse},
     environment::Environment,
-    local_node::{LocalChainInfoExt as _, LocalNodeClient, LocalNodeError},
+    local_node::{LocalNodeClient, LocalNodeError},
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode as _, ValidatorNodeProvider as _},
     notifier::{ChannelNotifier, Notifier as _},
     remote_node::RemoteNode,
@@ -852,15 +852,42 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "trace", skip_all)]
     async fn admin_committees(
         &self,
-    ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), LocalNodeError> {
+    ) -> Result<(Epoch, BTreeMap<Epoch, Arc<Committee>>), LocalNodeError> {
         let info = self.chain_info_with_committees(self.admin_chain_id).await?;
-        Ok((info.epoch, info.into_committees()?))
+        let hashes = info
+            .requested_committees
+            .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
+        let committees =
+            futures::future::try_join_all(hashes.into_iter().map(|(epoch, hash)| async move {
+                let committee = self
+                    .storage_client()
+                    .get_or_load_committee_by_hash(hash)
+                    .await?
+                    .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
+                Ok::<_, LocalNodeError>((epoch, committee))
+            }))
+            .await?
+            .into_iter()
+            .collect();
+        Ok((info.epoch, committees))
     }
 
     /// Obtains the committee for the latest epoch on the admin chain.
-    pub async fn admin_committee(&self) -> Result<(Epoch, Committee), LocalNodeError> {
+    pub async fn admin_committee(&self) -> Result<(Epoch, Arc<Committee>), LocalNodeError> {
         let info = self.chain_info_with_committees(self.admin_chain_id).await?;
-        Ok((info.epoch, info.into_current_committee()?))
+        let hash = info
+            .requested_committees
+            .as_ref()
+            .ok_or(LocalNodeError::InvalidChainInfoResponse)?
+            .get(&info.epoch)
+            .copied()
+            .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
+        let committee = self
+            .storage_client()
+            .get_or_load_committee_by_hash(hash)
+            .await?
+            .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
+        Ok((info.epoch, committee))
     }
 
     /// Obtains the validators for the latest epoch.
@@ -1592,7 +1619,7 @@ impl<Env: Environment> Client<Env> {
     )]
     fn check_certificate(
         highest_known_epoch: Epoch,
-        committees: &BTreeMap<Epoch, Committee>,
+        committees: &BTreeMap<Epoch, Arc<Committee>>,
         incoming_certificate: &ConfirmedBlockCertificate,
     ) -> Result<CheckCertificateResult, NodeError> {
         let block = incoming_certificate.block();
@@ -1632,7 +1659,7 @@ impl<Env: Environment> Client<Env> {
     pub(crate) async fn synchronize_chain_from_committee(
         &self,
         chain_id: ChainId,
-        committee: Committee,
+        committee: Arc<Committee>,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         #[cfg(with_metrics)]
         let _latency = if !self.is_chain_follow_only(chain_id) {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -859,11 +859,7 @@ impl<Env: Environment> Client<Env> {
             .ok_or(LocalNodeError::InvalidChainInfoResponse)?;
         let committees =
             futures::future::try_join_all(hashes.into_iter().map(|(epoch, hash)| async move {
-                let committee = self
-                    .storage_client()
-                    .get_or_load_committee_by_hash(hash)
-                    .await?
-                    .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
+                let committee = self.storage_client().get_or_load_committee_by_hash(hash).await?;
                 Ok::<_, LocalNodeError>((epoch, committee))
             }))
             .await?
@@ -885,8 +881,7 @@ impl<Env: Environment> Client<Env> {
         let committee = self
             .storage_client()
             .get_or_load_committee_by_hash(hash)
-            .await?
-            .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
+            .await?;
         Ok((info.epoch, committee))
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -19,7 +19,7 @@ use linera_chain::{
     types::ConfirmedBlockCertificate,
     ChainStateView,
 };
-use linera_execution::{committee::Committee, ExecutionRuntimeContext};
+use linera_execution::ExecutionRuntimeContext;
 use linera_storage::ChainRuntimeContext;
 use linera_views::{context::Context, ViewError};
 use serde::{Deserialize, Serialize};
@@ -150,9 +150,9 @@ pub struct ChainInfo {
     /// The requested owner balance, if any.
     #[debug(skip_if = Option::is_none)]
     pub requested_owner_balance: Option<Amount>,
-    /// The current committees.
+    /// Committee blob hashes indexed by epoch, if requested.
     #[debug(skip_if = Option::is_none)]
-    pub requested_committees: Option<BTreeMap<Epoch, Committee>>,
+    pub requested_committees: Option<BTreeMap<Epoch, CryptoHash>>,
     /// The received messages that are waiting be picked in the next block (if requested).
     #[debug(skip_if = Vec::is_empty)]
     pub requested_pending_message_bundles: Vec<IncomingBundle>,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -10,14 +10,15 @@ use std::{
 use futures::{stream::FuturesUnordered, TryStreamExt as _};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{ArithmeticError, Blob, BlockHeight, Epoch},
+    data_types::{ArithmeticError, Blob, BlockHeight},
     identifiers::{BlobId, ChainId, EventId, StreamId},
 };
 use linera_chain::{
     data_types::{BlockProposal, BundleExecutionPolicy, ProposedBlock},
     types::{Block, GenericCertificate},
+    ChainError, ChainExecutionContext,
 };
-use linera_execution::{committee::Committee, BlobState, Query, QueryOutcome, ResourceTracker};
+use linera_execution::{BlobState, ExecutionError, Query, QueryOutcome, ResourceTracker};
 use linera_storage::Storage;
 use linera_views::ViewError;
 use thiserror::Error;
@@ -69,6 +70,20 @@ pub enum LocalNodeError {
 
     #[error("Events not found: {0:?}")]
     EventsNotFound(Vec<EventId>),
+}
+
+impl From<ExecutionError> for LocalNodeError {
+    fn from(error: ExecutionError) -> Self {
+        match error {
+            ExecutionError::BlobsNotFound(blob_ids) => LocalNodeError::BlobsNotFound(blob_ids),
+            ExecutionError::EventsNotFound(event_ids) => LocalNodeError::EventsNotFound(event_ids),
+            ExecutionError::ViewError(view_error) => LocalNodeError::ViewError(view_error),
+            error => LocalNodeError::WorkerError(WorkerError::from(ChainError::ExecutionError(
+                Box::new(error),
+                ChainExecutionContext::Block,
+            ))),
+        }
+    }
 }
 
 impl From<WorkerError> for LocalNodeError {
@@ -448,40 +463,5 @@ where
             .state
             .get_next_height_to_preprocess(chain_id)
             .await?)
-    }
-}
-
-/// Extension trait for [`ChainInfo`]s from our local node. These should always be valid and
-/// contain the requested information.
-pub trait LocalChainInfoExt {
-    /// Returns the requested map of committees.
-    fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError>;
-
-    /// Returns the current committee.
-    fn into_current_committee(self) -> Result<Committee, LocalNodeError>;
-
-    /// Returns a reference to the current committee.
-    fn current_committee(&self) -> Result<&Committee, LocalNodeError>;
-}
-
-impl LocalChainInfoExt for ChainInfo {
-    fn into_committees(self) -> Result<BTreeMap<Epoch, Committee>, LocalNodeError> {
-        self.requested_committees
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)
-    }
-
-    fn into_current_committee(self) -> Result<Committee, LocalNodeError> {
-        self.requested_committees
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)?
-            .remove(&self.epoch)
-            .ok_or(LocalNodeError::InactiveChain(self.chain_id))
-    }
-
-    fn current_committee(&self) -> Result<&Committee, LocalNodeError> {
-        self.requested_committees
-            .as_ref()
-            .ok_or(LocalNodeError::InvalidChainInfoResponse)?
-            .get(&self.epoch)
-            .ok_or(LocalNodeError::InactiveChain(self.chain_id))
     }
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4138,8 +4138,7 @@ where
         .executing_worker()
         .storage
         .get_or_load_committee_by_hash(committee_hash)
-        .await?
-        .expect("committee blob should be present");
+        .await?;
     let expected_key = committee
         .validators
         .get(&env.executing_worker().public_key())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3264,7 +3264,9 @@ where
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let mut storage_builder = MemoryStorageBuilder::default();
     let env = TestEnvironment::new(&mut storage_builder, true, false).await?;
-    let committees = BTreeMap::from([(Epoch::from(1), env.committee().clone())]);
+    // CrossChainUpdateHelper only checks `contains_key` on this map, so a dummy hash
+    // per known epoch is enough.
+    let committees = BTreeMap::from([(Epoch::from(1), CryptoHash::test_hash("epoch 1"))]);
 
     let chain_0 = env.admin_description.clone();
     let chain_1 = dummy_chain_description(1);
@@ -4126,12 +4128,19 @@ where
         .handle_chain_info_query(query.clone())
         .await?;
     let manager = response.info.manager;
-    let expected_key = response
+    let committee_hash = *response
         .info
         .requested_committees
         .unwrap()
         .get(&response.info.epoch)
-        .unwrap()
+        .unwrap();
+    let committee = env
+        .executing_worker()
+        .storage
+        .get_or_load_committee_by_hash(committee_hash)
+        .await?
+        .expect("committee blob should be present");
+    let expected_key = committee
         .validators
         .get(&env.executing_worker().public_key())
         .unwrap()

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -2,11 +2,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, collections::BTreeMap};
+use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 
 use allocative::Allocative;
 use linera_base::{
-    crypto::{AccountPublicKey, ValidatorPublicKey},
+    crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
     data_types::ArithmeticError,
 };
 use serde::{Deserialize, Serialize};
@@ -255,5 +255,79 @@ impl Committee {
     /// Returns a mutable reference to this committee's [`ResourceControlPolicy`].
     pub fn policy_mut(&mut self) -> &mut ResourceControlPolicy {
         &mut self.policy
+    }
+}
+
+/// Process-global, append-only cache of committees keyed by their blob hash.
+///
+/// Committees are network-global state (created by the admin chain, agreed
+/// on by every validator), so caching them once per process avoids holding a
+/// separate copy in every chain's execution state. The map is populated
+/// lazily by `get_or_load_committee_by_hash` in the storage layer.
+#[derive(Clone, Debug, Default)]
+pub struct SharedCommittees {
+    map: Arc<papaya::HashMap<CryptoHash, Arc<Committee>>>,
+}
+
+impl SharedCommittees {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the cached committee for `hash`, if any.
+    pub fn get(&self, hash: CryptoHash) -> Option<Arc<Committee>> {
+        self.map.pin().get(&hash).cloned()
+    }
+
+    /// Inserts `committee` under `hash`. If an entry was already present, the
+    /// existing value wins and is returned (avoiding spurious clones when two
+    /// callers race to populate the same hash).
+    pub fn insert(&self, hash: CryptoHash, committee: Arc<Committee>) -> Arc<Committee> {
+        let pinned = self.map.pin();
+        match pinned.try_insert(hash, committee) {
+            Ok(inserted) => inserted.clone(),
+            Err(e) => e.current.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_committees_insert_and_get() {
+        let shared = SharedCommittees::new();
+        let hash = CryptoHash::test_hash("c0");
+        assert!(shared.get(hash).is_none());
+        let committee = Arc::new(Committee::default());
+        let inserted = shared.insert(hash, committee.clone());
+        assert!(Arc::ptr_eq(&inserted, &committee));
+        let fetched = shared.get(hash).unwrap();
+        assert!(Arc::ptr_eq(&fetched, &committee));
+    }
+
+    #[test]
+    fn shared_committees_insert_is_first_writer_wins() {
+        let shared = SharedCommittees::new();
+        let hash = CryptoHash::test_hash("c1");
+        let first = Arc::new(Committee::default());
+        let second = Arc::new(Committee::default());
+        let winner = shared.insert(hash, first.clone());
+        assert!(Arc::ptr_eq(&winner, &first));
+        let loser = shared.insert(hash, second.clone());
+        assert!(Arc::ptr_eq(&loser, &first));
+        assert!(!Arc::ptr_eq(&loser, &second));
+    }
+
+    #[test]
+    fn shared_committees_clones_share_storage() {
+        let a = SharedCommittees::new();
+        let b = a.clone();
+        let hash = CryptoHash::test_hash("c2");
+        let committee = Arc::new(Committee::default());
+        a.insert(hash, committee.clone());
+        let fetched = b.get(hash).unwrap();
+        assert!(Arc::ptr_eq(&fetched, &committee));
     }
 }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -533,6 +533,7 @@ where
 
                         let (_epoch, committee) = system
                             .current_committee()
+                            .await?
                             .ok_or_else(|| ExecutionError::UnauthorizedHttpRequest(url.clone()))?;
                         let allowed_hosts = &committee.policy().http_request_allow_list;
 

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -4,7 +4,7 @@
 use std::collections::BTreeMap;
 
 use linera_base::{
-    crypto::ValidatorPublicKey,
+    crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{Amount, ChainDescription, Epoch, Timestamp},
     doc_scalar,
     identifiers::{AccountOwner, ChainId},
@@ -81,7 +81,7 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     }
 
     #[graphql(derived(name = "committees"))]
-    async fn _committees(&self) -> &BTreeMap<Epoch, Committee> {
+    async fn _committees(&self) -> &BTreeMap<Epoch, CryptoHash> {
         self.committees.get()
     }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -552,11 +552,11 @@ pub trait ExecutionRuntimeContext {
         hash: CryptoHash,
     ) -> Result<Option<Arc<Committee>>, ExecutionError>;
 
-    /// Returns the committees for the epochs in the given range.
-    async fn get_committees(
+    /// Returns the committee blob hashes for the epochs in the given range.
+    async fn get_committee_hashes(
         &self,
         epoch_range: RangeInclusive<Epoch>,
-    ) -> Result<BTreeMap<Epoch, Committee>, ExecutionError> {
+    ) -> Result<BTreeMap<Epoch, CryptoHash>, ExecutionError> {
         let net_description = self
             .get_network_description()
             .await?
@@ -565,7 +565,7 @@ pub trait ExecutionRuntimeContext {
             (epoch_range.start().0..=epoch_range.end().0).map(|epoch| async move {
                 if epoch == 0 {
                     // Genesis epoch is stored in NetworkDescription.
-                    Ok((epoch, net_description.genesis_committee_blob_hash))
+                    Ok((Epoch(epoch), net_description.genesis_committee_blob_hash))
                 } else {
                     let event_id = EventId {
                         chain_id: net_description.admin_chain_id,
@@ -577,7 +577,7 @@ pub trait ExecutionRuntimeContext {
                         .await?
                         .ok_or_else(|| ExecutionError::EventsNotFound(vec![event_id]))?;
                     let event_data: EpochEventData = bcs::from_bytes(&event)?;
-                    Ok((epoch, event_data.blob_hash))
+                    Ok((Epoch(epoch), event_data.blob_hash))
                 }
             }),
         )
@@ -597,36 +597,7 @@ pub trait ExecutionRuntimeContext {
             missing_events.is_empty(),
             ExecutionError::EventsNotFound(missing_events)
         );
-        let committee_hashes = committee_hashes
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?;
-        let committees = futures::future::join_all(committee_hashes.into_iter().map(
-            |(epoch, committee_hash)| async move {
-                let blob_id = BlobId::new(committee_hash, BlobType::Committee);
-                let committee_blob = self
-                    .get_blob(blob_id)
-                    .await?
-                    .ok_or_else(|| ExecutionError::BlobsNotFound(vec![blob_id]))?;
-                Ok((Epoch(epoch), bcs::from_bytes(committee_blob.bytes())?))
-            },
-        ))
-        .await;
-        let missing_blobs = committees
-            .iter()
-            .filter_map(|result| {
-                if let Err(ExecutionError::BlobsNotFound(blob_ids)) = result {
-                    return Some(blob_ids);
-                }
-                None
-            })
-            .flatten()
-            .cloned()
-            .collect::<Vec<_>>();
-        ensure!(
-            missing_blobs.is_empty(),
-            ExecutionError::BlobsNotFound(missing_blobs)
-        );
-        committees.into_iter().collect()
+        committee_hashes.into_iter().collect()
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -542,7 +542,9 @@ pub trait ExecutionRuntimeContext {
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
 
-    /// Returns the committee whose serialized form hashes to `hash`.
+    /// Returns the committee whose serialized form hashes to `hash`. Returns
+    /// `ExecutionError::BlobsNotFound` if the committee blob is missing from
+    /// storage.
     ///
     /// Implementations should cache results in a process-wide
     /// [`SharedCommittees`] map so that repeated lookups are cheap across
@@ -550,7 +552,7 @@ pub trait ExecutionRuntimeContext {
     async fn get_or_load_committee_by_hash(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<Committee>>, ExecutionError>;
+    ) -> Result<Arc<Committee>, ExecutionError>;
 
     /// Returns the committee blob hashes for the epochs in the given range.
     async fn get_committee_hashes(
@@ -1380,13 +1382,16 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
     async fn get_or_load_committee_by_hash(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+    ) -> Result<Arc<Committee>, ExecutionError> {
         let blob_id = BlobId::new(hash, BlobType::Committee);
-        let Some(blob) = self.blobs.pin().get(&blob_id).cloned() else {
-            return Ok(None);
-        };
+        let blob = self
+            .blobs
+            .pin()
+            .get(&blob_id)
+            .cloned()
+            .ok_or(ExecutionError::BlobsNotFound(vec![blob_id]))?;
         let committee: Committee = bcs::from_bytes(blob.bytes())?;
-        Ok(Some(Arc::new(committee)))
+        Ok(Arc::new(committee))
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -65,7 +65,7 @@ pub use crate::wasm::{
     ServiceRuntimeApi, WasmContractModule, WasmExecutionError, WasmServiceModule,
 };
 pub use crate::{
-    committee::Committee,
+    committee::{Committee, SharedCommittees},
     execution::{ExecutionStateView, ServiceRuntimeEndpoint},
     execution_state_actor::{ExecutionRequest, ExecutionStateActor},
     policy::ResourceControlPolicy,
@@ -541,6 +541,16 @@ pub trait ExecutionRuntimeContext {
     async fn get_event(&self, event_id: EventId) -> Result<Option<Arc<Vec<u8>>>, ViewError>;
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
+
+    /// Returns the committee whose serialized form hashes to `hash`.
+    ///
+    /// Implementations should cache results in a process-wide
+    /// [`SharedCommittees`] map so that repeated lookups are cheap across
+    /// chains.
+    async fn get_or_load_committee_by_hash(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Option<Arc<Committee>>, ExecutionError>;
 
     /// Returns the committees for the epochs in the given range.
     async fn get_committees(
@@ -1394,6 +1404,18 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
             genesis_committee_blob_hash,
             name: "dummy network description".to_string(),
         }))
+    }
+
+    async fn get_or_load_committee_by_hash(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+        let blob_id = BlobId::new(hash, BlobType::Committee);
+        let Some(blob) = self.blobs.pin().get(&blob_id).cloned() else {
+            return Ok(None);
+        };
+        let committee: Committee = bcs::from_bytes(blob.bytes())?;
+        Ok(Some(Arc::new(committee)))
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -85,11 +85,12 @@ pub struct SystemExecutionStateView<C> {
     pub epoch: RegisterView<C, Epoch>,
     /// The admin of the chain.
     pub admin_chain_id: RegisterView<C, Option<ChainId>>,
-    /// The committees that we trust, indexed by epoch number.
-    // Not using a `MapView` because the set active of committees is supposed to be
+    /// The blob hashes of the committees we trust, indexed by epoch number.
+    // Not using a `MapView` because the set of active committees is supposed to be
     // small. Plus, currently, we would create the `BTreeMap` anyway in various places
-    // (e.g. the `OpenChain` operation).
-    pub committees: RegisterView<C, BTreeMap<Epoch, Committee>>,
+    // (e.g. the `OpenChain` operation). The actual committees live in the blob store
+    // and are cached process-wide via `SharedCommittees`.
+    pub committees: RegisterView<C, BTreeMap<Epoch, CryptoHash>>,
     /// Ownership of the chain.
     pub ownership: LazyRegisterView<C, ChainOwnership>,
     /// Balance of the chain. (Available to any user able to create blocks in the chain.)
@@ -317,15 +318,24 @@ where
     pub async fn is_active(&self) -> Result<bool, ViewError> {
         Ok(self.description.get().await?.is_some()
             && self.ownership.get().await?.is_active()
-            && self.current_committee().is_some()
+            && self.committees.get().contains_key(self.epoch.get())
             && self.admin_chain_id.get().is_some())
     }
 
     /// Returns the current committee, if any.
-    pub fn current_committee(&self) -> Option<(Epoch, &Committee)> {
-        let epoch = self.epoch.get();
-        let committee = self.committees.get().get(epoch)?;
-        Some((*epoch, committee))
+    pub async fn current_committee(
+        &self,
+    ) -> Result<Option<(Epoch, Arc<Committee>)>, ExecutionError> {
+        let epoch = *self.epoch.get();
+        let Some(&hash) = self.committees.get().get(&epoch) else {
+            return Ok(None);
+        };
+        let committee = self
+            .context()
+            .extra()
+            .get_or_load_committee_by_hash(hash)
+            .await?;
+        Ok(committee.map(|c| (epoch, c)))
     }
 
     async fn get_event(&self, event_id: EventId) -> Result<Arc<Vec<u8>>, ExecutionError> {
@@ -424,10 +434,14 @@ where
                     AdminOperation::CreateCommittee { epoch, blob_hash } => {
                         self.check_next_epoch(epoch)?;
                         let blob_id = BlobId::new(blob_hash, BlobType::Committee);
-                        let committee =
-                            bcs::from_bytes(self.read_blob_content(blob_id).await?.bytes())?;
+                        // Validate that the blob exists and deserializes as a Committee.
+                        self.context()
+                            .extra()
+                            .get_or_load_committee_by_hash(blob_hash)
+                            .await?
+                            .ok_or(ExecutionError::BlobsNotFound(vec![blob_id]))?;
                         self.blob_used(txn_tracker, blob_id).await?;
-                        self.committees.get_mut().insert(epoch, committee);
+                        self.committees.get_mut().insert(epoch, blob_hash);
                         self.epoch.set(epoch);
                         let event_data = EpochEventData {
                             blob_hash,
@@ -509,9 +523,14 @@ where
                     .to_event(&event_id)?;
                 let event_data: EpochEventData = bcs::from_bytes(&bytes)?;
                 let blob_id = BlobId::new(event_data.blob_hash, BlobType::Committee);
-                let committee = bcs::from_bytes(self.read_blob_content(blob_id).await?.bytes())?;
+                // Validate that the blob exists and deserializes as a Committee.
+                self.context()
+                    .extra()
+                    .get_or_load_committee_by_hash(event_data.blob_hash)
+                    .await?
+                    .ok_or(ExecutionError::BlobsNotFound(vec![blob_id]))?;
                 self.blob_used(txn_tracker, blob_id).await?;
-                self.committees.get_mut().insert(epoch, committee);
+                self.committees.get_mut().insert(epoch, event_data.blob_hash);
                 self.epoch.set(epoch);
             }
             ProcessRemovedEpoch(epoch) => {
@@ -858,7 +877,7 @@ where
         let committees = self
             .context()
             .extra()
-            .get_committees(min_active_epoch..=max_active_epoch)
+            .get_committee_hashes(min_active_epoch..=max_active_epoch)
             .await?;
         let admin_chain_id = self
             .context()

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -335,7 +335,7 @@ where
             .extra()
             .get_or_load_committee_by_hash(hash)
             .await?;
-        Ok(committee.map(|c| (epoch, c)))
+        Ok(Some((epoch, committee)))
     }
 
     async fn get_event(&self, event_id: EventId) -> Result<Arc<Vec<u8>>, ExecutionError> {
@@ -438,8 +438,7 @@ where
                         self.context()
                             .extra()
                             .get_or_load_committee_by_hash(blob_hash)
-                            .await?
-                            .ok_or(ExecutionError::BlobsNotFound(vec![blob_id]))?;
+                            .await?;
                         self.blob_used(txn_tracker, blob_id).await?;
                         self.committees.get_mut().insert(epoch, blob_hash);
                         self.epoch.set(epoch);
@@ -527,10 +526,11 @@ where
                 self.context()
                     .extra()
                     .get_or_load_committee_by_hash(event_data.blob_hash)
-                    .await?
-                    .ok_or(ExecutionError::BlobsNotFound(vec![blob_id]))?;
+                    .await?;
                 self.blob_used(txn_tracker, blob_id).await?;
-                self.committees.get_mut().insert(epoch, event_data.blob_hash);
+                self.committees
+                    .get_mut()
+                    .insert(epoch, event_data.blob_hash);
                 self.epoch.set(epoch);
             }
             ProcessRemovedEpoch(epoch) => {

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -121,6 +121,17 @@ impl SystemExecutionState {
                 .insert(id, mock_application.into());
         }
 
+        let mut committee_hashes = BTreeMap::new();
+        for (epoch, committee) in committees {
+            let blob = Blob::new_committee(bcs::to_bytes(&committee).expect("BCS should succeed"));
+            let hash = blob.id().hash;
+            extra
+                .add_blobs([blob])
+                .await
+                .expect("Adding committee blobs should not fail");
+            committee_hashes.insert(epoch, hash);
+        }
+
         let context = MemoryContext::new_for_testing(extra);
         let mut view = ExecutionStateView::load(context)
             .await
@@ -128,7 +139,7 @@ impl SystemExecutionState {
         view.system.description.set(description);
         view.system.epoch.set(epoch);
         view.system.admin_chain_id.set(admin_chain_id);
-        view.system.committees.set(committees);
+        view.system.committees.set(committee_hashes);
         view.system.ownership.set(ownership);
         view.system.balance.set(balance);
         for (account_owner, balance) in balances {

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1251,7 +1251,7 @@ async fn test_open_chain() -> anyhow::Result<()> {
     assert_eq!(*child_view.system.ownership.get().await?, child_ownership);
     assert_eq!(
         *child_view.system.committees.get(),
-        [(Epoch::ZERO, committee)]
+        [(Epoch::ZERO, committee_blob.id().hash)]
             .into_iter()
             .collect::<BTreeMap<_, _>>()
     );

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -316,7 +316,7 @@ where
 
     /// Returns the current committee, including weights and resource policy.
     async fn current_committee(&self) -> Result<Committee, Error> {
-        Ok(self.client.local_committee().await?)
+        Ok((*self.client.local_committee().await?).clone())
     }
 
     /// Returns the current epoch of the faucet's chain.

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -319,7 +319,7 @@ ChainInfo:
             KEY:
               TYPENAME: Epoch
             VALUE:
-              TYPENAME: Committee
+              TYPENAME: CryptoHash
     - requested_pending_message_bundles:
         SEQ:
           TYPENAME: IncomingBundle
@@ -441,16 +441,6 @@ ChainOwnership:
     - open_multi_leader_rounds: BOOL
     - timeout_config:
         TYPENAME: TimeoutConfig
-Committee:
-  STRUCT:
-    - validators:
-        MAP:
-          KEY:
-            TYPENAME: Secp256k1PublicKey
-          VALUE:
-            TYPENAME: ValidatorState
-    - policy:
-        TYPENAME: ResourceControlPolicy
 ConfirmedBlockCertificate:
   STRUCT:
     - value:
@@ -998,62 +988,6 @@ Reason:
               TYPENAME: BlockHeight
           - hash:
               TYPENAME: CryptoHash
-ResourceControlPolicy:
-  STRUCT:
-    - wasm_fuel_unit:
-        TYPENAME: Amount
-    - evm_fuel_unit:
-        TYPENAME: Amount
-    - read_operation:
-        TYPENAME: Amount
-    - write_operation:
-        TYPENAME: Amount
-    - byte_runtime:
-        TYPENAME: Amount
-    - byte_read:
-        TYPENAME: Amount
-    - byte_written:
-        TYPENAME: Amount
-    - blob_read:
-        TYPENAME: Amount
-    - blob_published:
-        TYPENAME: Amount
-    - blob_byte_read:
-        TYPENAME: Amount
-    - blob_byte_published:
-        TYPENAME: Amount
-    - byte_stored:
-        TYPENAME: Amount
-    - operation:
-        TYPENAME: Amount
-    - operation_byte:
-        TYPENAME: Amount
-    - message:
-        TYPENAME: Amount
-    - message_byte:
-        TYPENAME: Amount
-    - service_as_oracle_query:
-        TYPENAME: Amount
-    - http_request:
-        TYPENAME: Amount
-    - maximum_wasm_fuel_per_block: U64
-    - maximum_evm_fuel_per_block: U64
-    - maximum_service_oracle_execution_ms: U64
-    - maximum_block_size: U64
-    - maximum_bytecode_size: U64
-    - maximum_blob_size: U64
-    - maximum_published_blobs: U64
-    - maximum_block_proposal_size: U64
-    - maximum_bytes_read_per_block: U64
-    - maximum_bytes_written_per_block: U64
-    - maximum_oracle_response_bytes: U64
-    - maximum_http_response_bytes: U64
-    - http_request_timeout_ms: U64
-    - http_request_allow_list:
-        SEQ: STR
-    - free_application_ids:
-        SEQ:
-          TYPENAME: ApplicationId
 Response:
   STRUCT:
     - status: U16
@@ -1435,12 +1369,6 @@ ValidatedBlockCertificate:
           TUPLE:
             - TYPENAME: Secp256k1PublicKey
             - TYPENAME: Secp256k1Signature
-ValidatorState:
-  STRUCT:
-    - network_address: STR
-    - votes: U64
-    - account_public_key:
-        TYPENAME: AccountPublicKey
 VersionInfo:
   STRUCT:
     - crate_version:

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -556,7 +556,7 @@ impl Runnable for Job {
                         let command = command.clone();
                         async move {
                             // Update resource control policy
-                            let mut committee = chain_client.local_committee().await.unwrap();
+                            let committee = chain_client.local_committee().await.unwrap();
                             let mut policy = committee.policy().clone();
                             let validators = committee.validators().clone();
                             match command {
@@ -685,9 +685,9 @@ impl Runnable for Job {
                                 }
                                 _ => unreachable!(),
                             }
-                            committee = Committee::new(validators, policy)?;
+                            let new_committee = Committee::new(validators, policy)?;
                             chain_client
-                                .stage_new_committee(committee)
+                                .stage_new_committee(new_committee)
                                 .await
                                 .map(|outcome| outcome.map(Some))
                         }
@@ -1771,7 +1771,7 @@ impl Runnable for Job {
                     .make_chain_client(network_description.admin_chain_id)
                     .await?;
                 chain_client
-                    .synchronize_chain_state_from_committee(committee)
+                    .synchronize_chain_state_from_committee(Arc::new(committee))
                     .await?;
                 context.update_wallet_from_client(&chain_client).await?;
             }

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -290,7 +290,7 @@ impl Add {
                 let chain_client = chain_client.clone();
                 async move {
                     // Create the new committee.
-                    let mut committee = chain_client.local_committee().await?;
+                    let committee = chain_client.local_committee().await?;
                     let policy = committee.policy().clone();
                     let mut validators = committee.validators().clone();
 
@@ -303,9 +303,9 @@ impl Add {
                         },
                     );
 
-                    committee = Committee::new(validators, policy)?;
+                    let new_committee = Committee::new(validators, policy)?;
                     chain_client
-                        .stage_new_committee(committee)
+                        .stage_new_committee(new_committee)
                         .await
                         .map(|outcome| outcome.map(Some))
                 }
@@ -535,7 +535,7 @@ impl Update {
                 let batch = batch_clone.clone();
                 async move {
                     // Get current committee
-                    let mut committee = chain_client.local_committee().await?;
+                    let committee = chain_client.local_committee().await?;
                     let policy = committee.policy().clone();
                     let mut validators = committee.validators().clone();
 
@@ -586,9 +586,9 @@ impl Update {
                     }
 
                     // Create new committee
-                    committee = Committee::new(validators, policy)?;
+                    let new_committee = Committee::new(validators, policy)?;
                     chain_client
-                        .stage_new_committee(committee)
+                        .stage_new_committee(new_committee)
                         .await
                         .map(|outcome| outcome.map(Some))
                 }
@@ -761,7 +761,7 @@ impl Remove {
                 let chain_client = chain_client.clone();
                 async move {
                     // Create the new committee.
-                    let mut committee = chain_client.local_committee().await?;
+                    let committee = chain_client.local_committee().await?;
                     let policy = committee.policy().clone();
                     let mut validators = committee.validators().clone();
 
@@ -770,9 +770,9 @@ impl Remove {
                         return Ok(ClientOutcome::Committed(None));
                     }
 
-                    committee = Committee::new(validators, policy)?;
+                    let new_committee = Committee::new(validators, policy)?;
                     chain_client
-                        .stage_new_committee(committee)
+                        .stage_new_committee(new_committee)
                         .await
                         .map(|outcome| outcome.map(Some))
                 }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -32,7 +32,6 @@ use linera_base::{
 };
 use linera_client::client_options::ResourceControlPolicyConfig;
 use linera_core::worker::Notification;
-use linera_execution::committee::Committee;
 use linera_faucet_client::Faucet;
 use serde::{de::DeserializeOwned, ser::Serialize};
 use serde_command_opts::to_args;
@@ -1652,7 +1651,10 @@ impl NodeService {
         Ok(module_id.with_abi())
     }
 
-    pub async fn query_committees(&self, chain_id: &ChainId) -> Result<BTreeMap<Epoch, Committee>> {
+    pub async fn query_committees(
+        &self,
+        chain_id: &ChainId,
+    ) -> Result<BTreeMap<Epoch, CryptoHash>> {
         let query = format!(
             "query {{ chain(chainId:\"{chain_id}\") {{
                 executionState {{ system {{ committees }} }}

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -21,7 +21,8 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    BlobState, ExecutionRuntimeConfig, UserContractCode, UserServiceCode, WasmRuntime,
+    BlobState, ExecutionRuntimeConfig, SharedCommittees, UserContractCode, UserServiceCode,
+    WasmRuntime,
 };
 use linera_views::{
     backends::dual::{DualStoreRootKeyAssignment, StoreInUse},
@@ -428,6 +429,7 @@ pub struct DbStorage<Database, Clock = WallClock> {
     wasm_runtime: Option<WasmRuntime>,
     user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
     user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
+    shared_committees: SharedCommittees,
     caches: StorageCaches,
     execution_runtime_config: ExecutionRuntimeConfig,
 }
@@ -660,6 +662,10 @@ where
 
     fn thread_pool(&self) -> &Arc<linera_execution::ThreadPool> {
         &self.thread_pool
+    }
+
+    fn shared_committees(&self) -> &SharedCommittees {
+        &self.shared_committees
     }
 
     #[instrument(level = "trace", skip_all, fields(chain_id = %chain_id))]
@@ -1475,6 +1481,7 @@ impl<Database, C> DbStorage<Database, C> {
             wasm_runtime,
             user_contracts: Arc::new(papaya::HashMap::new()),
             user_services: Arc::new(papaya::HashMap::new()),
+            shared_committees: SharedCommittees::new(),
             caches: StorageCaches::new(cache_sizes),
             execution_runtime_config: ExecutionRuntimeConfig::default(),
         }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -23,15 +23,15 @@ use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     ChainError, ChainStateView,
 };
-#[cfg(with_revm)]
-use linera_execution::{
-    evm::revm::{EvmContractModule, EvmServiceModule},
-    EvmRuntime,
-};
 use linera_execution::{
     committee::Committee, BlobState, ExecutionError, ExecutionRuntimeConfig,
     ExecutionRuntimeContext, SharedCommittees, TransactionTracker, UserContractCode,
     UserServiceCode, WasmRuntime,
+};
+#[cfg(with_revm)]
+use linera_execution::{
+    evm::revm::{EvmContractModule, EvmServiceModule},
+    EvmRuntime,
 };
 #[cfg(with_wasm_runtime)]
 use linera_execution::{WasmContractModule, WasmServiceModule};
@@ -392,18 +392,17 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     async fn get_or_load_committee_by_hash(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+    ) -> Result<Arc<Committee>, ExecutionError> {
         if let Some(committee) = self.shared_committees().get(hash) {
-            return Ok(Some(committee));
+            return Ok(committee);
         }
         let blob_id = BlobId::new(hash, BlobType::Committee);
-        let Some(blob) = self.read_blob(blob_id).await? else {
-            return Ok(None);
-        };
+        let blob = self
+            .read_blob(blob_id)
+            .await?
+            .ok_or(ExecutionError::BlobsNotFound(vec![blob_id]))?;
         let committee = bcs::from_bytes(blob.bytes())?;
-        Ok(Some(
-            self.shared_committees().insert(hash, Arc::new(committee)),
-        ))
+        Ok(self.shared_committees().insert(hash, Arc::new(committee)))
     }
 
     /// Lists the blob IDs in storage.
@@ -522,7 +521,7 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
     async fn get_or_load_committee_by_hash(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+    ) -> Result<Arc<Committee>, ExecutionError> {
         self.storage.get_or_load_committee_by_hash(hash).await
     }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -15,7 +15,7 @@ use linera_base::{
         ApplicationDescription, Blob, BlockHeight, ChainDescription, CompressedBytecode,
         NetworkDescription, TimeDelta, Timestamp,
     },
-    identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
+    identifiers::{ApplicationId, BlobId, BlobType, ChainId, EventId, IndexAndEvent, StreamId},
     vm::VmRuntime,
 };
 pub use linera_cache::DEFAULT_CLEANUP_INTERVAL_SECS;
@@ -29,8 +29,9 @@ use linera_execution::{
     EvmRuntime,
 };
 use linera_execution::{
-    BlobState, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext, TransactionTracker,
-    UserContractCode, UserServiceCode, WasmRuntime,
+    committee::Committee, BlobState, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, SharedCommittees, TransactionTracker, UserContractCode,
+    UserServiceCode, WasmRuntime,
 };
 #[cfg(with_wasm_runtime)]
 use linera_execution::{WasmContractModule, WasmServiceModule};
@@ -383,6 +384,28 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         block_exporter_id: u32,
     ) -> Result<Self::BlockExporterContext, ViewError>;
 
+    /// Returns the process-wide committee cache shared by all chains.
+    fn shared_committees(&self) -> &SharedCommittees;
+
+    /// Returns the committee whose serialized form hashes to `hash`, loading it
+    /// from the blob store on cache miss.
+    async fn get_or_load_committee_by_hash(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+        if let Some(committee) = self.shared_committees().get(hash) {
+            return Ok(Some(committee));
+        }
+        let blob_id = BlobId::new(hash, BlobType::Committee);
+        let Some(blob) = self.read_blob(blob_id).await? else {
+            return Ok(None);
+        };
+        let committee = bcs::from_bytes(blob.bytes())?;
+        Ok(Some(
+            self.shared_committees().insert(hash, Arc::new(committee)),
+        ))
+    }
+
     /// Lists the blob IDs in storage.
     async fn list_blob_ids(&self) -> Result<Vec<BlobId>, ViewError>;
 
@@ -494,6 +517,13 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
         self.storage.read_network_description().await
+    }
+
+    async fn get_or_load_committee_by_hash(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+        self.storage.get_or_load_committee_by_hash(hash).await
     }
 
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError> {


### PR DESCRIPTION
Partial port of https://github.com/linera-io/linera-protocol/pull/6089.

## Motivation

We are using a lot of memory for the `committees` field in the system execution state view, because it is basically duplicated once for every chain worker.

## Proposal

Use a shared map.
(Like in #6089, but without some changes we only want on the testnet; e.g. we don't disallow chain info queries asking for the committees.)

Replace the map in the chain state with `Epoch`→`CryptoHash`: Instead of the whole committee, only keep the hash there.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Similar change on `testnet_conway`: #6089
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
