### PR TITLE
Backport gRPC metrics observability fixes (#6119 + #6120)

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -94,6 +94,14 @@ mod metrics {
         )
     });
 
+    pub static SERVER_REQUEST_CANCELLED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "server_request_cancelled",
+            "Server requests whose handler future was dropped before completion (e.g. client-side timeout / disconnect)",
+            &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
+        )
+    });
+
     pub static CROSS_CHAIN_MESSAGE_CHANNEL_FULL: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
             "cross_chain_message_channel_full",
@@ -283,6 +291,24 @@ impl GrpcServerHandle {
     }
 }
 
+#[cfg(with_metrics)]
+struct ServerRequestCancellationGuard {
+    method_name: String,
+    traffic_type: &'static str,
+    completed: bool,
+}
+
+#[cfg(with_metrics)]
+impl Drop for ServerRequestCancellationGuard {
+    fn drop(&mut self) {
+        if !self.completed {
+            metrics::SERVER_REQUEST_CANCELLED
+                .with_label_values(&[&self.method_name, self.traffic_type])
+                .inc();
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct GrpcPrometheusMetricsMiddlewareLayer;
 
@@ -330,14 +356,21 @@ where
 
         let future = self.service.call(request);
         async move {
+            #[cfg(with_metrics)]
+            let mut cancellation_guard = ServerRequestCancellationGuard {
+                method_name,
+                traffic_type,
+                completed: false,
+            };
             let response = future.await?;
             #[cfg(with_metrics)]
             {
+                cancellation_guard.completed = true;
                 metrics::SERVER_REQUEST_LATENCY
-                    .with_label_values(&[&method_name, traffic_type])
+                    .with_label_values(&[&cancellation_guard.method_name, traffic_type])
                     .observe(start.elapsed().as_secs_f64() * 1000.0);
                 metrics::SERVER_REQUEST_COUNT
-                    .with_label_values(&[&method_name, traffic_type])
+                    .with_label_values(&[&cancellation_guard.method_name, traffic_type])
                     .inc();
             }
             Ok(response)

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -66,7 +66,7 @@ mod metrics {
             "server_request_latency",
             "Server request latency",
             &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-            linear_bucket_interval(1.0, 25.0, 2000.0),
+            linear_bucket_interval(1.0, 50.0, 5000.0),
         )
     });
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -79,7 +79,7 @@ mod metrics {
             "proxy_request_latency",
             "Proxy request latency",
             &[METHOD_NAME_LABEL, TRAFFIC_TYPE_LABEL],
-            linear_bucket_interval(1.0, 50.0, 2000.0),
+            linear_bucket_interval(1.0, 50.0, 5000.0),
         )
     });
     pub static PROXY_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {


### PR DESCRIPTION
## Motivation

Backport of two gRPC metrics observability fixes from main into testnet_conway, so the same diagnostics are available on the live testnet validators:

- linera-io/linera-protocol#6119: raise gRPC latency histogram ceiling from 2s to 5s
- linera-io/linera-protocol#6120: record cancelled gRPC requests via Drop guard on server middleware

Both fixes are required to fully diagnose the timeout-storm pattern observed on testnet_conway 2026-04-18 (~40% of `PreviousEventBlocks` requests silently dropped from server-side metrics during timeout spikes; ~80% of those requests piled up in the `+Inf` latency bucket because the histogram capped at 2000ms).

## Proposal

Cherry-pick #6119 and #6120 onto testnet_conway. No conflicts; the diff is identical to the sum of the two main PRs.

- `linera-rpc/src/grpc/server.rs`: histogram ceiling 2s → 5s + new `server_request_cancelled` counter + Drop-based cancellation guard
- `linera-service/src/proxy/grpc.rs`: histogram ceiling 2s → 5s

## Test Plan

CI. Same plan as the original PRs — post-deploy on testnet_conway, validate that during a timeout storm `proxy_request_count` approximately equals `server_request_count + server_request_cancelled` per method.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Backports: linera-io/linera-protocol#6119, linera-io/linera-protocol#6120
