### PR TITLE
Restore merge_group trigger for Docker Compose CI now that the OOM is fixed

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: ["devnet_*", "testnet_*"]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull requests


### PR DESCRIPTION
## Motivation

PR #5908 removed the `merge_group:` trigger from `docker-compose.yml` because the in-container LTO build kept OOM-killing rustc. That OOM was just fixed in #6154 (route the workflow to `linera-io-self-hosted-builder`), so the disable is stale and `compose` is currently never running in the merge queue.

## Proposal

Add `merge_group:` back to `on:` in `.github/workflows/docker-compose.yml`. Inverse of one line in #5908. Verified green on main via dispatch run [25136143981](https://github.com/linera-io/linera-protocol/actions/runs/25136143981).

After this lands, repo admin should re-add `Docker Compose / compose` to the required checks for the `main` branch (#5908 had it removed).

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- Reverts the `merge_group:` removal from #5908
- Underlying OOM fix: #6154
- Issue: #5909
