### PR TITLE
Add checkpointing functions to historically hashable views

### DIFF
--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -430,7 +430,9 @@ where
             | ViewError::TryLockError(_)
             | ViewError::InconsistentEntries
             | ViewError::PostLoadValuesError
+            | ViewError::HasPendingChanges
             | ViewError::IoError(_) => Status::internal(err.to_string()),
+            ViewError::MalformedContent(_) => Status::invalid_argument(err.to_string()),
             ViewError::KeyTooLong | ViewError::ArithmeticError(_) => {
                 Status::out_of_range(err.to_string())
             }

--- a/linera-views/src/error.rs
+++ b/linera-views/src/error.rs
@@ -58,6 +58,14 @@ pub enum ViewError {
     /// The values are incoherent.
     #[error("post load values error")]
     PostLoadValuesError,
+
+    /// The operation requires the view to have no pending in-memory changes.
+    #[error("the view has pending in-memory changes; flush them before continuing")]
+    HasPendingChanges,
+
+    /// The canonical byte stream is malformed.
+    #[error("malformed canonical content stream: {0}")]
+    MalformedContent(&'static str),
 }
 
 impl ViewError {

--- a/linera-views/src/views/historical_hash_wrapper.rs
+++ b/linera-views/src/views/historical_hash_wrapper.rs
@@ -365,8 +365,16 @@ fn decode_key_values(bytes: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError>
 }
 
 fn hash_bytes(bytes: &[u8]) -> HasherOutput {
-    use crate::views::Hasher as _;
+    // Domain-separation tag: ensures the SHA3 input here cannot equal the SHA3 input of
+    // `make_hash` (`<32-byte stored_hash> || bcs(batch)`). For the two SHA3 inputs to
+    // coincide, an attacker would need a stored_hash equal to the first 32 bytes of this
+    // tag — i.e., a SHA3-256 preimage attack. The tag is therefore at least 32 bytes long.
+    const DOMAIN_TAG: &[u8] = b"linera-views::HistoricallyHashableView::dump_content/v1";
+    const _: () = assert!(DOMAIN_TAG.len() >= 32);
     let mut hasher = sha3::Sha3_256::default();
+    hasher
+        .update_with_bytes(DOMAIN_TAG)
+        .expect("Sha3_256 hashing of a byte slice cannot fail");
     hasher
         .update_with_bytes(bytes)
         .expect("Sha3_256 hashing of a byte slice cannot fail");

--- a/linera-views/src/views/historical_hash_wrapper.rs
+++ b/linera-views/src/views/historical_hash_wrapper.rs
@@ -297,10 +297,7 @@ impl<W: View> HistoricallyHashableView<W::Context, W> {
     ///
     /// **The inner view's in-memory state is undefined after this returns.** Callers
     /// should drop the view and reload before using it further.
-    pub async fn restore_from_content(
-        &mut self,
-        bytes: &[u8],
-    ) -> Result<HasherOutput, ViewError> {
+    pub async fn restore_from_content(&mut self, bytes: &[u8]) -> Result<HasherOutput, ViewError> {
         let entries = decode_key_values(bytes)?;
         let hash = hash_bytes(bytes);
 
@@ -309,7 +306,9 @@ impl<W: View> HistoricallyHashableView<W::Context, W> {
         let mut wrapper_hash_key = inner_base.clone();
         // The inner context's base key is `<wrapper_base><Inner tag>`; flipping the last
         // byte to `Hash` gives the wrapper's hash key.
-        *wrapper_hash_key.last_mut().expect("inner base key is non-empty") = KeyTag::Hash as u8;
+        *wrapper_hash_key
+            .last_mut()
+            .expect("inner base key is non-empty") = KeyTag::Hash as u8;
 
         let mut batch = Batch::new();
         // Wipe whatever is currently under the inner prefix.

--- a/linera-views/src/views/historical_hash_wrapper.rs
+++ b/linera-views/src/views/historical_hash_wrapper.rs
@@ -252,11 +252,10 @@ impl<W: View> HistoricallyHashableView<W::Context, W> {
     /// and arranges for the next save to record the hash of those bytes as the new
     /// stored hash. Subsequent updates extend the history from that hash normally.
     ///
-    /// The byte format is the concatenation, in sorted lexicographic key order, of
-    /// `(u64-LE key length, key, u64-LE value length, value)` records over every entry
-    /// stored under the inner view's prefix. Two views with identical persisted content
-    /// produce identical bytes by construction; the hash is therefore reproducible by
-    /// any party holding the bytes.
+    /// The bytes are the BCS encoding of `Vec<(Vec<u8>, Vec<u8>)>` — every entry stored
+    /// under the inner view's prefix, in sorted lexicographic key order. Two views with
+    /// identical persisted content produce identical bytes by construction; the hash is
+    /// therefore reproducible by any party holding the bytes.
     ///
     /// Errors with [`ViewError::HasPendingChanges`] if the inner view has unflushed
     /// changes — the dump reads from the underlying KV store and would silently miss
@@ -279,7 +278,7 @@ impl<W: View> HistoricallyHashableView<W::Context, W> {
                 error: Box::new(err),
                 must_reload_view: false,
             })?;
-        let bytes = encode_key_values(&key_values);
+        let bytes = bcs::to_bytes(&key_values)?;
         let hash = hash_bytes(&bytes);
         // Schedule the hash for the next save without forcing a save here, so the
         // checkpoint write coalesces with the rest of the block's batch.
@@ -344,57 +343,26 @@ impl<W: View> HistoricallyHashableView<W::Context, W> {
     }
 }
 
-/// Encodes `(key, value)` pairs into the canonical byte representation used by
-/// [`HistoricallyHashableView::dump_content`].
+/// Decodes a canonical content byte string (a BCS-encoded `Vec<(Vec<u8>, Vec<u8>)>`)
+/// and validates that keys are in strictly increasing lexicographic order. Returns
+/// [`ViewError::MalformedContent`] if the ordering invariant is violated; BCS framing
+/// errors surface as [`ViewError::BcsError`].
 ///
-/// The caller must pass entries in the same order the underlying store iterates them
-/// (sorted lexicographically by key). All current backends — Memory, RocksDB, DynamoDB
-/// (`query` ASC sort key), ScyllaDB (clustering ASC), IndexedDB (cursor default) — do.
-fn encode_key_values(entries: &[(Vec<u8>, Vec<u8>)]) -> Vec<u8> {
-    let mut bytes = Vec::new();
-    for (key, value) in entries {
-        bytes.extend_from_slice(&(key.len() as u64).to_le_bytes());
-        bytes.extend_from_slice(key);
-        bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
-        bytes.extend_from_slice(value);
-    }
-    bytes
-}
-
-/// Decodes the canonical byte representation produced by [`encode_key_values`]. Returns
-/// [`ViewError::MalformedContent`] if keys are not in strictly increasing lexicographic
-/// order (the canonical format is sorted; out-of-order or duplicate keys signal a
-/// malformed or hand-crafted input).
+/// The order check is at this layer rather than relying on BCS, because BCS does not
+/// constrain element ordering — only the bytes representation given a value. Two
+/// callers building entries in different orders would produce different bytes and
+/// different hashes; canonical content must always be sorted.
 #[expect(clippy::type_complexity)]
-fn decode_key_values(mut bytes: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
-    let mut entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
-    while !bytes.is_empty() {
-        let key = read_chunk(&mut bytes)?;
-        let value = read_chunk(&mut bytes)?;
-        if let Some((previous_key, _)) = entries.last() {
-            if key.as_slice() <= previous_key.as_slice() {
-                return Err(ViewError::MalformedContent(
-                    "keys must be in strictly increasing order",
-                ));
-            }
+fn decode_key_values(bytes: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
+    let entries: Vec<(Vec<u8>, Vec<u8>)> = bcs::from_bytes(bytes)?;
+    for window in entries.windows(2) {
+        if window[1].0 <= window[0].0 {
+            return Err(ViewError::MalformedContent(
+                "keys must be in strictly increasing order",
+            ));
         }
-        entries.push((key, value));
     }
     Ok(entries)
-}
-
-fn read_chunk(bytes: &mut &[u8]) -> Result<Vec<u8>, ViewError> {
-    if bytes.len() < 8 {
-        return Err(ViewError::MalformedContent("truncated length prefix"));
-    }
-    let (len_bytes, rest) = bytes.split_at(8);
-    let len = u64::from_le_bytes(len_bytes.try_into().expect("8 bytes")) as usize;
-    if rest.len() < len {
-        return Err(ViewError::MalformedContent("truncated chunk body"));
-    }
-    let (chunk, rest) = rest.split_at(len);
-    *bytes = rest;
-    Ok(chunk.to_vec())
 }
 
 fn hash_bytes(bytes: &[u8]) -> HasherOutput {
@@ -866,14 +834,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_decode_rejects_unsorted_keys() -> Result<(), ViewError> {
-        // Hand-craft bytes with keys in non-increasing order; restore should reject them.
-        let mut bytes = Vec::new();
-        for (k, v) in [&b"b"[..], b"a"].iter().zip([&b"v1"[..], b"v2"]) {
-            bytes.extend_from_slice(&(k.len() as u64).to_le_bytes());
-            bytes.extend_from_slice(k);
-            bytes.extend_from_slice(&(v.len() as u64).to_le_bytes());
-            bytes.extend_from_slice(v);
-        }
+        // BCS-encode entries in non-increasing key order; restore should reject them.
+        let entries: Vec<(Vec<u8>, Vec<u8>)> = vec![
+            (b"b".to_vec(), b"v1".to_vec()),
+            (b"a".to_vec(), b"v2".to_vec()),
+        ];
+        let bytes = bcs::to_bytes(&entries).expect("encoding cannot fail");
         let context = MemoryContext::new_for_testing(());
         let mut view =
             HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;

--- a/linera-views/src/views/historical_hash_wrapper.rs
+++ b/linera-views/src/views/historical_hash_wrapper.rs
@@ -16,7 +16,7 @@ use crate::{
     batch::Batch,
     common::from_bytes_option,
     context::Context,
-    store::ReadableKeyValueStore as _,
+    store::{ReadableKeyValueStore as _, WritableKeyValueStore as _},
     views::{ClonableView, Hasher, HasherOutput, ReplaceContext, View, ViewError, MIN_VIEW_TAG},
 };
 
@@ -51,6 +51,12 @@ pub struct HistoricallyHashableView<C, W> {
     /// Memoized hash, if any.
     #[allocative(visit = visit_allocative_simple)]
     hash: Mutex<Option<HasherOutput>>,
+    /// An override hash scheduled by [`Self::dump_content`]. While this is `Some`, the next
+    /// save records this value as the new stored hash without mixing in the pending inner
+    /// batch. Always derived from the canonical byte representation of the view's content,
+    /// never from a caller-supplied value.
+    #[allocative(visit = visit_allocative_simple)]
+    force_stored_hash: Option<HasherOutput>,
     /// Track context type.
     #[allocative(skip)]
     _phantom: PhantomData<C>,
@@ -99,6 +105,7 @@ where
             _phantom: PhantomData,
             stored_hash: self.stored_hash,
             hash: Mutex::new(*self.hash.get_mut().unwrap()),
+            force_stored_hash: self.force_stored_hash,
             inner: self.inner.with_context(ctx).await,
         }
     }
@@ -137,6 +144,7 @@ where
             _phantom: PhantomData,
             stored_hash: hash,
             hash: Mutex::new(hash),
+            force_stored_hash: None,
             inner,
         })
     }
@@ -150,10 +158,11 @@ where
     fn rollback(&mut self) {
         self.inner.rollback();
         *self.hash.get_mut().unwrap() = self.stored_hash;
+        self.force_stored_hash = None;
     }
 
     async fn has_pending_changes(&self) -> bool {
-        self.inner.has_pending_changes().await
+        self.force_stored_hash.is_some() || self.inner.has_pending_changes().await
     }
 
     fn pre_save(&self, batch: &mut Batch) -> Result<bool, ViewError> {
@@ -161,12 +170,19 @@ where
         self.inner.pre_save(&mut inner_batch)?;
         let new_hash = {
             let mut maybe_hash = self.hash.lock().unwrap();
-            match maybe_hash.as_mut() {
-                Some(hash) => *hash,
-                None => {
-                    let hash = Self::make_hash(self.stored_hash, &inner_batch)?;
-                    *maybe_hash = Some(hash);
-                    hash
+            if let Some(forced) = self.force_stored_hash {
+                // The override pre-empts the hash chain: the inner batch is still written
+                // to storage, but it does not contribute to the hash.
+                *maybe_hash = Some(forced);
+                forced
+            } else {
+                match maybe_hash.as_mut() {
+                    Some(hash) => *hash,
+                    None => {
+                        let hash = Self::make_hash(self.stored_hash, &inner_batch)?;
+                        *maybe_hash = Some(hash);
+                        hash
+                    }
                 }
             }
         };
@@ -189,12 +205,14 @@ where
             .unwrap()
             .expect("hash should be computed in pre_save");
         self.stored_hash = Some(new_hash);
+        self.force_stored_hash = None;
         self.inner.post_save();
     }
 
     fn clear(&mut self) {
         self.inner.clear();
         *self.hash.get_mut().unwrap() = None;
+        self.force_stored_hash = None;
     }
 }
 
@@ -207,6 +225,7 @@ where
             _phantom: PhantomData,
             stored_hash: self.stored_hash,
             hash: Mutex::new(*self.hash.get_mut().unwrap()),
+            force_stored_hash: self.force_stored_hash,
             inner: self.inner.clone_unchecked()?,
         })
     }
@@ -215,6 +234,9 @@ where
 impl<W: View> HistoricallyHashableView<W::Context, W> {
     /// Obtains a hash of the history of the changes in the view.
     pub async fn historical_hash(&mut self) -> Result<HasherOutput, ViewError> {
+        if let Some(forced) = self.force_stored_hash {
+            return Ok(forced);
+        }
         if let Some(hash) = self.hash.get_mut().unwrap() {
             return Ok(*hash);
         }
@@ -225,6 +247,163 @@ impl<W: View> HistoricallyHashableView<W::Context, W> {
         *self.hash.get_mut().unwrap() = Some(hash);
         Ok(hash)
     }
+
+    /// Returns the canonical byte representation of the inner view's persisted content
+    /// and arranges for the next save to record the hash of those bytes as the new
+    /// stored hash. Subsequent updates extend the history from that hash normally.
+    ///
+    /// The byte format is the concatenation, in sorted lexicographic key order, of
+    /// `(u64-LE key length, key, u64-LE value length, value)` records over every entry
+    /// stored under the inner view's prefix. Two views with identical persisted content
+    /// produce identical bytes by construction; the hash is therefore reproducible by
+    /// any party holding the bytes.
+    ///
+    /// Errors with [`ViewError::HasPendingChanges`] if the inner view has unflushed
+    /// changes — the dump reads from the underlying KV store and would silently miss
+    /// in-memory modifications.
+    pub async fn dump_content(&mut self) -> Result<(Vec<u8>, HasherOutput), ViewError> {
+        if self.inner.has_pending_changes().await {
+            return Err(ViewError::HasPendingChanges);
+        }
+        let context = self.inner.context();
+        // The inner context's base key is `<wrapper_base><Inner>`; passing it as the
+        // search prefix scopes the dump to the inner view's data and excludes the
+        // wrapper's hash key, which lives at `<wrapper_base><Hash>`.
+        let inner_prefix = context.base_key().bytes.clone();
+        let key_values = context
+            .store()
+            .find_key_values_by_prefix(&inner_prefix)
+            .await
+            .map_err(|err| ViewError::StoreError {
+                backend: "HistoricallyHashableView::dump_content",
+                error: Box::new(err),
+                must_reload_view: false,
+            })?;
+        let bytes = encode_key_values(&key_values);
+        let hash = hash_bytes(&bytes);
+        // Schedule the hash for the next save without forcing a save here, so the
+        // checkpoint write coalesces with the rest of the block's batch.
+        self.force_stored_hash = Some(hash);
+        *self.hash.get_mut().unwrap() = None;
+        Ok((bytes, hash))
+    }
+
+    /// Replaces the inner view's persisted content with `bytes` (a prior `dump_content`
+    /// output) and atomically records the hash of those bytes as the new stored hash.
+    /// Returns the recorded hash, so the caller can compare against an expected value.
+    ///
+    /// The replacement is save-atomic: this method writes a single batch containing the
+    /// inner-prefix wipe, the decoded `(key, value)` puts, and the wrapper's hash key.
+    /// The wrapper's normal `pre_save` lifecycle is bypassed.
+    ///
+    /// **The inner view's in-memory state is undefined after this returns.** Callers
+    /// should drop the view and reload before using it further.
+    pub async fn restore_from_content(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<HasherOutput, ViewError> {
+        let entries = decode_key_values(bytes)?;
+        let hash = hash_bytes(bytes);
+
+        let context = self.inner.context();
+        let inner_base = context.base_key().bytes.clone();
+        let mut wrapper_hash_key = inner_base.clone();
+        // The inner context's base key is `<wrapper_base><Inner tag>`; flipping the last
+        // byte to `Hash` gives the wrapper's hash key.
+        *wrapper_hash_key.last_mut().expect("inner base key is non-empty") = KeyTag::Hash as u8;
+
+        let mut batch = Batch::new();
+        // Wipe whatever is currently under the inner prefix.
+        batch.delete_key_prefix(inner_base.clone());
+        // Re-insert the decoded entries.
+        for (key, value) in entries {
+            let mut full_key = inner_base.clone();
+            full_key.extend_from_slice(&key);
+            batch.put_key_value_bytes(full_key, value);
+        }
+        // Persist the new stored hash atomically with the content replacement.
+        batch.put_key_value(wrapper_hash_key, &hash)?;
+
+        context
+            .store()
+            .write_batch(batch)
+            .await
+            .map_err(|err| ViewError::StoreError {
+                backend: "HistoricallyHashableView::restore_from_content",
+                error: Box::new(err),
+                must_reload_view: false,
+            })?;
+
+        // Update wrapper in-memory state; the inner view's in-memory state is now stale
+        // and the caller is contractually obliged to reload.
+        self.stored_hash = Some(hash);
+        *self.hash.get_mut().unwrap() = Some(hash);
+        self.force_stored_hash = None;
+
+        Ok(hash)
+    }
+}
+
+/// Encodes `(key, value)` pairs into the canonical byte representation used by
+/// [`HistoricallyHashableView::dump_content`].
+///
+/// The caller must pass entries in the same order the underlying store iterates them
+/// (sorted lexicographically by key). All current backends — Memory, RocksDB, DynamoDB
+/// (`query` ASC sort key), ScyllaDB (clustering ASC), IndexedDB (cursor default) — do.
+fn encode_key_values(entries: &[(Vec<u8>, Vec<u8>)]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for (key, value) in entries {
+        bytes.extend_from_slice(&(key.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(key);
+        bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(value);
+    }
+    bytes
+}
+
+/// Decodes the canonical byte representation produced by [`encode_key_values`]. Returns
+/// [`ViewError::MalformedContent`] if keys are not in strictly increasing lexicographic
+/// order (the canonical format is sorted; out-of-order or duplicate keys signal a
+/// malformed or hand-crafted input).
+#[expect(clippy::type_complexity)]
+fn decode_key_values(mut bytes: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
+    let mut entries: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+    while !bytes.is_empty() {
+        let key = read_chunk(&mut bytes)?;
+        let value = read_chunk(&mut bytes)?;
+        if let Some((previous_key, _)) = entries.last() {
+            if key.as_slice() <= previous_key.as_slice() {
+                return Err(ViewError::MalformedContent(
+                    "keys must be in strictly increasing order",
+                ));
+            }
+        }
+        entries.push((key, value));
+    }
+    Ok(entries)
+}
+
+fn read_chunk(bytes: &mut &[u8]) -> Result<Vec<u8>, ViewError> {
+    if bytes.len() < 8 {
+        return Err(ViewError::MalformedContent("truncated length prefix"));
+    }
+    let (len_bytes, rest) = bytes.split_at(8);
+    let len = u64::from_le_bytes(len_bytes.try_into().expect("8 bytes")) as usize;
+    if rest.len() < len {
+        return Err(ViewError::MalformedContent("truncated chunk body"));
+    }
+    let (chunk, rest) = rest.split_at(len);
+    *bytes = rest;
+    Ok(chunk.to_vec())
+}
+
+fn hash_bytes(bytes: &[u8]) -> HasherOutput {
+    use crate::views::Hasher as _;
+    let mut hasher = sha3::Sha3_256::default();
+    hasher
+        .update_with_bytes(bytes)
+        .expect("Sha3_256 hashing of a byte slice cannot fail");
+    hasher.finalize()
 }
 
 impl<C, W> Deref for HistoricallyHashableView<C, W> {
@@ -280,9 +459,7 @@ mod graphql {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        context::MemoryContext, register_view::RegisterView, store::WritableKeyValueStore as _,
-    };
+    use crate::{context::MemoryContext, register_view::RegisterView};
 
     #[tokio::test]
     async fn test_historically_hashable_view_initial_state() -> Result<(), ViewError> {
@@ -571,5 +748,138 @@ mod tests {
         assert_eq!(hash_before, hash_after);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dump_content_then_save_records_content_hash() -> Result<(), ViewError> {
+        // Persist some inner state, dump it, then save. The on-disk stored hash should be
+        // the hash of the canonical bytes — independent of the prior history-of-batches
+        // hash that the view had before dumping.
+        let context = MemoryContext::new_for_testing(());
+        let mut view =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
+
+        view.set(42);
+        let mut batch = Batch::new();
+        view.pre_save(&mut batch)?;
+        context.store().write_batch(batch).await?;
+        view.post_save();
+
+        let history_hash_before = view.historical_hash().await?;
+
+        let (bytes, content_hash) = view.dump_content().await?;
+        assert_ne!(history_hash_before, content_hash);
+        assert_eq!(view.historical_hash().await?, content_hash);
+
+        // Save: the override hash is persisted.
+        let mut batch = Batch::new();
+        view.pre_save(&mut batch)?;
+        context.store().write_batch(batch).await?;
+        view.post_save();
+
+        // Reload to confirm `stored_hash` on disk is now the content hash.
+        let mut reloaded =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
+        assert_eq!(reloaded.historical_hash().await?, content_hash);
+        assert_eq!(*reloaded.get(), 42);
+
+        // And re-dumping produces the same bytes (canonical layout is deterministic).
+        let (bytes_again, content_hash_again) = reloaded.dump_content().await?;
+        assert_eq!(bytes, bytes_again);
+        assert_eq!(content_hash, content_hash_again);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_restore_then_reload_matches_source() -> Result<(), ViewError> {
+        // Dump from one view's state, restore those bytes into a fresh store, reload, and
+        // confirm the restored view reports the same content hash and the same value.
+        let source_context = MemoryContext::new_for_testing(());
+        let mut source =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(source_context.clone())
+                .await?;
+        source.set(7);
+        let mut batch = Batch::new();
+        source.pre_save(&mut batch)?;
+        source_context.store().write_batch(batch).await?;
+        source.post_save();
+        let (bytes, expected_hash) = source.dump_content().await?;
+
+        // Restore into a fresh context and reload.
+        let target_context = MemoryContext::new_for_testing(());
+        let mut target =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(target_context.clone())
+                .await?;
+        let restored_hash = target.restore_from_content(&bytes).await?;
+        assert_eq!(restored_hash, expected_hash);
+
+        // Caller is contractually obliged to reload after restore.
+        let mut reloaded =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(target_context.clone())
+                .await?;
+        assert_eq!(reloaded.historical_hash().await?, expected_hash);
+        assert_eq!(*reloaded.get(), 7);
+
+        // And re-dumping produces identical bytes — full round-trip.
+        let (bytes_after_restore, _) = reloaded.dump_content().await?;
+        assert_eq!(bytes, bytes_after_restore);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_dump_content_errors_on_pending_changes() -> Result<(), ViewError> {
+        let context = MemoryContext::new_for_testing(());
+        let mut view =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
+        view.set(1);
+        // The set() call did not flush, so the view has pending changes.
+        match view.dump_content().await {
+            Err(ViewError::HasPendingChanges) => Ok(()),
+            other => panic!("expected HasPendingChanges, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dump_content_rollback_discards_override() -> Result<(), ViewError> {
+        // After dump_content, the view holds a forced-hash override. A rollback should
+        // discard it, restoring the prior history-of-batches hash.
+        let context = MemoryContext::new_for_testing(());
+        let mut view =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
+        view.set(99);
+        let mut batch = Batch::new();
+        view.pre_save(&mut batch)?;
+        context.store().write_batch(batch).await?;
+        view.post_save();
+
+        let history_hash = view.historical_hash().await?;
+        let (_, content_hash) = view.dump_content().await?;
+        assert_eq!(view.historical_hash().await?, content_hash);
+
+        view.rollback();
+        assert_eq!(view.historical_hash().await?, history_hash);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_decode_rejects_unsorted_keys() -> Result<(), ViewError> {
+        // Hand-craft bytes with keys in non-increasing order; restore should reject them.
+        let mut bytes = Vec::new();
+        for (k, v) in [&b"b"[..], b"a"].iter().zip([&b"v1"[..], b"v2"]) {
+            bytes.extend_from_slice(&(k.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(k);
+            bytes.extend_from_slice(&(v.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(v);
+        }
+        let context = MemoryContext::new_for_testing(());
+        let mut view =
+            HistoricallyHashableView::<_, RegisterView<_, u32>>::load(context.clone()).await?;
+        match view.restore_from_content(&bytes).await {
+            Err(ViewError::MalformedContent(_)) => Ok(()),
+            other => panic!("expected MalformedContent, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Motivation

In the future we want checkpoint chain states, and restore them from checkpoints.

That means the "historical" hash of the execution state view will not be the hash of the written batches since block 0, but the hash of the written batches since the most recent checkpoint and the checkpoint itself.

The historically hashable views currently don't support that.

## Proposal

Give historically hashable views the ability to:
* reset their contents to a value given as the serialized view, and
* reset the hash to the hash of those serialized bytes.

## Test Plan

Tests were added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
