### PR TITLE
Address SOLC rate limiting

### DIFF
--- a/.github/actions/get-solc/action.yml
+++ b/.github/actions/get-solc/action.yml
@@ -1,20 +1,9 @@
 name: Get Solc
-description: Download `solc` tool.
-author: Pontem Network team
-branding:
-  icon: sunrise
-  color: purple
+description: Download `solc` from the Solidity Foundation's binary distribution.
 inputs:
   version:
     default: "latest"
     description: Solc version (ex. `v0.8.15` or default `latest`).
-    required: false
-  token:
-    description: GITHUB_TOKEN. Optional
-    required: false
-  prerelease:
-    default: "false"
-    description: Allow pre-release. False by default.
     required: false
 runs:
   using: "composite"
@@ -24,5 +13,3 @@ runs:
       shell: bash
       env:
         SOLC_VERSION: ${{inputs.version}}
-        SOLC_PRERELEASE: ${{inputs.prerelease}}
-        SECRET_TOKEN: ${{inputs.token}}

--- a/.github/actions/get-solc/solc_download.sh
+++ b/.github/actions/get-solc/solc_download.sh
@@ -1,180 +1,58 @@
 #!/bin/bash
+set -euo pipefail
 
-# ======================================================================================================================
-# Solc folder
-# ======================================================================================================================
+# CI runs on Linux x86-64. Sources binaries from the Solidity Foundation's
+# CDN-fronted distribution (used by Hardhat, Foundry's svm, solc-select,
+# py-solc-x, Remix) to avoid the unauthenticated GitHub API rate limit.
+BIN_HOST="https://binaries.soliditylang.org/linux-amd64"
+
 SOLC_FOLDER="$HOME/.solc"
-if [ ! -e $SOLC_FOLDER ]; then
-  echo "Create solc folder: $SOLC_FOLDER"
-  mkdir -p $SOLC_FOLDER
+mkdir -p "$SOLC_FOLDER"
+
+VERSION="${SOLC_VERSION:-${1:-latest}}"
+VERSION_NO_V="${VERSION#v}"
+
+LIST_PATH="$(mktemp)"
+trap 'rm -f "$LIST_PATH"' EXIT
+echo "Download: $BIN_HOST/list.json"
+curl -fsSL -o "$LIST_PATH" "$BIN_HOST/list.json"
+
+if [[ "$VERSION" == "latest" || "$VERSION" == "new" || "$VERSION" == "last" ]]; then
+  VERSION_NO_V=$(jq -r '.latestRelease' "$LIST_PATH")
+  VERSION="v$VERSION_NO_V"
 fi
 
-# ======================================================================================================================
-# Token
-# ======================================================================================================================
-if [[ -z $SECRET_TOKEN ]]; then
-  SECRET_TOKEN=""
-  if [[ ! -z $2 ]]; then
-    SECRET_TOKEN=$2
-  fi
-fi
-if [[ ! -z $SECRET_TOKEN ]]; then
-  echo "Token: ***"
+FILENAME=$(jq -r --arg v "$VERSION_NO_V" '.releases[$v] // empty' "$LIST_PATH")
+if [[ -z "$FILENAME" ]]; then
+  echo "Solc release $VERSION not found at $BIN_HOST/list.json"
+  exit 1
 fi
 
-# ======================================================================================================================
-# releases.json
-# ======================================================================================================================
-RELEASES_PATH="$SOLC_FOLDER/releases.json"
-if [ ! -e $RELEASES_PATH ] || [ $(($(date "+%s") - $(date -r $RELEASES_PATH "+%s"))) -ge 600 ]; then
-  echo "Download: releases.json"
-  if [ -z $SECRET_TOKEN ]; then
-    curl -sL -o "$RELEASES_PATH.tmp" \
-      -s https://api.github.com/repos/ethereum/solidity/releases
-  else
-    curl -sL -o "$RELEASES_PATH.tmp" \
-      -H "Authorization: Bearer ${SECRET_TOKEN}" \
-      -s https://api.github.com/repos/ethereum/solidity/releases
-  fi
-  mv "$RELEASES_PATH.tmp" $RELEASES_PATH
-fi
-
-# check release.json
-MESSAGE=$(jq '.message?' -r $RELEASES_PATH)
-if [[ ! -z $MESSAGE ]]; then
-  echo "Message: $MESSAGE"
-  rm $RELEASES_PATH
-  exit 5
-fi
-
-# ======================================================================================================================
-# pre-release (prerelease=true)
-# ======================================================================================================================
-if [[ -z $SOLC_PRERELEASE ]]; then
-  SOLC_PRERELEASE="false"
-  if [[ ! -z $3 ]]; then
-    SOLC_PRERELEASE=$3
-  fi
-else
-  if [ $SOLC_PRERELEASE != "true" ] && [ $SOLC_PRERELEASE != "false" ]; then
-    SOLC_PRERELEASE="false"
-  else
-    SOLC_PRERELEASE="true"
-  fi
-fi
-
-echo "Pre-release: $SOLC_PRERELEASE"
-
-SELECT_PRERELEASE=""
-if [ $SOLC_PRERELEASE == "false" ]; then
-  SELECT_PRERELEASE=".prerelease==false"
-else
-  SELECT_PRERELEASE="."
-fi
-
-# ======================================================================================================================
-# Solc VERSION
-# ======================================================================================================================
-VERSION=""
-if [[ ! -z $SOLC_VERSION ]]; then
-  VERSION=$SOLC_VERSION
-elif [[ ! -z $1 ]]; then
-  VERSION=$1
-fi
-if [[ $VERSION == "latest" || $VERSION == "new" || $VERSION == "last" || -z $VERSION ]]; then
-  # Get the latest VERSION
-  VERSION=$(cat "$RELEASES_PATH" | jq -r '.[] | select(("${SELECT_PRERELEASE}") and .tag_name) .tag_name' | head -n1)
-  if [[ -z $VERSION ]]; then
-    echo "{$VERSION|$SOLC_PRERELEASE} The specified version of solc was not found"
-    exit 6
-  fi
-else
-  if [ ! $(cat "$RELEASES_PATH" | jq ".[] | select("${SELECT_PRERELEASE}" and .tag_name==\"${VERSION}\") .tag_name") ]; then
-    echo "{$VERSION} The specified version of solc was not found"
-    exit 1
-  fi
-fi
-echo "version: $VERSION"
-
-if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "freebsd"* || "$OSTYPE" == "cygwin" ]]; then
-  NAME="solc-static-linux"
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  NAME="solc-macos"
-elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-  NAME="solc-windows.exe"
-else
-  echo "Unknown OS"
-  exit 2
-fi
-
-# ======================================================================================================================
-# Download
-# ======================================================================================================================
-DOWNLOAD_URL=$(
-  cat "$RELEASES_PATH" |
-    jq -r "
-    .[]
-    | select(${SELECT_PRERELEASE} and .tag_name==\"${VERSION}\") .assets
-    | .[]
-    | select(.name==\"${NAME}\")
-    | .browser_download_url
-  "
-)
-
-if [ -z $DOWNLOAD_URL ]; then
-  echo "Releases \"${VERSION}/${NAME}\" not found"
-  exit 3
-fi
+EXPECTED_SHA=$(jq -r --arg p "$FILENAME" '.builds[] | select(.path == $p) | .sha256 // empty' "$LIST_PATH")
+EXPECTED_SHA="${EXPECTED_SHA#0x}"
 
 VERSION_DIR="$SOLC_FOLDER/$VERSION"
-if [ ! -e $VERSION_DIR ]; then
-  if ! mkdir -p $VERSION_DIR; then
-    echo "Failed to create a directory ${VERSION_DIR}"
-    exit 7
+mkdir -p "$VERSION_DIR"
+# Keep the historical filename so the cache key and downstream symlink in
+# rust.yml continue to work without changes.
+FILE_PATH="$VERSION_DIR/solc-static-linux"
+
+if [[ ! -e "$FILE_PATH" ]]; then
+  echo "Download: $BIN_HOST/$FILENAME"
+  curl -fsSL -o "$FILE_PATH.tmp" "$BIN_HOST/$FILENAME"
+  if [[ -n "$EXPECTED_SHA" ]]; then
+    ACTUAL_SHA=$(sha256sum "$FILE_PATH.tmp" | awk '{print $1}')
+    if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
+      echo "SHA-256 mismatch for $FILENAME"
+      echo "  expected: $EXPECTED_SHA"
+      echo "  actual:   $ACTUAL_SHA"
+      rm -f "$FILE_PATH.tmp"
+      exit 1
+    fi
   fi
+  mv "$FILE_PATH.tmp" "$FILE_PATH"
 fi
 
-FILE_PATH="$VERSION_DIR/$NAME"
-if [ ! -e $FILE_PATH ]; then
-  echo "Download: $DOWNLOAD_URL"
-  if [ -z $SECRET_TOKEN ]; then
-    curl -sL --fail \
-      -H "Accept: application/octet-stream" \
-      -o "$FILE_PATH.tmp" \
-      -s $DOWNLOAD_URL
-  else
-    curl -sL --fail \
-      -H "Accept: application/octet-stream" \
-      -H "Authorization: Bearer ${SECRET_TOKEN}" \
-      -o "$FILE_PATH.tmp" \
-      -s $DOWNLOAD_URL
-  fi
-  mv "$FILE_PATH.tmp" $FILE_PATH
-fi
-
-echo "chmod 1755 $FILE_PATH"
-chmod 1755 $FILE_PATH
-echo "create link $FILE_PATH"
-echo "OS: ${OSTYPE}"
-
-if [[ "$OSTYPE" == "linux-gnu"* || "$OSTYPE" == "freebsd"* || "$OSTYPE" == "cygwin" ]]; then
-  mkdir -p $HOME/.local/bin
-  ln -sf "$FILE_PATH" $HOME/.local/bin/solc
-  echo "$HOME/.local/bin" >>$GITHUB_PATH
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  ln -sf "$FILE_PATH" /usr/local/bin/solc
-elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" ]]; then
-  mkdir -p "$HOME/.local/bin"
-  ln -sf "$FILE_PATH" "$HOME/.local/bin/solc"
-  echo "$HOME/.local/bin" >>$GITHUB_PATH
-else
-  echo "Unknown OS"
-  exit 4
-fi
-
-# ======================================================================================================================
-# run
-# ======================================================================================================================
-echo "run: $FILE_PATH --version"
-$FILE_PATH --version
-solc --version
+chmod 755 "$FILE_PATH"
+echo "version: $VERSION"
+"$FILE_PATH" --version


### PR DESCRIPTION
## Motivation

We often hit SOLC rate limiting in CI which is annoying.

## Proposal

Change the target to `binaries.soliditylang.org`.

Why this is likely to be a better target. It is used by other EVM projects:
* Hardhat
* Foundry svm-rs
* solc-select
* py-solc-x
* Remix IDE

So, if it were rate-limited they would have changed targets.

## Test Plan

CI is the point.

## Release Plan

Can be backported to `testnet_conway` if it works.

## Links

None.