### PR TITLE
Modify the build pipeline to make our built artefacts compatible with Sentry's Wasm integration (#6115)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -60,7 +60,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     steps:
       # Install dependencies
@@ -84,6 +84,15 @@ jobs:
       uses: pnpm/action-setup@v4
       with:
         version: 10.17
+    - name: Install `wasm-split`
+      uses: jaxxstorm/action-install-gh-release@v3.0.0
+      with:
+          repo: getsentry/symbolicator
+          tag: 26.3.0
+          asset-name: wasm-split
+          extension-matching: disable
+          rename-to: wasm-split
+          chmod: 0755
 
     # Setup fixtures
     - name: Run the storage-service instance

--- a/default.nix
+++ b/default.nix
@@ -19,7 +19,8 @@
     openssl
     protobuf
     git
-    wasm-bindgen-cli
+    wasm-bindgen-cli_0_2_100
+    symbolicator
     pnpm
   ];
   checkInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,12 @@
     perSystem = { config, self', inputs', pkgs, lib, system, ... }: {
       _module.args.pkgs = import inputs.nixpkgs {
         inherit system;
-        overlays = [ (import inputs.rust-overlay) ];
+        overlays = [
+          (import inputs.rust-overlay)
+          (self: super: {
+            symbolicator = self.callPackage ./nix/symbolicator.nix {};
+          })
+        ];
       };
 
       packages = let

--- a/nix/symbolicator.nix
+++ b/nix/symbolicator.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  bzip2,
+  openssl,
+  zstd,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "symbolicator";
+  version = "26.3.0";
+
+  src = fetchFromGitHub {
+    owner = "getsentry";
+    repo = "symbolicator";
+    rev = finalAttrs.version;
+    hash = "sha256-up23SMS/TWmgPm+VsWCEX/G8A8MgG9Vzay76tsHzo2M=";
+    fetchSubmodules = true;
+  };
+
+  cargoHash = "sha256-GUWAG9mPPHUevA1IfFRpL9f93vUWb+/gaH0v+Dw9Rko=";
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    bzip2
+    openssl
+    zstd
+  ];
+
+  env = {
+    SYMBOLICATOR_GIT_VERSION = finalAttrs.src.rev;
+    SYMBOLICATOR_RELEASE = finalAttrs.version;
+    ZSTD_SYS_USE_PKG_CONFIG = true;
+  };
+
+  # tests require network access
+  doCheck = false;
+
+  meta = {
+    description = "Native Symbolication as a Service";
+    homepage = "https://getsentry.github.io/symbolicator/";
+    changelog = "https://github.com/getsentry/symbolicator/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+    mainProgram = "symbolicator";
+  };
+})

--- a/web/@linera/client/build.bash
+++ b/web/@linera/client/build.bash
@@ -34,7 +34,13 @@ wasm-bindgen \
     --out-name index \
     --typescript \
     --target web \
+    --keep-debug \
     --split-linked-modules
+
+wasm-split \
+    src/wasm/index_bg.wasm \
+    --strip \
+    --debug-out src/wasm/index_bg.debug.wasm
 
 mkdir -p dist
 cp -r src/wasm dist/


### PR DESCRIPTION
## Motivation

Our Wasm errors are currently a bit unpleasant to read on Sentry.

## Proposal

Use the `wasm-split` tool to generate debug information during build that can be uploaded to Sentry to provide a better Wasm debugging experience. This file will appear in `src/wasm/index_bg.debug.wasm`, and the main Wasm binary will also be modified to add a build ID that Sentry can use internally to tie it to its debug info. I recommend uploading the debug info whenever we publish the npm package.

As a bonus, this reduces the size of the built binary to 17 MiB.

## Test Plan

Check errors on Sentry.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)