### PR TITLE
Move late-binding post deploy from EVM to Linera side (#6173)

### DIFF
--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -406,34 +406,9 @@ else
 fi
 echo "  Relay owner (minter): $RELAY_OWNER"
 
-# ── 4. Deploy FungibleBridge on EVM ──
-echo "Deploying FungibleBridge..."
+# FungibleBridge is deployed below (step 7), after the wrapped-fungible app
+# is created so the canonical applicationId can be baked into its constructor.
 CHAIN_BYTES32="0x${BRIDGE_CHAIN_ID}"
-
-BRIDGE_OUTPUT=$(evm_exec \
-    forge create "$CONTRACTS_DIR/FungibleBridge.sol:FungibleBridge" \
-    --root "$CONTRACTS_DIR" \
-    --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
-    "${FORGE_USE_SOLC[@]}" --ignored-error-codes 6321 \
-    --out /tmp/forge-out --cache-path /tmp/forge-cache \
-    --rpc-url "$EVM_RPC_URL" \
-    --private-key "$EVM_PRIVATE_KEY" \
-    --broadcast \
-    --constructor-args \
-    "$LIGHT_CLIENT_ADDR" \
-    "$CHAIN_BYTES32" \
-    "$TOKEN_ADDRESS")
-BRIDGE_ADDRESS=$(echo "$BRIDGE_OUTPUT" | parse_address)
-wait_for_tx "$(echo "$BRIDGE_OUTPUT" | parse_tx_hash)"
-validate_eth_address "FungibleBridge address" "$BRIDGE_ADDRESS"
-BRIDGE_ADDR_HEX=$(echo "$BRIDGE_ADDRESS" | sed 's/^0x//')
-echo "  FungibleBridge: $BRIDGE_ADDRESS"
-
-# Write bridge address to shared dir for relay.
-if [[ -n "$COMPOSE_FILE" ]]; then
-    dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_ADDRESS' > /shared/bridge-address"
-fi
-echo "$BRIDGE_ADDRESS" > "$SHARED_DIR/bridge-address"
 
 # ── 5. Publish and create evm-bridge app ──
 echo "Syncing chain state..."
@@ -442,7 +417,6 @@ linera_exec process-inbox 2>&1
 echo "Publishing and creating evm-bridge app..."
 BRIDGE_PARAMS=$(
     CHAIN_ID="$EVM_CHAIN_ID" \
-    BRIDGE_HEX="$BRIDGE_ADDR_HEX" \
     TOKEN_HEX="$TOKEN_ADDR_HEX" \
     EVM_RPC_URL="$EVM_RPC_URL" \
     python3 -c "
@@ -451,7 +425,6 @@ def hex_to_array(h):
     return [int(h[i:i+2], 16) for i in range(0, len(h), 2)]
 params = {
     'source_chain_id': int(os.environ['CHAIN_ID']),
-    'bridge_contract_address': hex_to_array(os.environ['BRIDGE_HEX']),
     'token_address': hex_to_array(os.environ['TOKEN_HEX']),
     'rpc_endpoint': os.environ.get('EVM_RPC_URL', ''),
 }
@@ -524,9 +497,39 @@ if [[ -n "$COMPOSE_FILE" ]]; then
 fi
 echo "$WRAPPED_APP_ID" > "$SHARED_DIR/wrapped-app-id"
 
-# ── 7. Register app IDs on both sides ──
+APP_ID_BYTES32="0x${WRAPPED_APP_ID:0:64}"
+
+# ── 7. Deploy FungibleBridge with the wrapped-fungible applicationId baked in ──
+echo "Deploying FungibleBridge..."
+BRIDGE_OUTPUT=$(evm_exec \
+    forge create "$CONTRACTS_DIR/FungibleBridge.sol:FungibleBridge" \
+    --root "$CONTRACTS_DIR" \
+    --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
+    "${FORGE_USE_SOLC[@]}" --ignored-error-codes 6321 \
+    --out /tmp/forge-out --cache-path /tmp/forge-cache \
+    --rpc-url "$EVM_RPC_URL" \
+    --private-key "$EVM_PRIVATE_KEY" \
+    --broadcast \
+    --constructor-args \
+    "$LIGHT_CLIENT_ADDR" \
+    "$CHAIN_BYTES32" \
+    "$TOKEN_ADDRESS" \
+    "$APP_ID_BYTES32")
+BRIDGE_ADDRESS=$(echo "$BRIDGE_OUTPUT" | parse_address)
+wait_for_tx "$(echo "$BRIDGE_OUTPUT" | parse_tx_hash)"
+validate_eth_address "FungibleBridge address" "$BRIDGE_ADDRESS"
+BRIDGE_ADDR_HEX=$(echo "$BRIDGE_ADDRESS" | sed 's/^0x//')
+echo "  FungibleBridge: $BRIDGE_ADDRESS"
+
+# Write bridge address to shared dir for relay.
+if [[ -n "$COMPOSE_FILE" ]]; then
+    dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_ADDRESS' > /shared/bridge-address"
+fi
+echo "$BRIDGE_ADDRESS" > "$SHARED_DIR/bridge-address"
+
+# ── 8. Register app IDs on both sides ──
 echo "Registering fungible app in evm-bridge..."
-# BCS encoding: variant index 0 (RegisterFungibleApp) + 32-byte app ID hash
+# BCS encoding: variant index 0 (RegisterFungibleApp) + 32-byte app ID hash.
 # Must use the relay wallet since it owns the bridge chain.
 REGISTER_HEX="00${WRAPPED_APP_ID}"
 if [[ -n "$COMPOSE_FILE" ]]; then
@@ -542,15 +545,21 @@ else
     linera_exec execute-operation --application-id "$BRIDGE_APP_ID" --operation "$REGISTER_HEX" --chain-id "$BRIDGE_CHAIN_ID" 2>&1
 fi
 
-APP_ID_BYTES32="0x${WRAPPED_APP_ID:0:64}"
-echo "Registering fungibleApplicationId in FungibleBridge..."
-REGISTER_OUTPUT=$(evm_exec \
-    cast send --rpc-url "$EVM_RPC_URL" \
-    --private-key "$EVM_PRIVATE_KEY" \
-    "$BRIDGE_ADDRESS" \
-    'registerFungibleApplicationId(bytes32)' \
-    "$APP_ID_BYTES32")
-wait_for_tx "$(echo "$REGISTER_OUTPUT" | parse_tx_hash)"
+echo "Registering FungibleBridge address in evm-bridge..."
+# BCS encoding: variant index 3 (RegisterFungibleBridge) + 20-byte EVM address.
+REGISTER_BRIDGE_HEX="03${BRIDGE_ADDR_HEX}"
+if [[ -n "$COMPOSE_FILE" ]]; then
+    dc_exec linera-network env \
+        LINERA_WALLET=/shared/relay-wallet/wallet.json \
+        LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
+        LINERA_STORAGE=rocksdb:/shared/relay-wallet/client.db \
+        ./linera execute-operation \
+        --application-id "$BRIDGE_APP_ID" \
+        --operation "$REGISTER_BRIDGE_HEX" \
+        --chain-id "$BRIDGE_CHAIN_ID" 2>&1
+else
+    linera_exec execute-operation --application-id "$BRIDGE_APP_ID" --operation "$REGISTER_BRIDGE_HEX" --chain-id "$BRIDGE_CHAIN_ID" 2>&1
+fi
 echo "  App IDs registered on both sides"
 
 # ── 8. Fund FungibleBridge with ERC20 tokens ──

--- a/examples/evm-bridge/src/contract.rs
+++ b/examples/evm-bridge/src/contract.rs
@@ -15,13 +15,15 @@ use linera_sdk::{
 use wrapped_fungible::{WrappedFungibleOperation, WrappedFungibleTokenAbi};
 
 /// On-chain state: tracks processed deposits, verified block hashes,
-/// and the registered wrapped-fungible application.
+/// the registered wrapped-fungible application, and the registered EVM
+/// FungibleBridge contract address.
 #[derive(RootView)]
 #[view(context = ViewStorageContext)]
 pub struct BridgeState {
     pub processed_deposits: SetView<[u8; 32]>,
     pub verified_block_hashes: SetView<[u8; 32]>,
     pub fungible_app_id: RegisterView<Option<ApplicationId>>,
+    pub bridge_contract_address: RegisterView<Option<[u8; 20]>>,
 }
 
 pub struct EvmBridgeContract {
@@ -103,6 +105,16 @@ impl Contract for EvmBridgeContract {
                         .insert(&block_hash)
                         .expect("failed to insert verified block hash");
                 }
+            }
+            BridgeOperation::RegisterFungibleBridge { address } => {
+                self.runtime
+                    .authenticated_owner()
+                    .expect("RegisterFungibleBridge requires an authenticated signer");
+                assert!(
+                    self.state.bridge_contract_address.get().is_none(),
+                    "bridge contract address is already registered and cannot be changed"
+                );
+                self.state.bridge_contract_address.set(Some(address));
             }
         }
     }
@@ -189,7 +201,11 @@ impl EvmBridgeContract {
             log_index,
             logs.len()
         );
-        let bridge_contract = alloy_primitives::Address::from(params.bridge_contract_address);
+        let bridge_contract_bytes =
+            self.state.bridge_contract_address.get().expect(
+                "bridge contract address not registered — call RegisterFungibleBridge first",
+            );
+        let bridge_contract = alloy_primitives::Address::from(bridge_contract_bytes);
         let deposit = proof::parse_deposit_event(&logs[log_index as usize], bridge_contract)
             .expect("failed to parse DepositInitiated event");
 

--- a/examples/evm-bridge/src/service.rs
+++ b/examples/evm-bridge/src/service.rs
@@ -11,7 +11,7 @@ use evm_bridge::{BridgeParameters, EvmBridgeAbi};
 use linera_sdk::{
     ethereum::{EthereumQueries, ServiceEthereumClient},
     linera_base_types::WithServiceAbi,
-    views::{linera_views, RootView, SetView, View, ViewStorageContext},
+    views::{linera_views, RegisterView, RootView, SetView, View, ViewStorageContext},
     Service, ServiceRuntime,
 };
 
@@ -20,6 +20,7 @@ use linera_sdk::{
 #[view(context = ViewStorageContext)]
 pub struct BridgeState {
     pub processed_deposits: SetView<[u8; 32]>,
+    pub bridge_contract_address: RegisterView<Option<[u8; 20]>>,
 }
 
 #[derive(Clone)]
@@ -62,10 +63,13 @@ impl EvmBridgeService {
         params.source_chain_id
     }
 
-    /// The bridge contract address on EVM (hex-encoded).
-    async fn bridge_contract_address(&self) -> String {
-        let params: BridgeParameters = self.runtime.application_parameters();
-        format!("0x{}", hex::encode(params.bridge_contract_address))
+    /// The bridge contract address on EVM (hex-encoded), or `None` if it has
+    /// not yet been registered via `RegisterFungibleBridge`.
+    async fn bridge_contract_address(&self) -> Option<String> {
+        self.state
+            .bridge_contract_address
+            .get()
+            .map(|addr| format!("0x{}", hex::encode(addr)))
     }
 
     /// The ERC-20 token address on the source EVM chain (hex-encoded).

--- a/examples/evm-bridge/tests/process_deposit.rs
+++ b/examples/evm-bridge/tests/process_deposit.rs
@@ -70,7 +70,6 @@ impl TestBridge {
         // 1. Deploy bridge first
         let bridge_params = BridgeParameters {
             source_chain_id,
-            bridge_contract_address: [0xBB; 20],
             token_address,
             rpc_endpoint: String::new(),
         };
@@ -108,6 +107,18 @@ impl TestBridge {
                     bridge_app_id,
                     BridgeOperation::RegisterFungibleApp {
                         app_id: fungible_app_id.forget_abi(),
+                    },
+                );
+            })
+            .await;
+
+        // 4. Register the FungibleBridge contract address.
+        chain
+            .add_block(|block| {
+                block.with_operation(
+                    bridge_app_id,
+                    BridgeOperation::RegisterFungibleBridge {
+                        address: [0xBB; 20],
                     },
                 );
             })
@@ -182,6 +193,84 @@ impl TestBridge {
         let proof_nodes: Vec<Vec<u8>> = proof_bytes.into_iter().map(|b| b.to_vec()).collect();
         let block_header = build_test_header(receipts_root, 12345);
         (block_header, receipt, proof_nodes, tx_index, 0)
+    }
+
+    /// Like `setup`, but skips the FungibleBridge address registration so callers
+    /// can verify that `ProcessDeposit` panics when the address has not been set.
+    async fn setup_without_bridge_address() -> Self {
+        let (validator, bridge_module_id) =
+            TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, ()>().await;
+        let mut chain = validator.new_chain().await;
+        let chain_owner = AccountOwner::from(chain.public_key());
+
+        let token_address = [0xA0; 20];
+        let source_chain_id = 8453u64;
+
+        let bridge_params = BridgeParameters {
+            source_chain_id,
+            token_address,
+            rpc_endpoint: String::new(),
+        };
+        let bridge_app_id = chain
+            .create_application(bridge_module_id, bridge_params, (), vec![])
+            .await;
+
+        let fungible_module_id = chain
+            .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
+                "../wrapped-fungible",
+            )
+            .await;
+        let wrapped_params = WrappedParameters {
+            ticker_symbol: "wUSDC".to_string(),
+            minter: Some(chain_owner),
+            mint_chain_id: Some(chain.id()),
+            evm_token_address: token_address,
+            evm_source_chain_id: source_chain_id,
+            bridge_app_id: Some(bridge_app_id.forget_abi()),
+        };
+        let fungible_app_id = chain
+            .create_application(
+                fungible_module_id,
+                wrapped_params,
+                InitialStateBuilder::default().build(),
+                vec![],
+            )
+            .await;
+
+        chain
+            .add_block(|block| {
+                block.with_operation(
+                    bridge_app_id,
+                    BridgeOperation::RegisterFungibleApp {
+                        app_id: fungible_app_id.forget_abi(),
+                    },
+                );
+            })
+            .await;
+
+        let chain_id_bytes: [u8; 32] = chain.id().0.into();
+        let target_chain_b256 = B256::from(chain_id_bytes);
+
+        let owner_hash = match chain_owner {
+            AccountOwner::Address32(hash) => <[u8; 32]>::from(hash),
+            _ => panic!("expected Address32"),
+        };
+        let target_owner_b256 = B256::from(owner_hash);
+
+        let bridge_contract = Address::from([0xBB; 20]);
+        let token = Address::from(token_address);
+
+        TestBridge {
+            chain,
+            chain_owner,
+            bridge_app_id,
+            fungible_app_id,
+            source_chain_id,
+            bridge_contract,
+            token,
+            target_chain_b256,
+            target_owner_b256,
+        }
     }
 }
 
@@ -588,7 +677,6 @@ async fn test_instantiation_fails_with_unreachable_endpoint() {
     // Non-empty endpoint that is unreachable → instantiation should fail
     let bridge_params = BridgeParameters {
         source_chain_id,
-        bridge_contract_address: [0xBB; 20],
         token_address,
         rpc_endpoint: "http://localhost:8545".to_string(),
     };
@@ -654,7 +742,6 @@ async fn setup_bridge_with_anvil(
     // 1. Deploy bridge first
     let bridge_params = BridgeParameters {
         source_chain_id,
-        bridge_contract_address: [0xBB; 20],
         token_address,
         rpc_endpoint: anvil_endpoint.to_string(),
     };
@@ -692,6 +779,18 @@ async fn setup_bridge_with_anvil(
                 bridge_app_id,
                 BridgeOperation::RegisterFungibleApp {
                     app_id: fungible_app_id.forget_abi(),
+                },
+            );
+        })
+        .await;
+
+    // 4. Register the FungibleBridge contract address.
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::RegisterFungibleBridge {
+                    address: [0xBB; 20],
                 },
             );
         })
@@ -779,5 +878,75 @@ async fn test_register_fungible_app_cannot_be_called_twice() {
     assert!(
         result.is_err(),
         "registering fungible app a second time should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn test_process_deposit_rejects_when_bridge_address_unregistered() {
+    let tb = TestBridge::setup_without_bridge_address().await;
+    let (block_header, receipt, proof_nodes, tx_index, log_index) = tb.build_valid_deposit();
+
+    let result = tb
+        .chain
+        .try_add_block(|block| {
+            block.with_operation(
+                tb.bridge_app_id,
+                BridgeOperation::ProcessDeposit {
+                    block_header_rlp: block_header,
+                    receipt_rlp: receipt,
+                    proof_nodes,
+                    tx_index,
+                    log_index,
+                },
+            );
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "ProcessDeposit without RegisterFungibleBridge must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn test_register_fungible_bridge_is_one_shot() {
+    let (validator, bridge_module_id) =
+        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, ()>().await;
+    let mut chain = validator.new_chain().await;
+
+    let bridge_params = BridgeParameters {
+        source_chain_id: 8453u64,
+        token_address: [0xA0; 20],
+        rpc_endpoint: String::new(),
+    };
+    let bridge_app_id = chain
+        .create_application(bridge_module_id, bridge_params, (), vec![])
+        .await;
+
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::RegisterFungibleBridge {
+                    address: [0xCC; 20],
+                },
+            );
+        })
+        .await;
+
+    let result = chain
+        .try_add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::RegisterFungibleBridge {
+                    address: [0xDD; 20],
+                },
+            );
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "registering the bridge contract address a second time should be rejected"
     );
 }

--- a/linera-bridge/src/abi.rs
+++ b/linera-bridge/src/abi.rs
@@ -18,8 +18,6 @@ use serde::{Deserialize, Serialize};
 pub struct BridgeParameters {
     /// EVM chain ID of the source chain (e.g. 8453 for Base).
     pub source_chain_id: u64,
-    /// Address of the FungibleBridge contract on EVM.
-    pub bridge_contract_address: [u8; 20],
     /// ERC-20 token address on the source EVM chain.
     pub token_address: [u8; 20],
     /// JSON-RPC endpoint of the source EVM chain for finality verification.
@@ -48,4 +46,8 @@ pub enum BridgeOperation {
     /// the latest finalized block. Caches the hash only when submitted by an
     /// authenticated signer (chain owner) to prevent state bloat.
     VerifyBlockHash { block_hash: [u8; 32] },
+    /// Register the EVM FungibleBridge contract address.
+    /// Can only be called once, by the chain owner.
+    /// Must be set before ProcessDeposit can succeed.
+    RegisterFungibleBridge { address: [u8; 20] },
 }

--- a/linera-bridge/src/fungible_bridge.rs
+++ b/linera-bridge/src/fungible_bridge.rs
@@ -93,8 +93,8 @@ mod tests {
 
             let chain_id = CryptoHash::new(&TestString::new("test_chain"));
             let app_id = CryptoHash::new(&TestString::new("fungible_app"));
-            let bridge = deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, token);
-            register_fungible_application_id(&mut db, deployer, bridge, app_id);
+            let bridge =
+                deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, token, app_id);
 
             // Fund the bridge with the full token supply
             call_contract(
@@ -285,8 +285,8 @@ mod tests {
 
         let chain_id = CryptoHash::new(&TestString::new("test_chain"));
         let app_id = CryptoHash::new(&TestString::new("fungible_app"));
-        let bridge = deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, token);
-        register_fungible_application_id(&mut db, deployer, bridge, app_id);
+        let bridge =
+            deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, token, app_id);
 
         // Give depositor tokens (instead of funding the bridge)
         call_contract(
@@ -521,5 +521,48 @@ mod tests {
             result.is_err(),
             "deposit with insufficient balance should revert"
         );
+    }
+
+    #[test]
+    fn constructor_rejects_zero_app_id() {
+        use alloy_sol_types::SolValue;
+
+        let mut db = CacheDB::new(EmptyDB::default());
+        let deployer = Address::ZERO;
+        let secret = ValidatorSecretKey::generate();
+        let public = secret.public();
+        let validator_addr = validator_evm_address(&public);
+        let admin_chain_id = test_admin_chain_id();
+        let light_client = deploy_light_client(
+            &mut db,
+            deployer,
+            &[validator_addr],
+            &[1],
+            admin_chain_id,
+            0,
+        );
+        let token = deploy_mock_erc20(
+            &mut db,
+            deployer,
+            alloy_primitives::U256::from(INITIAL_SUPPLY),
+        );
+        let chain_id = CryptoHash::new(&TestString::new("test_chain"));
+        let chain_id_bytes: [u8; 32] = (*chain_id.as_bytes()).into();
+
+        let bytecode = compile_contract(
+            crate::evm::FUNGIBLE_BRIDGE_SOURCE,
+            "FungibleBridge.sol",
+            "FungibleBridge",
+        );
+        let zero_app_id: [u8; 32] = [0u8; 32];
+        let constructor_args =
+            (light_client, chain_id_bytes, token, zero_app_id).abi_encode_params();
+        let mut deploy_data = bytecode;
+        deploy_data.extend_from_slice(&constructor_args);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            deploy_contract(&mut db, deployer, deploy_data)
+        }));
+        assert!(result.is_err(), "deployment with zero app id must revert");
     }
 }

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -31,29 +31,21 @@ contract FungibleBridge is Microchain {
 
     // WrappedFungible application ID on Linera,
     // used to identify Burn events in the block stream.
-    // Set once via registerFungibleApplicationId after deployment.
-    bytes32 public fungibleApplicationId;
+    bytes32 public immutable fungibleApplicationId;
     // The ERC-20 token being bridged.
     IERC20 public immutable token;
-    // The deployer, authorized to register the application ID.
-    address public immutable deployer;
     uint256 public depositNonce;
 
     constructor(
         address _lightClient,
         bytes32 _chainId,
-        address _token
+        address _token,
+        bytes32 _fungibleApplicationId
     )
         Microchain(_lightClient, _chainId)
     {
+        require(_fungibleApplicationId != bytes32(0), "fungibleApplicationId must be non-zero");
         token = IERC20(_token);
-        deployer = msg.sender;
-    }
-
-    /// Registers the wrapped-fungible application ID. Can only be called once, by the deployer.
-    function registerFungibleApplicationId(bytes32 _fungibleApplicationId) external {
-        require(msg.sender == deployer, "only deployer can register");
-        require(fungibleApplicationId == bytes32(0), "application ID already registered");
         fungibleApplicationId = _fungibleApplicationId;
     }
 

--- a/linera-bridge/src/test_helpers.rs
+++ b/linera-bridge/src/test_helpers.rs
@@ -136,36 +136,23 @@ pub fn deploy_fungible_bridge(
     light_client: Address,
     chain_id: CryptoHash,
     token: Address,
+    application_id: CryptoHash,
 ) -> Address {
     let bytecode = compile_contract(
         evm::FUNGIBLE_BRIDGE_SOURCE,
         "FungibleBridge.sol",
         "FungibleBridge",
     );
-    let constructor_args = (light_client, *chain_id.as_bytes(), token).abi_encode_params();
+    let constructor_args = (
+        light_client,
+        *chain_id.as_bytes(),
+        token,
+        *application_id.as_bytes(),
+    )
+        .abi_encode_params();
     let mut deploy_data = bytecode;
     deploy_data.extend_from_slice(&constructor_args);
     deploy_contract(db, deployer, deploy_data)
-}
-
-pub fn register_fungible_application_id(
-    db: &mut CacheDB<EmptyDB>,
-    caller: Address,
-    bridge: Address,
-    application_id: CryptoHash,
-) {
-    use alloy_sol_types::sol;
-    sol! {
-        function registerFungibleApplicationId(bytes32 _applicationId) external;
-    }
-    call_contract(
-        db,
-        caller,
-        bridge,
-        &registerFungibleApplicationIdCall {
-            _applicationId: *application_id.as_bytes(),
-        },
-    );
 }
 
 const MOCK_ERC20_SOL: &str = r#"

--- a/linera-bridge/tests/anvil_deposit_proof.rs
+++ b/linera-bridge/tests/anvil_deposit_proof.rs
@@ -138,9 +138,10 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
         "FungibleBridge",
     );
     let bridge_constructor = (
-        deployer,                          // light_client (unused by deposit)
-        <[u8; 32]>::from(target_chain_id), // chainId
-        token_address,                     // token
+        deployer,                                // light_client (unused by deposit)
+        <[u8; 32]>::from(target_chain_id),       // chainId
+        token_address,                           // token
+        <[u8; 32]>::from(target_application_id), // fungibleApplicationId
     )
         .abi_encode_params();
 

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -159,51 +159,10 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     let erc20_addr = parse_deployed_address(&erc20_output)?;
     tracing::info!(%erc20_addr, "MockERC20 deployed");
 
-    // ── Phase 4: Deploy FungibleBridge on EVM (no applicationId needed at construction) ──
+    // ── Phase 4 (deferred): FungibleBridge is deployed after the wrapped-fungible
+    // app is created, so the wrapped applicationId can be baked into the constructor.
     let chain_a_bytes32 = format!("0x{chain_a}");
     let light_client = light_client_address();
-
-    tracing::info!("Deploying FungibleBridge...");
-    let bridge_output = exec_output(
-        &compose,
-        "foundry-tools",
-        &format!(
-            "forge create /contracts/FungibleBridge.sol:FungibleBridge \
-             --root /contracts --via-ir --optimize \
-             --ignored-error-codes 6321 \
-             --evm-version shanghai \
-             --out /tmp/forge-out --cache-path /tmp/forge-cache \
-             --rpc-url http://anvil:8545 \
-             --private-key {ANVIL_PRIVATE_KEY} \
-             --broadcast \
-             --constructor-args \
-             {light_client} \
-             {chain_a_bytes32} \
-             {erc20_addr}"
-        ),
-        project_name,
-        &compose_file,
-    )
-    .await;
-    let bridge_addr = parse_deployed_address(&bridge_output)?;
-    tracing::info!(%bridge_addr, "FungibleBridge deployed");
-
-    tracing::info!("Funding FungibleBridge with ERC20 tokens...");
-    exec_ok(
-        &compose,
-        "foundry-tools",
-        &format!(
-            "cast send --rpc-url http://anvil:8545 \
-             --private-key {ANVIL_PRIVATE_KEY} \
-             {erc20_addr} \
-             'transfer(address,uint256)(bool)' \
-             {bridge_addr} \
-             500000000000000000000"
-        ),
-        project_name,
-        &compose_file,
-    )
-    .await;
 
     // ── Phase 5: Publish and deploy Linera apps ──
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -229,7 +188,6 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             eb_module_id,
             serde_json::to_vec(&BridgeParameters {
                 source_chain_id: 31337,
-                bridge_contract_address: bridge_addr.0 .0,
                 token_address: erc20_addr.0 .0,
                 rpc_endpoint: String::new(),
             })?,
@@ -286,22 +244,63 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         .await?
         .expect("register fungible app committed");
 
+    // Deploy FungibleBridge with the wrapped-fungible applicationId baked in.
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
-    tracing::info!("Registering fungibleApplicationId in FungibleBridge...");
-    exec_ok(
+    tracing::info!("Deploying FungibleBridge...");
+    let bridge_output = exec_output(
         &compose,
         "foundry-tools",
         &format!(
-            "cast send --rpc-url http://anvil:8545 \
+            "forge create /contracts/FungibleBridge.sol:FungibleBridge \
+             --root /contracts --via-ir --optimize \
+             --ignored-error-codes 6321 \
+             --evm-version shanghai \
+             --out /tmp/forge-out --cache-path /tmp/forge-cache \
+             --rpc-url http://anvil:8545 \
              --private-key {ANVIL_PRIVATE_KEY} \
-             {bridge_addr} \
-             'registerFungibleApplicationId(bytes32)' \
+             --broadcast \
+             --constructor-args \
+             {light_client} \
+             {chain_a_bytes32} \
+             {erc20_addr} \
              {app_id_bytes32}"
         ),
         project_name,
         &compose_file,
     )
     .await;
+    let bridge_addr = parse_deployed_address(&bridge_output)?;
+    tracing::info!(%bridge_addr, "FungibleBridge deployed");
+
+    tracing::info!("Funding FungibleBridge with ERC20 tokens...");
+    exec_ok(
+        &compose,
+        "foundry-tools",
+        &format!(
+            "cast send --rpc-url http://anvil:8545 \
+             --private-key {ANVIL_PRIVATE_KEY} \
+             {erc20_addr} \
+             'transfer(address,uint256)(bool)' \
+             {bridge_addr} \
+             500000000000000000000"
+        ),
+        project_name,
+        &compose_file,
+    )
+    .await;
+
+    // Register the FungibleBridge contract address in the evm-bridge app.
+    tracing::info!("Registering FungibleBridge address in evm-bridge...");
+    let register_bridge_bytes = bcs::to_bytes(&BridgeOperation::RegisterFungibleBridge {
+        address: bridge_addr.0 .0,
+    })?;
+    let register_bridge_operation = Operation::User {
+        application_id: bridge_app_id,
+        bytes: register_bridge_bytes,
+    };
+    cc_a.execute_operations(vec![register_bridge_operation], vec![])
+        .await?
+        .expect("register bridge contract address committed");
     tracing::info!("All app IDs registered");
 
     // ── Phase 7: Start relay ──

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -28,7 +28,7 @@ use linera_bridge::{
     proof::gen::{DepositProofClient as _, HttpDepositProofClient},
 };
 use linera_bridge_e2e::{
-    compose_file_path, exec_ok, exec_output, light_client_address, parse_deployed_address,
+    compose_file_path, exec_output, light_client_address, parse_deployed_address,
     start_compose, wait_for_light_client,
     ANVIL_PRIVATE_KEY,
 };
@@ -122,7 +122,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     cc.synchronize_from_validators().await?;
     tracing::info!(%chain_id, %owner, "Chain claimed");
 
-    // ── Phase 3: Deploy MockERC20 + FungibleBridge on Anvil ──
+    // ── Phase 3: Deploy MockERC20 on Anvil ──
     tracing::info!("Deploying MockERC20...");
     let erc20_output = exec_output(
         &compose,
@@ -145,32 +145,6 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     tracing::info!(%erc20_addr, "MockERC20 deployed");
 
     let chain_id_bytes32 = format!("0x{chain_id}");
-
-    tracing::info!("Deploying FungibleBridge...");
-    let light_client = light_client_address();
-    let bridge_output = exec_output(
-        &compose,
-        "foundry-tools",
-        &format!(
-            "forge create /contracts/FungibleBridge.sol:FungibleBridge \
-             --root /contracts --via-ir --optimize \
-             --ignored-error-codes 6321 \
-             --evm-version shanghai \
-             --out /tmp/forge-out --cache-path /tmp/forge-cache \
-             --rpc-url http://anvil:8545 \
-             --private-key {ANVIL_PRIVATE_KEY} \
-             --broadcast \
-             --constructor-args \
-             {light_client} \
-             {chain_id_bytes32} \
-             {erc20_addr}"
-        ),
-        project_name,
-        &compose_file,
-    )
-    .await;
-    let bridge_addr = parse_deployed_address(&bridge_output)?;
-    tracing::info!(%bridge_addr, "FungibleBridge deployed");
 
     // ── Phase 4: Deploy wrapped-fungible + evm-bridge apps on Linera ──
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -209,7 +183,6 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     tracing::info!("Creating evm-bridge application...");
     let bridge_params = BridgeParameters {
         source_chain_id: 31337,
-        bridge_contract_address: bridge_addr.0 .0,
         token_address: erc20_addr.0 .0,
         rpc_endpoint: String::new(),
     };
@@ -262,23 +235,48 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         .await?
         .expect("register fungible app committed");
 
-    // 4e. Register wrapped-fungible applicationId in the EVM FungibleBridge
+    // 4e. Deploy FungibleBridge with the wrapped-fungible applicationId baked in
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
-    tracing::info!("Registering applicationId in FungibleBridge...");
-    exec_ok(
+    let light_client = light_client_address();
+    tracing::info!("Deploying FungibleBridge...");
+    let bridge_output = exec_output(
         &compose,
         "foundry-tools",
         &format!(
-            "cast send --rpc-url http://anvil:8545 \
+            "forge create /contracts/FungibleBridge.sol:FungibleBridge \
+             --root /contracts --via-ir --optimize \
+             --ignored-error-codes 6321 \
+             --evm-version shanghai \
+             --out /tmp/forge-out --cache-path /tmp/forge-cache \
+             --rpc-url http://anvil:8545 \
              --private-key {ANVIL_PRIVATE_KEY} \
-             {bridge_addr} \
-             'registerFungibleApplicationId(bytes32)' \
+             --broadcast \
+             --constructor-args \
+             {light_client} \
+             {chain_id_bytes32} \
+             {erc20_addr} \
              {app_id_bytes32}"
         ),
         project_name,
         &compose_file,
     )
     .await;
+    let bridge_addr = parse_deployed_address(&bridge_output)?;
+    tracing::info!(%bridge_addr, "FungibleBridge deployed");
+
+    // 4f. Register the FungibleBridge contract address in the evm-bridge app
+    tracing::info!("Registering FungibleBridge address in evm-bridge...");
+    let register_bridge_op = BridgeOperation::RegisterFungibleBridge {
+        address: bridge_addr.0 .0,
+    };
+    let register_bridge_bytes = bcs::to_bytes(&register_bridge_op)?;
+    let register_bridge_operation = Operation::User {
+        application_id: bridge_app_id,
+        bytes: register_bridge_bytes,
+    };
+    cc.execute_operations(vec![register_bridge_operation], vec![])
+        .await?
+        .expect("register bridge contract address committed");
 
     // ── Phase 5: Approve + Deposit on EVM ──
     let deposit_amount = U256::from(100u128 * 10u128.pow(18)); // 100 tokens

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -229,7 +229,8 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
              --constructor-args \
              {light_client} \
              {chain_a_bytes32} \
-             {erc20_addr}"
+             {erc20_addr} \
+             {app_id_bytes32}"
         ),
         project_name,
         &compose_file,
@@ -237,23 +238,6 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     .await;
     let bridge_addr = parse_deployed_address(&bridge_output)?;
     tracing::info!(%bridge_addr, "FungibleBridge deployed");
-
-    // Register the wrapped-fungible application ID
-    tracing::info!("Registering applicationId in FungibleBridge...");
-    exec_ok(
-        &compose,
-        "foundry-tools",
-        &format!(
-            "cast send --rpc-url http://anvil:8545 \
-             --private-key {ANVIL_PRIVATE_KEY} \
-             {bridge_addr} \
-             'registerFungibleApplicationId(bytes32)' \
-             {app_id_bytes32}"
-        ),
-        project_name,
-        &compose_file,
-    )
-    .await;
 
     // ── 7. Fund FungibleBridge with ERC20 tokens ──
     tracing::info!("Funding FungibleBridge with ERC20 tokens...");


### PR DESCRIPTION
Backport of #6173

## Motivation

Bridge deployment has a structural three-node cyclic dependency between:
1. `FungibleBridge.sol` (EVM), 
2. `evm-bridge` (Linera), and 
3. `wrapped-fungible` (Linera).

Each end-point needs an identifier from the next node in the cycle.

Today the cycle is broken on the EVM side — `FungibleBridge.sol` ships with an unset `fungibleApplicationId` and a one-shot, only-deployer `registerFungibleApplicationId(bytes32)` setter that wires the canonical wrapped-fungible app ID after deployment. That makes the contract that guards bridge funds carry mutable state and a deployment-time trust window where a compromised deployer key could bind the bridge to an attacker-chosen application ID.

This PR relocates the unavoidable late-bound write from EVM to Linera so that `FungibleBridge.sol` becomes immutable from genesis. The EVM-side `fungibleApplicationId` check (which is the line between "stall" and "drain")
is preserved, just enforced through an `immutable` constructor argument instead of a setter.

## Proposal

EVM side (`linera-bridge/src/solidity/FungibleBridge.sol`):

- `fungibleApplicationId` becomes a constructor `immutable`.
- Constructor signature gains `_fungibleApplicationId` and rejects the zero
  value with `require(_fungibleApplicationId != bytes32(0), …)`.
- `registerFungibleApplicationId(bytes32)` and the `deployer` slot are
  removed entirely.

Linera side (`examples/evm-bridge/`):

- `BridgeParameters` no longer carries `bridge_contract_address`.
- A new `RegisterView<Option<[u8; 20]>>` field is added to the inline state
  struct in `contract.rs`.
- `BridgeOperation::RegisterFungibleBridge { address: [u8; 20] }` is
  appended to the operation enum (BCS tag 3 — existing tags `0..=2` are
  preserved).
- The handler mirrors the existing `RegisterFungibleApp` shape:
  `authenticated_signer().expect(…)` plus a one-shot guard.
- The single read site at `examples/evm-bridge/src/contract.rs:196` now
  reads the address from state and panics if `RegisterFungibleBridge` has
  not been called.
- The service exposes the address as `Option<String>` since it can be `None`
  before registration.

Deployment orchestration (`examples/bridge-demo/setup.sh` and the e2e
helpers in `linera-bridge/tests/e2e/tests/*`):

1. Deploy `LightClient` + `MockERC20` on Anvil/EVM.
6. Publish + instantiate `evm-bridge` on Linera (no EVM address yet).
7. Publish + instantiate `wrapped-fungible` on Linera (uses the bridge app
    ID from step 2).
8. Deploy `FungibleBridge` on EVM with the canonical wrapped-fungible
    `applicationId` baked into the constructor — immutable from this point.
9. `linera execute-operation RegisterFungibleApp` (variant `0x00`,
    unchanged) and `RegisterFungibleBridge` (variant `0x03`, replaces
    `cast send registerFungibleApplicationId`).

`docker/docker-compose.bridge-test.yml` does not need changes: the relay
still reads `/shared/bridge-address`, just produced later in setup.sh, and
the `setup-complete` marker hides the file-write order from the relay.

## Test Plan

- CI
- manual: locally ran the Linera network stack and Anvil node, deployed the whole bridge stack and tested UI demo

## Release Plan

- These changes should follow regular release cycle

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)