### PR TITLE
[backport] ci: wait for docker daemon before docker steps

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -42,6 +42,23 @@ jobs:
           version: "34.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Self-hosted runners occasionally expose an unhealthy
+      # docker socket at job start despite
+      # RUNNER_WAIT_FOR_DOCKER_IN_SECONDS. Probe + retry so
+      # we do not fail the whole run on a startup race.
+      - name: Wait for docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if docker info >/dev/null 2>&1; then
+              echo "Docker ready after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Waiting for docker daemon ($i/60)..."
+            sleep 2
+          done
+          echo "Docker daemon did not become ready in 120s"
+          exit 1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -29,6 +29,23 @@ jobs:
       - name: Configure Docker to push to Artifact Registry
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
+      # Self-hosted builder occasionally exposes an unhealthy
+      # docker socket at job start despite
+      # RUNNER_WAIT_FOR_DOCKER_IN_SECONDS. Probe + retry so
+      # we do not fail the whole run on a startup race.
+      - name: Wait for docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if docker info >/dev/null 2>&1; then
+              echo "Docker ready after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Waiting for docker daemon ($i/60)..."
+            sleep 2
+          done
+          echo "Docker daemon did not become ready in 120s"
+          exit 1
+
       - name: Set env variables
         env:
           HEAD_REF: ${{ github.head_ref }}


### PR DESCRIPTION
## Motivation

Backport of #6104 to `testnet_conway`.

Bridge E2E and Docker Image workflows have intermittently failed at the very first docker-using step with `dial unix /var/run/docker.sock: connect: no such file or directory` on self-hosted runners despite `RUNNER_WAIT_FOR_DOCKER_IN_SECONDS=120`.

## Proposal

Clean cherry-pick of 86bc678b. Same 2 files, +34 lines. Adds a `Wait for docker daemon` step (probe `docker info`, retry up to 60 times at 2s intervals = 120s cap) before the first docker-using step in both workflows.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Main PR: #6104