### PR TITLE
Re-enable anvil_deposit_proof in CI with stabilization fixes.

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -108,3 +108,33 @@ jobs:
         env:
           RUSTFLAGS: ""
         run: cargo test -- --ignored --nocapture
+
+      - name: Install Foundry (provides `anvil`)
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: v1.7.0
+
+      - name: Ensure Solc Directory Exists
+        run: mkdir -p /home/runner/.solc
+      - name: Cache Solc
+        id: cache-solc
+        uses: actions/cache@v4
+        with:
+          path: /home/runner/.solc
+          key: solc-v0.8.33
+          restore-keys: solc-
+      - name: Get Solc
+        if: steps.cache-solc.outputs.cache-hit != 'true'
+        uses: ./.github/actions/get-solc
+        with:
+          version: v0.8.33
+      - name: Add Solc to PATH
+        run: echo "/home/runner/.solc" >> $GITHUB_PATH
+      - name: Create a Solc symbolic link
+        run: ln -sf /home/runner/.solc/v0.8.33/solc-static-linux /home/runner/.solc/solc
+
+      - name: Run anvil deposit-proof test
+        working-directory: linera-bridge
+        env:
+          RUSTFLAGS: ""
+        run: cargo test -p linera-bridge --test anvil_deposit_proof -- --ignored --nocapture

--- a/linera-bridge/tests/anvil_deposit_proof.rs
+++ b/linera-bridge/tests/anvil_deposit_proof.rs
@@ -73,8 +73,6 @@ contract MockERC20 {
 alloy_sol_types::sol! {
     function approve(address spender, uint256 amount) external returns (bool);
 
-    function registerFungibleApplicationId(bytes32 _fungibleApplicationId) external;
-
     function deposit(
         bytes32 target_chain_id,
         bytes32 target_application_id,
@@ -100,13 +98,19 @@ fn compile_contract(source_code: &str, file_name: &str, contract_name: &str) -> 
     .expect("solc compilation failed")
 }
 
+// Fixed gas budgets sized well above measured cost. Pinning these skips
+// the per-tx `eth_estimateGas` round-trip, which removes a CI-only race
+// where the simulation runs against a stale `latest` block before the
+// previous tx's state has propagated, surfacing as `extcodesize == 0`
+// reverts (`code: 3, data: 0x`) on typed external calls.
+const DEPLOY_GAS: u64 = 5_000_000;
+const CALL_GAS: u64 = 300_000;
+
 #[tokio::test]
 #[ignore] // Requires `anvil` and `solc`
 async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error>> {
-    // 1. Spawn Anvil
-    // Use Shanghai hardfork to avoid header field mismatches with older Anvil versions
-    // (Anvil v0.2.0 doesn't return all Cancun header fields via JSON-RPC).
-    let anvil = Anvil::new().arg("--hardfork").arg("shanghai").try_spawn()?;
+    // 1. Spawn Anvil targeting the Cancun EVM (Base's current hardfork).
+    let anvil = Anvil::new().arg("--hardfork").arg("cancun").try_spawn()?;
     let endpoint = anvil.endpoint();
 
     // Default Anvil account 0
@@ -118,17 +122,25 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
         .wallet(wallet)
         .connect_http(endpoint.parse()?);
 
+    // Probe readiness and cache chain id so per-tx fillers don't issue
+    // extra round-trips.
+    let chain_id = provider.get_chain_id().await?;
+
     // 2. Compile and deploy MockERC20
     let erc20_bytecode = compile_contract(MOCK_ERC20_SOL, "MockERC20.sol", "MockERC20");
     let initial_supply = U256::from(1_000_000_000u64);
     let mut erc20_deploy = erc20_bytecode;
     erc20_deploy.extend_from_slice(&(initial_supply,).abi_encode_params());
 
-    let tx = TransactionRequest::default().with_deploy_code(Bytes::from(erc20_deploy));
+    let tx = TransactionRequest::default()
+        .with_deploy_code(Bytes::from(erc20_deploy))
+        .with_chain_id(chain_id)
+        .with_gas_limit(DEPLOY_GAS);
     let receipt = provider.send_transaction(tx).await?.get_receipt().await?;
     let token_address = receipt.contract_address.ok_or("missing erc20 address")?;
 
-    // 3. Compile and deploy FungibleBridge
+    // 3. Compile and deploy FungibleBridge with the wrapped-fungible
+    // application ID baked into the constructor (immutable since #6173).
     let target_chain_id = B256::from([0xAA; 32]);
     let target_application_id = B256::from([0xBB; 32]);
 
@@ -148,21 +160,12 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
     let mut bridge_deploy = bridge_bytecode;
     bridge_deploy.extend_from_slice(&bridge_constructor);
 
-    let tx = TransactionRequest::default().with_deploy_code(Bytes::from(bridge_deploy));
+    let tx = TransactionRequest::default()
+        .with_deploy_code(Bytes::from(bridge_deploy))
+        .with_chain_id(chain_id)
+        .with_gas_limit(DEPLOY_GAS);
     let receipt = provider.send_transaction(tx).await?.get_receipt().await?;
     let bridge_address = receipt.contract_address.ok_or("missing bridge address")?;
-
-    // Register the wrapped-fungible application ID on the bridge.
-    // Since #5929 the application ID is set post-deployment via this call
-    // rather than through the constructor.
-    let register_data = registerFungibleApplicationIdCall {
-        _fungibleApplicationId: target_application_id,
-    }
-    .abi_encode();
-    let tx = TransactionRequest::default()
-        .to(bridge_address)
-        .input(register_data.into());
-    provider.send_transaction(tx).await?.get_receipt().await?;
 
     // 4. Approve bridge to spend tokens, then deposit
     let deposit_amount = U256::from(1_000_000u64);
@@ -175,7 +178,9 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
     .abi_encode();
     let tx = TransactionRequest::default()
         .to(token_address)
-        .input(approve_data.into());
+        .input(approve_data.into())
+        .with_chain_id(chain_id)
+        .with_gas_limit(CALL_GAS);
     provider.send_transaction(tx).await?.get_receipt().await?;
 
     let deposit_data = depositCall {
@@ -187,7 +192,9 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
     .abi_encode();
     let tx = TransactionRequest::default()
         .to(bridge_address)
-        .input(deposit_data.into());
+        .input(deposit_data.into())
+        .with_chain_id(chain_id)
+        .with_gas_limit(CALL_GAS);
     let deposit_receipt = provider.send_transaction(tx).await?.get_receipt().await?;
     let deposit_tx_hash = deposit_receipt.transaction_hash;
 

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -46,6 +46,7 @@ fn write_compilation_json(
   }},
   "settings": {{
     "viaIR": true,
+    "evmVersion": "cancun",
     {optimizer_block}"outputSelection": {{
       "*": {{
         "*": ["evm.bytecode"]


### PR DESCRIPTION
## Motivation

PR #6184 enabled this test in CI and was reverted in #6197 because the runs failed consistently with `code: 3, data: 0x` (empty-data revert).

## Proposal

This re-enables it with three fixes that together address the failure.

* Pre-fill `gas` and `chain_id` on every `TransactionRequest` and cache the chain id once after spawning Anvil. This skips the per-tx `eth_estimateGas` round-trip, which on a contended runner was racing against `latest` and surfacing as `extcodesize == 0` reverts (empty data) on typed external calls.

* Pin the solc target to `evmVersion: cancun` and switch Anvil from `--hardfork shanghai` to `--hardfork cancun`. Cancun matches the EVM Base currently runs, and pinning makes the bytecode independent of whatever default future solc releases ship with. The obsolete comment about Anvil v0.2.0 missing Cancun header fields is removed. We set it up to `cancun` because this is the version used by `base`.

* Pin `foundry-toolchain@v1` to `version: v1.7.0` instead of drifting with `stable`.

Also drops the orphan `registerFungibleApplicationId` ABI binding and call left over after #6173 made `fungibleApplicationId` an immutable constructor argument and removed the setter.

## Test Plan

CI is the point.

## Release Plan

Can be backported to `testnet_conway` when we are confident that it is correct.

## Links

None