### PR TITLE
Correct the `check_burn_completion`.

### DIFF
--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Linera-side monitoring: scans for BurnEvent stream events (auto-burns),
-//! forwards certificates to EVM, checks EVM for completion via ERC-20
-//! Transfer events, and retries unforwarded burns.
+//! forwards certificates to EVM, checks EVM for already-processed burns via
+//! `FungibleBridge.processedBurns`, and retries unforwarded burns.
 
 use std::{sync::Arc, time::Duration};
 
 use alloy::{primitives::Address, providers::Provider};
-use linera_base::data_types::BlockHeight;
 use tokio::sync::{Notify, RwLock};
 
 use super::{MonitorState, PendingBurn};
@@ -237,16 +236,23 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
     Ok(())
 }
 
+/// Detects burns that were already released on EVM (by a prior `addBlock`
+/// from us before a crash, or by another relayer). Queries the per-burn
+/// `processedBurns` mapping on FungibleBridge so the answer is intrinsic to
+/// the burn and survives any future change to the contract's per-block
+/// processing semantics. Marks each such burn complete *without* sending an
+/// EVM transaction, so `process_pending_burns` doesn't waste gas re-submitting
+/// blocks that would just revert with "block already verified".
 async fn check_burn_completion(
     monitor: &RwLock<MonitorState>,
     evm_client: &EvmClient<impl Provider>,
 ) -> anyhow::Result<()> {
-    let pending: Vec<(BlockHeight, usize, Address)> = {
+    let pending: Vec<(linera_base::data_types::BlockHeight, usize)> = {
         let state = monitor.read().await;
         state
             .pending_burns()
             .into_iter()
-            .map(|b| (b.value.height, b.value.burn_index, b.value.evm_recipient))
+            .map(|b| (b.value.height, b.value.burn_index))
             .collect()
     };
 
@@ -254,16 +260,151 @@ async fn check_burn_completion(
         return Ok(());
     }
 
-    for (height, burn_index, recipient) in pending {
-        let logs = evm_client.get_transfer_logs(recipient).await?;
-        if !logs.is_empty() {
-            monitor
-                .write()
-                .await
-                .complete_burn(height, burn_index)
-                .await;
+    for (height, burn_index) in pending {
+        match evm_client.is_burn_processed(height, burn_index).await {
+            Ok(true) => {
+                monitor
+                    .write()
+                    .await
+                    .complete_burn(height, burn_index)
+                    .await;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    ?height,
+                    burn_index,
+                    "Failed to query processedBurns for completion check: {e:#}"
+                );
+            }
         }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::U256;
+    use alloy_sol_types::sol;
+    use linera_base::{
+        crypto::{CryptoHash, TestString, ValidatorSecretKey},
+        data_types::{Amount, BlockHeight},
+    };
+    use revm::{database::CacheDB, primitives::Address};
+
+    use crate::{evm::microchain::addBlockCall, test_helpers::*};
+
+    sol! {
+        function isBurnProcessed(uint64 height, uint256 burnIndex) external view returns (bool);
+        function transfer(address to, uint256 amount) external returns (bool);
+    }
+
+    /// End-to-end check that `_onBlock` records each released burn under a
+    /// key that `isBurnProcessed(height, burnIndex)` can find. Submits a
+    /// cert with two burn events in one transaction — the multi-burn-in-
+    /// one-block case that block-level dedup couldn't distinguish — and
+    /// verifies both `(height, 0)` and `(height, 1)` flip to true.
+    #[test]
+    fn is_burn_processed_returns_true_after_release() {
+        let mut db = CacheDB::default();
+        let deployer = Address::ZERO;
+        let secret = ValidatorSecretKey::generate();
+        let public = secret.public();
+        let validator_addr = validator_evm_address(&public);
+        let admin_chain_id = test_admin_chain_id();
+        let light_client = deploy_light_client(
+            &mut db,
+            deployer,
+            &[validator_addr],
+            &[1],
+            admin_chain_id,
+            0,
+        );
+
+        // Fund the bridge so `token.transfer` inside `_onBlock` succeeds —
+        // a failed transfer reverts the whole `addBlock` and `processedBurns`
+        // would never be written, masking the property under test.
+        let initial_supply = U256::from(1_000_000_000_000_000_000_000_000u128);
+        let token = deploy_mock_erc20(&mut db, deployer, initial_supply);
+
+        let chain_id = CryptoHash::new(&TestString::new("test_chain"));
+        let app_id = CryptoHash::new(&TestString::new("fungible_app"));
+        let bridge =
+            deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, token, app_id);
+        call_contract(
+            &mut db,
+            deployer,
+            token,
+            &transferCall {
+                to: bridge,
+                amount: initial_supply,
+            },
+        );
+
+        let height = BlockHeight(1);
+        let events = vec![vec![
+            burn_event(app_id, [0xAA; 20], Amount::from_attos(100), 0),
+            burn_event(app_id, [0xBB; 20], Amount::from_attos(200), 1),
+        ]];
+
+        // Both burns are unset before the block is processed.
+        for burn_index in [0u64, 1] {
+            let (set, _, _) = call_contract(
+                &mut db,
+                deployer,
+                bridge,
+                &isBurnProcessedCall {
+                    height: height.0,
+                    burnIndex: U256::from(burn_index),
+                },
+            );
+            assert!(
+                !set,
+                "isBurnProcessed(height, {burn_index}) should be false before addBlock"
+            );
+        }
+
+        let cert = create_certificate_with_events(&secret, &public, chain_id, height, events);
+        call_contract(
+            &mut db,
+            deployer,
+            bridge,
+            &addBlockCall {
+                data: bcs::to_bytes(&cert).unwrap().into(),
+            },
+        );
+
+        // Both burns now report processed.
+        for burn_index in [0u64, 1] {
+            let (set, _, _) = call_contract(
+                &mut db,
+                deployer,
+                bridge,
+                &isBurnProcessedCall {
+                    height: height.0,
+                    burnIndex: U256::from(burn_index),
+                },
+            );
+            assert!(
+                set,
+                "isBurnProcessed(height, {burn_index}) must be true after addBlock"
+            );
+        }
+
+        // A burn at a height that wasn't processed must remain unset.
+        let (other, _, _) = call_contract(
+            &mut db,
+            deployer,
+            bridge,
+            &isBurnProcessedCall {
+                height: 2,
+                burnIndex: U256::ZERO,
+            },
+        );
+        assert!(
+            !other,
+            "isBurnProcessed for an unrelated (height, burnIndex) must be false"
+        );
+    }
 }

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -11,7 +11,7 @@ use alloy::{
 };
 use alloy_sol_types::SolCall;
 use anyhow::{Context as _, Result};
-use linera_base::data_types::Epoch;
+use linera_base::data_types::{BlockHeight, Epoch};
 
 use crate::proof::deposit_event_signature;
 
@@ -20,6 +20,7 @@ sol! {
     interface IFungibleBridge {
         function addBlock(bytes calldata data) external;
         function lightClient() external view returns (address);
+        function isBurnProcessed(uint64 height, uint256 burnIndex) external view returns (bool);
     }
 }
 
@@ -96,14 +97,21 @@ impl<P: Provider> EvmClient<P> {
         Ok(all_logs)
     }
 
-    /// Queries ERC-20 Transfer events from the bridge to a recipient.
-    pub async fn get_transfer_logs(&self, recipient: Address) -> Result<Vec<Log>> {
-        let transfer_sig = alloy::primitives::keccak256("Transfer(address,address,uint256)");
-        let filter = Filter::new()
-            .address(self.bridge_addr)
-            .event_signature(transfer_sig)
-            .topic2(B256::left_padding_from(recipient.as_slice()));
-        Ok(self.provider.get_logs(&filter).await?)
+    /// Returns whether the FungibleBridge has already released the burn
+    /// at `(height, burn_index)` — i.e. whether the corresponding
+    /// `_onBlock` loop iteration ran to completion in some prior `addBlock`
+    /// transaction. The answer is intrinsic to the burn rather than inferred
+    /// from block-level state or token transfer events.
+    pub async fn is_burn_processed(
+        &self,
+        height: BlockHeight,
+        burn_index: usize,
+    ) -> Result<bool> {
+        let bridge_contract = IFungibleBridge::new(self.bridge_addr, &self.provider);
+        Ok(bridge_contract
+            .isBurnProcessed(height.0, U256::from(burn_index))
+            .call()
+            .await?)
     }
 
     /// BCS-serialize and forward a certified block to FungibleBridge on EVM.

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -102,11 +102,7 @@ impl<P: Provider> EvmClient<P> {
     /// `_onBlock` loop iteration ran to completion in some prior `addBlock`
     /// transaction. The answer is intrinsic to the burn rather than inferred
     /// from block-level state or token transfer events.
-    pub async fn is_burn_processed(
-        &self,
-        height: BlockHeight,
-        burn_index: usize,
-    ) -> Result<bool> {
+    pub async fn is_burn_processed(&self, height: BlockHeight, burn_index: usize) -> Result<bool> {
         let bridge_contract = IFungibleBridge::new(self.bridge_addr, &self.provider);
         Ok(bridge_contract
             .isBurnProcessed(height.0, U256::from(burn_index))

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -36,6 +36,12 @@ contract FungibleBridge is Microchain {
     IERC20 public immutable token;
     uint256 public depositNonce;
 
+    /// Per-burn dedup mapping. Set inside `_onBlock` after each burn's
+    /// `token.transfer` succeeds. Internal: callers should use
+    /// `isBurnProcessed(height, burnIndex)` so the key encoding stays a
+    /// contract-private detail.
+    mapping(bytes32 => bool) internal processedBurns;
+
     constructor(address _lightClient, bytes32 _chainId, address _token, bytes32 _fungibleApplicationId)
         Microchain(_lightClient, _chainId)
     {
@@ -76,10 +82,22 @@ contract FungibleBridge is Microchain {
         );
     }
 
+    /// Returns whether the burn at (height, burnIndex) has already been
+    /// released by a prior `addBlock` call. `burnIndex` is the 0-based
+    /// position of the burn in the flat sequence of matched burn events
+    /// across the block — the same counter the off-chain relayer uses.
+    function isBurnProcessed(uint64 height, uint256 burnIndex) external view returns (bool) {
+        return processedBurns[keccak256(abi.encode(height, burnIndex))];
+    }
+
     /// Processes a Linera block and releases ERC-20 tokens for any BurnEvent
     /// events on the "burns" stream from the wrapped-fungible application.
+    /// Records each released burn in `processedBurns` so the off-chain
+    /// relayer can confirm completion per burn (not just per block).
     function _onBlock(BridgeTypes.Block memory blockValue) internal override {
         bytes32 burnsHash = keccak256("burns");
+        uint64 height = blockValue.header.height.value;
+        uint256 burnIndex = 0;
         for (uint256 i = 0; i < blockValue.body.events.length; i++) {
             BridgeTypes.Event[] memory txEvents = blockValue.body.events[i];
             for (uint256 j = 0; j < txEvents.length; j++) {
@@ -99,6 +117,8 @@ contract FungibleBridge is Microchain {
 
                 address target = address(burnEvt.target);
                 require(token.transfer(target, burnEvt.amount.value), "token transfer failed");
+                processedBurns[keccak256(abi.encode(height, burnIndex))] = true;
+                burnIndex++;
             }
         }
     }


### PR DESCRIPTION
  ## Motivation

`check_burn_completion` in `monitor::linera` is meant to detect burns whose containing block was already accepted on EVM (e.g. by a previous relay instance before a crash) and mark them complete *without* spending gas on a redundant `addBlock` submission. The implementation was broken in two ways:

  1. **Filter mismatch with the deployed contract.** It queried `Transfer(address,address,uint256)` logs filtered by `address = bridge_addr`. `FungibleBridge.sol` in this repo is not itself an ERC-20 — it inherits only `Microchain`, holds an external `IERC20 token`, and the burn-release path is `token.transfer(target, …)`. The `Transfer` event is therefore emitted with `log.address == address(token)`, not `bridge_addr`, so the filter returned the empty set every iteration. (If the bridge were ever rebuilt as an ERC-20 itself, the original filter would be correct — but for the deployed contract on this branch, it is mismatched.)
  2. **Mark-by-existence semantic.** Independently of (1): the code marked a pending burn complete based on the existence of *any* matching log. Two burns to the same recipient (same amount or otherwise) are indistinguishable since the EVM event carries no per-burn identifier under either contract design.

  The check was therefore dead code that provided false confidence. Burns were being reconciled only via the `forward_cert` "already verified" string-match path inside `process_pending_burns`, which costs gas (the `addBlock` tx is sent and reverts) and depends on a brittle revert-string match.

  ## Proposal

The logs approach is broken since it cannot distinguish between different operations.
Using the hash exposes to the same problem of authentication since a block can contain several transactions either in Linera or EVM.

The proposed solution is then to write whether the entries are processed or not directly in the chain. This is fairly radical but avoids problems in the future.

## Test Plan

CI

The test `is_burn_processed_returns_true_after_release` was introduced.

## Release Plan

Can be backported to `testnet_conway`.

## Links

None