### PR TITLE
backport to testnet_conway_debug: disable Cloud Logging on validator HTTP LB BackendConfig

### DIFF
--- a/kubernetes/linera-validator/templates/ingress.yaml
+++ b/kubernetes/linera-validator/templates/ingress.yaml
@@ -33,5 +33,7 @@ metadata:
   name: proxy-backend-config
 spec:
   timeoutSec: 2147483647  # Maximum possible value
+  logging:
+    enable: false  # GKE default sampleRate=1.0 was costing ~$1.6k/mo across our LBs. Re-enable on-demand for debugging via `kubectl patch`.
 
 {{- end }}


### PR DESCRIPTION
## Motivation

Backport of linera-io/linera-protocol#6190 to `testnet_conway_debug` (V1-V3 validators using the per-chain actor model).

The proxy-backend-config currently has no `logging` field set; GKE default in that case is `enable=true, sampleRate=1.0`, generating roughly $1.6k/month of Cloud Logging spend across the testnet-conway-validator clusters with no current consumer for the data.

## Proposal

Cherry-pick the same 2-line change as #6190.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Original PR (main): linera-io/linera-protocol#6190
- Sibling backport (testnet_conway, V4): linera-io/linera-protocol#6191