### PR TITLE
`find_first_key_by_prefix`, `find_last_key_by_prefix`

### DIFF
--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -191,6 +191,70 @@ where
         };
         Ok(result)
     }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        match self {
+            Self::First(store) => store
+                .find_first_key_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::First),
+            Self::Second(store) => store
+                .find_first_key_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::Second),
+        }
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        match self {
+            Self::First(store) => store
+                .find_last_key_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::First),
+            Self::Second(store) => store
+                .find_last_key_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::Second),
+        }
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        match self {
+            Self::First(store) => store
+                .find_first_key_value_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::First),
+            Self::Second(store) => store
+                .find_first_key_value_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::Second),
+        }
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        match self {
+            Self::First(store) => store
+                .find_last_key_value_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::First),
+            Self::Second(store) => store
+                .find_last_key_value_by_prefix(key_prefix)
+                .await
+                .map_err(DualStoreError::Second),
+        }
+    }
 }
 
 impl<S1, S2> WritableKeyValueStore for DualStore<S1, S2>

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -633,6 +633,39 @@ impl DynamoDbStoreInternal {
         Ok(response)
     }
 
+    /// Runs a single-row query with `Limit=1`, in the given direction.
+    async fn get_one_query_output(
+        &self,
+        attribute_str: &str,
+        start_key: &[u8],
+        key_prefix: &[u8],
+        scan_index_forward: bool,
+    ) -> Result<QueryOutput, DynamoDbStoreInternalError> {
+        let _guard = self.acquire().await;
+        let start_key = start_key.to_vec();
+        let mut prefixed_key_prefix = vec![1];
+        prefixed_key_prefix.extend(key_prefix);
+        let response = self
+            .client
+            .query()
+            .table_name(&self.namespace)
+            .projection_expression(attribute_str)
+            .key_condition_expression(format!(
+                "{PARTITION_ATTRIBUTE} = :partition and begins_with({KEY_ATTRIBUTE}, :prefix)"
+            ))
+            .expression_attribute_values(":partition", AttributeValue::B(Blob::new(start_key)))
+            .expression_attribute_values(
+                ":prefix",
+                AttributeValue::B(Blob::new(prefixed_key_prefix)),
+            )
+            .scan_index_forward(scan_index_forward)
+            .limit(1)
+            .send()
+            .boxed_sync()
+            .await?;
+        Ok(response)
+    }
+
     async fn read_value_bytes_general(
         &self,
         key_db: HashMap<String, AttributeValue>,
@@ -897,6 +930,68 @@ impl ReadableKeyValueStore for DynamoDbStoreInternal {
             .key_values()
             .map(|entry| entry.map(|(key, value)| (key.to_vec(), value.to_vec())))
             .collect()
+    }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, DynamoDbStoreInternalError> {
+        check_key_size(key_prefix)?;
+        let response = self
+            .get_one_query_output(KEY_ATTRIBUTE, &self.start_key, key_prefix, true)
+            .await?;
+        match response.items.and_then(|mut items| items.pop()) {
+            None => Ok(None),
+            Some(item) => Ok(Some(extract_key(key_prefix.len(), &item)?.to_vec())),
+        }
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, DynamoDbStoreInternalError> {
+        check_key_size(key_prefix)?;
+        let response = self
+            .get_one_query_output(KEY_ATTRIBUTE, &self.start_key, key_prefix, false)
+            .await?;
+        match response.items.and_then(|mut items| items.pop()) {
+            None => Ok(None),
+            Some(item) => Ok(Some(extract_key(key_prefix.len(), &item)?.to_vec())),
+        }
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, DynamoDbStoreInternalError> {
+        check_key_size(key_prefix)?;
+        let response = self
+            .get_one_query_output(KEY_VALUE_ATTRIBUTE, &self.start_key, key_prefix, true)
+            .await?;
+        match response.items.and_then(|mut items| items.pop()) {
+            None => Ok(None),
+            Some(item) => {
+                let (key, value) = extract_key_value(key_prefix.len(), &item)?;
+                Ok(Some((key.to_vec(), value.to_vec())))
+            }
+        }
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, DynamoDbStoreInternalError> {
+        check_key_size(key_prefix)?;
+        let response = self
+            .get_one_query_output(KEY_VALUE_ATTRIBUTE, &self.start_key, key_prefix, false)
+            .await?;
+        match response.items.and_then(|mut items| items.pop()) {
+            None => Ok(None),
+            Some(item) => {
+                let (key, value) = extract_key_value(key_prefix.len(), &item)?;
+                Ok(Some((key.to_vec(), value.to_vec())))
+            }
+        }
     }
 }
 

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -191,6 +191,85 @@ impl ReadableKeyValueStore for IndexedDbStore {
         })
         .await?
     }
+
+    async fn find_first_key_by_prefix(&self, key_prefix: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.find_one_key_by_prefix(key_prefix, indexed_db::CursorDirection::Next)
+            .await
+    }
+
+    async fn find_last_key_by_prefix(&self, key_prefix: &[u8]) -> Result<Option<Vec<u8>>> {
+        self.find_one_key_by_prefix(key_prefix, indexed_db::CursorDirection::Prev)
+            .await
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        self.find_one_key_value_by_prefix(key_prefix, indexed_db::CursorDirection::Next)
+            .await
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        self.find_one_key_value_by_prefix(key_prefix, indexed_db::CursorDirection::Prev)
+            .await
+    }
+}
+
+impl IndexedDbStore {
+    async fn find_one_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+        direction: indexed_db::CursorDirection,
+    ) -> Result<Option<Vec<u8>>> {
+        let key_prefix = self.full_key(key_prefix);
+        let range = prefix_to_range(&key_prefix);
+        self.with_object_store(|object_store| async move {
+            let cursor = object_store
+                .cursor()
+                .range(range)?
+                .direction(direction)
+                .open_key()
+                .await?;
+            Ok(cursor.primary_key().map(|key| {
+                let key = js_sys::Uint8Array::new(&key);
+                key.subarray(key_prefix.len() as u32, key.length()).to_vec()
+            }))
+        })
+        .await?
+    }
+
+    async fn find_one_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+        direction: indexed_db::CursorDirection,
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>> {
+        let key_prefix = self.full_key(key_prefix);
+        let range = prefix_to_range(&key_prefix);
+        self.with_object_store(|object_store| async move {
+            let cursor = object_store
+                .cursor()
+                .range(range)?
+                .direction(direction)
+                .open()
+                .await?;
+            Ok(cursor.primary_key().map(|key| {
+                let key = js_sys::Uint8Array::new(&key);
+                let key = key.subarray(key_prefix.len() as u32, key.length()).to_vec();
+                let value = js_sys::Uint8Array::new(
+                    &cursor
+                        .value()
+                        .expect("we should have a value because we have a key"),
+                )
+                .to_vec();
+                (key, value)
+            }))
+        })
+        .await?
+    }
 }
 
 impl WritableKeyValueStore for IndexedDbStore {

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -202,6 +202,37 @@ where
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
         Ok(self.store.find_key_values_by_prefix(key_prefix).await?)
     }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.store.find_first_key_by_prefix(key_prefix).await?)
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.store.find_last_key_by_prefix(key_prefix).await?)
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        Ok(self
+            .store
+            .find_first_key_value_by_prefix(key_prefix)
+            .await?)
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        Ok(self.store.find_last_key_value_by_prefix(key_prefix).await?)
+    }
 }
 
 impl<D> KeyValueDatabase for JournalingKeyValueDatabase<D>

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -348,6 +348,16 @@ where
         &self,
         key_prefix: &[u8],
     ) -> Result<Option<Vec<u8>>, Self::Error> {
+        if let Some(cache) = self.get_exclusive_cache() {
+            let mut cache = cache.lock().unwrap();
+            if let Some(keys) = cache.query_find_keys(key_prefix) {
+                #[cfg(with_metrics)]
+                metrics::FIND_KEYS_BY_PREFIX_CACHE_HIT_COUNT
+                    .with_label_values(&[])
+                    .inc();
+                return Ok(keys.into_iter().next());
+            }
+        }
         self.store.find_first_key_by_prefix(key_prefix).await
     }
 
@@ -355,6 +365,16 @@ where
         &self,
         key_prefix: &[u8],
     ) -> Result<Option<Vec<u8>>, Self::Error> {
+        if let Some(cache) = self.get_exclusive_cache() {
+            let mut cache = cache.lock().unwrap();
+            if let Some(keys) = cache.query_find_keys(key_prefix) {
+                #[cfg(with_metrics)]
+                metrics::FIND_KEYS_BY_PREFIX_CACHE_HIT_COUNT
+                    .with_label_values(&[])
+                    .inc();
+                return Ok(keys.into_iter().next_back());
+            }
+        }
         self.store.find_last_key_by_prefix(key_prefix).await
     }
 
@@ -362,6 +382,16 @@ where
         &self,
         key_prefix: &[u8],
     ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        if let Some(cache) = self.get_exclusive_cache() {
+            let mut cache = cache.lock().unwrap();
+            if let Some(key_values) = cache.query_find_key_values(key_prefix) {
+                #[cfg(with_metrics)]
+                metrics::FIND_KEY_VALUES_BY_PREFIX_CACHE_HIT_COUNT
+                    .with_label_values(&[])
+                    .inc();
+                return Ok(key_values.into_iter().next());
+            }
+        }
         self.store.find_first_key_value_by_prefix(key_prefix).await
     }
 
@@ -369,6 +399,16 @@ where
         &self,
         key_prefix: &[u8],
     ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        if let Some(cache) = self.get_exclusive_cache() {
+            let mut cache = cache.lock().unwrap();
+            if let Some(key_values) = cache.query_find_key_values(key_prefix) {
+                #[cfg(with_metrics)]
+                metrics::FIND_KEY_VALUES_BY_PREFIX_CACHE_HIT_COUNT
+                    .with_label_values(&[])
+                    .inc();
+                return Ok(key_values.into_iter().next_back());
+            }
+        }
         self.store.find_last_key_value_by_prefix(key_prefix).await
     }
 }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -343,6 +343,34 @@ where
         cache.insert_find_key_values(key_prefix.to_vec(), &key_values);
         Ok(key_values)
     }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.store.find_first_key_by_prefix(key_prefix).await
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.store.find_last_key_by_prefix(key_prefix).await
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        self.store.find_first_key_value_by_prefix(key_prefix).await
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        self.store.find_last_key_value_by_prefix(key_prefix).await
+    }
 }
 
 impl<K> WritableKeyValueStore for LruCachingStore<K>

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -211,6 +211,66 @@ impl ReadableKeyValueStore for MemoryStore {
         }
         Ok(key_values)
     }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, MemoryStoreError> {
+        let map = self
+            .map
+            .read()
+            .expect("MemoryStore lock should not be poisoned");
+        let len = key_prefix.len();
+        Ok(map
+            .range(get_key_range_for_prefix(key_prefix.to_vec()))
+            .next()
+            .map(|(key, _)| key[len..].to_vec()))
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, MemoryStoreError> {
+        let map = self
+            .map
+            .read()
+            .expect("MemoryStore lock should not be poisoned");
+        let len = key_prefix.len();
+        Ok(map
+            .range(get_key_range_for_prefix(key_prefix.to_vec()))
+            .next_back()
+            .map(|(key, _)| key[len..].to_vec()))
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, MemoryStoreError> {
+        let map = self
+            .map
+            .read()
+            .expect("MemoryStore lock should not be poisoned");
+        let len = key_prefix.len();
+        Ok(map
+            .range(get_key_range_for_prefix(key_prefix.to_vec()))
+            .next()
+            .map(|(key, value)| (key[len..].to_vec(), value.to_vec())))
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, MemoryStoreError> {
+        let map = self
+            .map
+            .read()
+            .expect("MemoryStore lock should not be poisoned");
+        let len = key_prefix.len();
+        Ok(map
+            .range(get_key_range_for_prefix(key_prefix.to_vec()))
+            .next_back()
+            .map(|(key, value)| (key[len..].to_vec(), value.to_vec())))
+    }
 }
 
 impl WritableKeyValueStore for MemoryStore {

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -31,6 +31,10 @@ pub struct KeyValueStoreMetrics {
     read_multi_values_bytes_latency: HistogramVec,
     find_keys_by_prefix_latency: HistogramVec,
     find_key_values_by_prefix_latency: HistogramVec,
+    find_first_key_by_prefix_latency: HistogramVec,
+    find_last_key_by_prefix_latency: HistogramVec,
+    find_first_key_value_by_prefix_latency: HistogramVec,
+    find_last_key_value_by_prefix_latency: HistogramVec,
     write_batch_latency: HistogramVec,
     clear_journal_latency: HistogramVec,
     connect_latency: HistogramVec,
@@ -131,6 +135,26 @@ impl KeyValueStoreMetrics {
         let entry1 = format!("{var_name}_find_key_values_by_prefix_latency");
         let entry2 = format!("{title_name} find key values by prefix latency");
         let find_key_values_by_prefix_latency =
+            register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
+
+        let entry1 = format!("{var_name}_find_first_key_by_prefix_latency");
+        let entry2 = format!("{title_name} find first key by prefix latency");
+        let find_first_key_by_prefix_latency =
+            register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
+
+        let entry1 = format!("{var_name}_find_last_key_by_prefix_latency");
+        let entry2 = format!("{title_name} find last key by prefix latency");
+        let find_last_key_by_prefix_latency =
+            register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
+
+        let entry1 = format!("{var_name}_find_first_key_value_by_prefix_latency");
+        let entry2 = format!("{title_name} find first key value by prefix latency");
+        let find_first_key_value_by_prefix_latency =
+            register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
+
+        let entry1 = format!("{var_name}_find_last_key_value_by_prefix_latency");
+        let entry2 = format!("{title_name} find last key value by prefix latency");
+        let find_last_key_value_by_prefix_latency =
             register_histogram_vec(&entry1, &entry2, &[], latency_buckets.clone());
 
         let entry1 = format!("{var_name}_write_batch_latency");
@@ -273,6 +297,10 @@ impl KeyValueStoreMetrics {
             read_multi_values_bytes_latency,
             find_keys_by_prefix_latency,
             find_key_values_by_prefix_latency,
+            find_first_key_by_prefix_latency,
+            find_last_key_by_prefix_latency,
+            find_first_key_value_by_prefix_latency,
+            find_last_key_value_by_prefix_latency,
             write_batch_latency,
             clear_journal_latency,
             connect_latency,
@@ -464,6 +492,50 @@ where
             .with_label_values(&[])
             .observe(key_values_size as f64);
         Ok(result)
+    }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let _latency = self
+            .counter
+            .find_first_key_by_prefix_latency
+            .measure_latency();
+        self.store.find_first_key_by_prefix(key_prefix).await
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        let _latency = self
+            .counter
+            .find_last_key_by_prefix_latency
+            .measure_latency();
+        self.store.find_last_key_by_prefix(key_prefix).await
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        let _latency = self
+            .counter
+            .find_first_key_value_by_prefix_latency
+            .measure_latency();
+        self.store.find_first_key_value_by_prefix(key_prefix).await
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error> {
+        let _latency = self
+            .counter
+            .find_last_key_value_by_prefix_latency
+            .measure_latency();
+        self.store.find_last_key_value_by_prefix(key_prefix).await
     }
 }
 

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -237,6 +237,78 @@ impl RocksDbStoreExecutor {
         Ok(key_values)
     }
 
+    fn find_first_key_by_prefix_internal(
+        &self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, RocksDbStoreInternalError> {
+        check_key_size(&key_prefix)?;
+        let mut prefix = self.start_key.clone();
+        prefix.extend(key_prefix);
+        let len = prefix.len();
+
+        let iter = self.get_find_prefix_iterator(&prefix);
+        Ok(iter.key().map(|key| key[len..].to_vec()))
+    }
+
+    fn find_last_key_by_prefix_internal(
+        &self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Option<Vec<u8>>, RocksDbStoreInternalError> {
+        check_key_size(&key_prefix)?;
+        let mut prefix = self.start_key.clone();
+        prefix.extend(key_prefix);
+        let len = prefix.len();
+
+        // RocksDB's reverse-iteration primitives interact awkwardly with our
+        // prefix-bounded scans (see e.g. interactions with prefix bloom filters and
+        // `iterate_upper_bound` on `seek_to_last`). Walking forward with the same
+        // bounded iterator that powers `find_keys_by_prefix` and keeping the last
+        // entry is robust and stays linear only in the size of the prefix range.
+        let mut iter = self.get_find_prefix_iterator(&prefix);
+        let mut last_key = None;
+        while let Some(key) = iter.key() {
+            last_key = Some(key[len..].to_vec());
+            iter.next();
+        }
+        Ok(last_key)
+    }
+
+    #[expect(clippy::type_complexity)]
+    fn find_first_key_value_by_prefix_internal(
+        &self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, RocksDbStoreInternalError> {
+        check_key_size(&key_prefix)?;
+        let mut prefix = self.start_key.clone();
+        prefix.extend(key_prefix);
+        let len = prefix.len();
+
+        let iter = self.get_find_prefix_iterator(&prefix);
+        Ok(iter
+            .item()
+            .map(|(key, value)| (key[len..].to_vec(), value.to_vec())))
+    }
+
+    #[expect(clippy::type_complexity)]
+    fn find_last_key_value_by_prefix_internal(
+        &self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, RocksDbStoreInternalError> {
+        check_key_size(&key_prefix)?;
+        let mut prefix = self.start_key.clone();
+        prefix.extend(key_prefix);
+        let len = prefix.len();
+
+        // See `find_last_key_by_prefix_internal` for why we walk forward.
+        let mut iter = self.get_find_prefix_iterator(&prefix);
+        let mut last = None;
+        while let Some((key, value)) = iter.item() {
+            last = Some((key[len..].to_vec(), value.to_vec()));
+            iter.next();
+        }
+        Ok(last)
+    }
+
     fn write_batch_internal(
         &self,
         batch: Batch,
@@ -535,6 +607,62 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
         self.spawn_mode
             .spawn(
                 move |x| executor.find_key_values_by_prefix_internal(x),
+                key_prefix,
+            )
+            .await
+    }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, RocksDbStoreInternalError> {
+        let executor = self.executor.clone();
+        let key_prefix = key_prefix.to_vec();
+        self.spawn_mode
+            .spawn(
+                move |x| executor.find_first_key_by_prefix_internal(x),
+                key_prefix,
+            )
+            .await
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, RocksDbStoreInternalError> {
+        let executor = self.executor.clone();
+        let key_prefix = key_prefix.to_vec();
+        self.spawn_mode
+            .spawn(
+                move |x| executor.find_last_key_by_prefix_internal(x),
+                key_prefix,
+            )
+            .await
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, RocksDbStoreInternalError> {
+        let executor = self.executor.clone();
+        let key_prefix = key_prefix.to_vec();
+        self.spawn_mode
+            .spawn(
+                move |x| executor.find_first_key_value_by_prefix_internal(x),
+                key_prefix,
+            )
+            .await
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, RocksDbStoreInternalError> {
+        let executor = self.executor.clone();
+        let key_prefix = key_prefix.to_vec();
+        self.spawn_mode
+            .spawn(
+                move |x| executor.find_last_key_value_by_prefix_internal(x),
                 key_prefix,
             )
             .await

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -237,6 +237,31 @@ impl RocksDbStoreExecutor {
         Ok(key_values)
     }
 
+    /// Returns an iterator positioned at the largest key with the given prefix, if any.
+    /// `total_order_seek` is enabled because the database uses a fixed-length prefix
+    /// extractor; without it, `seek_for_prev` only searches within the bloom-prefix
+    /// scope and misses keys whose extractor-prefix differs from the seek target.
+    fn get_find_prefix_reverse_iterator(
+        &self,
+        prefix: &[u8],
+    ) -> rocksdb::DBRawIteratorWithThreadMode<'_, DB> {
+        let mut read_opts = rocksdb::ReadOptions::default();
+        read_opts.set_async_io(true);
+        read_opts.set_total_order_seek(true);
+        let upper_bound = get_upper_bound_option(prefix);
+        let mut iter = self.db.raw_iterator_opt(read_opts);
+        match upper_bound.as_deref() {
+            Some(ub) => {
+                iter.seek_for_prev(ub);
+                if iter.key().is_some_and(|k| k == ub) {
+                    iter.prev();
+                }
+            }
+            None => iter.seek_to_last(),
+        }
+        iter
+    }
+
     fn find_first_key_by_prefix_internal(
         &self,
         key_prefix: Vec<u8>,
@@ -259,18 +284,11 @@ impl RocksDbStoreExecutor {
         prefix.extend(key_prefix);
         let len = prefix.len();
 
-        // RocksDB's reverse-iteration primitives interact awkwardly with our
-        // prefix-bounded scans (see e.g. interactions with prefix bloom filters and
-        // `iterate_upper_bound` on `seek_to_last`). Walking forward with the same
-        // bounded iterator that powers `find_keys_by_prefix` and keeping the last
-        // entry is robust and stays linear only in the size of the prefix range.
-        let mut iter = self.get_find_prefix_iterator(&prefix);
-        let mut last_key = None;
-        while let Some(key) = iter.key() {
-            last_key = Some(key[len..].to_vec());
-            iter.next();
-        }
-        Ok(last_key)
+        let iter = self.get_find_prefix_reverse_iterator(&prefix);
+        Ok(iter
+            .key()
+            .filter(|k| k.starts_with(&prefix))
+            .map(|key| key[len..].to_vec()))
     }
 
     #[expect(clippy::type_complexity)]
@@ -299,14 +317,11 @@ impl RocksDbStoreExecutor {
         prefix.extend(key_prefix);
         let len = prefix.len();
 
-        // See `find_last_key_by_prefix_internal` for why we walk forward.
-        let mut iter = self.get_find_prefix_iterator(&prefix);
-        let mut last = None;
-        while let Some((key, value)) = iter.item() {
-            last = Some((key[len..].to_vec(), value.to_vec()));
-            iter.next();
-        }
-        Ok(last)
+        let iter = self.get_find_prefix_reverse_iterator(&prefix);
+        Ok(iter
+            .item()
+            .filter(|(k, _)| k.starts_with(&prefix))
+            .map(|(key, value)| (key[len..].to_vec(), value.to_vec())))
     }
 
     fn write_batch_internal(

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -113,6 +113,14 @@ struct ScyllaDbClient {
     find_keys_by_prefix_bounded: PreparedStatement,
     find_key_values_by_prefix_unbounded: PreparedStatement,
     find_key_values_by_prefix_bounded: PreparedStatement,
+    find_first_key_by_prefix_unbounded: PreparedStatement,
+    find_first_key_by_prefix_bounded: PreparedStatement,
+    find_last_key_by_prefix_unbounded: PreparedStatement,
+    find_last_key_by_prefix_bounded: PreparedStatement,
+    find_first_key_value_by_prefix_unbounded: PreparedStatement,
+    find_first_key_value_by_prefix_bounded: PreparedStatement,
+    find_last_key_value_by_prefix_unbounded: PreparedStatement,
+    find_last_key_value_by_prefix_bounded: PreparedStatement,
     multi_key_values: papaya::HashMap<usize, PreparedStatement>,
     multi_keys: papaya::HashMap<usize, PreparedStatement>,
 }
@@ -180,6 +188,62 @@ impl ScyllaDbClient {
             ))
             .await?;
 
+        let find_first_key_by_prefix_unbounded = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? ORDER BY k ASC LIMIT 1"
+            ))
+            .await?;
+
+        let find_first_key_by_prefix_bounded = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? AND k < ? ORDER BY k ASC LIMIT 1"
+            ))
+            .await?;
+
+        let find_last_key_by_prefix_unbounded = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? ORDER BY k DESC LIMIT 1"
+            ))
+            .await?;
+
+        let find_last_key_by_prefix_bounded = session
+            .prepare(format!(
+                "SELECT k FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? AND k < ? ORDER BY k DESC LIMIT 1"
+            ))
+            .await?;
+
+        let find_first_key_value_by_prefix_unbounded = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? ORDER BY k ASC LIMIT 1"
+            ))
+            .await?;
+
+        let find_first_key_value_by_prefix_bounded = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? AND k < ? ORDER BY k ASC LIMIT 1"
+            ))
+            .await?;
+
+        let find_last_key_value_by_prefix_unbounded = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? ORDER BY k DESC LIMIT 1"
+            ))
+            .await?;
+
+        let find_last_key_value_by_prefix_bounded = session
+            .prepare(format!(
+                "SELECT k,v FROM {KEYSPACE}.\"{namespace}\" \
+                 WHERE root_key = ? AND k >= ? AND k < ? ORDER BY k DESC LIMIT 1"
+            ))
+            .await?;
+
         Ok(Self {
             session,
             namespace,
@@ -193,6 +257,14 @@ impl ScyllaDbClient {
             find_keys_by_prefix_bounded,
             find_key_values_by_prefix_unbounded,
             find_key_values_by_prefix_bounded,
+            find_first_key_by_prefix_unbounded,
+            find_first_key_by_prefix_bounded,
+            find_last_key_by_prefix_unbounded,
+            find_last_key_by_prefix_bounded,
+            find_first_key_value_by_prefix_unbounded,
+            find_first_key_value_by_prefix_bounded,
+            find_last_key_value_by_prefix_unbounded,
+            find_last_key_value_by_prefix_bounded,
             multi_key_values: papaya::HashMap::new(),
             multi_keys: papaya::HashMap::new(),
         })
@@ -503,6 +575,64 @@ impl ScyllaDbClient {
         }
         Ok(key_values)
     }
+
+    async fn find_one_key_by_prefix_internal(
+        &self,
+        root_key: &[u8],
+        key_prefix: Vec<u8>,
+        unbounded: &PreparedStatement,
+        bounded: &PreparedStatement,
+    ) -> Result<Option<Vec<u8>>, ScyllaDbStoreInternalError> {
+        Self::check_key_size(&key_prefix)?;
+        let session = &self.session;
+        let len = key_prefix.len();
+        let rows = match get_upper_bound_option(&key_prefix) {
+            None => {
+                let values = (root_key.to_vec(), key_prefix.clone());
+                Box::pin(session.execute_iter(unbounded.clone(), values)).await?
+            }
+            Some(upper_bound) => {
+                let values = (root_key.to_vec(), key_prefix.clone(), upper_bound);
+                Box::pin(session.execute_iter(bounded.clone(), values)).await?
+            }
+        };
+        let mut rows = rows.rows_stream::<(Vec<u8>,)>()?;
+        if let Some(row) = rows.next().await {
+            let (key,) = row?;
+            Ok(Some(key[len..].to_vec()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn find_one_key_value_by_prefix_internal(
+        &self,
+        root_key: &[u8],
+        key_prefix: Vec<u8>,
+        unbounded: &PreparedStatement,
+        bounded: &PreparedStatement,
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, ScyllaDbStoreInternalError> {
+        Self::check_key_size(&key_prefix)?;
+        let session = &self.session;
+        let len = key_prefix.len();
+        let rows = match get_upper_bound_option(&key_prefix) {
+            None => {
+                let values = (root_key.to_vec(), key_prefix.clone());
+                Box::pin(session.execute_iter(unbounded.clone(), values)).await?
+            }
+            Some(upper_bound) => {
+                let values = (root_key.to_vec(), key_prefix.clone(), upper_bound);
+                Box::pin(session.execute_iter(bounded.clone(), values)).await?
+            }
+        };
+        let mut rows = rows.rows_stream::<(Vec<u8>, Vec<u8>)>()?;
+        if let Some(row) = rows.next().await {
+            let (key, value) = row?;
+            Ok(Some((key[len..].to_vec(), value)))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 /// The client itself and the keeping of the count of active connections.
@@ -675,6 +805,66 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
         let _guard = self.acquire().await;
         Box::pin(store.find_key_values_by_prefix_internal(&self.root_key, key_prefix.to_vec()))
             .await
+    }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, ScyllaDbStoreInternalError> {
+        let store = self.store.deref();
+        let _guard = self.acquire().await;
+        Box::pin(store.find_one_key_by_prefix_internal(
+            &self.root_key,
+            key_prefix.to_vec(),
+            &store.find_first_key_by_prefix_unbounded,
+            &store.find_first_key_by_prefix_bounded,
+        ))
+        .await
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, ScyllaDbStoreInternalError> {
+        let store = self.store.deref();
+        let _guard = self.acquire().await;
+        Box::pin(store.find_one_key_by_prefix_internal(
+            &self.root_key,
+            key_prefix.to_vec(),
+            &store.find_last_key_by_prefix_unbounded,
+            &store.find_last_key_by_prefix_bounded,
+        ))
+        .await
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, ScyllaDbStoreInternalError> {
+        let store = self.store.deref();
+        let _guard = self.acquire().await;
+        Box::pin(store.find_one_key_value_by_prefix_internal(
+            &self.root_key,
+            key_prefix.to_vec(),
+            &store.find_first_key_value_by_prefix_unbounded,
+            &store.find_first_key_value_by_prefix_bounded,
+        ))
+        .await
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, ScyllaDbStoreInternalError> {
+        let store = self.store.deref();
+        let _guard = self.acquire().await;
+        Box::pin(store.find_one_key_value_by_prefix_internal(
+            &self.root_key,
+            key_prefix.to_vec(),
+            &store.find_last_key_value_by_prefix_unbounded,
+            &store.find_last_key_value_by_prefix_bounded,
+        ))
+        .await
     }
 }
 

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -252,6 +252,39 @@ where
         }
         Ok(key_values)
     }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        // The smallest stored key under any user-key prefix is `K|0` for the smallest
+        // user key `K`, since `K|0 < K|1 < ... < K'|0 < ...`. So strip the trailing
+        // 4-byte segment index.
+        Ok(self
+            .store
+            .find_first_key_by_prefix(key_prefix)
+            .await?
+            .map(|mut key| {
+                key.truncate(key.len() - 4);
+                key
+            }))
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        // The largest stored key under any user-key prefix is `K|n` for the largest
+        // user key `K` and its highest segment index `n`. Strip the trailing 4 bytes.
+        Ok(self
+            .store
+            .find_last_key_by_prefix(key_prefix)
+            .await?
+            .map(|mut key| {
+                key.truncate(key.len() - 4);
+                key
+            }))
+    }
 }
 
 impl<K> WritableKeyValueStore for ValueSplittingStore<K>
@@ -467,6 +500,34 @@ impl ReadableKeyValueStore for LimitedTestMemoryStore {
         key_prefix: &[u8],
     ) -> Result<Vec<Vec<u8>>, MemoryStoreError> {
         self.inner.find_keys_by_prefix(key_prefix).await
+    }
+
+    async fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, MemoryStoreError> {
+        self.inner.find_first_key_by_prefix(key_prefix).await
+    }
+
+    async fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<Vec<u8>>, MemoryStoreError> {
+        self.inner.find_last_key_by_prefix(key_prefix).await
+    }
+
+    async fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, MemoryStoreError> {
+        self.inner.find_first_key_value_by_prefix(key_prefix).await
+    }
+
+    async fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Option<(Vec<u8>, Vec<u8>)>, MemoryStoreError> {
+        self.inner.find_last_key_value_by_prefix(key_prefix).await
     }
 
     async fn find_key_values_by_prefix(

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -86,6 +86,74 @@ pub trait ReadableKeyValueStore: WithError {
     // https://github.com/rust-lang/impl-trait-utils/issues/17, but once that bug is fixed
     // we can revert them to `async fn` syntax, which is neater.
 
+    /// Returns the lexicographically smallest key matching the prefix, if any.
+    /// The prefix is not included in the returned key.
+    ///
+    /// Backends may override the default implementation, which loads every matching
+    /// key, with a more efficient single-key lookup.
+    fn find_first_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> impl Future<Output = Result<Option<Vec<u8>>, Self::Error>> {
+        async {
+            Ok(self
+                .find_keys_by_prefix(key_prefix)
+                .await?
+                .into_iter()
+                .next())
+        }
+    }
+
+    /// Returns the lexicographically largest key matching the prefix, if any.
+    /// The prefix is not included in the returned key.
+    ///
+    /// Backends may override the default implementation, which loads every matching
+    /// key, with a more efficient single-key lookup.
+    fn find_last_key_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> impl Future<Output = Result<Option<Vec<u8>>, Self::Error>> {
+        async {
+            Ok(self
+                .find_keys_by_prefix(key_prefix)
+                .await?
+                .into_iter()
+                .next_back())
+        }
+    }
+
+    /// Returns the `(key, value)` pair with the lexicographically smallest key matching
+    /// the prefix, if any. The prefix is not included in the returned key.
+    #[expect(clippy::type_complexity)]
+    fn find_first_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> impl Future<Output = Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error>> {
+        async {
+            Ok(self
+                .find_key_values_by_prefix(key_prefix)
+                .await?
+                .into_iter()
+                .next())
+        }
+    }
+
+    /// Returns the `(key, value)` pair with the lexicographically largest key matching
+    /// the prefix, if any. The prefix is not included in the returned key.
+    #[expect(clippy::type_complexity)]
+    fn find_last_key_value_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> impl Future<Output = Result<Option<(Vec<u8>, Vec<u8>)>, Self::Error>> {
+        async {
+            Ok(self
+                .find_key_values_by_prefix(key_prefix)
+                .await?
+                .into_iter()
+                .next_back())
+        }
+    }
+
     /// Reads a single `key` and deserializes the result if present.
     fn read_value<V: DeserializeOwned>(
         &self,

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -184,9 +184,9 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
         let mut set_key_value1 = HashSet::new();
         let mut keys_request_deriv = Vec::new();
         let key_values_by_prefix = store.find_key_values_by_prefix(key_prefix).await.unwrap();
-        for (key, value) in key_values_by_prefix {
+        for (key, value) in key_values_by_prefix.iter() {
             keys_request_deriv.push(key.clone());
-            set_key_value1.insert((key, value));
+            set_key_value1.insert((key.clone(), value.clone()));
         }
         // Check find_keys / find_key_values
         assert_eq!(keys_request, keys_request_deriv);
@@ -194,6 +194,21 @@ pub async fn run_reads<S: KeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec
         for i in 1..keys_request.len() {
             assert!(keys_request[i - 1] < keys_request[i]);
         }
+        // Check find_{first,last}_key[_value]_by_prefix against the full lists.
+        let first_key = store.find_first_key_by_prefix(key_prefix).await.unwrap();
+        let last_key = store.find_last_key_by_prefix(key_prefix).await.unwrap();
+        let first_kv = store
+            .find_first_key_value_by_prefix(key_prefix)
+            .await
+            .unwrap();
+        let last_kv = store
+            .find_last_key_value_by_prefix(key_prefix)
+            .await
+            .unwrap();
+        assert_eq!(first_key, keys_request.first().cloned());
+        assert_eq!(last_key, keys_request.last().cloned());
+        assert_eq!(first_kv, key_values_by_prefix.first().cloned());
+        assert_eq!(last_kv, key_values_by_prefix.last().cloned());
         // Check the obtained values
         let mut set_key_value2 = HashSet::new();
         for (key, value) in &key_values {

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -662,6 +662,68 @@ where
         Ok(count)
     }
 
+    /// Returns the lexicographically smallest key matching the prefix, if any.
+    /// The prefix is not included in the returned key.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::map_view::ByteMapView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut map = ByteMapView::load(context).await.unwrap();
+    /// map.insert(vec![0, 1], String::from("Hello"));
+    /// map.insert(vec![1, 2], String::from("World"));
+    /// assert_eq!(map.first_key(Vec::new()).await.unwrap(), Some(vec![0, 1]));
+    /// # })
+    /// ```
+    pub async fn first_key(&self, prefix: Vec<u8>) -> Result<Option<Vec<u8>>, ViewError> {
+        if self.updates.is_empty() && !self.deletion_set.has_pending_changes() {
+            let base = self.context.base_key().base_index(&prefix);
+            return Ok(self.context.store().find_first_key_by_prefix(&base).await?);
+        }
+        let mut result = None;
+        self.for_each_key_while(
+            |key| {
+                result = Some(key.to_vec());
+                Ok(false)
+            },
+            prefix,
+        )
+        .await?;
+        Ok(result)
+    }
+
+    /// Returns the lexicographically largest key matching the prefix, if any.
+    /// The prefix is not included in the returned key.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::MemoryContext;
+    /// # use linera_views::map_view::ByteMapView;
+    /// # use linera_views::views::View;
+    /// # let context = MemoryContext::new_for_testing(());
+    /// let mut map = ByteMapView::load(context).await.unwrap();
+    /// map.insert(vec![0, 1], String::from("Hello"));
+    /// map.insert(vec![1, 2], String::from("World"));
+    /// assert_eq!(map.last_key(Vec::new()).await.unwrap(), Some(vec![1, 2]));
+    /// # })
+    /// ```
+    pub async fn last_key(&self, prefix: Vec<u8>) -> Result<Option<Vec<u8>>, ViewError> {
+        if self.updates.is_empty() && !self.deletion_set.has_pending_changes() {
+            let base = self.context.base_key().base_index(&prefix);
+            return Ok(self.context.store().find_last_key_by_prefix(&base).await?);
+        }
+        let mut result = None;
+        self.for_each_key(
+            |key| {
+                result = Some(key.to_vec());
+                Ok(())
+            },
+            prefix,
+        )
+        .await?;
+        Ok(result)
+    }
+
     /// Applies a function f on each key/value pair matching a prefix. The key is the
     /// shortened one by the prefix. The value is an enum that can be either a value
     /// or its serialization. This is needed in order to avoid a scenario where we
@@ -902,6 +964,63 @@ where
     /// ```
     pub async fn key_values(&self) -> Result<Vec<(Vec<u8>, V)>, ViewError> {
         self.key_values_by_prefix(Vec::new()).await
+    }
+
+    /// Returns the `(key, value)` pair with the lexicographically smallest key matching
+    /// the prefix, if any. The prefix is not included in the returned key.
+    pub async fn first_key_value(
+        &self,
+        prefix: Vec<u8>,
+    ) -> Result<Option<(Vec<u8>, V)>, ViewError> {
+        if self.updates.is_empty() && !self.deletion_set.has_pending_changes() {
+            let base = self.context.base_key().base_index(&prefix);
+            let Some((short_key, value_bytes)) = self
+                .context
+                .store()
+                .find_first_key_value_by_prefix(&base)
+                .await?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some((short_key, bcs::from_bytes(&value_bytes)?)));
+        }
+        let mut result = None;
+        self.for_each_key_value_while(
+            |key, value| {
+                result = Some((key.to_vec(), value.into_owned()));
+                Ok(false)
+            },
+            prefix,
+        )
+        .await?;
+        Ok(result)
+    }
+
+    /// Returns the `(key, value)` pair with the lexicographically largest key matching
+    /// the prefix, if any. The prefix is not included in the returned key.
+    pub async fn last_key_value(&self, prefix: Vec<u8>) -> Result<Option<(Vec<u8>, V)>, ViewError> {
+        if self.updates.is_empty() && !self.deletion_set.has_pending_changes() {
+            let base = self.context.base_key().base_index(&prefix);
+            let Some((short_key, value_bytes)) = self
+                .context
+                .store()
+                .find_last_key_value_by_prefix(&base)
+                .await?
+            else {
+                return Ok(None);
+            };
+            return Ok(Some((short_key, bcs::from_bytes(&value_bytes)?)));
+        }
+        let mut result = None;
+        self.for_each_key_value(
+            |key, value| {
+                result = Some((key.to_vec(), value.into_owned()));
+                Ok(())
+            },
+            prefix,
+        )
+        .await?;
+        Ok(result)
     }
 }
 
@@ -1529,6 +1648,40 @@ where
     pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         self.map.iterative_count().await
     }
+
+    /// Returns the lexicographically smallest index in the map, if any. The order is
+    /// determined by serialization.
+    pub async fn first_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.map.first_key(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some(BaseKey::deserialize_value(&short_key)?))
+    }
+
+    /// Returns the lexicographically largest index in the map, if any. The order is
+    /// determined by serialization.
+    pub async fn last_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.map.last_key(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some(BaseKey::deserialize_value(&short_key)?))
+    }
+
+    /// Returns the `(index, value)` pair with the lexicographically smallest index, if any.
+    pub async fn first_index_value(&self) -> Result<Option<(I, V)>, ViewError> {
+        let Some((short_key, value)) = self.map.first_key_value(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some((BaseKey::deserialize_value(&short_key)?, value)))
+    }
+
+    /// Returns the `(index, value)` pair with the lexicographically largest index, if any.
+    pub async fn last_index_value(&self) -> Result<Option<(I, V)>, ViewError> {
+        let Some((short_key, value)) = self.map.last_key_value(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some((BaseKey::deserialize_value(&short_key)?, value)))
+    }
 }
 
 impl<C, I, V> MapView<C, I, V>
@@ -2081,6 +2234,38 @@ where
     /// ```
     pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         self.map.iterative_count().await
+    }
+
+    /// Returns the smallest index in the map (per the custom serialization order), if any.
+    pub async fn first_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.map.first_key(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some(I::from_custom_bytes(&short_key)?))
+    }
+
+    /// Returns the largest index in the map (per the custom serialization order), if any.
+    pub async fn last_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.map.last_key(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some(I::from_custom_bytes(&short_key)?))
+    }
+
+    /// Returns the `(index, value)` pair with the smallest index, if any.
+    pub async fn first_index_value(&self) -> Result<Option<(I, V)>, ViewError> {
+        let Some((short_key, value)) = self.map.first_key_value(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some((I::from_custom_bytes(&short_key)?, value)))
+    }
+
+    /// Returns the `(index, value)` pair with the largest index, if any.
+    pub async fn last_index_value(&self) -> Result<Option<(I, V)>, ViewError> {
+        let Some((short_key, value)) = self.map.last_key_value(Vec::new()).await? else {
+            return Ok(None);
+        };
+        Ok(Some((I::from_custom_bytes(&short_key)?, value)))
     }
 }
 

--- a/linera-views/src/views/set_view.rs
+++ b/linera-views/src/views/set_view.rs
@@ -236,6 +236,36 @@ impl<C: Context> ByteSetView<C> {
         Ok(keys)
     }
 
+    /// Returns the lexicographically smallest key in the set, if any.
+    pub async fn first_key(&self) -> Result<Option<Vec<u8>>, ViewError> {
+        if self.updates.is_empty() && !self.delete_storage_first {
+            let base = &self.context.base_key().bytes;
+            return Ok(self.context.store().find_first_key_by_prefix(base).await?);
+        }
+        let mut result = None;
+        self.for_each_key_while(|key| {
+            result = Some(key.to_vec());
+            Ok(false)
+        })
+        .await?;
+        Ok(result)
+    }
+
+    /// Returns the lexicographically largest key in the set, if any.
+    pub async fn last_key(&self) -> Result<Option<Vec<u8>>, ViewError> {
+        if self.updates.is_empty() && !self.delete_storage_first {
+            let base = &self.context.base_key().bytes;
+            return Ok(self.context.store().find_last_key_by_prefix(base).await?);
+        }
+        let mut result = None;
+        self.for_each_key(|key| {
+            result = Some(key.to_vec());
+            Ok(())
+        })
+        .await?;
+        Ok(result)
+    }
+
     /// Returns the number of entries in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -245,7 +275,7 @@ impl<C: Context> ByteSetView<C> {
     /// let mut set = ByteSetView::load(context).await.unwrap();
     /// set.insert(vec![0, 1]);
     /// set.insert(vec![0, 2]);
-    /// assert_eq!(set.keys().await.unwrap(), vec![vec![0, 1], vec![0, 2]]);
+    /// assert_eq!(set.iterative_count().await.unwrap(), 2);
     /// # })
     /// ```
     pub async fn iterative_count(&self) -> Result<usize, ViewError> {
@@ -569,6 +599,22 @@ impl<C: Context, I: Serialize + DeserializeOwned + Send> SetView<C, I> {
         self.set.iterative_count().await
     }
 
+    /// Returns the smallest index in the set, if any. The order is determined by serialization.
+    pub async fn first_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.set.first_key().await? else {
+            return Ok(None);
+        };
+        Ok(Some(BaseKey::deserialize_value(&short_key)?))
+    }
+
+    /// Returns the largest index in the set, if any. The order is determined by serialization.
+    pub async fn last_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.set.last_key().await? else {
+            return Ok(None);
+        };
+        Ok(Some(BaseKey::deserialize_value(&short_key)?))
+    }
+
     /// Applies a function f on each index. Indices are visited in an order
     /// determined by the serialization. If the function returns false, then the
     /// loop ends prematurely.
@@ -851,6 +897,22 @@ where
     /// ```
     pub async fn iterative_count(&self) -> Result<usize, ViewError> {
         self.set.iterative_count().await
+    }
+
+    /// Returns the smallest index in the set (per the custom serialization order), if any.
+    pub async fn first_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.set.first_key().await? else {
+            return Ok(None);
+        };
+        Ok(Some(I::from_custom_bytes(&short_key)?))
+    }
+
+    /// Returns the largest index in the set (per the custom serialization order), if any.
+    pub async fn last_index(&self) -> Result<Option<I>, ViewError> {
+        let Some(short_key) = self.set.last_key().await? else {
+            return Ok(None);
+        };
+        Ok(Some(I::from_custom_bytes(&short_key)?))
     }
 
     /// Applies a function f on each index. Indices are visited in an order

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -20,13 +20,13 @@ use linera_views::{
     key_value_store_view::{KeyValueStoreView, ViewContainer},
     log_view::HashedLogView,
     lru_caching::LruCachingMemoryDatabase,
-    map_view::{ByteMapView, HashedMapView},
+    map_view::{ByteMapView, CustomMapView, HashedMapView, MapView},
     memory::MemoryDatabase,
     queue_view::HashedQueueView,
     random::make_deterministic_rng,
     reentrant_collection_view::HashedReentrantCollectionView,
     register_view::HashedRegisterView,
-    set_view::HashedSetView,
+    set_view::{ByteSetView, CustomSetView, HashedSetView, SetView},
     store::{KeyValueDatabase, TestKeyValueDatabase as _, WritableKeyValueStore as _},
     test_utils::{
         get_random_byte_vector, get_random_key_value_operations, get_random_key_values,
@@ -619,6 +619,31 @@ pub struct ByteMapStateView<C> {
     pub map: ByteMapView<C, u8>,
 }
 
+#[derive(CryptoHashRootView)]
+pub struct MapStateView<C> {
+    pub map: MapView<C, u32, u32>,
+}
+
+#[derive(CryptoHashRootView)]
+pub struct CustomMapStateView<C> {
+    pub map: CustomMapView<C, u128, u32>,
+}
+
+#[derive(CryptoHashRootView)]
+pub struct ByteSetStateView<C> {
+    pub set: ByteSetView<C>,
+}
+
+#[derive(CryptoHashRootView)]
+pub struct SetStateView<C> {
+    pub set: SetView<C, u32>,
+}
+
+#[derive(CryptoHashRootView)]
+pub struct CustomSetStateView<C> {
+    pub set: CustomSetView<C, u128>,
+}
+
 #[tokio::test]
 async fn test_byte_map_view() -> Result<()> {
     let context = MemoryContext::new_for_testing(());
@@ -642,6 +667,191 @@ async fn test_byte_map_view() -> Result<()> {
         view.map.remove_by_prefix(vec![2]);
         let val = view.map.get_mut(&[2, 3]).await?;
         assert_eq!(val, None);
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_byte_map_view_first_last_key() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+
+    // Empty view: both first/last return None on the fast path.
+    {
+        let view = ByteMapStateView::load(context.clone()).await?;
+        assert_eq!(view.map.first_key(Vec::new()).await?, None);
+        assert_eq!(view.map.last_key(Vec::new()).await?, None);
+    }
+
+    // Fast path: fresh load with persisted entries, no staged changes.
+    {
+        let mut view = ByteMapStateView::load(context.clone()).await?;
+        view.map.insert(vec![0, 1], 1);
+        view.map.insert(vec![2, 3], 3);
+        view.map.insert(vec![4, 5], 5);
+        view.save().await?;
+    }
+    {
+        let view = ByteMapStateView::load(context.clone()).await?;
+        assert_eq!(view.map.first_key(Vec::new()).await?, Some(vec![0, 1]));
+        assert_eq!(view.map.last_key(Vec::new()).await?, Some(vec![4, 5]));
+        // Prefix is stripped from the returned key.
+        assert_eq!(view.map.first_key(vec![2]).await?, Some(vec![3]));
+        assert_eq!(view.map.last_key(vec![2]).await?, Some(vec![3]));
+        assert_eq!(view.map.first_key(vec![9]).await?, None);
+        assert_eq!(
+            view.map.first_key_value(Vec::new()).await?,
+            Some((vec![0, 1], 1))
+        );
+        assert_eq!(
+            view.map.last_key_value(Vec::new()).await?,
+            Some((vec![4, 5], 5))
+        );
+    }
+
+    // Slow path: staged inserts merged with persisted entries.
+    {
+        let mut view = ByteMapStateView::load(context.clone()).await?;
+        view.map.insert(vec![1, 0], 10); // smaller than persisted [2, 3]
+        view.map.insert(vec![5, 0], 50); // larger than persisted [4, 5]
+        assert_eq!(view.map.first_key(Vec::new()).await?, Some(vec![0, 1]));
+        assert_eq!(view.map.last_key(Vec::new()).await?, Some(vec![5, 0]));
+    }
+
+    // Slow path: staged removal of the smallest persisted key.
+    {
+        let mut view = ByteMapStateView::load(context.clone()).await?;
+        view.map.remove(vec![0, 1]);
+        assert_eq!(view.map.first_key(Vec::new()).await?, Some(vec![2, 3]));
+        assert_eq!(view.map.last_key(Vec::new()).await?, Some(vec![4, 5]));
+    }
+
+    // Slow path: prefix removal wipes some persisted keys.
+    {
+        let mut view = ByteMapStateView::load(context.clone()).await?;
+        view.map.remove_by_prefix(vec![0]);
+        assert_eq!(view.map.first_key(Vec::new()).await?, Some(vec![2, 3]));
+        assert_eq!(view.map.last_key(Vec::new()).await?, Some(vec![4, 5]));
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_map_view_first_last_index() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    {
+        let mut view = MapStateView::load(context.clone()).await?;
+        view.map.insert(&3u32, 30)?;
+        view.map.insert(&7u32, 70)?;
+        view.save().await?;
+    }
+    {
+        let view = MapStateView::load(context.clone()).await?;
+        // BCS encodes u32 little-endian, so byte order matches numeric order only
+        // when heights stay in the same byte; for small values like 3 and 7 that's fine.
+        assert_eq!(view.first_index_etc().await?, (Some(3), Some(7)));
+        assert_eq!(view.map.first_index_value().await?, Some((3u32, 30u32)));
+        assert_eq!(view.map.last_index_value().await?, Some((7u32, 70u32)));
+    }
+    Ok(())
+}
+
+impl<C: linera_views::context::Context + Send + Sync + 'static> MapStateView<C> {
+    async fn first_index_etc(&self) -> Result<(Option<u32>, Option<u32>), anyhow::Error> {
+        Ok((self.map.first_index().await?, self.map.last_index().await?))
+    }
+}
+
+#[tokio::test]
+async fn test_byte_map_view_first_last_byte_boundary() -> Result<()> {
+    // Lexicographic key order for ByteMapView matches numeric value only when keys are
+    // stored bit-aligned. With raw byte keys this is straightforward; the test pins down
+    // that the underlying store's first/last-by-prefix returns lex-min/max correctly.
+    let context = MemoryContext::new_for_testing(());
+    {
+        let mut view = ByteMapStateView::load(context.clone()).await?;
+        view.map.insert(vec![0, 1], 0); // smallest by byte order
+        view.map.insert(vec![1, 0], 1);
+        view.map.insert(vec![255, 255], 99); // largest
+        view.save().await?;
+    }
+    {
+        let view = ByteMapStateView::load(context.clone()).await?;
+        assert_eq!(view.map.first_key(Vec::new()).await?, Some(vec![0, 1]));
+        assert_eq!(view.map.last_key(Vec::new()).await?, Some(vec![255, 255]));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_custom_map_view_first_last_index() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    {
+        let mut view = CustomMapStateView::load(context.clone()).await?;
+        // CustomSerialize for u128 reverses bcs to big-endian, so byte order matches
+        // numeric order — including across byte boundaries (1 vs. 256).
+        view.map.insert(&1u128, 10)?;
+        view.map.insert(&256u128, 256)?;
+        view.map.insert(&7u128, 70)?;
+        view.save().await?;
+    }
+    {
+        let view = CustomMapStateView::load(context.clone()).await?;
+        assert_eq!(view.map.first_index().await?, Some(1u128));
+        assert_eq!(view.map.last_index().await?, Some(256u128));
+        assert_eq!(view.map.first_index_value().await?, Some((1u128, 10u32)));
+        assert_eq!(view.map.last_index_value().await?, Some((256u128, 256u32)));
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_set_view_first_last() -> Result<()> {
+    let context = MemoryContext::new_for_testing(());
+    {
+        let mut view = SetStateView::load(context.clone()).await?;
+        assert_eq!(view.set.first_index().await?, None);
+        view.set.insert(&3u32)?;
+        view.set.insert(&7u32)?;
+        view.save().await?;
+    }
+    {
+        let view = SetStateView::load(context.clone()).await?;
+        assert_eq!(view.set.first_index().await?, Some(3));
+        assert_eq!(view.set.last_index().await?, Some(7));
+    }
+
+    // ByteSetView fast/slow paths.
+    let context = MemoryContext::new_for_testing(());
+    {
+        let mut view = ByteSetStateView::load(context.clone()).await?;
+        view.set.insert(vec![5]);
+        view.set.insert(vec![1]);
+        view.save().await?;
+    }
+    {
+        let mut view = ByteSetStateView::load(context.clone()).await?;
+        // Fast path.
+        assert_eq!(view.set.first_key().await?, Some(vec![1]));
+        assert_eq!(view.set.last_key().await?, Some(vec![5]));
+        // Slow path: stage an insert that's the new largest.
+        view.set.insert(vec![9]);
+        assert_eq!(view.set.first_key().await?, Some(vec![1]));
+        assert_eq!(view.set.last_key().await?, Some(vec![9]));
+    }
+
+    // CustomSetView with values straddling a byte boundary.
+    let context = MemoryContext::new_for_testing(());
+    {
+        let mut view = CustomSetStateView::load(context.clone()).await?;
+        view.set.insert(&1u128)?;
+        view.set.insert(&256u128)?;
+        view.save().await?;
+    }
+    {
+        let view = CustomSetStateView::load(context.clone()).await?;
+        assert_eq!(view.set.first_index().await?, Some(1u128));
+        assert_eq!(view.set.last_index().await?, Some(256u128));
     }
     Ok(())
 }


### PR DESCRIPTION
## Motivation

As discussed in #6163, it's useful to be able to read the last key of a map view.

## Proposal

Add `find_first_key_by_prefix`, `find_last_key_by_prefix`, and the value variants to `ReadableKeyValueStore`, with default impls falling back to `find_keys_by_prefix(...).first()/.last()`. Native overrides:

- memory: `BTreeMap` range, O(log N)
- RocksDB
- DynamoDB: `Query` with `Limit=1` and `ScanIndexForward=true/false`
- IndexedDB: `IDBCursor` with `Next`/`Prev` direction
- Wrappers (journaling, value_splitting, lru_caching, metering, dual): forward to the inner store; metering adds latency histograms; value_splitting strips the 4-byte segment index from the result.

Adds view-level helpers:
- `ByteMapView::first_key`, `last_key`, `first_key_value`, `last_key_value`
- `MapView` / `CustomMapView::first_index`, `last_index`,
  `first_index_value`, `last_index_value`
- `ByteSetView::first_key`, `last_key`
- `SetView` / `CustomSetView::first_index`, `last_index`

The view methods take a fast path straight to the store when there are no staged changes; otherwise they fall back to the existing `for_each_key_while` / `for_each_index` machinery, which already handles the merge of in-memory updates with persisted state.


## Test Plan

Tests were added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
