### PR TITLE
[testnet_conway] Build release binaries on host for Docker Compose CI to avoid in-container OOM

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -54,13 +54,20 @@ jobs:
         # run: echo 1048576 > /proc/sys/fs/aio-max-nr
       - name: Build client binary
         run: |
-          cargo install --path linera-service --bin linera --bin linera-server --debug --locked
+          cargo install --path linera-service \
+            --bin linera --bin linera-proxy --bin linera-server \
+            --features scylladb,metrics,jemalloc --locked
+          mkdir -p docker/binaries
+          cp target/release/linera target/release/linera-proxy target/release/linera-server docker/binaries/
       # TODO(#2709): Remove this step once this workflow runs in a custom runner
       - name: Patch Docker compose file to run ScyllaDB in developer mode
         run: |
           sed -i -e '/SCYLLA_AUTO_CONF/{N;s/command:/  SCYLLA_ENABLE_EXPERIMENTAL: 1/p;N;N;N;N;d}' \
             docker/docker-compose.yml
       - name: Run Compose
+        env:
+          DOCKER_BUILDKIT: 1
+          LINERA_BINARIES: docker/binaries
         run: |
           cd docker
           ./compose.sh

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -36,12 +36,17 @@ cd "$ROOT_DIR"
 
 GIT_COMMIT=$(git rev-parse --short HEAD)
 
+DOCKER_BUILD_ARGS=(--build-arg "git_commit=$GIT_COMMIT")
+if [ -n "${LINERA_BINARIES:-}" ]; then
+    DOCKER_BUILD_ARGS+=(--build-arg "binaries=$LINERA_BINARIES")
+fi
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera || exit 1
+    docker build "${DOCKER_BUILD_ARGS[@]}" -f docker/Dockerfile . -t linera || exit 1
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
     if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera . || exit 1
+        docker build "${DOCKER_BUILD_ARGS[@]}" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera . || exit 1
     else
         echo "Unsupported Architecture: $CPU_ARCH"
         exit 1


### PR DESCRIPTION
## Motivation

Backport of #6138 to `testnet_conway`. The Docker Compose CI workflow OOM-kills `rustc` during thin-LTO linking when the Dockerfile rebuilds release binaries from scratch inside the DinD container on `linera-io-self-hosted-ci`. Closes #5909 on this branch.

The workflow today also wastes work: step `Build client binary` already runs a `cargo install --debug` on the host before `docker build` discards it and recompiles in release inside the container.

## Proposal

Same shape as #6138, adapted for this branch (the script is named `docker/compose.sh` here rather than `docker/ci-compose.sh`):

- `.github/workflows/docker-compose.yml`: in step `Build client binary`, drop `--debug`, add `--bin linera-proxy` and `--features scylladb,metrics,jemalloc` so the host build matches the Dockerfile, then stage the three binaries from `target/release/` into `docker/binaries/`. On the `Run Compose` step, set `LINERA_BINARIES=docker/binaries` and `DOCKER_BUILDKIT=1` so BuildKit prunes the unused `builder` stage.
- `docker/compose.sh`: when `LINERA_BINARIES` is set, pass `--build-arg binaries=$LINERA_BINARIES` to `docker build`. Default (local dev) behavior is byte-for-byte unchanged.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- Forward-port: #6138
- Closes #5909
