### PR TITLE
Log linera-base `ChainId` instead of proto field.

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -1004,7 +1004,7 @@ where
         err,
         fields(
             nickname = self.state.nickname(),
-            chain_id = ?request.get_ref().chain_id
+            chain_id = ?request.get_ref().chain_id()
         )
     )]
     async fn handle_pending_blob(


### PR DESCRIPTION
## Motivation


The instrument attribute is formatting the protobuf-generated `Option<api::ChainId>` field, which Debug-prints as a byte array, instead of calling the `GrpcProxyable::chain_id()` method that returns `Option<linera_base::…::ChainId>` (hex via `Debug`).

## Proposal

Use `chain_id()`, which converts it, instead of the `chain_id` field.

## Test Plan

CI
Logs should be more readable now.

## Release Plan

- Backport to `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
