### PR TITLE
[testnet] Switch to the github access for the "protoc"

### DIFF
--- a/.github/actions/install-protoc/action.yml
+++ b/.github/actions/install-protoc/action.yml
@@ -1,0 +1,20 @@
+name: Install Protoc
+description: Install the Protocol Buffers compiler from official GitHub releases.
+inputs:
+  version:
+    description: Protoc version (e.g. "34.1").
+    required: false
+    default: "34.1"
+runs:
+  using: "composite"
+  steps:
+    - name: Download and install protoc
+      shell: bash
+      env:
+        PB_VER: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        curl -fsSL -o /tmp/protoc.zip \
+          "https://github.com/protocolbuffers/protobuf/releases/download/v${PB_VER}/protoc-${PB_VER}-linux-x86_64.zip"
+        sudo unzip -o /tmp/protoc.zip -d /usr/local
+        protoc --version

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -28,10 +28,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run benchmarks
       run: |
         cargo bench -p linera-service

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -40,10 +40,7 @@ jobs:
           mdbook-version: '0.4.48'
 
       - name: 'Install Protoc'
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "34.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-protoc
 
       - name: 'Install mdbook linkcheck'
         uses: taiki-e/cache-cargo-install-action@v2

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -37,10 +37,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "34.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-protoc
 
       # Self-hosted runners occasionally expose an unhealthy
       # docker socket at job start despite

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -45,10 +45,7 @@ jobs:
           fetch-depth: 0
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "34.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: ./.github/actions/install-protoc
       # TODO(#2709): Uncomment once this workflow runs in a custom runner
       # - name: Update aio-max-nr
         # run: echo 1048576 > /proc/sys/fs/aio-max-nr

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -43,10 +43,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Compute docs
       run: |
         cargo doc --all-features
@@ -66,10 +63,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Install cargo tools
       run: |
         cargo install --locked cargo-index

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -43,10 +43,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -36,10 +36,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Check indexer library compiles
       run: |
         cargo check --locked -p linera-indexer
@@ -59,10 +56,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run indexer integration tests
       run: |
         cargo test --locked -p linera-indexer --lib

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -49,10 +49,7 @@ jobs:
       run: |
         cargo install --git https://github.com/ma2bd/cargo-all-features --branch workspace_metadata --locked
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run cargo check-all-features
       run: |
         cargo check-all-features --all-targets

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -38,10 +38,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Build
       run: |
         cargo build --release -p linera-service

--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -52,10 +52,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run the remote-net tests
       run: |
         cargo test -p linera-service remote_net_grpc --features remote-net

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,10 +67,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run the storage-service instance
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
@@ -191,10 +188,7 @@ jobs:
         cache-workspaces: |
           examples -> target
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run Wasm application tests
       run: |
         cd examples
@@ -213,10 +207,7 @@ jobs:
         cache-workspaces: |
           linera-sdk/tests/fixtures -> target
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run linera-sdk fixtures
       run: |
         cd linera-sdk/tests/fixtures
@@ -237,10 +228,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown --locked
@@ -265,10 +253,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Check for outdated CLI.md
       run: |
         if ! diff CLI.md <(cargo run --bin linera -- help-markdown)
@@ -288,10 +273,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run the storage-service instance
       run: |
         cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
@@ -336,10 +318,7 @@ jobs:
     - name: Check if Solc is in PATH
       run: which solc || echo "Solc not found in PATH"
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Install serde-generate-bin
       run: |
         cargo install serde-generate-bin@0.8.0 --locked
@@ -376,10 +355,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Build example applications
       run: |
         cd examples
@@ -531,10 +507,7 @@ jobs:
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run Wasm application lints
       run: |
         cd examples
@@ -557,10 +530,7 @@ jobs:
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run clippy
       run: |
         cargo clippy --locked --all-targets --all-features
@@ -584,10 +554,7 @@ jobs:
         ln -sf toolchains/nightly/rust-toolchain.toml
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Run cargo doc
       run: |
         cargo doc --locked --all-features
@@ -602,10 +569,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Check linera-service GraphQL schema
       run: |
         diff <(cargo run --locked --bin linera-schema-export) linera-service-graphql-client/gql/service_schema.graphql

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -45,10 +45,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
-      uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+      uses: ./.github/actions/install-protoc
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -50,10 +50,8 @@ jobs:
       with:
         version: 10.11.0
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Protoc
+      uses: ./.github/actions/install-protoc
     - uses: jetli/wasm-bindgen-action@v0.2.0
       with:
         version: 0.2.100

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -71,10 +71,8 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         rustflags: ""
-    - uses: arduino/setup-protoc@v3
-      with:
-        version: "34.1"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Protoc
+      uses: ./.github/actions/install-protoc
     - uses: nanasess/setup-chromedriver@v2
     - uses: jetli/wasm-pack-action@v0.4.0
       with:


### PR DESCRIPTION
## Motivation

Protoc is often failing because rate limiting. 

Backport https://github.com/linera-io/linera-protocol/pull/6148

## Proposal

Apply the same change as in `main`.

## Test Plan

CI is the point.

## Release Plan

This is to `testnet_conway`.

## Links

None