### PR TITLE
Clean up bridge ABI duplication and tighten typed fields

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3860,6 +3860,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-trie",
  "anyhow",
+ "linera-base",
  "serde",
 ]
 

--- a/examples/evm-bridge/src/contract.rs
+++ b/examples/evm-bridge/src/contract.rs
@@ -8,7 +8,7 @@ use evm_bridge::{BridgeOperation, BridgeParameters, DepositKey, EvmBridgeAbi};
 use linera_bridge::proof;
 use linera_sdk::{
     ethereum::{ContractEthereumClient, EthereumQueries},
-    linera_base_types::{Account, AccountOwner, Amount, ApplicationId, ChainId, WithContractAbi},
+    linera_base_types::{Account, Amount, ApplicationId, WithContractAbi},
     views::{linera_views, RegisterView, RootView, SetView, View, ViewStorageContext},
     Contract, ContractRuntime,
 };
@@ -208,7 +208,7 @@ impl EvmBridgeContract {
         // 5. Replay protection
         let deposit_key = DepositKey {
             source_chain_id: params.source_chain_id,
-            block_hash: block_hash.0,
+            block_hash,
             tx_index,
             log_index,
         };
@@ -237,15 +237,12 @@ impl EvmBridgeContract {
         }
 
         // 6. Convert deposit fields to Linera types and call Mint
-        let target_chain_id =
-            ChainId::try_from(deposit.target_chain_id.as_slice()).expect("invalid target chain ID");
-        let target_owner = AccountOwner::from(deposit.target_account_owner.0);
         let amount = Amount::try_from(deposit.amount).expect("deposit amount exceeds u128");
 
         let mint_op = WrappedFungibleOperation::Mint {
             target_account: Account {
-                chain_id: target_chain_id,
-                owner: target_owner,
+                chain_id: deposit.target_chain_id,
+                owner: deposit.target_account_owner,
             },
             amount,
         };

--- a/examples/evm-bridge/src/lib.rs
+++ b/examples/evm-bridge/src/lib.rs
@@ -7,46 +7,11 @@
 //! on EVM and mints wrapped tokens on Linera via the wrapped-fungible app.
 
 use async_graphql::{Request, Response};
-pub use linera_bridge::proof::DepositKey;
-use linera_sdk::linera_base_types::{ApplicationId, ContractAbi, ServiceAbi};
-use serde::{Deserialize, Serialize};
-
-/// Parameters for a deployed bridge instance.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct BridgeParameters {
-    /// EVM chain ID of the source chain (e.g. 8453 for Base).
-    pub source_chain_id: u64,
-    /// Address of the FungibleBridge contract on EVM.
-    pub bridge_contract_address: [u8; 20],
-    /// ERC-20 token address on the source EVM chain.
-    pub token_address: [u8; 20],
-    /// JSON-RPC endpoint of the source EVM chain for finality verification.
-    /// When non-empty, `ProcessDeposit` requires the block hash to be verified first
-    /// via `VerifyBlockHash`.
-    pub rpc_endpoint: String,
-}
-
-/// Operations accepted by the bridge contract.
-#[derive(Debug, Deserialize, Serialize)]
-pub enum BridgeOperation {
-    /// Register the wrapped-fungible token application.
-    /// Can only be called once, by the chain owner.
-    RegisterFungibleApp { app_id: ApplicationId },
-    /// Verify a deposit proof and mint wrapped tokens.
-    ProcessDeposit {
-        block_header_rlp: Vec<u8>,
-        receipt_rlp: Vec<u8>,
-        proof_nodes: Vec<Vec<u8>>,
-        tx_index: u64,
-        log_index: u64,
-    },
-    /// Verify that an EVM block hash is authentic and finalized.
-    ///
-    /// Queries the EVM node to confirm the block exists and its number is at or below
-    /// the latest finalized block. Caches the hash only when submitted by an
-    /// authenticated signer (chain owner) to prevent state bloat.
-    VerifyBlockHash { block_hash: [u8; 32] },
-}
+pub use linera_bridge::{
+    abi::{BridgeOperation, BridgeParameters},
+    proof::DepositKey,
+};
+use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};
 
 pub struct EvmBridgeAbi;
 

--- a/linera-bridge/Cargo.toml
+++ b/linera-bridge/Cargo.toml
@@ -19,7 +19,6 @@ offchain = [
     "dep:alloy-sol-types",
     "dep:async-trait",
     "dep:bcs",
-    "dep:linera-base",
     "dep:linera-execution",
     "dep:op-alloy-network",
     "dep:thiserror",
@@ -66,6 +65,7 @@ alloy-primitives.workspace = true
 alloy-rlp.workspace = true
 alloy-trie.workspace = true
 anyhow.workspace = true
+linera-base.workspace = true
 serde.workspace = true
 thiserror = { workspace = true, optional = true }
 
@@ -82,7 +82,6 @@ alloy = { workspace = true, optional = true, default-features = false, features 
 ] }
 alloy-sol-types = { workspace = true, optional = true }
 bcs = { workspace = true, optional = true }
-linera-base = { workspace = true, optional = true }
 linera-execution = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["full"] }

--- a/linera-bridge/src/abi.rs
+++ b/linera-bridge/src/abi.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Canonical ABI types for the EVM→Linera bridge application.
+//!
+//! These types define the BCS-stable wire format used between:
+//! - the on-chain `evm-bridge` Wasm contract (which deserializes operations),
+//! - the off-chain relay (which serializes operations to submit them),
+//! - and end-to-end tests (which exercise the full pipeline).
+//!
+//! Hosting them here ensures all three sites stay in lockstep without manual copying.
+
+use linera_base::identifiers::ApplicationId;
+use serde::{Deserialize, Serialize};
+
+/// Parameters for a deployed bridge instance.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BridgeParameters {
+    /// EVM chain ID of the source chain (e.g. 8453 for Base).
+    pub source_chain_id: u64,
+    /// Address of the FungibleBridge contract on EVM.
+    pub bridge_contract_address: [u8; 20],
+    /// ERC-20 token address on the source EVM chain.
+    pub token_address: [u8; 20],
+    /// JSON-RPC endpoint of the source EVM chain for finality verification.
+    /// When non-empty, `ProcessDeposit` requires the block hash to be verified first
+    /// via `VerifyBlockHash`.
+    pub rpc_endpoint: String,
+}
+
+/// Operations accepted by the bridge contract.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum BridgeOperation {
+    /// Register the wrapped-fungible token application.
+    /// Can only be called once, by the chain owner.
+    RegisterFungibleApp { app_id: ApplicationId },
+    /// Verify a deposit proof and mint wrapped tokens.
+    ProcessDeposit {
+        block_header_rlp: Vec<u8>,
+        receipt_rlp: Vec<u8>,
+        proof_nodes: Vec<Vec<u8>>,
+        tx_index: u64,
+        log_index: u64,
+    },
+    /// Verify that an EVM block hash is authentic and finalized.
+    ///
+    /// Queries the EVM node to confirm the block exists and its number is at or below
+    /// the latest finalized block. Caches the hash only when submitted by an
+    /// authenticated signer (chain owner) to prevent state bloat.
+    VerifyBlockHash { block_hash: [u8; 32] },
+}

--- a/linera-bridge/src/fungible_bridge.rs
+++ b/linera-bridge/src/fungible_bridge.rs
@@ -333,8 +333,8 @@ mod tests {
             DEPOSITOR,
             t.bridge,
             &bridge::depositCall {
-                target_chain_id: <[u8; 32]>::from(*t.chain_id.as_bytes()).into(),
-                target_application_id: <[u8; 32]>::from(*t.app_id.as_bytes()).into(),
+                target_chain_id: *t.chain_id.as_bytes(),
+                target_application_id: *t.app_id.as_bytes(),
                 target_account_owner: target_owner_bytes().into(),
                 amount: alloy_primitives::U256::from(DEPOSIT_AMOUNT),
             },
@@ -364,14 +364,8 @@ mod tests {
 
         // chain id = 1 in revm mainnet context
         assert_eq!(event.data.source_chain_id, alloy_primitives::U256::from(1));
-        assert_eq!(
-            event.data.target_chain_id,
-            alloy_primitives::B256::from(<[u8; 32]>::from(*t.chain_id.as_bytes()))
-        );
-        assert_eq!(
-            event.data.target_application_id,
-            alloy_primitives::B256::from(<[u8; 32]>::from(*t.app_id.as_bytes()))
-        );
+        assert_eq!(event.data.target_chain_id, *t.chain_id.as_bytes());
+        assert_eq!(event.data.target_application_id, *t.app_id.as_bytes());
         assert_eq!(
             event.data.target_account_owner,
             alloy_primitives::B256::from(target_owner_bytes())
@@ -419,8 +413,8 @@ mod tests {
             DEPOSITOR,
             t.bridge,
             &bridge::depositCall {
-                target_chain_id: <[u8; 32]>::from(*t.chain_id.as_bytes()).into(),
-                target_application_id: <[u8; 32]>::from(*t.app_id.as_bytes()).into(),
+                target_chain_id: *t.chain_id.as_bytes(),
+                target_application_id: *t.app_id.as_bytes(),
                 target_account_owner: target_owner_bytes().into(),
                 amount: alloy_primitives::U256::from(DEPOSIT_AMOUNT),
             },
@@ -451,8 +445,8 @@ mod tests {
             DEPOSITOR,
             t.bridge,
             &bridge::depositCall {
-                target_chain_id: <[u8; 32]>::from(*t.chain_id.as_bytes()).into(),
-                target_application_id: <[u8; 32]>::from(*t.app_id.as_bytes()).into(),
+                target_chain_id: *t.chain_id.as_bytes(),
+                target_application_id: *t.app_id.as_bytes(),
                 target_account_owner: target_owner_bytes().into(),
                 amount: alloy_primitives::U256::from(DEPOSIT_AMOUNT),
             },
@@ -480,7 +474,7 @@ mod tests {
             DEPOSITOR,
             t.bridge,
             &bridge::depositCall {
-                target_chain_id: <[u8; 32]>::from(*t.chain_id.as_bytes()).into(),
+                target_chain_id: *t.chain_id.as_bytes(),
                 target_application_id: [0xFF; 32].into(),
                 target_account_owner: target_owner_bytes().into(),
                 amount: alloy_primitives::U256::from(DEPOSIT_AMOUNT),
@@ -516,8 +510,8 @@ mod tests {
             DEPOSITOR,
             t.bridge,
             &bridge::depositCall {
-                target_chain_id: <[u8; 32]>::from(*t.chain_id.as_bytes()).into(),
-                target_application_id: <[u8; 32]>::from(*t.app_id.as_bytes()).into(),
+                target_chain_id: *t.chain_id.as_bytes(),
+                target_application_id: *t.app_id.as_bytes(),
                 target_account_owner: target_owner_bytes().into(),
                 amount: alloy_primitives::U256::from(too_much),
             },

--- a/linera-bridge/src/lib.rs
+++ b/linera-bridge/src/lib.rs
@@ -8,6 +8,9 @@
 /// EVM receipt proof verification and deposit event parsing.
 pub mod proof;
 
+/// Canonical BCS-stable ABI types for the EVM→Linera bridge application.
+pub mod abi;
+
 // -- Off-chain only (requires `not(chain)` / default features) --
 
 /// EVM contract ABIs, relay clients, and Solidity sources.

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -160,11 +160,6 @@ impl ServeOptions {
             .install_default()
             .expect("failed to install rustls crypto provider");
 
-        // Tonic pulls in rustls 0.23 which requires an explicit crypto provider.
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .expect("failed to install rustls crypto provider");
-
         Box::pin(linera_bridge::relay::run(
             &self.rpc_url,
             self.wallet.as_deref(),
@@ -186,7 +181,7 @@ impl ServeOptions {
                 event_cache_size: self.event_cache_size,
                 cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
             },
-            self.monitor_scan_interval,
+            std::time::Duration::from_secs(self.monitor_scan_interval),
             self.monitor_start_block,
             self.max_retries,
             self.sqlite_path.as_deref(),
@@ -290,7 +285,7 @@ impl InitLightClientOptions {
             .find(|c| c.origin() == ChainOrigin::Root(0))
             .ok_or_else(|| anyhow::anyhow!("no admin chain (Root(0)) in genesis config"))?
             .id();
-        let admin_chain_bytes = <[u8; 32]>::from(*admin_chain_id.0.as_bytes());
+        let admin_chain_bytes = *admin_chain_id.0.as_bytes();
 
         let mut validators: Vec<String> = Vec::new();
         let mut weights: Vec<u64> = Vec::new();

--- a/linera-bridge/src/monitor/db.rs
+++ b/linera-bridge/src/monitor/db.rs
@@ -10,6 +10,7 @@
 use std::path::Path;
 
 use anyhow::Result;
+use linera_base::data_types::BlockHeight;
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     SqlitePool,
@@ -164,23 +165,28 @@ impl BridgeDb {
             "INSERT OR IGNORE INTO burns (linera_height, burn_index, evm_recipient, amount)
              VALUES (?, ?, ?, ?)",
         )
-        .bind(burn.linera_height as i64)
+        .bind(burn.height.0 as i64)
         .bind(burn.burn_index as i64)
-        .bind(&burn.evm_recipient)
-        .bind(&burn.amount)
+        .bind(format!("{:#x}", burn.evm_recipient))
+        .bind(burn.amount.to_string())
         .execute(&self.pool)
         .await?;
         Ok(())
     }
 
     /// Updates a burn's status and timestamp.
-    pub async fn update_burn_status(&self, height: u64, index: usize, status: &str) -> Result<()> {
+    pub async fn update_burn_status(
+        &self,
+        height: BlockHeight,
+        index: usize,
+        status: &str,
+    ) -> Result<()> {
         sqlx::query(
             "UPDATE burns SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
              WHERE linera_height = ? AND burn_index = ?",
         )
         .bind(status)
-        .bind(height as i64)
+        .bind(height.0 as i64)
         .bind(index as i64)
         .execute(&self.pool)
         .await?;
@@ -188,13 +194,18 @@ impl BridgeDb {
     }
 
     /// Stores raw BCS-serialized certificate bytes for a burn.
-    pub async fn store_burn_raw(&self, height: u64, index: usize, raw: &[u8]) -> Result<()> {
+    pub async fn store_burn_raw(
+        &self,
+        height: BlockHeight,
+        index: usize,
+        raw: &[u8],
+    ) -> Result<()> {
         sqlx::query(
             "UPDATE burns SET raw_cert = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
              WHERE linera_height = ? AND burn_index = ?",
         )
         .bind(raw)
-        .bind(height as i64)
+        .bind(height.0 as i64)
         .bind(index as i64)
         .execute(&self.pool)
         .await?;
@@ -207,6 +218,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use alloy::primitives::{Address, B256, U256};
+    use linera_base::data_types::Amount;
     use test_case::test_case;
 
     use super::*;
@@ -227,7 +239,7 @@ mod tests {
     fn test_deposit_key() -> DepositKey {
         DepositKey {
             source_chain_id: 8453,
-            block_hash: [0xAA; 32],
+            block_hash: B256::from([0xAA; 32]),
             tx_index: 5,
             log_index: 0,
         }
@@ -245,10 +257,12 @@ mod tests {
 
     fn test_burn() -> PendingBurn {
         PendingBurn {
-            linera_height: 100,
+            height: BlockHeight(100),
             burn_index: 0,
-            evm_recipient: "0xabcdef1234567890abcdef1234567890abcdef12".to_string(),
-            amount: "500000".to_string(),
+            evm_recipient: "0xabcdef1234567890abcdef1234567890abcdef12"
+                .parse()
+                .unwrap(),
+            amount: Amount::from_attos(500_000),
         }
     }
 
@@ -348,14 +362,15 @@ mod tests {
         let db = open_db(use_file).await;
         db.insert_burn(&test_burn()).await.unwrap();
 
+        let burn = test_burn();
         let row: (String, String, String) = sqlx::query_as(
             "SELECT evm_recipient, amount, status FROM burns WHERE linera_height = 100",
         )
         .fetch_one(&db.pool)
         .await
         .unwrap();
-        assert_eq!(row.0, "0xabcdef1234567890abcdef1234567890abcdef12");
-        assert_eq!(row.1, "500000");
+        assert_eq!(row.0, format!("{:#x}", burn.evm_recipient));
+        assert_eq!(row.1, burn.amount.to_string());
         assert_eq!(row.2, "pending");
     }
 
@@ -365,7 +380,9 @@ mod tests {
     async fn test_complete_burn(use_file: bool) {
         let db = open_db(use_file).await;
         db.insert_burn(&test_burn()).await.unwrap();
-        db.update_burn_status(100, 0, "completed").await.unwrap();
+        db.update_burn_status(BlockHeight(100), 0, "completed")
+            .await
+            .unwrap();
 
         let (status,): (String,) =
             sqlx::query_as("SELECT status FROM burns WHERE linera_height = 100")
@@ -398,7 +415,9 @@ mod tests {
         db.insert_burn(&test_burn()).await.unwrap();
 
         let cert_bytes = vec![10, 20, 30, 40, 50];
-        db.store_burn_raw(100, 0, &cert_bytes).await.unwrap();
+        db.store_burn_raw(BlockHeight(100), 0, &cert_bytes)
+            .await
+            .unwrap();
 
         let (raw,): (Vec<u8>,) =
             sqlx::query_as("SELECT raw_cert FROM burns WHERE linera_height = 100")

--- a/linera-bridge/src/monitor/evm.rs
+++ b/linera-bridge/src/monitor/evm.rs
@@ -94,7 +94,7 @@ pub(crate) async fn retry_pending_deposits<E: linera_core::environment::Environm
                 // Persist raw BCS operation bytes so deposits can be replayed without the relayer.
                 if let Some(db) = monitor.read().await.db() {
                     for &log_index in &proof.log_indices {
-                        let op = crate::relay::evm::BridgeOperation::ProcessDeposit {
+                        let op = crate::abi::BridgeOperation::ProcessDeposit {
                             block_header_rlp: proof.block_header_rlp.clone(),
                             receipt_rlp: proof.receipt_rlp.clone(),
                             proof_nodes: proof.proof_nodes.clone(),
@@ -180,7 +180,7 @@ async fn evm_scan_iteration(
 
         let key = DepositKey {
             source_chain_id: deposit.source_chain_id.to::<u64>(),
-            block_hash: block_hash.0,
+            block_hash,
             tx_index,
             log_index,
         };

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use alloy::{primitives::Address, providers::Provider};
+use linera_base::data_types::BlockHeight;
 use tokio::sync::RwLock;
 
 use super::{MonitorState, PendingBurn};
@@ -48,10 +49,10 @@ pub async fn linera_scan_loop<E: linera_core::environment::Environment + 'static
             let state = monitor.read().await;
             for b in state.burns_ready_for_retry(max_retries) {
                 let _ = pending_burn_tx.try_send(PendingBurn {
-                    linera_height: b.value.linera_height,
+                    height: b.value.height,
                     burn_index: b.value.burn_index,
-                    evm_recipient: b.value.evm_recipient.clone(),
-                    amount: b.value.amount.clone(),
+                    evm_recipient: b.value.evm_recipient,
+                    amount: b.value.amount,
                 });
             }
         }
@@ -60,7 +61,7 @@ pub async fn linera_scan_loop<E: linera_core::environment::Environment + 'static
         tracing::trace!(
             pending = summary.burns_pending,
             completed = summary.burns_forwarded,
-            last_height = summary.last_scanned_linera_height,
+            last_height = %summary.last_scanned_linera_height,
             "Linera burn scan complete"
         );
 
@@ -77,14 +78,14 @@ pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment
     mut pending_rx: tokio::sync::mpsc::Receiver<PendingBurn>,
 ) -> anyhow::Result<()> {
     while let Some(pending) = pending_rx.recv().await {
-        let credit_height = pending.linera_height;
+        let credit_height = pending.height;
         let burn_index = pending.burn_index;
         {
             let mut state = monitor.write().await;
             if let Some(b) = state.burns.get_mut(&(credit_height, burn_index)) {
                 if b.forwarded {
                     tracing::trace!(
-                        credit_height,
+                        ?credit_height,
                         burn_index,
                         "Burn already completed, skipping"
                     );
@@ -96,7 +97,7 @@ pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment
             }
         }
 
-        tracing::info!(credit_height, burn_index, "Processing burn...");
+        tracing::info!(?credit_height, burn_index, "Processing burn...");
 
         // Read the certificate at the burn's block height (already contains the auto-burn).
         let cert = match async {
@@ -108,7 +109,7 @@ pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment
                     anyhow::bail!("Block at height {} not found", credit_height);
                 };
                 let c = linera_client.read_certificate(h).await?;
-                if c.block().header.height.0 == credit_height {
+                if c.block().header.height == credit_height {
                     break Ok(c);
                 }
                 hash = c.block().header.previous_block_hash;
@@ -119,7 +120,7 @@ pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment
             Ok(cert) => cert,
             Err(e) => {
                 tracing::warn!(
-                    credit_height,
+                    ?credit_height,
                     burn_index,
                     "Failed to read certificate: {e:#}"
                 );
@@ -140,7 +141,7 @@ pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment
                 .await
             {
                 tracing::warn!(
-                    credit_height,
+                    ?credit_height,
                     burn_index,
                     "Failed to store burn raw bytes: {e:#}"
                 );
@@ -150,16 +151,16 @@ pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment
         // Forward cert to EVM.
         let completed = match evm_client.forward_cert(&cert).await {
             Ok(()) => {
-                tracing::info!(credit_height, burn_index, "Burn forwarded to EVM");
+                tracing::info!(?credit_height, burn_index, "Burn forwarded to EVM");
                 true
             }
             Err(e) => {
                 let msg = format!("{e:#}");
                 if msg.contains("already verified") {
-                    tracing::trace!(credit_height, burn_index, "Block already verified on EVM");
+                    tracing::trace!(?credit_height, burn_index, "Block already verified on EVM");
                     true
                 } else {
-                    tracing::warn!(credit_height, burn_index, "EVM forwarding failed: {e:#}");
+                    tracing::warn!(?credit_height, burn_index, "EVM forwarding failed: {e:#}");
                     monitor
                         .write()
                         .await
@@ -191,8 +192,8 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
 
     linera_client.sync().await?;
     let info = linera_client.chain_info().await?;
-    let current_height = info.next_block_height.0;
-    if current_height == 0 || current_height <= last_height {
+    let current_height = info.next_block_height;
+    if current_height.0 == 0 || current_height <= last_height {
         return Ok(());
     }
 
@@ -202,7 +203,7 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
     let mut hash = info.block_hash;
     while let Some(h) = hash {
         let block = linera_client.read_confirmed_block(h).await?;
-        let height = block.block().header.height.0;
+        let height = block.block().header.height;
         if height < last_height {
             break;
         }
@@ -213,27 +214,31 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
 
     let mut new_burns = Vec::new();
     for block in &blocks {
-        let height = block.block().header.height.0;
+        let height = block.block().header.height;
         let burn_events = find_burn_events(&block.block().body.events, fungible_app_id);
         for (burn_index, burn_event) in burn_events.into_iter().enumerate() {
-            let recipient = format!("0x{}", hex::encode(burn_event.target));
-            new_burns.push((height, burn_index, recipient, burn_event.amount.to_string()));
+            new_burns.push((
+                height,
+                burn_index,
+                Address::from(burn_event.target),
+                burn_event.amount,
+            ));
         }
     }
 
     for (height, burn_index, recipient, amount) in &new_burns {
-        tracing::info!(height, burn_index, recipient, amount, "Discovered burn");
+        tracing::info!(?height, burn_index, %recipient, %amount, "Discovered burn");
         let _ = pending_burn_tx.try_send(PendingBurn {
-            linera_height: *height,
+            height: *height,
             burn_index: *burn_index,
-            evm_recipient: recipient.clone(),
-            amount: amount.clone(),
+            evm_recipient: *recipient,
+            amount: *amount,
         });
     }
 
     let mut state = monitor.write().await;
     state.last_scanned_linera_height = current_height;
-    crate::relay::metrics::set_last_scanned_linera_height(current_height);
+    crate::relay::metrics::set_last_scanned_linera_height(current_height.0);
     Ok(())
 }
 
@@ -241,15 +246,12 @@ async fn check_burn_completion(
     monitor: &RwLock<MonitorState>,
     evm_client: &EvmClient<impl Provider>,
 ) -> anyhow::Result<()> {
-    let pending: Vec<(u64, usize, Address)> = {
+    let pending: Vec<(BlockHeight, usize, Address)> = {
         let state = monitor.read().await;
         state
             .pending_burns()
             .into_iter()
-            .filter_map(|b| {
-                let addr: Address = b.value.evm_recipient.parse().ok()?;
-                Some((b.value.linera_height, b.value.burn_index, addr))
-            })
+            .map(|b| (b.value.height, b.value.burn_index, b.value.evm_recipient))
             .collect()
     };
 

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -19,7 +19,10 @@ use std::{
 };
 
 use alloy::primitives::{Address, B256, U256};
-use linera_base::identifiers::ApplicationId;
+use linera_base::{
+    data_types::{Amount, BlockHeight},
+    identifiers::ApplicationId,
+};
 use linera_execution::{Query, QueryResponse};
 use tokio::sync::RwLock;
 
@@ -56,10 +59,10 @@ pub struct PendingDeposit {
 /// A pending burn detected by the Linera scanner, sent to the retry loop.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PendingBurn {
-    pub linera_height: u64,
+    pub height: BlockHeight,
     pub burn_index: usize,
-    pub evm_recipient: String,
-    pub amount: String,
+    pub evm_recipient: Address,
+    pub amount: Amount,
 }
 
 /// Wraps a pending bridging request with tracking metadata.
@@ -93,9 +96,9 @@ pub type TrackedBurn = Tracked<PendingBurn>;
 /// In-memory monitoring state shared across scan loops and HTTP handlers.
 pub struct MonitorState {
     pub(crate) deposits: HashMap<DepositKey, TrackedDeposit>,
-    pub(crate) burns: HashMap<(u64, usize), TrackedBurn>,
+    pub(crate) burns: HashMap<(BlockHeight, usize), TrackedBurn>,
     pub(crate) last_scanned_evm_block: u64,
-    pub(crate) last_scanned_linera_height: u64,
+    pub(crate) last_scanned_linera_height: BlockHeight,
     db: Option<db::BridgeDb>,
 }
 
@@ -105,7 +108,7 @@ impl MonitorState {
             deposits: HashMap::new(),
             burns: HashMap::new(),
             last_scanned_evm_block: start_evm_block,
-            last_scanned_linera_height: 0,
+            last_scanned_linera_height: BlockHeight(0),
             db: None,
         }
     }
@@ -157,7 +160,7 @@ impl MonitorState {
     /// Uses Entry API instead of insert() to avoid overwriting existing entries
     /// that may have accumulated retry state.
     pub async fn track_burn(&mut self, pending: PendingBurn) -> bool {
-        let key = (pending.linera_height, pending.burn_index);
+        let key = (pending.height, pending.burn_index);
         match self.burns.entry(key) {
             Entry::Occupied(_) => false,
             Entry::Vacant(e) => {
@@ -173,28 +176,21 @@ impl MonitorState {
         }
     }
 
-    pub async fn complete_burn(&mut self, linera_height: u64, burn_index: usize) {
-        if let Some(b) = self.burns.get_mut(&(linera_height, burn_index)) {
+    pub async fn complete_burn(&mut self, height: BlockHeight, burn_index: usize) {
+        if let Some(b) = self.burns.get_mut(&(height, burn_index)) {
             b.forwarded = true;
             crate::relay::metrics::burn_completed();
             if let Some(db) = &self.db {
-                if let Err(e) = db
-                    .update_burn_status(linera_height, burn_index, "completed")
-                    .await
-                {
+                if let Err(e) = db.update_burn_status(height, burn_index, "completed").await {
                     tracing::warn!(
-                        linera_height,
+                        ?height,
                         burn_index,
                         "Failed to update burn status in SQLite: {e:#}"
                     );
                 }
             }
         } else {
-            tracing::warn!(
-                linera_height,
-                burn_index,
-                "Attempted to complete unknown burn"
-            );
+            tracing::warn!(?height, burn_index, "Attempted to complete unknown burn");
         }
     }
 
@@ -263,21 +259,21 @@ impl MonitorState {
         }
     }
 
-    pub fn mark_burn_retried(&mut self, height: u64, burn_index: usize) {
+    pub fn mark_burn_retried(&mut self, height: BlockHeight, burn_index: usize) {
         if let Some(b) = self.burns.get_mut(&(height, burn_index)) {
             b.retry_count += 1;
             b.last_retry_at = Some(Instant::now());
         }
     }
 
-    pub async fn mark_burn_failed(&mut self, height: u64, burn_index: usize) {
+    pub async fn mark_burn_failed(&mut self, height: BlockHeight, burn_index: usize) {
         if let Some(b) = self.burns.get_mut(&(height, burn_index)) {
             b.failed = true;
             crate::relay::metrics::burn_failed();
             if let Some(db) = &self.db {
                 if let Err(e) = db.update_burn_status(height, burn_index, "failed").await {
                     tracing::warn!(
-                        height,
+                        ?height,
                         burn_index,
                         "Failed to update burn status in SQLite: {e:#}"
                     );
@@ -305,7 +301,7 @@ pub struct StatusSummary {
     pub burns_pending: usize,
     pub burns_forwarded: usize,
     pub last_scanned_evm_block: u64,
-    pub last_scanned_linera_height: u64,
+    pub last_scanned_linera_height: BlockHeight,
 }
 
 /// Runs deposit and burn retry loops concurrently.
@@ -350,6 +346,7 @@ fn retry_eligible(retry_count: u32, last_retry_at: Option<Instant>, max_retries:
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, B256, U256};
+    use linera_base::data_types::{Amount, BlockHeight};
 
     use super::*;
 
@@ -357,7 +354,7 @@ mod tests {
     fn test_deposit_key_hash_matches_evm_bridge() {
         let key = DepositKey {
             source_chain_id: 8453,
-            block_hash: [0xAA; 32],
+            block_hash: B256::from([0xAA; 32]),
             tx_index: 5,
             log_index: 0,
         };
@@ -370,13 +367,13 @@ mod tests {
     fn test_deposit_key_different_log_index_different_hash() {
         let key1 = DepositKey {
             source_chain_id: 8453,
-            block_hash: [0xAA; 32],
+            block_hash: B256::from([0xAA; 32]),
             tx_index: 5,
             log_index: 0,
         };
         let key2 = DepositKey {
             source_chain_id: 8453,
-            block_hash: [0xAA; 32],
+            block_hash: B256::from([0xAA; 32]),
             tx_index: 5,
             log_index: 1,
         };
@@ -389,7 +386,7 @@ mod tests {
 
         let key = DepositKey {
             source_chain_id: 8453,
-            block_hash: [0xAA; 32],
+            block_hash: B256::from([0xAA; 32]),
             tx_index: 1,
             log_index: 0,
         };
@@ -418,17 +415,17 @@ mod tests {
 
         state
             .track_burn(PendingBurn {
-                linera_height: 10,
+                height: BlockHeight(10),
                 burn_index: 0,
-                evm_recipient: "0xabcd".to_string(),
-                amount: "500".to_string(),
+                evm_recipient: Address::from([0xab; 20]),
+                amount: Amount::from_attos(500),
             })
             .await;
 
         assert_eq!(state.pending_burns().len(), 1);
         assert_eq!(state.completed_burns().len(), 0);
 
-        state.complete_burn(10, 0).await;
+        state.complete_burn(BlockHeight(10), 0).await;
 
         assert_eq!(state.pending_burns().len(), 0);
         assert_eq!(state.completed_burns().len(), 1);
@@ -440,7 +437,7 @@ mod tests {
 
         let key = DepositKey {
             source_chain_id: 1,
-            block_hash: [0; 32],
+            block_hash: B256::ZERO,
             tx_index: 0,
             log_index: 0,
         };
@@ -455,10 +452,10 @@ mod tests {
             .await;
         state
             .track_burn(PendingBurn {
-                linera_height: 5,
+                height: BlockHeight(5),
                 burn_index: 0,
-                evm_recipient: "0x1234".to_string(),
-                amount: "100".to_string(),
+                evm_recipient: Address::from([0x12; 20]),
+                amount: Amount::from_attos(100),
             })
             .await;
 
@@ -497,7 +494,7 @@ mod tests {
         let mut state = MonitorState::new(0);
         let key = DepositKey {
             source_chain_id: 1,
-            block_hash: [0; 32],
+            block_hash: B256::ZERO,
             tx_index: 0,
             log_index: 0,
         };

--- a/linera-bridge/src/proof/mod.rs
+++ b/linera-bridge/src/proof/mod.rs
@@ -74,6 +74,10 @@ use alloy_primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy_rlp::Encodable;
 use alloy_trie::{proof::ProofRetainer, HashBuilder, Nibbles};
 use anyhow::{anyhow, ensure, Result};
+use linera_base::{
+    crypto::CryptoHash,
+    identifiers::{AccountOwner, ApplicationId, ChainId},
+};
 
 /// A decoded log from an EVM transaction receipt.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,12 +88,16 @@ pub struct ReceiptLog {
 }
 
 /// Parsed `DepositInitiated` event data.
+///
+/// Fields are typed by their natural domain: Linera-side identifiers use the
+/// canonical `linera-base` types, while Ethereum-side values use `alloy`
+/// primitive types (`Address`, `B256`, `U256`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DepositEvent {
     pub source_chain_id: U256,
-    pub target_chain_id: B256,
-    pub target_application_id: B256,
-    pub target_account_owner: B256,
+    pub target_chain_id: ChainId,
+    pub target_application_id: ApplicationId,
+    pub target_account_owner: AccountOwner,
     pub depositor: Address,
     pub token: Address,
     pub amount: U256,
@@ -105,7 +113,7 @@ pub struct DepositEvent {
 )]
 pub struct DepositKey {
     pub source_chain_id: u64,
-    pub block_hash: [u8; 32],
+    pub block_hash: B256,
     pub tx_index: u64,
     pub log_index: u64,
 }
@@ -115,7 +123,7 @@ impl DepositKey {
     pub fn hash(&self) -> [u8; 32] {
         let mut data = [0u8; 56];
         data[0..8].copy_from_slice(&self.source_chain_id.to_le_bytes());
-        data[8..40].copy_from_slice(&self.block_hash);
+        data[8..40].copy_from_slice(self.block_hash.as_slice());
         data[40..48].copy_from_slice(&self.tx_index.to_le_bytes());
         data[48..56].copy_from_slice(&self.log_index.to_le_bytes());
         keccak256(data).0
@@ -438,11 +446,18 @@ pub fn parse_deposit_event(log: &ReceiptLog, expected_emitter: Address) -> Resul
         "invalid ABI encoding: address padding bytes (128..140) must be zero"
     );
 
+    let mut chain_id_bytes = [0u8; 32];
+    chain_id_bytes.copy_from_slice(&d[32..64]);
+    let mut application_id_bytes = [0u8; 32];
+    application_id_bytes.copy_from_slice(&d[64..96]);
+    let mut account_owner_bytes = [0u8; 32];
+    account_owner_bytes.copy_from_slice(&d[96..128]);
+
     Ok(DepositEvent {
         source_chain_id: U256::from_be_slice(&d[0..32]),
-        target_chain_id: B256::from_slice(&d[32..64]),
-        target_application_id: B256::from_slice(&d[64..96]),
-        target_account_owner: B256::from_slice(&d[96..128]),
+        target_chain_id: ChainId(CryptoHash::from(chain_id_bytes)),
+        target_application_id: ApplicationId::new(CryptoHash::from(application_id_bytes)),
+        target_account_owner: AccountOwner::from(account_owner_bytes),
         depositor,
         token: Address::from_slice(&d[140..160]),
         amount: U256::from_be_slice(&d[160..192]),
@@ -792,9 +807,18 @@ mod tests {
 
         let event = parse_deposit_event(&log, TEST_BRIDGE).unwrap();
         assert_eq!(event.source_chain_id, U256::from(8453));
-        assert_eq!(event.target_chain_id, target_chain_id);
-        assert_eq!(event.target_application_id, target_app_id);
-        assert_eq!(event.target_account_owner, target_owner);
+        assert_eq!(
+            event.target_chain_id,
+            ChainId(CryptoHash::from(target_chain_id.0))
+        );
+        assert_eq!(
+            event.target_application_id,
+            ApplicationId::new(CryptoHash::from(target_app_id.0))
+        );
+        assert_eq!(
+            event.target_account_owner,
+            AccountOwner::from(target_owner.0)
+        );
         assert_eq!(event.depositor, depositor);
         assert_eq!(event.token, token);
         assert_eq!(event.amount, U256::from(1_000_000));

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -32,25 +32,6 @@ sol! {
     function currentEpoch() external view returns (uint32);
 }
 
-/// Must match `evm_bridge::BridgeOperation` variant-for-variant for BCS compatibility.
-#[derive(serde::Serialize)]
-#[allow(dead_code)]
-pub(crate) enum BridgeOperation {
-    RegisterFungibleApp {
-        app_id: linera_base::identifiers::ApplicationId,
-    },
-    ProcessDeposit {
-        block_header_rlp: Vec<u8>,
-        receipt_rlp: Vec<u8>,
-        proof_nodes: Vec<Vec<u8>>,
-        tx_index: u64,
-        log_index: u64,
-    },
-    VerifyBlockHash {
-        block_hash: [u8; 32],
-    },
-}
-
 /// Maximum block range per `eth_getLogs` query.
 const MAX_LOG_BLOCK_RANGE: u64 = 10_000;
 

--- a/linera-bridge/src/relay/linera.rs
+++ b/linera-bridge/src/relay/linera.rs
@@ -3,7 +3,7 @@
 
 //! Centralized Linera client for all bridge chain interactions.
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, Event},
@@ -17,13 +17,14 @@ use crate::proof::DepositKey;
 
 /// A write operation to be executed on the bridge chain.
 /// Sent to the main loop which serializes all chain mutations.
+#[derive(Debug)]
 pub(crate) enum ChainOperation {
     ProcessInbox {
-        response: oneshot::Sender<Result<Vec<ConfirmedBlockCertificate>, String>>,
+        response: oneshot::Sender<Result<Vec<ConfirmedBlockCertificate>>>,
     },
     ProcessDeposit {
         proof: crate::proof::gen::DepositProof,
-        response: oneshot::Sender<Result<(), String>>,
+        response: oneshot::Sender<Result<()>>,
     },
 }
 
@@ -116,11 +117,8 @@ impl<E: linera_core::environment::Environment> LineraClient<E> {
                 response: resp_tx,
             })
             .await
-            .map_err(|_| anyhow::anyhow!("Chain operation channel closed"))?;
-        resp_rx
-            .await
-            .map_err(|_| anyhow::anyhow!("Response channel closed"))?
-            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| "Chain operation channel closed")?;
+        resp_rx.await.with_context(|| "Response channel closed")?
     }
 
     pub async fn process_inbox(&self) -> Result<Vec<ConfirmedBlockCertificate>> {
@@ -128,11 +126,8 @@ impl<E: linera_core::environment::Environment> LineraClient<E> {
         self.op_tx
             .send(ChainOperation::ProcessInbox { response: resp_tx })
             .await
-            .map_err(|_| anyhow::anyhow!("Chain operation channel closed"))?;
-        resp_rx
-            .await
-            .map_err(|_| anyhow::anyhow!("Response channel closed"))?
-            .map_err(|e| anyhow::anyhow!(e))
+            .with_context(|| "Chain operation channel closed")?;
+        resp_rx.await.with_context(|| "Response channel closed")?
     }
 }
 

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -95,7 +95,7 @@ pub async fn run(
     evm_light_client_address: Option<&str>,
     port: u16,
     cache_sizes: linera_storage::StorageCacheConfig,
-    monitor_scan_interval: u64,
+    monitor_scan_interval: Duration,
     monitor_start_block: u64,
     max_retries: u32,
     sqlite_path: Option<&Path>,
@@ -254,7 +254,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     evm_private_key: &str,
     evm_light_client_address: Option<&str>,
     port: u16,
-    monitor_scan_interval: u64,
+    monitor_scan_interval: Duration,
     monitor_start_block: u64,
     max_retries: u32,
     sqlite_path_override: Option<&Path>,
@@ -318,7 +318,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     let admin_notifications = chain_client.subscribe_to(admin_chain_id)?;
     let mut notifications = futures::stream::select(chain_notifications, admin_notifications);
     let (listener, _abort_handle, _) = chain_client.listen().await?;
-    let chain_listener_handle = tokio::spawn(listener);
+    let mut chain_listener_handle = tokio::spawn(listener);
 
     // ── Monitor state + scan/retry ──
     let mut monitor_state = MonitorState::new(monitor_start_block);
@@ -326,10 +326,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
         .parent()
         .unwrap_or(storage_dir)
         .join("bridge_relay.sqlite3");
-    let sqlite_path = match sqlite_path_override {
-        Some(p) => p,
-        None => &default_sqlite_path,
-    };
+    let sqlite_path = sqlite_path_override.unwrap_or(&default_sqlite_path);
     let db = monitor::db::BridgeDb::open(sqlite_path)
         .await
         .with_context(|| {
@@ -341,12 +338,11 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     tracing::info!(path = %sqlite_path.display(), "Opened bridge relay SQLite database");
     monitor_state.set_db(db);
     let monitor = Arc::new(RwLock::new(monitor_state));
-    let scan_interval = Duration::from_secs(monitor_scan_interval);
     let (pending_deposit_tx, pending_deposit_rx) =
         tokio::sync::mpsc::channel::<monitor::PendingDeposit>(64);
     let (pending_burn_tx, pending_burn_rx) = tokio::sync::mpsc::channel::<monitor::PendingBurn>(64);
 
-    let evm_scan_handle = {
+    let mut evm_scan_handle = {
         let monitor = Arc::clone(&monitor);
         let evm_client = Arc::clone(&evm_client);
         let linera_client = Arc::clone(&linera_client);
@@ -355,11 +351,11 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
             evm_client,
             linera_client,
             pending_deposit_tx,
-            scan_interval,
+            monitor_scan_interval,
             max_retries,
         ))
     };
-    let linera_scan_handle = {
+    let mut linera_scan_handle = {
         let monitor = Arc::clone(&monitor);
         let evm_client = Arc::clone(&evm_client);
         let linera_client = Arc::clone(&linera_client);
@@ -368,12 +364,12 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
             evm_client,
             linera_client,
             pending_burn_tx,
-            scan_interval,
+            monitor_scan_interval,
             max_retries,
         ))
     };
 
-    let retry_handle = {
+    let mut retry_handle = {
         let monitor = Arc::clone(&monitor);
         let evm_client = Arc::clone(&evm_client);
         let linera_client = Arc::clone(&linera_client);
@@ -394,7 +390,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     tracing::info!("HTTP server listening on {bind_addr}");
 
     let tcp_listener = tokio::net::TcpListener::bind(&bind_addr).await?;
-    let http_server_handle = tokio::spawn(async move {
+    let mut http_server_handle = tokio::spawn(async move {
         axum::serve(tcp_listener, app)
             .await
             .context("HTTP server error")
@@ -411,11 +407,6 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
 
     // ── Main loop: process chain operations + notifications ──
     tracing::info!("Listening for chain operations and notifications...");
-    let mut chain_listener_handle = chain_listener_handle;
-    let mut evm_scan_handle = evm_scan_handle;
-    let mut linera_scan_handle = linera_scan_handle;
-    let mut retry_handle = retry_handle;
-    let mut http_server_handle = http_server_handle;
     loop {
         tokio::select! {
             result = &mut chain_listener_handle => {
@@ -511,12 +502,12 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
                             let (certs, _) = chain_client.process_inbox().await?;
                             Ok(certs)
                         }.await;
-                        let _ = response.send(result.map_err(|e: anyhow::Error| format!("{e:#}")));
+                        let _ = response.send(result);
                     }
                     linera::ChainOperation::ProcessDeposit { proof, response } => {
                         let result = async {
                             let operations: Vec<_> = proof.log_indices.iter().map(|&log_index| {
-                                let op = evm::BridgeOperation::ProcessDeposit {
+                                let op = crate::abi::BridgeOperation::ProcessDeposit {
                                     block_header_rlp: proof.block_header_rlp.clone(),
                                     receipt_rlp: proof.receipt_rlp.clone(),
                                     proof_nodes: proof.proof_nodes.clone(),
@@ -555,7 +546,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
                             };
                             Ok(())
                         }.await;
-                        let _ = response.send(result.map_err(|e: anyhow::Error| format!("{e:#}")));
+                        let _ = response.send(result);
                         update_balance_metrics(&evm_client, &linera_client).await;
                     }
                 }

--- a/linera-bridge/src/test_helpers.rs
+++ b/linera-bridge/src/test_helpers.rs
@@ -124,8 +124,7 @@ pub fn deploy_microchain(
     let test_source = std::fs::read_to_string("tests/solidity/MicrochainTest.sol")
         .expect("MicrochainTest.sol not found");
     let bytecode = compile_contract(&test_source, "MicrochainTest.sol", "MicrochainTest");
-    let constructor_args =
-        (light_client, <[u8; 32]>::from(*chain_id.as_bytes())).abi_encode_params();
+    let constructor_args = (light_client, *chain_id.as_bytes()).abi_encode_params();
     let mut deploy_data = bytecode;
     deploy_data.extend_from_slice(&constructor_args);
     deploy_contract(db, deployer, deploy_data)
@@ -143,8 +142,7 @@ pub fn deploy_fungible_bridge(
         "FungibleBridge.sol",
         "FungibleBridge",
     );
-    let constructor_args =
-        (light_client, <[u8; 32]>::from(*chain_id.as_bytes()), token).abi_encode_params();
+    let constructor_args = (light_client, *chain_id.as_bytes(), token).abi_encode_params();
     let mut deploy_data = bytecode;
     deploy_data.extend_from_slice(&constructor_args);
     deploy_contract(db, deployer, deploy_data)
@@ -165,7 +163,7 @@ pub fn register_fungible_application_id(
         caller,
         bridge,
         &registerFungibleApplicationIdCall {
-            _applicationId: <[u8; 32]>::from(*application_id.as_bytes()).into(),
+            _applicationId: *application_id.as_bytes(),
         },
     );
 }
@@ -317,7 +315,7 @@ pub fn deploy_light_client(
     epoch: u32,
 ) -> Address {
     let bytecode = compile_contract(evm::light_client::SOURCE, "LightClient.sol", "LightClient");
-    let chain_id_bytes = <[u8; 32]>::from(*admin_chain_id.as_bytes());
+    let chain_id_bytes = *admin_chain_id.as_bytes();
     let constructor_args =
         (validators.to_vec(), weights.to_vec(), chain_id_bytes, epoch).abi_encode_params();
     let mut deploy_data = bytecode;

--- a/linera-bridge/tests/anvil_deposit_proof.rs
+++ b/linera-bridge/tests/anvil_deposit_proof.rs
@@ -18,6 +18,10 @@ use alloy::{
 };
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_sol_types::{SolCall, SolValue};
+use linera_base::{
+    crypto::CryptoHash,
+    identifiers::{AccountOwner, ApplicationId, ChainId},
+};
 use linera_bridge::{
     evm::{BRIDGE_TYPES_SOURCE, FUNGIBLE_BRIDGE_SOURCE, WRAPPED_FUNGIBLE_TYPES_SOURCE},
     proof::{
@@ -203,9 +207,18 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
 
     // Anvil's default chain ID is 31337
     assert_eq!(deposit.source_chain_id, U256::from(31337u64));
-    assert_eq!(deposit.target_chain_id, target_chain_id);
-    assert_eq!(deposit.target_application_id, target_application_id);
-    assert_eq!(deposit.target_account_owner, target_owner);
+    assert_eq!(
+        deposit.target_chain_id,
+        ChainId(CryptoHash::from(target_chain_id.0))
+    );
+    assert_eq!(
+        deposit.target_application_id,
+        ApplicationId::new(CryptoHash::from(target_application_id.0))
+    );
+    assert_eq!(
+        deposit.target_account_owner,
+        AccountOwner::from(target_owner.0)
+    );
     assert_eq!(deposit.depositor, deployer);
     assert_eq!(deposit.token, token_address);
     assert_eq!(deposit.amount, deposit_amount);

--- a/linera-bridge/tests/anvil_deposit_proof.rs
+++ b/linera-bridge/tests/anvil_deposit_proof.rs
@@ -73,6 +73,8 @@ contract MockERC20 {
 alloy_sol_types::sol! {
     function approve(address spender, uint256 amount) external returns (bool);
 
+    function registerFungibleApplicationId(bytes32 _fungibleApplicationId) external;
+
     function deposit(
         bytes32 target_chain_id,
         bytes32 target_application_id,
@@ -136,10 +138,9 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
         "FungibleBridge",
     );
     let bridge_constructor = (
-        deployer,                                // light_client (unused by deposit)
-        <[u8; 32]>::from(target_chain_id),       // chainId
-        <[u8; 32]>::from(target_application_id), // applicationId
-        token_address,                           // token
+        deployer,                          // light_client (unused by deposit)
+        <[u8; 32]>::from(target_chain_id), // chainId
+        token_address,                     // token
     )
         .abi_encode_params();
 
@@ -149,6 +150,18 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
     let tx = TransactionRequest::default().with_deploy_code(Bytes::from(bridge_deploy));
     let receipt = provider.send_transaction(tx).await?.get_receipt().await?;
     let bridge_address = receipt.contract_address.ok_or("missing bridge address")?;
+
+    // Register the wrapped-fungible application ID on the bridge.
+    // Since #5929 the application ID is set post-deployment via this call
+    // rather than through the constructor.
+    let register_data = registerFungibleApplicationIdCall {
+        _fungibleApplicationId: target_application_id,
+    }
+    .abi_encode();
+    let tx = TransactionRequest::default()
+        .to(bridge_address)
+        .input(register_data.into());
+    provider.send_transaction(tx).await?.get_receipt().await?;
 
     // 4. Approve bridge to spend tokens, then deposit
     let deposit_amount = U256::from(1_000_000u64);

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -3889,7 +3889,6 @@ dependencies = [
  "linera-client",
  "linera-core",
  "linera-execution",
- "linera-persistent",
  "linera-storage",
  "linera-views",
  "linera-wallet-json",

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -30,9 +30,10 @@ use anyhow::Context as _;
 use linera_base::{
     crypto::InMemorySigner,
     data_types::{Amount, Bytecode},
-    identifiers::{AccountOwner, ApplicationId},
+    identifiers::AccountOwner,
     vm::VmRuntime,
 };
+use linera_bridge::abi::{BridgeOperation, BridgeParameters};
 use linera_bridge_e2e::{
     compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
     start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
@@ -43,23 +44,7 @@ use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use serde::Serialize;
 use wrapped_fungible::{Account, InitialState, WrappedFungibleOperation, WrappedParameters};
-
-// ── Inline evm-bridge types ──
-
-#[derive(Clone, Debug, serde::Deserialize, Serialize)]
-struct BridgeParameters {
-    source_chain_id: u64,
-    bridge_contract_address: [u8; 20],
-    token_address: [u8; 20],
-    rpc_endpoint: String,
-}
-
-#[derive(Debug, Serialize)]
-enum BridgeOperation {
-    RegisterFungibleApp { app_id: ApplicationId },
-}
 
 sol! {
     #[sol(rpc)]
@@ -362,7 +347,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             None,
             relay_port,
             linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
-            5,  // monitor_scan_interval
+            std::time::Duration::from_secs(5),  // monitor_scan_interval
             0,  // monitor_start_block
             5,  // max_retries
             None,
@@ -437,7 +422,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
 
     let deposit_key = linera_bridge::proof::DepositKey {
         source_chain_id: 31337,
-        block_hash: deposit_receipt.block_hash.unwrap().0,
+        block_hash: deposit_receipt.block_hash.unwrap(),
         tx_index: 0,
         log_index: 0,
     };

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -97,7 +97,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             Some(&light_client.to_string()),
             relay_port,
             linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
-            5,  // monitor_scan_interval
+            std::time::Duration::from_secs(5),  // monitor_scan_interval
             0,  // monitor_start_block
             5,  // max_retries
             None,

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -20,10 +20,13 @@ use anyhow::Context as _;
 use linera_base::{
     crypto::InMemorySigner,
     data_types::{Amount, Bytecode},
-    identifiers::{AccountOwner, ApplicationId},
+    identifiers::AccountOwner,
     vm::VmRuntime,
 };
-use linera_bridge::proof::gen::{DepositProofClient as _, HttpDepositProofClient};
+use linera_bridge::{
+    abi::{BridgeOperation, BridgeParameters},
+    proof::gen::{DepositProofClient as _, HttpDepositProofClient},
+};
 use linera_bridge_e2e::{
     compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
     start_compose, wait_for_light_client,
@@ -35,39 +38,8 @@ use linera_execution::{Operation, Query, QueryResponse, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use wrapped_fungible::{InitialState, WrappedParameters};
-
-// ── Inline evm-bridge types ─────────────────────────────────────────────────
-// Inlined to avoid a dependency on evm-bridge, which pulls in linera-bridge
-// with the `chain` feature — that disables `proof::gen` via feature unification.
-
-/// Must match `evm_bridge::BridgeParameters` field-for-field for BCS compatibility.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct BridgeParameters {
-    source_chain_id: u64,
-    bridge_contract_address: [u8; 20],
-    token_address: [u8; 20],
-    rpc_endpoint: String,
-}
-
-/// Must match `evm_bridge::BridgeOperation` variant-for-variant for BCS compatibility.
-#[derive(Debug, Deserialize, Serialize)]
-enum BridgeOperation {
-    RegisterFungibleApp {
-        app_id: ApplicationId,
-    },
-    ProcessDeposit {
-        block_header_rlp: Vec<u8>,
-        receipt_rlp: Vec<u8>,
-        proof_nodes: Vec<Vec<u8>>,
-        tx_index: u64,
-        log_index: u64,
-    },
-    VerifyBlockHash {
-        block_hash: [u8; 32],
-    },
-}
 
 // ── Solidity interfaces for EVM calls ───────────────────────────────────────
 
@@ -367,7 +339,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     let log_index = proof.log_indices[0];
     let deposit_key = linera_bridge::proof::DepositKey {
         source_chain_id: 31337, // Anvil chain ID
-        block_hash: deposit_receipt.block_hash.unwrap().0,
+        block_hash: deposit_receipt.block_hash.unwrap(),
         tx_index,
         log_index,
     };


### PR DESCRIPTION
## Motivation

Looking at the code reveals some issue with the `linera-bridge`.

## Proposal

Following corrections are done:
* Eliminate the code duplication for `BridgeOperation` and `BridgeParameters`.
* Make the types explicit: `B256` for Ethereum, `ChainId`, `CryptoHash` and so for the Linera world.
* Use ˙BlockHeight` for the Linera block heights.
* Simplify the `.map_err(_)`.
* Remove the `let mut handle = handle` and similar.
* Bug fix: remove a `rustls::crypto::ring::default_provider().install_default()`.
* Eliminate `String` for address and the type `Address`.
* Use `Duration` for duration instead of seconds.

## Test Plan

CI

## Release Plan

Can be backported to `testnet_conway`.

## Links

None.