### PR TITLE
Stream all available blobs in DownloadBlobs and skip missing

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -843,15 +843,15 @@ impl<Env: Environment> Client<Env> {
         // block bodies, so they don't need to be fetched from a validator. The
         // chain worker resolves them from `Block::created_blobs()` during
         // `handle_certificate`.
-        let created_blob_ids: BTreeSet<BlobId> = certificates
+        let created_blob_ids = certificates
             .iter()
             .flat_map(|certificate| certificate.value().block().created_blob_ids())
-            .collect();
-        let required_blob_ids: Vec<_> = certificates
+            .collect::<BTreeSet<BlobId>>();
+        let required_blob_ids = certificates
             .iter()
             .flat_map(|certificate| certificate.value().required_blob_ids())
             .filter(|blob_id| !created_blob_ids.contains(blob_id))
-            .collect();
+            .collect::<Vec<_>>();
 
         match self
             .local_node

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -632,15 +632,13 @@ where
             .read_blobs(&blob_ids)
             .await
             .map_err(Self::view_error_to_status)?;
-        let stream = futures::stream::iter(blob_ids.into_iter().zip(blobs).map(
-            |(blob_id, maybe_blob)| {
-                let blob = maybe_blob
-                    .map(Arc::unwrap_or_clone)
-                    .ok_or_else(|| Status::not_found(format!("Blob not found {blob_id}")))?;
-                BlobContent::try_from(blob.into_content())
-                    .map_err(|err| Status::internal(err.to_string()))
-            },
-        ));
+        let stream = futures::stream::iter(blobs.into_iter().filter_map(|maybe_blob| {
+            let blob = maybe_blob?;
+            Some(
+                BlobContent::try_from(blob.content().clone())
+                    .map_err(|err| Status::internal(err.to_string())),
+            )
+        }));
         Ok(Response::new(Box::pin(stream)))
     }
 

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -300,16 +300,12 @@ where
                 })));
             }
         };
-        let messages =
-            blob_ids
-                .into_iter()
-                .zip(blobs)
-                .map(|(blob_id, maybe_blob)| match maybe_blob {
-                    Some(blob) => RpcMessage::DownloadBlobResponse(Box::new(
-                        Arc::unwrap_or_clone(blob).into_content(),
-                    )),
-                    None => RpcMessage::Error(Box::new(NodeError::BlobsNotFound(vec![blob_id]))),
-                });
+        let messages = blobs.into_iter().filter_map(|maybe_blob| {
+            let blob = maybe_blob?;
+            Some(RpcMessage::DownloadBlobResponse(Box::new(
+                blob.content().clone(),
+            )))
+        });
         Some(Box::pin(futures::stream::iter(messages)))
     }
 }


### PR DESCRIPTION
## Motivation

The streaming `DownloadBlobs` RPC added in #5976 terminates the response
stream on the first missing blob, dropping any blobs that would have
been yielded after it:

- gRPC (`linera-service/src/proxy/grpc.rs`): the handler yields
  `Err(Status::not_found(...))` for a missing blob, which terminates
  the gRPC response stream. Subsequent blobs queued for that batch are
  silently lost.
- Simple transport (`linera-service/src/proxy/main.rs`): the handler
  interleaves `RpcMessage::Error(BlobsNotFound([single_id]))` items
  among `DownloadBlobResponse` items. The current consumer in
  `RemoteNode::download_blobs` propagates the first error via `?`,
  which drops the rest of the batch on the floor.

A batch of N blobs where blob K is missing returns at most K successful
blobs to the caller, even if the validator has all of blobs K+1..N
available. The follow-up #6157 wires this RPC into the per-peer
fallback path and relies on partial progress being reported correctly,
which the current broken server semantics prevent.

## Proposal

Both server handlers now yield only the blobs that are present, in
request order, and silently skip missing blobs. The client compares
the IDs it received against the IDs it asked for and re-requests any
missing IDs from another peer.

This preserves the existing wire format on both transports.
Storage-level errors that occur before any blob has been yielded
continue to surface as a top-level error on the response (gRPC) or as
an early `RpcMessage::Error` (simple transport).

Also addresses the review comment from afck on #6105 / #6155: the
type annotation on `created_blob_ids` in
`Client::process_certificates` moves from the `let` binding to the
`.collect()` call (turbofish style).

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch
  alongside #5976. #6156 is the WIP backport of #5976 and should be
  updated to include this fix before being merged.
