### PR TITLE
Only put _fast_ pending blocks in the wallet.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -109,7 +109,7 @@ pub trait ClientContext {
                 chain_id,
                 chain.block_hash,
                 chain.next_block_height,
-                &chain.pending_proposal,
+                &chain.pending_fast_proposal,
                 chain.owner,
                 self.timing_sender(),
                 follow_only,

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -430,12 +430,15 @@ impl<Env: Environment> ClientContext<Env> {
             .map_err(error::Inner::wallet)?
             .and_then(|chain| chain.owner);
 
-        let pending_proposal = client
+        // Only persist proposals that were made in the fast round: they need to be
+        // remembered across sessions even if the chain has since progressed past the
+        // fast round, so the proposer can retry them.
+        let pending_fast_proposal = client
             .pending_proposal()
             .await
             .filter(|p| p.round.is_some_and(|r| r.is_fast()));
         let new_chain = wallet::Chain {
-            pending_proposal,
+            pending_fast_proposal,
             owner: existing_owner,
             ..info.as_ref().into()
         };
@@ -1019,7 +1022,7 @@ impl<Env: Environment> ClientContext<Env> {
             for chain_client in chain_clients {
                 let info = chain_client.chain_info().await?;
                 let client_owner = chain_client.preferred_owner();
-                let pending_proposal = chain_client
+                let pending_fast_proposal = chain_client
                     .pending_proposal()
                     .await
                     .filter(|p| p.round.is_some_and(|r| r.is_fast()));
@@ -1027,7 +1030,7 @@ impl<Env: Environment> ClientContext<Env> {
                     .insert(
                         info.chain_id,
                         wallet::Chain {
-                            pending_proposal,
+                            pending_fast_proposal,
                             owner: client_owner,
                             ..info.as_ref().into()
                         },

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -431,8 +431,7 @@ impl<Env: Environment> ClientContext<Env> {
             .and_then(|chain| chain.owner);
 
         // Only persist proposals that were made in the fast round: they need to be
-        // remembered across sessions even if the chain has since progressed past the
-        // fast round, so the proposer can retry them.
+        // remembered across sessions to make sure there are no conflicting fast proposals.
         let pending_fast_proposal = client
             .pending_proposal()
             .await

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -430,8 +430,13 @@ impl<Env: Environment> ClientContext<Env> {
             .map_err(error::Inner::wallet)?
             .and_then(|chain| chain.owner);
 
+        let pending_proposal = if info.manager.current_round.is_fast() {
+            client.pending_proposal().await
+        } else {
+            None
+        };
         let new_chain = wallet::Chain {
-            pending_proposal: client.pending_proposal().await,
+            pending_proposal,
             owner: existing_owner,
             ..info.as_ref().into()
         };
@@ -1015,7 +1020,11 @@ impl<Env: Environment> ClientContext<Env> {
             for chain_client in chain_clients {
                 let info = chain_client.chain_info().await?;
                 let client_owner = chain_client.preferred_owner();
-                let pending_proposal = chain_client.pending_proposal().await;
+                let pending_proposal = if info.manager.current_round.is_fast() {
+                    chain_client.pending_proposal().await
+                } else {
+                    None
+                };
                 self.wallet()
                     .insert(
                         info.chain_id,

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -430,11 +430,10 @@ impl<Env: Environment> ClientContext<Env> {
             .map_err(error::Inner::wallet)?
             .and_then(|chain| chain.owner);
 
-        let pending_proposal = if info.manager.current_round.is_fast() {
-            client.pending_proposal().await
-        } else {
-            None
-        };
+        let pending_proposal = client
+            .pending_proposal()
+            .await
+            .filter(|p| p.round.is_some_and(|r| r.is_fast()));
         let new_chain = wallet::Chain {
             pending_proposal,
             owner: existing_owner,
@@ -1020,11 +1019,10 @@ impl<Env: Environment> ClientContext<Env> {
             for chain_client in chain_clients {
                 let info = chain_client.chain_info().await?;
                 let client_owner = chain_client.preferred_owner();
-                let pending_proposal = if info.manager.current_round.is_fast() {
-                    chain_client.pending_proposal().await
-                } else {
-                    None
-                };
+                let pending_proposal = chain_client
+                    .pending_proposal()
+                    .await
+                    .filter(|p| p.round.is_some_and(|r| r.is_fast()));
                 self.wallet()
                     .insert(
                         info.chain_id,

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -70,11 +70,10 @@ impl chain_listener::ClientContext for ClientContext {
     ) -> Result<(), Error> {
         let info = client.chain_info().await?;
         let existing_owner = self.wallet().get(info.chain_id).and_then(|c| c.owner);
-        let pending_proposal = if info.manager.current_round.is_fast() {
-            client.pending_proposal().await
-        } else {
-            None
-        };
+        let pending_proposal = client
+            .pending_proposal()
+            .await
+            .filter(|p| p.round.is_some_and(|r| r.is_fast()));
         self.wallet().insert(
             info.chain_id,
             wallet::Chain {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -70,14 +70,14 @@ impl chain_listener::ClientContext for ClientContext {
     ) -> Result<(), Error> {
         let info = client.chain_info().await?;
         let existing_owner = self.wallet().get(info.chain_id).and_then(|c| c.owner);
-        let pending_proposal = client
+        let pending_fast_proposal = client
             .pending_proposal()
             .await
             .filter(|p| p.round.is_some_and(|r| r.is_fast()));
         self.wallet().insert(
             info.chain_id,
             wallet::Chain {
-                pending_proposal,
+                pending_fast_proposal,
                 owner: existing_owner,
                 ..info.as_ref().into()
             },
@@ -252,7 +252,7 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
             block_hash: chain_a_info.block_hash,
             next_block_height: chain_a_info.next_block_height,
             timestamp: clock.current_time(),
-            pending_proposal: None,
+            pending_fast_proposal: None,
             epoch: Some(chain_a_info.epoch),
         },
     );
@@ -265,7 +265,7 @@ async fn test_chain_listener_follow_only() -> anyhow::Result<()> {
             block_hash: chain_b_info.block_hash,
             next_block_height: chain_b_info.next_block_height,
             timestamp: clock.current_time(),
-            pending_proposal: None,
+            pending_fast_proposal: None,
             epoch: Some(chain_b_info.epoch),
         },
     );
@@ -603,7 +603,7 @@ async fn test_listener_uses_autosigner_for_incoming_messages() -> anyhow::Result
             block_hash: chain0_info.block_hash,
             next_block_height: chain0_info.next_block_height,
             timestamp: clock.current_time(),
-            pending_proposal: None,
+            pending_fast_proposal: None,
             epoch: Some(chain0_info.epoch),
         },
     );

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -70,7 +70,11 @@ impl chain_listener::ClientContext for ClientContext {
     ) -> Result<(), Error> {
         let info = client.chain_info().await?;
         let existing_owner = self.wallet().get(info.chain_id).and_then(|c| c.owner);
-        let pending_proposal = client.pending_proposal().await;
+        let pending_proposal = if info.manager.current_round.is_fast() {
+            client.pending_proposal().await
+        } else {
+            None
+        };
         self.wallet().insert(
             info.chain_id,
             wallet::Chain {

--- a/linera-client/src/unit_tests/client_context.rs
+++ b/linera-client/src/unit_tests/client_context.rs
@@ -136,10 +136,8 @@ async fn test_wallet_drops_non_fast_pending_proposal() -> anyhow::Result<()> {
     let ownership = ChainOwnership::multiple([(owner0, 100), (owner1, 100)], 10, timeout_config);
     client.change_ownership(ownership).await?;
 
-    // Validators 1 and 2 validate but don't confirm; validator 3 is offline. The burn fails
-    // and leaves a pending proposal in a multi-leader round.
-    builder.set_fault_type([1, 2], FaultType::DontProcessValidated);
-    builder.set_fault_type([3], FaultType::Offline);
+    // Three offline validators make the burn fail; the proposal stays pending.
+    builder.set_fault_type([1, 2, 3], FaultType::OfflineWithInfo);
     assert!(client
         .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await

--- a/linera-client/src/unit_tests/client_context.rs
+++ b/linera-client/src/unit_tests/client_context.rs
@@ -1,0 +1,159 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for [`ClientContext::update_wallet_from_client`].
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use linera_base::{
+    crypto::InMemorySigner,
+    data_types::{Amount, Round, TimeDelta},
+    identifiers::{AccountOwner, ChainId},
+    ownership::{ChainOwnership, TimeoutConfig},
+};
+use linera_core::{
+    client::{chain_client, Client, ListeningMode},
+    environment,
+    join_set_ext::JoinSet,
+    test_utils::{FaultType, MemoryStorageBuilder, TestBuilder},
+    worker::{DEFAULT_BLOCK_CACHE_SIZE, DEFAULT_EXECUTION_STATE_CACHE_SIZE},
+};
+use linera_rpc::node_provider::DEFAULT_MAX_BACKOFF;
+
+use crate::{client_context::ClientContext, config::GenesisConfig};
+
+/// Builds a production [`ClientContext`] with a fresh in-memory wallet, sharing validators
+/// with the given [`TestBuilder`].
+async fn make_context(
+    builder: &mut TestBuilder<MemoryStorageBuilder>,
+    signer: InMemorySigner,
+    chain_id: ChainId,
+) -> anyhow::Result<ClientContext<environment::Test>> {
+    let genesis_config = GenesisConfig::new_for_testing(builder);
+    let admin_chain_id = genesis_config.admin_chain_id();
+    let storage = builder.make_storage().await?;
+    let client = Client::new(
+        environment::Impl {
+            storage,
+            network: builder.make_node_provider(),
+            signer,
+            wallet: environment::TestWallet::default(),
+        },
+        admin_chain_id,
+        false,
+        [(chain_id, ListeningMode::FullChain)],
+        format!("Client node for {:.8}", chain_id),
+        Some(Duration::from_secs(30)),
+        Some(Duration::from_secs(1)),
+        HashSet::new(),
+        chain_client::Options::test_default(),
+        DEFAULT_BLOCK_CACHE_SIZE,
+        DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+        &linera_core::client::RequestsSchedulerConfig::default(),
+    );
+    Ok(ClientContext {
+        client: Arc::new(client),
+        genesis_config,
+        send_timeout: Duration::from_secs(4),
+        recv_timeout: Duration::from_secs(4),
+        retry_delay: Duration::from_secs(1),
+        max_retries: 10,
+        max_backoff: DEFAULT_MAX_BACKOFF,
+        chain_listeners: JoinSet::default(),
+        default_chain: None,
+        client_metrics: None,
+    })
+}
+
+/// A fast-round pending proposal must be persisted in the wallet.
+#[test_log::test(tokio::test)]
+async fn test_wallet_persists_fast_pending_proposal() -> anyhow::Result<()> {
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
+    let mut client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    client.options_mut().allow_fast_blocks = true;
+    let chain_id = client.chain_id();
+    let owner = client.identity().await?;
+
+    let timeout_config = TimeoutConfig {
+        fast_round_duration: Some(TimeDelta::from_secs(5)),
+        ..TimeoutConfig::default()
+    };
+    let ownership = ChainOwnership {
+        super_owners: BTreeSet::from_iter([owner]),
+        owners: BTreeMap::default(),
+        first_leader: None,
+        multi_leader_rounds: 10,
+        open_multi_leader_rounds: false,
+        timeout_config,
+    };
+    client.change_ownership(ownership).await?;
+
+    // Three offline validators make the burn fail; the proposal stays pending.
+    builder.set_fault_type([1, 2, 3], FaultType::OfflineWithInfo);
+    assert!(client
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
+        .await
+        .is_err());
+    let pending = client
+        .pending_proposal()
+        .await
+        .expect("expected fast pending proposal after failed burn");
+    assert_eq!(pending.round, Some(Round::Fast));
+
+    let context = make_context(&mut builder, signer, chain_id).await?;
+    context.update_wallet_from_client(&client).await?;
+    let stored = context
+        .wallet()
+        .get(chain_id)
+        .expect("wallet missing chain entry")
+        .pending_proposal
+        .expect("wallet missing fast pending proposal");
+    assert_eq!(stored.round, Some(Round::Fast));
+    Ok(())
+}
+
+/// A non-fast pending proposal must NOT be persisted in the wallet.
+#[test_log::test(tokio::test)]
+async fn test_wallet_drops_non_fast_pending_proposal() -> anyhow::Result<()> {
+    let mut signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
+    let client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let chain_id = client.chain_id();
+    let owner0 = client.identity().await?;
+    let owner1: AccountOwner = signer.generate_new().into();
+
+    let timeout_config = TimeoutConfig {
+        fast_round_duration: Some(TimeDelta::from_secs(5)),
+        ..TimeoutConfig::default()
+    };
+    let ownership = ChainOwnership::multiple([(owner0, 100), (owner1, 100)], 10, timeout_config);
+    client.change_ownership(ownership).await?;
+
+    // Validators 1 and 2 validate but don't confirm; validator 3 is offline. The burn fails
+    // and leaves a pending proposal in a multi-leader round.
+    builder.set_fault_type([1, 2], FaultType::DontProcessValidated);
+    builder.set_fault_type([3], FaultType::Offline);
+    assert!(client
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
+        .await
+        .is_err());
+    let pending = client
+        .pending_proposal()
+        .await
+        .expect("expected non-fast pending proposal after failed burn");
+    assert_eq!(pending.round, Some(Round::MultiLeader(0)));
+
+    let context = make_context(&mut builder, signer, chain_id).await?;
+    context.update_wallet_from_client(&client).await?;
+    let stored = context
+        .wallet()
+        .get(chain_id)
+        .expect("wallet missing chain entry");
+    assert!(stored.pending_proposal.is_none());
+    Ok(())
+}

--- a/linera-client/src/unit_tests/client_context.rs
+++ b/linera-client/src/unit_tests/client_context.rs
@@ -73,7 +73,8 @@ async fn make_context(
 #[test_log::test(tokio::test)]
 async fn test_wallet_persists_fast_pending_proposal() -> anyhow::Result<()> {
     let signer = InMemorySigner::new(None);
-    let mut builder = TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
+    let mut builder =
+        TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
     let mut client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
     client.options_mut().allow_fast_blocks = true;
     let chain_id = client.chain_id();
@@ -121,7 +122,8 @@ async fn test_wallet_persists_fast_pending_proposal() -> anyhow::Result<()> {
 #[test_log::test(tokio::test)]
 async fn test_wallet_drops_non_fast_pending_proposal() -> anyhow::Result<()> {
     let mut signer = InMemorySigner::new(None);
-    let mut builder = TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
+    let mut builder =
+        TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
     let client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
     let chain_id = client.chain_id();
     let owner0 = client.identity().await?;

--- a/linera-client/src/unit_tests/client_context.rs
+++ b/linera-client/src/unit_tests/client_context.rs
@@ -112,7 +112,7 @@ async fn test_wallet_persists_fast_pending_proposal() -> anyhow::Result<()> {
         .wallet()
         .get(chain_id)
         .expect("wallet missing chain entry")
-        .pending_proposal
+        .pending_fast_proposal
         .expect("wallet missing fast pending proposal");
     assert_eq!(stored.round, Some(Round::Fast));
     Ok(())
@@ -154,6 +154,6 @@ async fn test_wallet_drops_non_fast_pending_proposal() -> anyhow::Result<()> {
         .wallet()
         .get(chain_id)
         .expect("wallet missing chain entry");
-    assert!(stored.pending_proposal.is_none());
+    assert!(stored.pending_fast_proposal.is_none());
     Ok(())
 }

--- a/linera-client/src/unit_tests/mod.rs
+++ b/linera-client/src/unit_tests/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod chain_listener;
+mod client_context;

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1519,6 +1519,7 @@ impl<Env: Environment> ChainClient<Env> {
             block: proposed_block,
             blobs,
             auto_retry_outcome: Some(auto_retry_outcome),
+            round: None,
         });
         Ok(block)
     }
@@ -1973,6 +1974,9 @@ impl<Env: Environment> ChainClient<Env> {
             Either::Right(timeout) => return Ok(ClientOutcome::WaitForTimeout(timeout)),
         };
         debug!("Proposing block for round {}", round);
+        if let Some(pending) = proposal_guard.as_mut() {
+            pending.round.get_or_insert(round);
+        }
 
         let already_handled_locally = info
             .manager

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -19,7 +19,7 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::{CryptoHash, Signer as _, ValidatorPublicKey},
     data_types::{
-        ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, TimeDelta, Timestamp,
+        ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, Round, TimeDelta, Timestamp,
     },
     ensure,
     identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
@@ -2061,6 +2061,9 @@ pub struct PendingProposal {
     /// against the committed execution outcome.
     #[serde(default)]
     pub auto_retry_outcome: Option<BlockExecutionOutcome>,
+    /// The round in which this proposal was first submitted, if any.
+    #[serde(default)]
+    pub round: Option<Round>,
 }
 
 enum ReceiveCertificateMode {

--- a/linera-core/src/environment/wallet/memory.rs
+++ b/linera-core/src/environment/wallet/memory.rs
@@ -140,7 +140,7 @@ mod tests {
             block_hash: None,
             next_block_height: height.into(),
             timestamp: Timestamp::from(0),
-            pending_proposal: None,
+            pending_fast_proposal: None,
             epoch: None,
         }
     }

--- a/linera-core/src/environment/wallet/mod.rs
+++ b/linera-core/src/environment/wallet/mod.rs
@@ -21,7 +21,8 @@ pub struct Chain {
     pub block_hash: Option<CryptoHash>,
     pub next_block_height: BlockHeight,
     pub timestamp: Timestamp,
-    pub pending_proposal: Option<PendingProposal>,
+    /// A pending block proposal that was made in the fast round.
+    pub pending_fast_proposal: Option<PendingProposal>,
     pub epoch: Option<Epoch>,
 }
 
@@ -32,7 +33,7 @@ impl From<&ChainInfo> for Chain {
             block_hash: info.block_hash,
             next_block_height: info.next_block_height,
             timestamp: info.timestamp,
-            pending_proposal: None,
+            pending_fast_proposal: None,
             epoch: Some(info.epoch),
         }
     }
@@ -64,7 +65,7 @@ impl Chain {
             block_hash: None,
             timestamp: now,
             next_block_height: BlockHeight::ZERO,
-            pending_proposal: None,
+            pending_fast_proposal: None,
             epoch: Some(current_epoch),
         }
     }

--- a/linera-core/src/environment/wallet/mod.rs
+++ b/linera-core/src/environment/wallet/mod.rs
@@ -21,7 +21,6 @@ pub struct Chain {
     pub block_hash: Option<CryptoHash>,
     pub next_block_height: BlockHeight,
     pub timestamp: Timestamp,
-    /// A pending block proposal that was made in the fast round.
     pub pending_fast_proposal: Option<PendingProposal>,
     pub epoch: Option<Epoch>,
 }

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -130,6 +130,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
                     },
                     blobs: vec![Blob::new_data(b"blob".to_vec())],
                     auto_retry_outcome: None,
+                    round: None,
                 }),
                 ..admin_description.into()
             },

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -118,7 +118,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
             &wallet::Chain {
                 owner: Some(new_pubkey.into()),
                 timestamp: clock.current_time(),
-                pending_proposal: Some(PendingProposal {
+                pending_fast_proposal: Some(PendingProposal {
                     block: ProposedBlock {
                         chain_id,
                         epoch: Epoch::ZERO,

--- a/linera-wallet-json/src/display.rs
+++ b/linera-wallet-json/src/display.rs
@@ -84,8 +84,8 @@ impl ChainDetails {
             println!("{:<20}  {hash}", "Latest block hash:");
         }
 
-        if self.user_chain.pending_proposal.is_some() {
-            println!("{:<20}  present", "Pending proposal:");
+        if self.user_chain.pending_fast_proposal.is_some() {
+            println!("{:<20}  present", "Pending fast proposal:");
         }
     }
 }


### PR DESCRIPTION
## Motivation

Storing the pending block in the wallet is mainly important for _fast_ blocks, where liveness depends on the client not making any conflicting proposal.

Blocks proposals can also quite large, and take up a lot of space in the wallet.

## Proposal

Only persist _fast_ proposals.

## Test Plan

Tests were added to `linera-client`.

## Release Plan

- Backport to `testnet_conway`.
- Release SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
