### PR TITLE
Split QueueView and BucketQueueView into separate gungraun benchmark groups

### DIFF
--- a/.github/scripts/format-bench-results.sh
+++ b/.github/scripts/format-bench-results.sh
@@ -73,7 +73,8 @@ fmt_cell() {
 group_label() {
   case "$1" in
     map_view_group)                    echo "MapView" ;;
-    queue_view_group)                  echo "QueueView / BucketQueueView" ;;
+    queue_view_group)                  echo "QueueView" ;;
+    bucket_queue_view_group)           echo "BucketQueueView" ;;
     register_view_group)               echo "RegisterView" ;;
     collection_view_group)             echo "CollectionView" ;;
     reentrant_collection_view_group)   echo "ReentrantCollectionView" ;;

--- a/linera-views/benches/gungraun_views.rs
+++ b/linera-views/benches/gungraun_views.rs
@@ -624,7 +624,12 @@ library_benchmark_group!(
         bench_queue_push_back,
         bench_queue_front,
         bench_queue_delete_front,
-        bench_queue_pre_save,
+        bench_queue_pre_save
+);
+
+library_benchmark_group!(
+    name = bucket_queue_view_group;
+    benchmarks =
         bench_bucket_queue_push_back,
         bench_bucket_queue_front,
         bench_bucket_queue_delete_front,
@@ -673,6 +678,7 @@ main!(
     library_benchmark_groups =
         map_view_group,
         queue_view_group,
+        bucket_queue_view_group,
         register_view_group,
         collection_view_group,
         reentrant_collection_view_group,


### PR DESCRIPTION
## Motivation

The instruction-count benchmark report from `gungraun_views` currently bundles `QueueView` and `BucketQueueView` results into a single section titled "QueueView / BucketQueueView". Because the per-bench IDs (`push_1000`, `front_100_from_1000`, `delete_500_from_1000`, `pre_save_1000`) are reused across both view families, the rendered table contains duplicate row names with no per-row label, making it impossible to tell from the report which view a result belongs to. This came up while reviewing the +1.85% `front_100_from_1000` regression on #6220.

## Proposal

- `linera-views/benches/gungraun_views.rs`: split the existing `queue_view_group` so that `bench_queue_*` stays in `queue_view_group` and `bench_bucket_queue_*` moves into a new `bucket_queue_view_group`. Register the new group in `main!(library_benchmark_groups = …)`.
- `.github/scripts/format-bench-results.sh`: update `group_label()` so `queue_view_group → "QueueView"` and `bucket_queue_view_group → "BucketQueueView"`. The CI report will then have two distinct sections, each with the four per-bench rows under a single, unambiguous header.

No benchmark logic, IDs, or setups change — only group membership and section labels.

## Test Plan

- `cargo bench -p linera-views --bench gungraun_views --no-run` builds clean.
- `cargo clippy -p linera-views --benches --all-features -- -D warnings` is clean.
- `cargo fmt --check -p linera-views` is clean.
- `bash -n .github/scripts/format-bench-results.sh` syntax OK.
- The full report rendering (valgrind + comparison against a `main` baseline) only runs in CI; the next CI run on this PR will confirm the table renders with two separate sections.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Follow-up to #6220 review discussion.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)