### PR TITLE
[testnet] Remove some `unreachable` and `.unwrap()`.

### DIFF
--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -633,13 +633,13 @@ where
         amount: Amount,
     ) -> Result<Option<OutgoingMessage>, ExecutionError> {
         if source == AccountOwner::CHAIN {
+            let authenticated_signer =
+                authenticated_signer.ok_or(ExecutionError::UnauthenticatedTransferOwner)?;
             ensure!(
-                authenticated_signer.is_some()
-                    && self
-                        .ownership
-                        .get()
-                        .await?
-                        .verify_owner(&authenticated_signer.unwrap()),
+                self.ownership
+                    .get()
+                    .await?
+                    .verify_owner(&authenticated_signer),
                 ExecutionError::UnauthenticatedTransferOwner
             );
         } else {

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -970,7 +970,6 @@ impl DynamoDbStoreInternalError {
 
     fn type_description_of(value: &AttributeValue) -> String {
         match value {
-            AttributeValue::B(_) => unreachable!("creating an error type for the correct type"),
             AttributeValue::Bool(_) => "a boolean",
             AttributeValue::Bs(_) => "a list of binary blobs",
             AttributeValue::L(_) => "a list",

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -521,9 +521,7 @@ where
                 == S::MAX_BATCH_SIZE - 1
             {
                 (true, true)
-            } else if let Some(next_block_size) =
-                iter.next_batch_size(&block_batch, block_size)?
-            {
+            } else if let Some(next_block_size) = iter.next_batch_size(&block_batch, block_size)? {
                 let next_transaction_size = transaction_size + next_block_size + key_len;
                 let transaction_flush = next_transaction_size > max_transaction_size;
                 let block_flush = transaction_flush

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -517,20 +517,21 @@ where
         let mut transaction_batch = S::Batch::default();
         let mut transaction_size = 0;
         while iter.write_next_value(&mut block_batch, &mut block_size)? {
-            let (block_flush, transaction_flush) = {
-                if iter.is_empty() || transaction_batch.len() == S::MAX_BATCH_SIZE - 1 {
-                    (true, true)
-                } else {
-                    let next_block_size = iter
-                        .next_batch_size(&block_batch, block_size)?
-                        .expect("iter is not empty");
-                    let next_transaction_size = transaction_size + next_block_size + key_len;
-                    let transaction_flush = next_transaction_size > max_transaction_size;
-                    let block_flush = transaction_flush
-                        || block_batch.len() == S::MAX_BATCH_SIZE - 2
-                        || next_block_size > max_block_size;
-                    (block_flush, transaction_flush)
-                }
+            let (block_flush, transaction_flush) = if transaction_batch.len()
+                == S::MAX_BATCH_SIZE - 1
+            {
+                (true, true)
+            } else if let Some(next_block_size) =
+                iter.next_batch_size(&block_batch, block_size)?
+            {
+                let next_transaction_size = transaction_size + next_block_size + key_len;
+                let transaction_flush = next_transaction_size > max_transaction_size;
+                let block_flush = transaction_flush
+                    || block_batch.len() == S::MAX_BATCH_SIZE - 2
+                    || next_block_size > max_block_size;
+                (block_flush, transaction_flush)
+            } else {
+                (true, true)
             };
             if block_flush {
                 block_size += block_batch.overhead_size();

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -210,14 +210,11 @@ where
                 .read_multi_values_bytes(&keys_add)
                 .await?
                 .into_iter();
-            for (idx, count) in n_blocks.iter().enumerate() {
-                if count > &1 {
-                    let value = big_values.get_mut(idx).unwrap();
-                    if let Some(ref mut value) = value {
-                        for _ in 1..*count {
-                            let segment = segments.next().unwrap().unwrap();
-                            value.extend(segment);
-                        }
+            for (big_value, count) in big_values.iter_mut().zip(&n_blocks) {
+                if let Some(value) = big_value {
+                    for _ in 1..*count {
+                        let segment = segments.next().unwrap().unwrap();
+                        value.extend(segment);
                     }
                 }
             }

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -612,9 +612,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                     .store()
                     .read_value(&key)
                     .await?
-                    .ok_or_else(|| {
-                        ViewError::MissingEntries("BucketQueueView::back".into())
-                    })?;
+                    .ok_or_else(|| ViewError::MissingEntries("BucketQueueView::back".into()))?;
                 let result = data.last().unwrap().clone();
                 self.stored_buckets.back_mut().unwrap().state = State::Loaded { data };
                 Ok(Some(result))

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -611,9 +611,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
         };
         match &bucket.state {
             State::Loaded { data } => Ok(Some(
-                data.last()
-                    .expect("a stored bucket is never empty")
-                    .clone(),
+                data.last().expect("a stored bucket is never empty").clone(),
             )),
             State::NotLoaded { .. } => {
                 let key = self.get_bucket_key(bucket.index)?;
@@ -623,10 +621,7 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                     .read_value::<Vec<T>>(&key)
                     .await?
                     .ok_or_else(|| ViewError::MissingEntries("BucketQueueView::back".into()))?;
-                let result = data
-                    .last()
-                    .expect("a stored bucket is never empty")
-                    .clone();
+                let result = data.last().expect("a stored bucket is never empty").clone();
                 self.stored_buckets
                     .back_mut()
                     .expect("stored_buckets is non-empty since we just accessed its back element")

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -603,22 +603,23 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
         let Some(bucket) = self.stored_buckets.back() else {
             return Ok(None);
         };
-        if !bucket.is_loaded() {
-            let key = self.get_bucket_key(bucket.index)?;
-            let data = self.context.store().read_value(&key).await?;
-            let data = match data {
-                Some(data) => data,
-                None => {
-                    return Err(ViewError::MissingEntries("BucketQueueView::back".into()));
-                }
-            };
-            self.stored_buckets.back_mut().unwrap().state = State::Loaded { data };
+        match &bucket.state {
+            State::Loaded { data } => Ok(Some(data.last().unwrap().clone())),
+            State::NotLoaded { .. } => {
+                let key = self.get_bucket_key(bucket.index)?;
+                let data: Vec<T> = self
+                    .context
+                    .store()
+                    .read_value(&key)
+                    .await?
+                    .ok_or_else(|| {
+                        ViewError::MissingEntries("BucketQueueView::back".into())
+                    })?;
+                let result = data.last().unwrap().clone();
+                self.stored_buckets.back_mut().unwrap().state = State::Loaded { data };
+                Ok(Some(result))
+            }
         }
-        let state = &self.stored_buckets.back_mut().unwrap().state;
-        let State::Loaded { data } = state else {
-            unreachable!();
-        };
-        Ok(Some(data.last().unwrap().clone()))
     }
 
     async fn read_context(

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -607,10 +607,10 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
             State::Loaded { data } => Ok(Some(data.last().unwrap().clone())),
             State::NotLoaded { .. } => {
                 let key = self.get_bucket_key(bucket.index)?;
-                let data: Vec<T> = self
+                let data = self
                     .context
                     .store()
-                    .read_value(&key)
+                    .read_value::<Vec<T>>(&key)
                     .await?
                     .ok_or_else(|| ViewError::MissingEntries("BucketQueueView::back".into()))?;
                 let result = data.last().unwrap().clone();

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -484,11 +484,17 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
     pub fn front_mut(&mut self) -> Option<&mut T> {
         match self.cursor {
             Some(Cursor { offset, position }) => {
-                let bucket = self.stored_buckets.get_mut(offset).unwrap();
+                let bucket = self
+                    .stored_buckets
+                    .get_mut(offset)
+                    .expect("cursor.offset must be a valid index into stored_buckets");
                 let State::Loaded { data } = &mut bucket.state else {
                     unreachable!();
                 };
-                Some(data.get_mut(position).unwrap())
+                Some(
+                    data.get_mut(position)
+                        .expect("cursor.position must be a valid index within the front bucket"),
+                )
             }
             None => self.new_back_values.front_mut(),
         }
@@ -604,7 +610,11 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
             return Ok(None);
         };
         match &bucket.state {
-            State::Loaded { data } => Ok(Some(data.last().unwrap().clone())),
+            State::Loaded { data } => Ok(Some(
+                data.last()
+                    .expect("a stored bucket is never empty")
+                    .clone(),
+            )),
             State::NotLoaded { .. } => {
                 let key = self.get_bucket_key(bucket.index)?;
                 let data = self
@@ -613,8 +623,14 @@ impl<C: Context, T: DeserializeOwned + Clone, const N: usize> BucketQueueView<C,
                     .read_value::<Vec<T>>(&key)
                     .await?
                     .ok_or_else(|| ViewError::MissingEntries("BucketQueueView::back".into()))?;
-                let result = data.last().unwrap().clone();
-                self.stored_buckets.back_mut().unwrap().state = State::Loaded { data };
+                let result = data
+                    .last()
+                    .expect("a stored bucket is never empty")
+                    .clone();
+                self.stored_buckets
+                    .back_mut()
+                    .expect("stored_buckets is non-empty since we just accessed its back element")
+                    .state = State::Loaded { data };
                 Ok(Some(result))
             }
         }

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -221,10 +221,7 @@ where
         self.delete_storage_first = false;
         match &mut self.update {
             Some(value) => value,
-            update => {
-                *update = Some(self.stored_value.clone());
-                update.as_mut().unwrap()
-            }
+            update => update.insert(self.stored_value.clone()),
         }
     }
 

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -219,10 +219,7 @@ where
     /// ```
     pub fn get_mut(&mut self) -> &mut T {
         self.delete_storage_first = false;
-        match &mut self.update {
-            Some(value) => value,
-            update => update.insert(self.stored_value.clone()),
-        }
+        self.update.get_or_insert_with(|| self.stored_value.clone())
     }
 
     fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {


### PR DESCRIPTION
## Motivation

There are some unreachable / .unwrap() statements that we can remove without changing
any of the behavior of the code.

Backport https://github.com/linera-io/linera-protocol/pull/6205

## Proposal

The corrections I found only in `linera-views` and `linera-execution`.

## Test Plan

CI

## Release Plan

This is the backport.

## Links

None.