### PR TITLE
[main] EVM finality check via Linera service (#6123)

### DIFF
--- a/examples/bridge-demo/index.html
+++ b/examples/bridge-demo/index.html
@@ -666,6 +666,7 @@
         lineraChain = await faucet.claimChain(wallet, lineraOwner);
 
         const client = await new linera.Client(wallet, signer);
+        await client.start();
         const chain = await client.chain(lineraChain, { owner: lineraOwner });
         wrappedApp = await chain.application(APP_ID);
         console.log('[bridge-demo] Linera initialized', { lineraChain, lineraOwner, APP_ID, BRIDGE_APP_ID });

--- a/examples/evm-bridge/src/contract.rs
+++ b/examples/evm-bridge/src/contract.rs
@@ -3,7 +3,7 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
-use alloy_primitives::{Bytes, B256};
+use alloy_primitives::Bytes;
 use evm_bridge::{BridgeOperation, BridgeParameters, DepositKey, EvmBridgeAbi};
 use linera_bridge::proof;
 use linera_sdk::{
@@ -122,19 +122,26 @@ impl EvmBridgeContract {
             "rpc_endpoint must be configured to verify block hashes"
         );
 
-        let client = ContractEthereumClient::new(params.rpc_endpoint.clone());
-        assert!(
-            client
-                .is_block_hash_finalized(B256::from(block_hash))
-                .await
-                .expect("failed to check block finality — block may not exist"),
-            "block is not finalized"
-        );
+        // Use our own service as an oracle so that the underlying EVM JSON-RPC
+        // calls (two of them) collapse into one deterministic boolean in the
+        // block's oracle responses.
+        let application_id = self.runtime.application_id();
+        let hash_hex = hex::encode(block_hash);
+        let query = async_graphql::Request::new(format!(
+            "query {{ isBlockHashFinalized(blockHash: \"0x{hash_hex}\") }}"
+        ));
+        let response = self.runtime.query_service(application_id, &query);
 
-        log::info!(
-            "verified block hash {} is finalized",
-            hex::encode(block_hash)
-        );
+        let async_graphql::Value::Object(data) = response.data else {
+            panic!("Unexpected response from service: {response:#?}");
+        };
+        let finalized = match &data["isBlockHashFinalized"] {
+            async_graphql::Value::Boolean(b) => *b,
+            other => panic!("Unexpected value for isBlockHashFinalized: {other:#?}"),
+        };
+        assert!(finalized, "block is not finalized");
+
+        log::info!("verified block hash 0x{hash_hex} is finalized");
     }
 
     async fn process_deposit(

--- a/examples/evm-bridge/src/service.rs
+++ b/examples/evm-bridge/src/service.rs
@@ -5,9 +5,11 @@
 
 use std::sync::Arc;
 
+use alloy_primitives::B256;
 use async_graphql::{EmptyMutation, EmptySubscription, Object, Request, Response, Schema};
 use evm_bridge::{BridgeParameters, EvmBridgeAbi};
 use linera_sdk::{
+    ethereum::{EthereumQueries, ServiceEthereumClient},
     linera_base_types::WithServiceAbi,
     views::{linera_views, RootView, SetView, View, ViewStorageContext},
     Service, ServiceRuntime,
@@ -86,5 +88,27 @@ impl EvmBridgeService {
             .contains(&bytes)
             .await
             .expect("failed to check processed deposits")
+    }
+
+    /// Verifies that the given EVM block hash is finalized on the source chain.
+    ///
+    /// Makes the EVM JSON-RPC calls in the service runtime so that the contract
+    /// sees a single deterministic oracle response (the boolean result) instead
+    /// of multiple raw HTTP responses with non-deterministic headers.
+    async fn is_block_hash_finalized(&self, block_hash: String) -> bool {
+        let bytes: [u8; 32] = hex::decode(block_hash.strip_prefix("0x").unwrap_or(&block_hash))
+            .expect("invalid hex")
+            .try_into()
+            .expect("hash must be 32 bytes");
+        let params: BridgeParameters = self.runtime.application_parameters();
+        assert!(
+            !params.rpc_endpoint.is_empty(),
+            "rpc_endpoint must be configured to verify block hashes"
+        );
+        let client = ServiceEthereumClient::new(params.rpc_endpoint);
+        client
+            .is_block_hash_finalized(B256::from(bytes))
+            .await
+            .expect("failed to check block finality — block may not exist")
     }
 }


### PR DESCRIPTION
Backport of https://github.com/linera-io/linera-protocol/pull/6123

## Motivation

The Linera `evm-bridge` contract verifies EVM block finality by calling the source chain's JSON-RPC from inside the contract. Each check fires two raw HTTP requests (`eth_getBlockByHash` +
`eth_getBlockByNumber("finalized")`), and each request becomes a separate `OracleResponse::Http` entry in the block's oracle responses. Those HTTP entries contain non-deterministic headers (e.g. `Date`) and can
differ byte-for-byte across validators, making reproducibility and replay more fragile than it needs to be.

Separately, the bridge-demo frontend (`examples/bridge-demo/index.html`) was not calling `client.start()` after constructing the `linera.Client`. Without it, the chain listener never runs, no validator
notifications are received, and the wrapped-fungible balance on the user's chain stays at zero after a successful deposit on EVM.

## Proposal

1. **Move the finality check into the bridge's own service (service-as-oracle pattern).**
    - `examples/evm-bridge/src/service.rs` gains an `is_block_hash_finalized(blockHash: String) -> bool` GraphQL query that performs the two EVM RPC calls via `ServiceEthereumClient`.
    - `examples/evm-bridge/src/contract.rs::verify_block_hash` stops constructing `ContractEthereumClient` and instead calls `runtime.query_service(self_application_id, graphql)` and asserts on the returned
boolean.
    - Net effect: the contract emits exactly one `OracleResponse::Service` carrying a deterministic boolean, instead of two `OracleResponse::Http` with per-validator HTTP metadata.

2. **Add `await client.start()` in the bridge-demo frontend.**
    - After the listener-lifetime refactor (#5937 / PR 5985), `client.start()` is required to spawn the chain listener. Without it, deposits appear to succeed on EVM but the wrapped balance on Linera never
updates.

## Test Plan
- CI
- Manual demo verification: rebuild the `evm-bridge` Wasm module, run `make -C linera-bridge demo`, deposit from the frontend, and confirm:
  - Wrapped balance on the user's Linera chain updates without calling `processInbox` manually (exercises the `client.start()` fix).
  - The bridge chain's `ProcessDeposit` block has a single `OracleResponse::Service` for the finality check (exercises the service-as-oracle path).

## Release Plan

- These changes should be backported to the `main` branch

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)