### PR TITLE
Add test of coherence of execution outcome.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -587,6 +587,28 @@ impl Block {
             && *previous_block_hash == self.header.previous_block_hash
     }
 
+    /// Returns whether the block's execution produced the given outcome.
+    pub fn outcome_matches(&self, expected: &BlockExecutionOutcome) -> bool {
+        let BlockExecutionOutcome {
+            state_hash,
+            messages,
+            previous_message_blocks,
+            previous_event_blocks,
+            oracle_responses,
+            events,
+            blobs,
+            operation_results,
+        } = expected;
+        self.header.state_hash == *state_hash
+            && self.body.messages == *messages
+            && self.body.previous_message_blocks == *previous_message_blocks
+            && self.body.previous_event_blocks == *previous_event_blocks
+            && self.body.oracle_responses == *oracle_responses
+            && self.body.events == *events
+            && self.body.blobs == *blobs
+            && self.body.operation_results == *operation_results
+    }
+
     pub fn into_proposal(self) -> (ProposedBlock, BlockExecutionOutcome) {
         let proposed_block = ProposedBlock {
             chain_id: self.header.chain_id,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -328,6 +328,12 @@ pub enum Error {
          The committed certificate hash is {0}"
     )]
     Conflict(CryptoHash),
+
+    #[error(
+        "Execution outcome mismatch: AutoRetry and committed execution produced \
+         different outcomes for the same block"
+    )]
+    ExecutionOutcomeMismatch,
 }
 
 impl From<Infallible> for Error {
@@ -1508,10 +1514,11 @@ impl<Env: Environment> ChainClient<Env> {
                 skipped.insert(origin);
             }
         }
-        let (proposed_block, _) = block.clone().into_proposal();
+        let (proposed_block, auto_retry_outcome) = block.clone().into_proposal();
         *proposal_guard = Some(PendingProposal {
             block: proposed_block,
             blobs,
+            auto_retry_outcome: Some(auto_retry_outcome),
         });
         Ok(block)
     }
@@ -1930,6 +1937,7 @@ impl<Env: Environment> ChainClient<Env> {
             // Otherwise we are free to propose our own pending block.
             let proposed_block = pending.block.clone();
             let blobs = pending.blobs.clone();
+            let auto_retry_outcome = pending.auto_retry_outcome.clone();
             let round = self.round_for_oracle(&info, &owner).await?;
             let (block, _, _) = self
                 .client
@@ -1940,6 +1948,16 @@ impl<Env: Environment> ChainClient<Env> {
                     BundleExecutionPolicy::committed(),
                 )
                 .await?;
+            // Sanity check: the committed execution should produce the same outcome
+            // as the initial AutoRetry execution. A mismatch indicates a fuel
+            // accounting divergence between the two execution paths.
+            if let Some(auto_retry_outcome) = auto_retry_outcome {
+                let (_, committed_outcome) = block.clone().into_proposal();
+                ensure!(
+                    auto_retry_outcome == committed_outcome,
+                    Error::ExecutionOutcomeMismatch
+                );
+            }
             debug!("Proposing the local pending block.");
             (block, blobs)
         } else {

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1937,7 +1937,7 @@ impl<Env: Environment> ChainClient<Env> {
             // Otherwise we are free to propose our own pending block.
             let proposed_block = pending.block.clone();
             let blobs = pending.blobs.clone();
-            let auto_retry_outcome = pending.auto_retry_outcome.as_ref();
+            let staging_outcome = pending.auto_retry_outcome.as_ref();
             let round = self.round_for_oracle(&info, &owner).await?;
             let (block, _, _) = self
                 .client
@@ -1951,9 +1951,9 @@ impl<Env: Environment> ChainClient<Env> {
             // Sanity check: the committed execution should produce the same outcome
             // as the initial AutoRetry execution. A mismatch indicates a divergence
             // between the two execution paths.
-            if let Some(auto_retry_outcome) = auto_retry_outcome {
+            if let Some(staging_outcome) = staging_outcome {
                 ensure!(
-                    block.outcome_matches(auto_retry_outcome),
+                    block.outcome_matches(staging_outcome),
                     Error::ExecutionOutcomeMismatch
                 );
             }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1949,12 +1949,11 @@ impl<Env: Environment> ChainClient<Env> {
                 )
                 .await?;
             // Sanity check: the committed execution should produce the same outcome
-            // as the initial AutoRetry execution. A mismatch indicates a fuel
-            // accounting divergence between the two execution paths.
+            // as the initial AutoRetry execution. A mismatch indicates a divergence
+            // between the two execution paths.
             if let Some(auto_retry_outcome) = auto_retry_outcome {
-                let (_, committed_outcome) = block.clone().into_proposal();
                 ensure!(
-                    *auto_retry_outcome == committed_outcome,
+                    block.outcome_matches(auto_retry_outcome),
                     Error::ExecutionOutcomeMismatch
                 );
             }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1937,7 +1937,7 @@ impl<Env: Environment> ChainClient<Env> {
             // Otherwise we are free to propose our own pending block.
             let proposed_block = pending.block.clone();
             let blobs = pending.blobs.clone();
-            let auto_retry_outcome = pending.auto_retry_outcome.clone();
+            let auto_retry_outcome = pending.auto_retry_outcome.as_ref();
             let round = self.round_for_oracle(&info, &owner).await?;
             let (block, _, _) = self
                 .client
@@ -1954,7 +1954,7 @@ impl<Env: Environment> ChainClient<Env> {
             if let Some(auto_retry_outcome) = auto_retry_outcome {
                 let (_, committed_outcome) = block.clone().into_proposal();
                 ensure!(
-                    auto_retry_outcome == committed_outcome,
+                    *auto_retry_outcome == committed_outcome,
                     Error::ExecutionOutcomeMismatch
                 );
             }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -28,7 +28,10 @@ use linera_base::{
 #[cfg(not(target_arch = "wasm32"))]
 use linera_base::{data_types::Bytecode, identifiers::ModuleId, vm::VmRuntime};
 use linera_chain::{
-    data_types::{BlockProposal, BundleExecutionPolicy, ChainAndHeight, LiteVote, ProposedBlock},
+    data_types::{
+        BlockExecutionOutcome, BlockProposal, BundleExecutionPolicy, ChainAndHeight, LiteVote,
+        ProposedBlock,
+    },
     manager::LockingBlock,
     types::{
         Block, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
@@ -2054,6 +2057,10 @@ impl Drop for AbortOnDrop {
 pub struct PendingProposal {
     pub block: ProposedBlock,
     pub blobs: Vec<Blob>,
+    /// The execution outcome from the AutoRetry execution, used as a sanity check
+    /// against the committed execution outcome.
+    #[serde(default)]
+    pub auto_retry_outcome: Option<BlockExecutionOutcome>,
 }
 
 enum ReceiveCertificateMode {

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -129,6 +129,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
                         previous_block_hash: None,
                     },
                     blobs: vec![Blob::new_data(b"blob".to_vec())],
+                    auto_retry_outcome: None,
                 }),
                 ..admin_description.into()
             },


### PR DESCRIPTION
## Motivation

The client works by executing the proposal twice: Once with all `IncomingBundle`  and another one with the failing `IncomingBundle`s marked as rejected.
We did not check whether that was coherent.

## Proposal

Add a simple check for the coherence of the outcome of both executions.

## Test Plan

CI

The scenario that this test intends to catch should not occur in `main` but did occur in other work on Block execution.

## Release Plan

This could be backported to `testnet_conway`.

## Links

None