### PR TITLE
Chain recovery fixes and extensions (#6063, #6080, #6102)

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -401,7 +401,7 @@ where
                 .get_mut()
                 .get_mut(&update)
                 .ok_or_else(|| {
-                    ChainError::InternalError("message counter should be present".into())
+                    ChainError::CorruptedChainState("message counter should be present".into())
                 })?;
             *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
             if *counter == 0 {
@@ -531,7 +531,7 @@ where
             .await
             .map_err(|error| match error {
                 InboxError::ViewError(error) => ChainError::ViewError(error),
-                error => ChainError::InternalError(format!(
+                error => ChainError::CorruptedChainState(format!(
                     "while processing messages in certified block: {error}"
                 )),
             })?;
@@ -653,7 +653,7 @@ where
     ) -> Result<Vec<ReadGuardedView<OutboxStateView<C>>>, ChainError> {
         let vec_of_options = self.outboxes.try_load_entries(targets).await?;
         let optional_vec = vec_of_options.into_iter().collect::<Option<Vec<_>>>();
-        optional_vec.ok_or_else(|| ChainError::InternalError("Missing outboxes".into()))
+        optional_vec.ok_or_else(|| ChainError::CorruptedChainState("Missing outboxes".into()))
     }
 
     /// Executes a block with a specified policy for handling bundle failures.
@@ -861,7 +861,7 @@ where
         let mut previous_message_blocks = BTreeMap::new();
         for (hash, (recipient, height)) in hashes.into_iter().zip(recipient_heights) {
             let hash = hash.ok_or_else(|| {
-                ChainError::InternalError("missing entry in confirmed_log".into())
+                ChainError::CorruptedChainState("missing entry in confirmed_log".into())
             })?;
             previous_message_blocks.insert(recipient, (hash, height));
         }
@@ -881,7 +881,7 @@ where
         let mut previous_event_blocks = BTreeMap::new();
         for (hash, (stream, height)) in hashes.into_iter().zip(stream_heights) {
             let hash = hash.ok_or_else(|| {
-                ChainError::InternalError("missing entry in confirmed_log".into())
+                ChainError::CorruptedChainState("missing entry in confirmed_log".into())
             })?;
             previous_event_blocks.insert(stream, (hash, height));
         }
@@ -1200,13 +1200,17 @@ where
                         let index =
                             usize::try_from(height.0).map_err(|_| ArithmeticError::Overflow)?;
                         Some(self.confirmed_log.get(index).await?.ok_or_else(|| {
-                            ChainError::InternalError("missing entry in confirmed_log".into())
+                            ChainError::CorruptedChainState("missing entry in confirmed_log".into())
                         })?)
                     }
                     // The block with last added message has not been executed yet. If we have it,
                     // it's in preprocessed_blocks.
                     Some(height) => Some(self.preprocessed_blocks.get(&height).await?.ok_or_else(
-                        || ChainError::InternalError("missing entry in preprocessed_blocks".into()),
+                        || {
+                            ChainError::CorruptedChainState(
+                                "missing entry in preprocessed_blocks".into(),
+                            )
+                        },
                     )?),
                     None => None, // No message to that sender was added yet.
                 };
@@ -1222,7 +1226,7 @@ where
                     (Some(_), None) => {
                         // Outbox indicates there was a previous message block, but
                         // previous_message_blocks has no idea about it - possible bug
-                        return Err(ChainError::InternalError(
+                        return Err(ChainError::CorruptedChainState(
                             "block indicates no previous message block,\
                             but we have one in the outbox"
                                 .into(),

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -149,6 +149,8 @@ pub enum ChainError {
     },
     #[error("Internal error {0}")]
     InternalError(String),
+    #[error("Corrupted chain state: {0}")]
+    CorruptedChainState(String),
     #[error("Block proposal has size {0} which is too large")]
     BlockProposalTooLarge(usize),
     #[error(transparent)]
@@ -209,6 +211,7 @@ impl ChainError {
             | ChainError::UnexpectedMessage { .. }
             | ChainError::InboxGapDetected { .. }
             | ChainError::InternalError(_)
+            | ChainError::CorruptedChainState(_)
             | ChainError::BcsError(_) => true,
             ChainError::ExecutionError(execution_error, _) => execution_error.is_local(),
         }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -750,6 +750,55 @@ where
     }
 }
 
+/// The safety-critical fields of a [`ChainManager`]: previously cast votes and the
+/// locking block. Re-applying these after a chain reset prevents a validator from
+/// being tricked into double-signing at a height/round it has already voted on.
+#[derive(Debug, Default)]
+pub struct ManagerSafetySnapshot {
+    confirmed_vote: Option<Vote<ConfirmedBlock>>,
+    validated_vote: Option<Vote<ValidatedBlock>>,
+    timeout_vote: Option<Vote<Timeout>>,
+    fallback_vote: Option<Vote<Timeout>>,
+    locking_block: Option<LockingBlock>,
+    locking_blobs: Vec<(BlobId, Blob)>,
+}
+
+impl ManagerSafetySnapshot {
+    /// Reads the safety-critical fields from the given `manager`.
+    pub async fn capture<C>(manager: &ChainManager<C>) -> Result<Self, ViewError>
+    where
+        C: Context + Clone + 'static,
+    {
+        Ok(Self {
+            confirmed_vote: manager.confirmed_vote.get().clone(),
+            validated_vote: manager.validated_vote.get().clone(),
+            timeout_vote: manager.timeout_vote.get().clone(),
+            fallback_vote: manager.fallback_vote.get().clone(),
+            locking_block: manager.locking_block.get().clone(),
+            locking_blobs: manager.locking_blobs.index_values().await?,
+        })
+    }
+
+    /// Writes the captured fields back into `manager`, overriding anything that
+    /// may have been produced by re-execution. The restored state is the safe
+    /// upper bound on what this validator has already committed to.
+    pub fn restore<C>(self, manager: &mut ChainManager<C>) -> Result<(), ViewError>
+    where
+        C: Context + Clone + 'static,
+    {
+        manager.confirmed_vote.set(self.confirmed_vote);
+        manager.validated_vote.set(self.validated_vote);
+        manager.timeout_vote.set(self.timeout_vote);
+        manager.fallback_vote.set(self.fallback_vote);
+        manager.locking_block.set(self.locking_block);
+        manager.locking_blobs.clear();
+        for (blob_id, blob) in self.locking_blobs {
+            manager.locking_blobs.insert(&blob_id, blob)?;
+        }
+        Ok(())
+    }
+}
+
 /// Chain manager information that is included in `ChainInfo` sent to clients.
 #[derive(Default, Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -46,10 +46,10 @@ pub struct ChainWorkerConfig {
     pub cross_chain_message_chunk_limit: usize,
     /// Whether to attempt recovery via `RevertConfirm` when an inbox gap is detected.
     pub allow_revert_confirm: bool,
-    /// If set, reset the chain state and re-execute all blocks when an
-    /// `IncorrectOutcome` error is encountered — but only if the given duration has
+    /// If set, reset the chain state and re-execute all blocks when the chain
+    /// state is detected to be corrupted — but only if the given duration has
     /// elapsed since block 0 was last executed (to prevent reset loops).
-    pub reset_on_incorrect_outcome: Option<Duration>,
+    pub reset_on_corrupted_chain_state: Option<Duration>,
 }
 
 impl ChainWorkerConfig {
@@ -83,7 +83,7 @@ impl Default for ChainWorkerConfig {
             priority_bundle_origins: HashSet::new(),
             cross_chain_message_chunk_limit: usize::MAX,
             allow_revert_confirm: false,
-            reset_on_incorrect_outcome: None,
+            reset_on_corrupted_chain_state: None,
         }
     }
 }

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -50,6 +50,11 @@ pub struct ChainWorkerConfig {
     /// state is detected to be corrupted — but only if the given duration has
     /// elapsed since block 0 was last executed (to prevent reset loops).
     pub reset_on_corrupted_chain_state: Option<Duration>,
+    /// Optional whitelist restricting which chains are eligible for the
+    /// `allow_revert_confirm` and `reset_on_corrupted_chain_state` recovery
+    /// mechanisms. If `None`, every chain is eligible (subject to the
+    /// respective feature flag). If `Some`, only chains in the set are.
+    pub recovery_whitelist: Option<HashSet<ChainId>>,
 }
 
 impl ChainWorkerConfig {
@@ -63,6 +68,14 @@ impl ChainWorkerConfig {
     /// Gets a reference to the [`ValidatorSecretKey`], if available.
     pub fn key_pair(&self) -> Option<&ValidatorSecretKey> {
         self.key_pair.as_ref().map(Arc::as_ref)
+    }
+
+    /// Returns whether `chain_id` is allowed to attempt the `RevertConfirm` and
+    /// corrupted-state-reset recovery mechanisms.
+    pub(crate) fn recovery_allowed_for(&self, chain_id: &ChainId) -> bool {
+        self.recovery_whitelist
+            .as_ref()
+            .is_none_or(|set| set.contains(chain_id))
     }
 }
 
@@ -84,6 +97,7 @@ impl Default for ChainWorkerConfig {
             cross_chain_message_chunk_limit: usize::MAX,
             allow_revert_confirm: false,
             reset_on_corrupted_chain_state: None,
+            recovery_whitelist: None,
         }
     }
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1021,7 +1021,7 @@ where
         if let Some(prev) = sender_previous_height {
             if prev >= next_height_to_receive {
                 let chain_id = self.chain_id();
-                if self.config.allow_revert_confirm {
+                if self.config.allow_revert_confirm && self.config.recovery_allowed_for(&chain_id) {
                     warn!(
                         %chain_id,
                         "Inbox gap detected from {origin}: \
@@ -1231,6 +1231,9 @@ where
             return Ok(None);
         };
         let chain_id = self.chain_id();
+        if !self.config.recovery_allowed_for(&chain_id) {
+            return Ok(None);
+        }
         let local_time = self.storage.clock().current_time();
         let block_zero_time = *self.chain.block_zero_executed_at.get();
         let elapsed = local_time.duration_since(block_zero_time);

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -27,7 +27,7 @@ use linera_chain::{
         BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
         OriginalProposal, ProposalContent, ProposedBlock,
     },
-    manager,
+    manager::{self, ManagerSafetySnapshot},
     types::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
         ValidatedBlockCertificate,
@@ -925,32 +925,12 @@ where
                 .await?;
             // We should always agree on the messages and state hash.
             if outcome != verified {
-                if let Some(min_duration) = self.config.reset_on_incorrect_outcome {
-                    let block_zero_time = *self.chain.block_zero_executed_at.get();
-                    let elapsed = local_time.duration_since(block_zero_time);
-                    if elapsed >= min_duration {
-                        warn!(
-                            "IncorrectOutcome for block {height}; \
-                            resetting chain state and re-executing"
-                        );
-                        return self
-                            .reset_and_reexecute_chain(
-                                block_hash,
-                                height,
-                                notify_when_messages_are_delivered,
-                            )
-                            .await;
-                    }
-                    warn!(
-                        "IncorrectOutcome for block {height}; \
-                        not resetting because only {elapsed:?} elapsed since last \
-                        block 0 execution (minimum: {min_duration:?})"
-                    );
-                }
-                return Err(WorkerError::IncorrectOutcome {
-                    submitted: Box::new(outcome),
-                    computed: Box::new(verified),
-                });
+                return Err(ChainError::CorruptedChainState(format!(
+                    "computed block outcome differs from the certificate.\n\
+                    Computed: {verified:#?}\n\
+                    Submitted: {outcome:#?}"
+                ))
+                .into());
             }
             ConfirmedBlock::new(Block::new(proposed_block, verified))
         };
@@ -1241,17 +1221,40 @@ where
         Ok(actions)
     }
 
+    /// If the config enables corruption recovery and the min-duration guard is
+    /// satisfied, resets the chain state and re-executes all confirmed blocks.
+    /// Returns `RevertConfirm` requests to dispatch, or `None` if no reset happened.
+    pub(crate) async fn maybe_reset_corrupted_chain_state(
+        &mut self,
+    ) -> Result<Option<Vec<CrossChainRequest>>, WorkerError> {
+        let Some(min_duration) = self.config.reset_on_corrupted_chain_state else {
+            return Ok(None);
+        };
+        let chain_id = self.chain_id();
+        let local_time = self.storage.clock().current_time();
+        let block_zero_time = *self.chain.block_zero_executed_at.get();
+        let elapsed = local_time.duration_since(block_zero_time);
+        if elapsed < min_duration {
+            warn!(
+                %chain_id, ?elapsed, ?min_duration,
+                "Not resetting corrupted chain state; not enough time elapsed \
+                since last block 0 execution"
+            );
+            return Ok(None);
+        }
+        warn!(%chain_id, "Corrupted chain state detected; resetting and re-executing");
+        Ok(Some(self.reset_and_reexecute_chain().await?))
+    }
+
     /// Resets the chain state completely and re-executes all confirmed blocks from storage.
-    /// Sends `RevertConfirm` to all known senders so they resend cross-chain messages.
+    /// Returns a `RevertConfirm` request for every known sender so they resend cross-chain
+    /// messages that may have been lost during the reset.
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
     ))]
-    async fn reset_and_reexecute_chain(
+    pub(crate) async fn reset_and_reexecute_chain(
         &mut self,
-        failed_block_hash: CryptoHash,
-        failed_height: BlockHeight,
-        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
-    ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+    ) -> Result<Vec<CrossChainRequest>, WorkerError> {
         let chain_id = self.chain_id();
         let tip_height = self.chain.tip_state.get().next_block_height;
 
@@ -1260,7 +1263,11 @@ where
         let hashes = self.chain.confirmed_log.read(..).await?;
         let preprocessed = self.chain.preprocessed_blocks.index_values().await?;
 
-        // 2. Clear the chain state entirely and save.
+        // 2. Snapshot safety-critical manager state so that we cannot be tricked
+        //    into double-signing if the reset wipes votes we already cast.
+        let manager_snapshot = ManagerSafetySnapshot::capture(&self.chain.manager).await?;
+
+        // 3. Clear the chain state entirely and save.
         self.chain.clear();
         self.knows_chain_is_active = false;
         self.save().await?;
@@ -1270,7 +1277,7 @@ where
             re-executing all blocks"
         );
 
-        // 3. Re-load certificates one at a time by hash and re-process them.
+        // 4. Re-load certificates one at a time by hash and re-process them.
         for (index, hash) in hashes.into_iter().enumerate() {
             let height = BlockHeight(index as u64);
             let cert = self
@@ -1291,46 +1298,42 @@ where
             Box::pin(self.process_confirmed_block(cert, None)).await?;
         }
 
-        // 4. Now process the original certificate that triggered the error.
-        let failed_certificate = self
-            .storage
-            .read_certificate(failed_block_hash)
-            .await?
-            .map(Arc::unwrap_or_clone)
-            .ok_or_else(|| WorkerError::LocalBlockNotFound {
-                height: failed_height,
-                chain_id,
-            })?;
-        let result = Box::pin(
-            self.process_confirmed_block(failed_certificate, notify_when_messages_are_delivered),
-        )
-        .await?;
-
-        // 5. Send RevertConfirm to all senders so they resend messages we may
-        //    have lost during the reset.
-        let (info, mut actions, outcome) = result;
-        for sender_id in sender_ids {
-            actions
-                .cross_chain_requests
-                .push(CrossChainRequest::RevertConfirm {
-                    sender: sender_id,
-                    recipient: chain_id,
-                    retransmit_from: BlockHeight::ZERO,
-                });
+        // 5. Restore any previously cast votes and locking block so we cannot be
+        //    asked to sign a conflicting statement at the same height/round. Votes
+        //    in the manager always belong to the pending height (one past the tip),
+        //    so restoring is only meaningful if re-execution landed at the same
+        //    tip. Otherwise the restored state would refer to a stale pending
+        //    height and could only break the manager's invariants without any
+        //    safety benefit — so we drop the snapshot in that case.
+        let new_tip_height = self.chain.tip_state.get().next_block_height;
+        if new_tip_height == tip_height {
+            manager_snapshot.restore(&mut self.chain.manager)?;
+            self.save().await?;
+        } else {
+            warn!(
+                %tip_height, %new_tip_height,
+                "Dropping manager snapshot: pre-reset tip differs from post-reset tip"
+            );
         }
 
+        // 6. Build RevertConfirm requests so each sender resends messages we may
+        //    have lost during the reset.
+        let revert_requests = sender_ids
+            .into_iter()
+            .map(|sender| CrossChainRequest::RevertConfirm {
+                sender,
+                recipient: chain_id,
+                retransmit_from: BlockHeight::ZERO,
+            })
+            .collect::<Vec<_>>();
+
         warn!(
-            "Chain reset and re-executed up to height {}; \
-            sent RevertConfirm to {} senders",
-            self.chain.tip_state.get().next_block_height,
-            actions
-                .cross_chain_requests
-                .iter()
-                .filter(|r| matches!(r, CrossChainRequest::RevertConfirm { .. }))
-                .count(),
+            tip_height = %self.chain.tip_state.get().next_block_height,
+            num_revert_confirms = revert_requests.len(),
+            "Chain reset and re-executed; sending RevertConfirm to senders"
         );
 
-        Ok((info, actions, outcome))
+        Ok(revert_requests)
     }
 
     #[instrument(skip_all, fields(

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -41,7 +41,9 @@ use linera_execution::{
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::{
+    batch::Batch,
     context::{Context, InactiveContext},
+    store::WritableKeyValueStore as _,
     views::{ReplaceContext as _, RootView as _, View as _},
 };
 use tokio::sync::oneshot;
@@ -1270,10 +1272,16 @@ where
         //    into double-signing if the reset wipes votes we already cast.
         let manager_snapshot = ManagerSafetySnapshot::capture(&self.chain.manager).await?;
 
-        // 3. Clear the chain state entirely and save.
-        self.chain.clear();
+        // 3. Wipe every key under this chain's storage root and reload a fresh
+        //    `ChainStateView`. `ChainStateView::clear` + `save` would only reset
+        //    the in-memory view; `HistoricallyHashableView` deliberately keeps
+        //    its `stored_hash` across clears, so the historical hash would carry
+        //    over from the pre-reset state and the replayed block outcomes would
+        //    never match the original certificates' `state_hash`. Deleting the
+        //    storage prefix and reloading is equivalent to creating the chain
+        //    from scratch, which is what replay expects.
+        self.wipe_and_reload_chain().await?;
         self.knows_chain_is_active = false;
-        self.save().await?;
         warn!(
             %chain_id,
             "Cleared chain state up to height {tip_height}; \
@@ -2127,6 +2135,43 @@ where
             return Err(WorkerError::PoisonedWorker);
         }
         Ok(())
+    }
+
+    /// Deletes every key under this chain's storage root and replaces `self.chain`
+    /// with a freshly loaded (empty) view. If either the write or the reload fails,
+    /// the worker is marked as poisoned: the partial deletion may have left
+    /// storage inconsistent with the in-memory view, so it cannot be reused.
+    #[instrument(skip_all, fields(
+        chain_id = %self.chain_id()
+    ))]
+    async fn wipe_and_reload_chain(&mut self) -> Result<(), WorkerError> {
+        let context = self.chain.context().clone();
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(Vec::new());
+        if let Err(error) = context.store().write_batch(batch).await {
+            tracing::error!(
+                ?error,
+                chain_id = %self.chain_id(),
+                "Wiping chain storage failed; marking worker as poisoned"
+            );
+            self.poisoned = true;
+            return Err(WorkerError::PoisonedWorker);
+        }
+        match ChainStateView::load(context).await {
+            Ok(chain) => {
+                self.chain = chain;
+                Ok(())
+            }
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    chain_id = %self.chain_id(),
+                    "Reloading chain after wipe failed; marking worker as poisoned"
+                );
+                self.poisoned = true;
+                Err(WorkerError::PoisonedWorker)
+            }
+        }
     }
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -42,7 +42,7 @@ use linera_chain::{
     data_types::{
         BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, ChainAndHeight,
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
-        PostedMessage, ProposedBlock, SignatureAggregator, Transaction,
+        PostedMessage, ProposedBlock, SignatureAggregator, Transaction, Vote,
     },
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -4610,6 +4610,353 @@ where
         bundles[1].origin, chain_1,
         "Non-priority chain bundle should be second"
     );
+
+    Ok(())
+}
+
+/// Tests the RevertConfirm recovery mechanism.
+///
+/// Simulates the scenario where the sender's outbox was drained (via a spurious
+/// confirmation) but the recipient still has anticipated messages in `removed_bundles`
+/// that were never delivered. The RevertConfirm mechanism should detect the gap,
+/// request the sender to re-add the missing heights to its outbox, and resend the
+/// bundles so the inbox can reconcile.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_revert_confirm_recovery<B>(mut storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(&mut storage_builder, true, false).await?;
+    env.worker = env.worker.with_allow_revert_confirm(true);
+    let chain_1 = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await
+        .id();
+    let chain_2 = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ONE)
+        .await
+        .id();
+
+    // Step 1: Create two transfer certificates from chain_1 to chain_2.
+    let cert_0 = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            None,
+        )
+        .await;
+    let cert_1 = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(3),
+            Vec::new(),
+            Some(&cert_0),
+        )
+        .await;
+
+    // Step 2: Process both certs on chain_1 (adds heights 0, 1 to outbox for chain_2).
+    env.worker()
+        .process_confirmed_block(cert_0.clone(), None)
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_1.clone(), None)
+        .await?;
+
+    // Step 3: Deliver height 0 to chain_2 and confirm it on chain_1.
+    // (Normal flow for height 0 only.)
+    let actions = env
+        .worker()
+        .handle_cross_chain_request(update_recipient_direct(chain_2, &cert_0))
+        .await?;
+    // The actions should contain a ConfirmUpdatedRecipient.
+    for request in actions.cross_chain_requests {
+        env.worker().handle_cross_chain_request(request).await?;
+    }
+
+    // Step 4: Send a spurious ConfirmUpdatedRecipient that claims chain_2 already
+    // received up to height 1. This drains height 1 from chain_1's outbox even
+    // though chain_2 never received it.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::from(1),
+        })
+        .await?;
+
+    // Verify chain_1's outbox for chain_2 is now empty.
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        let outbox = chain.outboxes.try_load_entry(&chain_2).await?;
+        assert!(
+            outbox.is_none() || outbox.unwrap().queue.count() == 0,
+            "Outbox should be drained by the spurious confirm"
+        );
+    }
+
+    // Step 5: Create cert_2 from chain_1 (height 2), process it on chain_1, and
+    // deliver it to chain_2. The UpdateRecipient carries previous_height=Some(1)
+    // (cert_2's predecessor for chain_2 is cert_1 at height 1). Since chain_2's
+    // next_height_to_receive is only 1 (it received height 0 but not 1), the
+    // proactive gap detection fires immediately — no need for chain_2 to have
+    // consumed the missing message first.
+    let cert_2 = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(2),
+            Vec::new(),
+            Some(&cert_1),
+        )
+        .await;
+    // Process cert_2 on chain_1 so the block is in confirmed_log.
+    env.worker()
+        .process_confirmed_block(cert_2.clone(), None)
+        .await?;
+
+    // Now manually deliver height 2's cross-chain update to chain_2.
+    let actions = env
+        .worker()
+        .handle_cross_chain_request(update_recipient_direct(chain_2, &cert_2))
+        .await?;
+    // Should contain a RevertConfirm (not a ConfirmUpdatedRecipient).
+    assert!(
+        actions
+            .cross_chain_requests
+            .iter()
+            .any(|r| matches!(r, CrossChainRequest::RevertConfirm { .. })),
+        "Expected RevertConfirm but got: {:?}",
+        actions.cross_chain_requests,
+    );
+    // Now process the full chain of requests (RevertConfirm → resend → confirm).
+    let mut requests = std::collections::VecDeque::from(actions.cross_chain_requests);
+    let mut iterations = 0;
+    while let Some(request) = requests.pop_front() {
+        iterations += 1;
+        assert!(iterations < 20, "Too many iterations in cross-chain loop");
+        let actions = env.worker().handle_cross_chain_request(request).await?;
+        requests.extend(actions.cross_chain_requests);
+    }
+
+    // Step 7: Verify recovery — chain_2 received all three heights.
+    {
+        let chain = env.worker().chain_state_view(chain_2).await?;
+        let inbox = chain
+            .inboxes
+            .try_load_entry(&chain_1)
+            .await?
+            .expect("chain_2 should have an inbox for chain_1");
+        assert_eq!(
+            inbox.removed_bundles.count(),
+            0,
+            "removed_bundles should be empty"
+        );
+        // Heights 0, 1, 2 should all be in added_bundles (delivered but not yet
+        // consumed by a block on chain_2).
+        assert_eq!(
+            inbox.added_bundles.count(),
+            3,
+            "all three heights should have been delivered"
+        );
+    }
+
+    Ok(())
+}
+
+/// Tests the reset-on-corrupted-chain-state recovery mechanism.
+///
+/// Corrupts a chain's `previous_message_blocks` in storage so that re-executing the
+/// next block produces a different `BlockExecutionOutcome`. First verifies that the
+/// corruption causes `CorruptedChainState` without the recovery flag, then enables the
+/// flag and verifies that the chain is reset and re-executed successfully.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_reset_on_corrupted_chain_state<B>(mut storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(&mut storage_builder, true, false).await?;
+    let chain_id = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await
+        .id();
+    let target_id = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ONE)
+        .await
+        .id();
+    let storage = env.worker.storage.clone();
+
+    // Step 1: Create and fully process block 0 (transfer from chain to target).
+    let cert_0 = env
+        .make_simple_transfer_certificate(
+            chain_id,
+            sender_key_pair.public(),
+            target_id,
+            Amount::from_tokens(5),
+            Vec::new(),
+            None,
+        )
+        .await;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_0.clone(), &())
+        .await?;
+
+    // Verify block 0 was processed.
+    {
+        let chain = env.worker().chain_state_view(chain_id).await?;
+        assert_eq!(
+            chain.tip_state.get().next_block_height,
+            BlockHeight::from(1)
+        );
+    }
+
+    // Step 2: Plant a confirmed vote in the chain manager. After the reset, it must
+    // still be present — otherwise the validator could be tricked into double-signing.
+    let planted_vote = {
+        let key_pair = env.worker.chain_worker_config.key_pair().unwrap().copy();
+        let mut chain = storage.load_chain(chain_id).await?;
+        let vote = Vote::new(cert_0.value().clone(), Round::Fast, &key_pair);
+        chain.manager.confirmed_vote.set(Some(vote.clone()));
+        chain.save().await?;
+        vote
+    };
+
+    // Step 3: Corrupt `previous_message_blocks` in storage. This directly affects
+    // the BlockExecutionOutcome (it's a field in the outcome struct), so the next
+    // block's computed outcome will differ from the certificate's.
+    {
+        let mut chain = storage.load_chain(chain_id).await?;
+        // Remove the entry for target_id. Block 1's locally computed outcome will
+        // then have no previous_message_blocks entry for target_id, while the
+        // certificate's outcome has one pointing to height 0.
+        chain
+            .execution_state
+            .previous_message_blocks
+            .remove(&target_id)?;
+        chain.save().await?;
+    }
+
+    // Step 3: Create block 1 certificate.
+    let cert_1 = env
+        .make_simple_transfer_certificate(
+            chain_id,
+            sender_key_pair.public(),
+            target_id,
+            Amount::from_tokens(3),
+            Vec::new(),
+            Some(&cert_0),
+        )
+        .await;
+
+    // Step 4: Verify that WITHOUT recovery, processing fails with CorruptedChainState.
+    {
+        let worker_no_recovery = WorkerState::new(
+            storage.clone(),
+            ChainWorkerConfig {
+                nickname: "No-recovery worker".to_string(),
+                allow_inactive_chains: true,
+                allow_messages_from_deprecated_epochs: true,
+                block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
+                ..ChainWorkerConfig::default()
+            }
+            .with_key_pair(Some(
+                env.worker.chain_worker_config.key_pair().unwrap().copy(),
+            )),
+            None,
+        );
+
+        assert_matches!(
+            worker_no_recovery
+                .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+                .await,
+            Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
+        );
+    }
+
+    // Step 5: Now create a worker WITH recovery enabled and process the same block.
+    let worker_with_recovery = WorkerState::new(
+        storage.clone(),
+        ChainWorkerConfig {
+            nickname: "Recovery worker".to_string(),
+            allow_inactive_chains: true,
+            allow_messages_from_deprecated_epochs: true,
+            reset_on_corrupted_chain_state: Some(Duration::from_secs(0)),
+            block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
+            ..ChainWorkerConfig::default()
+        }
+        .with_key_pair(Some(
+            env.worker.chain_worker_config.key_pair().unwrap().copy(),
+        )),
+        None,
+    );
+
+    // The first call returns the original error but triggers a background reset that
+    // re-executes prior blocks and fixes the corruption.
+    assert_matches!(
+        worker_with_recovery
+            .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+            .await,
+        Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
+    );
+    // The previously cast confirmed vote must have survived the reset, or the
+    // validator could be tricked into double-signing. We check this before the
+    // retry because `apply_confirmed_block` for cert_1 would otherwise wipe the
+    // manager during the course of the retry.
+    {
+        let chain = worker_with_recovery.chain_state_view(chain_id).await?;
+        let restored_vote = chain.manager.confirmed_vote.get().as_ref();
+        assert_eq!(
+            restored_vote.map(|v| v.signature),
+            Some(planted_vote.signature),
+            "confirmed_vote should be restored after reset-and-reexecute"
+        );
+    }
+    // After the reset, retrying the certificate should succeed.
+    worker_with_recovery
+        .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+        .await?;
+
+    // Step 6: Verify recovery — chain should be at height 2 with correct state.
+    {
+        let chain = worker_with_recovery.chain_state_view(chain_id).await?;
+        assert_eq!(
+            chain.tip_state.get().next_block_height,
+            BlockHeight::from(2),
+            "Chain should have processed both blocks after recovery"
+        );
+        // Balance should be correct: 100 - 5 - 3 = 92.
+        assert_eq!(
+            *chain.execution_state.system.balance.get(),
+            Amount::from_tokens(92),
+            "Balance should be correct after re-execution"
+        );
+        // previous_message_blocks should be fixed (pointing to height 1, not 999).
+        let prev = chain
+            .execution_state
+            .previous_message_blocks
+            .get(&target_id)
+            .await?;
+        assert_eq!(
+            prev,
+            Some(BlockHeight::from(1)),
+            "previous_message_blocks should be corrected after re-execution"
+        );
+    }
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4780,19 +4780,6 @@ where
 /// next block produces a different `BlockExecutionOutcome`. First verifies that the
 /// corruption causes `CorruptedChainState` without the recovery flag, then enables the
 /// flag and verifies that the chain is reset and re-executed successfully.
-//
-// TODO(#6063-port): Disabled on main because `ExecutionStateView` wraps its inner
-// view in `HistoricallyHashableView`, so the execution state hash is history-
-// dependent. `reset_and_reexecute_chain` wipes the chain and replays the
-// confirmed log, which produces a fresh (empty) history and therefore a
-// different hash than the original certificate's — making the re-execution
-// fail with another `CorruptedChainState`. On `testnet_conway` the equivalent
-// view uses plain `HashableView`, so the hash is state-based and the test
-// passes. Fixing this requires either replaying the stored batches verbatim
-// or switching the hash back to state-based. Keeping the recovery code so
-// the CLI flags and `CorruptedChainState` routing are in place, but this test
-// cannot be enabled until the underlying mismatch is resolved.
-#[ignore = "Incompatible with HistoricallyHashableView on main (see TODO above)"]
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4780,6 +4780,19 @@ where
 /// next block produces a different `BlockExecutionOutcome`. First verifies that the
 /// corruption causes `CorruptedChainState` without the recovery flag, then enables the
 /// flag and verifies that the chain is reset and re-executed successfully.
+//
+// TODO(#6063-port): Disabled on main because `ExecutionStateView` wraps its inner
+// view in `HistoricallyHashableView`, so the execution state hash is history-
+// dependent. `reset_and_reexecute_chain` wipes the chain and replays the
+// confirmed log, which produces a fresh (empty) history and therefore a
+// different hash than the original certificate's — making the re-execution
+// fail with another `CorruptedChainState`. On `testnet_conway` the equivalent
+// view uses plain `HashableView`, so the hash is state-based and the test
+// passes. Fixing this requires either replaying the stored batches verbatim
+// or switching the hash back to state-based. Keeping the recovery code so
+// the CLI flags and `CorruptedChainState` routing are in place, but this test
+// cannot be enabled until the underlying mismatch is resolved.
+#[ignore = "Incompatible with HistoricallyHashableView on main (see TODO above)"]
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
@@ -4888,7 +4901,45 @@ where
         );
     }
 
-    // Step 5: Now create a worker WITH recovery enabled and process the same block.
+    // Step 4b: Verify that with recovery enabled but a whitelist that EXCLUDES
+    // `chain_id`, no reset happens — retrying still fails with the same error.
+    {
+        let worker_not_whitelisted = WorkerState::new(
+            storage.clone(),
+            ChainWorkerConfig {
+                nickname: "Whitelist-excludes worker".to_string(),
+                allow_inactive_chains: true,
+                allow_messages_from_deprecated_epochs: true,
+                reset_on_corrupted_chain_state: Some(Duration::from_secs(0)),
+                recovery_whitelist: Some(HashSet::from([target_id])),
+                block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
+                ..ChainWorkerConfig::default()
+            }
+            .with_key_pair(Some(
+                env.worker().chain_worker_config.key_pair().unwrap().copy(),
+            )),
+            None,
+        );
+
+        assert_matches!(
+            worker_not_whitelisted
+                .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+                .await,
+            Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
+        );
+        // Retry: without a reset there is no way to recover, so the same error repeats.
+        // The retry serializes behind the background reset task's write lock, so by the
+        // time it starts the reset task has already decided to skip.
+        assert_matches!(
+            worker_not_whitelisted
+                .fully_handle_certificate_with_notifications(cert_1.clone(), &())
+                .await,
+            Err(WorkerError::ChainError(ref e)) if matches!(**e, ChainError::CorruptedChainState(_))
+        );
+    }
+
+    // Step 5: Now create a worker WITH recovery enabled and a whitelist that
+    // includes `chain_id`, and process the same block.
     let worker_with_recovery = WorkerState::new(
         storage.clone(),
         ChainWorkerConfig {
@@ -4896,6 +4947,7 @@ where
             allow_inactive_chains: true,
             allow_messages_from_deprecated_epochs: true,
             reset_on_corrupted_chain_state: Some(Duration::from_secs(0)),
+            recovery_whitelist: Some(HashSet::from([chain_id])),
             block_time_grace_period: Duration::from_micros(TEST_GRACE_PERIOD_MICROS),
             ..ChainWorkerConfig::default()
         }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -597,7 +597,17 @@ pub struct WorkerState<StorageClient: Storage> {
     /// manages its own lifetime via a keep-alive task. A background sweep
     /// periodically removes dead entries.
     chain_workers: ChainWorkerMap<StorageClient>,
+    /// Shard-routing dispatcher for outbound cross-chain requests. Used when we need
+    /// to send cross-chain requests outside of the normal `NetworkActions` return
+    /// path — in particular, the `RevertConfirm`s emitted after resetting a
+    /// corrupted chain. The RPC server layer installs this; without it, we fall
+    /// back to dispatching locally through `handle_cross_chain_request`.
+    outbound_cross_chain_sender: Option<OutboundCrossChainSender>,
 }
+
+/// Dispatcher for outbound cross-chain requests that handles the source-shard-to-
+/// target-shard routing that the worker itself is not aware of.
+pub type OutboundCrossChainSender = Arc<dyn Fn(CrossChainRequest) + Send + Sync>;
 
 impl<StorageClient> Clone for WorkerState<StorageClient>
 where
@@ -612,6 +622,7 @@ where
             chain_modes: self.chain_modes.clone(),
             delivery_notifiers: self.delivery_notifiers.clone(),
             chain_workers: self.chain_workers.clone(),
+            outbound_cross_chain_sender: self.outbound_cross_chain_sender.clone(),
         }
     }
 }
@@ -774,7 +785,17 @@ where
             chain_modes,
             delivery_notifiers: Arc::default(),
             chain_workers,
+            outbound_cross_chain_sender: None,
         }
+    }
+
+    /// Installs a shard-routing dispatcher used for outbound cross-chain requests
+    /// generated outside the normal response path (specifically, after resetting a
+    /// corrupted chain). Without it, such requests are dispatched locally in a
+    /// loop via `handle_cross_chain_request`.
+    pub fn with_outbound_cross_chain_sender(mut self, sender: OutboundCrossChainSender) -> Self {
+        self.outbound_cross_chain_sender = Some(sender);
+        self
     }
 
     #[instrument(level = "trace", skip(self, certificate, notifier))]
@@ -868,9 +889,11 @@ where
     /// task ensures it survives cancellation of the originating request: if the
     /// caller's future is dropped mid-way through re-execution, the chain would
     /// otherwise be left at a partial tip and our safety snapshot would be lost.
-    /// Generated `RevertConfirm` requests are dispatched through the normal
-    /// cross-chain pipeline. Errors are logged; the caller already has the
-    /// original error to propagate.
+    /// Generated `RevertConfirm` requests are dispatched via the installed
+    /// shard-routing sender when present (sharded validators), or locally
+    /// through `handle_cross_chain_request` otherwise (client nodes and tests).
+    /// Errors are logged; the caller already has the original error to
+    /// propagate.
     fn spawn_reset_corrupted_chain_state(
         &self,
         chain_id: ChainId,
@@ -893,16 +916,27 @@ where
                     }
                 }
             };
-            let mut queue = VecDeque::from(requests);
-            while let Some(request) = queue.pop_front() {
-                match this.handle_cross_chain_request(request).await {
-                    Ok(actions) => queue.extend(actions.cross_chain_requests),
-                    Err(error) => {
-                        tracing::warn!(
-                            %chain_id, %error,
-                            "Failed to dispatch cross-chain request after \
-                            resetting corrupted chain state"
-                        );
+            if let Some(sender) = &this.outbound_cross_chain_sender {
+                // Sharded validator path: let the RPC layer route each request to
+                // the shard that owns the target chain.
+                for request in requests {
+                    sender(request);
+                }
+            } else {
+                // No routing dispatcher is installed (client node or test), so all
+                // involved chains are co-located on this worker. Dispatch locally
+                // in a loop, following any cascading cross-chain requests.
+                let mut queue = VecDeque::from(requests);
+                while let Some(request) = queue.pop_front() {
+                    match this.handle_cross_chain_request(request).await {
+                        Ok(actions) => queue.extend(actions.cross_chain_requests),
+                        Err(error) => {
+                            warn!(
+                                %chain_id, %error,
+                                "Failed to dispatch cross-chain request after \
+                                resetting corrupted chain state"
+                            );
+                        }
                     }
                 }
             }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -26,9 +26,7 @@ use linera_cache::{UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
 #[cfg(with_testing)]
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
-    data_types::{
-        BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock,
-    },
+    data_types::{BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock},
     types::{
         Block, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock, ValidatedBlockCertificate,
@@ -368,15 +366,6 @@ pub enum WorkerError {
     #[error("The block does not contain the hash that we expected for the previous block")]
     InvalidBlockChaining,
     #[error(
-        "The given outcome is not what we computed after executing the block.\n\
-        Computed: {computed:#?}\n\
-        Submitted: {submitted:#?}"
-    )]
-    IncorrectOutcome {
-        computed: Box<BlockExecutionOutcome>,
-        submitted: Box<BlockExecutionOutcome>,
-    },
-    #[error(
         "Block timestamp ({block_timestamp}) is further in the future from local time \
         ({local_time}) than block time grace period ({block_time_grace_period:?})"
     )]
@@ -462,7 +451,6 @@ impl WorkerError {
             | WorkerError::MissingNetworkDescription
             | WorkerError::Thread(_)
             | WorkerError::ReadCertificatesError(_)
-            | WorkerError::IncorrectOutcome { .. }
             | WorkerError::PoisonedWorker => true,
             WorkerError::ChainError(chain_error) => chain_error.is_local(),
         }
@@ -493,6 +481,17 @@ impl WorkerError {
                     must_reload_view: true,
                     ..
                 })
+        )
+    }
+
+    /// Returns `true` if this error indicates that the chain's persisted state is
+    /// internally inconsistent, so the worker should consider resetting and
+    /// re-executing it from storage.
+    fn indicates_corrupted_chain_state(&self) -> bool {
+        matches!(
+            self,
+            WorkerError::ChainError(chain_error)
+                if matches!(chain_error.as_ref(), ChainError::CorruptedChainState(_))
         )
     }
 }
@@ -857,9 +856,58 @@ where
         if let Err(error) = &result {
             if error.must_reload_view() {
                 self.evict_poisoned_worker(chain_id, &state);
+            } else if error.indicates_corrupted_chain_state() {
+                self.spawn_reset_corrupted_chain_state(chain_id, state);
             }
         }
         result
+    }
+
+    /// Spawns a detached task that re-acquires the write lock and recovers the
+    /// chain from a detected state corruption. Running the recovery in a separate
+    /// task ensures it survives cancellation of the originating request: if the
+    /// caller's future is dropped mid-way through re-execution, the chain would
+    /// otherwise be left at a partial tip and our safety snapshot would be lost.
+    /// Generated `RevertConfirm` requests are dispatched through the normal
+    /// cross-chain pipeline. Errors are logged; the caller already has the
+    /// original error to propagate.
+    fn spawn_reset_corrupted_chain_state(
+        &self,
+        chain_id: ChainId,
+        state: ChainWorkerArc<StorageClient>,
+    ) where
+        StorageClient: Clone,
+    {
+        let this = self.clone();
+        linera_base::Task::spawn(async move {
+            let requests = {
+                let mut guard = handle::write_lock(&state).await;
+                match guard.maybe_reset_corrupted_chain_state().await {
+                    Ok(Some(requests)) => requests,
+                    Ok(None) => return,
+                    Err(error) => {
+                        tracing::error!(
+                            %chain_id, %error, "Failed to reset corrupted chain state"
+                        );
+                        return;
+                    }
+                }
+            };
+            let mut queue = VecDeque::from(requests);
+            while let Some(request) = queue.pop_front() {
+                match this.handle_cross_chain_request(request).await {
+                    Ok(actions) => queue.extend(actions.cross_chain_requests),
+                    Err(error) => {
+                        tracing::warn!(
+                            %chain_id, %error,
+                            "Failed to dispatch cross-chain request after \
+                            resetting corrupted chain state"
+                        );
+                    }
+                }
+            }
+        })
+        .forget();
     }
 
     /// Evicts a poisoned chain worker from the cache, but only if the entry still

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -370,6 +370,20 @@ where
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(cross_chain_config.queue_size);
 
+        // Give the worker a shard-routing sender for cross-chain requests generated
+        // outside the normal `NetworkActions` return path (specifically, the
+        // `RevertConfirm`s emitted after resetting a corrupted chain).
+        let state = {
+            let routing_network = internal_network.clone();
+            let routing_sender = cross_chain_sender.clone();
+            state.with_outbound_cross_chain_sender(std::sync::Arc::new(move |request| {
+                let shard_id = routing_network.get_shard_id(request.target_chain_id());
+                if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
+                    error!(%error, "dropping cross-chain request");
+                }
+            }))
+        };
+
         let (notification_sender, _) =
             tokio::sync::broadcast::channel(notification_config.notification_queue_size);
 

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -124,7 +124,7 @@ where
     }
 
     pub fn spawn(
-        self,
+        mut self,
         shutdown_signal: CancellationToken,
         join_set: &mut JoinSet<()>,
     ) -> ServerHandle {
@@ -138,6 +138,23 @@ where
             mpsc::channel(self.cross_chain_config.queue_size);
 
         let (notification_sender, _) = sync::broadcast::channel(1000);
+
+        // Give the worker a shard-routing sender for cross-chain requests generated
+        // outside the normal `NetworkActions` return path (specifically, the
+        // `RevertConfirm`s emitted after resetting a corrupted chain).
+        {
+            let routing_network = self.network.clone();
+            let routing_sender = cross_chain_sender.clone();
+            self.state = self
+                .state
+                .clone()
+                .with_outbound_cross_chain_sender(Arc::new(move |request| {
+                    let shard_id = routing_network.get_shard_id(request.target_chain_id());
+                    if let Err(error) = routing_sender.clone().try_send((request, shard_id)) {
+                        tracing::error!(%error, "dropping cross-chain request");
+                    }
+                }));
+        }
 
         join_set.spawn_task(Self::forward_cross_chain_queries(
             self.state.nickname().to_string(),

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -68,7 +68,7 @@ struct ServerContext {
     chain_info_max_received_log_entries: usize,
     cross_chain_message_chunk_limit: usize,
     allow_revert_confirm: bool,
-    reset_on_incorrect_outcome_mins: Option<u64>,
+    reset_on_corrupted_chain_state_mins: Option<u64>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -101,8 +101,8 @@ impl ServerContext {
             block_cache_size: self.block_cache_size,
             execution_state_cache_size: self.execution_state_cache_size,
             allow_revert_confirm: self.allow_revert_confirm,
-            reset_on_incorrect_outcome: self
-                .reset_on_incorrect_outcome_mins
+            reset_on_corrupted_chain_state: self
+                .reset_on_corrupted_chain_state_mins
                 .map(|m| Duration::from_secs(m * 60)),
             ..ChainWorkerConfig::default()
         };
@@ -474,12 +474,12 @@ enum ServerCommand {
         #[arg(long, default_value_t = false)]
         allow_revert_confirm: bool,
 
-        /// On IncorrectOutcome errors, reset the chain state and re-execute all
-        /// blocks from scratch. Sends RevertConfirm to all known senders. The
+        /// On detection of corrupted chain state, reset the chain state and re-execute
+        /// all blocks from scratch. Sends RevertConfirm to all known senders. The
         /// value is the minimum number of minutes since the last reset before
         /// another reset is allowed (to prevent loops).
         #[arg(long)]
-        reset_on_incorrect_outcome_mins: Option<u64>,
+        reset_on_corrupted_chain_state_mins: Option<u64>,
 
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
@@ -614,7 +614,7 @@ async fn run(options: ServerOptions) {
             chain_info_max_received_log_entries,
             cross_chain_message_chunk_limit,
             allow_revert_confirm,
-            reset_on_incorrect_outcome_mins,
+            reset_on_corrupted_chain_state_mins,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -634,7 +634,7 @@ async fn run(options: ServerOptions) {
                 chain_info_max_received_log_entries,
                 cross_chain_message_chunk_limit,
                 allow_revert_confirm,
-                reset_on_incorrect_outcome_mins,
+                reset_on_corrupted_chain_state_mins,
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -16,6 +16,7 @@ pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\
 
 use std::{
     borrow::Cow,
+    collections::HashSet,
     num::NonZeroU16,
     path::{Path, PathBuf},
     sync::Arc,
@@ -27,6 +28,7 @@ use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt, TryFutureExt as _};
 use linera_base::{
     crypto::{CryptoRng, Ed25519SecretKey},
+    identifiers::ChainId,
     listen_for_shutdown_signals,
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
@@ -69,6 +71,7 @@ struct ServerContext {
     cross_chain_message_chunk_limit: usize,
     allow_revert_confirm: bool,
     reset_on_corrupted_chain_state_mins: Option<u64>,
+    recovery_whitelist: Option<HashSet<ChainId>>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -104,6 +107,7 @@ impl ServerContext {
             reset_on_corrupted_chain_state: self
                 .reset_on_corrupted_chain_state_mins
                 .map(|m| Duration::from_secs(m * 60)),
+            recovery_whitelist: self.recovery_whitelist.clone(),
             ..ChainWorkerConfig::default()
         };
         let state = WorkerState::new(storage, config, None);
@@ -481,6 +485,13 @@ enum ServerCommand {
         #[arg(long)]
         reset_on_corrupted_chain_state_mins: Option<u64>,
 
+        /// Optional whitelist of chain IDs allowed to use the `--allow-revert-confirm`
+        /// and `--reset-on-corrupted-chain-state-mins` recovery mechanisms. If not
+        /// specified, every chain is eligible. Values may be passed as a
+        /// comma-separated list or by repeating the flag.
+        #[arg(long, value_delimiter = ',')]
+        recovery_whitelist: Option<Vec<ChainId>>,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -615,6 +626,7 @@ async fn run(options: ServerOptions) {
             cross_chain_message_chunk_limit,
             allow_revert_confirm,
             reset_on_corrupted_chain_state_mins,
+            recovery_whitelist,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -635,6 +647,7 @@ async fn run(options: ServerOptions) {
                 cross_chain_message_chunk_limit,
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
+                recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };


### PR DESCRIPTION
Port of  #6063, #6080 and #6102.

## Motivation

On `testnet_conway`:
* We activate reset-and-reexecute for a chain in more cases than just incorrect outcome.
* We restore a validator's votes after reexecuting.
* There is an option to set a whitelist for chain recovery.
* The `RevertConfirm` messages resulting from re-execution are routed to the correct shard.

## Proposal

Port these changes to `main`.

Note that _clearing_ the chain state view wouldn't reset the historical hash, so we delete it.

## Test Plan

CI; tests were extended.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- `testnet_conway` PRs: #6063, #6080, #6102
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
