### PR TITLE
Tighten URI validation in extract_grpc_method_name.

### DIFF
--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -56,7 +56,7 @@ pub const ERROR_TYPE_LABEL: &str = "error_type";
 /// input being recorded verbatim as a Prometheus label value.
 const MAX_PROTO_IDENT_LEN: usize = 128;
 
-/// Returns `true` if `s` is a valid protobuf identifier (`[A-Za-z_][A-Za-z0-9_]*`)
+/// Returns `true` if `s` is a valid protobuf identifier (`[A-Za-z][A-Za-z0-9_]*`)
 /// within the length cap.
 fn is_proto_identifier(s: &str) -> bool {
     if s.is_empty() || s.len() > MAX_PROTO_IDENT_LEN {
@@ -64,10 +64,7 @@ fn is_proto_identifier(s: &str) -> bool {
     }
     let mut bytes = s.bytes();
     let first = bytes.next().expect("non-empty checked above");
-    if !first.is_ascii_alphabetic() && first != b'_' {
-        return false;
-    }
-    bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    first.is_ascii_alphabetic() && bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
 }
 
 /// Returns `true` if `s` is a fully-qualified proto Service-Name: two or more
@@ -179,6 +176,16 @@ mod method_name_tests {
         assert_eq!(extract_grpc_method_name("/foo.bar/Method-x"), "non_grpc");
         assert_eq!(extract_grpc_method_name("/foo.bar/Method?x"), "non_grpc");
         assert_eq!(extract_grpc_method_name("/foo.bar/.Method"), "non_grpc");
+    }
+
+    #[test]
+    fn identifier_starting_with_underscore_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo.bar/_Method"), "non_grpc");
+        assert_eq!(extract_grpc_method_name("/_foo.bar/Method"), "non_grpc");
+        assert_eq!(
+            extract_grpc_method_name("/foo.bar/________________"),
+            "non_grpc"
+        );
     }
 
     #[test]

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -70,11 +70,17 @@ fn is_proto_identifier(s: &str) -> bool {
     bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
 }
 
-/// Returns `true` if `s` is a fully-qualified proto Service-Name, i.e. one or more
-/// proto identifiers joined by dots with at least one dot (`package.Service` or
-/// `outer.inner.Service`).
+/// Returns `true` if `s` is a fully-qualified proto Service-Name: two or more
+/// proto identifiers joined by dots, e.g. `package.Service` or `outer.inner.Service`.
 fn is_proto_service_name(s: &str) -> bool {
-    s.contains('.') && s.split('.').all(is_proto_identifier)
+    let mut parts = s.split('.');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    let Some(second) = parts.next() else {
+        return false;
+    };
+    is_proto_identifier(first) && is_proto_identifier(second) && parts.all(is_proto_identifier)
 }
 
 /// Extracts the gRPC method name from a request URI path.

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -51,15 +51,47 @@ pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
 /// Prometheus label for the error variant name, e.g. `"WorkerError::UnexpectedBlockHeight"`.
 pub const ERROR_TYPE_LABEL: &str = "error_type";
 
+/// Maximum length of a single proto identifier accepted as a service or method name.
+/// Real proto identifiers are far shorter than this; the cap guards against attacker
+/// input being recorded verbatim as a Prometheus label value.
+const MAX_PROTO_IDENT_LEN: usize = 128;
+
+/// Returns `true` if `s` is a valid protobuf identifier (`[A-Za-z_][A-Za-z0-9_]*`)
+/// within the length cap.
+fn is_proto_identifier(s: &str) -> bool {
+    if s.is_empty() || s.len() > MAX_PROTO_IDENT_LEN {
+        return false;
+    }
+    let mut bytes = s.bytes();
+    let first = bytes.next().expect("non-empty checked above");
+    if !first.is_ascii_alphabetic() && first != b'_' {
+        return false;
+    }
+    bytes.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+/// Returns `true` if `s` is a fully-qualified proto Service-Name, i.e. one or more
+/// proto identifiers joined by dots with at least one dot (`package.Service` or
+/// `outer.inner.Service`).
+fn is_proto_service_name(s: &str) -> bool {
+    s.contains('.') && s.split('.').all(is_proto_identifier)
+}
+
 /// Extracts the gRPC method name from a request URI path.
 ///
-/// gRPC paths have the form `/{package}.{Service}/{Method}` — the first segment
-/// always contains a dot. Non-gRPC requests (health checks, bot probes, etc.) return
-/// `"non_grpc"` to prevent unbounded label cardinality.
+/// gRPC paths follow the HTTP/2 form `"/" Service-Name "/" {method name}`, where
+/// `Service-Name` is `{proto package} "." {service name}` and the method name is a
+/// single proto identifier. Anything that does not match this exact shape — health
+/// probes, browser requests, bot scans probing for `.env` files, etc. — is mapped
+/// to `"non_grpc"` so the value is safe to use as a Prometheus label without
+/// blowing up cardinality or label-value length.
 pub fn extract_grpc_method_name(path: &str) -> &str {
-    let parts: Vec<&str> = path.splitn(3, '/').collect();
-    if parts.len() == 3 && parts[1].contains('.') {
-        parts[2]
+    let mut parts = path.splitn(3, '/');
+    let (Some(""), Some(service), Some(method)) = (parts.next(), parts.next(), parts.next()) else {
+        return "non_grpc";
+    };
+    if is_proto_service_name(service) && is_proto_identifier(method) {
+        method
     } else {
         "non_grpc"
     }
@@ -111,5 +143,62 @@ mod method_name_tests {
     #[test]
     fn empty_path() {
         assert_eq!(extract_grpc_method_name(""), "non_grpc");
+    }
+
+    #[test]
+    fn dot_env_bot_scan_does_not_leak_into_label() {
+        assert_eq!(
+            extract_grpc_method_name(
+                "/.env.local/.env.production/.env.staging/.env.development/.env.test"
+            ),
+            "non_grpc"
+        );
+    }
+
+    #[test]
+    fn service_starting_with_dot_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/.foo.bar/Method"), "non_grpc");
+    }
+
+    #[test]
+    fn method_with_extra_path_segments_is_rejected() {
+        assert_eq!(
+            extract_grpc_method_name("/foo.bar/Method/extra"),
+            "non_grpc"
+        );
+    }
+
+    #[test]
+    fn method_with_invalid_characters_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo.bar/Method-x"), "non_grpc");
+        assert_eq!(extract_grpc_method_name("/foo.bar/Method?x"), "non_grpc");
+        assert_eq!(extract_grpc_method_name("/foo.bar/.Method"), "non_grpc");
+    }
+
+    #[test]
+    fn empty_method_segment_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo.bar/"), "non_grpc");
+    }
+
+    #[test]
+    fn empty_service_segment_is_rejected() {
+        assert_eq!(extract_grpc_method_name("//Method"), "non_grpc");
+    }
+
+    #[test]
+    fn service_with_consecutive_dots_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo..bar/Method"), "non_grpc");
+    }
+
+    #[test]
+    fn overlong_method_is_rejected() {
+        let long_method = "M".repeat(MAX_PROTO_IDENT_LEN + 1);
+        let path = format!("/foo.bar/{long_method}");
+        assert_eq!(extract_grpc_method_name(&path), "non_grpc");
+    }
+
+    #[test]
+    fn path_without_leading_slash_is_rejected() {
+        assert_eq!(extract_grpc_method_name("foo.bar/Method"), "non_grpc");
     }
 }


### PR DESCRIPTION
## Motivation

The `linera-proxy` and validator gRPC server record the gRPC method name as a Prometheus label (`linera_proxy_request_*{method_name=...}` and the symmetric server-side metrics). The previous `extract_grpc_method_name` only required `parts[1]` to contain a `.`, so any path with a dotted segment passed through. Internet bot scans probing for `.env` files (path like `/.env.local/.env.production/.env.staging/...`) made it through that check, and the entire tail of the path landed in `parts[2]` and was used verbatim as the label value.

Mimir rejects values longer than its `max_label_value_length` (default 2048) with `err-mimir-label-value-too-long` (HTTP 400), which trips `prometheus_remote_storage_samples_failed_total` and the `AlloyRemoteWriteFailures` alert. Even without the length cap, attacker-shaped paths are a cardinality bomb in `method_name`.

## Proposal

Replace the `parts[1].contains(.)` heuristic with a strict gRPC URI parse:
- Path must be `"/" Service-Name "/" {method name}`.
- Service-Name must be one or more proto identifiers joined by dots, with at least one dot (so `package.Service` qualifies, but `.env.local` does not — a leading dot makes the first split component empty and fails the identifier check).
- Method name must be a single proto identifier.
- Both length-capped at 128 bytes as belt-and-braces.

Anything outside this shape returns `"non_grpc"`, the existing fallback. External contract, return type, and callers are unchanged.

Side effect: per-call `Vec<&str>` allocation removed (zero-alloc destructured `splitn` iterator).

## Test Plan

CI. Added 9 unit tests covering the bot-scan input, leading-dot service, extra path segments, invalid characters, empty segments, consecutive dots, an overlong method, and a missing leading slash. Existing positive tests stay green.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
