### PR TITLE
[testnet] Backport: only persist fast pending proposals in the wallet (#6166)

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -425,11 +425,17 @@ impl<Env: Environment> ClientContext<Env> {
             .map_err(error::Inner::wallet)?
             .and_then(|chain| chain.owner);
 
+        // Only persist proposals that were made in the fast round: they need to be
+        // remembered across sessions to make sure there are no conflicting fast proposals.
+        let pending_proposal = chain_client
+            .pending_proposal()
+            .await
+            .filter(|p| p.round.is_some_and(|r| r.is_fast()));
         self.wallet()
             .insert(
                 info.chain_id,
                 wallet::Chain {
-                    pending_proposal: chain_client.pending_proposal().await,
+                    pending_proposal,
                     owner: existing_owner,
                     ..info.as_ref().into()
                 },
@@ -1030,7 +1036,10 @@ impl<Env: Environment> ClientContext<Env> {
             for chain_client in chain_clients {
                 let info = chain_client.chain_info().await?;
                 let client_owner = chain_client.preferred_owner();
-                let pending_proposal = chain_client.pending_proposal().await;
+                let pending_proposal = chain_client
+                    .pending_proposal()
+                    .await
+                    .filter(|p| p.round.is_some_and(|r| r.is_fast()));
                 self.wallet()
                     .insert(
                         info.chain_id,

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -75,7 +75,10 @@ impl chain_listener::ClientContext for ClientContext {
     ) -> Result<(), Error> {
         let info = client.chain_info().await?;
         let existing_owner = self.wallet().get(info.chain_id).and_then(|c| c.owner);
-        let pending_proposal = client.pending_proposal().await;
+        let pending_proposal = client
+            .pending_proposal()
+            .await
+            .filter(|p| p.round.is_some_and(|r| r.is_fast()));
         self.wallet().insert(
             info.chain_id,
             wallet::Chain {

--- a/linera-client/src/unit_tests/client_context.rs
+++ b/linera-client/src/unit_tests/client_context.rs
@@ -1,0 +1,159 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for [`ClientContext::update_wallet_from_client`].
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use linera_base::{
+    crypto::InMemorySigner,
+    data_types::{Amount, Round, TimeDelta},
+    identifiers::{AccountOwner, ChainId},
+    ownership::{ChainOwnership, TimeoutConfig},
+};
+use linera_core::{
+    client::{chain_client, Client, ListeningMode},
+    environment,
+    join_set_ext::JoinSet,
+    test_utils::{FaultType, MemoryStorageBuilder, TestBuilder},
+    worker::{DEFAULT_BLOCK_CACHE_SIZE, DEFAULT_EXECUTION_STATE_CACHE_SIZE},
+};
+use linera_rpc::node_provider::DEFAULT_MAX_BACKOFF;
+
+use crate::{client_context::ClientContext, config::GenesisConfig};
+
+/// Builds a production [`ClientContext`] with a fresh in-memory wallet, sharing validators
+/// with the given [`TestBuilder`].
+async fn make_context(
+    builder: &mut TestBuilder<MemoryStorageBuilder>,
+    signer: InMemorySigner,
+    chain_id: ChainId,
+) -> anyhow::Result<ClientContext<environment::Test>> {
+    let genesis_config = GenesisConfig::new_for_testing(builder);
+    let admin_chain_id = genesis_config.admin_chain_id();
+    let storage = builder.make_storage().await?;
+    let client = Client::new(
+        environment::Impl {
+            storage,
+            network: builder.make_node_provider(),
+            signer,
+            wallet: environment::TestWallet::default(),
+        },
+        admin_chain_id,
+        false,
+        [(chain_id, ListeningMode::FullChain)],
+        format!("Client node for {chain_id:.8}"),
+        Some(Duration::from_secs(30)),
+        Some(Duration::from_secs(1)),
+        HashSet::new(),
+        HashSet::new(),
+        chain_client::Options::test_default(),
+        &linera_core::client::RequestsSchedulerConfig::default(),
+        DEFAULT_BLOCK_CACHE_SIZE,
+        DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+    );
+    Ok(ClientContext {
+        client: Arc::new(client),
+        genesis_config,
+        send_timeout: Duration::from_secs(4),
+        recv_timeout: Duration::from_secs(4),
+        retry_delay: Duration::from_secs(1),
+        max_retries: 10,
+        max_backoff: DEFAULT_MAX_BACKOFF,
+        chain_listeners: JoinSet::default(),
+        default_chain: None,
+        client_metrics: None,
+    })
+}
+
+/// A fast-round pending proposal must be persisted in the wallet.
+#[test_log::test(tokio::test)]
+async fn test_wallet_persists_fast_pending_proposal() -> anyhow::Result<()> {
+    let signer = InMemorySigner::new(None);
+    let mut builder =
+        TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
+    let mut client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    client.options_mut().allow_fast_blocks = true;
+    let chain_id = client.chain_id();
+    let owner = client.identity().await?;
+
+    let timeout_config = TimeoutConfig {
+        fast_round_duration: Some(TimeDelta::from_secs(5)),
+        ..TimeoutConfig::default()
+    };
+    let ownership = ChainOwnership {
+        super_owners: BTreeSet::from_iter([owner]),
+        owners: BTreeMap::default(),
+        multi_leader_rounds: 10,
+        open_multi_leader_rounds: false,
+        timeout_config,
+    };
+    client.change_ownership(ownership).await?;
+
+    // Three offline validators make the burn fail; the proposal stays pending.
+    builder.set_fault_type([1, 2, 3], FaultType::OfflineWithInfo);
+    assert!(client
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
+        .await
+        .is_err());
+    let pending = client
+        .pending_proposal()
+        .await
+        .expect("expected fast pending proposal after failed burn");
+    assert_eq!(pending.round, Some(Round::Fast));
+
+    let context = make_context(&mut builder, signer, chain_id).await?;
+    context.update_wallet_from_client(&client).await?;
+    let stored = context
+        .wallet()
+        .get(chain_id)
+        .expect("wallet missing chain entry")
+        .pending_proposal
+        .expect("wallet missing fast pending proposal");
+    assert_eq!(stored.round, Some(Round::Fast));
+    Ok(())
+}
+
+/// A non-fast pending proposal must NOT be persisted in the wallet.
+#[test_log::test(tokio::test)]
+async fn test_wallet_drops_non_fast_pending_proposal() -> anyhow::Result<()> {
+    let mut signer = InMemorySigner::new(None);
+    let mut builder =
+        TestBuilder::new(MemoryStorageBuilder::default(), 4, 0, signer.clone()).await?;
+    let client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let chain_id = client.chain_id();
+    let owner0 = client.identity().await?;
+    let owner1: AccountOwner = signer.generate_new().into();
+
+    let timeout_config = TimeoutConfig {
+        fast_round_duration: Some(TimeDelta::from_secs(5)),
+        ..TimeoutConfig::default()
+    };
+    let ownership = ChainOwnership::multiple([(owner0, 100), (owner1, 100)], 10, timeout_config);
+    client.change_ownership(ownership).await?;
+
+    // Three offline validators make the burn fail; the proposal stays pending.
+    builder.set_fault_type([1, 2, 3], FaultType::OfflineWithInfo);
+    assert!(client
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
+        .await
+        .is_err());
+    let pending = client
+        .pending_proposal()
+        .await
+        .expect("expected non-fast pending proposal after failed burn");
+    assert_eq!(pending.round, Some(Round::MultiLeader(0)));
+
+    let context = make_context(&mut builder, signer, chain_id).await?;
+    context.update_wallet_from_client(&client).await?;
+    let stored = context
+        .wallet()
+        .get(chain_id)
+        .expect("wallet missing chain entry");
+    assert!(stored.pending_proposal.is_none());
+    Ok(())
+}

--- a/linera-client/src/unit_tests/mod.rs
+++ b/linera-client/src/unit_tests/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod chain_listener;
+mod client_context;

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1548,6 +1548,7 @@ impl<Env: Environment> ChainClient<Env> {
         *proposal_guard = Some(PendingProposal {
             block: proposed_block,
             blobs,
+            round: None,
         });
         Ok(block)
     }
@@ -1989,6 +1990,9 @@ impl<Env: Environment> ChainClient<Env> {
             Either::Right(timeout) => return Ok(ClientOutcome::WaitForTimeout(timeout)),
         };
         debug!("Proposing block for round {}", round);
+        if let Some(pending) = proposal_guard.as_mut() {
+            pending.round.get_or_insert(round);
+        }
 
         let already_handled_locally = info
             .manager

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -19,7 +19,7 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::{CryptoHash, Signer as _, ValidatorPublicKey},
     data_types::{
-        ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, TimeDelta, Timestamp,
+        ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, Round, TimeDelta, Timestamp,
     },
     ensure,
     identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
@@ -2000,6 +2000,9 @@ impl Drop for AbortOnDrop {
 pub struct PendingProposal {
     pub block: ProposedBlock,
     pub blobs: Vec<Blob>,
+    /// The round in which this proposal was first submitted, if any.
+    #[serde(default)]
+    pub round: Option<Round>,
 }
 
 enum ReceiveCertificateMode {

--- a/linera-service/tests/wallet.rs
+++ b/linera-service/tests/wallet.rs
@@ -131,6 +131,7 @@ async fn test_save_wallet_with_pending_blobs() -> anyhow::Result<()> {
                         previous_block_hash: None,
                     },
                     blobs: vec![Blob::new_data(b"blob".to_vec())],
+                    round: None,
                 }),
                 ..admin_description.into()
             },


### PR DESCRIPTION
Backport of #6166 from main (commit 73d02dc) without renaming the wallet's `pending_proposal` field, to stay compatible with existing clients on this branch.

## Motivation

Storing the pending block in the wallet is mainly important for _fast_ blocks, where liveness depends on the client not making any conflicting proposal.

Blocks proposals can also quite large, and take up a lot of space in the wallet.

## Proposal

Only persist _fast_ proposals.

## Test Plan

Tests were added to `linera-client`.

## Release Plan

- Release SDK.

## Links

- PR to `main`: #6166
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
