### PR TITLE
linera-service: remove noisy OTLP fallback warning at CLI startup

### DIFF
--- a/linera-service/src/tracing/opentelemetry.rs
+++ b/linera-service/src/tracing/opentelemetry.rs
@@ -133,11 +133,6 @@ pub fn init(log_name: &str, otlp_endpoint: Option<&str>) {
             Ok(ep) if !ep.is_empty() => ep,
             _ => {
                 crate::tracing::init(log_name);
-                tracing::warn!(
-                    "LINERA_OTLP_EXPORTER_ENDPOINT not set and no endpoint provided. \
-                     Falling back to standard tracing without OpenTelemetry span export. \
-                     Baggage propagation is still enabled."
-                );
                 return;
             }
         },


### PR DESCRIPTION
## Motivation

The `linera` CLI calls `init_with_opentelemetry()` unconditionally on startup so the W3C `BaggagePropagator` and `TraceContextPropagator` are registered globally for traffic-type labeling, regardless of whether OTLP export is configured.

When `LINERA_OTLP_EXPORTER_ENDPOINT` is unset, the function silently falls back to plain tracing init — but also emits a `WARN` line:

> LINERA_OTLP_EXPORTER_ENDPOINT not set and no endpoint provided. Falling back to standard tracing without OpenTelemetry span export. Baggage propagation is still enabled.

This is the expected path in dev, in tests, and in CI runs that do not deploy OTLP. The warning carries no actionable signal and floods every CLI invocation. End-to-end tests that spawn `linera` thousands of times (notably `test_end_to_end_faucet_with_long_chains`) emit 2000+ of these per run, making it the dominant log line in the long_faucet_chain_test workflow.

## Proposal

Drop the `tracing::warn!` call in the no-endpoint branch. Behavior is unchanged: the propagator is still registered and plain tracing is still initialized.

Frontport of testnet_conway commit `9b2d3c97dd3` ("Remove noisy OTLP fallback warnings from startup", 2026-02-18). The two branches keep this code in different files (`linera-base/src/tracing_opentelemetry.rs` on testnet_conway vs `linera-service/src/tracing/opentelemetry.rs` on main), so the cherry-pick was applied manually. The removed block is structurally identical.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.