### PR TITLE
[testnet] Treat chain_modes=None as tracking every chain to fix validator TTL (#6167)

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1037,7 +1037,10 @@ where
             .or_default()
             .clone();
 
-        let is_tracked = self.chain_modes.as_ref().is_some_and(|chain_modes| {
+        // `chain_modes=None` means "no tracked/sender distinction" (validators) — treat
+        // every chain as tracked so it routes through `config.ttl`, not the unset
+        // `config.sender_chain_ttl` which would skip `spawn_keep_alive` entirely.
+        let is_tracked = self.chain_modes.as_ref().is_none_or(|chain_modes| {
             chain_modes
                 .read()
                 .unwrap()


### PR DESCRIPTION
Backport of #6167.

## Motivation

PR #5992 fixed an inverted TTL assignment in `create_chain_worker`, swapping the branches so tracked chains use the long `config.ttl` and sender chains use the short `config.sender_chain_ttl`. Correct for clients (PM workers, wallets) where `chain_modes=Some(...)` distinguishes tracked from sender chains.

Validators construct WorkerState with `chain_modes=None` (linera-service/src/server.rs:113) and have no tracked-vs-sender distinction. With `chain_modes=None`, `is_tracked` is always false, so post-#5992 every chain on a validator routes through `config.sender_chain_ttl`. The validator binary has no `--sender-chain-worker-ttl-ms` CLI flag, so `sender_chain_ttl` stays at the `ChainWorkerConfig::default()` value of `None`.

Result: `spawn_keep_alive` is never called for any chain worker on a validator. The `Arc<ChainWorker>` drops the moment the in-flight request finishes, taking the per-chain `LruCachingStore` with it. Every subsequent request reloads chain state from Scylla.

V4 (running e9d74e2) measured 24h post-deploy vs V1-V3 control (still on the actor model in testnet_conway_debug, where `is_tracked=false` correctly routes to `config.ttl=30s`):

- `read_value` LRU cache hit rate: V4 2.66% vs V1-V3 75%
- `find_keys_by_prefix` cache hit rate: V4 1.81% vs V1-V3 48%
- `read_multi_value` rate to Scylla: V4 ~691/s vs V1-V3 ~75/s (9.2x)

## Proposal

Treat `chain_modes=None` as "tracking every chain this node serves" — the validator natural semantic, since validators have no tracked-vs-sender split. For clients, behavior is unchanged: `chain_modes=Some(map)` still computes `is_tracked` from map membership and Full listening mode.

One-line change: outer `chain_modes.as_ref().is_some_and(...)` becomes `is_none_or`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

## Links

- #6167 (main PR)
- #5992 (the inversion fix this complements for validators)