### PR TITLE
Migrate image workflows to WIF via composite gcp-auth action

### DIFF
--- a/.github/actions/gcp-auth/action.yml
+++ b/.github/actions/gcp-auth/action.yml
@@ -1,0 +1,72 @@
+# Composite action: authenticate to Google Cloud via Workload Identity
+# Federation, then install/configure the gcloud SDK.
+#
+# Why this exists:
+#   Every image-push workflow in this repo (agent-sandbox-image.yml,
+#   build-runner-image.yml, build-linera-utils.yml) needs the same three
+#   things before it can `docker push` or `gcloud builds submit`:
+#     1. WIF auth using the org-wide GitHub Apps provider.
+#     2. The gcloud CLI on PATH.
+#     3. (Optionally) Docker credential helper wired up for Artifact Registry.
+#   Copy-pasting the WIF provider ARN into every workflow makes provider
+#   rotations error-prone, so we centralize it here.
+#
+# How to use it:
+#   Call from a job that has `permissions: id-token: write` (composite
+#   actions inherit job permissions but cannot declare their own) and that
+#   has already run `actions/checkout@v4` (the action is referenced by
+#   path, so the repo must be on disk):
+#
+#     - uses: actions/checkout@v4
+#     - uses: ./.github/actions/gcp-auth
+#       with:
+#         service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+#         configure_docker_for: us-docker.pkg.dev   # optional
+#
+# References:
+#   - google-github-actions/auth README:
+#     https://github.com/google-github-actions/auth
+#   - GCP WIF with deployment pipelines:
+#     https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines
+
+name: GCP Auth (WIF)
+description: >-
+  Authenticate to Google Cloud via Workload Identity Federation and set up
+  the gcloud SDK. Optionally configure Docker for Artifact Registry.
+
+inputs:
+  service_account:
+    description: >-
+      Service account email to impersonate via Workload Identity Federation
+      (e.g. actions-runner@linera-io-dev.iam.gserviceaccount.com).
+    required: true
+  configure_docker_for:
+    description: >-
+      If non-empty, run `gcloud auth configure-docker <value> --quiet` so
+      `docker push` can use the WIF-derived credentials. Set to e.g.
+      `us-docker.pkg.dev` for Artifact Registry. Leave empty when the
+      workflow only uses `gcloud builds submit` (Cloud Build authenticates
+      directly and does not need a Docker credential helper).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        # Org-wide WIF provider. Hard-coded on purpose: the whole reason
+        # this composite action exists is so the ARN lives in exactly one
+        # place. If it ever rotates, change it here, not in every workflow.
+        workload_identity_provider: >-
+          projects/886017272224/locations/global/workloadIdentityPools/github-apps-pool/providers/github-apps-provider
+        service_account: ${{ inputs.service_account }}
+
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Configure Docker for Artifact Registry
+      if: inputs.configure_docker_for != ''
+      shell: bash
+      run: gcloud auth configure-docker "${{ inputs.configure_docker_for }}" --quiet

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -60,18 +60,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       # GCP auth is only needed to push the bridge image on release branches.
-      - name: Auth to GCP
-        if: github.event_name == 'push'
-        uses: google-github-actions/auth@v2
+      - if: github.event_name == 'push'
+        uses: ./.github/actions/gcp-auth
         with:
-          workload_identity_provider: >-
-            projects/886017272224/locations/global/workloadIdentityPools/github-apps-pool/providers/github-apps-provider
-          service_account: >-
-            actions-runner@linera-io-dev.iam.gserviceaccount.com
-
-      - name: Configure Docker for GCP
-        if: github.event_name == 'push'
-        run: gcloud auth configure-docker us-docker.pkg.dev
+          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+          configure_docker_for: us-docker.pkg.dev
 
       - name: Build linera image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -39,6 +39,10 @@ on:
 
 permissions:
   contents: read
+  # Required for Workload Identity Federation auth via the composite
+  # action below. Replaces the long-lived SA JSON key that lived in
+  # repo secrets (GCP_SA_ACTIONS_RUNNER_KEY).
+  id-token: write
 
 jobs:
   build:
@@ -51,16 +55,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
 
-      - name: Auth service account
-        uses: google-github-actions/auth@v1
+      - uses: ./.github/actions/gcp-auth
         with:
-          credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-
-      - name: Configure Docker to push to Artifact Registry
-        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+          configure_docker_for: us-docker.pkg.dev
 
       - name: Set env variables
         env:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -7,6 +7,10 @@ on:
 
 permissions:
   contents: read
+  # Required for Workload Identity Federation auth via the composite
+  # action below. Replaces the long-lived SA JSON key that lived in
+  # repo secrets (GCP_SA_ACTIONS_RUNNER_KEY).
+  id-token: write
 
 jobs:
   build-and-push:
@@ -18,16 +22,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Auth service account
-        uses: google-github-actions/auth@v1
+      - uses: ./.github/actions/gcp-auth
         with:
-          credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
-
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-
-      - name: Configure Docker to push to Artifact Registry
-        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+          configure_docker_for: us-docker.pkg.dev
 
       # Self-hosted builder occasionally exposes an unhealthy
       # docker socket at job start despite


### PR DESCRIPTION
## Motivation

`build_image.yml` and `docker_image.yml` still authenticate to GCP via `google-github-actions/auth@v1` with a long-lived service-account JSON key (`secrets.GCP_SA_ACTIONS_RUNNER_KEY`). Anyone with write access to the repo can read repo secrets, so a stale or compromised collaborator account can exfiltrate the key and use it to push to Artifact Registry indefinitely. Workload Identity Federation replaces the JSON key with short-lived OIDC tokens scoped to a single workflow run, eliminating the long-lived credential.

`bridge-e2e.yml` is already on WIF (auth@v2) but still inlines the same boilerplate.

linera-infra/#989 introduced a composite action that centralizes the WIF auth + gcloud setup + Docker config. This PR copies that composite action into linera-protocol and adopts it across all 3 image workflows, so the WIF provider ARN lives in exactly one place per repo.

## Proposal

1. New `.github/actions/gcp-auth/action.yml`: byte-for-byte copy of the composite action that landed in linera-infra/#989. Hard-codes the org-wide WIF provider ARN; takes `service_account` and optional `configure_docker_for` as inputs.

2. `build_image.yml` and `docker_image.yml`: replace the inline `auth@v1 + credentials_json + setup-gcloud@v1 + configure-docker` block with a single `uses: ./.github/actions/gcp-auth` step. Add `id-token: write` to the job permissions block (required for WIF; the composite action documents this requirement at the top). Drops the `secrets.GCP_SA_ACTIONS_RUNNER_KEY` reference; the secret can be deleted from the repo after merge (only consumers were these 2 workflows, verified via `gh search code`).

3. `bridge-e2e.yml`: replace the inline `auth@v2 + workload_identity_provider + service_account + configure-docker` block with the same `uses: ./.github/actions/gcp-auth` step. The workflow already has `id-token: write` at the workflow level. Pure dedup, no semantic change.

The composite action defaults match the existing config: same WIF provider, same `actions-runner@linera-io-dev.iam.gserviceaccount.com` SA, same Artifact Registry host (`us-docker.pkg.dev`).

## Test Plan

- CI.
- WIF flow is already proven for this repo by `bridge-e2e.yml` running on every push using the same provider ARN and same SA.
- All 4 YAML files parse cleanly.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- linera-infra#989: introduced the source composite action.
