### PR TITLE
Increase timeout for test-crates-and-docrs job

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -59,7 +59,7 @@ jobs:
 
   test-crates-and-docrs:
     runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

Job is timing out at 60 minutes.

## Proposal

Increased timeout for the test-crates-and-docrs job from 60 to 90 minutes. 

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
