### PR TITLE
`--never-reject-application-ids`; remove unused code (#6014, #6009)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -185,6 +185,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `--reject-message-bundles-without-application-ids <REJECT_MESSAGE_BUNDLES_WITHOUT_APPLICATION_IDS>` — A set of application IDs. If specified, only bundles with at least one message from one of these applications will be accepted
 * `--reject-message-bundles-with-other-application-ids <REJECT_MESSAGE_BUNDLES_WITH_OTHER_APPLICATION_IDS>` — A set of application IDs. If specified, only bundles where all messages are from one of these applications will be accepted
 * `--process-events-from-application-ids <PROCESS_EVENTS_FROM_APPLICATION_IDS>` — A set of application IDs. If specified, only events coming from streams created by applications from this set will be processed
+* `--never-reject-application-ids <NEVER_REJECT_APPLICATION_IDS>` — A set of application IDs whose messages must never be rejected. Bundles whose messages are all from one of these applications bypass the other rejection rules (except `--restrict-chain-ids-to`), and on execution failure they (and subsequent bundles from the same sender) are removed from the block for later retry instead of being rejected, with a warning logged. Bundles that contain any message from an application not on this list can be rejected
 * `--timings` — Enable timing reports during operations
 * `--timing-interval <TIMING_INTERVAL>` — Interval in seconds between timing reports (defaults to 5)
 

--- a/linera-base/src/crypto/mod.rs
+++ b/linera-base/src/crypto/mod.rs
@@ -36,17 +36,6 @@ pub type ValidatorSignature = secp256k1::Secp256k1Signature;
 /// The key pair of a validator.
 pub type ValidatorKeypair = secp256k1::Secp256k1KeyPair;
 
-/// Signature scheme used for the public key.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
-pub enum SignatureScheme {
-    /// Ed25519
-    Ed25519,
-    /// secp256k1
-    Secp256k1,
-    /// EVM secp256k1
-    EvmSecp256k1,
-}
-
 /// The public key of a chain owner.
 /// The corresponding private key is allowed to propose blocks
 /// on the chain and transfer account's tokens.
@@ -217,15 +206,6 @@ impl AccountSecretKey {
 }
 
 impl AccountPublicKey {
-    /// Returns the signature scheme of the public key.
-    pub fn scheme(&self) -> SignatureScheme {
-        match self {
-            AccountPublicKey::Ed25519(_) => SignatureScheme::Ed25519,
-            AccountPublicKey::Secp256k1(_) => SignatureScheme::Secp256k1,
-            AccountPublicKey::EvmSecp256k1(_) => SignatureScheme::EvmSecp256k1,
-        }
-    }
-
     /// Returns the byte representation of the public key.
     pub fn as_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).expect("serialization to bytes should not fail")

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -13,7 +13,6 @@ use std::{
     hash::Hash,
     io, iter,
     num::ParseIntError,
-    path::Path,
     str::FromStr,
     sync::Arc,
 };
@@ -190,12 +189,6 @@ impl TimeDelta {
         TimeDelta(secs.saturating_mul(1_000_000))
     }
 
-    /// Returns the given duration, rounded to the nearest microsecond and capped to the maximum
-    /// [`TimeDelta`] value.
-    pub fn from_duration(duration: Duration) -> Self {
-        TimeDelta::from_micros(u64::try_from(duration.as_micros()).unwrap_or(u64::MAX))
-    }
-
     /// Returns this [`TimeDelta`] as a number of microseconds.
     pub const fn as_micros(&self) -> u64 {
         self.0
@@ -365,24 +358,6 @@ pub struct SendMessageRequest<Message> {
     pub grant: Resources,
     /// The message itself.
     pub message: Message,
-}
-
-impl<Message> SendMessageRequest<Message>
-where
-    Message: Serialize,
-{
-    /// Serializes the internal `Message` type into raw bytes.
-    pub fn into_raw(self) -> SendMessageRequest<Vec<u8>> {
-        let message = bcs::to_bytes(&self.message).expect("Failed to serialize message");
-
-        SendMessageRequest {
-            destination: self.destination,
-            authenticated: self.authenticated,
-            is_tracked: self.is_tracked,
-            grant: self.grant,
-            message,
-        }
-    }
 }
 
 /// An error type for arithmetic errors.
@@ -784,11 +759,6 @@ pub enum ChainOrigin {
 }
 
 impl ChainOrigin {
-    /// Whether the chain was created by another chain.
-    pub fn is_child(&self) -> bool {
-        matches!(self, ChainOrigin::Child { .. })
-    }
-
     /// Returns the root chain number, if this is a root chain.
     pub fn root(&self) -> Option<u32> {
         match self {
@@ -937,11 +907,6 @@ impl ChainDescription {
     pub fn timestamp(&self) -> Timestamp {
         self.timestamp
     }
-
-    /// Whether the chain was created by another chain.
-    pub fn is_child(&self) -> bool {
-        self.origin.is_child()
-    }
 }
 
 impl BcsHashable<'_> for ChainDescription {}
@@ -1024,6 +989,7 @@ impl ApplicationPermissions {
 
     /// Creates new `ApplicationPermissions` where the given applications are the only ones
     /// whose operations are allowed and mandatory, and they can also close the chain.
+    #[cfg(with_testing)]
     pub fn new_multiple(app_ids: Vec<ApplicationId>) -> Self {
         Self {
             execute_operations: Some(app_ids.clone()),
@@ -1513,11 +1479,6 @@ impl Blob {
     /// Gets a reference to the inner blob's bytes.
     pub fn bytes(&self) -> &[u8] {
         self.content.bytes()
-    }
-
-    /// Loads data blob from a file.
-    pub fn load_data_blob_from_file(path: impl AsRef<Path>) -> io::Result<Self> {
-        Ok(Self::new_data(fs::read(path)?))
     }
 
     /// Returns whether the blob is of [`BlobType::Committee`] variant.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1588,6 +1588,12 @@ pub struct MessagePolicy {
     /// A collection of applications: If `Some`, only event streams from those
     /// applications will be processed.
     pub process_events_from_application_ids: Option<HashSet<GenericApplicationId>>,
+    /// A collection of applications whose messages must never be rejected. Bundles whose
+    /// messages are all from one of these applications bypass the other rejection rules
+    /// (except `restrict_chain_ids_to`), and on execution failure they are discarded for
+    /// later retry instead of being rejected. A bundle that contains any message from an
+    /// application not on this list can be rejected. An empty set disables this feature.
+    pub never_reject_application_ids: HashSet<GenericApplicationId>,
 }
 
 /// A blanket policy to apply to all messages by default.
@@ -1617,35 +1623,6 @@ pub enum BlanketMessagePolicy {
 }
 
 impl MessagePolicy {
-    /// Constructs a new `MessagePolicy`.
-    pub fn new(
-        blanket: BlanketMessagePolicy,
-        restrict_chain_ids_to: Option<HashSet<ChainId>>,
-        reject_message_bundles_without_application_ids: Option<HashSet<GenericApplicationId>>,
-        reject_message_bundles_with_other_application_ids: Option<HashSet<GenericApplicationId>>,
-        process_events_from_application_ids: Option<HashSet<GenericApplicationId>>,
-    ) -> Self {
-        Self {
-            blanket,
-            restrict_chain_ids_to,
-            reject_message_bundles_without_application_ids,
-            reject_message_bundles_with_other_application_ids,
-            process_events_from_application_ids,
-        }
-    }
-
-    /// Constructs a new `MessagePolicy` that accepts all messages.
-    #[cfg(with_testing)]
-    pub fn new_accept_all() -> Self {
-        Self {
-            blanket: BlanketMessagePolicy::Accept,
-            restrict_chain_ids_to: None,
-            reject_message_bundles_without_application_ids: None,
-            reject_message_bundles_with_other_application_ids: None,
-            process_events_from_application_ids: None,
-        }
-    }
-
     /// Returns `true` if the blanket policy is to ignore messages.
     #[instrument(level = "trace", skip(self))]
     pub fn is_ignore(&self) -> bool {

--- a/linera-base/src/hashed.rs
+++ b/linera-base/src/hashed.rs
@@ -21,19 +21,7 @@ pub struct Hashed<T> {
 }
 
 impl<T> Hashed<T> {
-    /// Creates an instance of [`Hashed`] with the given `hash` value.
-    ///
-    /// Note on usage: This method is unsafe because it allows the caller to create a Hashed
-    /// with a hash that doesn't match the value. This is necessary for the rewrite state when
-    /// signers sign over old `Certificate` type.
-    pub fn unchecked_new(value: T, hash: CryptoHash) -> Self {
-        Self { value, hash }
-    }
-
     /// Creates an instance of [`Hashed`] with the given `value`.
-    ///
-    /// Note: Contrary to its `unchecked_new` counterpart, this method is safe because it
-    /// calculates the hash from the value.
     pub fn new<'de>(value: T) -> Self
     where
         T: BcsHashable<'de>,

--- a/linera-base/src/http.rs
+++ b/linera-base/src/http.rs
@@ -48,26 +48,6 @@ impl Request {
             body: payload.into(),
         }
     }
-
-    /// Creates an HTTP POST [`Request`] for a `url` with a body that's the `payload` serialized to
-    /// JSON.
-    pub fn post_json(
-        url: impl Into<String>,
-        payload: &impl Serialize,
-    ) -> Result<Self, serde_json::Error> {
-        Ok(Request {
-            method: Method::Post,
-            url: url.into(),
-            headers: vec![Header::new("Content-Type", b"application/json")],
-            body: serde_json::to_vec(payload)?,
-        })
-    }
-
-    /// Adds a header to this [`Request`].
-    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<Vec<u8>>) -> Self {
-        self.headers.push(Header::new(name, value));
-        self
-    }
 }
 
 /// The method used in an HTTP request.
@@ -173,12 +153,6 @@ impl Response {
             headers: vec![],
             body: vec![],
         }
-    }
-
-    /// Adds a header to this [`Response`].
-    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<Vec<u8>>) -> Self {
-        self.headers.push(Header::new(name, value));
-        self
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -435,17 +435,6 @@ impl std::str::FromStr for GenericApplicationId {
     }
 }
 
-impl GenericApplicationId {
-    /// Returns the `ApplicationId`, or `None` if it is `System`.
-    pub fn user_application_id(&self) -> Option<&ApplicationId> {
-        if let GenericApplicationId::User(app_id) = self {
-            Some(app_id)
-        } else {
-            None
-        }
-    }
-}
-
 impl<A> From<ApplicationId<A>> for AccountOwner {
     fn from(app_id: ApplicationId<A>) -> Self {
         AccountOwner::Address32(app_id.application_description_hash)

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -132,6 +132,7 @@ impl ChainOwnership {
     }
 
     /// Adds a regular owner.
+    #[cfg(with_testing)]
     pub fn with_regular_owner(mut self, owner: AccountOwner, weight: u64) -> Self {
         self.owners.insert(owner, weight);
         self

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -72,10 +72,6 @@ impl<T: CertificateValue> GenericCertificate<T> {
         self.value.hash()
     }
 
-    pub fn destructure(self) -> (T, Round, Vec<(ValidatorPublicKey, ValidatorSignature)>) {
-        (self.value, self.round, self.signatures)
-    }
-
     pub fn signatures(&self) -> &Vec<(ValidatorPublicKey, ValidatorSignature)> {
         &self.signatures
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -35,7 +35,7 @@ use linera_views::{
     views::{ClonableView, RootView, View},
 };
 use serde::{Deserialize, Serialize};
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::{
     block::{Block, ConfirmedBlock},
@@ -710,10 +710,10 @@ where
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         exec_policy: BundleExecutionPolicy,
-    ) -> Result<(BlockExecutionOutcome, ResourceTracker), ChainError> {
+    ) -> Result<(BlockExecutionOutcome, ResourceTracker, HashSet<ChainId>), ChainError> {
         // AutoRetry is incompatible with replaying oracle responses because discarding or
         // rejecting bundles would change which transactions execute.
-        if !matches!(exec_policy.on_failure, BundleFailurePolicy::Abort) {
+        if !matches!(&exec_policy.on_failure, BundleFailurePolicy::Abort) {
             assert!(
                 replaying_oracle_responses.is_none(),
                 "Cannot use AutoRetry policy when replaying oracle responses"
@@ -759,13 +759,17 @@ where
             block,
         )?;
 
-        // Extract failure policy settings.
-        let max_failures = match exec_policy.on_failure {
-            BundleFailurePolicy::Abort => 0,
-            BundleFailurePolicy::AutoRetry { max_failures } => max_failures,
+        // Extract failure-policy parameters from exec_policy.
+        let (max_failures, never_reject_application_ids) = match &exec_policy.on_failure {
+            BundleFailurePolicy::Abort => (0, Arc::new(HashSet::new())),
+            BundleFailurePolicy::AutoRetry {
+                max_failures,
+                never_reject_application_ids,
+            } => (*max_failures, never_reject_application_ids.clone()),
         };
         let auto_retry = !matches!(exec_policy.on_failure, BundleFailurePolicy::Abort);
         let mut failure_count = 0u32;
+        let mut never_reject_discarded_origins = HashSet::new();
 
         // Track cumulative bundle execution time if time budget is set.
         let time_budget = exec_policy.time_budget;
@@ -837,6 +841,10 @@ where
             *chain = saved_chain;
             block_execution_tracker.restore_checkpoint(&saved_tracker);
 
+            let all_messages_never_reject = !never_reject_application_ids.is_empty()
+                && incoming_bundle.messages().all(|posted_msg| {
+                    never_reject_application_ids.contains(&posted_msg.message.application_id())
+                });
             if error.is_limit_error() && i > 0 {
                 failure_count += 1;
                 // If we've exceeded max failures, discard all remaining message bundles.
@@ -860,10 +868,23 @@ where
                 };
                 Self::discard_remaining_bundles(block, i, maybe_sender);
                 // Continue without incrementing i (next transaction is now at i).
-            } else if incoming_bundle.bundle.is_protected()
-                || incoming_bundle.action == MessageAction::Reject
+            } else if (all_messages_never_reject || incoming_bundle.bundle.is_protected())
+                && incoming_bundle.action != MessageAction::Reject
             {
-                // Protected bundles cannot be rejected. Failed rejected bundles fail the block.
+                let origin = incoming_bundle.origin;
+                never_reject_discarded_origins.insert(origin);
+                warn!(
+                    %error,
+                    index = i,
+                    %origin,
+                    "Message bundle cannot be rejected (protected or never-reject); \
+                    discarding the bundle (and same-sender subsequent bundles) for retry \
+                    in a later block"
+                );
+                Self::discard_remaining_bundles(block, i, Some(origin));
+                // Continue without incrementing i (next transaction is now at i).
+            } else if incoming_bundle.action == MessageAction::Reject {
+                // Failed rejected bundles fail the block.
                 return Err(ChainError::ExecutionError(error, context));
             } else {
                 // Reject the bundle: either a non-limit error, or the first bundle
@@ -944,6 +965,7 @@ where
                 operation_results,
             },
             resource_tracker,
+            never_reject_discarded_origins,
         ))
     }
 
@@ -988,7 +1010,15 @@ where
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         policy: BundleExecutionPolicy,
-    ) -> Result<(ProposedBlock, BlockExecutionOutcome, ResourceTracker), ChainError> {
+    ) -> Result<
+        (
+            ProposedBlock,
+            BlockExecutionOutcome,
+            ResourceTracker,
+            HashSet<ChainId>,
+        ),
+        ChainError,
+    > {
         assert_eq!(
             block.chain_id,
             self.execution_state.context().extra().chain_id()
@@ -1049,7 +1079,9 @@ where
             policy,
         )
         .await
-        .map(|(outcome, tracker)| (block, outcome, tracker))
+        .map(|(outcome, tracker, never_reject_origins)| {
+            (block, outcome, tracker, never_reject_origins)
+        })
     }
 
     /// Tracks emitted events per stream and returns the set of streams where new contiguous

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1162,16 +1162,6 @@ where
         Ok(updated_streams)
     }
 
-    /// Returns whether this is a child chain.
-    pub async fn is_child(&self) -> Result<bool, ChainError> {
-        let description = self.execution_state.system.description.get().await?;
-        let Some(description) = description else {
-            // Root chains are always initialized, so this must be a child chain.
-            return Ok(true);
-        };
-        Ok(description.is_child())
-    }
-
     /// Verifies that the block is valid according to the chain's application permission settings.
     #[instrument(skip_all, fields(
         block_height = %block.height,

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -98,24 +98,6 @@ impl ProposedBlock {
         })
     }
 
-    /// Returns an iterator over all incoming [`PostedMessage`]s in this block.
-    pub fn incoming_messages(&self) -> impl Iterator<Item = &PostedMessage> {
-        self.incoming_bundles()
-            .flat_map(|incoming_bundle| &incoming_bundle.bundle.messages)
-    }
-
-    /// Returns the number of incoming messages.
-    pub fn message_count(&self) -> usize {
-        self.incoming_bundles()
-            .map(|im| im.bundle.messages.len())
-            .sum()
-    }
-
-    /// Returns an iterator over all transactions as references.
-    pub fn transaction_refs(&self) -> impl Iterator<Item = &Transaction> {
-        self.transactions.iter()
-    }
-
     /// Returns all operations in this block.
     pub fn operations(&self) -> impl Iterator<Item = &Operation> {
         self.transactions.iter().filter_map(|tx| match tx {
@@ -670,10 +652,6 @@ impl BlockExecutionOutcome {
 
     pub fn iter_created_blobs_ids(&self) -> impl Iterator<Item = BlobId> + '_ {
         self.blobs.iter().flatten().map(|blob| blob.id())
-    }
-
-    pub fn created_blobs_ids(&self) -> HashSet<BlobId> {
-        self.iter_created_blobs_ids().collect()
     }
 }
 

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -2,7 +2,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    sync::Arc,
+};
 
 use allocative::Allocative;
 use async_graphql::SimpleObject;
@@ -17,7 +20,9 @@ use linera_base::{
         Amount, Blob, BlockHeight, Epoch, Event, MessagePolicy, OracleResponse, Round, Timestamp,
     },
     doc_scalar, ensure, hex, hex_debug,
-    identifiers::{Account, AccountOwner, ApplicationId, BlobId, ChainId, StreamId},
+    identifiers::{
+        Account, AccountOwner, ApplicationId, BlobId, ChainId, GenericApplicationId, StreamId,
+    },
     time::Duration,
 };
 use linera_execution::{committee::Committee, Message, MessageKind, Operation, OutgoingMessage};
@@ -263,6 +268,15 @@ impl IncomingBundle {
                 return None;
             }
         }
+        if !policy.never_reject_application_ids.is_empty()
+            && self.messages().all(|posted_msg| {
+                policy
+                    .never_reject_application_ids
+                    .contains(&posted_msg.message.application_id())
+            })
+        {
+            return Some(self);
+        }
         if let Some(app_ids) = &policy.reject_message_bundles_without_application_ids {
             if !self
                 .messages()
@@ -301,8 +315,8 @@ pub enum MessageAction {
     Reject,
 }
 
-/// Policy for handling message bundle execution failures.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+/// Policy for handling message bundle execution failures during block execution.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum BundleFailurePolicy {
     /// Abort block execution on any bundle failure. The proposal is never modified.
     #[default]
@@ -315,16 +329,23 @@ pub enum BundleFailurePolicy {
     /// - For limit errors (block too large, fuel exceeded, etc.): discard the bundle
     ///   so it can be retried in a later block, unless it's the first transaction
     ///   (in which case it's inherently too large and gets rejected).
-    /// - For non-limit errors: reject the bundle (triggering bounced messages).
+    /// - For bundles whose messages are all from applications in
+    ///   `never_reject_application_ids`: discard the bundle (and subsequent bundles from
+    ///   the same sender) so they can be retried in a later block, and log a warning.
+    /// - For all other non-limit errors: reject the bundle (triggering bounced messages).
     /// - After `max_failures` discarded bundles, discard all remaining message bundles.
     AutoRetry {
         /// Maximum number of discarded bundles before discarding all remaining message bundles.
         max_failures: u32,
+        /// Applications whose messages must never be rejected. A failed bundle whose messages
+        /// are all from such applications is discarded instead of rejected. A bundle that
+        /// contains any message from an application not on this list can be rejected.
+        never_reject_application_ids: Arc<HashSet<GenericApplicationId>>,
     },
 }
 
-/// Policy for bundle execution during block preparation.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// Policy for executing message bundles during block execution.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BundleExecutionPolicy {
     /// How to handle bundle execution failures.
     pub on_failure: BundleFailurePolicy,

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -267,16 +267,6 @@ where
         self.validated_vote.get().as_ref()
     }
 
-    /// Returns the most recent timeout vote we cast.
-    pub fn timeout_vote(&self) -> Option<&Vote<Timeout>> {
-        self.timeout_vote.get().as_ref()
-    }
-
-    /// Returns the most recent fallback vote we cast.
-    pub fn fallback_vote(&self) -> Option<&Vote<Timeout>> {
-        self.fallback_vote.get().as_ref()
-    }
-
     /// Returns the lowest round where we can still vote to validate or confirm a block. This is
     /// the round to which the timeout applies.
     ///

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -67,15 +67,17 @@ impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
         local_time: Timestamp,
         published_blobs: &[Blob],
     ) -> Result<(ProposedBlock, BlockExecutionOutcome, ResourceTracker), ChainError> {
-        self.execute_block(
-            block,
-            local_time,
-            None,
-            published_blobs,
-            None,
-            BundleExecutionPolicy::committed(),
-        )
-        .await
+        let (block, outcome, tracker, _) = self
+            .execute_block(
+                block,
+                local_time,
+                None,
+                published_blobs,
+                None,
+                BundleExecutionPolicy::committed(),
+            )
+            .await?;
+        Ok((block, outcome, tracker))
     }
 }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -178,6 +178,15 @@ pub struct Options {
     #[arg(long, value_parser = util::parse_app_set)]
     pub process_events_from_application_ids: Option<HashSet<GenericApplicationId>>,
 
+    /// A set of application IDs whose messages must never be rejected. Bundles whose messages
+    /// are all from one of these applications bypass the other rejection rules (except
+    /// `--restrict-chain-ids-to`), and on execution failure they (and subsequent bundles from
+    /// the same sender) are removed from the block for later retry instead of being rejected,
+    /// with a warning logged. Bundles that contain any message from an application not on this
+    /// list can be rejected.
+    #[arg(long, value_parser = util::parse_app_set)]
+    pub never_reject_application_ids: Option<HashSet<GenericApplicationId>>,
+
     /// Enable timing reports during operations
     #[cfg(not(web))]
     #[arg(long)]
@@ -320,14 +329,21 @@ impl Default for Options {
 impl Options {
     /// Creates [`chain_client::Options`] with the corresponding values.
     pub(crate) fn to_chain_client_options(&self) -> chain_client::Options {
-        let message_policy = MessagePolicy::new(
-            self.blanket_message_policy,
-            self.restrict_chain_ids_to.clone(),
-            self.reject_message_bundles_without_application_ids.clone(),
-            self.reject_message_bundles_with_other_application_ids
+        let message_policy = MessagePolicy {
+            blanket: self.blanket_message_policy,
+            restrict_chain_ids_to: self.restrict_chain_ids_to.clone(),
+            reject_message_bundles_without_application_ids: self
+                .reject_message_bundles_without_application_ids
                 .clone(),
-            self.process_events_from_application_ids.clone(),
-        );
+            reject_message_bundles_with_other_application_ids: self
+                .reject_message_bundles_with_other_application_ids
+                .clone(),
+            process_events_from_application_ids: self.process_events_from_application_ids.clone(),
+            never_reject_application_ids: self
+                .never_reject_application_ids
+                .clone()
+                .unwrap_or_default(),
+        };
         let cross_chain_message_delivery =
             CrossChainMessageDelivery::new(self.wait_for_outgoing_messages);
         chain_client::Options {

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -61,6 +61,7 @@ pub struct ChainWorkerConfig {
 
 impl ChainWorkerConfig {
     /// Configures the `key_pair` in this [`ChainWorkerConfig`].
+    #[cfg(with_testing)]
     pub fn with_key_pair(mut self, key_pair: Option<ValidatorSecretKey>) -> Self {
         self.key_pair = key_pair.map(Arc::new);
         self

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -5,7 +5,7 @@
 
 use std::{
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     sync::{self, Arc},
 };
 
@@ -949,7 +949,7 @@ where
         } else {
             let oracle_responses = Some(block.body.oracle_responses.clone());
             let (proposed_block, outcome) = block.clone().into_proposal();
-            let (proposed_block, verified, _resource_tracker) = chain
+            let (proposed_block, verified, _resource_tracker, _) = chain
                 .execute_block(
                     proposed_block,
                     local_time,
@@ -1789,7 +1789,16 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
         policy: BundleExecutionPolicy,
-    ) -> Result<(ProposedBlock, Block, ChainInfoResponse, ResourceTracker), WorkerError> {
+    ) -> Result<
+        (
+            ProposedBlock,
+            Block,
+            ChainInfoResponse,
+            ResourceTracker,
+            HashSet<ChainId>,
+        ),
+        WorkerError,
+    > {
         self.initialize_and_save_if_needed().await?;
         let local_time = self.storage.clock().current_time();
         let signer = block.authenticated_signer;
@@ -1799,7 +1808,7 @@ where
         self.chain
             .remove_bundles_from_inboxes(block.timestamp, true, block.incoming_bundles())
             .await?;
-        let (executed_block, resource_tracker) =
+        let (executed_block, resource_tracker, never_reject_origins) =
             Box::pin(self.execute_block(block, local_time, round, published_blobs, policy)).await?;
 
         // No need to sign: only used internally.
@@ -1816,7 +1825,13 @@ where
         }
 
         let (proposed_block, _) = executed_block.clone().into_proposal();
-        Ok((proposed_block, executed_block, response, resource_tracker))
+        Ok((
+            proposed_block,
+            executed_block,
+            response,
+            resource_tracker,
+            never_reject_origins,
+        ))
     }
 
     /// Validates and executes a block proposed to extend this chain.
@@ -1934,7 +1949,7 @@ where
         let block = if let Some(outcome) = outcome {
             outcome.clone().with(proposal.content.block.clone())
         } else {
-            let (executed_block, _resource_tracker) = Box::pin(self.execute_block(
+            let (executed_block, _resource_tracker, _) = Box::pin(self.execute_block(
                 block.clone(),
                 local_time,
                 round.multi_leader(),
@@ -2118,15 +2133,11 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
         policy: BundleExecutionPolicy,
-    ) -> Result<(Block, ResourceTracker), WorkerError> {
-        let (proposed_block, outcome, resource_tracker) = Box::pin(self.chain.execute_block(
-            block,
-            local_time,
-            round,
-            published_blobs,
-            None,
-            policy,
-        ))
+    ) -> Result<(Block, ResourceTracker, HashSet<ChainId>), WorkerError> {
+        let (proposed_block, outcome, resource_tracker, never_reject_origins) = Box::pin(
+            self.chain
+                .execute_block(block, local_time, round, published_blobs, None, policy),
+        )
         .await?;
         let executed_block = Block::new(proposed_block, outcome);
         let block_hash = CryptoHash::new(&executed_block);
@@ -2141,7 +2152,7 @@ where
                 .await,
             );
         }
-        Ok((executed_block, resource_tracker))
+        Ok((executed_block, resource_tracker, never_reject_origins))
     }
 
     /// Initializes and saves the current chain if it is not active yet.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -151,7 +151,7 @@ impl Options {
             max_block_limit_errors: 3,
             max_new_events_per_block: 10,
             staging_bundles_time_budget: None,
-            message_policy: MessagePolicy::new_accept_all(),
+            message_policy: MessagePolicy::default(),
             cross_chain_message_delivery: CrossChainMessageDelivery::NonBlocking,
             quorum_grace_period: DEFAULT_QUORUM_GRACE_PERIOD,
             blob_download_timeout: Duration::from_secs(1),
@@ -174,6 +174,9 @@ impl Options {
         BundleExecutionPolicy {
             on_failure: BundleFailurePolicy::AutoRetry {
                 max_failures: self.max_block_limit_errors,
+                never_reject_application_ids: Arc::new(
+                    self.message_policy.never_reject_application_ids.clone(),
+                ),
             },
             time_budget: self.staging_bundles_time_budget,
         }
@@ -204,6 +207,9 @@ pub struct ChainClient<Env: Environment> {
     initial_block_hash: Option<CryptoHash>,
     /// Optional timing sender for benchmarking.
     timing_sender: Option<mpsc::UnboundedSender<(u64, TimingType)>>,
+    /// Sender chain IDs whose bundles were discarded due to the never-reject policy.
+    /// These origins are excluded from `process_inbox` until the client is restarted.
+    skipped_origins: Arc<papaya::HashSet<ChainId>>,
 }
 
 impl<Env: Environment> Clone for ChainClient<Env> {
@@ -216,6 +222,7 @@ impl<Env: Environment> Clone for ChainClient<Env> {
             initial_next_block_height: self.initial_next_block_height,
             initial_block_hash: self.initial_block_hash,
             timing_sender: self.timing_sender.clone(),
+            skipped_origins: self.skipped_origins.clone(),
         }
     }
 }
@@ -359,6 +366,7 @@ impl<Env: Environment> ChainClient<Env> {
             initial_block_hash,
             initial_next_block_height,
             timing_sender,
+            skipped_origins: Arc::new(papaya::HashSet::new()),
         }
     }
 
@@ -557,10 +565,12 @@ impl<Env: Environment> ChainClient<Env> {
             );
         }
 
+        let skipped = self.skipped_origins.pin();
         Ok(info
             .requested_pending_message_bundles
             .into_iter()
             .filter_map(|bundle| bundle.apply_policy(&self.options.message_policy))
+            .filter(|bundle| !skipped.contains(&bundle.origin))
             .take(self.options.max_pending_message_bundles)
             .collect())
     }
@@ -1519,13 +1529,21 @@ impl<Env: Environment> ChainClient<Env> {
         let round = self.round_for_oracle(&info, &identity).await?;
         // Make sure every incoming message succeeds and otherwise remove them.
         // Also, compute the final certified hash while we're at it.
-        let (block, _) = Box::pin(self.client.stage_block_execution(
+        let (block, _, never_reject_origins) = Box::pin(self.client.stage_block_execution(
             proposed_block,
             round,
             blobs.clone(),
             self.options.bundle_execution_policy(),
         ))
         .await?;
+        // Record origins whose bundles were discarded due to the never-reject policy so
+        // that `process_inbox` stops retrying them until the client is restarted.
+        if !never_reject_origins.is_empty() {
+            let skipped = self.skipped_origins.pin();
+            for origin in never_reject_origins {
+                skipped.insert(origin);
+            }
+        }
         let (proposed_block, _) = block.clone().into_proposal();
         *proposal_guard = Some(PendingProposal {
             block: proposed_block,
@@ -1701,7 +1719,7 @@ impl<Env: Environment> ChainClient<Env> {
         ))
         .await
         {
-            Ok((_, response)) => Ok((
+            Ok((_, response, _)) => Ok((
                 response.info.chain_balance,
                 response.info.requested_owner_balance,
             )),
@@ -1928,7 +1946,7 @@ impl<Env: Environment> ChainClient<Env> {
                         .get_locking_blobs(&blob_ids, self.chain_id)
                         .await?
                         .ok_or_else(|| Error::InternalError("Missing local locking blobs"))?;
-                    let block = self
+                    let (block, _, _) = self
                         .client
                         .stage_block_execution(
                             proposed_block,
@@ -1936,8 +1954,7 @@ impl<Env: Environment> ChainClient<Env> {
                             blobs.clone(),
                             BundleExecutionPolicy::committed(),
                         )
-                        .await?
-                        .0;
+                        .await?;
                     debug!("Retrying locking block from fast round.");
                     (block, blobs)
                 }
@@ -1947,7 +1964,7 @@ impl<Env: Environment> ChainClient<Env> {
             let proposed_block = pending.block.clone();
             let blobs = pending.blobs.clone();
             let round = self.round_for_oracle(&info, &owner).await?;
-            let (block, _) = self
+            let (block, _, _) = self
                 .client
                 .stage_block_execution(
                     proposed_block,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -18,7 +18,7 @@ use futures::{
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     abi::Abi,
-    crypto::{signer, AccountPublicKey, CryptoHash, Signer, ValidatorPublicKey},
+    crypto::{signer, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
         ChainDescription, Epoch, MessagePolicy, Round, Timestamp,
@@ -51,7 +51,7 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, SystemOperation, EPOCH_STREAM_NAME,
         REMOVED_EPOCH_STREAM_NAME,
     },
-    ExecutionError, Operation, Query, QueryOutcome, QueryResponse, SystemQuery, SystemResponse,
+    ExecutionError, Operation, Query, QueryOutcome,
 };
 use linera_storage::{Clock as _, Storage as _};
 use linera_views::ViewError;
@@ -1575,11 +1575,12 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     /// Queries a system application.
+    #[cfg(with_testing)]
     #[instrument(level = "trace", skip(query))]
     pub async fn query_system_application(
         &self,
-        query: SystemQuery,
-    ) -> Result<QueryOutcome<SystemResponse>, Error> {
+        query: linera_execution::SystemQuery,
+    ) -> Result<QueryOutcome<linera_execution::SystemResponse>, Error> {
         let (
             QueryOutcome {
                 response,
@@ -1588,7 +1589,7 @@ impl<Env: Environment> ChainClient<Env> {
             _,
         ) = self.query_application(Query::System(query), None).await?;
         match response {
-            QueryResponse::System(response) => Ok(QueryOutcome {
+            linera_execution::QueryResponse::System(response) => Ok(QueryOutcome {
                 response,
                 operations,
             }),
@@ -1613,7 +1614,7 @@ impl<Env: Environment> ChainClient<Env> {
             _,
         ) = self.query_application(query, None).await?;
         match response {
-            QueryResponse::User(response_bytes) => {
+            linera_execution::QueryResponse::User(response_bytes) => {
                 let response = serde_json::from_slice(&response_bytes)?;
                 Ok(QueryOutcome {
                     response,
@@ -2184,10 +2185,11 @@ impl<Env: Environment> ChainClient<Env> {
     /// Rotates the key of the chain.
     ///
     /// Replaces current owners of the chain with the new key pair.
+    #[cfg(with_testing)]
     #[instrument(level = "trace")]
     pub async fn rotate_key_pair(
         &self,
-        public_key: AccountPublicKey,
+        public_key: linera_base::crypto::AccountPublicKey,
     ) -> Result<ClientOutcome<ConfirmedBlockCertificate>, Error> {
         Box::pin(self.transfer_ownership(public_key.into())).await
     }
@@ -2677,6 +2679,7 @@ impl<Env: Environment> ChainClient<Env> {
     /// Sends money to a chain.
     /// Do not check balance. (This may block the client)
     /// Do not confirm the transaction.
+    #[cfg(with_testing)]
     #[instrument(level = "trace")]
     pub async fn transfer_to_account_unsafe_unconfirmed(
         &self,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1883,12 +1883,17 @@ impl<Env: Environment> Client<Env> {
         round: Option<u32>,
         published_blobs: Vec<Blob>,
         policy: BundleExecutionPolicy,
-    ) -> Result<(Block, ChainInfoResponse), chain_client::Error> {
+    ) -> Result<(Block, ChainInfoResponse, HashSet<ChainId>), chain_client::Error> {
         let mut downloaded_events = HashSet::<EventId>::new();
         loop {
             let result = self
                 .local_node
-                .stage_block_execution(block.clone(), round, published_blobs.clone(), policy)
+                .stage_block_execution(
+                    block.clone(),
+                    round,
+                    published_blobs.clone(),
+                    policy.clone(),
+                )
                 .await;
             if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
                 let validators = self.validator_nodes().await?;
@@ -1909,7 +1914,7 @@ impl<Env: Environment> Client<Env> {
                 }
                 // All reported events were already downloaded; don't loop forever.
             }
-            if let Ok((_, executed_block, _, _)) = &result {
+            if let Ok((_, executed_block, _, _, _)) = &result {
                 let hash = CryptoHash::new(executed_block);
                 let notification = Notification {
                     chain_id: executed_block.header.chain_id,
@@ -1920,8 +1925,14 @@ impl<Env: Environment> Client<Env> {
                 };
                 self.notifier.notify(&[notification]);
             }
-            let (_modified_block, executed_block, response, _resource_tracker) = result?;
-            return Ok((executed_block, response));
+            let (
+                _modified_block,
+                executed_block,
+                response,
+                _resource_tracker,
+                never_reject_origins,
+            ) = result?;
+            return Ok((executed_block, response, never_reject_origins));
         }
     }
 }

--- a/linera-core/src/client/requests_scheduler/node_info.rs
+++ b/linera-core/src/client/requests_scheduler/node_info.rs
@@ -109,11 +109,6 @@ impl<Env: Environment> NodeInfo<Env> {
         self.total_requests += 1;
     }
 
-    /// Returns the current EMA success rate.
-    pub(super) fn ema_success_rate(&self) -> f64 {
-        self.ema_success_rate
-    }
-
     /// Returns the total number of requests processed.
     pub(super) fn total_requests(&self) -> u64 {
         self.total_requests

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -465,29 +465,6 @@ impl<Env: Environment> RequestsScheduler<Env> {
         self.in_flight_tracker.get_alternative_peers(key).await
     }
 
-    /// Returns current performance metrics for all managed nodes.
-    ///
-    /// Each entry contains:
-    /// - Performance score (f64, normalized 0.0-1.0)
-    /// - EMA success rate (f64, 0.0-1.0)
-    /// - Total requests processed (u64)
-    ///
-    /// Useful for monitoring and debugging node performance.
-    pub async fn get_node_scores(&self) -> BTreeMap<ValidatorPublicKey, (f64, f64, u64)> {
-        let nodes = self.nodes.read().await;
-        let mut result = BTreeMap::new();
-
-        for (key, info) in nodes.iter() {
-            let score = info.calculate_score();
-            result.insert(
-                *key,
-                (score, info.ema_success_rate(), info.total_requests()),
-            );
-        }
-
-        result
-    }
-
     /// Wraps a request operation with performance tracking and capacity management.
     ///
     /// This method:

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -124,18 +124,8 @@ impl ChainInfoQuery {
         }
     }
 
-    pub fn test_next_block_height(mut self, height: BlockHeight) -> Self {
-        self.test_next_block_height = Some(height);
-        self
-    }
-
     pub fn with_committees(mut self) -> Self {
         self.request_committees = true;
-        self
-    }
-
-    pub fn with_owner_balance(mut self, owner: AccountOwner) -> Self {
-        self.request_owner_balance = owner;
         self
     }
 
@@ -164,6 +154,7 @@ impl ChainInfoQuery {
         self
     }
 
+    #[cfg(with_testing)]
     pub fn with_fallback(mut self) -> Self {
         self.request_fallback = true;
         self

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, HashMap, HashSet, VecDeque},
     sync::Arc,
 };
 
@@ -146,7 +146,16 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
         policy: BundleExecutionPolicy,
-    ) -> Result<(ProposedBlock, Block, ChainInfoResponse, ResourceTracker), LocalNodeError> {
+    ) -> Result<
+        (
+            ProposedBlock,
+            Block,
+            ChainInfoResponse,
+            ResourceTracker,
+            HashSet<ChainId>,
+        ),
+        LocalNodeError,
+    > {
         Ok(self
             .node
             .state

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -13,7 +13,7 @@ use futures::StreamExt;
 use linera_base::{
     crypto::{AccountSecretKey, CryptoHash, InMemorySigner},
     data_types::*,
-    identifiers::{Account, AccountOwner, ApplicationId, BlobId, BlobType},
+    identifiers::{Account, AccountOwner, ApplicationId, BlobId, BlobType, GenericApplicationId},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -2690,8 +2690,10 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.options_mut().message_policy =
-        MessagePolicy::new(BlanketMessagePolicy::Ignore, None, None, None, None);
+    receiver.options_mut().message_policy = MessagePolicy {
+        blanket: BlanketMessagePolicy::Ignore,
+        ..Default::default()
+    };
     receiver.synchronize_from_validators().await?;
     assert!(receiver.process_inbox().await?.0.is_empty());
     // The message was ignored.
@@ -2702,8 +2704,10 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.options_mut().message_policy =
-        MessagePolicy::new(BlanketMessagePolicy::Reject, None, None, None, None);
+    receiver.options_mut().message_policy = MessagePolicy {
+        blanket: BlanketMessagePolicy::Reject,
+        ..Default::default()
+    };
     let certs = receiver.process_inbox().await?.0;
     assert_eq!(certs.len(), 1);
     sender.synchronize_from_validators().await?;
@@ -2734,13 +2738,10 @@ where
     );
 
     // The receiver will only accept messages from sender, and not from sender2.
-    receiver.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        Some([sender.chain_id()].into_iter().collect()),
-        None,
-        None,
-        None,
-    );
+    receiver.options_mut().message_policy = MessagePolicy {
+        restrict_chain_ids_to: Some([sender.chain_id()].into_iter().collect()),
+        ..Default::default()
+    };
     receiver.synchronize_from_validators().await?;
     let certs = receiver.process_inbox().await?.0;
     assert_eq!(certs.len(), 1);
@@ -2748,13 +2749,51 @@ where
     assert_eq!(receiver.local_balance().await.unwrap(), Amount::ONE);
 
     // Let's accept the other one, too.
-    receiver.options_mut().message_policy =
-        MessagePolicy::new(BlanketMessagePolicy::Accept, None, None, None, None);
+    receiver.options_mut().message_policy = MessagePolicy::default();
     let certs = receiver.process_inbox().await?.0;
     assert_eq!(certs.len(), 1);
     assert_eq!(
         receiver.local_balance().await.unwrap(),
         Amount::from_tokens(2)
+    );
+
+    // A never-reject application bypasses a blanket Reject policy: the bundle must be accepted.
+    sender
+        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient)
+        .await
+        .unwrap_ok_committed();
+    receiver.synchronize_from_validators().await?;
+    receiver.options_mut().message_policy = MessagePolicy {
+        blanket: BlanketMessagePolicy::Reject,
+        never_reject_application_ids: [GenericApplicationId::System].into_iter().collect(),
+        ..Default::default()
+    };
+    let certs = receiver.process_inbox().await?.0;
+    assert_eq!(certs.len(), 1);
+    // The transfer was accepted (not bounced).
+    assert_eq!(
+        receiver.local_balance().await.unwrap(),
+        Amount::from_tokens(3)
+    );
+
+    // `restrict_chain_ids_to` still dominates over never-reject: a message from a non-whitelisted
+    // chain is still filtered out even if it belongs to a never-reject application.
+    sender
+        .transfer(AccountOwner::CHAIN, Amount::ONE, recipient)
+        .await
+        .unwrap_ok_committed();
+    receiver.synchronize_from_validators().await?;
+    receiver.options_mut().message_policy = MessagePolicy {
+        restrict_chain_ids_to: Some([sender2.chain_id()].into_iter().collect()),
+        never_reject_application_ids: [GenericApplicationId::System].into_iter().collect(),
+        ..Default::default()
+    };
+    // The message from `sender` is filtered out and not processed; receiver balance unchanged.
+    let certs = receiver.process_inbox().await?.0;
+    assert_eq!(certs.len(), 0);
+    assert_eq!(
+        receiver.local_balance().await.unwrap(),
+        Amount::from_tokens(3)
     );
 
     Ok(())
@@ -3190,13 +3229,10 @@ where
             None,
             BlockHeight::ZERO,
             chain_client::Options {
-                message_policy: MessagePolicy::new(
-                    BlanketMessagePolicy::Reject,
-                    None,
-                    None,
-                    None,
-                    None,
-                ),
+                message_policy: MessagePolicy {
+                    blanket: BlanketMessagePolicy::Reject,
+                    ..Default::default()
+                },
                 ..chain_client::Options::test_default()
             },
         )

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -24,8 +24,8 @@ use hex_game::{HexAbi, Operation as HexOperation, Timeouts};
 use linera_base::{
     crypto::{CryptoHash, InMemorySigner},
     data_types::{
-        Amount, BlanketMessagePolicy, BlobContent, BlockHeight, Bytecode, ChainDescription, Epoch,
-        Event, MessagePolicy, OracleResponse, Round, TimeDelta, Timestamp,
+        Amount, BlobContent, BlockHeight, Bytecode, ChainDescription, Epoch, Event, MessagePolicy,
+        OracleResponse, Round, TimeDelta, Timestamp,
     },
     identifiers::{
         AccountOwner, ApplicationId, BlobId, BlobType, DataBlobHash, ModuleId, StreamId, StreamName,
@@ -799,13 +799,10 @@ where
 
     receiver.synchronize_from_validators().await.unwrap();
 
-    receiver.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        Some([sender.chain_id()].into_iter().collect()),
-        None,
-        None,
-        None,
-    );
+    receiver.options_mut().message_policy = MessagePolicy {
+        restrict_chain_ids_to: Some([sender.chain_id()].into_iter().collect()),
+        ..Default::default()
+    };
 
     // Receiver should only process the event from sender now.
     let certs = receiver.process_inbox().await.unwrap().0;
@@ -826,8 +823,7 @@ where
     );
 
     // Let's receive from everyone again.
-    receiver.options_mut().message_policy =
-        MessagePolicy::new(BlanketMessagePolicy::Accept, None, None, None, None);
+    receiver.options_mut().message_policy = MessagePolicy::default();
 
     // Receiver should now process the event from sender2 as well.
     let certs = receiver.process_inbox().await.unwrap().0;
@@ -862,26 +858,22 @@ where
 
     // Turn on the events publishing whitelist: with no applications on it, processing the
     // events will effectively be disabled.
-    receiver.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        None,
-        None,
-        None,
-        Some(Default::default()),
-    );
+    receiver.options_mut().message_policy = MessagePolicy {
+        process_events_from_application_ids: Some(Default::default()),
+        ..Default::default()
+    };
 
     // Receiver should not process the event.
     let certs = receiver.process_inbox().await.unwrap().0;
     assert!(certs.is_empty());
 
     // Let's whitelist the social app now.
-    receiver.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        None,
-        None,
-        None,
-        Some([application_id.forget_abi().into()].into_iter().collect()),
-    );
+    receiver.options_mut().message_policy = MessagePolicy {
+        process_events_from_application_ids: Some(
+            [application_id.forget_abi().into()].into_iter().collect(),
+        ),
+        ..Default::default()
+    };
 
     // Receiver should process the new event now.
     let certs = receiver.process_inbox().await.unwrap().0;
@@ -1374,13 +1366,12 @@ where
     campaign_chain.synchronize_from_validators().await?;
 
     // Test 1: Accept bundles with at least one message from fungible app.
-    campaign_chain.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        None,
-        Some([fungible_id.forget_abi().into()].into_iter().collect()),
-        None,
-        None,
-    );
+    campaign_chain.options_mut().message_policy = MessagePolicy {
+        reject_message_bundles_without_application_ids: Some(
+            [fungible_id.forget_abi().into()].into_iter().collect(),
+        ),
+        ..Default::default()
+    };
     let certs = campaign_chain.process_inbox().await?.0;
     assert_eq!(certs.len(), 1, "Should accept bundle with fungible message");
 
@@ -1398,13 +1389,12 @@ where
     campaign_chain.synchronize_from_validators().await?;
 
     // Test 2: Accept bundles with at least one message from crowd-funding app.
-    campaign_chain.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        None,
-        Some([crowd_funding_id.forget_abi().into()].into_iter().collect()),
-        None,
-        None,
-    );
+    campaign_chain.options_mut().message_policy = MessagePolicy {
+        reject_message_bundles_without_application_ids: Some(
+            [crowd_funding_id.forget_abi().into()].into_iter().collect(),
+        ),
+        ..Default::default()
+    };
     let certs = campaign_chain.process_inbox().await?.0;
     assert_eq!(
         certs.len(),
@@ -1428,13 +1418,12 @@ where
     // Test 3: Reject bundles without any message from a non-existent app.
     // Use a different application description hash to create a fake app ID.
     let fake_app_id = ApplicationId::new(CryptoHash::test_hash("fake app"));
-    campaign_chain.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        None,
-        Some([fake_app_id.into()].into_iter().collect()),
-        None,
-        None,
-    );
+    campaign_chain.options_mut().message_policy = MessagePolicy {
+        reject_message_bundles_without_application_ids: Some(
+            [fake_app_id.into()].into_iter().collect(),
+        ),
+        ..Default::default()
+    };
     let certs = campaign_chain.process_inbox().await?.0;
     assert_eq!(
         certs.len(),
@@ -1444,13 +1433,12 @@ where
 
     // Test 4: Reject bundles that contain messages from apps not in the allowlist.
     // The bundle has messages from both fungible and crowd-funding, but we only allow fungible.
-    campaign_chain.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        None,
-        None,
-        Some([fungible_id.forget_abi().into()].into_iter().collect()),
-        None,
-    );
+    campaign_chain.options_mut().message_policy = MessagePolicy {
+        reject_message_bundles_with_other_application_ids: Some(
+            [fungible_id.forget_abi().into()].into_iter().collect(),
+        ),
+        ..Default::default()
+    };
     let certs = campaign_chain.process_inbox().await?.0;
     assert_eq!(
         certs.len(),
@@ -1459,11 +1447,8 @@ where
     );
 
     // Test 5: Accept bundles when all app messages are in the allowlist.
-    campaign_chain.options_mut().message_policy = MessagePolicy::new(
-        BlanketMessagePolicy::Accept,
-        None,
-        None,
-        Some(
+    campaign_chain.options_mut().message_policy = MessagePolicy {
+        reject_message_bundles_with_other_application_ids: Some(
             [
                 fungible_id.forget_abi().into(),
                 crowd_funding_id.forget_abi().into(),
@@ -1471,8 +1456,8 @@ where
             .into_iter()
             .collect(),
         ),
-        None,
-    );
+        ..Default::default()
+    };
     let certs = campaign_chain.process_inbox().await?.0;
     assert_eq!(
         certs.len(),

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -396,7 +396,7 @@ where
         .with_timestamp(1)
         .with_operation(publish_counter_op)
         .with_operation(publish_meta_op);
-    let (_, publish_executed, _, _) = env
+    let (_, publish_executed, _, _, _) = env
         .worker()
         .stage_block_execution(
             publish_block,
@@ -431,7 +431,7 @@ where
     let create_counter_block = make_child_block(&publish_cert.into_value())
         .with_timestamp(2)
         .with_operation(create_counter_op);
-    let (_, create_counter_executed, _, _) = env
+    let (_, create_counter_executed, _, _, _) = env
         .worker()
         .stage_block_execution(
             create_counter_block,
@@ -466,7 +466,7 @@ where
     let create_meta_block = make_child_block(&create_counter_cert.into_value())
         .with_timestamp(3)
         .with_operation(create_meta_op);
-    let (_, create_meta_executed, _, _) = env
+    let (_, create_meta_executed, _, _, _) = env
         .worker()
         .stage_block_execution(
             create_meta_block,
@@ -489,7 +489,7 @@ where
             application_id: meta_app_id,
             bytes: fail_op_bytes,
         });
-    let (_, send_fail_executed, _, _) = env
+    let (_, send_fail_executed, _, _, _) = env
         .worker()
         .stage_block_execution(
             send_fail_block,
@@ -534,14 +534,17 @@ where
 
     // Stage execution with AutoRetry policy.
     // This should handle the failing message by rejecting the bundle.
-    let (modified_block, auto_retry_executed, _, _) = env
+    let (modified_block, auto_retry_executed, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block.clone(),
             None,
             vec![],
             BundleExecutionPolicy {
-                on_failure: BundleFailurePolicy::AutoRetry { max_failures: 3 },
+                on_failure: BundleFailurePolicy::AutoRetry {
+                    max_failures: 3,
+                    never_reject_application_ids: Default::default(),
+                },
                 time_budget: None,
             },
         )
@@ -563,7 +566,7 @@ where
     // Now stage the modified block with Abort policy.
     // Since the bundle is already marked as Reject, this should succeed
     // and produce the same outcome.
-    let (_, abort_executed, _, _) = env
+    let (_, abort_executed, _, _, _) = env
         .worker()
         .stage_block_execution(
             modified_block.clone(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -800,7 +800,7 @@ where
         .await
         .unwrap();
     // Stage execution to get the block for certificate creation.
-    let (_, block, _, _) = env
+    let (_, block, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block,
@@ -829,7 +829,7 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    let (_, block, _, _) = env
+    let (_, block, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block,
@@ -857,7 +857,7 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    let (_, block, _, _) = env
+    let (_, block, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block,
@@ -3589,7 +3589,7 @@ where
             timeout_config: TimeoutConfig::default(),
         })
         .with_authenticated_signer(Some(owner0));
-    let (_, block0, _, _) = env
+    let (_, block0, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block0,
@@ -3656,7 +3656,7 @@ where
 
     // Now owner 0 can propose a block, but owner 1 can't.
     let proposed_block1 = make_child_block(&value0).with_simple_transfer(chain_1, small_transfer);
-    let (_, block1, _, _) = env
+    let (_, block1, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block1.clone(),
@@ -3711,7 +3711,7 @@ where
     // Create block2, also at height 1, but different from block 1.
     let amount = Amount::from_tokens(1);
     let proposed_block2 = make_child_block(&value0.clone()).with_simple_transfer(chain_1, amount);
-    let (_, block2, _, _) = env
+    let (_, block2, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block2.clone(),
@@ -3855,7 +3855,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (_, block0, _, _) = env
+    let (_, block0, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block0,
@@ -3972,7 +3972,7 @@ where
                 ..TimeoutConfig::default()
             },
         });
-    let (_, block0, _, _) = env
+    let (_, block0, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block0,
@@ -4005,7 +4005,7 @@ where
         .into_proposal_with_round(owner0, &signer, Round::Fast)
         .await
         .unwrap();
-    let (_, block1, _, _) = env
+    let (_, block1, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block1.clone(),
@@ -4067,7 +4067,7 @@ where
     env.worker().handle_block_proposal(proposal3).await?;
 
     // A validated block certificate from a later round can override the locked fast block.
-    let (_, block2, _, _) = env
+    let (_, block2, _, _, _) = env
         .worker()
         .stage_block_execution(
             proposed_block2.clone(),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -641,6 +641,7 @@ where
     StorageClient: Storage,
 {
     /// Sets the cross-chain message chunk limit.
+    #[cfg(with_testing)]
     pub fn set_cross_chain_message_chunk_limit(&mut self, limit: usize) {
         self.chain_worker_config.cross_chain_message_chunk_limit = limit;
     }
@@ -651,6 +652,7 @@ where
     }
 
     /// Sets the priority bundle origins.
+    #[cfg(with_testing)]
     pub fn with_priority_bundle_origins(
         mut self,
         origins: std::collections::HashSet<ChainId>,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     sync::{Arc, Mutex, RwLock},
     time::Duration,
 };
@@ -1082,7 +1082,16 @@ where
         round: Option<u32>,
         published_blobs: Vec<Blob>,
         policy: BundleExecutionPolicy,
-    ) -> Result<(ProposedBlock, Block, ChainInfoResponse, ResourceTracker), WorkerError> {
+    ) -> Result<
+        (
+            ProposedBlock,
+            Block,
+            ChainInfoResponse,
+            ResourceTracker,
+            HashSet<ChainId>,
+        ),
+        WorkerError,
+    > {
         let chain_id = block.chain_id;
         self.chain_write(chain_id, move |mut guard| async move {
             guard

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -2,53 +2,16 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, collections::BTreeMap, str::FromStr, sync::Arc};
+use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 
 use allocative::Allocative;
 use linera_base::{
-    crypto::{AccountPublicKey, CryptoError, ValidatorPublicKey},
+    crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::Epoch,
 };
 use serde::{Deserialize, Serialize};
 
 use crate::policy::ResourceControlPolicy;
-
-/// The identity of a validator.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug)]
-pub struct ValidatorName(pub ValidatorPublicKey);
-
-impl Serialize for ValidatorName {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        if serializer.is_human_readable() {
-            serializer.serialize_str(&self.to_string())
-        } else {
-            serializer.serialize_newtype_struct("ValidatorName", &self.0)
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for ValidatorName {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        if deserializer.is_human_readable() {
-            let s = String::deserialize(deserializer)?;
-            let value = Self::from_str(&s).map_err(serde::de::Error::custom)?;
-            Ok(value)
-        } else {
-            #[derive(Deserialize)]
-            #[serde(rename = "ValidatorName")]
-            struct ValidatorNameDerived(ValidatorPublicKey);
-
-            let value = ValidatorNameDerived::deserialize(deserializer)?;
-            Ok(Self(value.0))
-        }
-    }
-}
 
 /// Public state of a validator.
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, Allocative)]
@@ -198,26 +161,6 @@ impl<'a> From<&'a Committee> for CommitteeMinimal<'a> {
     }
 }
 
-impl std::fmt::Display for ValidatorName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        self.0.fmt(f)
-    }
-}
-
-impl std::str::FromStr for ValidatorName {
-    type Err = CryptoError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ValidatorName(ValidatorPublicKey::from_str(s)?))
-    }
-}
-
-impl From<ValidatorPublicKey> for ValidatorName {
-    fn from(value: ValidatorPublicKey) -> Self {
-        Self(value)
-    }
-}
-
 impl Committee {
     pub fn new(
         validators: BTreeMap<ValidatorPublicKey, ValidatorState>,
@@ -265,22 +208,10 @@ impl Committee {
         }
     }
 
-    pub fn keys_and_weights(&self) -> impl Iterator<Item = (ValidatorPublicKey, u64)> + '_ {
-        self.validators
-            .iter()
-            .map(|(name, validator)| (*name, validator.votes))
-    }
-
     pub fn account_keys_and_weights(&self) -> impl Iterator<Item = (AccountPublicKey, u64)> + '_ {
         self.validators
             .values()
             .map(|validator| (validator.account_public_key, validator.votes))
-    }
-
-    pub fn network_address(&self, author: &ValidatorPublicKey) -> Option<&str> {
-        self.validators
-            .get(author)
-            .map(|state| state.network_address.as_ref())
     }
 
     pub fn quorum_threshold(&self) -> u64 {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -7,7 +7,7 @@
 mod tests;
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 
@@ -288,34 +288,6 @@ pub struct SystemResponse {
 /// Optional user message attached to a transfer.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default, Debug, Serialize, Deserialize)]
 pub struct UserData(pub Option<[u8; 32]>);
-
-impl UserData {
-    pub fn from_option_string(opt_str: Option<String>) -> Result<Self, usize> {
-        // Convert the Option<String> to Option<[u8; 32]>
-        let option_array = match opt_str {
-            Some(s) => {
-                // Convert the String to a Vec<u8>
-                let vec = s.into_bytes();
-                if vec.len() <= 32 {
-                    // Create an array from the Vec<u8>
-                    let mut array = [b' '; 32];
-
-                    // Copy bytes from the vector into the array
-                    let len = vec.len().min(32);
-                    array[..len].copy_from_slice(&vec[..len]);
-
-                    Some(array)
-                } else {
-                    return Err(vec.len());
-                }
-            }
-            None => None,
-        };
-
-        // Return the UserData with the converted Option<[u8; 32]>
-        Ok(UserData(option_array))
-    }
-}
 
 #[derive(Debug)]
 pub struct CreateApplicationResult {
@@ -955,45 +927,6 @@ where
             .await?;
 
         Ok(description)
-    }
-
-    /// Retrieves the recursive dependencies of applications and applies a topological sort.
-    pub async fn find_dependencies(
-        &mut self,
-        mut stack: Vec<ApplicationId>,
-        txn_tracker: &mut TransactionTracker,
-    ) -> Result<Vec<ApplicationId>, ExecutionError> {
-        // What we return at the end.
-        let mut result = Vec::new();
-        // The entries already inserted in `result`.
-        let mut sorted = HashSet::new();
-        // The entries for which dependencies have already been pushed once to the stack.
-        let mut seen = HashSet::new();
-
-        while let Some(id) = stack.pop() {
-            if sorted.contains(&id) {
-                continue;
-            }
-            if seen.contains(&id) {
-                // Second time we see this entry. It was last pushed just before its
-                // dependencies -- which are now fully sorted.
-                sorted.insert(id);
-                result.push(id);
-                continue;
-            }
-            // First time we see this entry:
-            // 1. Mark it so that its dependencies are no longer pushed to the stack.
-            seen.insert(id);
-            // 2. Schedule all the (yet unseen) dependencies, then this entry for a second visit.
-            stack.push(id);
-            let app = self.describe_application(id, txn_tracker).await?;
-            for child in app.required_application_ids.iter().rev() {
-                if !seen.contains(child) {
-                    stack.push(*child);
-                }
-            }
-        }
-        Ok(result)
     }
 
     /// Records a blob that is used in this block. If this is the first use on this chain, creates

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -350,9 +350,6 @@ impl From<::wasmer::InstantiationError> for WasmExecutionError {
 pub mod test {
     use std::{path::Path, sync::LazyLock};
 
-    #[cfg(with_fs)]
-    use super::{WasmContractModule, WasmRuntime, WasmServiceModule};
-
     fn build_applications_in_directory(dir: &str) -> Result<(), std::io::Error> {
         let output = std::process::Command::new("cargo")
             .current_dir(dir)
@@ -390,17 +387,5 @@ pub mod test {
             }
         }
         Err(std::io::Error::last_os_error())
-    }
-
-    #[cfg(with_fs)]
-    pub async fn build_example_application(
-        name: &str,
-        wasm_runtime: impl Into<Option<WasmRuntime>>,
-    ) -> Result<(WasmContractModule, WasmServiceModule), anyhow::Error> {
-        let (contract_path, service_path) = get_example_bytecode_paths(name)?;
-        let wasm_runtime = wasm_runtime.into().unwrap_or_default();
-        let contract = WasmContractModule::from_file(&contract_path, wasm_runtime).await?;
-        let service = WasmServiceModule::from_file(&service_path, wasm_runtime).await?;
-        Ok((contract, service))
     }
 }

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -245,7 +245,7 @@ impl BlockBuilder {
                     .clone()
             })
             .collect();
-        let (_, block, _, resource_tracker) = self
+        let (_, block, _, resource_tracker, _) = self
             .validator
             .worker()
             .stage_block_execution(


### PR DESCRIPTION
Backport #6014, #6009.

## Motivation

In some use cases we never want to reject an application's messages.

Backporting #6009 hit a few merge conflicts because #6014 was missing.

## Proposal

First backport #6014, removing unused code.

Backport #6009: Add a new `MessagePolicy` field and matching CLI flag listing application IDs whose messages must never be rejected. Bundles containing any such message bypass the other rejection rules (except `--restrict-chain-ids-to`), and if execution fails they are discarded (along with subsequent bundles from the same sender) for retry in a later block, with a warning logged
instead of triggering a bounce.

## Test Plan

Tests were extended.

## Release Plan

- Release SDK

## Links

- PRs to `main`: #6014, #6009
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
