### PR TITLE
Record cancelled gRPC requests via Drop guard on server middleware

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -94,6 +94,14 @@ mod metrics {
         )
     });
 
+    pub static SERVER_REQUEST_CANCELLED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "server_request_cancelled",
+            "Server requests whose handler future was dropped before completion (e.g. client-side timeout / disconnect)",
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+        )
+    });
+
     pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
             "cross_chain_message_channel_full",
@@ -283,6 +291,24 @@ impl GrpcServerHandle {
     }
 }
 
+#[cfg(with_metrics)]
+struct ServerRequestCancellationGuard {
+    method_name: String,
+    traffic_type: &'static str,
+    completed: bool,
+}
+
+#[cfg(with_metrics)]
+impl Drop for ServerRequestCancellationGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            metrics::SERVER_REQUEST_CANCELLED
+                .with_label_values(&[&self.method_name, self.traffic_type])
+                .inc();
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct GrpcPrometheusMetricsMiddlewareLayer;
 
@@ -330,14 +356,21 @@ where
 
         let future = self.service.call(request);
         async move {
+            #[cfg(with_metrics)]
+            let mut cancellation_guard = ServerRequestCancellationGuard {
+                method_name,
+                traffic_type,
+                completed: false,
+            };
             let response = future.await?;
             #[cfg(with_metrics)]
             {
+                cancellation_guard.completed = true;
                 metrics::SERVER_REQUEST_LATENCY
-                    .with_label_values(&[&method_name, traffic_type])
+                    .with_label_values(&[&cancellation_guard.method_name, traffic_type])
                     .observe(start.elapsed().as_secs_f64() * 1000.0);
                 metrics::SERVER_REQUEST_COUNT
-                    .with_label_values(&[&method_name, traffic_type])
+                    .with_label_values(&[&cancellation_guard.method_name, traffic_type])
                     .inc();
             }
             Ok(response)


### PR DESCRIPTION
## Motivation

When the 4s RPC timeout fires on the proxy, tonic/hyper drops the server handler future (verified in hyper 1.6.0 `H2Stream::poll2`). The existing server metrics middleware only records latency and count AFTER `future.await?` completes successfully, so cancelled requests are silently dropped from every server-side metric.

Measured impact on testnet_conway during the 2026-04-18 12:45 UTC latency spike:

- `sum(rate(linera_proxy_request_count{method_name="PreviousEventBlocks"}[5m]))` = 347 req/s
- `sum(rate(linera_server_request_count{method_name="PreviousEventBlocks"}[5m]))` = 205 req/s
- `sum(rate(linera_proxy_request_error{method_name="PreviousEventBlocks"}[5m]))` = 70 req/s (~20% error rate)

~40% of requests the proxy sees never land in the server histogram. The server dashboards look artificially healthy during exactly the periods where observability matters most.

## Proposal

Add a Drop-based cancellation guard to the server metrics middleware. The guard is created at the top of the async block, so it is captured by the future state machine and runs its Drop impl when the future is dropped (which is how tonic/hyper signals cancellation).

On successful completion the guard is marked `completed = true`, which suppresses the increment. On drop before completion, the new `server_request_cancelled{method_name, traffic_type}` counter is incremented.

The existing `server_request_count` / `server_request_latency` semantics are unchanged (they still only cover completed requests), so existing dashboards keep working. Cancellations become a new, additive signal: total requests received = completed + cancelled.

## Test Plan

CI. Post-deploy validation on testnet_conway: during a timeout storm, `proxy_request_count` should approximately equal `server_request_count + server_request_cancelled` per method within scrape noise. If the hypothesis is correct this will close the ~40% gap observed on 2026-04-18.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Related: linera-io/linera-protocol#6119 (bucket ceiling fix, prerequisite for seeing the ~4s cancellation cluster in the latency histogram)
