### PR TITLE
Treat chain_modes=None as tracking every chain to fix validator TTL

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1044,7 +1044,10 @@ where
             .or_default()
             .clone();
 
-        let is_tracked = self.chain_modes.as_ref().is_some_and(|chain_modes| {
+        // `chain_modes=None` means "no tracked/sender distinction" (validators) — treat
+        // every chain as tracked so it routes through `config.ttl`, not the unset
+        // `config.sender_chain_ttl` which would skip `spawn_keep_alive` entirely.
+        let is_tracked = self.chain_modes.as_ref().is_none_or(|chain_modes| {
             chain_modes
                 .read()
                 .unwrap()


### PR DESCRIPTION
## Motivation

PR #5991 fixed an inverted TTL assignment in `create_chain_worker`, swapping the branches so tracked chains use the long `config.ttl` and sender chains use the short `config.sender_chain_ttl`. Correct for clients (PM workers, wallets) where `chain_modes=Some(...)` distinguishes tracked from sender chains.

Validators construct WorkerState with `chain_modes=None` (linera-service/src/server.rs:113) and have no tracked-vs-sender distinction. With `chain_modes=None`, `is_tracked` is always false, so post-#5991 every chain on a validator routes through `config.sender_chain_ttl`. The validator binary has no `--sender-chain-worker-ttl-ms` CLI flag, so `sender_chain_ttl` stays at the `ChainWorkerConfig::default()` value of `None`.

Result: `spawn_keep_alive` is never called for any chain worker on a validator. The `Arc<ChainWorker>` drops the moment the in-flight request finishes, taking the per-chain `LruCachingStore` with it. Every subsequent request reloads chain state from Scylla.

Empirical from testnet_conway V4 (running the post-#5991 no-actor code) vs V1-V3 (still running pre-fix actor.rs on testnet_conway_debug, where `is_tracked=false` correctly routes to `config.ttl=30s`):

- `read_value` LRU cache hit rate: V4 2.66% vs V1-V3 75%
- `find_keys_by_prefix` cache hit rate: V4 1.81% vs V1-V3 48%
- `read_multi_value` rate to Scylla: V4 ~691/s vs V1-V3 ~75/s (9.2x)
- p99 Scylla read latency: V4 42ms vs V1-V3 19-22ms; 30x worse stddev

## Proposal

Treat `chain_modes=None` as "tracking every chain this node serves" — the validator natural semantic, since validators have no tracked-vs-sender split. For clients, behavior is unchanged: `chain_modes=Some(map)` still computes `is_tracked` from map membership and Full listening mode.

One-line change: `chain_modes.as_ref().is_some_and(...)` becomes `is_none_or`. Inner `ListeningMode::is_full` check preserved unchanged.

Restores the actor-model property (validators routed through `config.ttl`) without re-inverting the branches that #5991 correctly fixed for clients.

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest testnet branch.

## Links

- #5991, #5992, #6000 (the inversion fix this complements for validators)
- #6160 (companion helm change adding `--chain-worker-ttl-ms` to validator chart)