### PR TITLE
docs: rephrase operators pointer for first-time readers

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -60,7 +60,7 @@
 
 # Node Operators
 
-- [Validator deployment (moved)](operators.md)
+- [Node Operators](operators.md)
 
 ---
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -14,12 +14,10 @@ This documentation is split into two main parts:
    [developers](developers/getting_started.md) building applications using the
    Linera Rust SDK.
 
-Validator-operator documentation has moved to a dedicated site at
-<https://docs.infra.linera.net/>. The matching deployment artifacts
-(Helm charts, docker-compose stack, deploy scripts) live at
-<https://github.com/linera-io/linera-artifacts>. The
-[Node Operators](operators.md) page in this manual now just redirects
-there.
+If you operate a Linera validator, the [Node Operators](operators.md)
+section points to a dedicated site at <https://docs.infra.linera.net/>,
+with deployment artifacts (Helm charts, Docker Compose stack, deploy
+scripts) at <https://github.com/linera-io/linera-artifacts>.
 
 > **NEW: Publish and test your Web3 application on the Linera Testnet!**
 >


### PR DESCRIPTION
## Summary

* Rewrites the front-page paragraph in `docs/introduction.md` so it no longer reads as a migration notice ("has moved to", "now just redirects there"). For a first-time reader, the migration history is irrelevant — they care about what's where.
* Drops the `(moved)` suffix from the sidebar entry in `docs/SUMMARY.md`; the entry is now just `Node Operators`.
* `docs/operators.md` is unchanged — it remains the meta-refresh page added in #6194.

Closes #6231

## Test plan

* `mdbook build` locally renders the new front-page paragraph and the cleaned-up sidebar entry without warnings.
* `docs/operators.md` still meta-refreshes to https://docs.infra.linera.net/.
* No behavioural change for the existing `[output.html.redirect]` rules in `mdbook/book.toml`.

Once merged, `linera-io/linera-documentation` will bump its submodule pin to pick this up alongside the operators redirect fix from #6194 (tracked in linera-documentation#254 / PR linera-documentation#255).