### PR TITLE
[testnet_conway] Route Docker Compose CI to self-hosted-builder pool to avoid in-container OOM

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -35,8 +35,8 @@ permissions:
 
 jobs:
   compose:
-    if: ${{ github.event_name == 'merge_group' }}
-    runs-on: linera-io-self-hosted-ci
+    if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
+    runs-on: linera-io-self-hosted-builder
     timeout-minutes: 40
 
     steps:


### PR DESCRIPTION
## Motivation

Backport of #6154 to `testnet_conway`. Closes #5909 on this branch.

## Proposal

Same one-line `runs-on:` change as #6154, plus aligning the compose job `if:` gate with main (`merge_group || workflow_dispatch`). The current testnet_conway gate is `merge_group` only, but testnet_conway has no merge queue — without this, the job never runs on testnet_conway and there is no path to manually verify the fix.

## Test Plan

CI (will dispatch on the branch first to verify, same as #6154).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Forward-port: #6154
- Closes #5909
