### PR TITLE
[testnet] Remove unused code, fix naming. (#6136)

### DIFF
--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -76,7 +76,7 @@ pub(crate) async fn update_linera_balance_metric<E: linera_core::environment::En
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn run(
     rpc_url: &str,
     faucet_url: Option<&str>,
@@ -277,7 +277,7 @@ pub async fn run(
     .await
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     chain_client: ChainClient<E>,
     rpc_url: &str,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::large_futures)]
+#![expect(clippy::large_futures)]
 
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -163,7 +163,7 @@ struct ListeningClient<C: ClientContext> {
 }
 
 impl<C: ClientContext + 'static> ListeningClient<C> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         client: ContextChainClient<C>,
         abort_handle: AbortOnDrop,

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -273,7 +273,7 @@ where
     // not worth refactoring this because
     // https://github.com/linera-io/linera-protocol/issues/5082
     // https://github.com/linera-io/linera-protocol/issues/5083
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub async fn new(
         storage: S,
         wallet: W,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -260,7 +260,7 @@ pub struct Client<Env: Environment> {
 impl<Env: Environment> Client<Env> {
     /// Creates a new `Client` with a new cache and notifiers.
     #[instrument(level = "trace", skip_all)]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         environment: Env,
         admin_chain_id: ChainId,

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -174,7 +174,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
     /// - `max_cache_size`: Maximum number of entries in the cache
     /// - `max_request_ttl`: Maximum latency for an in-flight request before we stop deduplicating it
     /// - `retry_delay_ms`: Delay in milliseconds between starting requests to different peers.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn with_config(
         nodes: impl IntoIterator<Item = RemoteNode<Env::ValidatorNode>>,
         weights: ScoringWeights,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -359,7 +359,7 @@ pub struct CertificatesByHeightRequest {
 pub(crate) struct CompressedHeights<'a>(pub(crate) &'a [BlockHeight]);
 
 /// Formats a `Vec<BlockHeight>` as compressed ranges for use with `#[debug(with = "...")]`.
-#[allow(clippy::ptr_arg)]
+#[expect(clippy::ptr_arg)]
 pub(crate) fn debug_compressed_heights(
     heights: &Vec<BlockHeight>,
     f: &mut fmt::Formatter<'_>,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -10,7 +10,7 @@
 // because they are slow and their behavior appears to be correctly check by the
 // test with memory.
 
-#![allow(clippy::large_futures)]
+#![expect(clippy::large_futures)]
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -41,8 +41,8 @@ use linera_chain::{
 use linera_execution::{
     committee::Committee,
     system::{
-        AdminOperation, OpenChainConfig, SystemMessage, SystemOperation,
-        EPOCH_STREAM_NAME as NEW_EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
+        AdminOperation, OpenChainConfig, SystemMessage, SystemOperation, EPOCH_STREAM_NAME,
+        REMOVED_EPOCH_STREAM_NAME,
     },
     test_utils::{
         dummy_chain_description, ExpectedCall, RegisterMockApplication, SystemExecutionState,
@@ -2793,7 +2793,7 @@ where
     ]);
     let event_id = EventId {
         chain_id: admin_chain_id,
-        stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+        stream_id: StreamId::system(EPOCH_STREAM_NAME),
         index: 1,
     };
     let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
@@ -2905,7 +2905,7 @@ where
                     OracleResponse::Event(
                         EventId {
                             chain_id: admin_chain_id,
-                            stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+                            stream_id: StreamId::system(EPOCH_STREAM_NAME),
                             index: 1,
                         },
                         bcs::to_bytes(&blob_hash).unwrap(),
@@ -3018,7 +3018,7 @@ where
                 previous_message_blocks: BTreeMap::new(),
                 previous_event_blocks: BTreeMap::new(),
                 events: vec![vec![Event {
-                    stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+                    stream_id: StreamId::system(EPOCH_STREAM_NAME),
                     index: 1,
                     value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
                 }]],
@@ -3140,7 +3140,7 @@ where
             previous_event_blocks: BTreeMap::new(),
             events: vec![
                 vec![Event {
-                    stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+                    stream_id: StreamId::system(EPOCH_STREAM_NAME),
                     index: 1,
                     value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
                 }],
@@ -3265,11 +3265,11 @@ where
             messages: vec![Vec::new()],
             previous_message_blocks: BTreeMap::new(),
             previous_event_blocks: BTreeMap::from([(
-                StreamId::system(NEW_EPOCH_STREAM_NAME),
+                StreamId::system(EPOCH_STREAM_NAME),
                 (certificate1.hash(), BlockHeight(0)),
             )]),
             events: vec![vec![Event {
-                stream_id: StreamId::system(NEW_EPOCH_STREAM_NAME),
+                stream_id: StreamId::system(EPOCH_STREAM_NAME),
                 index: 2,
                 value: bcs::to_bytes(&committee_blob.id().hash).unwrap(),
             }]],

--- a/linera-ethereum/src/test_utils/mod.rs
+++ b/linera-ethereum/src/test_utils/mod.rs
@@ -36,7 +36,7 @@ sol!(
     "./contracts/EventNumerics.json"
 );
 
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 #[derive(Clone)]
 pub struct EthereumClient {
     pub provider: FillProvider<

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::field_reassign_with_default)]
-
 use std::{collections::BTreeMap, vec};
 
 use assert_matches::assert_matches;

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::field_reassign_with_default)]
-
 use linera_base::{
     crypto::AccountSecretKey,
     data_types::{Amount, BlockHeight, Timestamp},

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -1155,7 +1155,7 @@ pub enum DatabaseToolCommand {
     ListChainIds,
 }
 
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 #[derive(Clone, clap::Parser)]
 pub enum NetCommand {
     /// Start a Local Linera Network

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -496,7 +496,7 @@ impl ClientWrapper {
     }
 
     /// Runs `linera service` with all available options.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub async fn run_node_service_with_all_options(
         &self,
         port: impl Into<Option<u16>>,

--- a/linera-service/src/controller.rs
+++ b/linera-service/src/controller.rs
@@ -54,7 +54,7 @@ where
     Ctx::Environment: 'static,
     <Ctx::Environment as linera_core::Environment>::Storage: Clone,
 {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         chain_id: ChainId,
         controller_id: ApplicationId,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1091,30 +1091,24 @@ impl QueryResponseCache {
 
     /// Looks up a cached response. Returns `Some(bytes)` on hit, `None` on miss
     /// (including when the chain has no cache entry yet).
-    #[allow(clippy::question_mark)]
     fn get(&self, chain_id: ChainId, app_id: &ApplicationId, request: &[u8]) -> Option<Vec<u8>> {
         let pinned = self.chains.pin();
-        let Some(mutex) = pinned.get(&chain_id) else {
-            #[cfg(with_metrics)]
-            query_cache_metrics::QUERY_CACHE_MISS
-                .with_label_values(&[])
-                .inc();
-            return None;
-        };
-        let mut cache = mutex.lock().expect("LRU mutex poisoned");
-        let key = (*app_id, request.to_vec());
-        let result = cache.lru.get(&key).cloned();
+        let result = pinned.get(&chain_id).and_then(|mutex| {
+            mutex
+                .lock()
+                .expect("LRU mutex poisoned")
+                .lru
+                .get(&(*app_id, request.to_vec()))
+                .cloned()
+        });
         #[cfg(with_metrics)]
         {
-            if result.is_some() {
-                query_cache_metrics::QUERY_CACHE_HIT
-                    .with_label_values(&[])
-                    .inc();
+            let metric = if result.is_some() {
+                &query_cache_metrics::QUERY_CACHE_HIT
             } else {
-                query_cache_metrics::QUERY_CACHE_MISS
-                    .with_label_values(&[])
-                    .inc();
-            }
+                &query_cache_metrics::QUERY_CACHE_MISS
+            };
+            metric.with_label_values(&[]).inc();
         }
         result
     }
@@ -1256,7 +1250,7 @@ where
     /// `query_cache_size` controls the per-chain LRU cache capacity for application query
     /// responses. Pass `None` to disable the cache (the default). Enable with
     /// `--query-cache-size <N>`. Incompatible with `--long-lived-services`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         config: ChainListenerConfig,
         port: NonZeroU16,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -252,7 +252,7 @@ fn get_block_keys() -> Vec<Vec<u8>> {
 }
 
 #[derive(Default)]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub(crate) struct MultiPartitionBatch {
     keys_value_bytes: Vec<(Vec<u8>, Vec<(Vec<u8>, Vec<u8>)>)>,
 }
@@ -1041,14 +1041,10 @@ impl Clock for WallClock {
         Timestamp::now()
     }
 
-    async fn sleep(&self, delta: TimeDelta) {
-        linera_base::time::timer::sleep(delta.as_duration()).await
-    }
-
     async fn sleep_until(&self, timestamp: Timestamp) {
         let delta = timestamp.delta_since(Timestamp::now());
         if delta > TimeDelta::ZERO {
-            self.sleep(delta).await
+            linera_base::time::timer::sleep(delta.as_duration()).await
         }
     }
 }
@@ -1072,11 +1068,6 @@ impl TestClockInner {
             // Receiver may have been dropped if the sleep was cancelled.
             sender.send(()).ok();
         }
-    }
-
-    fn add_sleep(&mut self, delta: TimeDelta) -> Receiver<()> {
-        let target_time = self.time.saturating_add(delta);
-        self.add_sleep_until(target_time)
     }
 
     fn add_sleep_until(&mut self, time: Timestamp) -> Receiver<()> {
@@ -1112,15 +1103,6 @@ pub struct TestClock(Arc<std::sync::Mutex<TestClockInner>>);
 impl Clock for TestClock {
     fn current_time(&self) -> Timestamp {
         self.lock().time
-    }
-
-    async fn sleep(&self, delta: TimeDelta) {
-        if delta == TimeDelta::ZERO {
-            return;
-        }
-        let receiver = self.lock().add_sleep(delta);
-        // Sender may have been dropped if the clock was dropped; just stop waiting.
-        receiver.await.ok();
     }
 
     async fn sleep_until(&self, timestamp: Timestamp) {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{
         ApplicationDescription, Blob, BlockHeight, ChainDescription, CompressedBytecode, Epoch,
-        NetworkDescription, TimeDelta, Timestamp,
+        NetworkDescription, Timestamp,
     },
     identifiers::{ApplicationId, BlobId, BlobType, ChainId, EventId, IndexAndEvent, StreamId},
     vm::VmRuntime,
@@ -570,8 +570,6 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
 #[cfg_attr(web, async_trait(?Send))]
 pub trait Clock {
     fn current_time(&self) -> Timestamp;
-
-    async fn sleep(&self, delta: TimeDelta);
 
     async fn sleep_until(&self, timestamp: Timestamp);
 }

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -546,11 +546,10 @@ mod tests {
     // The key splitting means that when a key is overwritten
     // some previous segments may still be present.
     #[tokio::test]
-    #[expect(clippy::assertions_on_constants)]
     async fn test_value_splitting1_testing_leftovers() {
         let store = LimitedTestMemoryStore::new();
         const MAX_LEN: usize = LimitedTestMemoryStore::MAX_VALUE_SIZE;
-        assert!(MAX_LEN > 10);
+        const _: () = assert!(MAX_LEN > 10);
         let big_store = ValueSplittingStore::new(store.clone());
         let key = vec![0, 0];
         // Write a key with a long value

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -17,7 +17,7 @@ key directly in memory and uses it to sign.
 
 // We sometimes need functions in this module to be async in order to
 // ensure the generated code will return a `Promise`.
-#![allow(clippy::unused_async)]
+#![expect(clippy::unused_async)]
 #![recursion_limit = "256"]
 
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
Backport of #6136.

## Motivation

* A constant is imported with an alias for no reason.
* `Clock::sleep` and `Block::outcome_matches` are unused.
* `#[allow(…)]` attributes don't alert us if they're unneeded.

## Proposal

* Import `EPOCH_STREAM_NAME` without an alias.
* Remove unused code.
* Use `#[expect(…)]`; remove it if it fails.

## Test Plan

CI

## Release Plan

- Nothing to do.

## Links

- PR to `main`: #6136
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
