### PR TITLE
Build release binaries on host for Docker Compose CI to avoid in-container OOM

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -43,6 +43,10 @@ jobs:
         with:
           version: "34.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install libunwind-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libunwind-dev
       # TODO(#2709): Uncomment once this workflow runs in a custom runner
       # - name: Update aio-max-nr
       # run: echo 1048576 > /proc/sys/fs/aio-max-nr

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -48,13 +48,20 @@ jobs:
       # run: echo 1048576 > /proc/sys/fs/aio-max-nr
       - name: Build client binary
         run: |
-          cargo install --path linera-service --bin linera --bin linera-server --debug --locked
+          cargo install --path linera-service \
+            --bin linera --bin linera-proxy --bin linera-server \
+            --features scylladb,metrics,jemalloc --locked
+          mkdir -p docker/binaries
+          cp target/release/linera target/release/linera-proxy target/release/linera-server docker/binaries/
       # TODO(#2709): Remove this step once this workflow runs in a custom runner
       - name: Patch Docker compose file to run ScyllaDB in developer mode
         run: |
           sed -i -e '/SCYLLA_AUTO_CONF/{N;s/command:/  SCYLLA_ENABLE_EXPERIMENTAL: 1/p;N;N;N;N;d}' \
             docker/docker-compose.yml
       - name: Run Compose
+        env:
+          DOCKER_BUILDKIT: 1
+          LINERA_BINARIES: docker/binaries
         run: |
           cd docker
           ./ci-compose.sh

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -69,6 +69,14 @@ jobs:
         run: |
           cd docker
           ./ci-compose.sh
+      - name: Dump compose logs on failure
+        if: failure()
+        run: |
+          cd docker
+          docker compose ps -a || true
+          docker compose logs --no-color --tail=200 || true
+          echo "--- shard-init binary inspection ---"
+          docker compose run --rm --entrypoint sh shard-init -c "ldd ./linera 2>&1 | head -20; echo ---; ./linera --version 2>&1 || echo \"linera exec failed: \$?\"" || true
       # TODO(#2709): Uncomment once this workflow runs in a custom runner
       # - name: Setup upterm session
       # uses: lhotari/action-upterm@v1

--- a/docker/ci-compose.sh
+++ b/docker/ci-compose.sh
@@ -36,12 +36,17 @@ cd "$ROOT_DIR"
 
 GIT_COMMIT=$(git rev-parse --short HEAD)
 
+DOCKER_BUILD_ARGS=(--build-arg "git_commit=$GIT_COMMIT")
+if [ -n "${LINERA_BINARIES:-}" ]; then
+    DOCKER_BUILD_ARGS+=(--build-arg "binaries=$LINERA_BINARIES")
+fi
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera || exit 1
+    docker build "${DOCKER_BUILD_ARGS[@]}" -f docker/Dockerfile . -t linera || exit 1
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
     if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera . || exit 1
+        docker build "${DOCKER_BUILD_ARGS[@]}" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera . || exit 1
     else
         echo "Unsupported Architecture: $CPU_ARCH"
         exit 1


### PR DESCRIPTION
## Motivation

The Docker Compose CI workflow OOM-kills `rustc` during thin-LTO linking when the Dockerfile rebuilds release binaries from scratch inside the DinD container on `linera-io-self-hosted-ci`. The runner host has 64 GB of RAM, but the DinD container is memory-limited and a `cargo build --release` of `linera-server` with thin-LTO does not fit. Closes #5909.

The workflow today also wastes work: step `Build client binary` already runs a `cargo install --debug` on the host before `docker build` discards it and recompiles in release inside the container.

Evidence: runs [23879379363](https://github.com/linera-io/linera-protocol/actions/runs/23879379363) and [23867309806](https://github.com/linera-io/linera-protocol/actions/runs/23867309806) — `rustc` killed at ~664s and ~617s during LTO linking.

## Proposal

Use the existing `binaries` build-arg in `docker/Dockerfile` to skip the in-container compilation entirely:

- `.github/workflows/docker-compose.yml`: in step `Build client binary`, drop `--debug`, add `--bin linera-proxy` and `--features scylladb,metrics,jemalloc` so the host build matches the Dockerfile, then stage the three binaries from `target/release/` into `docker/binaries/` (the docker build context, since `target/` is in `.dockerignore`). On the `Run Compose` step, set `LINERA_BINARIES=docker/binaries` and `DOCKER_BUILDKIT=1` (the latter matches the convention in `build_image.yml` and `docker_image.yml` and ensures BuildKit prunes the unused `builder` stage out of the build graph; classic builder would still execute it and re-OOM).
- `docker/ci-compose.sh`: when `LINERA_BINARIES` is set, pass `--build-arg binaries=$LINERA_BINARIES` to `docker build`. Default (local dev) behavior is byte-for-byte unchanged — running `./ci-compose.sh` with no env var still triggers the in-container build.

Net CI work: one release build on the host instead of debug-host + release-LTO-DinD, so this should be strictly faster than the path we last saw pass, not just unstuck.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- Closes #5909
- Prior art: #5984 — same OOM class on a different workflow, addressed by routing to a runner pool with more DinD memory.
