### PR TITLE
Raise gRPC latency histogram ceiling from 2s to 5s to surface timeouts

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -66,7 +66,7 @@ mod metrics {
             "server_request_latency",
             "Server request latency",
             &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-            linear_bucket_interval(1.0, 25.0, 2000.0),
+            linear_bucket_interval(1.0, 50.0, 5000.0),
         )
     });
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -74,7 +74,7 @@ mod metrics {
             "proxy_request_latency",
             "Proxy request latency",
             &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-            linear_bucket_interval(1.0, 50.0, 2000.0),
+            linear_bucket_interval(1.0, 50.0, 5000.0),
         )
     });
     pub static PROXY_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {


### PR DESCRIPTION
## Motivation

The proxy and server gRPC latency histograms cap at 2000ms, but the proxy-server RPC timeout is 4000ms. Requests above 2s land in the `+Inf` bucket, which `histogram_quantile` cannot interpolate — so p95/p99 are effectively unobservable for any method whose tail exceeds the ceiling.

On testnet_conway right now, ~80% of `PreviousEventBlocks` requests take >2s on both histograms. Quantiles for this (and any other slow path) are meaningless today. When the 4s timeout fires, the cluster of ~4s latencies also lands in `+Inf`, so we cannot distinguish slow but healthy from timed-out in either histogram.

## Proposal

Raise both histograms ceiling to 5000ms, above the 4s timeout boundary, so timed-out requests land in a real bucket. Unify the width at 50ms:

- `linera-service/src/proxy/grpc.rs`: `linear_bucket_interval(1.0, 50.0, 2000.0)` → `linear_bucket_interval(1.0, 50.0, 5000.0)` (41 → 101 buckets)
- `linera-rpc/src/grpc/server.rs`: `linear_bucket_interval(1.0, 25.0, 2000.0)` → `linear_bucket_interval(1.0, 50.0, 5000.0)` (81 → 101 buckets)

Proxy keeps its current 50ms granularity. Server loses a factor of 2 in granularity (25ms → 50ms) — a deliberate trade-off against series cardinality.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links
