### PR TITLE
Fix `next_height_to_preprocess` to return numeric max

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -507,7 +507,9 @@ where
     ///
     /// The "+ 1" is so that it can be used in the same places as `next_block_height`.
     pub async fn next_height_to_preprocess(&self) -> Result<BlockHeight, ChainError> {
-        if let Some(height) = self.preprocessed_blocks.indices().await?.last() {
+        // `indices()` returns heights in serialization order (BCS little-endian for `u64`),
+        // which does not match numeric order, so we take the numeric max rather than the last.
+        if let Some(height) = self.preprocessed_blocks.indices().await?.into_iter().max() {
             return Ok(height.saturating_add(BlockHeight(1)));
         }
         Ok(self.tip_state.get().next_block_height)

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -940,6 +940,30 @@ async fn prepare_test_with_dummy_mock_application(
     Ok((application, application_id, chain, block, time))
 }
 
+/// `BlockHeight` is BCS-encoded as a little-endian `u64`, so the lexicographic
+/// order of `preprocessed_blocks` keys does not match the numeric order of heights:
+/// height 1 → `[01, 00, ..]` sorts after height 256 → `[00, 01, ..]`. This regression
+/// test pins down that `next_height_to_preprocess` returns the numeric maximum.
+#[tokio::test]
+async fn test_next_height_to_preprocess_with_misordered_keys() {
+    let chain_id = TestEnvironment::new().admin_chain_id();
+    let mut chain = ChainStateView::new(chain_id).await;
+
+    chain
+        .preprocessed_blocks
+        .insert(&BlockHeight(256), CryptoHash::test_hash("a"))
+        .unwrap();
+    chain
+        .preprocessed_blocks
+        .insert(&BlockHeight(1), CryptoHash::test_hash("b"))
+        .unwrap();
+
+    assert_eq!(
+        chain.next_height_to_preprocess().await.unwrap(),
+        BlockHeight(257),
+    );
+}
+
 /// View struct without a trailing field, simulating the `ChainStateView` layout
 /// on `testnet_conway` (18 fields, positions 0–17).
 #[derive(RootView)]


### PR DESCRIPTION
## Motivation

`MapView::indices()` returns keys in serialization order. `BlockHeight` is BCS-encoded as a little-endian `u64`, so the lexicographic order does not match the numeric order (e.g. height 1 sorts after height 256).

Currently the client uses `last()` and therefore may fail to send the required blocks if the validator is missing an event.

## Proposal

Take the numeric max instead of the last index.

## Test Plan

A regression test was added.

## Release Plan

- Release SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
