### PR TITLE
[main] Improve Docker build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,15 @@
 **/node_modules
 **/dist
 **/web-frontend
+web/@linera/client/src/wasm
+**/.env.local
+**/.DS_Store
+**/.vscode
+**/.idea
+**/.zed
+**/.vite
+**/*.swp
+**/*.swo
 *.log
 # ignore .git and .cache folders
 .git
@@ -16,7 +25,7 @@ README-secret.md
 # github related files
 .github/
 **/target
-Dockerfile
+**/Dockerfile*
 .dockerignore
 .gitignore
 .gcloudignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.6
+#
 # Build arguments:
 #
 # - `git_commit` is the hash of the current git commit — used for
@@ -9,6 +11,9 @@
 # - `build_flag` is either "--release" or an empty string.
 # - `build_folder` is either "release" or "debug".
 # - `build_features` is a comma-separated list of features to build the binaries with.
+#
+# Requires BuildKit for `RUN --mount=type=cache` (DOCKER_BUILDKIT=1, `docker buildx`,
+# or recent Docker Desktop/Engine).
 
 ARG git_commit
 ARG build_date
@@ -19,49 +24,132 @@ ARG build_folder=release
 ARG build_features=scylladb,metrics,jemalloc
 ARG rustflags="-C force-frame-pointers=yes -L /usr/lib/x86_64-linux-gnu"
 
-FROM rust:1.86-slim-bookworm AS builder
+# ── Stage 0: chef base (rust + cargo-chef + system deps) ──
+FROM rust:1.86-slim-bookworm AS chef
+
+# `rm -f /etc/apt/apt.conf.d/docker-clean`: Debian's slim images ship that file
+# with `APT::Keep-Downloaded-Packages "false";`, which makes apt delete
+# downloaded `.deb` files right after install. That defeats the cache mount on
+# `/var/cache/apt` — every rebuild re-downloads. Remove the config so packages
+# stay in the cache mount across builds.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install --no-install-recommends -y \
+    pkg-config \
+    protobuf-compiler \
+    libprotobuf-dev \
+    clang \
+    make \
+    libunwind-dev
+
+WORKDIR /app
+
+# Pre-install the toolchain matching rust-toolchain.toml so planner/builder
+# stages don't trigger rustup downloads. The layer caches on the file's hash.
+COPY rust-toolchain.toml rust-toolchain.toml
+RUN rustup show
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo install cargo-chef --version 0.1.71 --locked
+
+# ── Stage 1: planner — generate dependency recipe from full source ──
+
+FROM chef AS planner
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo chef prepare --recipe-path recipe.json
+
+# The examples/ workspace is separate from the root workspace, but some
+# examples are dev-dependencies of root crates so Cargo must resolve them.
+# Build minimal stubs (Cargo.toml + dummy sources) for every example member.
+RUN set -e && \
+    mkdir /examples-stubs && \
+    cp examples/Cargo.toml /examples-stubs/Cargo.toml && \
+    find examples -mindepth 2 -name Cargo.toml | while read -r toml; do \
+      rel=$(dirname "${toml#examples/}"); \
+      mkdir -p "/examples-stubs/$rel/src"; \
+      cp "$toml" "/examples-stubs/$rel/Cargo.toml"; \
+      touch "/examples-stubs/$rel/src/lib.rs"; \
+      grep -A3 '^\[\[bin\]\]' "$toml" 2>/dev/null | \
+        grep 'path' | sed 's/.*= *"\(.*\)"/\1/' | while read -r bin_path; do \
+          mkdir -p "/examples-stubs/$rel/$(dirname "$bin_path")"; \
+          printf 'fn main() {}\n' > "/examples-stubs/$rel/$bin_path"; \
+        done; \
+    done
+
+# ── Stage 2: builder — cook deps (cached), then build source ──
+
+FROM chef AS builder_src
 ARG git_commit
 ARG build_flag
 ARG build_folder
 ARG build_features
 ARG rustflags
 
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    protobuf-compiler \
-    clang \
-    make \
-    libunwind-dev
+COPY --from=planner /app/recipe.json recipe.json
 
-COPY . .
+# linera-version's build.rs uses include!() for type definitions and hashes
+# files from other crates at build-script runtime. These must exist before
+# `cargo chef cook` because cook triggers the build script.
+COPY linera-version/src/serde_pretty linera-version/src/serde_pretty
+COPY linera-version/src/version_info linera-version/src/version_info
+COPY linera-version/api-hashes.json linera-version/api-hashes.json
+COPY linera-rpc/tests/snapshots linera-rpc/tests/snapshots
+COPY linera-service-graphql-client/gql linera-service-graphql-client/gql
+COPY linera-sdk/wit linera-sdk/wit
+
+# Examples workspace stubs for dev-dep resolution during cook.
+COPY --from=planner /examples-stubs examples
 
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}
 
-RUN cargo build ${build_flag:+"$build_flag"} \
+# Cook dependencies — cached until Cargo.toml / Cargo.lock change.
+# The three cache mounts persist cargo's registry, git deps, and the
+# compilation target/ across builds so unchanged deps never recompile.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo chef cook ${build_flag:+"$build_flag"} \
+    --recipe-path recipe.json \
     --bin linera-proxy \
     --bin linera-server \
     --bin linera \
     --features $build_features
 
-RUN mv \
-    target/"$build_folder"/linera \
-    target/"$build_folder"/linera-proxy \
-    target/"$build_folder"/linera-server \
-    ./
+# Copy full source and build (only changed crates recompile).
+COPY . .
+# target/ is a cache mount — build + copy binaries OUT of it in the same RUN
+# so they persist in the image layer (cache mounts don't survive the RUN).
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build ${build_flag:+"$build_flag"} \
+        --bin linera-proxy \
+        --bin linera-server \
+        --bin linera \
+        --features $build_features \
+    && cp \
+        target/"$build_folder"/linera \
+        target/"$build_folder"/linera-proxy \
+        target/"$build_folder"/linera-server \
+        /
 
-# Optionally copy binaries instead of using the build images above
-FROM scratch AS builder_copy
+# Optionally copy binaries instead of using the build stage above
+FROM scratch AS builder_src_copy
 ARG binaries
 COPY \
     "$binaries"/linera \
     "$binaries"/linera-server \
     "$binaries"/linera-proxy \
-    ./
+    /
 
-FROM builder$copy AS binaries
+FROM builder_src$copy AS binaries
 
-# Setup running environment for container
+# ── Stage 3: runtime ──
 FROM debian:bookworm-slim
 
 ARG git_commit
@@ -73,11 +161,12 @@ LABEL build_date=$build_date
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     openssl \
-    libunwind8
-RUN update-ca-certificates
+    libunwind8 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=binaries \
-    linera \
-    linera-server \
-    linera-proxy \
+    /linera \
+    /linera-server \
+    /linera-proxy \
     ./

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -1,3 +1,8 @@
+# syntax=docker/dockerfile:1.6
+#
+# Requires BuildKit for `RUN --mount=type=cache` (DOCKER_BUILDKIT=1, `docker buildx`,
+# or recent Docker Desktop/Engine).
+
 ARG git_commit
 ARG build_date
 ARG build_flag=--release
@@ -6,22 +11,40 @@ ARG rustflags="-C force-frame-pointers=yes"
 
 # ── Stage 0: chef base (rust + cargo-chef + system deps) ──
 
-FROM rust:1.88-slim-bookworm AS chef
+FROM rust:1.86-slim-bookworm AS chef
 
-RUN apt-get update && apt-get install -y \
+# `rm -f /etc/apt/apt.conf.d/docker-clean`: Debian's slim images ship that file
+# with `APT::Keep-Downloaded-Packages "false";`, which makes apt delete
+# downloaded `.deb` files right after install. That defeats the cache mount on
+# `/var/cache/apt` — every rebuild re-downloads. Remove the config so packages
+# stay in the cache mount across builds.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install --no-install-recommends -y \
     pkg-config \
     protobuf-compiler \
-    clang \
-    && rm -rf /var/lib/apt/lists/*
+    libprotobuf-dev \
+    clang
 
-RUN cargo install cargo-chef --locked
 WORKDIR /app
+
+# Pre-install the toolchain matching rust-toolchain.toml so planner/builder
+# stages don't trigger rustup downloads. The layer caches on the file's hash.
+COPY rust-toolchain.toml rust-toolchain.toml
+RUN rustup show
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo install cargo-chef --version 0.1.71 --locked
 
 # ── Stage 1: planner — generate dependency recipe from full source ──
 
 FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cargo chef prepare --recipe-path recipe.json
 
 # The examples/ workspace is separate from the root workspace, but
 # `fungible` is a dev-dependency of linera-bridge so Cargo must resolve it.
@@ -68,7 +91,10 @@ ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}
 
 # Cook dependencies — this layer is cached until Cargo.toml / Cargo.lock change.
-RUN cargo chef cook ${build_flag:+"$build_flag"} \
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo chef cook ${build_flag:+"$build_flag"} \
     --recipe-path recipe.json \
     --bin linera-bridge \
     -p linera-bridge \
@@ -76,10 +102,15 @@ RUN cargo chef cook ${build_flag:+"$build_flag"} \
 
 # Copy full source and build (only changed crates recompile).
 COPY . .
-RUN cargo build ${build_flag:+"$build_flag"} \
-    --bin linera-bridge \
-    -p linera-bridge \
-    --features relay \
+# target/ is a cache mount — build + copy binary OUT in same RUN so it persists
+# in the image layer (cache mounts don't survive across RUNs).
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build ${build_flag:+"$build_flag"} \
+        --bin linera-bridge \
+        -p linera-bridge \
+        --features relay \
     && cp target/"$build_folder"/linera-bridge /usr/local/bin/linera-bridge
 
 # ── Stage 3: runtime ──

--- a/docker/ci-compose.sh
+++ b/docker/ci-compose.sh
@@ -36,6 +36,10 @@ cd "$ROOT_DIR"
 
 GIT_COMMIT=$(git rev-parse --short HEAD)
 
+# Dockerfile uses `RUN --mount=type=cache`, which needs BuildKit. Docker 23+
+# enables BuildKit by default; this flag ensures it's on everywhere.
+export DOCKER_BUILDKIT=1
+
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera || exit 1
 elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
Bacmport of #6125 

## Motivation

`docker/Dockerfile` and `docker/Dockerfile.bridge` re-downloaded dependencies and recompiled the whole workspace on every build. A single-char edit to `Cargo.toml` or a Debian package bump meant ~15 minutes of
cook time, on repeat. The planner/builder stages also triggered rustup downloads because the stock `rust:*-slim-bookworm` images' toolchain never matched `rust-toolchain.toml`. And cosmetic file changes (IDE
dotfiles, swap files, web artifacts) busted the Docker context hash, invalidating otherwise-good cache layers.

## Proposal

Turn on real caching end-to-end, keep toolchain pinned to `rust-toolchain.toml`, stop leaking context churn.

- **Opt into BuildKit + cache mounts.** Add `# syntax=docker/dockerfile:1.6` to both Dockerfiles. Use `RUN --mount=type=cache` on:
  - `/var/cache/apt` + `/var/lib/apt` — apt package downloads persist across builds.
  - `/usr/local/cargo/registry` + `/usr/local/cargo/git` — crates.io / git deps persist.
  - `/app/target` — compilation output persists; changed crates still trigger recompile, unchanged don't.

  Export `DOCKER_BUILDKIT=1` in `docker/compose.sh` so local compose builds use BuildKit unconditionally (Docker 23+ defaults to on; older engines get explicit opt-in).

- **Fix the apt cache mount.** Debian slim images ship `/etc/apt/apt.conf.d/docker-clean` which deletes downloaded `.deb` files right after install — defeats the cache mount. `rm -f
/etc/apt/apt.conf.d/docker-clean` before `apt-get install`. Add `--no-install-recommends` to trim image size. Keep `libprotobuf-dev` explicit since `--no-install-recommends` drops it and `linera-rpc`'s build.rs
needs headers.

- **Pin builder toolchain to `rust-toolchain.toml`.** Both Dockerfiles `COPY rust-toolchain.toml` then `RUN rustup show` in the `chef` stage. Toolchain installs once per toolchain-file change, not per build.
`docker/Dockerfile.bridge` drops from `rust:1.88-slim-bookworm` to `rust:1.86-slim-bookworm` so both images share a base layer and match the repo's pinned version.

- **cargo-chef for `docker/Dockerfile`.** Was doing a raw `cargo build` on full source. Now three stages: `chef` (toolchain + system deps + cargo-chef), `planner` (`cargo chef prepare`), `builder_src` (`cargo
chef cook` against recipe, then `cargo build` against copied source). Dep cook layer caches on `Cargo.toml` / `Cargo.lock` changes only.

- **examples-stubs for dev-dep resolution.** The planner stage in `docker/Dockerfile` generates minimal `Cargo.toml` + `src/lib.rs` / `fn main() {}` stubs for every `examples/` member, because some examples are
dev-deps of root crates and Cargo must resolve them during `cargo chef cook` even though they never build into the target binaries. `docker/Dockerfile.bridge` already had an equivalent stub step.

- **Same-`RUN` build+copy.** `target/` is a cache mount — binaries inside it don't persist past the `RUN`. So `cargo build … && cp target/$build_folder/linera* /` happens in one `RUN`, landing the binaries in the
  image layer.

- **`.dockerignore` hygiene.** Ignore IDE dirs (`.vscode`, `.idea`, `.zed`), swap files (`*.swp`, `*.swo`), `.DS_Store`, `**/.env.local`, `**/.vite`, `web/@linera/client/src/wasm`, and change `Dockerfile` →
`**/Dockerfile*` so Dockerfile edits themselves don't appear in the build context. Less context churn = more cache hits.

## Test Plan

- Local baseline:
  DOCKER_BUILDKIT=1 docker buildx build -f docker/Dockerfile        --load -t linera .
  DOCKER_BUILDKIT=1 docker buildx build -f docker/Dockerfile.bridge --load -t linera-bridge .
Cold build succeeds; warm rebuild (no source change) is near-instant — every cook/build step reports `CACHED`.

- Source-change rebuilds: touched a single file in `linera-core`, rebuilt. `cargo chef cook` layer stays `CACHED`; only the `cargo build` layer recompiles the changed crate + its dependents.

- Toolchain-change rebuilds: bumped `rust-toolchain.toml`, rebuilt. The `COPY rust-toolchain.toml` + `rustup show` layer is the first to invalidate; system-deps layer upstream stays `CACHED`.

- apt cache verified: `docker buildx du` shows `cache/apt` / `lib/apt` entries growing across successive cold builds; second cold build's `apt-get install` reports `Hit` instead of `Get`.

- Compose smoke: `./docker/compose.sh` still runs end-to-end with `DOCKER_BUILDKIT=1` auto-exported.

- CI: existing `docker-build-and-publish` and `docker-compose` jobs build both images. Any incompatibility surfaces there.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Stacks on top of PR #6124 (`pr/bridge-init-extraction`).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)