### PR TITLE
Cancun hardfork anvil in docker-compose tests

### DIFF
--- a/docker/docker-compose.bridge-test.yml
+++ b/docker/docker-compose.bridge-test.yml
@@ -2,7 +2,7 @@ services:
   # 0. Anvil - local EVM node for LightClient contract
   anvil:
     image: ghcr.io/foundry-rs/foundry:stable
-    entrypoint: ["anvil", "--host", "0.0.0.0", "--code-size-limit", "300000", "--hardfork", "shanghai", "--slots-in-an-epoch", "1", "--block-time", "1"]
+    entrypoint: ["anvil", "--host", "0.0.0.0", "--code-size-limit", "300000", "--hardfork", "cancun", "--slots-in-an-epoch", "1", "--block-time", "1"]
     ports:
       - "${ANVIL_PORT:-8545}:8545"
     healthcheck:


### PR DESCRIPTION
## Motivation

Anvil tests were updated to use `cancun` hardfork but docker-compose wasn't.

## Proposal

Use `--hardfork cancun` in there as well.

## Test Plan

CI

## Release Plan

- These changes should be backported to `main`.

## Links

https://github.com/linera-io/linera-protocol/pull/6209#discussion_r3177090962
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
