### PR TITLE
Use the `Epoch` type for linera epochs.

### DIFF
--- a/linera-bridge/src/evm/light_client.rs
+++ b/linera-bridge/src/evm/light_client.rs
@@ -54,7 +54,7 @@ mod tests {
             &call,
         );
 
-        assert_eq!(light_client.query_current_epoch(), 1);
+        assert_eq!(light_client.query_current_epoch(), Epoch(1));
     }
 
     #[test]
@@ -471,14 +471,14 @@ mod tests {
             )
         }
 
-        fn query_current_epoch(&mut self) -> u32 {
+        fn query_current_epoch(&mut self) -> Epoch {
             let (epoch, _, _) = call_contract(
                 &mut self.db,
                 self.deployer,
                 self.contract,
                 &currentEpochCall {},
             );
-            epoch
+            Epoch(epoch)
         }
 
         fn verify_block(&mut self, data: Vec<u8>) {
@@ -549,7 +549,7 @@ mod tests {
             &call,
         );
 
-        assert_eq!(light_client.query_current_epoch(), 1);
+        assert_eq!(light_client.query_current_epoch(), Epoch(1));
     }
 
     #[test]
@@ -625,7 +625,7 @@ mod tests {
             &call,
         );
 
-        assert_eq!(light_client.query_current_epoch(), 1);
+        assert_eq!(light_client.query_current_epoch(), Epoch(1));
     }
 
     /// Creates a committee blob with multiple validators and returns `(committee_bytes, blob_hash)`.

--- a/linera-bridge/src/relay/committee.rs
+++ b/linera-bridge/src/relay/committee.rs
@@ -55,9 +55,8 @@ pub async fn relay_committee<P: Provider>(
 }
 
 /// Catches up the LightClient with any committee updates missed while offline.
-/// Scans admin chain blocks from height 0 and relays committees newer than the
-/// LightClient's current epoch. Must succeed before the relay enters the main
-/// serve loop.
+/// Scans admin chain blocks and relays committees newer than the LightClient's
+/// current epoch. Must succeed before the relay enters the main serve loop.
 pub async fn catch_up<S, P>(
     storage: &S,
     evm_client: &EvmClient<P>,
@@ -69,13 +68,12 @@ where
     P: Provider,
 {
     let current_epoch = match evm_client.get_current_epoch().await {
-        Ok(epoch) => Epoch(epoch),
+        Ok(epoch) => epoch,
         Err(e) => {
             tracing::info!("LightClient not initialized yet, skipping catch-up: {e:#}");
             return Ok(());
         }
     };
-
     tracing::info!(
         %current_epoch,
         %admin_chain_id,
@@ -83,12 +81,12 @@ where
         "Checking for missed committee updates"
     );
 
-    if admin_chain_height == BlockHeight(0) {
+    let heights: Vec<BlockHeight> = (0..admin_chain_height.0).map(BlockHeight).collect();
+
+    if heights.is_empty() {
         tracing::info!("No admin chain blocks to scan");
         return Ok(());
     }
-
-    let heights: Vec<BlockHeight> = (0..admin_chain_height.0).map(BlockHeight).collect();
 
     let certs = storage
         .read_certificates_by_heights(admin_chain_id, &heights)

--- a/linera-bridge/src/relay/committee.rs
+++ b/linera-bridge/src/relay/committee.rs
@@ -55,8 +55,9 @@ pub async fn relay_committee<P: Provider>(
 }
 
 /// Catches up the LightClient with any committee updates missed while offline.
-/// Scans admin chain blocks and relays committees newer than the LightClient's
-/// current epoch. Must succeed before the relay enters the main serve loop.
+/// Scans admin chain blocks from height 0 and relays committees newer than the
+/// LightClient's current epoch. Must succeed before the relay enters the main
+/// serve loop.
 pub async fn catch_up<S, P>(
     storage: &S,
     evm_client: &EvmClient<P>,
@@ -68,25 +69,26 @@ where
     P: Provider,
 {
     let current_epoch = match evm_client.get_current_epoch().await {
-        Ok(epoch) => epoch,
+        Ok(epoch) => Epoch(epoch),
         Err(e) => {
             tracing::info!("LightClient not initialized yet, skipping catch-up: {e:#}");
             return Ok(());
         }
     };
+
     tracing::info!(
-        current_epoch,
+        %current_epoch,
         %admin_chain_id,
         %admin_chain_height,
         "Checking for missed committee updates"
     );
 
-    let heights: Vec<BlockHeight> = (0..admin_chain_height.0).map(BlockHeight).collect();
-
-    if heights.is_empty() {
+    if admin_chain_height == BlockHeight(0) {
         tracing::info!("No admin chain blocks to scan");
         return Ok(());
     }
+
+    let heights: Vec<BlockHeight> = (0..admin_chain_height.0).map(BlockHeight).collect();
 
     let certs = storage
         .read_certificates_by_heights(admin_chain_id, &heights)
@@ -95,7 +97,7 @@ where
     let mut relayed = 0u32;
     for cert in certs.into_iter().flatten() {
         if let Some((epoch, blob_hash)) = find_create_committee(&cert) {
-            if epoch.0 <= current_epoch {
+            if epoch <= current_epoch {
                 continue;
             }
             let blob_id = BlobId::new(blob_hash, BlobType::Committee);

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -11,6 +11,7 @@ use alloy::{
 };
 use alloy_sol_types::SolCall;
 use anyhow::{Context as _, Result};
+use linera_base::data_types::Epoch;
 
 use crate::proof::deposit_event_signature;
 
@@ -152,7 +153,7 @@ impl<P: Provider> EvmClient<P> {
     }
 
     /// Queries the LightClient's current epoch.
-    pub async fn get_current_epoch(&self) -> Result<u32> {
+    pub async fn get_current_epoch(&self) -> Result<Epoch> {
         let lc_addr = self.get_light_client_address().await?;
         let call = currentEpochCall {};
         let tx = alloy::rpc::types::TransactionRequest::default()
@@ -165,7 +166,7 @@ impl<P: Provider> EvmClient<P> {
             .context("failed to query LightClient.currentEpoch()")?;
         let epoch = currentEpochCall::abi_decode_returns(&result)
             .context("failed to decode currentEpoch response")?;
-        Ok(epoch)
+        Ok(Epoch(epoch))
     }
 
     /// Relays a committee update to the LightClient contract.


### PR DESCRIPTION
## Motivation

Linera epochs have their own types, "Epoch".
We can use them in `linera-bridge`.

## Proposal

Do the change

## Test Plan

CI

## Release Plan

Can be backported to `testnet_conway`.

## Links

None