### PR TITLE
Log linera-base `ChainId` instead of proto field. (#6217)

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -1006,7 +1006,7 @@ where
         err,
         fields(
             nickname = self.state.nickname(),
-            chain_id = ?request.get_ref().chain_id
+            chain_id = ?request.get_ref().chain_id()
         )
     )]
     async fn handle_pending_blob(
@@ -1037,7 +1037,7 @@ where
         err,
         fields(
             nickname = self.state.nickname(),
-            chain_id = ?request.get_ref().chain_id
+            chain_id = ?request.get_ref().chain_id()
         )
     )]
     async fn previous_event_blocks(


### PR DESCRIPTION
Backport of #6217 

## Motivation

The instrument attribute is formatting the protobuf-generated `Option<api::ChainId>` field, which Debug-prints as a byte array, instead of calling the `GrpcProxyable::chain_id()` method that returns `Option<linera_base::…::ChainId>` (hex via `Debug`).

## Proposal

Use `chain_id()`, which converts it, instead of the `chain_id` field.

## Test Plan

CI
Logs should be more readable now.

## Release Plan

- Release SDK.
- Hotfix validators.
 
## Links

- PR to `main`: #6217
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
