### PR TITLE
Sync admin chain and retry on `EventsNotFound` in `local_committee` (#6122)

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1985,13 +1985,13 @@ impl<Env: Environment> ChainClient<Env> {
         let certificate = if round.is_fast() {
             let hashed_value = ConfirmedBlock::new(block);
             self.client
-                .submit_block_proposal(&committee, proposal, hashed_value)
+                .submit_block_proposal(committee.clone(), proposal, hashed_value)
                 .await?
         } else {
             let hashed_value = ValidatedBlock::new(block);
             let certificate = self
                 .client
-                .submit_block_proposal(&committee, proposal, hashed_value.clone())
+                .submit_block_proposal(committee.clone(), proposal, hashed_value.clone())
                 .await?;
             self.client.finalize_block(&committee, certificate).await?
         };

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -642,6 +642,17 @@ impl<Env: Environment> ChainClient<Env> {
                 self.synchronize_chain_state(self.chain_id).await?;
                 self.chain_info_with_committees().await?
             }
+            Err(LocalNodeError::EventsNotFound(event_ids))
+                if event_ids
+                    .iter()
+                    .all(|event_id| event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)) =>
+            {
+                // `initialize_and_save_if_needed` couldn't start the chain because
+                // the admin chain's epoch events aren't synced yet.
+                self.synchronize_chain_state(self.client.admin_chain_id)
+                    .await?;
+                self.chain_info_with_committees().await?
+            }
             Err(err) => return Err(err.into()),
         };
         let hash = info

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -969,7 +969,7 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "trace", skip_all)]
     async fn submit_block_proposal<T: ProcessableCertificate>(
         self: &Arc<Self>,
-        committee: &Committee,
+        committee: Arc<Committee>,
         proposal: Box<BlockProposal>,
         value: T,
     ) -> Result<GenericCertificate<T>, chain_client::Error> {
@@ -1026,7 +1026,7 @@ impl<Env: Environment> Client<Env> {
         });
 
         let certificate = self
-            .communicate_chain_action(committee, submit_action, value)
+            .communicate_chain_action(&committee, submit_action, value)
             .await?;
 
         clock_skew_check_handle.await;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -3094,6 +3094,73 @@ where
     Ok(())
 }
 
+/// Regression test: a client whose local node has the chain's description blob but
+/// hasn't yet synced the admin chain's `NewCommittee` event for the chain's active
+/// epoch must still be able to fetch its own committee — `local_committee` syncs the
+/// admin chain on its own rather than failing with `EventsNotFound` or `InactiveChain`.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_local_committee_syncs_admin_chain<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let new_public_key = signer.generate_new();
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+
+    let admin_client = builder.add_root_chain(0, Amount::from_tokens(1000)).await?;
+    let parent = builder.add_root_chain(1, Amount::from_tokens(1000)).await?;
+
+    // Create a new epoch on the admin chain.
+    admin_client
+        .stage_new_committee(builder.initial_committee.clone())
+        .await
+        .unwrap();
+
+    // Migrate `parent` to the new epoch and open a child chain at that epoch.
+    parent.synchronize_from_validators().await.unwrap();
+    parent.process_inbox().await.unwrap();
+    let (child_desc, certificate) = Box::pin(parent.open_chain(
+        ChainOwnership::single(new_public_key.into()),
+        ApplicationPermissions::default(),
+        Amount::from_tokens(10),
+    ))
+    .await
+    .unwrap_ok_committed();
+    assert_eq!(certificate.block().header.epoch, Epoch::from(1));
+
+    // A fresh client with genesis-only storage: no admin-chain events past epoch 0.
+    let mut child_client = builder
+        .make_client(child_desc.id(), None, BlockHeight::ZERO)
+        .await?;
+    child_client.set_preferred_owner(new_public_key.into());
+    // Pre-seed the child's description blob so that the first `chain_info()` call
+    // makes it past the blob-lookup and triggers initialization, which needs the
+    // admin chain's epoch events to load the committee for epoch 1. This is the
+    // exact state a web client ends up in after receiving the chain description
+    // but before syncing the admin chain.
+    child_client
+        .storage_client()
+        .write_blob(&Blob::new_chain_description(&child_desc))
+        .await?;
+
+    // Before the fix, this returned `EventsNotFound` because
+    // `initialize_and_save_if_needed` couldn't find the admin chain's
+    // `NewCommittee` event for epoch 1. `local_committee` must sync
+    // the admin chain on its own and succeed.
+    let committee = child_client.local_committee().await?;
+    assert_eq!(
+        committee.validators.len(),
+        builder.initial_committee.validators.len()
+    );
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]


### PR DESCRIPTION
Partial port of #6122

## Motivation

#6122 fixed an oversight in the original implementation on `testnet_conway`.

## Proposal

Apply the fix on `main`, too.

## Test Plan

A regression test was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- `testnet_conway` PR: #6122
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
