### PR TITLE
Pin tonic in the project template to work with Rust 1.86.0

### DIFF
--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -23,6 +23,12 @@ unicode-segmentation = {{ version = ">=1.9, <1.13" }}
 {linera_sdk_dev_dep}
 tokio = {{ version = "1.40", features = ["rt", "sync"] }}
 
+# TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
+tonic = {{ version = ">=0.14, <0.14.6", default-features = false }}
+tonic-build = {{ version = ">=0.14, <0.14.6", default-features = false }}
+tonic-prost = {{ version = ">=0.14, <0.14.6", default-features = false }}
+tonic-prost-build = {{ version = ">=0.14, <0.14.6", default-features = false }}
+
 [[bin]]
 name = "{contract_binary_name}"
 path = "src/contract.rs"


### PR DESCRIPTION
Backport of the last commit of https://github.com/linera-io/linera-protocol/pull/6240.

## Motivation

`tonic 0.14.6` bumped its MSRV to Rust 1.88. `linera project new` generates a fresh cargo project with no lockfile, so on CI (rustc 1.86.0) `test_project_new` fails:

  error: rustc 1.86.0 is not supported by the following packages:
    tonic@0.14.6 requires rustc 1.88
    tonic-build@0.14.6 requires rustc 1.88
    tonic-prost@0.14.6 requires rustc 1.88
    tonic-prost-build@0.14.6 requires rustc 1.88

## Proposal

Pin all four to `>=0.14, <0.14.6` in `[dev-dependencies]` (where the transitive chain via `linera-sdk[test, wasmer]` lives), with `default-features = false` to avoid pulling tokio's `net` feature into the wasm32 release build.

## Test Plan

This fixes `test_project_new`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- PR to `main`: https://github.com/linera-io/linera-protocol/pull/6240
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
