### PR TITLE
CLI: respect NO_COLOR and never emit ANSI escape codes to stdout

### DIFF
--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2038,7 +2038,47 @@ fn init_tracing(options: &Options) {
     linera_base::tracing::init(&options.command.log_file_name());
 }
 
+/// Resolve the desired color override based on the `NO_COLOR`, `CLICOLOR`, and
+/// `CLICOLOR_FORCE` environment variables, as specified by <https://no-color.org>.
+///
+/// Returns `Some(false)` when colors must be disabled, `Some(true)` when they must be
+/// forced on, or `None` to leave auto-detection alone.
+fn color_override_from_env(
+    no_color: Option<&std::ffi::OsStr>,
+    clicolor: Option<&str>,
+    clicolor_force: Option<&str>,
+) -> Option<bool> {
+    let no_color_set = no_color.is_some_and(|value| !value.is_empty());
+    let clicolor_zero = clicolor == Some("0");
+    if no_color_set || clicolor_zero {
+        Some(false)
+    } else if clicolor_force == Some("1") {
+        Some(true)
+    } else {
+        None
+    }
+}
+
+/// Configure color output according to the `NO_COLOR` / `CLICOLOR` / `CLICOLOR_FORCE`
+/// environment variables, as specified by <https://no-color.org>.
+///
+/// This only affects styling applied via the `colored` crate, which is used for
+/// `tracing` messages written to stderr. Stdout is always plain text.
+fn configure_colors() {
+    let no_color = std::env::var_os("NO_COLOR");
+    let clicolor = std::env::var("CLICOLOR").ok();
+    let clicolor_force = std::env::var("CLICOLOR_FORCE").ok();
+    if let Some(enabled) = color_override_from_env(
+        no_color.as_deref(),
+        clicolor.as_deref(),
+        clicolor_force.as_deref(),
+    ) {
+        colored::control::set_override(enabled);
+    }
+}
+
 fn main() -> anyhow::Result<process::ExitCode> {
+    configure_colors();
     let options = Options::init();
     let mut runtime = if options.common.tokio_threads == Some(1) {
         tokio::runtime::Builder::new_current_thread()
@@ -2590,5 +2630,53 @@ Make sure to use a Linera client compatible with this network.
             options.run_with_storage(Job(options.clone())).await??;
             Ok(0)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::color_override_from_env;
+
+    #[test]
+    fn no_color_disables_colors() {
+        assert_eq!(
+            color_override_from_env(Some(OsStr::new("1")), None, None),
+            Some(false),
+        );
+        assert_eq!(
+            color_override_from_env(Some(OsStr::new("anything")), None, Some("1")),
+            Some(false),
+            "NO_COLOR must win over CLICOLOR_FORCE",
+        );
+    }
+
+    #[test]
+    fn empty_no_color_is_ignored() {
+        assert_eq!(
+            color_override_from_env(Some(OsStr::new("")), None, None),
+            None,
+        );
+    }
+
+    #[test]
+    fn clicolor_zero_disables_colors() {
+        assert_eq!(color_override_from_env(None, Some("0"), None), Some(false),);
+    }
+
+    #[test]
+    fn clicolor_force_one_forces_colors() {
+        assert_eq!(color_override_from_env(None, None, Some("1")), Some(true),);
+    }
+
+    #[test]
+    fn no_env_leaves_defaults() {
+        assert_eq!(color_override_from_env(None, None, None), None);
+        assert_eq!(
+            color_override_from_env(None, Some("1"), None),
+            None,
+            "CLICOLOR=1 should not force or disable",
+        );
     }
 }

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -3,7 +3,6 @@
 
 use std::{num::NonZeroU16, str::FromStr};
 
-use colored::Colorize as _;
 use linera_base::{data_types::Amount, listen_for_shutdown_signals, time::Duration};
 use linera_client::client_options::ResourceControlPolicyConfig;
 use linera_rpc::config::CrossChainConfig;
@@ -309,25 +308,14 @@ async fn print_messages_and_create_faucet(
          and LINERA_STORAGE as follows.\n"
     );
     println!(
-        "{}",
-        format!(
-            "export LINERA_WALLET=\"{}\"",
-            client.wallet_path().display(),
-        )
-        .bold(),
+        "export LINERA_WALLET=\"{}\"",
+        client.wallet_path().display(),
     );
     println!(
-        "{}",
-        format!(
-            "export LINERA_KEYSTORE=\"{}\"",
-            client.keystore_path().display(),
-        )
-        .bold()
+        "export LINERA_KEYSTORE=\"{}\"",
+        client.keystore_path().display(),
     );
-    println!(
-        "{}",
-        format!("export LINERA_STORAGE=\"{}\"", client.storage_path()).bold(),
-    );
+    println!("export LINERA_STORAGE=\"{}\"", client.storage_path(),);
 
     // Run the faucet using a separate wallet so it doesn't lock the admin wallet.
     // Keep half the balance on the admin chain for fee payments (e.g. committee changes).
@@ -340,10 +328,7 @@ async fn print_messages_and_create_faucet(
             .await?;
 
         eprintln!("To connect to this network, you can use the following faucet URL:");
-        println!(
-            "{}",
-            format!("export LINERA_FAUCET_URL=\"http://localhost:{faucet_port}\"").bold(),
-        );
+        println!("export LINERA_FAUCET_URL=\"http://localhost:{faucet_port}\"");
 
         let service = faucet_client
             .run_faucet(Some(faucet_port.into()), Some(faucet_chain), faucet_amount)


### PR DESCRIPTION
## Motivation

Closes #5980.

The `colored` crate was used to style `linera net up`'s stdout, emitting raw ANSI escape codes in the `export LINERA_*` lines. This broke `eval "$(linera net up ...)"` in shells that do not strip escapes, and generally violated the project guideline that stdout should be clean, machine-parseable text.

Additionally, there was no explicit handling of the `NO_COLOR`, `CLICOLOR`, or `CLICOLOR_FORCE` environment variables defined by the [no-color.org](https://no-color.org) specification.

## Proposal

1. **Clean stdout in `linera net up`** ([linera-service/src/cli/net_up_utils.rs](cci:7://file:///C:/Users/isanoxel/CascadeProjects/linera-protocol/linera-service/src/cli/net_up_utils.rs:0:0-0:0)):
   - Drop `use colored::Colorize as _;`.
   - Remove all four `.bold()` calls on the `export LINERA_WALLET`, `LINERA_KEYSTORE`, `LINERA_STORAGE`, and `LINERA_FAUCET_URL` lines and simplify the surrounding `println!` invocations.

2. **Honor `NO_COLOR` / `CLICOLOR` / `CLICOLOR_FORCE` on stderr** ([linera-service/src/cli/main.rs](cci:7://file:///C:/Users/isanoxel/CascadeProjects/linera-protocol/linera-service/src/cli/main.rs:0:0-0:0)):
   - Add a pure helper [color_override_from_env](cci:1://file:///C:/Users/isanoxel/CascadeProjects/linera-protocol/linera-service/src/cli/main.rs:2040:0-2059:1) that returns the desired `colored::control` override based on the three environment variables, following the no-color.org precedence rules (`NO_COLOR` wins over `CLICOLOR_FORCE`; an empty `NO_COLOR` is ignored).
   - Add a [configure_colors](cci:1://file:///C:/Users/isanoxel/CascadeProjects/linera-protocol/linera-service/src/cli/main.rs:2061:0-2077:1) wrapper that reads the process environment and applies the override, called once at the top of `fn main()`.

## Test Plan

- Five new unit tests in [linera-service/src/cli/main.rs](cci:7://file:///C:/Users/isanoxel/CascadeProjects/linera-protocol/linera-service/src/cli/main.rs:0:0-0:0) cover: `NO_COLOR` set, empty `NO_COLOR` ignored, `CLICOLOR=0`, `CLICOLOR_FORCE=1`, and `NO_COLOR` precedence over `CLICOLOR_FORCE`.
- `cargo test -p linera-service --bin linera tests::` → **5 passed**.
- `cargo clippy -p linera-service --bin linera --all-targets -- -D warnings` → clean.
- `cargo +nightly fmt` applied (no diff remaining).

The full `--all-features` clippy matrix was deferred to CI due to local memory constraints; happy to address anything CI flags.

## Release Plan

Nothing to backport. The behavior change is strictly an improvement for downstream consumers piping or evaluating `linera net up` output; the text content is unchanged.

## Links

- Closes #5980