### PR TITLE
Address a bug in `linera-bridge` and restructure the way we handle by using a Write Ahead Log.

### DIFF
--- a/linera-bridge/src/monitor/db.rs
+++ b/linera-bridge/src/monitor/db.rs
@@ -9,11 +9,12 @@
 
 use std::path::Path;
 
-use anyhow::Result;
+use alloy::primitives::{Address, B256, U256};
+use anyhow::{Context as _, Result};
 use linera_base::data_types::BlockHeight;
 use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
-    SqlitePool,
+    Row, SqlitePool,
 };
 
 use super::{PendingBurn, PendingDeposit};
@@ -191,6 +192,77 @@ impl BridgeDb {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Loads every deposit whose status is still `pending`, used at relay
+    /// startup to repopulate the in-memory `MonitorState` so that work
+    /// in flight at the time of the previous shutdown is not lost.
+    pub async fn load_pending_deposits(&self) -> Result<Vec<PendingDeposit>> {
+        let rows = sqlx::query(
+            "SELECT source_chain_id, block_hash, tx_index, log_index, tx_hash, depositor, amount, nonce
+             FROM deposits WHERE status = 'pending'",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let source_chain_id: i64 = row.get(0);
+            let block_hash: Vec<u8> = row.get(1);
+            let tx_index: i64 = row.get(2);
+            let log_index: i64 = row.get(3);
+            let tx_hash: Vec<u8> = row.get(4);
+            let depositor: Vec<u8> = row.get(5);
+            let amount: String = row.get(6);
+            let nonce: String = row.get(7);
+
+            out.push(PendingDeposit {
+                key: DepositKey {
+                    source_chain_id: source_chain_id as u64,
+                    block_hash: B256::try_from(block_hash.as_slice())
+                        .context("invalid block_hash in deposits row")?,
+                    tx_index: tx_index as u64,
+                    log_index: log_index as u64,
+                },
+                tx_hash: B256::try_from(tx_hash.as_slice())
+                    .context("invalid tx_hash in deposits row")?,
+                depositor: Address::try_from(depositor.as_slice())
+                    .context("invalid depositor in deposits row")?,
+                amount: U256::from_str_radix(&amount, 10)
+                    .context("invalid amount in deposits row")?,
+                nonce: U256::from_str_radix(&nonce, 10).context("invalid nonce in deposits row")?,
+            });
+        }
+        Ok(out)
+    }
+
+    /// Loads every burn whose status is still `pending`, used at relay
+    /// startup to repopulate the in-memory `MonitorState`.
+    pub async fn load_pending_burns(&self) -> Result<Vec<PendingBurn>> {
+        let rows = sqlx::query(
+            "SELECT linera_height, burn_index, evm_recipient, amount
+             FROM burns WHERE status = 'pending'",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let height: i64 = row.get(0);
+            let burn_index: i64 = row.get(1);
+            let evm_recipient: String = row.get(2);
+            let amount: String = row.get(3);
+
+            out.push(PendingBurn {
+                height: BlockHeight(height as u64),
+                burn_index: burn_index as usize,
+                evm_recipient: evm_recipient
+                    .parse()
+                    .context("invalid evm_recipient in burns row")?,
+                amount: amount.parse().context("invalid amount in burns row")?,
+            });
+        }
+        Ok(out)
     }
 
     /// Stores raw BCS-serialized certificate bytes for a burn.

--- a/linera-bridge/src/monitor/evm.rs
+++ b/linera-bridge/src/monitor/evm.rs
@@ -7,7 +7,7 @@
 use std::{sync::Arc, time::Duration};
 
 use alloy::providers::Provider;
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 
 use super::{MonitorState, PendingDeposit};
 use crate::{
@@ -16,18 +16,18 @@ use crate::{
 };
 
 /// Background task that polls EVM for `DepositInitiated` events and checks
-/// Linera for completion.
+/// Linera for completion. Newly-discovered deposits are written to
+/// `MonitorState` (and SQLite) and the consumer is woken via `notify`.
 pub async fn evm_scan_loop<E: linera_core::environment::Environment + 'static>(
     monitor: Arc<RwLock<MonitorState>>,
     evm_client: Arc<EvmClient<impl Provider + 'static>>,
     linera_client: Arc<LineraClient<E>>,
-    pending_deposit_tx: tokio::sync::mpsc::Sender<PendingDeposit>,
+    deposit_notify: Arc<Notify>,
     scan_interval: Duration,
-    max_retries: u32,
 ) {
     loop {
         let (scan_result, completion_result) = tokio::join!(
-            evm_scan_iteration(&monitor, &evm_client, &pending_deposit_tx),
+            evm_scan_iteration(&monitor, &evm_client, &deposit_notify),
             check_deposit_completion(&monitor, &linera_client),
         );
 
@@ -36,22 +36,6 @@ pub async fn evm_scan_loop<E: linera_core::environment::Environment + 'static>(
         }
         if let Err(error) = completion_result {
             tracing::warn!(error = ?error, "Deposit completion check failed");
-        }
-
-        // Re-enqueue deposits that are eligible for retry.
-        {
-            let state = monitor.read().await;
-            for d in state.deposits_ready_for_retry(max_retries) {
-                if let Err(error) = pending_deposit_tx.try_send(PendingDeposit {
-                    key: d.value.key.clone(),
-                    tx_hash: d.value.tx_hash,
-                    depositor: d.value.depositor,
-                    amount: d.value.amount,
-                    nonce: d.value.nonce,
-                }) {
-                    tracing::warn!(?error, "Failed to enqueue deposit for retry");
-                }
-            }
         }
 
         let summary = monitor.read().await.status_summary();
@@ -66,30 +50,36 @@ pub async fn evm_scan_loop<E: linera_core::environment::Environment + 'static>(
     }
 }
 
-/// Receives pending deposits from the scanner and retries them.
-pub(crate) async fn retry_pending_deposits<E: linera_core::environment::Environment>(
+/// Drains `MonitorState.deposits` for items ready for retry, processing one at
+/// a time. Sleeps on `notify` (woken by the scanner) or on `poll_interval`
+/// (whichever comes first) when nothing is ready.
+pub(crate) async fn process_pending_deposits<E: linera_core::environment::Environment>(
     monitor: &RwLock<MonitorState>,
     linera_client: &LineraClient<E>,
     proof_client: &crate::proof::gen::HttpDepositProofClient,
-    mut pending_rx: tokio::sync::mpsc::Receiver<PendingDeposit>,
+    notify: &Notify,
+    poll_interval: Duration,
+    max_retries: u32,
 ) -> anyhow::Result<()> {
     use crate::proof::gen::DepositProofClient as _;
 
-    while let Some(pending) = pending_rx.recv().await {
-        let tx_hash = pending.tx_hash;
-        {
-            let mut state = monitor.write().await;
-            if let Some(d) = state.deposits.get_mut(&pending.key) {
-                if d.forwarded {
-                    tracing::trace!(%tx_hash, "Deposit already completed, skipping");
-                    continue;
+    loop {
+        let pending = monitor.read().await.next_deposit_for_retry(max_retries);
+        let Some(pending) = pending else {
+            tracing::trace!(
+                ?poll_interval,
+                "EVM deposits processor sleeping until notified or poll interval elapses"
+            );
+            tokio::select! {
+                _ = notify.notified() => {
+                    tracing::trace!("EVM deposits processor notified about new pending item");
                 }
-                d.last_retry_at = Some(std::time::Instant::now());
-            } else {
-                state.track_deposit(pending.clone()).await;
+                _ = tokio::time::sleep(poll_interval) => {}
             }
-        }
+            continue;
+        };
 
+        let tx_hash = pending.tx_hash;
         tracing::info!(%tx_hash, "Processing pending deposit...");
         match proof_client.generate_deposit_proof(tx_hash).await {
             Ok(proof) => {
@@ -128,14 +118,12 @@ pub(crate) async fn retry_pending_deposits<E: linera_core::environment::Environm
 
         monitor.write().await.mark_deposit_retried(&pending.key);
     }
-
-    anyhow::bail!("Pending deposit channel closed");
 }
 
 async fn evm_scan_iteration(
     monitor: &RwLock<MonitorState>,
     evm_client: &EvmClient<impl Provider>,
-    pending_tx: &tokio::sync::mpsc::Sender<PendingDeposit>,
+    notify: &Notify,
 ) -> anyhow::Result<()> {
     let last_block = monitor.read().await.last_scanned_evm_block;
 
@@ -149,6 +137,7 @@ async fn evm_scan_iteration(
         .await?;
     let bridge_addr = evm_client.bridge_addr();
 
+    let mut tracked_any = false;
     for log in &logs {
         let block_hash = match log.block_hash {
             Some(h) => h,
@@ -187,21 +176,27 @@ async fn evm_scan_iteration(
             log_index,
         };
 
-        if let Err(error) = pending_tx.try_send(PendingDeposit {
-            key,
-            tx_hash,
-            depositor: deposit.depositor,
-            amount: deposit.amount,
-            nonce: deposit.nonce,
-        }) {
-            tracing::warn!(?error, %tx_hash, "Failed to enqueue discovered deposit");
-        }
+        let was_new = monitor
+            .write()
+            .await
+            .track_deposit(PendingDeposit {
+                key,
+                tx_hash,
+                depositor: deposit.depositor,
+                amount: deposit.amount,
+                nonce: deposit.nonce,
+            })
+            .await;
+        tracked_any |= was_new;
     }
 
     let mut state = monitor.write().await;
     state.last_scanned_evm_block = current_block;
     crate::relay::metrics::set_last_scanned_evm_block(current_block);
 
+    if tracked_any {
+        notify.notify_one();
+    }
     Ok(())
 }
 

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -5,14 +5,11 @@
 //! forwards certificates to EVM, checks EVM for completion via ERC-20
 //! Transfer events, and retries unforwarded burns.
 
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{sync::Arc, time::Duration};
 
 use alloy::{primitives::Address, providers::Provider};
 use linera_base::data_types::BlockHeight;
-use tokio::sync::RwLock;
+use tokio::sync::{Notify, RwLock};
 
 use super::{MonitorState, PendingBurn};
 use crate::relay::{
@@ -22,18 +19,18 @@ use crate::relay::{
 };
 
 /// Background task that scans Linera block history for BurnEvent stream
-/// events and checks EVM for completion.
+/// events and checks EVM for completion. Newly-discovered burns are written
+/// to `MonitorState` (and SQLite) and the consumer is woken via `notify`.
 pub async fn linera_scan_loop<E: linera_core::environment::Environment + 'static>(
     monitor: Arc<RwLock<MonitorState>>,
     evm_client: Arc<EvmClient<impl Provider + 'static>>,
     linera_client: Arc<LineraClient<E>>,
-    pending_burn_tx: tokio::sync::mpsc::Sender<PendingBurn>,
+    burn_notify: Arc<Notify>,
     scan_interval: Duration,
-    max_retries: u32,
 ) {
     loop {
         let (scan_result, completion_result) = tokio::join!(
-            linera_scan_iteration(&monitor, &linera_client, &pending_burn_tx),
+            linera_scan_iteration(&monitor, &linera_client, &burn_notify),
             check_burn_completion(&monitor, &evm_client),
         );
 
@@ -42,21 +39,6 @@ pub async fn linera_scan_loop<E: linera_core::environment::Environment + 'static
         }
         if let Err(error) = completion_result {
             tracing::warn!(?error, "Burn completion check failed");
-        }
-
-        // Re-enqueue burns that are eligible for retry.
-        {
-            let state = monitor.read().await;
-            for b in state.burns_ready_for_retry(max_retries) {
-                if let Err(error) = pending_burn_tx.try_send(PendingBurn {
-                    height: b.value.height,
-                    burn_index: b.value.burn_index,
-                    evm_recipient: b.value.evm_recipient,
-                    amount: b.value.amount,
-                }) {
-                    tracing::warn!(?error, "Failed to enqueue burn for retry");
-                }
-            }
         }
 
         let summary = monitor.read().await.status_summary();
@@ -71,34 +53,35 @@ pub async fn linera_scan_loop<E: linera_core::environment::Environment + 'static
     }
 }
 
-/// Receives pending burns, reads the certificate containing the auto-burn,
-/// and forwards it to EVM.
-pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment + 'static>(
+/// Drains `MonitorState.burns` for items ready for retry, processing one at a
+/// time. Sleeps on `notify` (woken by the scanner) or on `poll_interval`
+/// (whichever comes first) when nothing is ready.
+pub(crate) async fn process_pending_burns<E: linera_core::environment::Environment + 'static>(
     monitor: &RwLock<MonitorState>,
     evm_client: &EvmClient<impl Provider>,
     linera_client: &LineraClient<E>,
-    mut pending_rx: tokio::sync::mpsc::Receiver<PendingBurn>,
+    notify: &Notify,
+    poll_interval: Duration,
+    max_retries: u32,
 ) -> anyhow::Result<()> {
-    while let Some(pending) = pending_rx.recv().await {
+    loop {
+        let pending = monitor.read().await.next_burn_for_retry(max_retries);
+        let Some(pending) = pending else {
+            tracing::trace!(
+                ?poll_interval,
+                "Linera burns processor sleeping until notified or poll interval elapses"
+            );
+            tokio::select! {
+                _ = notify.notified() => {
+                    tracing::trace!("Linera burns processor notified about new pending item");
+                }
+                _ = tokio::time::sleep(poll_interval) => {}
+            }
+            continue;
+        };
+
         let credit_height = pending.height;
         let burn_index = pending.burn_index;
-        {
-            let mut state = monitor.write().await;
-            if let Some(b) = state.burns.get_mut(&(credit_height, burn_index)) {
-                if b.forwarded {
-                    tracing::trace!(
-                        ?credit_height,
-                        burn_index,
-                        "Burn already completed, skipping"
-                    );
-                    continue;
-                }
-                b.last_retry_at = Some(Instant::now());
-            } else {
-                state.track_burn(pending).await;
-            }
-        }
-
         tracing::info!(?credit_height, burn_index, "Processing burn...");
 
         // Read the certificate at the burn's block height (already contains the auto-burn).
@@ -181,14 +164,12 @@ pub(crate) async fn retry_pending_burns<E: linera_core::environment::Environment
             relay::update_balance_metrics(evm_client, linera_client).await;
         }
     }
-
-    anyhow::bail!("Pending burn channel closed");
 }
 
 async fn linera_scan_iteration<E: linera_core::environment::Environment>(
     monitor: &RwLock<MonitorState>,
     linera_client: &LineraClient<E>,
-    pending_burn_tx: &tokio::sync::mpsc::Sender<PendingBurn>,
+    notify: &Notify,
 ) -> anyhow::Result<()> {
     let last_height = monitor.read().await.last_scanned_linera_height;
 
@@ -228,26 +209,31 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
         }
     }
 
+    let mut tracked_any = false;
     for (height, burn_index, recipient, amount) in &new_burns {
         tracing::info!(?height, burn_index, %recipient, %amount, "Discovered burn");
-        if let Err(error) = pending_burn_tx.try_send(PendingBurn {
-            height: *height,
-            burn_index: *burn_index,
-            evm_recipient: *recipient,
-            amount: *amount,
-        }) {
-            tracing::warn!(
-                ?error,
-                ?height,
-                burn_index,
-                "Failed to enqueue discovered burn"
-            );
-        }
+        let was_new = monitor
+            .write()
+            .await
+            .track_burn(PendingBurn {
+                height: *height,
+                burn_index: *burn_index,
+                evm_recipient: *recipient,
+                amount: *amount,
+            })
+            .await;
+        tracked_any |= was_new;
     }
 
-    let mut state = monitor.write().await;
-    state.last_scanned_linera_height = current_height;
+    {
+        let mut state = monitor.write().await;
+        state.last_scanned_linera_height = current_height;
+    }
     crate::relay::metrics::set_last_scanned_linera_height(current_height.0);
+
+    if tracked_any {
+        notify.notify_one();
+    }
     Ok(())
 }
 

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -360,6 +360,7 @@ pub struct StatusSummary {
 /// pending work from `MonitorState` (the SQLite WAL is the source of truth)
 /// and is woken either by a `Notify` signal from the corresponding scanner or
 /// by a periodic poll for items whose retry backoff has just elapsed.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn retry_loop<E: linera_core::environment::Environment + 'static>(
     monitor: Arc<RwLock<MonitorState>>,
     proof_client: crate::proof::gen::HttpDepositProofClient,
@@ -701,5 +702,4 @@ mod tests {
         state.complete_burn(height, 0).await;
         assert!(state.next_burn_for_retry(10).is_none());
     }
-
 }

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -240,6 +240,58 @@ impl MonitorState {
             .collect()
     }
 
+    /// Returns one pending deposit whose backoff has elapsed, cloned so the
+    /// caller can drop the read lock before doing slow work. Used by the
+    /// processing loop in place of an mpsc receiver.
+    pub fn next_deposit_for_retry(&self, max_retries: u32) -> Option<PendingDeposit> {
+        self.deposits
+            .values()
+            .find(|d| {
+                !d.forwarded
+                    && !d.failed
+                    && retry_eligible(d.retry_count, d.last_retry_at, max_retries)
+            })
+            .map(|d| d.value.clone())
+    }
+
+    /// Returns one pending burn whose backoff has elapsed, cloned so the
+    /// caller can drop the read lock before doing slow work.
+    pub fn next_burn_for_retry(&self, max_retries: u32) -> Option<PendingBurn> {
+        self.burns
+            .values()
+            .find(|b| {
+                !b.forwarded
+                    && !b.failed
+                    && retry_eligible(b.retry_count, b.last_retry_at, max_retries)
+            })
+            .map(|b| b.value.clone())
+    }
+
+    /// Repopulates `deposits` and `burns` from the SQLite WAL. Called once at
+    /// relay startup so that requests in flight at the previous shutdown are
+    /// recovered instead of silently orphaned.
+    pub async fn load_from_db(&mut self) -> anyhow::Result<()> {
+        let Some(db) = self.db.as_ref() else {
+            return Ok(());
+        };
+        let deposits = db.load_pending_deposits().await?;
+        let burns = db.load_pending_burns().await?;
+        let n_deposits = deposits.len();
+        let n_burns = burns.len();
+        for d in deposits {
+            self.deposits.insert(d.key.clone(), Tracked::new(d));
+        }
+        for b in burns {
+            self.burns.insert((b.height, b.burn_index), Tracked::new(b));
+        }
+        tracing::info!(
+            deposits = n_deposits,
+            burns = n_burns,
+            "Recovered pending bridge requests from SQLite WAL"
+        );
+        Ok(())
+    }
+
     pub fn mark_deposit_retried(&mut self, key: &DepositKey) {
         if let Some(d) = self.deposits.get_mut(key) {
             d.retry_count += 1;
@@ -304,22 +356,26 @@ pub struct StatusSummary {
     pub last_scanned_linera_height: BlockHeight,
 }
 
-/// Runs deposit and burn retry loops concurrently.
-/// Returns if either encounters an unrecoverable error.
+/// Runs the deposit and burn processing loops concurrently. Each loop reads
+/// pending work from `MonitorState` (the SQLite WAL is the source of truth)
+/// and is woken either by a `Notify` signal from the corresponding scanner or
+/// by a periodic poll for items whose retry backoff has just elapsed.
 pub(crate) async fn retry_loop<E: linera_core::environment::Environment + 'static>(
     monitor: Arc<RwLock<MonitorState>>,
     proof_client: crate::proof::gen::HttpDepositProofClient,
     evm_client: Arc<crate::relay::evm::EvmClient<impl alloy::providers::Provider + 'static>>,
     linera_client: Arc<crate::relay::linera::LineraClient<E>>,
-    pending_deposit_rx: tokio::sync::mpsc::Receiver<PendingDeposit>,
-    pending_burn_rx: tokio::sync::mpsc::Receiver<PendingBurn>,
+    deposit_notify: Arc<tokio::sync::Notify>,
+    burn_notify: Arc<tokio::sync::Notify>,
+    poll_interval: Duration,
+    max_retries: u32,
 ) -> anyhow::Result<()> {
     tokio::select! {
-        result = evm::retry_pending_deposits(
-            &monitor, &linera_client, &proof_client, pending_deposit_rx,
+        result = evm::process_pending_deposits(
+            &monitor, &linera_client, &proof_client, &deposit_notify, poll_interval, max_retries,
         ) => result,
-        result = linera::retry_pending_burns(
-            &monitor, &evm_client, &linera_client, pending_burn_rx,
+        result = linera::process_pending_burns(
+            &monitor, &evm_client, &linera_client, &burn_notify, poll_interval, max_retries,
         ) => result,
     }
 }
@@ -516,4 +572,134 @@ mod tests {
         state.mark_deposit_failed(&key).await;
         assert_eq!(state.deposits_ready_for_retry(10).len(), 0);
     }
+
+    /// `next_deposit_for_retry` is the API the processor uses to drain pending
+    /// work from the WAL. Verifies it returns the tracked deposit while the
+    /// item is fresh, returns `None` once backoff is set, and skips items
+    /// that have been completed.
+    #[tokio::test]
+    async fn next_deposit_for_retry_returns_pending_then_respects_backoff() {
+        let mut state = MonitorState::new(0);
+        let key = DepositKey {
+            source_chain_id: 1,
+            block_hash: B256::ZERO,
+            tx_index: 0,
+            log_index: 0,
+        };
+        state
+            .track_deposit(PendingDeposit {
+                key: key.clone(),
+                tx_hash: B256::ZERO,
+                depositor: Address::ZERO,
+                amount: U256::from(1_000_000u64),
+                nonce: U256::ZERO,
+            })
+            .await;
+
+        let next = state.next_deposit_for_retry(10);
+        assert!(matches!(next, Some(p) if p.key == key));
+
+        state.mark_deposit_retried(&key);
+        assert!(state.next_deposit_for_retry(10).is_none());
+
+        state.complete_deposit(&key).await;
+        assert!(state.next_deposit_for_retry(10).is_none());
+    }
+
+    /// Regression for the silent-drop bug: a saturated mpsc channel used to
+    /// drop newly-scanned deposits, and the scanner's watermark advance made
+    /// the loss unrecoverable. With storage as the queue, the scanner writes
+    /// directly to `MonitorState` so the processor will always see the item
+    /// on its next poll regardless of backpressure.
+    #[tokio::test]
+    async fn scanner_writes_directly_to_state_so_processor_sees_them() {
+        let mut state = MonitorState::new(100);
+
+        // Simulate the scanner discovering many deposits in a single iteration.
+        for i in 0..128u64 {
+            state
+                .track_deposit(PendingDeposit {
+                    key: DepositKey {
+                        source_chain_id: 1,
+                        block_hash: B256::ZERO,
+                        tx_index: i,
+                        log_index: 0,
+                    },
+                    tx_hash: B256::ZERO,
+                    depositor: Address::ZERO,
+                    amount: U256::ZERO,
+                    nonce: U256::from(i),
+                })
+                .await;
+        }
+        state.last_scanned_evm_block = 200;
+
+        // Every deposit is recoverable by the processor — there is no "channel
+        // full" code path that could lose them.
+        assert_eq!(state.deposits_ready_for_retry(10).len(), 128);
+        assert!(state.next_deposit_for_retry(10).is_some());
+    }
+
+    /// Bug #2 fix: pending requests recovered from SQLite at startup.
+    #[tokio::test]
+    async fn load_from_db_recovers_pending_items_on_startup() {
+        let db = db::BridgeDb::open_in_memory().await.unwrap();
+        let key = DepositKey {
+            source_chain_id: 1,
+            block_hash: B256::from([0xAA; 32]),
+            tx_index: 7,
+            log_index: 0,
+        };
+        db.insert_deposit(&PendingDeposit {
+            key: key.clone(),
+            tx_hash: B256::from([0xBB; 32]),
+            depositor: Address::from([0xCC; 20]),
+            amount: U256::from(42u64),
+            nonce: U256::from(3u64),
+        })
+        .await
+        .unwrap();
+        db.insert_burn(&PendingBurn {
+            height: BlockHeight(99),
+            burn_index: 2,
+            evm_recipient: Address::from([0xDD; 20]),
+            amount: Amount::from_attos(7),
+        })
+        .await
+        .unwrap();
+
+        let mut state = MonitorState::new(0);
+        state.set_db(db);
+        state.load_from_db().await.unwrap();
+
+        assert_eq!(state.pending_deposits().len(), 1);
+        assert_eq!(state.pending_burns().len(), 1);
+        let recovered = state.next_deposit_for_retry(10).unwrap();
+        assert_eq!(recovered.key, key);
+        assert_eq!(recovered.nonce, U256::from(3u64));
+    }
+
+    /// Same as the deposit version, but for the burn pipeline.
+    #[tokio::test]
+    async fn next_burn_for_retry_returns_pending_then_respects_backoff() {
+        let mut state = MonitorState::new(0);
+        let height = BlockHeight(101);
+        state
+            .track_burn(PendingBurn {
+                height,
+                burn_index: 0,
+                evm_recipient: Address::from([0xab; 20]),
+                amount: Amount::from_attos(500),
+            })
+            .await;
+
+        assert!(state.next_burn_for_retry(10).is_some());
+        state.mark_burn_retried(height, 0);
+        assert!(state.next_burn_for_retry(10).is_none());
+
+        // Once forwarded, the item is no longer offered for retry.
+        state.complete_burn(height, 0).await;
+        assert!(state.next_burn_for_retry(10).is_none());
+    }
+
 }

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -39,7 +39,7 @@ use linera_views::{
     lru_prefix_cache::StorageCacheConfig,
 };
 use linera_wallet_json::PersistentWallet;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{mpsc, Notify, RwLock};
 
 use crate::{
     monitor::{self, MonitorState},
@@ -337,35 +337,38 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
         })?;
     tracing::info!(path = %sqlite_path.display(), "Opened bridge relay SQLite database");
     monitor_state.set_db(db);
+    monitor_state
+        .load_from_db()
+        .await
+        .context("failed to recover pending bridge requests from SQLite WAL")?;
     let monitor = Arc::new(RwLock::new(monitor_state));
-    let (pending_deposit_tx, pending_deposit_rx) =
-        tokio::sync::mpsc::channel::<monitor::PendingDeposit>(64);
-    let (pending_burn_tx, pending_burn_rx) = tokio::sync::mpsc::channel::<monitor::PendingBurn>(64);
+    let deposit_notify = Arc::new(Notify::new());
+    let burn_notify = Arc::new(Notify::new());
 
     let mut evm_scan_handle = {
         let monitor = Arc::clone(&monitor);
         let evm_client = Arc::clone(&evm_client);
         let linera_client = Arc::clone(&linera_client);
+        let deposit_notify = Arc::clone(&deposit_notify);
         tokio::spawn(monitor::evm::evm_scan_loop(
             monitor,
             evm_client,
             linera_client,
-            pending_deposit_tx,
+            deposit_notify,
             monitor_scan_interval,
-            max_retries,
         ))
     };
     let mut linera_scan_handle = {
         let monitor = Arc::clone(&monitor);
         let evm_client = Arc::clone(&evm_client);
         let linera_client = Arc::clone(&linera_client);
+        let burn_notify = Arc::clone(&burn_notify);
         tokio::spawn(monitor::linera::linera_scan_loop(
             monitor,
             evm_client,
             linera_client,
-            pending_burn_tx,
+            burn_notify,
             monitor_scan_interval,
-            max_retries,
         ))
     };
 
@@ -379,8 +382,10 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
             proof_client,
             evm_client,
             linera_client,
-            pending_deposit_rx,
-            pending_burn_rx,
+            deposit_notify,
+            burn_notify,
+            monitor_scan_interval,
+            max_retries,
         ))
     };
 


### PR DESCRIPTION
## Motivation

The EVM and Linera scan loops used bounded mpsc channels (capacity 64) to hand pending requests to the retry/processor loop. When the channel filled up, the scanner used try_send and silently dropped the request, then advanced its watermark — making the loss unrecoverable on the next pass.

## Proposal

Tather than reintroduce backpressure, remove the channels entirely. SQLite (already a write-through store via MonitorState) becomes the work queue. A tokio::sync::Notify provides low-latency wakeup so the consumer doesn't have to wait a full poll interval after a new item arrives. As a side effect, this also fixes a separate bug — pending requests in flight at shutdown were never reloaded into memory on startup.

## Test Plan

CI

## Release Plan

Can be backported to `testnet_conway`.

## Links

None