### PR TITLE
Drop redundant `execution_state_hash` field from `ChainStateView`

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -198,8 +198,6 @@ where
 {
     /// Execution state, including system and user applications.
     pub execution_state: ExecutionStateView<C>,
-    /// Hash of the execution state.
-    pub execution_state_hash: RegisterView<C, Option<CryptoHash>>,
 
     /// Block-chaining state.
     pub tip_state: RegisterView<C, ChainTipState>,
@@ -457,9 +455,6 @@ where
             // The chain was already initialized.
             return Ok(());
         }
-        // Recompute the state hash.
-        let hash = self.execution_state.crypto_hash_mut().await?;
-        self.execution_state_hash.set(Some(hash));
         let maybe_committee = self
             .execution_state
             .system
@@ -1113,7 +1108,6 @@ where
         if block.header.height == BlockHeight::ZERO {
             self.block_zero_executed_at.set(local_time);
         }
-        self.execution_state_hash.set(Some(block.header.state_hash));
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block).await?;
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1866,7 +1866,7 @@ where
             Box::pin(self.execute_block(block, local_time, round, published_blobs, policy)).await?;
 
         // No need to sign: only used internally.
-        let info = ChainInfo::from_chain_view(&self.chain).await?;
+        let info = ChainInfo::from_chain_view(&mut self.chain).await?;
         let mut response = ChainInfoResponse::new(info, None);
         if let Some(owner) = executed_block.header.authenticated_owner {
             response.info.requested_owner_balance = self
@@ -2059,8 +2059,8 @@ where
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, WorkerError> {
         self.initialize_and_save_if_needed().await?;
+        let mut info = ChainInfo::from_chain_view(&mut self.chain).await?;
         let chain = &self.chain;
-        let mut info = ChainInfo::from_chain_view(chain).await?;
         if query.request_committees {
             info.requested_committees = Some(chain.execution_state.system.committees.get().clone());
         }
@@ -2206,8 +2206,8 @@ where
         Ok(())
     }
 
-    pub(crate) async fn chain_info_response(&self) -> Result<ChainInfoResponse, WorkerError> {
-        let info = ChainInfo::from_chain_view(&self.chain).await?;
+    pub(crate) async fn chain_info_response(&mut self) -> Result<ChainInfoResponse, WorkerError> {
+        let info = ChainInfo::from_chain_view(&mut self.chain).await?;
         Ok(ChainInfoResponse::new(info, self.config.key_pair()))
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -256,7 +256,7 @@ impl CrossChainRequest {
 }
 
 impl ChainInfo {
-    pub async fn from_chain_view<C, S>(view: &ChainStateView<C>) -> Result<Self, ViewError>
+    pub async fn from_chain_view<C, S>(view: &mut ChainStateView<C>) -> Result<Self, ViewError>
     where
         C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
         ChainRuntimeContext<S>: ExecutionRuntimeContext,
@@ -272,7 +272,7 @@ impl ChainInfo {
             block_hash: tip_state.block_hash,
             next_block_height: tip_state.next_block_height,
             timestamp: *view.execution_state.system.timestamp.get(),
-            state_hash: *view.execution_state_hash.get(),
+            state_hash: Some(view.execution_state.crypto_hash_mut().await?),
             requested_committees: None,
             requested_owner_balance: None,
             requested_pending_message_bundles: Vec::new(),

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -138,7 +138,6 @@ query Chain(
         timestamp
       }
     }
-    executionStateHash
     tipState {
       blockHash
       nextBlockHeight

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -328,10 +328,6 @@ type ChainStateExtendedView {
 	"""
 	executionState: ExecutionStateView!
 	"""
-	Hash of the execution state.
-	"""
-	executionStateHash: CryptoHash
-	"""
 	Block-chaining state.
 	"""
 	tipState: ChainTipState!

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -23,6 +23,12 @@ unicode-segmentation = {{ version = ">=1, <1.13" }}
 {linera_sdk_dev_dep}
 tokio = {{ version = "1.40", features = ["rt", "sync"] }}
 
+# TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
+tonic = {{ version = ">=0.14, <0.14.6", default-features = false }}
+tonic-build = {{ version = ">=0.14, <0.14.6", default-features = false }}
+tonic-prost = {{ version = ">=0.14, <0.14.6", default-features = false }}
+tonic-prost-build = {{ version = ">=0.14, <0.14.6", default-features = false }}
+
 [[bin]]
 name = "{contract_binary_name}"
 path = "src/contract.rs"


### PR DESCRIPTION
## Motivation

The hash is already maintained inside `ExecutionStateView`'s `HistoricallyHashableView` wrapper.

## Proposal

`ChainInfo::from_chain_view` now reads it via `crypto_hash_mut`, which requires `&mut`; propagate the mutability up through `chain_info_response`.

(An alternative would be to implement a `crypto_hash` function that actually `lock`s the mutex instead; or a `stored_hash` function that only returns the last _stored_ value.)

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
