### PR TITLE
Widen load_view_latency histogram cap from 10ms to 1s

### DIFF
--- a/linera-views/src/metrics.rs
+++ b/linera-views/src/metrics.rs
@@ -20,9 +20,9 @@ pub fn increment_counter(counter: &LazyLock<IntCounterVec>, struct_name: &str, b
 pub static LOAD_VIEW_LATENCY: LazyLock<prometheus::HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
         "load_view_latency",
-        "Load view latency",
+        "Load view latency in milliseconds",
         &[],
-        exponential_bucket_latencies(10.0),
+        exponential_bucket_latencies(1000.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

The `load_view_latency` histogram caps its top finite bucket at **10 ms**:

```rust
exponential_bucket_latencies(10.0)
// → [0.001, 0.003, 0.009, 0.027, 0.081, 0.243, 0.729, 2.187, 10.0] ms (+ +Inf)
```

Eight of the nine finite buckets are sub-millisecond, so anything above ~2.2 ms falls into `+Inf`. Result: `histogram_quantile(0.99, …)` saturates at 10 ms whenever the true tail exceeds it, making p99/p999 graphs unreadable for any non-trivial slow-tail load. Current production traffic is comfortably above 2.2 ms in places, so the rendered p99 is a saturation artifact rather than the real value.

## Proposal

Match the cap and shape used by the sibling `SAVE_VIEW_LATENCY` metric (1 s, also millisecond-unit). Two diffs:

1. `exponential_bucket_latencies(10.0)` → `exponential_bucket_latencies(1000.0)` — yields 14 buckets `[0.001, 0.003, 0.009, 0.027, 0.081, 0.243, 0.729, 2.187, 6.561, 19.683, 59.049, 177.147, 531.441, 1000.0]` ms (+ `+Inf`). Adds 5 buckets in the previously-blind 5–500 ms slow-tail range.
2. Description gains `"in milliseconds"`, mirroring `SAVE_VIEW_LATENCY` so the unit is unambiguous to dashboard authors.

If 1 s still proves too tight after we observe real production data, easy follow-up to push to `10000.0` (matching the metering-layer convention).

## Test Plan

CI. Pure metric-registration change (bucket vector + help string); no logic, no API surface — `LOAD_VIEW_LATENCY` is `#[doc(hidden)]` and the only consumer is `linera-views-derive` calling `.measure_latency()`.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Backport PR (testnet_conway): #6241
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)