### PR TITLE
Setup sh slimdown

### DIFF
--- a/docker/docker-compose.bridge-testnet.yml
+++ b/docker/docker-compose.bridge-testnet.yml
@@ -3,7 +3,8 @@
 # Defaults match the testnet host layout (env at /etc/linera-bridge,
 # data at /var/lib/linera-bridge). Override RELAYER_ENV_FILE,
 # RELAYER_ENV_SECRET, RELAYER_DATA_DIR to reuse this compose file
-# from a developer machine.
+# from a developer machine pointing at a real network — see
+# examples/bridge-demo/spawn-relayer.sh.
 #
 # Prerequisites (testnet operator does this once on the VM):
 #   1. Create /var/lib/linera-bridge (data) and /etc/linera-bridge (env)

--- a/examples/bridge-demo/README.md
+++ b/examples/bridge-demo/README.md
@@ -104,140 +104,70 @@ make demo-logs   # tail relay logs
 make down        # stop everything and remove volumes
 ```
 
-## Testnet / direct mode
+## Spawn just the relayer (against an external network)
 
-For real network deployments, run everything directly on the host instead of
-through Docker.
+When you already have contracts deployed on a real EVM (e.g. Base Sepolia)
+and apps published on a real Linera network (e.g. testnet Conway), and you
+just want to run the relayer locally pointing at those artifacts, use
+`spawn-relayer.sh`. It does **not** deploy or register anything — operator
+supplies a pre-built env file and a pre-populated data directory.
 
-### Prerequisites
-
-- [Foundry](https://book.getfoundry.sh/getting-started/installation) (`forge`, `cast`)
-- `linera` CLI (built from this repo or installed)
-- `linera-bridge` CLI: `cargo build -p linera-bridge --features relay`
-- pnpm (for the frontend)
-- A funded EVM account (private key with ETH for gas)
-- An EVM RPC endpoint (e.g. Base Sepolia)
-- A running Linera testnet with faucet
-
-### 1. Build the Wasm binaries
-
-From the `linera-bridge/` directory:
-
-```bash
-make build-wasm
-```
-
-This compiles `fungible`, `wrapped-fungible`, and `evm-bridge` to
-`examples/target/wasm32-unknown-unknown/release/`.
-
-### 2. Initialize wallet and claim a bridge chain
-
-```bash
-export FAUCET_URL=https://faucet.testnet-conway.linera.net
-
-# Initialize a Linera wallet from the faucet
-linera wallet init --faucet "$FAUCET_URL"
-
-# Claim a chain that the relay will use as the "bridge chain"
-linera wallet request-chain --faucet "$FAUCET_URL"
-```
-
-Note the **chain ID** and **owner** printed by `request-chain` — you'll need
-them for both the setup script and the relay.
-
-### 3. Deploy contracts
-
-Pick a shared directory for coordination files between the setup script and
-the relay:
-
-```bash
-export SHARED_DIR="/tmp/bridge-demo-$(date +%Y%m%d-%H%M%S)"
-mkdir -p "$SHARED_DIR"
-```
-
-Run the setup script to deploy EVM contracts and Linera apps:
+For full local development (anvil + local validator + frontend) use
+`make demo` from `linera-bridge/` instead — that's what `setup.sh` is for.
 
 ```bash
 cd examples/bridge-demo
-
-./setup.sh \
-  --evm-rpc-url https://base-sepolia.g.alchemy.com/v2/YOUR_KEY \
-  --evm-private-key 0x... \
-  --evm-chain-id 84532 \
-  --linera-bridge-chain-id <CHAIN_ID> \
-  --relay-owner <OWNER> \
-  --faucet-url "$FAUCET_URL" \
-  --linera-wallet ~/.config/linera/wallet.json \
-  --linera-keystore ~/.config/linera/keystore.json \
-  --linera-storage rocksdb:~/.config/linera/client.db \
-  --shared-dir "$SHARED_DIR"
+./spawn-relayer.sh \
+  --env-file /path/to/relayer.env \
+  --env-secret-file /path/to/relayer.env.secret \
+  --data-dir /path/to/wallet-host-dir
 ```
 
-The setup script:
-1. Fetches validator info and deploys the **LightClient** contract
-2. Deploys a **MockERC20** token (or pass `--token-address` to use an existing one)
-3. Publishes **wrapped-fungible** and **evm-bridge** apps on the bridge chain
-4. Deploys the **FungibleBridge** contract (referencing LightClient + apps)
-5. Funds the bridge with ERC-20 tokens
-6. Writes contract/app addresses to `$SHARED_DIR` (relay picks them up) and
-   `.env.local` (frontend reads them)
+Internally this is `docker compose -f docker/docker-compose.bridge-testnet.yml up -d relayer`
+with the env-file + data-dir paths injected via `RELAYER_ENV_FILE`,
+`RELAYER_ENV_SECRET`, `RELAYER_DATA_DIR`.
 
-### 4. Start the relay
+The env file must contain the keys consumed by `bridge-entrypoint.sh`:
 
-The relay uses the same wallet, keystore, and storage as the `linera` CLI.
-By default it reads from `~/.config/linera/` — the same location `linera
-wallet init` writes to. You can override with `--wallet`, `--keystore`,
-`--storage` flags or `LINERA_WALLET`, `LINERA_KEYSTORE`, `LINERA_STORAGE`
-env vars.
-
-Pass the contract addresses and app IDs from the setup script output:
-
-```bash
-linera-bridge serve \
-  --rpc-url <evm-rpc> \
-  --faucet-url "$FAUCET_URL" \
-  --linera-bridge-chain-id <chain-id> \
-  --linera-bridge-address <bridge-app-id-on-linera> \
-  --linera-fungible-address <fungible-app-id-on-linera> \
-  --evm-bridge-address <bridge-contract-address-on-evm> \
-  --evm-private-key <relayer-private-key>
+```
+RPC_URL=https://sepolia.base.org
+FAUCET_URL=https://faucet.testnet-conway.linera.net
+EVM_BRIDGE_ADDRESS=0x...
+LINERA_BRIDGE_APP=...
+LINERA_FUNGIBLE_APP=...
+LINERA_BRIDGE_CHAIN_ID=...
+LINERA_BRIDGE_CHAIN_OWNER=...
+LINERA_WALLET=/data/wallet.json
+LINERA_KEYSTORE=/data/keystore.json
+LINERA_STORAGE=rocksdb:/data/client.db
+MONITOR_SCAN_INTERVAL=30
+MONITOR_START_BLOCK=0
+MAX_RETRIES=10
+PORT=3001
 ```
 
-On restart, run the same command — the relay loads persistent state from
-the wallet and storage, and syncs from validators to catch up.
+Plus `EVM_PRIVATE_KEY=0x...` in the secret env file.
 
-### 5. Start the frontend
+The data dir is bind-mounted at `/data` in the container and must already
+contain `wallet.json`, `keystore.json`, and `client.db` for a wallet that
+owns the bridge chain on the target Linera network.
 
-```bash
-pnpm install && pnpm dev
-```
+For a production testnet deployment runbook see
+[`docker/README.testnet.md`](../../docker/README.testnet.md).
 
-Open <http://localhost:5173>, connect MetaMask to your EVM network, and use
-the deposit/withdraw forms.
+### Setup script flags (Docker mode)
 
-### Setup script flags
-
-| Flag | Default (Docker) | Default (Direct) | Description |
-|------|-------------------|-------------------|-------------|
-| `--compose-file PATH` | -- | -- | Enables Docker mode |
-| `--evm-rpc-url URL` | `http://anvil:8545` | `http://localhost:8545` | EVM JSON-RPC endpoint |
-| `--evm-private-key KEY` | Anvil account 0 | **required** | Private key for EVM txs |
-| `--evm-chain-id ID` | 31337 | 31337 | EVM chain ID |
-| `--light-client-address ADDR` | read from `/shared/` | deployed if omitted | Skip LightClient deploy |
-| `--linera-bridge-chain-id ID` | polled from relay | **required** | Linera bridge chain (64 hex chars) |
-| `--token-address ADDR` | deployed | deployed | Skip MockERC20 deploy |
-| `--relay-owner OWNER` | read from `/shared/` | **required** | Relay's AccountOwner (minter) |
-| `--faucet-url URL` | `http://localhost:8080` | `http://localhost:8080` | Linera faucet |
-| `--relay-url URL` | `http://localhost:3001` | `http://localhost:3001` | Relay HTTP endpoint |
-| `--ticker-symbol SYM` | wTT | wTT | Wrapped token ticker |
-| `--fund-amount WEI` | 500e18 | 500e18 | Fund bridge with ERC-20; 0 to skip |
-| `--shared-dir PATH` | auto (`/tmp/bridge-demo-*`) | auto | Shared state directory for relay coordination |
-| `--wasm-dir PATH` | `/wasm` | `../../examples/target/wasm32-unknown-unknown/release` | Directory with `.wasm` binaries |
-| `--contracts-dir PATH` | `/contracts` | `../../linera-bridge/src/solidity` | Solidity source root |
-| `--output PATH` | `.env.local` | `.env.local` | Output env file |
-| `--linera-wallet PATH` | -- | auto (temp dir) | Path to existing Linera wallet.json |
-| `--linera-keystore PATH` | -- | auto (temp dir) | Path to existing Linera keystore.json |
-| `--linera-storage CONFIG` | -- | auto (temp dir) | Linera storage config (e.g. `rocksdb:path/to/db`) |
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--compose-file PATH` | **required** | Docker Compose file |
+| `--faucet-url URL` | `http://localhost:8080` | Linera faucet |
+| `--relay-url URL` | `http://localhost:3001` | Relay HTTP endpoint |
+| `--ticker-symbol SYM` | wTT | Wrapped token ticker |
+| `--fund-amount WEI` | 500e18 | Fund bridge with ERC-20; 0 to skip |
+| `--shared-dir PATH` | auto (`/tmp/bridge-demo-*`) | Shared state directory for relay coordination |
+| `--wasm-dir PATH` | `/wasm` | Directory with `.wasm` binaries |
+| `--contracts-dir PATH` | `/contracts` | Solidity source root |
+| `--output PATH` | `.env.local` | Output env file |
 
 ## How a deposit works
 

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# Setup script for the EVM↔Linera bridge demo.
+# Setup script for the EVM↔Linera bridge demo (local development).
 #
-# Two modes:
-#   Docker mode:  ./setup.sh --compose-file ../../docker/docker-compose.bridge-test.yml
-#   Direct mode:  ./setup.sh --evm-rpc-url URL --evm-private-key KEY \
-#                   --light-client-address ADDR --linera-bridge-chain-id ID
+# Brings up the local compose stack, deploys EVM contracts, publishes Linera
+# apps, registers IDs on both sides, optionally funds the bridge, and writes
+# .env.local for the demo frontend.
 #
-# Docker mode runs forge/cast/linera inside Docker containers (local dev).
-# Direct mode calls them directly on the host (real network deployments).
+# Usage:
+#   ./setup.sh --compose-file ../../docker/docker-compose.bridge-test.yml
 #
-# Outputs: .env.local with all required environment variables for the frontend.
+# To spawn just the relayer container against an already-deployed local stack
+# (no deploy / no register), use the companion script `spawn-relayer.sh`.
 
 set -euo pipefail
 
@@ -35,12 +35,6 @@ FUND_AMOUNT="500000000000000000000"
 SHARED_DIR=""
 WALLET_DIR="/tmp/wallet"
 EXTRA_WALLET_ID=1
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-LINERA_BIN=""
-LINERA_BRIDGE_BIN=""
-LINERA_WALLET_PATH=""
-LINERA_KEYSTORE_PATH=""
-LINERA_STORAGE_PATH=""
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 
@@ -65,46 +59,21 @@ usage() {
     cat <<EOF
 Usage: $(basename "$0") [OPTIONS]
 
-Docker mode (local dev):
   $(basename "$0") --compose-file ../../docker/docker-compose.bridge-test.yml
 
-Direct mode (real networks):
-  $(basename "$0") --evm-rpc-url URL --evm-private-key KEY \\
-    --linera-bridge-chain-id ID --relay-owner OWNER --faucet-url URL
-
 Options:
-  --compose-file PATH       Docker Compose file (enables Docker mode)
-  --evm-rpc-url URL         EVM JSON-RPC endpoint
-                            Docker default: http://anvil:8545
-                            Direct default: http://localhost:8545
-  --evm-private-key KEY     Private key for EVM transactions
-                            Docker default: Anvil account 0
-  --evm-chain-id ID         EVM chain ID (default: 31337)
-  --light-client-address ADDR  LightClient contract address (skip deploy)
-                            Docker mode reads from /shared/
-                            Direct mode deploys if not provided
-  --linera-bridge-chain-id ID      Linera bridge chain ID (64 hex chars)
-                            Docker mode polls /shared/
-  --token-address ADDR      ERC20 token address (skip MockERC20 deploy)
-  --wasm-dir PATH           Directory with .wasm binaries
-                            Docker default: /wasm
-                            Direct default: ../../examples/target/wasm32-unknown-unknown/release
+  --compose-file PATH       Docker Compose file (required)
+  --wasm-dir PATH           Directory with .wasm binaries (default: /wasm)
   --contracts-dir PATH      Solidity source root for forge --root
-                            Docker default: /contracts
-                            Direct default: ../../linera-bridge/src/solidity
+                            (default: /contracts)
   --output PATH             Output env file (default: .env.local in script dir)
   --faucet-url URL          Linera faucet URL (default: http://localhost:8080)
   --relay-url URL           Relay service URL (default: http://localhost:3001)
-  --relay-owner OWNER       Relay's AccountOwner (minter for wrapped-fungible)
-                            Docker mode reads from /shared/
   --ticker-symbol SYM       Wrapped token ticker (default: wTT)
   --fund-amount WEI         Fund bridge with this many tokens; 0 to skip
                             (default: 500000000000000000000)
   --shared-dir PATH         Directory for shared state files (bridge-address,
                             app IDs). Default: /tmp/bridge-demo-<timestamp>
-  --linera-wallet PATH      Path to existing Linera wallet.json
-  --linera-keystore PATH    Path to existing Linera keystore.json
-  --linera-storage CONFIG   Linera storage config (e.g. rocksdb:/path/to/client.db)
   --help                    Show this help
 EOF
     exit 0
@@ -114,24 +83,14 @@ EOF
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --compose-file)      COMPOSE_FILE="$2"; shift 2 ;;
-        --evm-rpc-url)       EVM_RPC_URL="$2"; shift 2 ;;
-        --evm-private-key)   EVM_PRIVATE_KEY="$2"; shift 2 ;;
-        --evm-chain-id)      EVM_CHAIN_ID="$2"; shift 2 ;;
-        --light-client-address) LIGHT_CLIENT_ADDR="$2"; shift 2 ;;
-        --linera-bridge-chain-id)   BRIDGE_CHAIN_ID="$2"; shift 2 ;;
-        --token-address)     TOKEN_ADDRESS="$2"; shift 2 ;;
         --wasm-dir)          WASM_DIR="$2"; shift 2 ;;
         --contracts-dir)     CONTRACTS_DIR="$2"; shift 2 ;;
         --output)            OUTPUT_FILE="$2"; shift 2 ;;
         --faucet-url)        FAUCET_URL="$2"; shift 2 ;;
         --relay-url)         RELAY_URL="$2"; shift 2 ;;
-        --relay-owner)       RELAY_OWNER="$2"; shift 2 ;;
         --ticker-symbol)     TICKER_SYMBOL="$2"; shift 2 ;;
         --fund-amount)       FUND_AMOUNT="$2"; shift 2 ;;
         --shared-dir)        SHARED_DIR="$2"; shift 2 ;;
-        --linera-wallet)     LINERA_WALLET_PATH="$2"; shift 2 ;;
-        --linera-keystore)   LINERA_KEYSTORE_PATH="$2"; shift 2 ;;
-        --linera-storage)    LINERA_STORAGE_PATH="$2"; shift 2 ;;
         --help)              usage ;;
         *) die "Unknown option: $1" ;;
     esac
@@ -139,6 +98,7 @@ done
 
 # Also accept COMPOSE_FILE from env var.
 COMPOSE_FILE="${COMPOSE_FILE:-${BRIDGE_COMPOSE_FILE:-}}"
+[[ -n "$COMPOSE_FILE" ]] || die "--compose-file is required; see --help"
 
 # ── Docker helpers ──
 dc() {
@@ -149,28 +109,17 @@ dc_exec() {
     dc exec -T "$@"
 }
 
-# ── Command execution abstraction ──
+# ── Command execution helpers ──
 evm_exec() {
-    if [[ -n "$COMPOSE_FILE" ]]; then
-        dc_exec foundry-tools "$@"
-    else
-        "$@"
-    fi
+    dc_exec foundry-tools "$@"
 }
 
 linera_exec() {
-    if [[ -n "$COMPOSE_FILE" ]]; then
-        dc_exec linera-network env \
-            LINERA_WALLET="$WALLET_DIR/wallet_${EXTRA_WALLET_ID}.json" \
-            LINERA_KEYSTORE="$WALLET_DIR/keystore_${EXTRA_WALLET_ID}.json" \
-            LINERA_STORAGE="rocksdb:$WALLET_DIR/client_${EXTRA_WALLET_ID}.db" \
-            ./linera "$@"
-    else
-        LINERA_WALLET="$LINERA_WALLET_PATH" \
-        LINERA_KEYSTORE="$LINERA_KEYSTORE_PATH" \
-        LINERA_STORAGE="$LINERA_STORAGE_PATH" \
-        "$LINERA_BIN" "$@"
-    fi
+    dc_exec linera-network env \
+        LINERA_WALLET="$WALLET_DIR/wallet_${EXTRA_WALLET_ID}.json" \
+        LINERA_KEYSTORE="$WALLET_DIR/keystore_${EXTRA_WALLET_ID}.json" \
+        LINERA_STORAGE="rocksdb:$WALLET_DIR/client_${EXTRA_WALLET_ID}.db" \
+        ./linera "$@"
 }
 
 # Parse "Deployed to: 0x..." from forge create output.
@@ -195,54 +144,17 @@ wait_for_tx() {
         --rpc-url "$EVM_RPC_URL" "$tx_hash" >/dev/null
 }
 
-# ── Mode detection & defaults ──
-if [[ -n "$COMPOSE_FILE" ]]; then
-    echo "Mode: Docker (compose file: $COMPOSE_FILE)"
-    EVM_RPC_URL="${EVM_RPC_URL:-http://anvil:8545}"
-    EVM_PRIVATE_KEY="${EVM_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
-    WASM_DIR="${WASM_DIR:-/wasm}"
-    CONTRACTS_DIR="${CONTRACTS_DIR:-/contracts}"
-    OUTPUT_FILE="${OUTPUT_FILE:-$SCRIPT_DIR/.env.local}"
-    FAUCET_URL="${FAUCET_URL:-http://localhost:8080}"
-    RELAY_URL="${RELAY_URL:-http://localhost:3001}"
-    # Docker container has its own solc; don't force a version download.
-    FORGE_USE_SOLC=()
-else
-    echo "Mode: Direct"
-    [[ -z "$EVM_PRIVATE_KEY" ]] && die "--evm-private-key is required in direct mode"
-    [[ -z "$BRIDGE_CHAIN_ID" ]] && die "--linera-bridge-chain-id is required in direct mode"
-    EVM_RPC_URL="${EVM_RPC_URL:-http://localhost:8545}"
-    WASM_DIR="${WASM_DIR:-$SCRIPT_DIR/../../examples/target/wasm32-unknown-unknown/release}"
-    CONTRACTS_DIR="${CONTRACTS_DIR:-$SCRIPT_DIR/../../linera-bridge/src/solidity}"
-    OUTPUT_FILE="${OUTPUT_FILE:-$SCRIPT_DIR/.env.local}"
-    FAUCET_URL="${FAUCET_URL:-http://localhost:8080}"
-    RELAY_URL="${RELAY_URL:-http://localhost:3001}"
-    FORGE_USE_SOLC=(--use 0.8.33)
-
-    # Resolve binaries: prefer target/debug, then target/release, then PATH.
-    if [[ -z "$LINERA_BIN" ]]; then
-        if [[ -x "$REPO_ROOT/target/debug/linera" ]]; then
-            LINERA_BIN="$REPO_ROOT/target/debug/linera"
-        elif [[ -x "$REPO_ROOT/target/release/linera" ]]; then
-            LINERA_BIN="$REPO_ROOT/target/release/linera"
-        else
-            LINERA_BIN="$(command -v linera 2>/dev/null || true)"
-            [[ -z "$LINERA_BIN" ]] && die "linera binary not found — build with 'cargo build -p linera-service' or add to PATH"
-        fi
-    fi
-    if [[ -z "$LINERA_BRIDGE_BIN" ]]; then
-        if [[ -x "$REPO_ROOT/target/debug/linera-bridge" ]]; then
-            LINERA_BRIDGE_BIN="$REPO_ROOT/target/debug/linera-bridge"
-        elif [[ -x "$REPO_ROOT/target/release/linera-bridge" ]]; then
-            LINERA_BRIDGE_BIN="$REPO_ROOT/target/release/linera-bridge"
-        else
-            LINERA_BRIDGE_BIN="$(command -v linera-bridge 2>/dev/null || true)"
-            [[ -z "$LINERA_BRIDGE_BIN" ]] && die "linera-bridge binary not found — build with 'cargo build -p linera-bridge --features cli' or add to PATH"
-        fi
-    fi
-    echo "  linera:        $LINERA_BIN"
-    echo "  linera-bridge: $LINERA_BRIDGE_BIN"
-fi
+# ── Defaults ──
+echo "Compose file: $COMPOSE_FILE"
+EVM_RPC_URL="${EVM_RPC_URL:-http://anvil:8545}"
+EVM_PRIVATE_KEY="${EVM_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+WASM_DIR="${WASM_DIR:-/wasm}"
+CONTRACTS_DIR="${CONTRACTS_DIR:-/contracts}"
+OUTPUT_FILE="${OUTPUT_FILE:-$SCRIPT_DIR/.env.local}"
+FAUCET_URL="${FAUCET_URL:-http://localhost:8080}"
+RELAY_URL="${RELAY_URL:-http://localhost:3001}"
+# Docker container has its own solc; don't force a version download.
+FORGE_USE_SOLC=()
 
 # ── Shared dir for relay coordination ──
 if [[ -z "$SHARED_DIR" ]]; then
@@ -252,158 +164,75 @@ mkdir -p "$SHARED_DIR"
 echo "  Shared dir: $SHARED_DIR"
 
 echo "=== Bridge Demo Setup ==="
-
-# ── 0. Resolve Linera wallet paths (direct mode only) ──
-# Resolve env var fallbacks early so we can print them.
-if [[ -z "$COMPOSE_FILE" ]]; then
-    LINERA_WALLET_PATH="${LINERA_WALLET_PATH:-${LINERA_WALLET:-}}"
-    LINERA_KEYSTORE_PATH="${LINERA_KEYSTORE_PATH:-${LINERA_KEYSTORE:-}}"
-    LINERA_STORAGE_PATH="${LINERA_STORAGE_PATH:-${LINERA_STORAGE:-}}"
-    if [[ -n "$LINERA_WALLET_PATH" ]]; then
-        # Use caller-provided wallet paths.
-        [[ -z "$LINERA_KEYSTORE_PATH" ]] && die "--linera-keystore is required when --linera-wallet is set"
-        [[ -z "$LINERA_STORAGE_PATH" ]] && die "--linera-storage is required when --linera-wallet is set"
-        echo "  Using wallet at $LINERA_WALLET_PATH"
-    else
-        # Create a temporary wallet.
-        LINERA_TMP_DIR="$SHARED_DIR/linera-wallet"
-        mkdir -p "$LINERA_TMP_DIR"
-        LINERA_WALLET_PATH="$LINERA_TMP_DIR/wallet.json"
-        LINERA_KEYSTORE_PATH="$LINERA_TMP_DIR/keystore.json"
-        LINERA_STORAGE_PATH="rocksdb:$LINERA_TMP_DIR/client.db"
-        if [[ ! -f "$LINERA_WALLET_PATH" ]]; then
-            echo "Initializing Linera wallet from faucet..."
-            linera_exec wallet init --faucet "$FAUCET_URL"
-        else
-            echo "  Using existing wallet at $LINERA_TMP_DIR"
-        fi
-    fi
-fi
-
 echo ""
 echo "Configuration:"
 echo "  EVM RPC URL:        $EVM_RPC_URL"
 echo "  EVM chain ID:       $EVM_CHAIN_ID"
-echo "  Bridge chain ID:    ${BRIDGE_CHAIN_ID:-(will be read from /shared/)}"
-echo "  Relay owner:        ${RELAY_OWNER:-(will be read from /shared/)}"
+echo "  Bridge chain ID:    (will be read from /shared/)"
+echo "  Relay owner:        (will be read from /shared/)"
 echo "  Faucet URL:         $FAUCET_URL"
 echo "  Shared dir:         $SHARED_DIR"
-if [[ -z "$COMPOSE_FILE" ]]; then
-echo "  Linera wallet:      $LINERA_WALLET_PATH"
-echo "  Linera keystore:    $LINERA_KEYSTORE_PATH"
-echo "  Linera storage:     $LINERA_STORAGE_PATH"
-fi
 echo ""
 
-# ── 1. Deploy or read LightClient ──
-if [[ -n "$COMPOSE_FILE" && -z "$LIGHT_CLIENT_ADDR" ]]; then
-    echo "Reading LightClient address from /shared/..."
-    LIGHT_CLIENT_ADDR=$(dc_exec foundry-tools cat /shared/light-client-address | tr -d '[:space:]')
-elif [[ -z "$LIGHT_CLIENT_ADDR" ]]; then
-    echo "Fetching LightClient constructor args from faucet..."
-    LC_ARGS_JSON=$("$LINERA_BRIDGE_BIN" init-light-client --faucet-url "$FAUCET_URL" --output /dev/null)
-    LC_VALIDATORS=$(echo "$LC_ARGS_JSON" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-print('[' + ','.join(d['validators']) + ']')
-")
-    LC_WEIGHTS=$(echo "$LC_ARGS_JSON" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-print('[' + ','.join(str(w) for w in d['weights']) + ']')
-")
-    LC_ADMIN_CHAIN=$(echo "$LC_ARGS_JSON" | python3 -c "
-import sys, json; print(json.load(sys.stdin)['admin_chain_id'])
-")
-    LC_EPOCH=$(echo "$LC_ARGS_JSON" | python3 -c "
-import sys, json; print(json.load(sys.stdin)['epoch'])
-")
-    echo "  Deploying LightClient (epoch=$LC_EPOCH)..."
-    LC_OUTPUT=$(evm_exec \
-        forge create "LightClient.sol:LightClient" \
-        --root "$CONTRACTS_DIR" \
-        --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
-        "${FORGE_USE_SOLC[@]}" \
-        --out /tmp/forge-out --cache-path /tmp/forge-cache \
-        --rpc-url "$EVM_RPC_URL" \
-        --private-key "$EVM_PRIVATE_KEY" \
-        --broadcast \
-        --constructor-args \
-        "$LC_VALIDATORS" "$LC_WEIGHTS" "$LC_ADMIN_CHAIN" "$LC_EPOCH")
-    LIGHT_CLIENT_ADDR=$(echo "$LC_OUTPUT" | parse_address)
-    wait_for_tx "$(echo "$LC_OUTPUT" | parse_tx_hash)"
-fi
+# ── 1. Read LightClient address (deployed by bridge-init in compose) ──
+echo "Reading LightClient address from /shared/..."
+LIGHT_CLIENT_ADDR=$(dc_exec foundry-tools cat /shared/light-client-address | tr -d '[:space:]')
 validate_eth_address "LightClient address" "$LIGHT_CLIENT_ADDR"
 echo "  LightClient: $LIGHT_CLIENT_ADDR"
 
-# ── 2. Read bridge chain ID (Docker mode only) ──
-if [[ -n "$COMPOSE_FILE" && -z "$BRIDGE_CHAIN_ID" ]]; then
-    echo "Waiting for bridge chain ID..."
-    for i in $(seq 1 30); do
-        BRIDGE_CHAIN_ID=$(dc_exec foundry-tools cat /shared/bridge-chain-id 2>/dev/null | tr -d '[:space:]')
-        BRIDGE_CHAIN_ID=$(normalize_hex "$BRIDGE_CHAIN_ID")
-        if echo "$BRIDGE_CHAIN_ID" | grep -qE '^[a-f0-9]{64}$'; then
-            break
-        fi
-        BRIDGE_CHAIN_ID=""
-        echo "  Waiting... ($i/30)"
-        sleep 2
-    done
-    if [[ -z "$BRIDGE_CHAIN_ID" ]]; then
-        die "Bridge chain ID not found within timeout"
-    fi
-else
+# ── 2. Read bridge chain ID ──
+echo "Waiting for bridge chain ID..."
+BRIDGE_CHAIN_ID=""
+for i in $(seq 1 30); do
+    BRIDGE_CHAIN_ID=$(dc_exec foundry-tools cat /shared/bridge-chain-id 2>/dev/null | tr -d '[:space:]')
     BRIDGE_CHAIN_ID=$(normalize_hex "$BRIDGE_CHAIN_ID")
-fi
+    if echo "$BRIDGE_CHAIN_ID" | grep -qE '^[a-f0-9]{64}$'; then
+        break
+    fi
+    BRIDGE_CHAIN_ID=""
+    echo "  Waiting... ($i/30)"
+    sleep 2
+done
+[[ -z "$BRIDGE_CHAIN_ID" ]] && die "Bridge chain ID not found within timeout"
 validate_hex64 "Bridge chain ID" "$BRIDGE_CHAIN_ID"
 echo "  Bridge chain: $BRIDGE_CHAIN_ID"
 
-# ── 2b. Create extra wallet copy (Docker mode only) ──
-if [[ -n "$COMPOSE_FILE" ]]; then
-    echo "Creating extra wallet copy..."
-    dc_exec linera-network sh -c "\
-        cp $WALLET_DIR/wallet_0.json $WALLET_DIR/wallet_${EXTRA_WALLET_ID}.json && \
-        cp $WALLET_DIR/keystore_0.json $WALLET_DIR/keystore_${EXTRA_WALLET_ID}.json && \
-        cp -r $WALLET_DIR/client_0.db $WALLET_DIR/client_${EXTRA_WALLET_ID}.db"
-fi
+# ── 2b. Create extra wallet copy ──
+echo "Creating extra wallet copy..."
+dc_exec linera-network sh -c "\
+    cp $WALLET_DIR/wallet_0.json $WALLET_DIR/wallet_${EXTRA_WALLET_ID}.json && \
+    cp $WALLET_DIR/keystore_0.json $WALLET_DIR/keystore_${EXTRA_WALLET_ID}.json && \
+    cp -r $WALLET_DIR/client_0.db $WALLET_DIR/client_${EXTRA_WALLET_ID}.db"
 
-# ── 3. Deploy MockERC20 (skip if --token-address was provided) ──
-if [[ -z "$TOKEN_ADDRESS" ]]; then
-    echo "Deploying MockERC20..."
-    ERC20_OUTPUT=$(evm_exec \
-        forge create "$CONTRACTS_DIR/MockERC20.sol:MockERC20" \
-        --root "$CONTRACTS_DIR" \
-        --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
-        "${FORGE_USE_SOLC[@]}" \
-        --out /tmp/forge-out --cache-path /tmp/forge-cache \
-        --rpc-url "$EVM_RPC_URL" \
-        --private-key "$EVM_PRIVATE_KEY" \
-        --broadcast \
-        --constructor-args "TestToken" "TT" 1000000000000000000000)
-    TOKEN_ADDRESS=$(echo "$ERC20_OUTPUT" | parse_address)
-    wait_for_tx "$(echo "$ERC20_OUTPUT" | parse_tx_hash)"
-    echo "  MockERC20: $TOKEN_ADDRESS"
-else
-    echo "  Using existing token: $TOKEN_ADDRESS"
-fi
+# ── 3. Deploy MockERC20 ──
+echo "Deploying MockERC20..."
+ERC20_OUTPUT=$(evm_exec \
+    forge create "$CONTRACTS_DIR/MockERC20.sol:MockERC20" \
+    --root "$CONTRACTS_DIR" \
+    --via-ir --optimize --optimizer-runs 1 --evm-version shanghai \
+    "${FORGE_USE_SOLC[@]}" \
+    --out /tmp/forge-out --cache-path /tmp/forge-cache \
+    --rpc-url "$EVM_RPC_URL" \
+    --private-key "$EVM_PRIVATE_KEY" \
+    --broadcast \
+    --constructor-args "TestToken" "TT" 1000000000000000000000)
+TOKEN_ADDRESS=$(echo "$ERC20_OUTPUT" | parse_address)
+wait_for_tx "$(echo "$ERC20_OUTPUT" | parse_tx_hash)"
+echo "  MockERC20: $TOKEN_ADDRESS"
 validate_eth_address "Token address" "$TOKEN_ADDRESS"
 TOKEN_ADDR_HEX=$(echo "$TOKEN_ADDRESS" | sed 's/^0x//')
 
 # ── 3b. Read relay owner (minter for wrapped-fungible) ──
 echo "Reading relay owner..."
-if [[ -n "$COMPOSE_FILE" ]]; then
-    for i in $(seq 1 30); do
-        RELAY_OWNER=$(dc_exec foundry-tools cat /shared/relay-owner 2>/dev/null | tr -d '[:space:]')
-        if [[ -n "$RELAY_OWNER" ]]; then
-            break
-        fi
-        echo "  Waiting for relay owner... ($i/30)"
-        sleep 2
-    done
-    [[ -z "$RELAY_OWNER" ]] && die "Relay owner not found within timeout"
-else
-    [[ -z "$RELAY_OWNER" ]] && die "--relay-owner is required in direct mode"
-fi
+for i in $(seq 1 30); do
+    RELAY_OWNER=$(dc_exec foundry-tools cat /shared/relay-owner 2>/dev/null | tr -d '[:space:]')
+    if [[ -n "$RELAY_OWNER" ]]; then
+        break
+    fi
+    echo "  Waiting for relay owner... ($i/30)"
+    sleep 2
+done
+[[ -z "$RELAY_OWNER" ]] && die "Relay owner not found within timeout"
 echo "  Relay owner (minter): $RELAY_OWNER"
 
 # FungibleBridge is deployed below (step 7), after the wrapped-fungible app
@@ -446,9 +275,7 @@ validate_hex64 "Linera bridge app ID" "$BRIDGE_APP_ID"
 echo "  Linera bridge app: $BRIDGE_APP_ID"
 
 # Write bridge app ID to shared dir for relay.
-if [[ -n "$COMPOSE_FILE" ]]; then
-    dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_APP_ID' > /shared/bridge-app-id"
-fi
+dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_APP_ID' > /shared/bridge-app-id"
 echo "$BRIDGE_APP_ID" > "$SHARED_DIR/bridge-app-id"
 
 # ── 6. Publish and create wrapped-fungible app ──
@@ -492,9 +319,7 @@ validate_hex64 "Wrapped-fungible app ID" "$WRAPPED_APP_ID"
 echo "  Wrapped-fungible app: $WRAPPED_APP_ID"
 
 # Write wrapped-fungible app ID to shared dir for relay.
-if [[ -n "$COMPOSE_FILE" ]]; then
-    dc_exec --user root foundry-tools sh -c "echo '$WRAPPED_APP_ID' > /shared/wrapped-app-id"
-fi
+dc_exec --user root foundry-tools sh -c "echo '$WRAPPED_APP_ID' > /shared/wrapped-app-id"
 echo "$WRAPPED_APP_ID" > "$SHARED_DIR/wrapped-app-id"
 
 APP_ID_BYTES32="0x${WRAPPED_APP_ID:0:64}"
@@ -522,9 +347,7 @@ BRIDGE_ADDR_HEX=$(echo "$BRIDGE_ADDRESS" | sed 's/^0x//')
 echo "  FungibleBridge: $BRIDGE_ADDRESS"
 
 # Write bridge address to shared dir for relay.
-if [[ -n "$COMPOSE_FILE" ]]; then
-    dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_ADDRESS' > /shared/bridge-address"
-fi
+dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_ADDRESS' > /shared/bridge-address"
 echo "$BRIDGE_ADDRESS" > "$SHARED_DIR/bridge-address"
 
 # ── 8. Register app IDs on both sides ──
@@ -532,34 +355,26 @@ echo "Registering fungible app in evm-bridge..."
 # BCS encoding: variant index 0 (RegisterFungibleApp) + 32-byte app ID hash.
 # Must use the relay wallet since it owns the bridge chain.
 REGISTER_HEX="00${WRAPPED_APP_ID}"
-if [[ -n "$COMPOSE_FILE" ]]; then
-    dc_exec linera-network env \
-        LINERA_WALLET=/shared/relay-wallet/wallet.json \
-        LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
-        LINERA_STORAGE=rocksdb:/shared/relay-wallet/client.db \
-        ./linera execute-operation \
-        --application-id "$BRIDGE_APP_ID" \
-        --operation "$REGISTER_HEX" \
-        --chain-id "$BRIDGE_CHAIN_ID" 2>&1
-else
-    linera_exec execute-operation --application-id "$BRIDGE_APP_ID" --operation "$REGISTER_HEX" --chain-id "$BRIDGE_CHAIN_ID" 2>&1
-fi
+dc_exec linera-network env \
+    LINERA_WALLET=/shared/relay-wallet/wallet.json \
+    LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
+    LINERA_STORAGE=rocksdb:/shared/relay-wallet/client.db \
+    ./linera execute-operation \
+    --application-id "$BRIDGE_APP_ID" \
+    --operation "$REGISTER_HEX" \
+    --chain-id "$BRIDGE_CHAIN_ID" 2>&1
 
 echo "Registering FungibleBridge address in evm-bridge..."
 # BCS encoding: variant index 3 (RegisterFungibleBridge) + 20-byte EVM address.
 REGISTER_BRIDGE_HEX="03${BRIDGE_ADDR_HEX}"
-if [[ -n "$COMPOSE_FILE" ]]; then
-    dc_exec linera-network env \
-        LINERA_WALLET=/shared/relay-wallet/wallet.json \
-        LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
-        LINERA_STORAGE=rocksdb:/shared/relay-wallet/client.db \
-        ./linera execute-operation \
-        --application-id "$BRIDGE_APP_ID" \
-        --operation "$REGISTER_BRIDGE_HEX" \
-        --chain-id "$BRIDGE_CHAIN_ID" 2>&1
-else
-    linera_exec execute-operation --application-id "$BRIDGE_APP_ID" --operation "$REGISTER_BRIDGE_HEX" --chain-id "$BRIDGE_CHAIN_ID" 2>&1
-fi
+dc_exec linera-network env \
+    LINERA_WALLET=/shared/relay-wallet/wallet.json \
+    LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
+    LINERA_STORAGE=rocksdb:/shared/relay-wallet/client.db \
+    ./linera execute-operation \
+    --application-id "$BRIDGE_APP_ID" \
+    --operation "$REGISTER_BRIDGE_HEX" \
+    --chain-id "$BRIDGE_CHAIN_ID" 2>&1
 echo "  App IDs registered on both sides"
 
 # ── 8. Fund FungibleBridge with ERC20 tokens ──
@@ -590,9 +405,7 @@ LINERA_EVM_CHAIN_ID=$EVM_CHAIN_ID
 EOF
 
 # Write setup-complete marker so the relay knows it's safe to start.
-if [[ -n "$COMPOSE_FILE" ]]; then
-    dc_exec --user root foundry-tools sh -c "echo 'done' > /shared/setup-complete"
-fi
+dc_exec --user root foundry-tools sh -c "echo 'done' > /shared/setup-complete"
 
 echo ""
 echo "=== Setup Complete ==="
@@ -611,27 +424,6 @@ echo "Environment written to:       $OUTPUT_FILE"
 echo "Shared state dir:             $SHARED_DIR"
 echo ""
 echo "Next steps:"
-if [[ -n "$COMPOSE_FILE" ]]; then
 echo "  Start the frontend:"
 echo "     cd examples/bridge-demo"
 echo "     pnpm install && pnpm dev"
-else
-echo "  1. Start the relay:"
-echo "     linera-bridge serve \\"
-echo "       --rpc-url $EVM_RPC_URL \\"
-echo "       --faucet-url $FAUCET_URL \\"
-echo "       --wallet $LINERA_WALLET_PATH \\"
-echo "       --keystore $LINERA_KEYSTORE_PATH \\"
-echo "       --storage $LINERA_STORAGE_PATH \\"
-echo "       --linera-bridge-chain-id $BRIDGE_CHAIN_ID \\"
-echo "       --linera-bridge-chain-owner $RELAY_OWNER \\"
-echo "       --evm-bridge-address $BRIDGE_ADDRESS \\"
-echo "       --linera-bridge-address $BRIDGE_APP_ID \\"
-echo "       --linera-fungible-address $WRAPPED_APP_ID \\"
-echo "       --evm-private-key 0x... \\"
-echo "       --monitor-scan-interval 30 \\"
-echo "       --max-retries 10"
-echo "  2. Start the frontend:"
-echo "     cd examples/bridge-demo"
-echo "     pnpm install && pnpm dev"
-fi

--- a/examples/bridge-demo/spawn-relayer.sh
+++ b/examples/bridge-demo/spawn-relayer.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Spawn a single linera-bridge relayer container against an already-deployed
+# local stack. No deploys, no app registrations.
+#
+# Usage:
+#   ./spawn-relayer.sh --env-file PATH --data-dir PATH [--env-secret-file PATH]
+#
+# --env-file:        env file consumed by the linera-bridge container (must
+#                    contain RPC_URL, FAUCET_URL, EVM_BRIDGE_ADDRESS,
+#                    LINERA_BRIDGE_APP, LINERA_FUNGIBLE_APP,
+#                    LINERA_BRIDGE_CHAIN_ID, LINERA_BRIDGE_CHAIN_OWNER,
+#                    LINERA_WALLET=/data/..., LINERA_KEYSTORE=/data/...,
+#                    LINERA_STORAGE=rocksdb:/data/..., MONITOR_*,
+#                    MAX_RETRIES, PORT).
+# --env-secret-file: optional second env file (e.g. EVM_PRIVATE_KEY=0x...).
+#                    If omitted, an empty temp file is used.
+# --data-dir:        host directory bind-mounted at /data in the container
+#                    (wallet.json, keystore.json, client.db).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+ENV_FILE=""
+ENV_SECRET_FILE=""
+DATA_DIR=""
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env-file)        ENV_FILE="$2"; shift 2 ;;
+        --env-secret-file) ENV_SECRET_FILE="$2"; shift 2 ;;
+        --data-dir)        DATA_DIR="$2"; shift 2 ;;
+        --help) echo "Usage: $(basename "$0") --env-file PATH --data-dir PATH [--env-secret-file PATH]"; exit 0 ;;
+        *) die "Unknown option: $1" ;;
+    esac
+done
+
+[[ -n "$ENV_FILE" ]] || die "--env-file is required"
+[[ -f "$ENV_FILE" ]] || die "--env-file path does not exist: $ENV_FILE"
+[[ -n "$DATA_DIR" ]] || die "--data-dir is required"
+[[ -d "$DATA_DIR" ]] || die "--data-dir path does not exist or is not a directory: $DATA_DIR"
+
+if [[ -z "$ENV_SECRET_FILE" ]]; then
+    ENV_SECRET_FILE="$(mktemp)"
+    trap 'rm -f "$ENV_SECRET_FILE"' EXIT
+fi
+[[ -f "$ENV_SECRET_FILE" ]] || die "--env-secret-file path does not exist: $ENV_SECRET_FILE"
+
+RELAYER_COMPOSE="$(cd "$SCRIPT_DIR/../.." && pwd)/docker/docker-compose.bridge-testnet.yml"
+[[ -f "$RELAYER_COMPOSE" ]] || die "expected compose file at $RELAYER_COMPOSE"
+
+echo "Spawning relayer:"
+echo "  Env file:        $ENV_FILE"
+echo "  Env secret file: $ENV_SECRET_FILE"
+echo "  Data dir:        $DATA_DIR"
+
+RELAYER_ENV_FILE="$ENV_FILE" \
+RELAYER_ENV_SECRET="$ENV_SECRET_FILE" \
+RELAYER_DATA_DIR="$DATA_DIR" \
+    docker compose -f "$RELAYER_COMPOSE" up -d relayer

--- a/examples/bridge-demo/spawn-relayer.sh
+++ b/examples/bridge-demo/spawn-relayer.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Spawn a single linera-bridge relayer container against an already-deployed
-# local stack. No deploys, no app registrations.
+# Spawn a single linera-bridge relayer container against an external network
+# where contracts and Linera apps are already deployed (e.g. Base Sepolia +
+# testnet Conway). No deploys, no app registrations.
+#
+# For full local development (anvil + local validator + frontend) use
+# `make demo` from linera-bridge/ instead — that path uses setup.sh.
 #
 # Usage:
 #   ./spawn-relayer.sh --env-file PATH --data-dir PATH [--env-secret-file PATH]


### PR DESCRIPTION
## Motivation

`examples/bridge-demo/setup.sh` had two operating modes — a local
docker-compose flow and a "direct mode" that ran `forge`/`cast`/`linera`
on the host for real-network deploys. The direct mode duplicated logic
that production deployment tooling will own, and conflated local-dev
ergonomics with testnet provisioning.

This PR slims `setup.sh` down to a local-development-only docker flow
and adds a small companion script for spawning just the relayer
container against an existing external-network deployment.

## Proposal

- `examples/bridge-demo/setup.sh`: drop direct-mode-with-deploy
  entirely. Removes the host-execution path, the wallet bootstrap,
  the `--relayer-env` writer, the deploy-block capture, and direct-mode
  CLI flags (`--evm-rpc-url`, `--evm-private-key`, `--evm-chain-id`,
  `--light-client-address`, `--linera-bridge-chain-id`,
  `--token-address`, `--relay-owner`, `--linera-wallet`,
  `--linera-keystore`, `--linera-storage`). `evm_exec`/`linera_exec`
  collapse to compose-only single paths. `--compose-file` is now
  strictly required.
- New `examples/bridge-demo/spawn-relayer.sh`: thin wrapper that takes
  `--env-file`, `--data-dir`, optional `--env-secret-file` and runs
  `docker compose -f docker/docker-compose.bridge-testnet.yml up -d
  relayer` with the operator-supplied env file and host data dir bound
  at `/data` in the container. Used to run the relayer locally against
  contracts and Linera apps already deployed on a real network (e.g.
  Base Sepolia + testnet Conway). Does not deploy or register
  anything.
- `examples/bridge-demo/README.md`: replace the long "Testnet / direct
  mode" walkthrough with a short "Spawn just the relayer (against an
  external network)" section pointing at `spawn-relayer.sh`. Trim the
  setup.sh flag table to docker-mode flags only.
- `docker/docker-compose.bridge-testnet.yml` header: clarify the
  override mechanism is for a developer machine pointing at a real
  network; reference `spawn-relayer.sh`.

## Test Plan

- manual. both old and new scripts are used only locally.

## Release Plan

- These changes should be backported to `main` brach.

## Links

- Stacked on top of #6050 (specialised testnet docker-compose).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)