### PR TITLE
docker_image workflow: replace '/' in branch name with '-' for image tag

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -55,6 +55,9 @@ jobs:
             BRANCH_NAME="${REF_NAME}"
           fi
 
+          # Docker tags forbid '/'; replace with '-' for use as a tag.
+          BRANCH_TAG="${BRANCH_NAME//\//-}"
+
           echo "GIT_COMMIT_SHORT=${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
           echo "GIT_COMMIT_LONG=${GITHUB_SHA}" >> "$GITHUB_ENV"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> "$GITHUB_ENV"
@@ -65,7 +68,7 @@ jobs:
           for IMAGE_VAR in LINERA:linera INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter BRIDGE:linera-bridge; do
             VAR="${IMAGE_VAR%%:*}"
             NAME="${IMAGE_VAR##*:}"
-            echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_NAME}" >> "$GITHUB_ENV"
+            echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_TAG}" >> "$GITHUB_ENV"
             echo "${VAR}_IMAGE_SHORT=${REGISTRY_BASE}/${NAME}:${GITHUB_SHA:0:7}" >> "$GITHUB_ENV"
             echo "${VAR}_IMAGE_LONG=${REGISTRY_BASE}/${NAME}:${GITHUB_SHA}" >> "$GITHUB_ENV"
           done


### PR DESCRIPTION
## Motivation

Running the `Docker Image` workflow via `workflow_dispatch` on a branch whose name contains a slash fails before any build starts. The branch name is used directly as a Docker image tag, but Docker / OCI tags forbid `/`. Per the canonical grammar in `distribution/reference` (regexp.go line 68): `tag = [\w][\w.-]{0,127}`.

Source: https://github.com/distribution/reference/blob/main/regexp.go#L68

Same fix already applied to `linera-io/pm-app` in https://github.com/linera-io/pm-app/pull/526.

## Proposal

Sanitize the branch name before using it as an image tag by replacing every `/` with `-`. The raw `BRANCH_NAME` env var is preserved; only the tag form (`BRANCH_TAG`) is sanitized. The single sanitized variable is reused across all five images built in the loop.

Before: `linera:ndr-ds/some-feature` (rejected by Docker daemon)
After:  `linera:ndr-ds-some-feature` (valid)

Branches without slashes (e.g. `testnet_conway`, `devnet_*`) are unaffected.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- https://github.com/linera-io/pm-app/pull/526