### PR TITLE
disable Cloud Logging on validator HTTP LB BackendConfig

### DIFF
--- a/kubernetes/linera-validator/templates/ingress.yaml
+++ b/kubernetes/linera-validator/templates/ingress.yaml
@@ -33,5 +33,7 @@ metadata:
   name: proxy-backend-config
 spec:
   timeoutSec: 2147483647  # Maximum possible value
+  logging:
+    enable: false  # GKE default sampleRate=1.0 was costing ~$1.6k/mo across our LBs. Re-enable on-demand for debugging via `kubectl patch`.
 
 {{- end }}


### PR DESCRIPTION
## Motivation

The proxy-backend-config currently has no `logging` field set. Per GKE Ingress docs, the default behavior in that case is `enable=true, sampleRate=1.0` — every HTTP request hitting the validator load balancer is shipped to Cloud Logging.

Across the 4 testnet-conway-validator clusters this has been the dominant share of a roughly $1.6k/month Cloud Logging bill, with no current consumer (alert, dashboard, or query) for the data.

## Proposal

Set `logging.enable: false` on the BackendConfig.

To re-enable on demand during debugging, run `kubectl edit backendconfig proxy-backend-config` against the specific cluster being investigated and flip the field back to `true`. Logging is forward-only after enablement.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

Backports:
- linera-io/linera-protocol#6192 (testnet_conway, V4 validators)
- linera-io/linera-protocol#6193 (testnet_conway_debug, V1-V3 validators)

## Links

- Companion PR: linera-io/linera-infra#1025 (faucet BackendConfig, plus backport linera-io/linera-infra#1026)