### PR TITLE
Skip Rust CI on docs-only changes

### DIFF
--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -27,8 +27,31 @@ permissions:
   contents: read
 
 jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.files-changed.outputs.paths }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Filter paths
+        uses: dorny/paths-filter@v3
+        id: files-changed
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            paths:
+              - '!docker/**'
+              - '!configuration/**'
+              - '!kubernetes/**'
+              - '!docs/**'
+              - '!mdbook/**'
+              - '!CONTRIBUTING.md'
+              - '!INSTALL.md'
+              - '!README.md'
+
   check-all-features-partition:
-    if: github.event_name != 'pull_request'
+    needs: changed-files
+    if: github.event_name != 'pull_request' && needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,8 +52,11 @@ jobs:
               - '!docker/**'
               - '!configuration/**'
               - '!kubernetes/**'
+              - '!docs/**'
+              - '!mdbook/**'
               - '!CONTRIBUTING.md'
               - '!INSTALL.md'
+              - '!README.md'
   changed-files-kubernetes:
     runs-on: ubuntu-latest
     outputs:
@@ -68,8 +71,11 @@ jobs:
           filters: |
             paths:
               - '!configuration/**'
+              - '!docs/**'
+              - '!mdbook/**'
               - '!CONTRIBUTING.md'
               - '!INSTALL.md'
+              - '!README.md'
   execution-wasmtime-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'


### PR DESCRIPTION
## Motivation

The `changed-files` path filter in `rust.yml` excludes `docker/**`, `configuration/**`, `kubernetes/**`, `CONTRIBUTING.md`, and `INSTALL.md`, but does not exclude pure-docs paths. So a PR that only touches `README.md`, `docs/`, or the `mdbook/` book source still spins up the entire Rust matrix on `ubuntu-latest` (and self-hosted) for ~25-30 minutes of critical-path CI.

`lint-check-all-features.yml` has no path filtering at all, so the 6 partitions also run on docs-only changes.

## Proposal

Two changes, both purely additive to existing path filters:

1. Extend the existing `changed-files` and `changed-files-kubernetes` exclusion lists in `rust.yml` to add `docs/**`, `mdbook/**`, and `README.md`. Verified by listing the repo: `docs/` contains only `.md`, `.png`, `.svg`, `.txt` files plus release-version metadata, and `mdbook/` contains only `book.toml`, theme assets, and JS, with zero `.rs` files.
2. Add a matching `changed-files` job to `lint-check-all-features.yml` and gate `check-all-features-partition` on it. The `lint-check-all-features` summary job already uses `if: always()` and treats `skipped` as success, so a docs-only run still produces a green required check.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)