### PR TITLE
Push Arc deeper through certificate and block paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,11 +74,23 @@ Contributions should generally follow the [Rust API guidelines](https://rust-lan
 
 Any content-addressed immutable data (also known as hash-consed data) — for
 example `Block`, `Blob`, `ConfirmedBlockCertificate` — should be cached and
-passed around as `Arc<T>`. For the "one allocation per content" invariant to
-hold, you must always insert through the dedup cache (`linera-cache`'s
-`ValueCache`) and never `Arc::new` it off-path. See the
-[`linera-cache` README](linera-cache/README.md) for how the invariant is
-enforced.
+passed around as `Arc<T>`.
+
+**Never construct `Arc::new(value)` for a hash-consed type.** Always obtain
+the canonical `Arc<T>` from the dedup cache. Concretely:
+
+- For freshly-constructed `ConfirmedBlockCertificate`s (e.g. from network or
+  proposal flows), call `Storage::cache_certificate`.
+- For freshly-constructed `ConfirmedBlock`s, call
+  `Storage::cache_confirmed_block`.
+- For freshly-constructed `Blob`s, call `Storage::cache_blob`.
+- For values being re-inserted from a borrowed reference, use
+  `ValueCache::insert_hashed` or `ValueCache::insert_arc`.
+
+`Arc::new` for a hash-consed value bypasses the dedup index and creates a
+duplicate allocation, breaking the "one allocation per content" invariant.
+See the [`linera-cache` README](linera-cache/README.md) for how the
+invariant is enforced.
 
 
 ## Formatting and linting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,17 @@ Contributions should generally follow the [Rust API guidelines](https://rust-lan
   unawaited futures or unhandled errors. `let _x =` should only be used for RAII guards.
 
 
+## Hash-consed types and `Arc<T>`
+
+Any content-addressed immutable data (also known as hash-consed data) — for
+example `Block`, `Blob`, `ConfirmedBlockCertificate` — should be cached and
+passed around as `Arc<T>`. For the "one allocation per content" invariant to
+hold, you must always insert through the dedup cache (`linera-cache`'s
+`ValueCache`) and never `Arc::new` it off-path. See the
+[`linera-cache` README](linera-cache/README.md) for how the invariant is
+enforced.
+
+
 ## Formatting and linting
 
 Make sure to fix the lint errors reported by

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1383,6 +1383,12 @@ impl From<Blob> for BlobContent {
     }
 }
 
+impl From<Arc<Blob>> for BlobContent {
+    fn from(blob: Arc<Blob>) -> BlobContent {
+        blob.content().clone()
+    }
+}
+
 /// A blob of binary data, with its hash.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Allocative)]
 pub struct Blob {

--- a/linera-bridge/src/relay/linera.rs
+++ b/linera-bridge/src/relay/linera.rs
@@ -3,6 +3,8 @@
 
 //! Centralized Linera client for all bridge chain interactions.
 
+use std::sync::Arc;
+
 use anyhow::{Context as _, Result};
 use linera_base::{
     crypto::CryptoHash,
@@ -88,14 +90,17 @@ impl<E: linera_core::environment::Environment> LineraClient<E> {
     pub async fn read_confirmed_block(
         &self,
         hash: CryptoHash,
-    ) -> Result<linera_chain::block::ConfirmedBlock> {
+    ) -> Result<Arc<linera_chain::block::ConfirmedBlock>> {
         self.chain_client
             .read_confirmed_block(hash)
             .await
             .map_err(|e| anyhow::anyhow!(e))
     }
 
-    pub async fn read_certificate(&self, hash: CryptoHash) -> Result<ConfirmedBlockCertificate> {
+    pub async fn read_certificate(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Arc<ConfirmedBlockCertificate>> {
         self.chain_client
             .read_certificate(hash)
             .await

--- a/linera-cache/README.md
+++ b/linera-cache/README.md
@@ -2,6 +2,30 @@
 
 Caching utilities for the Linera protocol.
 
+## Hash-consing and the "one allocation per content" invariant
+
+[`ValueCache`] is the canonical home for content-addressed immutable data
+(also known as hash-consed data) such as `Block`, `Blob`, and
+`ConfirmedBlockCertificate`. For such types the cache guarantees that at
+most one allocation exists per distinct content at any time, and all
+consumers share the same `Arc<T>`.
+
+The guarantee is implemented by combining two structures:
+
+- A bounded `quick_cache` (S3-FIFO eviction) for hot-path lookups.
+- A lock-free `papaya::HashMap<K, Weak<V>>` weak index that survives bounded
+  eviction. If the bounded cache evicts an entry while a consumer still
+  holds an `Arc`, re-requesting the same key returns the existing
+  allocation instead of creating a duplicate.
+
+A background task periodically sweeps dead `Weak` entries from the index to
+prevent unbounded growth.
+
+For the invariant to hold, all inserts of hash-consed values must go
+through the cache (e.g. [`ValueCache::insert_hashed`] or
+[`ValueCache::insert_arc`]). Constructing an `Arc::new(value)` off-path
+creates a duplicate allocation that bypasses the dedup index.
+
 <!-- cargo-rdme end -->
 
 ## Contributing

--- a/linera-cache/src/lib.rs
+++ b/linera-cache/src/lib.rs
@@ -2,6 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Caching utilities for the Linera protocol.
+//!
+//! ## Hash-consing and the "one allocation per content" invariant
+//!
+//! [`ValueCache`] is the canonical home for content-addressed immutable data
+//! (also known as hash-consed data) such as `Block`, `Blob`, and
+//! `ConfirmedBlockCertificate`. For such types the cache guarantees that at
+//! most one allocation exists per distinct content at any time, and all
+//! consumers share the same `Arc<T>`.
+//!
+//! The guarantee is implemented by combining two structures:
+//!
+//! - A bounded `quick_cache` (S3-FIFO eviction) for hot-path lookups.
+//! - A lock-free `papaya::HashMap<K, Weak<V>>` weak index that survives bounded
+//!   eviction. If the bounded cache evicts an entry while a consumer still
+//!   holds an `Arc`, re-requesting the same key returns the existing
+//!   allocation instead of creating a duplicate.
+//!
+//! A background task periodically sweeps dead `Weak` entries from the index to
+//! prevent unbounded growth.
+//!
+//! For the invariant to hold, all inserts of hash-consed values must go
+//! through the cache (e.g. [`ValueCache::insert_hashed`] or
+//! [`ValueCache::insert_arc`]). Constructing an `Arc::new(value)` off-path
+//! creates a duplicate allocation that bypasses the dedup index.
 
 mod unique_value_cache;
 mod value_cache;

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -77,7 +77,6 @@ where
     }
 
     /// Inserts a pre-wrapped `Arc<V>` into the cache, returning the canonical `Arc`.
-    #[cfg(with_testing)]
     pub fn insert_arc(&self, key: &K, value: Arc<V>) -> Arc<V> {
         self.dedup_insert(key, value)
     }
@@ -204,14 +203,16 @@ where
     }
 }
 
-impl<T: Send + Sync + 'static> ValueCache<CryptoHash, Hashed<T>> {
-    /// Inserts a [`Hashed<T>`] into the cache, returning the canonical `Arc`.
+impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
+    /// Inserts a value constructed from a [`Hashed<T>`] into the cache, keyed
+    /// by its hash, returning the canonical `Arc<V>`.
     ///
     /// The `value` is wrapped in a [`Cow`] so that it is only cloned if it
     /// needs to be inserted in the cache.
-    pub fn insert_hashed(&self, value: Cow<Hashed<T>>) -> Arc<Hashed<T>>
+    pub fn insert_hashed<T>(&self, value: Cow<Hashed<T>>) -> Arc<V>
     where
         T: Clone,
+        V: From<Hashed<T>>,
     {
         let hash = (*value).hash();
         // Fast path: already in bounded cache
@@ -227,14 +228,15 @@ impl<T: Send + Sync + 'static> ValueCache<CryptoHash, Hashed<T>> {
             }
         }
         drop(guard);
-        self.dedup_insert(&hash, Arc::new(value.into_owned()))
+        self.dedup_insert(&hash, Arc::new(value.into_owned().into()))
     }
 
-    /// Inserts multiple [`Hashed<T>`]s into the cache.
+    /// Inserts multiple values constructed from [`Hashed<T>`]s into the cache.
     #[cfg(with_testing)]
-    pub fn insert_all_hashed<'a>(&self, values: impl IntoIterator<Item = Cow<'a, Hashed<T>>>)
+    pub fn insert_all_hashed<'a, T>(&self, values: impl IntoIterator<Item = Cow<'a, Hashed<T>>>)
     where
         T: Clone + 'a,
+        V: From<Hashed<T>>,
     {
         for value in values {
             self.insert_hashed(value);
@@ -284,6 +286,12 @@ mod tests {
 
     impl linera_base::crypto::BcsHashable<'_> for TestValue {}
 
+    impl From<Hashed<TestValue>> for TestValue {
+        fn from(value: Hashed<TestValue>) -> Self {
+            value.into_inner()
+        }
+    }
+
     fn create_test_value(n: u64) -> Hashed<TestValue> {
         Hashed::new(TestValue(n))
     }
@@ -292,7 +300,7 @@ mod tests {
         iter.into_iter().map(create_test_value).collect()
     }
 
-    fn new_hashed_cache(size: usize) -> ValueCache<CryptoHash, Hashed<TestValue>> {
+    fn new_hashed_cache(size: usize) -> ValueCache<CryptoHash, TestValue> {
         ValueCache::new(size, DEFAULT_CLEANUP_INTERVAL_SECS)
     }
 
@@ -317,7 +325,7 @@ mod tests {
 
         cache.insert_hashed(Cow::Borrowed(&value));
         assert!(cache.contains(&hash));
-        assert_eq!(cache.get(&hash).as_deref(), Some(&value));
+        assert_eq!(cache.get(&hash).as_deref(), Some(value.inner()));
     }
 
     #[test]
@@ -331,14 +339,14 @@ mod tests {
 
         for value in &values {
             assert!(cache.contains(&value.hash()));
-            assert_eq!(cache.get(&value.hash()).as_deref(), Some(value));
+            assert_eq!(cache.get(&value.hash()).as_deref(), Some(value.inner()));
         }
 
         // Batch insert
         let cache2 = new_hashed_cache(TEST_CACHE_SIZE);
         cache2.insert_all_hashed(values.iter().map(Cow::Borrowed));
         for value in &values {
-            assert_eq!(cache2.get(&value.hash()).as_deref(), Some(value));
+            assert_eq!(cache2.get(&value.hash()).as_deref(), Some(value.inner()));
         }
     }
 

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -154,6 +154,18 @@ impl ConfirmedBlock {
     }
 }
 
+impl From<Hashed<Block>> for ConfirmedBlock {
+    fn from(block: Hashed<Block>) -> Self {
+        Self::from_hashed(block)
+    }
+}
+
+impl From<Hashed<Block>> for ValidatedBlock {
+    fn from(block: Hashed<Block>) -> Self {
+        Self::from_hashed(block)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Allocative)]
 #[serde(transparent)]
 pub struct Timeout(Hashed<TimeoutInner>);

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -56,6 +56,12 @@ impl From<GenericCertificate<ConfirmedBlock>> for Certificate {
     }
 }
 
+impl From<&GenericCertificate<ConfirmedBlock>> for Certificate {
+    fn from(cert: &GenericCertificate<ConfirmedBlock>) -> Certificate {
+        Certificate::Confirmed(cert.clone())
+    }
+}
+
 impl Serialize for GenericCertificate<ConfirmedBlock> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -18,7 +18,6 @@ use linera_base::{
         ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round, Timestamp,
     },
     ensure,
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
 };
 use linera_cache::{UniqueValueCache, ValueCache};
@@ -106,7 +105,7 @@ where
     /// Wrapped in `Arc` so the keep-alive task can read it without acquiring
     /// the `RwLock`.
     last_access: Arc<AtomicTimestamp>,
-    block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+    block_values: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
     chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
@@ -150,7 +149,7 @@ where
     pub(crate) async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
-        block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+        block_values: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
         execution_state_cache: Option<
             Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>,
         >,
@@ -251,12 +250,16 @@ where
         chain_id = %self.chain_id(),
         blob_id = %blob_id
     ))]
-    pub(crate) async fn download_pending_blob(&self, blob_id: BlobId) -> Result<Blob, WorkerError> {
+    pub(crate) async fn download_pending_blob(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<Arc<Blob>, WorkerError> {
         if let Some(blob) = self.chain.manager.pending_blob(&blob_id).await? {
-            return Ok(blob);
+            return Ok(Arc::new(blob));
         }
-        let blob = self.storage.read_blob(blob_id).await?;
-        blob.map(Arc::unwrap_or_clone)
+        self.storage
+            .read_blob(blob_id)
+            .await?
             .ok_or(WorkerError::BlobsNotFound(vec![blob_id]))
     }
 
@@ -426,10 +429,8 @@ where
         let mut uncached_hashes = Vec::new();
 
         for (i, hash) in hashes.iter().enumerate() {
-            if let Some(hashed_block) = self.block_values.get(hash) {
-                blocks.push(Some(Arc::new(ConfirmedBlock::from_hashed(
-                    Arc::unwrap_or_clone(hashed_block),
-                ))));
+            if let Some(block) = self.block_values.get(hash) {
+                blocks.push(Some(block));
             } else {
                 blocks.push(None);
                 uncached_indices.push(i);
@@ -442,7 +443,7 @@ where
             for (i, maybe_block) in uncached_indices.into_iter().zip(from_storage) {
                 if let Some(block) = &maybe_block {
                     self.block_values
-                        .insert_hashed(Cow::Borrowed(block.inner()));
+                        .insert_arc(&block.inner().hash(), block.clone());
                 }
                 blocks[i] = maybe_block;
             }
@@ -1645,7 +1646,7 @@ where
     pub(crate) async fn read_certificate(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<ConfirmedBlockCertificate>, WorkerError> {
+    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, WorkerError> {
         let certificate_hash = match self.chain.confirmed_log.get(height.try_into()?).await? {
             Some(hash) => hash,
             None => return Ok(None),
@@ -1654,7 +1655,6 @@ where
             .storage
             .read_certificate(certificate_hash)
             .await?
-            .map(Arc::unwrap_or_clone)
             .ok_or_else(|| WorkerError::ReadCertificatesError(vec![certificate_hash]))?;
         Ok(Some(certificate))
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -255,7 +255,7 @@ where
         blob_id: BlobId,
     ) -> Result<Arc<Blob>, WorkerError> {
         if let Some(blob) = self.chain.manager.pending_blob(&blob_id).await? {
-            return Ok(Arc::new(blob));
+            return Ok(self.storage.cache_blob(blob));
         }
         self.storage
             .read_blob(blob_id)
@@ -441,10 +441,6 @@ where
         if !uncached_hashes.is_empty() {
             let from_storage = self.storage.read_confirmed_blocks(uncached_hashes).await?;
             for (i, maybe_block) in uncached_indices.into_iter().zip(from_storage) {
-                if let Some(block) = &maybe_block {
-                    self.block_values
-                        .insert_arc(&block.inner().hash(), block.clone());
-                }
                 blocks[i] = maybe_block;
             }
         }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2039,7 +2039,7 @@ impl<Env: Environment> ChainClient<Env> {
             "process_pending_block_without_prepare completing"
         );
         debug!(round = %certificate.round, "Sending confirmed block to validators");
-        let certificate = Arc::new(certificate);
+        let certificate = self.client.storage_client().cache_certificate(certificate);
         self.update_validators(Some(&committee), Some(certificate.clone()))
             .await?;
         // Clear the pending proposal now that the block has been committed.
@@ -2099,7 +2099,7 @@ impl<Env: Environment> ChainClient<Env> {
             .client
             .finalize_block(&committee, certificate.clone())
             .await?;
-        let certificate = Arc::new(certificate);
+        let certificate = self.client.storage_client().cache_certificate(certificate);
         self.update_validators(Some(&committee), Some(certificate.clone()))
             .await?;
         Ok(ClientOutcome::Committed(Some(Arc::unwrap_or_clone(
@@ -3208,7 +3208,7 @@ impl<Env: Environment> ChainClient<Env> {
         for certificate in certificates {
             match remote_node
                 .handle_confirmed_certificate(
-                    (*certificate).clone(),
+                    certificate.clone(),
                     CrossChainMessageDelivery::NonBlocking,
                 )
                 .await
@@ -3227,7 +3227,7 @@ impl<Env: Environment> ChainClient<Env> {
                     remote_node.upload_blobs(missing_blobs).await?;
                     remote_node
                         .handle_confirmed_certificate(
-                            Arc::unwrap_or_clone(certificate),
+                            certificate,
                             CrossChainMessageDelivery::NonBlocking,
                         )
                         .await?;

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -828,7 +828,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn update_validators(
         &self,
         old_committee: Option<&Committee>,
-        latest_certificate: Option<ConfirmedBlockCertificate>,
+        latest_certificate: Option<Arc<ConfirmedBlockCertificate>>,
     ) -> Result<(), Error> {
         let update_validators_start = linera_base::time::Instant::now();
         // Communicate the new certificate now.
@@ -853,7 +853,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn communicate_chain_updates(
         &self,
         committee: &Committee,
-        latest_certificate: Option<ConfirmedBlockCertificate>,
+        latest_certificate: Option<Arc<ConfirmedBlockCertificate>>,
     ) -> Result<(), Error> {
         let delivery = self.options.cross_chain_message_delivery;
         let height = self.chain_info().await?.next_block_height;
@@ -2039,11 +2039,14 @@ impl<Env: Environment> ChainClient<Env> {
             "process_pending_block_without_prepare completing"
         );
         debug!(round = %certificate.round, "Sending confirmed block to validators");
+        let certificate = Arc::new(certificate);
         self.update_validators(Some(&committee), Some(certificate.clone()))
             .await?;
         // Clear the pending proposal now that the block has been committed.
         *proposal_guard = None;
-        Ok(ClientOutcome::Committed(Some(certificate)))
+        Ok(ClientOutcome::Committed(Some(Arc::unwrap_or_clone(
+            certificate,
+        ))))
     }
 
     fn send_timing(&self, start: Instant, timing_type: TimingType) {
@@ -2096,9 +2099,12 @@ impl<Env: Environment> ChainClient<Env> {
             .client
             .finalize_block(&committee, certificate.clone())
             .await?;
+        let certificate = Arc::new(certificate);
         self.update_validators(Some(&committee), Some(certificate.clone()))
             .await?;
-        Ok(ClientOutcome::Committed(Some(certificate)))
+        Ok(ClientOutcome::Committed(Some(Arc::unwrap_or_clone(
+            certificate,
+        ))))
     }
 
     /// Returns the number for the round number oracle to use when staging a block proposal.
@@ -2690,14 +2696,14 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     #[instrument(level = "trace", skip(hash))]
-    pub async fn read_confirmed_block(&self, hash: CryptoHash) -> Result<ConfirmedBlock, Error> {
-        let block = self
-            .client
+    pub async fn read_confirmed_block(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Arc<ConfirmedBlock>, Error> {
+        self.client
             .storage_client()
             .read_confirmed_block(hash)
-            .await?;
-        block
-            .map(Arc::unwrap_or_clone)
+            .await?
             .ok_or(Error::MissingConfirmedBlock(hash))
     }
 
@@ -2705,10 +2711,11 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn read_certificate(
         &self,
         hash: CryptoHash,
-    ) -> Result<ConfirmedBlockCertificate, Error> {
-        let certificate = self.client.storage_client().read_certificate(hash).await?;
-        certificate
-            .map(Arc::unwrap_or_clone)
+    ) -> Result<Arc<ConfirmedBlockCertificate>, Error> {
+        self.client
+            .storage_client()
+            .read_certificate(hash)
+            .await?
             .ok_or(Error::ReadCertificatesError(vec![hash]))
     }
 
@@ -3196,13 +3203,12 @@ impl<Env: Environment> ChainClient<Env> {
             .await?
             .into_iter()
             .flatten()
-            .map(Arc::unwrap_or_clone)
             .collect::<Vec<_>>();
 
         for certificate in certificates {
             match remote_node
                 .handle_confirmed_certificate(
-                    certificate.clone(),
+                    (*certificate).clone(),
                     CrossChainMessageDelivery::NonBlocking,
                 )
                 .await
@@ -3217,12 +3223,11 @@ impl<Env: Environment> ChainClient<Env> {
                         .await?
                         .into_iter()
                         .flatten()
-                        .map(Arc::unwrap_or_clone)
                         .collect();
                     remote_node.upload_blobs(missing_blobs).await?;
                     remote_node
                         .handle_confirmed_certificate(
-                            certificate,
+                            Arc::unwrap_or_clone(certificate),
                             CrossChainMessageDelivery::NonBlocking,
                         )
                         .await?;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -757,7 +757,7 @@ impl<Env: Environment> Client<Env> {
                 Ok((certificates, unresolved, validator_key)) => {
                     for certificate in certificates {
                         let mode = ReceiveCertificateMode::AlreadyChecked;
-                        self.receive_sender_certificate(certificate, mode, None)
+                        self.receive_sender_certificate(Arc::new(certificate), mode, None)
                             .await?;
                     }
                     validators.retain(|node| node.public_key != validator_key);
@@ -916,7 +916,7 @@ impl<Env: Environment> Client<Env> {
     pub async fn get_chain_description_blob(
         &self,
         chain_id: ChainId,
-    ) -> Result<Blob, chain_client::Error> {
+    ) -> Result<Arc<Blob>, chain_client::Error> {
         let chain_desc_id = BlobId::new(chain_id.0, BlobType::ChainDescription);
         let blob = self
             .local_node
@@ -925,7 +925,7 @@ impl<Env: Environment> Client<Env> {
             .await?;
         if let Some(blob) = blob {
             // We have the blob - return it.
-            return Ok(Arc::unwrap_or_clone(blob));
+            return Ok(blob);
         }
         // Recover history from the current validators, according to the admin chain.
         self.synchronize_chain_state(self.admin_chain_id).await?;
@@ -1046,7 +1046,7 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
         height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
+        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
         let nodes = self.make_nodes(committee)?;
         communicate_with_quorum(
@@ -1163,7 +1163,7 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "trace", skip_all)]
     async fn receive_sender_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
         mode: ReceiveCertificateMode,
         nodes: Option<Vec<RemoteNode<Env::ValidatorNode>>>,
     ) -> Result<(), chain_client::Error> {
@@ -1178,11 +1178,12 @@ impl<Env: Environment> Client<Env> {
         } else {
             self.validator_nodes().await?
         };
-        if let Err(err) = self.handle_certificate(certificate.clone()).await {
+        if let Err(err) = self.handle_certificate((*certificate).clone()).await {
             match &err {
                 LocalNodeError::BlobsNotFound(blob_ids) => {
                     self.download_blobs(&nodes, blob_ids).await?;
-                    self.handle_certificate(certificate.clone()).await?;
+                    self.handle_certificate(Arc::unwrap_or_clone(certificate))
+                        .await?;
                 }
                 _ => {
                     // The certificate is not as expected. Give up.
@@ -1324,7 +1325,7 @@ impl<Env: Environment> Client<Env> {
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self
-                    .receive_sender_certificate(certificate, mode, None)
+                    .receive_sender_certificate(Arc::new(certificate), mode, None)
                     .await
                 {
                     warn!(%error, %hash, "Received invalid certificate");
@@ -1422,7 +1423,7 @@ impl<Env: Environment> Client<Env> {
                 .try_read_local_certificate(sender_chain_id, current_height, current_hash)
                 .await?
             {
-                Arc::unwrap_or_clone(local)
+                local
             } else {
                 let downloaded = self
                     .requests_scheduler
@@ -1438,7 +1439,7 @@ impl<Env: Environment> Client<Env> {
                         height: current_height,
                     });
                 };
-                certificate
+                Arc::new(certificate)
             };
 
             // Validate the certificate.
@@ -1521,7 +1522,7 @@ impl<Env: Environment> Client<Env> {
             let certificate = if let Some(certificate) =
                 self.storage_client().read_certificate(current_hash).await?
             {
-                Arc::unwrap_or_clone(certificate)
+                certificate
             } else {
                 let downloaded = self
                     .requests_scheduler
@@ -1540,7 +1541,7 @@ impl<Env: Environment> Client<Env> {
                 Client::<Env>::check_certificate(max_epoch, &committees, &certificate)?
                     .into_result()?;
 
-                certificate
+                Arc::new(certificate)
             };
 
             let block = certificate.block();
@@ -1895,7 +1896,7 @@ impl<Env: Environment> Client<Env> {
         &self,
         blob_ids: Vec<BlobId>,
         remote_nodes: &[RemoteNode<Env::ValidatorNode>],
-    ) -> Result<Vec<Blob>, chain_client::Error> {
+    ) -> Result<Vec<Arc<Blob>>, chain_client::Error> {
         let timeout = self.options.blob_download_timeout;
         // Deduplicate IDs.
         let blob_ids = blob_ids.into_iter().collect::<BTreeSet<_>>();
@@ -1908,7 +1909,7 @@ impl<Env: Environment> Client<Env> {
                         .download_certificate_for_blob(&remote_node, blob_id)
                         .await?;
                     self.receive_sender_certificate(
-                        certificate,
+                        Arc::new(certificate),
                         ReceiveCertificateMode::NeedsCheck,
                         Some(vec![remote_node.clone()]),
                     )
@@ -1918,7 +1919,6 @@ impl<Env: Environment> Client<Env> {
                         .storage_client()
                         .read_blob(blob_id)
                         .await?
-                        .map(Arc::unwrap_or_clone)
                         .ok_or_else(|| LocalNodeError::BlobsNotFound(vec![blob_id]))?;
                     Result::<_, chain_client::Error>::Ok(blob)
                 },

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -757,8 +757,12 @@ impl<Env: Environment> Client<Env> {
                 Ok((certificates, unresolved, validator_key)) => {
                     for certificate in certificates {
                         let mode = ReceiveCertificateMode::AlreadyChecked;
-                        self.receive_sender_certificate(Arc::new(certificate), mode, None)
-                            .await?;
+                        self.receive_sender_certificate(
+                            self.storage_client().cache_certificate(certificate),
+                            mode,
+                            None,
+                        )
+                        .await?;
                     }
                     validators.retain(|node| node.public_key != validator_key);
                     remaining_event_ids = unresolved;
@@ -1325,7 +1329,11 @@ impl<Env: Environment> Client<Env> {
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self
-                    .receive_sender_certificate(Arc::new(certificate), mode, None)
+                    .receive_sender_certificate(
+                        self.storage_client().cache_certificate(certificate),
+                        mode,
+                        None,
+                    )
                     .await
                 {
                     warn!(%error, %hash, "Received invalid certificate");
@@ -1439,7 +1447,7 @@ impl<Env: Environment> Client<Env> {
                         height: current_height,
                     });
                 };
-                Arc::new(certificate)
+                self.storage_client().cache_certificate(certificate)
             };
 
             // Validate the certificate.
@@ -1541,7 +1549,7 @@ impl<Env: Environment> Client<Env> {
                 Client::<Env>::check_certificate(max_epoch, &committees, &certificate)?
                     .into_result()?;
 
-                Arc::new(certificate)
+                self.storage_client().cache_certificate(certificate)
             };
 
             let block = certificate.block();
@@ -1909,7 +1917,7 @@ impl<Env: Environment> Client<Env> {
                         .download_certificate_for_blob(&remote_node, blob_id)
                         .await?;
                     self.receive_sender_certificate(
-                        Arc::new(certificate),
+                        self.storage_client().cache_certificate(certificate),
                         ReceiveCertificateMode::NeedsCheck,
                         Some(vec![remote_node.clone()]),
                     )

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -180,14 +180,9 @@ where
     pub async fn read_blobs_from_storage(
         &self,
         blob_ids: &[BlobId],
-    ) -> Result<Option<Vec<Blob>>, LocalNodeError> {
+    ) -> Result<Option<Vec<Arc<Blob>>>, LocalNodeError> {
         let storage = self.storage_client();
-        Ok(storage
-            .read_blobs(blob_ids)
-            .await?
-            .into_iter()
-            .map(|opt| opt.map(Arc::unwrap_or_clone))
-            .collect())
+        Ok(storage.read_blobs(blob_ids).await?.into_iter().collect())
     }
 
     /// Reads blob states from storage.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -76,7 +76,7 @@ pub trait ValidatorNode {
     /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -2,6 +2,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 #[cfg(not(web))]
 use futures::stream::BoxStream;
 #[cfg(web)]
@@ -115,7 +117,7 @@ pub trait ValidatorNode {
     // See also https://github.com/rust-lang/impl-trait-utils/issues/17
     fn upload_blobs(
         &self,
-        blobs: Vec<Blob>,
+        blobs: Vec<Arc<Blob>>,
     ) -> impl futures::Future<Output = Result<Vec<BlobId>, NodeError>> {
         let tasks: Vec<_> = blobs
             .into_iter()

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashSet, VecDeque};
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+};
 
 use custom_debug_derive::Debug;
 use futures::future::try_join_all;
@@ -64,7 +67,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     pub(crate) async fn handle_confirmed_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         let chain_id = certificate.inner().chain_id();
@@ -111,7 +114,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     pub(crate) async fn handle_optimized_confirmed_certificate(
         &self,
-        certificate: &ConfirmedBlockCertificate,
+        certificate: &Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         if let Some(result) = self.try_lite_certificate(certificate, delivery).await {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -562,7 +562,7 @@ where
             .download_pending_blob(chain_id, blob_id)
             .await
             .map_err(Into::into);
-        sender.send(result.map(|blob| blob.into_content()))
+        sender.send(result.map(|blob| blob.content().clone()))
     }
 
     async fn do_handle_pending_blob(
@@ -874,7 +874,7 @@ impl<S: Storage + Clone + Send + Sync + 'static> ChainClient<S> {
         &self,
         from: CryptoHash,
         limit: u32,
-    ) -> anyhow::Result<Vec<ConfirmedBlock>> {
+    ) -> anyhow::Result<Vec<Arc<ConfirmedBlock>>> {
         let mut hash = Some(from);
         let mut values = Vec::new();
         for _ in 0..limit {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -152,11 +152,11 @@ where
 
     async fn handle_confirmed_certificate(
         &self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, sender)
+            validator.do_handle_certificate(Arc::unwrap_or_clone(certificate), sender)
         })
         .await
     }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5070,16 +5070,9 @@ where
         .await;
 
     // Process all three blocks on chain_1.
-    env.worker()
-        .process_confirmed_block(cert_0.clone(), None)
-        .await?;
-    env.worker()
-        .process_confirmed_block(cert_1.clone(), None)
-        .await?;
-    let (_, actions, _) = env
-        .worker()
-        .process_confirmed_block(cert_2.clone(), None)
-        .await?;
+    env.worker().process_confirmed_block(cert_0, None).await?;
+    env.worker().process_confirmed_block(cert_1, None).await?;
+    let (_, actions, _) = env.worker().process_confirmed_block(cert_2, None).await?;
 
     // With chunk_limit=1, only the first chunk (height 0) should be returned.
     // The remaining heights stay in the outbox for delivery after confirmation.
@@ -5194,9 +5187,7 @@ where
     env.worker()
         .process_confirmed_block(cert_0.clone(), None)
         .await?;
-    env.worker()
-        .process_confirmed_block(cert_1.clone(), None)
-        .await?;
+    env.worker().process_confirmed_block(cert_1, None).await?;
     env.worker()
         .process_confirmed_block(cert_2.clone(), None)
         .await?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -248,7 +248,7 @@ where
     )]
     async fn send_confirmed_certificate(
         &mut self,
-        certificate: &GenericCertificate<ConfirmedBlock>,
+        certificate: &Arc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -248,12 +248,12 @@ where
     )]
     async fn send_confirmed_certificate(
         &mut self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: &GenericCertificate<ConfirmedBlock>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self
             .remote_node
-            .handle_optimized_confirmed_certificate(&certificate, delivery)
+            .handle_optimized_confirmed_certificate(certificate, delivery)
             .await;
 
         let mut sent_admin_chain = false;
@@ -275,7 +275,7 @@ where
                 Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
                     // The validator is missing the blobs required by the certificate.
                     self.remote_node
-                        .check_blobs_not_found(&certificate, &blob_ids)?;
+                        .check_blobs_not_found(certificate, &blob_ids)?;
                     // The certificate is confirmed, so the blobs must be in storage.
                     let maybe_blobs = self
                         .client
@@ -680,7 +680,7 @@ where
         chain_id: ChainId,
         target_block_height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
+        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
         // Phase 1: Height synchronization
         let info = if target_block_height.0 > 0 {
@@ -726,7 +726,7 @@ where
         chain_id: ChainId,
         target_block_height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
+        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let height = target_block_height.try_sub_one()?;
 
@@ -746,7 +746,10 @@ where
         };
 
         // Optimistically try sending just the last certificate
-        let info = match self.send_confirmed_certificate(certificate, delivery).await {
+        let info = match self
+            .send_confirmed_certificate(&certificate, delivery)
+            .await
+        {
             Ok(info) => info,
             Err(error) => {
                 tracing::debug!(
@@ -774,7 +777,7 @@ where
                 .await?;
 
             for certificate in certificates {
-                self.send_confirmed_certificate(certificate, delivery)
+                self.send_confirmed_certificate(&certificate, delivery)
                     .await?;
             }
         }
@@ -787,18 +790,14 @@ where
         &self,
         chain_id: ChainId,
         heights: Vec<BlockHeight>,
-    ) -> Result<Vec<GenericCertificate<ConfirmedBlock>>, chain_client::Error> {
+    ) -> Result<Vec<Arc<GenericCertificate<ConfirmedBlock>>>, chain_client::Error> {
         let storage = self.client.local_node.storage_client();
 
         let certificates_by_height = storage
             .read_certificates_by_heights(chain_id, &heights)
             .await?;
 
-        Ok(certificates_by_height
-            .into_iter()
-            .flatten()
-            .map(Arc::unwrap_or_clone)
-            .collect())
+        Ok(certificates_by_height.into_iter().flatten().collect())
     }
 
     /// Initializes a new chain on the validator by sending the chain description and dependencies.
@@ -959,13 +958,12 @@ where
                         .await?
                         .into_iter()
                         .flatten()
-                        .map(Arc::unwrap_or_clone)
                         .collect::<Vec<_>>();
 
                     // Send each certificate
                     for certificate in certificates {
                         updater
-                            .send_confirmed_certificate(certificate, delivery)
+                            .send_confirmed_certificate(&certificate, delivery)
                             .await?;
                     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -19,7 +19,6 @@ use linera_base::{
         Timestamp,
     },
     doc_scalar,
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
 };
 use linera_cache::{UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
@@ -585,7 +584,7 @@ pub struct WorkerState<StorageClient: Storage> {
     storage: StorageClient,
     /// Configuration options for chain workers.
     chain_worker_config: ChainWorkerConfig,
-    block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+    block_cache: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
     /// Chains tracked by a worker, along with their listening modes.
@@ -695,16 +694,13 @@ where
         let block = Arc::unwrap_or_clone(block);
 
         match certificate.value.kind {
-            linera_chain::types::CertificateKind::Confirmed => {
-                let value = ConfirmedBlock::from_hashed(block);
-                Ok(Either::Left(
-                    certificate
-                        .with_value(value)
-                        .ok_or(WorkerError::InvalidLiteCertificate)?,
-                ))
-            }
+            linera_chain::types::CertificateKind::Confirmed => Ok(Either::Left(
+                certificate
+                    .with_value(block)
+                    .ok_or(WorkerError::InvalidLiteCertificate)?,
+            )),
             linera_chain::types::CertificateKind::Validated => {
-                let value = ValidatedBlock::from_hashed(block);
+                let value = ValidatedBlock::from_hashed(block.into_inner());
                 Ok(Either::Right(
                     certificate
                         .with_value(value)
@@ -1236,7 +1232,7 @@ where
         &self,
         chain_id: ChainId,
         height: BlockHeight,
-    ) -> Result<Option<ConfirmedBlockCertificate>, WorkerError> {
+    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, WorkerError> {
         let state = self.get_or_create_chain_worker(chain_id).await?;
         let guard = handle::read_lock_initialized(&state).await?;
         guard.read_certificate(height).await
@@ -1434,7 +1430,7 @@ where
         &self,
         chain_id: ChainId,
         blob_id: BlobId,
-    ) -> Result<Blob, WorkerError> {
+    ) -> Result<Arc<Blob>, WorkerError> {
         trace!("{} <-- download_pending_blob({blob_id:8})", self.nickname());
         let result = self
             .chain_read(chain_id, |guard| async move {

--- a/linera-exporter/src/runloops/validator_exporter.rs
+++ b/linera-exporter/src/runloops/validator_exporter.rs
@@ -117,7 +117,7 @@ where
             crate::metrics::VALIDATOR_EXPORTER_QUEUE_LENGTH
                 .with_label_values(&[self.node.address()])
                 .set(receiver.len() as i64);
-            match self.dispatch_block((*block).clone()).await {
+            match self.dispatch_block(block.clone()).await {
                 Ok(_) => {}
 
                 Err(NodeError::BlobsNotFound(blobs_to_maybe_send)) => {
@@ -126,7 +126,7 @@ where
                         .filter(|id| blobs_to_maybe_send.contains(id))
                         .collect();
                     self.upload_blobs(blobs).await?;
-                    self.dispatch_block((*block).clone()).await?
+                    self.dispatch_block(block).await?
                 }
 
                 Err(e) => Err(e)?,
@@ -180,7 +180,7 @@ where
 
     async fn dispatch_block(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
     ) -> Result<(), NodeError> {
         let delivery = CrossChainMessageDelivery::NonBlocking;
         let block_id = BlockId::from_confirmed_block(certificate.value());

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use linera_base::{
     crypto::CryptoHash,
     data_types::{BlobContent, BlockHeight, NetworkDescription},
@@ -101,7 +103,7 @@ impl ValidatorNode for Client {
 
     async fn handle_confirmed_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -280,12 +280,12 @@ impl ValidatorNode for GrpcClient {
     #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_confirmed_certificate(
         &self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages: bool = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
-            certificate,
+            certificate: Arc::unwrap_or_clone(certificate),
             wait_for_outgoing_messages,
         };
         GrpcClient::try_into_chain_info(client_delegate!(

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -988,7 +988,7 @@ where
         {
             Ok(blob) => {
                 Self::log_request_success("download_pending_blob", traffic_type);
-                Ok(Response::new(blob.into_content().try_into()?))
+                Ok(Response::new(blob.content().clone().try_into()?))
             }
             Err(error) => {
                 Self::log_request_error("download_pending_blob", traffic_type, &error.error_type());

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -2,6 +2,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use futures::{sink::SinkExt, stream::StreamExt};
 use linera_base::{
     crypto::CryptoHash,
@@ -118,12 +120,12 @@ impl ValidatorNode for SimpleClient {
     /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
-            certificate,
+            certificate: Arc::unwrap_or_clone(certificate),
             wait_for_outgoing_messages,
         };
         let request = RpcMessage::ConfirmedCertificate(Box::new(request));

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -348,7 +348,7 @@ where
                     .await
                 {
                     Ok(blob) => Ok(Some(RpcMessage::DownloadPendingBlobResponse(Box::new(
-                        blob.into(),
+                        blob.content().clone(),
                     )))),
                     Err(error) => {
                         self.log_error(&error, "Failed to handle pending blob request");

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -820,7 +820,7 @@ where
         };
         if let Some(hash) = hash {
             let block = client.read_confirmed_block(hash).await?;
-            Ok(Some(block))
+            Ok(Some(Arc::unwrap_or_clone(block)))
         } else {
             Ok(None)
         }
@@ -870,7 +870,7 @@ where
             };
             let value = client.read_confirmed_block(next_hash).await?;
             hash = value.block().header.previous_block_hash;
-            values.push(value);
+            values.push(Arc::unwrap_or_clone(value));
         }
         Ok(values)
     }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -807,7 +807,7 @@ where
         &self,
         hash: Option<CryptoHash>,
         chain_id: ChainId,
-    ) -> Result<Option<ConfirmedBlock>, Error> {
+    ) -> Result<Option<Arc<ConfirmedBlock>>, Error> {
         let client = self
             .context
             .lock()
@@ -819,8 +819,7 @@ where
             None => client.chain_info().await?.block_hash,
         };
         if let Some(hash) = hash {
-            let block = client.read_confirmed_block(hash).await?;
-            Ok(Some(Arc::unwrap_or_clone(block)))
+            Ok(Some(client.read_confirmed_block(hash).await?))
         } else {
             Ok(None)
         }
@@ -847,7 +846,7 @@ where
         from: Option<CryptoHash>,
         chain_id: ChainId,
         limit: Option<u32>,
-    ) -> Result<Vec<ConfirmedBlock>, Error> {
+    ) -> Result<Vec<Arc<ConfirmedBlock>>, Error> {
         let client = self
             .context
             .lock()
@@ -870,7 +869,7 @@ where
             };
             let value = client.read_confirmed_block(next_hash).await?;
             hash = value.block().header.previous_block_hash;
-            values.push(Arc::unwrap_or_clone(value));
+            values.push(value);
         }
         Ok(values)
     }

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -666,15 +666,15 @@ where
         request: Request<CryptoHash>,
     ) -> Result<Response<Certificate>, Status> {
         let hash = request.into_inner().try_into()?;
-        let certificate: linera_chain::types::Certificate = Arc::unwrap_or_clone(
-            self.0
-                .storage
-                .read_certificate(hash)
-                .await
-                .map_err(Self::view_error_to_status)?
-                .ok_or_else(|| Status::not_found(hash.to_string()))?,
-        )
-        .into();
+        let certificate: linera_chain::types::Certificate = self
+            .0
+            .storage
+            .read_certificate(hash)
+            .await
+            .map_err(Self::view_error_to_status)?
+            .ok_or_else(|| Status::not_found(hash.to_string()))?
+            .as_ref()
+            .into();
         Ok(Response::new(certificate.try_into()?))
     }
 
@@ -750,8 +750,7 @@ where
 
         let returned_certificates =
             limiter.take_if(certificates_by_height, |lim, certificate| {
-                let cert: linera_chain::types::Certificate =
-                    Arc::unwrap_or_clone(certificate).into();
+                let cert: linera_chain::types::Certificate = certificate.as_ref().into();
                 Ok(lim.fits::<Certificate>(cert.clone())?.then_some(cert))
             })?;
 

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -475,10 +475,8 @@ where
             }
             DownloadBlob(blob_id) => {
                 let blob = self.storage.read_blob(*blob_id).await?;
-                let blob = blob
-                    .map(Arc::unwrap_or_clone)
-                    .ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
-                let content = blob.into_content();
+                let blob = blob.ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                let content = blob.content().clone();
                 Ok(Some(RpcMessage::DownloadBlobResponse(Box::new(content))))
             }
             DownloadConfirmedBlock(hash) => {

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -69,7 +69,7 @@ impl ValidatorNode for DummyValidatorNode {
 
     async fn handle_confirmed_certificate(
         &self,
-        _: GenericCertificate<ConfirmedBlock>,
+        _: Arc<GenericCertificate<ConfirmedBlock>>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1016,6 +1016,23 @@ where
         self.write_batch(batch).await
     }
 
+    fn cache_certificate(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+    ) -> Arc<ConfirmedBlockCertificate> {
+        self.caches
+            .certificate
+            .insert(&certificate.hash(), certificate)
+    }
+
+    fn cache_blob(&self, blob: Blob) -> Arc<Blob> {
+        self.caches.blob.insert(&blob.id(), blob)
+    }
+
+    fn cache_confirmed_block(&self, block: ConfirmedBlock) -> Arc<ConfirmedBlock> {
+        self.caches.confirmed_block.insert(&block.hash(), block)
+    }
+
     #[instrument(skip_all, fields(%hash))]
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError> {
         if self.caches.certificate.contains(&hash) || self.caches.certificate_raw.contains(&hash) {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -138,6 +138,33 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     /// Tests existence of the certificate with the given hash.
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError>;
 
+    /// Inserts a certificate into the in-memory dedup cache and returns the
+    /// canonical [`Arc`]. If the cache already holds an `Arc` for this hash,
+    /// the passed-in `certificate` is dropped and the existing `Arc` is
+    /// returned. This must be used (rather than `Arc::new`) for any
+    /// freshly-constructed [`ConfirmedBlockCertificate`] that should
+    /// participate in the "one allocation per content" invariant.
+    fn cache_certificate(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+    ) -> Arc<ConfirmedBlockCertificate>;
+
+    /// Inserts a blob into the in-memory dedup cache and returns the canonical
+    /// [`Arc`]. If the cache already holds an `Arc` for this blob ID, the
+    /// passed-in `blob` is dropped and the existing `Arc` is returned. This
+    /// must be used (rather than `Arc::new`) for any freshly-constructed
+    /// [`Blob`] that should participate in the "one allocation per content"
+    /// invariant.
+    fn cache_blob(&self, blob: Blob) -> Arc<Blob>;
+
+    /// Inserts a confirmed block into the in-memory dedup cache and returns
+    /// the canonical [`Arc`]. If the cache already holds an `Arc` for this
+    /// hash, the passed-in `block` is dropped and the existing `Arc` is
+    /// returned. This must be used (rather than `Arc::new`) for any
+    /// freshly-constructed [`ConfirmedBlock`] that should participate in the
+    /// "one allocation per content" invariant.
+    fn cache_confirmed_block(&self, block: ConfirmedBlock) -> Arc<ConfirmedBlock>;
+
     /// Reads the certificate with the given hash.
     async fn read_certificate(
         &self,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -263,10 +263,14 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         let contract_bytecode_blob_id = application_description.contract_bytecode_blob_id();
         let content = match txn_tracker.get_blob_content(&contract_bytecode_blob_id) {
             Some(content) => content.clone(),
-            None => Arc::unwrap_or_clone(self.read_blob(contract_bytecode_blob_id).await?.ok_or(
-                ExecutionError::BlobsNotFound(vec![contract_bytecode_blob_id]),
-            )?)
-            .into_content(),
+            None => self
+                .read_blob(contract_bytecode_blob_id)
+                .await?
+                .ok_or(ExecutionError::BlobsNotFound(vec![
+                    contract_bytecode_blob_id,
+                ]))?
+                .content()
+                .clone(),
         };
         let compressed_contract_bytecode = CompressedBytecode {
             compressed_bytes: content.into_arc_bytes(),
@@ -326,10 +330,14 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         let service_bytecode_blob_id = application_description.service_bytecode_blob_id();
         let content = match txn_tracker.get_blob_content(&service_bytecode_blob_id) {
             Some(content) => content.clone(),
-            None => Arc::unwrap_or_clone(self.read_blob(service_bytecode_blob_id).await?.ok_or(
-                ExecutionError::BlobsNotFound(vec![service_bytecode_blob_id]),
-            )?)
-            .into_content(),
+            None => self
+                .read_blob(service_bytecode_blob_id)
+                .await?
+                .ok_or(ExecutionError::BlobsNotFound(vec![
+                    service_bytecode_blob_id,
+                ]))?
+                .content()
+                .clone(),
         };
         let compressed_service_bytecode = CompressedBytecode {
             compressed_bytes: content.into_arc_bytes(),


### PR DESCRIPTION
## Motivation

Follow-up to #5944. The previous PR added Arc-based caching, but consumers still
called `Arc::unwrap_or_clone` at many sites because function signatures took
owned values. This PR pushes Arc deeper through those signatures and consolidates
the worker-side block cache shape.

## Proposal

- `Storage::read_blob`, `read_confirmed_block`, `read_certificate` and friends
  now return `Arc<...>` instead of cloning out of the cache.
- `ChainWorkerState::block_values` and `WorkerState::block_cache` now store
  `Arc<ValueCache<CryptoHash, ConfirmedBlock>>` (previously `Hashed<Block>`),
  so cache hits return the consumer-shaped `Arc<ConfirmedBlock>` directly with
  no per-hit conversion.
- `ValueCache::insert_hashed` is now generic: `insert_hashed<T>(Cow<Hashed<T>>)`
  on `ValueCache<CryptoHash, V>` where `V: From<Hashed<T>>`.
- Added `impl From<Hashed<Block>> for ConfirmedBlock` and `ValidatedBlock`.
- `WorkerState::process_confirmed_block` keeps owned `ConfirmedBlockCertificate`
  to satisfy the `chain_write` static-lifetime closure introduced in #6090; the
  inner `ChainWorkerState::process_confirmed_block` takes `&cert` so internal
  callers (recovery paths) skip clones entirely.
- `Client::receive_sender_certificate` now takes `Arc<ConfirmedBlockCertificate>`
  so the local-storage hit path in `download_sender_block_with_sending_ancestors`
  and `download_event_bearing_blocks` keeps the Arc end-to-end (saves a full cert
  clone per cached hit).
- Removed an `Arc::unwrap_or_clone` and a redundant full-cert clone in
  `chain_client::handle_certificates` by keeping `Arc<Cert>` through the
  iteration.

Net: workspace-wide `Arc::unwrap_or_clone` calls drop from 38 to 21 (-45%). The
remaining 21 are at API boundaries (network/RPC wire format, async-graphql
output, `LiteCertificate::with_value`, oracle response variants, test
utilities) where eliminating them would cascade across trait or wire contracts.

## Test Plan

CI.

## Release Plan

- Should be backported to `testnet_conway`

## Links

- Builds on #5944