### PR TITLE
Add chainWorkerTtlMs helm value to validator chart

### DIFF
--- a/kubernetes/linera-validator/templates/shards.yaml
+++ b/kubernetes/linera-validator/templates/shards.yaml
@@ -155,6 +155,9 @@ spec:
                 {{- if .Values.notificationQueueSize }}
                 --notification-queue-size {{ .Values.notificationQueueSize }}
                 {{- end }}
+                {{- if .Values.chainWorkerTtlMs }}
+                --chain-worker-ttl-ms {{ .Values.chainWorkerTtlMs | int }}
+                {{- end }}
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -113,9 +113,9 @@ executionStateCacheSize: 20000
 # state is freed. Higher values keep chains warm across notification gaps and
 # brief client restarts at the cost of more memory; lower values bound memory
 # at the cost of cold ChainStateView reloads from Scylla on next access.
-# Binary default: 30000 (30 seconds). Recommended for production: 600000 (10 minutes).
-# Set to empty string to use the binary default.
-chainWorkerTtlMs: 600000
+# Binary default: 30000 (30 seconds).
+# Set to a number (e.g. 600000) to override; leave empty to use the binary default.
+chainWorkerTtlMs: ""
 
 # Dual storage mode (RocksDB + ScyllaDB)
 dualStore: false

--- a/kubernetes/linera-validator/values.yaml
+++ b/kubernetes/linera-validator/values.yaml
@@ -108,6 +108,15 @@ blockCacheSize: 20000
 # Execution state cache size (number of entries)
 executionStateCacheSize: 20000
 
+# Chain worker TTL in milliseconds.
+# How long an idle chain worker stays in memory on the validator before its
+# state is freed. Higher values keep chains warm across notification gaps and
+# brief client restarts at the cost of more memory; lower values bound memory
+# at the cost of cold ChainStateView reloads from Scylla on next access.
+# Binary default: 30000 (30 seconds). Recommended for production: 600000 (10 minutes).
+# Set to empty string to use the binary default.
+chainWorkerTtlMs: 600000
+
 # Dual storage mode (RocksDB + ScyllaDB)
 dualStore: false
 


### PR DESCRIPTION
## Motivation

The validator helm chart does not pass `--chain-worker-ttl-ms` to `linera-server`, so validators run with the binary default of 30 seconds. Combined with the single-partition-per-chain Scylla schema, this means any worker restart or notification gap longer than 30 s drops the chain worker from validator memory; the next request triggers a cold `ChainStateView` reload from Scylla on the chain single shard. Under burst load (concurrent `process_inbox` across many chains) this saturates per-shard reader permits and produces validator p99 latency spikes.

PM workers (clients) already run with a 30 min TTL set in `linera-infra:helm/pm-infra-backend/values.yaml`; the asymmetry made the validator side the limiting factor.

## Proposal

Add a `chainWorkerTtlMs` value to the validator chart and pass it as `--chain-worker-ttl-ms` to `linera-server` when set. The flag is optional; an empty value (the default) falls back to the binary default of 30 s, so this PR is purely a capability addition with no behaviour change. Operators can override per environment when ready. The template uses the same conditional pattern as `crossChainQueueSize` and `notificationQueueSize`.

## Test Plan

CI

## Release Plan

Nothing to do / These changes follow the usual release cycle.
