### PR TITLE
Widen load_view_latency histogram cap from 10ms to 1s [backport]

### DIFF
--- a/linera-views/src/metrics.rs
+++ b/linera-views/src/metrics.rs
@@ -20,9 +20,9 @@ pub fn increment_counter(counter: &LazyLock<IntCounterVec>, struct_name: &str, b
 pub static LOAD_VIEW_LATENCY: LazyLock<prometheus::HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
         "load_view_latency",
-        "Load view latency",
+        "Load view latency in milliseconds",
         &[],
-        exponential_bucket_latencies(10.0),
+        exponential_bucket_latencies(1000.0),
     )
 });
 


### PR DESCRIPTION
## Motivation

Backport of #6239 to `testnet_conway`.

The `load_view_latency` histogram caps its top finite bucket at **10 ms**, with 8 of the 9 finite buckets sub-millisecond. Anything above ~2.2 ms falls into `+Inf`, so `histogram_quantile(0.99, …)` saturates at 10 ms whenever the true tail exceeds it. Production traffic is comfortably above 2.2 ms in places — the rendered p99 in current Grafana panels is a saturation artifact, not the real value.

## Proposal

Cherry-pick of the main commit. Cap raised to 1 s (matching `SAVE_VIEW_LATENCY` directly above), and the description gains `"in milliseconds"` for unit-disambiguation.

New buckets: `[0.001, 0.003, 0.009, 0.027, 0.081, 0.243, 0.729, 2.187, 6.561, 19.683, 59.049, 177.147, 531.441, 1000.0]` ms (+ `+Inf`) — adds 5 buckets in the previously-blind 5–500 ms slow-tail range.

## Test Plan

CI. Identical diff to #6239; clippy clean against `testnet_conway` tip locally.

## Release Plan

- Backport for the `testnet_conway` release line. Will go out in the next validator hotfix.

## Links

- Main PR: #6239
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)