### PR TITLE
Patch build.bash to work locally, without wasm-split

### DIFF
--- a/web/@linera/client/build.bash
+++ b/web/@linera/client/build.bash
@@ -37,10 +37,14 @@ wasm-bindgen \
     --keep-debug \
     --split-linked-modules
 
-wasm-split \
-    src/wasm/index_bg.wasm \
-    --strip \
-    --debug-out src/wasm/index_bg.debug.wasm
+if command -v wasm-split >/dev/null; then
+    wasm-split \
+        src/wasm/index_bg.wasm \
+        --strip \
+        --debug-out src/wasm/index_bg.debug.wasm
+else
+    echo "wasm-split not found, skipping (debug wasm and stripping disabled)" >&2
+fi
 
 mkdir -p dist
 cp -r src/wasm dist/


### PR DESCRIPTION
## Motivation

Right now the `build.bash` – building `linera-web` – doesn't work locally due to missing `wasm-split`.

## Proposal

Fix this by detecting whether it's installed before it's run.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
