### PR TITLE
Route Docker Compose CI to self-hosted-builder pool to avoid in-container OOM

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   compose:
     if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
-    runs-on: linera-io-self-hosted-ci
+    runs-on: linera-io-self-hosted-builder
     timeout-minutes: 40
 
     steps:


### PR DESCRIPTION
## Motivation

Docker Compose CI currently OOM-kills `rustc` during thin-LTO linking inside the DinD sidecar on `linera-io-self-hosted-ci` (24Gi DinD limit). The linera workspace LTO link needs more (32Gi was sufficient in testing on the same runner pod). Closes #5909.

## Proposal

Same shape as #5984 for `docker_image.yml`: route this workflow to `linera-io-self-hosted-builder`, which was provisioned in linera-io/linera-infra#899 with 56Gi DinD memory specifically for memory-heavy in-container builds.

## Test Plan

CI (will dispatch on the branch first to verify).

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- Closes #5909
- Prior art: #5984 + linera-io/linera-infra#899
