### PR TITLE
[testnet] admin_committee: chain-state fallback on storage miss

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -812,6 +812,11 @@ impl<Env: Environment> Client<Env> {
 
     /// Returns all committees known to the process at epochs up to and including the admin
     /// chain's current epoch, together with that epoch.
+    ///
+    /// On a miss in the shared cache / storage path (introduced in #6122), falls back to the
+    /// admin chain's own `system::committees` view in chain state and seeds the shared cache
+    /// from it. Transitional: depends on chain-state committees still being populated, so
+    /// must be revisited if/when #6114 is ported to testnet.
     #[instrument(level = "trace", skip_all)]
     async fn admin_committees(
         &self,
@@ -820,25 +825,55 @@ impl<Env: Environment> Client<Env> {
         let info = self.local_node.handle_chain_info_query(query).await?.info;
         let max_epoch = info.epoch;
         let mut committees = BTreeMap::new();
+        let mut needs_fallback = false;
         for index in 0..=max_epoch.0 {
             let epoch = Epoch(index);
             if let Some(committee) = self.storage_client().get_or_load_committee(epoch).await? {
                 committees.insert(epoch, (*committee).clone());
+            } else {
+                needs_fallback = true;
+            }
+        }
+        if needs_fallback {
+            let info = self.chain_info_with_committees(self.admin_chain_id).await?;
+            if let Some(chain_state) = info.requested_committees.as_ref() {
+                for (epoch, committee) in chain_state {
+                    if !committees.contains_key(epoch) {
+                        self.storage_client()
+                            .shared_committees()
+                            .insert(*epoch, Arc::new(committee.clone()));
+                        committees.insert(*epoch, committee.clone());
+                    }
+                }
             }
         }
         Ok((max_epoch, committees))
     }
 
     /// Obtains the committee for the latest epoch on the admin chain.
+    ///
+    /// See `admin_committees` for the fallback rationale (transitional).
     pub async fn admin_committee(&self) -> Result<(Epoch, Arc<Committee>), LocalNodeError> {
         let query = ChainInfoQuery::new(self.admin_chain_id);
         let info = self.local_node.handle_chain_info_query(query).await?.info;
-        let committee = self
-            .storage_client()
-            .get_or_load_committee(info.epoch)
-            .await?
+        let epoch = info.epoch;
+        if let Some(committee) = self.storage_client().get_or_load_committee(epoch).await? {
+            return Ok((epoch, committee));
+        }
+        // Slow path: events/blob missing in storage. Use the admin chain's own
+        // `committees` view (still populated until #6114 is ported) and seed the
+        // shared cache so subsequent calls hit the fast path.
+        let info = self.chain_info_with_committees(self.admin_chain_id).await?;
+        let committee = info
+            .requested_committees
+            .as_ref()
+            .and_then(|m| m.get(&epoch).cloned())
             .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
-        Ok((info.epoch, committee))
+        let arc_committee = self
+            .storage_client()
+            .shared_committees()
+            .insert(epoch, Arc::new(committee));
+        Ok((epoch, arc_committee))
     }
 
     /// Obtains the validators for the latest epoch.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -815,8 +815,8 @@ impl<Env: Environment> Client<Env> {
     ///
     /// On a miss in the shared cache / storage path (introduced in #6122), falls back to the
     /// admin chain's own `system::committees` view in chain state and seeds the shared cache
-    /// from it. Transitional: depends on chain-state committees still being populated, so
-    /// must be revisited if/when #6114 is ported to testnet.
+    /// from it. This relies on chain-state committees still being populated, which is the
+    /// case on testnet — #6114 (which removes that view) is not being ported here.
     #[instrument(level = "trace", skip_all)]
     async fn admin_committees(
         &self,
@@ -861,8 +861,8 @@ impl<Env: Environment> Client<Env> {
             return Ok((epoch, committee));
         }
         // Slow path: events/blob missing in storage. Use the admin chain's own
-        // `committees` view (still populated until #6114 is ported) and seed the
-        // shared cache so subsequent calls hit the fast path.
+        // `committees` view (still populated on testnet — #6114 is not being
+        // ported) and seed the shared cache so subsequent calls hit the fast path.
         let info = self.chain_info_with_committees(self.admin_chain_id).await?;
         let committee = info
             .requested_committees

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -243,6 +243,10 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
             return Ok(Some(committee));
         }
         let Some(net_description) = self.read_network_description().await? else {
+            tracing::warn!(
+                ?epoch,
+                "get_or_load_committee: NetworkDescription missing in storage"
+            );
             return Ok(None);
         };
         let blob_hash = if epoch.0 == 0 {
@@ -253,13 +257,25 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
                 stream_id: StreamId::system(EPOCH_STREAM_NAME),
                 index: epoch.0,
             };
-            match self.read_event(event_id).await? {
+            match self.read_event(event_id.clone()).await? {
                 Some(bytes) => bcs::from_bytes(&bytes)?,
-                None => return Ok(None),
+                None => {
+                    tracing::warn!(
+                        ?epoch,
+                        ?event_id,
+                        "get_or_load_committee: NewCommittee event missing in storage"
+                    );
+                    return Ok(None);
+                }
             }
         };
         let blob_id = BlobId::new(blob_hash, BlobType::Committee);
         let Some(blob) = self.read_blob(blob_id).await? else {
+            tracing::warn!(
+                ?epoch,
+                ?blob_id,
+                "get_or_load_committee: committee blob missing in storage"
+            );
             return Ok(None);
         };
         let committee: Committee = bcs::from_bytes(blob.bytes())?;


### PR DESCRIPTION
## Motivation

PR #6122 changed `Client::admin_committee` and `Client::admin_committees` to read committees via `Storage::get_or_load_committee` (shared cache, then `EPOCH_STREAM_NAME` events plus committee blob), instead of the pre-#6122 path of reading from the admin chain `system::committees` view in chain state. On a `testnet_conway` faucet PVC the new path returns `None` (one of `NetworkDescription`, the epoch event, or the committee blob is not present in this storage), so the function bails with `LocalNodeError::InactiveChain(admin_chain_id)` and the faucet crash-loops on every startup.

The pre-#6122 chain-state path still works on this storage. The rolled-back image proves it. PR #6114 (which removes `system::committees` from chain state) is on `main` but not on `testnet_conway`, so the chain-state field is still populated here.

## Proposal

In `Client::admin_committee` and `Client::admin_committees`, try the shared-cache and storage path first. On a miss, fall back to the admin chain `system::committees` view (the pre-#6122 source) and seed the shared cache from it so subsequent calls hit the fast path. The healthy case pays no extra cost; the slow path only fires when the cache and storage path both miss.

This is a transitional fix. It depends on the admin chain `system::committees` view still being populated. Before #6114 is ported to `testnet_conway`, this fallback must be replaced by an admin-chain backfill mechanism that fetches the missing events and committee blobs from validators.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.