### PR TITLE
Simplify bridge initialization phase.

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -123,11 +123,6 @@ jobs:
           context: .
           file: ./docker/Dockerfile.bridge
           load: true
-<<<<<<< HEAD
-          tags: linera-bridge:latest
-
-      - name: Build example Wasm for bridge tests
-=======
           tags: |
             linera-bridge:latest
             ${{ github.event_name != 'workflow_dispatch' && format('{0}/linera-bridge:{1}', env.GCP_REGISTRY, github.base_ref || github.ref_name) || '' }}
@@ -138,8 +133,7 @@ jobs:
           BRANCH="${{ github.base_ref || github.ref_name }}"
           docker push "${GCP_REGISTRY}/linera-bridge:${BRANCH}"
 
-      - name: Build example Wasm modules for bridge tests
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
+      - name: Build example Wasm for bridge tests
         run: cargo build --release --target wasm32-unknown-unknown -p wrapped-fungible -p evm-bridge
         working-directory: examples
 

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -74,11 +74,25 @@ jobs:
       - name: Configure Docker for GCP
         run: gcloud auth configure-docker us-docker.pkg.dev
 
+      # In merge_group events, github.ref_name is "gh-readonly-queue/<base>/<head>"
+      # which contains slashes invalid in Docker tags. Resolve the real base
+      # branch so pulls/pushes use a clean tag.
+      - name: Compute base branch
+        id: base-branch
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            REF="${{ github.event.merge_group.base_ref }}"
+            BRANCH="${REF#refs/heads/}"
+          else
+            BRANCH="${{ github.base_ref || github.ref_name }}"
+          fi
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
       - name: Pull linera image
         id: pull-images
         continue-on-error: true
         run: |
-          BRANCH="${{ github.base_ref || github.ref_name }}"
+          BRANCH="${{ steps.base-branch.outputs.name }}"
           docker pull "${GCP_REGISTRY}/linera:${BRANCH}"
           docker tag "${GCP_REGISTRY}/linera:${BRANCH}" linera-test
 
@@ -111,7 +125,7 @@ jobs:
         if: steps.changes.outputs.bridge == 'false'
         continue-on-error: true
         run: |
-          BRANCH="${{ github.base_ref || github.ref_name }}"
+          BRANCH="${{ steps.base-branch.outputs.name }}"
           docker pull "${GCP_REGISTRY}/linera-bridge:${BRANCH}"
           docker tag "${GCP_REGISTRY}/linera-bridge:${BRANCH}" linera-bridge:latest
 
@@ -125,13 +139,12 @@ jobs:
           load: true
           tags: |
             linera-bridge:latest
-            ${{ github.event_name != 'workflow_dispatch' && format('{0}/linera-bridge:{1}', env.GCP_REGISTRY, github.base_ref || github.ref_name) || '' }}
+            ${{ github.event_name == 'push' && format('{0}/linera-bridge:{1}', env.GCP_REGISTRY, github.ref_name) || '' }}
 
       - name: Push bridge image to registry
-        if: steps.build-bridge.outcome == 'success' && github.event_name != 'workflow_dispatch'
+        if: steps.build-bridge.outcome == 'success' && github.event_name == 'push'
         run: |
-          BRANCH="${{ github.base_ref || github.ref_name }}"
-          docker push "${GCP_REGISTRY}/linera-bridge:${BRANCH}"
+          docker push "${GCP_REGISTRY}/linera-bridge:${{ github.ref_name }}"
 
       - name: Build example Wasm for bridge tests
         run: cargo build --release --target wasm32-unknown-unknown -p wrapped-fungible -p evm-bridge

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -62,8 +62,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Pull pre-built linera images from GCP registry
+      # GCP auth is only needed to push the bridge image on release branches.
       - name: Auth to GCP
+        if: github.event_name == 'push'
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: >-
@@ -72,32 +73,10 @@ jobs:
             actions-runner@linera-io-dev.iam.gserviceaccount.com
 
       - name: Configure Docker for GCP
+        if: github.event_name == 'push'
         run: gcloud auth configure-docker us-docker.pkg.dev
 
-      # In merge_group events, github.ref_name is "gh-readonly-queue/<base>/<head>"
-      # which contains slashes invalid in Docker tags. Resolve the real base
-      # branch so pulls/pushes use a clean tag.
-      - name: Compute base branch
-        id: base-branch
-        run: |
-          if [ "${{ github.event_name }}" = "merge_group" ]; then
-            REF="${{ github.event.merge_group.base_ref }}"
-            BRANCH="${REF#refs/heads/}"
-          else
-            BRANCH="${{ github.base_ref || github.ref_name }}"
-          fi
-          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
-
-      - name: Pull linera image
-        id: pull-images
-        continue-on-error: true
-        run: |
-          BRANCH="${{ steps.base-branch.outputs.name }}"
-          docker pull "${GCP_REGISTRY}/linera:${BRANCH}"
-          docker tag "${GCP_REGISTRY}/linera:${BRANCH}" linera-test
-
       - name: Build linera image
-        if: steps.pull-images.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -111,27 +90,8 @@ jobs:
       - name: Build foundry-jq image
         run: docker build -t foundry-jq -f ./docker/Dockerfile.foundry ./docker
 
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            bridge:
-              - 'linera-bridge/**'
-              - '!linera-bridge/tests/e2e/**'
-              - 'docker/Dockerfile.bridge'
-
-      - name: Pull bridge image (unchanged)
-        id: pull-bridge
-        if: steps.changes.outputs.bridge == 'false'
-        continue-on-error: true
-        run: |
-          BRANCH="${{ steps.base-branch.outputs.name }}"
-          docker pull "${GCP_REGISTRY}/linera-bridge:${BRANCH}"
-          docker tag "${GCP_REGISTRY}/linera-bridge:${BRANCH}" linera-bridge:latest
-
       - name: Build bridge image
         id: build-bridge
-        if: steps.changes.outputs.bridge == 'true' || steps.pull-bridge.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -123,9 +123,23 @@ jobs:
           context: .
           file: ./docker/Dockerfile.bridge
           load: true
+<<<<<<< HEAD
           tags: linera-bridge:latest
 
       - name: Build example Wasm for bridge tests
+=======
+          tags: |
+            linera-bridge:latest
+            ${{ github.event_name != 'workflow_dispatch' && format('{0}/linera-bridge:{1}', env.GCP_REGISTRY, github.base_ref || github.ref_name) || '' }}
+
+      - name: Push bridge image to registry
+        if: steps.build-bridge.outcome == 'success' && github.event_name != 'workflow_dispatch'
+        run: |
+          BRANCH="${{ github.base_ref || github.ref_name }}"
+          docker push "${GCP_REGISTRY}/linera-bridge:${BRANCH}"
+
+      - name: Build example Wasm modules for bridge tests
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
         run: cargo build --release --target wasm32-unknown-unknown -p wrapped-fungible -p evm-bridge
         working-directory: examples
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5436,11 +5436,7 @@ dependencies = [
  "linera-client",
  "linera-core",
  "linera-execution",
-<<<<<<< HEAD
- "linera-faucet-client",
  "linera-persistent",
-=======
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
  "linera-storage",
  "linera-views",
  "linera-wallet-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5436,8 +5436,11 @@ dependencies = [
  "linera-client",
  "linera-core",
  "linera-execution",
+<<<<<<< HEAD
  "linera-faucet-client",
  "linera-persistent",
+=======
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
  "linera-storage",
  "linera-views",
  "linera-wallet-json",

--- a/docker/bridge-entrypoint.sh
+++ b/docker/bridge-entrypoint.sh
@@ -16,6 +16,8 @@ set -- linera-bridge serve \
     --linera-bridge-address="${LINERA_BRIDGE_APP:?LINERA_BRIDGE_APP is required}" \
     --linera-fungible-address="${LINERA_FUNGIBLE_APP:?LINERA_FUNGIBLE_APP is required}" \
     --evm-private-key="${EVM_PRIVATE_KEY:?EVM_PRIVATE_KEY is required}" \
+    --linera-bridge-chain-id="${LINERA_BRIDGE_CHAIN_ID:?LINERA_BRIDGE_CHAIN_ID is required}" \
+    --linera-bridge-chain-owner="${LINERA_BRIDGE_CHAIN_OWNER:?LINERA_BRIDGE_CHAIN_OWNER is required}" \
     --port="${PORT:-5001}" \
     --monitor-scan-interval="${MONITOR_SCAN_INTERVAL:-30}" \
     --monitor-start-block="${MONITOR_START_BLOCK:-0}" \
@@ -25,17 +27,6 @@ set -- linera-bridge serve \
     --lite-certificate-cache-size="${LITE_CERTIFICATE_CACHE_SIZE:-1000}" \
     --certificate-raw-cache-size="${CERTIFICATE_RAW_CACHE_SIZE:-1000}" \
     --event-cache-size="${EVENT_CACHE_SIZE:-1000}"
-
-# Optional: faucet URL (required when wallet doesn't exist or chain ID not provided)
-if [ -n "$FAUCET_URL" ]; then
-    set -- "$@" --faucet-url="$FAUCET_URL"
-fi
-
-# Optional: bridge chain ID + owner (owner is required when chain ID is provided)
-if [ -n "$LINERA_BRIDGE_CHAIN_ID" ]; then
-    set -- "$@" --linera-bridge-chain-id="$LINERA_BRIDGE_CHAIN_ID"
-    set -- "$@" --linera-bridge-chain-owner="${LINERA_BRIDGE_CHAIN_OWNER:?LINERA_BRIDGE_CHAIN_OWNER is required when LINERA_BRIDGE_CHAIN_ID is set}"
-fi
 
 # LINERA_WALLET, LINERA_KEYSTORE, LINERA_STORAGE are read directly by clap
 # via `env = "..."`, so they don't need explicit --flags here.

--- a/examples/bridge-demo/foundry.toml
+++ b/examples/bridge-demo/foundry.toml
@@ -1,6 +1,0 @@
-[profile.default]
-src = "."
-via_ir = true
-optimizer = true
-optimizer_runs = 1
-evm_version = "shanghai"

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -321,7 +321,8 @@ import sys, json; print(json.load(sys.stdin)['epoch'])
     echo "  Deploying LightClient (epoch=$LC_EPOCH)..."
     LC_OUTPUT=$(evm_exec \
         forge create "LightClient.sol:LightClient" \
-        --root "$CONTRACTS_DIR" --config-path "$SCRIPT_DIR/foundry.toml" \
+        --root "$CONTRACTS_DIR" \
+        --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
         "${FORGE_USE_SOLC[@]}" \
         --out /tmp/forge-out --cache-path /tmp/forge-cache \
         --rpc-url "$EVM_RPC_URL" \
@@ -371,7 +372,8 @@ if [[ -z "$TOKEN_ADDRESS" ]]; then
     echo "Deploying MockERC20..."
     ERC20_OUTPUT=$(evm_exec \
         forge create "$CONTRACTS_DIR/MockERC20.sol:MockERC20" \
-        --root "$CONTRACTS_DIR" --config-path "$SCRIPT_DIR/foundry.toml" \
+        --root "$CONTRACTS_DIR" \
+        --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
         "${FORGE_USE_SOLC[@]}" \
         --out /tmp/forge-out --cache-path /tmp/forge-cache \
         --rpc-url "$EVM_RPC_URL" \
@@ -410,7 +412,8 @@ CHAIN_BYTES32="0x${BRIDGE_CHAIN_ID}"
 
 BRIDGE_OUTPUT=$(evm_exec \
     forge create "$CONTRACTS_DIR/FungibleBridge.sol:FungibleBridge" \
-    --root "$CONTRACTS_DIR" --config-path "$SCRIPT_DIR/foundry.toml" \
+    --root "$CONTRACTS_DIR" \
+    --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
     "${FORGE_USE_SOLC[@]}" --ignored-error-codes 6321 \
     --out /tmp/forge-out --cache-path /tmp/forge-cache \
     --rpc-url "$EVM_RPC_URL" \

--- a/linera-bridge/Cargo.toml
+++ b/linera-bridge/Cargo.toml
@@ -45,8 +45,11 @@ relay = [
     "dep:linera-chain",
     "dep:linera-client",
     "dep:linera-core",
+<<<<<<< HEAD
     "dep:linera-faucet-client",
     "dep:linera-persistent",
+=======
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
     "dep:linera-storage",
     "dep:linera-wallet-json",
     "dep:linera-views",
@@ -104,8 +107,11 @@ hex = { workspace = true, optional = true }
 linera-chain = { workspace = true, optional = true }
 linera-client = { workspace = true, optional = true }
 linera-core = { workspace = true, optional = true }
+<<<<<<< HEAD
 linera-faucet-client = { workspace = true, optional = true }
 linera-persistent = { workspace = true, optional = true, features = ["fs"] }
+=======
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
 linera-storage = { workspace = true, optional = true }
 linera-views = { workspace = true, optional = true }
 linera-wallet-json = { workspace = true, optional = true }

--- a/linera-bridge/Cargo.toml
+++ b/linera-bridge/Cargo.toml
@@ -45,11 +45,7 @@ relay = [
     "dep:linera-chain",
     "dep:linera-client",
     "dep:linera-core",
-<<<<<<< HEAD
-    "dep:linera-faucet-client",
     "dep:linera-persistent",
-=======
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
     "dep:linera-storage",
     "dep:linera-wallet-json",
     "dep:linera-views",
@@ -107,11 +103,7 @@ hex = { workspace = true, optional = true }
 linera-chain = { workspace = true, optional = true }
 linera-client = { workspace = true, optional = true }
 linera-core = { workspace = true, optional = true }
-<<<<<<< HEAD
-linera-faucet-client = { workspace = true, optional = true }
 linera-persistent = { workspace = true, optional = true, features = ["fs"] }
-=======
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
 linera-storage = { workspace = true, optional = true }
 linera-views = { workspace = true, optional = true }
 linera-wallet-json = { workspace = true, optional = true }

--- a/linera-bridge/Makefile
+++ b/linera-bridge/Makefile
@@ -42,7 +42,6 @@ relayer-up: ## Run the bridge relayer container
 	@echo "  EVM_PRIVATE_KEY      = $(EVM_PRIVATE_KEY)"
 	@echo ""
 	@echo "Optional:"
-	@echo "  FAUCET_URL           = $(or $(FAUCET_URL),(not set))"
 	@echo "  PORT                 = $(or $(PORT),3001)"
 	@echo "  MONITOR_SCAN_INTERVAL= $(or $(MONITOR_SCAN_INTERVAL),30)"
 	@echo "  MONITOR_START_BLOCK  = $(or $(MONITOR_START_BLOCK),0)"
@@ -59,7 +58,6 @@ relayer-up: ## Run the bridge relayer container
 		-e LINERA_BRIDGE_APP="$(LINERA_BRIDGE_APP)" \
 		-e LINERA_FUNGIBLE_APP="$(LINERA_FUNGIBLE_APP)" \
 		-e EVM_PRIVATE_KEY="$(EVM_PRIVATE_KEY)" \
-		$(if $(FAUCET_URL),-e FAUCET_URL="$(FAUCET_URL)") \
 		$(if $(PORT),-e PORT="$(PORT)") \
 		$(if $(MONITOR_SCAN_INTERVAL),-e MONITOR_SCAN_INTERVAL="$(MONITOR_SCAN_INTERVAL)") \
 		$(if $(MONITOR_START_BLOCK),-e MONITOR_START_BLOCK="$(MONITOR_START_BLOCK)") \

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -54,10 +54,6 @@ struct ServeOptions {
     #[arg(long)]
     rpc_url: String,
 
-    /// URL of the Linera faucet (required when wallet doesn't exist or chain ID not provided)
-    #[arg(long)]
-    faucet_url: Option<String>,
-
     /// Path to the wallet state file.
     #[arg(long = "wallet", env = "LINERA_WALLET")]
     wallet: Option<PathBuf>,
@@ -70,13 +66,13 @@ struct ServeOptions {
     #[arg(long = "storage", env = "LINERA_STORAGE")]
     storage: Option<String>,
 
-    /// Linera bridge chain ID. If omitted, claims a new chain from faucet.
+    /// Linera bridge chain ID
     #[arg(long)]
-    linera_bridge_chain_id: Option<linera_base::identifiers::ChainId>,
+    linera_bridge_chain_id: linera_base::identifiers::ChainId,
 
-    /// Owner to use for the bridge chain. Required when --linera-bridge-chain-id is provided.
-    #[arg(long, requires = "linera_bridge_chain_id")]
-    linera_bridge_chain_owner: Option<linera_base::identifiers::AccountOwner>,
+    /// Owner of the bridge chain
+    #[arg(long)]
+    linera_bridge_chain_owner: linera_base::identifiers::AccountOwner,
 
     /// Address of the FungibleBridge contract on EVM.
     #[arg(long)]
@@ -171,7 +167,6 @@ impl ServeOptions {
 
         Box::pin(linera_bridge::relay::run(
             &self.rpc_url,
-            self.faucet_url.as_deref(),
             self.wallet.as_deref(),
             self.keystore.as_deref(),
             self.storage.as_deref(),

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -33,11 +33,7 @@ use linera_base::{
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::{client::ChainClient, worker::Reason};
 use linera_execution::{Operation, WasmRuntime};
-<<<<<<< HEAD
-use linera_faucet_client::Faucet;
 use linera_persistent::Persist;
-=======
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
 use linera_storage::{DbStorage, Storage as _};
 use linera_views::{
     backends::{
@@ -136,42 +132,15 @@ pub async fn run(
         wallet_path.display(),
     );
 
-<<<<<<< HEAD
-    let mut signer: InMemorySigner =
-        linera_persistent::File::<InMemorySigner>::read(&keystore_path)
-            .context("failed to read keystore")?
-            .into_value();
+    let signer: InMemorySigner = linera_persistent::File::<InMemorySigner>::read(&keystore_path)
+        .context("failed to read keystore")?
+        .into_value();
 
     // Parse storage path: expect "rocksdb:/path/to/db"
     let db_path = storage_path
         .strip_prefix("rocksdb:")
         .context("storage config must start with 'rocksdb:'")?;
     let mut storage = create_rocksdb_storage(Path::new(db_path), cache_sizes).await?;
-=======
-    let keystore =
-        linera_wallet_json::Keystore::read(&keystore_path).context("failed to read keystore")?;
-    let signer = keystore.into_signer();
-
-    // Parse storage config and create storage.
-    let mut storage_config: StorageConfig = storage_path.parse()?;
-    storage_config.namespace = "bridge_relay".to_string();
-    let store_config = storage_config.add_common_storage_options(common_storage_options)?;
-    let cache_sizes = common_storage_options.storage_cache_sizes();
-    let (mut storage, db_path) = match store_config {
-        StoreConfig::RocksDb { config, namespace } => {
-            let path = config.inner_config.path_with_guard.path_buf.clone();
-            let storage = DbStorage::<RocksDbDatabase, _>::maybe_create_and_connect(
-                &config,
-                &namespace,
-                Some(WasmRuntime::default()),
-                cache_sizes,
-            )
-            .await?;
-            (storage, path)
-        }
-        _ => anyhow::bail!("only rocksdb storage is supported by the bridge relay"),
-    };
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
 
     // Wallet: must already exist
     tracing::info!(path = %wallet_path.display(), "Loading existing wallet");
@@ -219,52 +188,8 @@ pub async fn run(
     )
     .await?;
 
-<<<<<<< HEAD
-        // Register the chain with the specified owner.
-        ctx.update_wallet_for_new_chain(
-            cid,
-            Some(owner),
-            linera_base::data_types::Timestamp::default(),
-            linera_base::data_types::Epoch::ZERO,
-        )
-        .await?;
-
-        // Register for notifications so the listener can connect to validators.
-        ctx.client
-            .extend_chain_mode(cid, linera_core::client::ListeningMode::FullChain);
-
-        // Sync from validators.
-        let chain_client = ctx.make_chain_client(cid).await?;
-        chain_client.synchronize_from_validators().await?;
-
-        tracing::info!(%cid, %owner, "Using pre-existing chain");
-        (cid, owner)
-    } else {
-        // Claim from faucet.
-        let faucet = faucet
-            .as_ref()
-            .context("--faucet-url is required when --linera-bridge-chain-id is not provided")?;
-        tracing::info!("Claiming bridge chain from faucet...");
-        let owner = AccountOwner::from(signer.generate_new());
-        let chain_desc = faucet.claim(&owner).await?;
-        let cid = chain_desc.id();
-        tracing::info!(%cid, %owner, "Chain claimed, extending wallet...");
-        ctx.extend_with_chain(chain_desc, Some(owner)).await?;
-
-        // Save updated keystore (has new key from generate_new).
-        let mut ks_file = linera_persistent::File::new(&keystore_path, signer.clone())?;
-        ks_file.persist().await?;
-
-        // Sync bridge chain.
-        let chain_client = ctx.make_chain_client(cid).await?;
-        chain_client.synchronize_from_validators().await?;
-        tracing::info!(%cid, "Bridge chain claimed and synced");
-        (cid, owner)
-    };
-=======
     ctx.client
         .extend_chain_mode(chain_id, linera_core::client::ListeningMode::FullChain);
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
 
     let chain_client = ctx.make_chain_client(chain_id).await?;
     chain_client.synchronize_from_validators().await?;

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -33,8 +33,11 @@ use linera_base::{
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::{client::ChainClient, worker::Reason};
 use linera_execution::{Operation, WasmRuntime};
+<<<<<<< HEAD
 use linera_faucet_client::Faucet;
 use linera_persistent::Persist;
+=======
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
 use linera_storage::{DbStorage, Storage as _};
 use linera_views::{
     backends::{
@@ -88,12 +91,11 @@ pub(crate) async fn update_linera_balance_metric<E: linera_core::environment::En
 #[expect(clippy::too_many_arguments)]
 pub async fn run(
     rpc_url: &str,
-    faucet_url: Option<&str>,
     wallet_path: Option<&Path>,
     keystore_path: Option<&Path>,
     storage_config: Option<&str>,
-    chain_id_arg: Option<ChainId>,
-    chain_owner_arg: Option<AccountOwner>,
+    chain_id: ChainId,
+    chain_owner: AccountOwner,
     evm_bridge_address: &str,
     linera_bridge_address: &str,
     linera_fungible_address: &str,
@@ -128,12 +130,13 @@ pub async fn run(
         "Resolved paths"
     );
 
-    // ── Common init ──
-    let faucet = faucet_url.map(|url| {
-        tracing::info!("Using Linera faucet at {url}");
-        Faucet::new(url.to_string())
-    });
+    anyhow::ensure!(
+        wallet_path.exists(),
+        "wallet not found at {}",
+        wallet_path.display(),
+    );
 
+<<<<<<< HEAD
     let mut signer: InMemorySigner =
         linera_persistent::File::<InMemorySigner>::read(&keystore_path)
             .context("failed to read keystore")?
@@ -144,25 +147,39 @@ pub async fn run(
         .strip_prefix("rocksdb:")
         .context("storage config must start with 'rocksdb:'")?;
     let mut storage = create_rocksdb_storage(Path::new(db_path), cache_sizes).await?;
+=======
+    let keystore =
+        linera_wallet_json::Keystore::read(&keystore_path).context("failed to read keystore")?;
+    let signer = keystore.into_signer();
 
-    // ── Wallet: load existing or create fresh ──
-    let wallet = if wallet_path.exists() {
-        tracing::info!("Loading existing wallet from {}", wallet_path.display());
-        let wallet = PersistentWallet::read(&wallet_path).context("failed to read wallet")?;
-        wallet
-            .genesis_config()
-            .initialize_storage(&mut storage)
+    // Parse storage config and create storage.
+    let mut storage_config: StorageConfig = storage_path.parse()?;
+    storage_config.namespace = "bridge_relay".to_string();
+    let store_config = storage_config.add_common_storage_options(common_storage_options)?;
+    let cache_sizes = common_storage_options.storage_cache_sizes();
+    let (mut storage, db_path) = match store_config {
+        StoreConfig::RocksDb { config, namespace } => {
+            let path = config.inner_config.path_with_guard.path_buf.clone();
+            let storage = DbStorage::<RocksDbDatabase, _>::maybe_create_and_connect(
+                &config,
+                &namespace,
+                Some(WasmRuntime::default()),
+                cache_sizes,
+            )
             .await?;
-        wallet
-    } else {
-        let faucet = faucet
-            .as_ref()
-            .context("--faucet-url is required when no wallet exists")?;
-        tracing::info!("Creating new wallet at {}", wallet_path.display());
-        let genesis_config = faucet.genesis_config().await?;
-        genesis_config.initialize_storage(&mut storage).await?;
-        PersistentWallet::create(&wallet_path, genesis_config).context("failed to create wallet")?
+            (storage, path)
+        }
+        _ => anyhow::bail!("only rocksdb storage is supported by the bridge relay"),
     };
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
+
+    // Wallet: must already exist
+    tracing::info!(path = %wallet_path.display(), "Loading existing wallet");
+    let wallet = PersistentWallet::read(&wallet_path).context("failed to read wallet")?;
+    wallet
+        .genesis_config()
+        .initialize_storage(&mut storage)
+        .await?;
 
     let admin_chain_id = wallet.genesis_config().admin_chain_id();
     let genesis_config = wallet.genesis_config().clone();
@@ -185,21 +202,24 @@ pub async fn run(
     let admin_chain_height = admin_client.chain_info().await?.next_block_height;
     tracing::info!(%admin_chain_height, "Admin chain synced");
 
-    // ── Resolve bridge chain ──
-    let (chain_id, _owner) = if let Some(cid) = chain_id_arg {
-        let owner = chain_owner_arg.context(
-            "--linera-bridge-chain-owner is required when --linera-bridge-chain-id is provided",
-        )?;
+    // ── Register bridge chain in the local wallet ──
+    anyhow::ensure!(
+        signer
+            .contains_key(&chain_owner)
+            .await
+            .context("failed to query keystore")?,
+        "keystore does not contain a key for owner {chain_owner}"
+    );
 
-        // Verify the keystore has the signing key for this owner.
-        anyhow::ensure!(
-            signer
-                .contains_key(&owner)
-                .await
-                .context("failed to query keystore")?,
-            "keystore does not contain a key for owner {owner}"
-        );
+    ctx.update_wallet_for_new_chain(
+        chain_id,
+        Some(chain_owner),
+        linera_base::data_types::Timestamp::default(),
+        linera_base::data_types::Epoch::ZERO,
+    )
+    .await?;
 
+<<<<<<< HEAD
         // Register the chain with the specified owner.
         ctx.update_wallet_for_new_chain(
             cid,
@@ -241,8 +261,14 @@ pub async fn run(
         tracing::info!(%cid, "Bridge chain claimed and synced");
         (cid, owner)
     };
+=======
+    ctx.client
+        .extend_chain_mode(chain_id, linera_core::client::ListeningMode::FullChain);
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
 
     let chain_client = ctx.make_chain_client(chain_id).await?;
+    chain_client.synchronize_from_validators().await?;
+    tracing::info!(%chain_id, %chain_owner, "Bridge chain registered and synced");
 
     Box::pin(serve_loop(
         chain_client,

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -3889,8 +3889,11 @@ dependencies = [
  "linera-client",
  "linera-core",
  "linera-execution",
+<<<<<<< HEAD
  "linera-faucet-client",
  "linera-persistent",
+=======
+>>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
  "linera-storage",
  "linera-views",
  "linera-wallet-json",
@@ -3928,6 +3931,7 @@ dependencies = [
  "linera-storage",
  "linera-storage-runtime",
  "linera-views",
+ "linera-wallet-json",
  "rand 0.8.5",
  "reqwest 0.12.28",
  "rustls 0.23.37",

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -3889,11 +3889,7 @@ dependencies = [
  "linera-client",
  "linera-core",
  "linera-execution",
-<<<<<<< HEAD
- "linera-faucet-client",
  "linera-persistent",
-=======
->>>>>>> b31c0accb0 (Extract bridge initialization/setup from linera-bridge (#6124))
  "linera-storage",
  "linera-views",
  "linera-wallet-json",

--- a/linera-bridge/tests/e2e/Cargo.toml
+++ b/linera-bridge/tests/e2e/Cargo.toml
@@ -35,6 +35,7 @@ linera-persistent = { path = "../../../linera-persistent", features = ["fs"] }
 linera-storage = { path = "../../../linera-storage", features = ["wasmer"] }
 linera-storage-runtime = { path = "../../../linera-storage-runtime" }
 linera-views = { path = "../../../linera-views" }
+linera-wallet-json = { path = "../../../linera-wallet-json" }
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "json",

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -95,6 +95,8 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     tracing::info!("Creating programmatic Linera client...");
     let faucet = Faucet::new("http://localhost:8080".to_string());
     let genesis_config = faucet.genesis_config().await?;
+    // Snapshot for later — relay::run now requires a pre-existing wallet on disk.
+    let relay_genesis_config = genesis_config.clone();
 
     let config = MemoryStoreConfig {
         max_stream_queries: 10,
@@ -336,6 +338,10 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         ks.persist().await?;
     }
 
+    // Pre-bootstrap the relay's wallet — `linera_bridge::relay::run` no longer
+    // auto-creates one from a faucet; it expects an existing wallet on disk.
+    linera_wallet_json::PersistentWallet::create(&wallet_path, relay_genesis_config)?;
+
     let relay_port = 3002u16;
     let bridge_addr_str = format!("{bridge_addr}");
     let bridge_app_str = format!("{bridge_app_id}");
@@ -344,12 +350,11 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     let relay_handle = tokio::spawn(async move {
         Box::pin(linera_bridge::relay::run(
             "http://localhost:8545",
-            Some("http://localhost:8080"),
             Some(wallet_path.as_path()),
             Some(keystore_path.as_path()),
             Some(&storage_config),
-            Some(chain_a),
-            Some(owner_a),
+            chain_a,
+            owner_a,
             &bridge_addr_str,
             &bridge_app_str,
             &fungible_app_str,

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -76,15 +76,19 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
     let storage_config = format!("rocksdb:{}", relay_dir.path().join("client.db").display());
     let relay_port = 3003u16;
 
+    // Pre-bootstrap the relay's wallet — `linera_bridge::relay::run` no longer
+    // auto-creates one from a faucet; it expects an existing wallet on disk.
+    let relay_genesis_config = faucet.genesis_config().await?;
+    linera_wallet_json::PersistentWallet::create(&wallet_path, relay_genesis_config)?;
+
     let relay_handle = tokio::spawn(async move {
         Box::pin(linera_bridge::relay::run(
             "http://localhost:8545",
-            Some("http://localhost:8080"),
             Some(wallet_path.as_path()),
             Some(keystore_path.as_path()),
             Some(&storage_config),
-            Some(relay_chain_id),
-            Some(relay_owner),
+            relay_chain_id,
+            relay_owner,
             // Dummy values — committee relay only needs the LightClient, not the bridge apps.
             "0x0000000000000000000000000000000000000000",
             "0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
Backport of #6124 

## Motivation

`linera-bridge` has unnecessary dependency on `linera-faucet-client` only to create the wallet during init phase.

## Proposal

Remove it from the `linera-bridge` binary and use `linera` in setup step.

## Test Plan

Manual and CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

#6124 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
