### PR TITLE
Frontport of the disabling of key,value size tracking in `KeyValueStoreView`.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -577,7 +577,6 @@ View or update the resource control policy
 * `--blob-published <BLOB_PUBLISHED>` — Set the base price to publish a blob
 * `--blob-byte-read <BLOB_BYTE_READ>` — Set the price to read a blob, per byte
 * `--blob-byte-published <BLOB_BYTE_PUBLISHED>` — The price to publish a blob, per byte
-* `--byte-stored <BYTE_STORED>` — Set the price per byte stored
 * `--operation <OPERATION>` — Set the base price of sending an operation from a block..
 * `--operation-byte <OPERATION_BYTE>` — Set the additional price for each byte in the argument of a user operation
 * `--message <MESSAGE>` — Set the base price of sending a message from a block..
@@ -727,7 +726,6 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--blob-published-price <BLOB_PUBLISHED_PRICE>` — Set the base price to publish a blob. (This will overwrite value from `--policy-config`)
 * `--blob-byte-read-price <BLOB_BYTE_READ_PRICE>` — Set the price to read a blob, per byte. (This will overwrite value from `--policy-config`)
 * `--blob-byte-published-price <BLOB_BYTE_PUBLISHED_PRICE>` — Set the price to publish a blob, per byte. (This will overwrite value from `--policy-config`)
-* `--byte-stored-price <BYTE_STORED_PRICE>` — Set the price per byte stored. (This will overwrite value from `--policy-config`)
 * `--operation-price <OPERATION_PRICE>` — Set the base price of sending an operation from a block.. (This will overwrite value from `--policy-config`)
 * `--operation-byte-price <OPERATION_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user operation. (This will overwrite value from `--policy-config`)
 * `--message-price <MESSAGE_PRICE>` — Set the base price of sending a message from a block.. (This will overwrite value from `--policy-config`)

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -337,8 +337,6 @@ pub struct Resources {
     /// The size of the messages to be sent.
     // TODO(#1531): Account for the type of message to be sent.
     pub message_size: u32,
-    /// An increase in the amount of storage space.
-    pub storage_size_delta: u32,
     /// A number of service-as-oracle requests to be performed.
     pub service_as_oracle_queries: u32,
     /// A number of HTTP requests to be performed.

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -58,7 +58,6 @@ fn resources_test_case() -> Resources {
         messages: 93,
         read_operations: 12,
         write_operations: 2,
-        storage_size_delta: 700_000_000,
         service_as_oracle_queries: 7,
         http_requests: 3,
     }
@@ -84,7 +83,6 @@ fn send_message_request_test_case() -> SendMessageRequest<Vec<u8>> {
             messages: 0,
             read_operations: 1,
             write_operations: 0,
-            storage_size_delta: 0,
             service_as_oracle_queries: 0,
             http_requests: 0,
         },

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -411,7 +411,7 @@ where
                 callback,
             } => {
                 let mut view = self.state.users.try_load_entry_mut(&id).await?;
-                view.write_batch(batch).await?;
+                view.write_batch(batch)?;
                 callback.respond(());
             }
 
@@ -810,17 +810,14 @@ where
                 callback.respond(validation_round);
             }
 
-            TotalStorageSize {
+            HasEmptyStorage {
                 application,
                 callback,
             } => {
                 let view = self.state.users.try_load_entry(&application).await?;
                 let result = match view {
-                    Some(view) => {
-                        let total_size = view.total_size();
-                        (total_size.key, total_size.value)
-                    }
-                    None => (0, 0),
+                    Some(view) => view.count().await? == 0,
+                    None => true,
                 };
                 callback.respond(result);
             }
@@ -1546,10 +1543,10 @@ pub enum ExecutionRequest {
         callback: Sender<Option<u32>>,
     },
 
-    TotalStorageSize {
+    HasEmptyStorage {
         application: ApplicationId,
         #[debug(skip)]
-        callback: Sender<(u32, u32)>,
+        callback: Sender<bool>,
     },
 
     AllowApplicationLogs {

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -47,9 +47,6 @@ pub struct ResourceControlPolicy {
     pub blob_byte_read: Amount,
     /// The price to publish a blob, per byte.
     pub blob_byte_published: Amount,
-    /// The price of increasing storage by a byte.
-    // TODO(#1536): This is not fully supported.
-    pub byte_stored: Amount,
     /// The base price of adding an operation to a block.
     pub operation: Amount,
     /// The additional price for each byte in the argument of a user operation.
@@ -112,7 +109,6 @@ impl fmt::Display for ResourceControlPolicy {
             blob_published,
             blob_byte_read,
             blob_byte_published,
-            byte_stored,
             operation,
             operation_byte,
             message,
@@ -149,7 +145,6 @@ impl fmt::Display for ResourceControlPolicy {
             {blob_published:.2} base cost per published blob\n\
             {blob_byte_read:.2} cost of reading blobs, per byte\n\
             {blob_byte_published:.2} cost of publishing blobs, per byte\n\
-            {byte_stored:.2} cost per byte stored\n\
             {operation:.2} per operation\n\
             {operation_byte:.2} per byte in the argument of an operation\n\
             {service_as_oracle_query:.2} per query to a service as an oracle\n\
@@ -200,7 +195,6 @@ impl ResourceControlPolicy {
             blob_published: Amount::ZERO,
             blob_byte_read: Amount::ZERO,
             blob_byte_published: Amount::ZERO,
-            byte_stored: Amount::ZERO,
             operation: Amount::ZERO,
             operation_byte: Amount::ZERO,
             message: Amount::ZERO,
@@ -285,7 +279,6 @@ impl ResourceControlPolicy {
             blob_byte_published: Amount::from_nanos(100),
             read_operation: Amount::from_micros(10),
             write_operation: Amount::from_micros(20),
-            byte_stored: Amount::from_nanos(10),
             message_byte: Amount::from_nanos(100),
             operation_byte: Amount::from_nanos(10),
             operation: Amount::from_micros(10),
@@ -334,7 +327,6 @@ impl ResourceControlPolicy {
         )?;
         amount.try_add_assign(self.message.try_mul(resources.messages as u128)?)?;
         amount.try_add_assign(self.message_bytes_price(resources.message_size as u64)?)?;
-        amount.try_add_assign(self.bytes_stored_price(resources.storage_size_delta as u64)?)?;
         amount.try_add_assign(
             self.service_as_oracle_queries_price(resources.service_as_oracle_queries)?,
         )?;
@@ -380,12 +372,6 @@ impl ResourceControlPolicy {
         self.blob_byte_published
             .try_mul(count as u128)?
             .try_add(self.blob_published)
-    }
-
-    // TODO(#1536): This is not fully implemented.
-    #[allow(dead_code)]
-    pub(crate) fn bytes_stored_price(&self, count: u64) -> Result<Amount, ArithmeticError> {
-        self.byte_stored.try_mul(count as u128)
     }
 
     /// Returns how much it would cost to perform `count` queries to services running as oracles.

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -181,8 +181,6 @@ pub struct ResourceTracker {
     pub event_bytes_read: u64,
     /// The number of event bytes published.
     pub event_bytes_published: u64,
-    /// The change in the number of bytes being stored by user applications.
-    pub bytes_stored: i32,
     /// The number of operations executed.
     pub operations: u32,
     /// The total size of the arguments of user operations.
@@ -254,9 +252,6 @@ impl fmt::Display for ResourceTracker {
         }
         if self.bytes_written != 0 {
             storage_parts.push(format!("bytes_written={}", self.bytes_written));
-        }
-        if self.bytes_stored != 0 {
-            storage_parts.push(format!("bytes_stored={}", self.bytes_stored));
         }
         if !storage_parts.is_empty() {
             lines.push(format!("storage: {}", storage_parts.join(", ")));
@@ -732,19 +727,6 @@ where
                 .ok_or(ArithmeticError::Overflow)?;
         }
         self.update_balance(self.policy.blob_published_price(size)?)?;
-        Ok(())
-    }
-
-    /// Tracks a change in the number of bytes stored.
-    // TODO(#1536): This is not fully implemented.
-    #[allow(dead_code)]
-    pub(crate) fn track_stored_bytes(&mut self, delta: i32) -> Result<(), ExecutionError> {
-        self.tracker.as_mut().bytes_stored = self
-            .tracker
-            .as_mut()
-            .bytes_stored
-            .checked_add(delta)
-            .ok_or(ArithmeticError::Overflow)?;
         Ok(())
     }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -988,14 +988,12 @@ where
 
     fn has_empty_storage(&mut self, application: ApplicationId) -> Result<bool, ExecutionError> {
         let this = self.inner();
-        let (key_size, value_size) = this
-            .execution_state_sender
-            .send_request(move |callback| ExecutionRequest::TotalStorageSize {
+        this.execution_state_sender
+            .send_request(move |callback| ExecutionRequest::HasEmptyStorage {
                 application,
                 callback,
             })?
-            .recv_response()?;
-        Ok(key_size + value_size == 0)
+            .recv_response()
     }
 
     fn maximum_blob_size(&mut self) -> Result<u64, ExecutionError> {

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -214,7 +214,6 @@ async fn test_fee_consumption(
         byte_runtime: Amount::from_millis(1),
         byte_read: Amount::from_tokens(7),
         byte_written: Amount::from_tokens(11),
-        byte_stored: Amount::from_tokens(13),
         operation: Amount::from_tokens(17),
         operation_byte: Amount::from_tokens(19),
         message: Amount::from_tokens(23),

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -137,7 +137,6 @@ impl From<Resources> for wit_contract_api::Resources {
             blob_bytes_to_read: resources.blob_bytes_to_read,
             messages: resources.messages,
             message_size: resources.message_size,
-            storage_size_delta: resources.storage_size_delta,
             service_as_oracle_queries: resources.service_as_oracle_queries,
             http_requests: resources.http_requests,
         }

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -114,7 +114,6 @@ interface contract-runtime-api {
         blob-bytes-to-publish: u32,
         messages: u32,
         message-size: u32,
-        storage-size-delta: u32,
         service-as-oracle-queries: u32,
         http-requests: u32,
     }

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -252,10 +252,6 @@ pub struct ResourceControlPolicyOverrides {
     #[arg(long)]
     pub blob_byte_published: Option<Amount>,
 
-    /// Set the price per byte stored.
-    #[arg(long)]
-    pub byte_stored: Option<Amount>,
-
     /// Set the base price of sending an operation from a block..
     #[arg(long)]
     pub operation: Option<Amount>,
@@ -614,11 +610,6 @@ pub enum ClientCommand {
         /// (This will overwrite value from `--policy-config`)
         #[arg(long)]
         blob_byte_published_price: Option<Amount>,
-
-        /// Set the price per byte stored.
-        /// (This will overwrite value from `--policy-config`)
-        #[arg(long)]
-        byte_stored_price: Option<Amount>,
 
         /// Set the base price of sending an operation from a block..
         /// (This will overwrite value from `--policy-config`)

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -574,7 +574,6 @@ impl Runnable for Job {
                                             blob_published,
                                             blob_byte_read,
                                             blob_byte_published,
-                                            byte_stored,
                                             operation,
                                             operation_byte,
                                             message,
@@ -620,8 +619,6 @@ impl Runnable for Job {
                                             .unwrap_or(existing_policy.blob_byte_read),
                                         blob_byte_published: blob_byte_published
                                             .unwrap_or(existing_policy.blob_byte_published),
-                                        byte_stored: byte_stored
-                                            .unwrap_or(existing_policy.byte_stored),
                                         operation: operation.unwrap_or(existing_policy.operation),
                                         operation_byte: operation_byte
                                             .unwrap_or(existing_policy.operation_byte),
@@ -2199,7 +2196,6 @@ async fn run(options: &Options) -> Result<i32, Error> {
             byte_runtime_price,
             byte_read_price,
             byte_written_price,
-            byte_stored_price,
             blob_read_price,
             blob_published_price,
             blob_byte_read_price,
@@ -2245,7 +2241,6 @@ async fn run(options: &Options) -> Result<i32, Error> {
                 blob_byte_read: blob_byte_read_price.unwrap_or(existing_policy.blob_byte_read),
                 blob_byte_published: blob_byte_published_price
                     .unwrap_or(existing_policy.blob_byte_published),
-                byte_stored: byte_stored_price.unwrap_or(existing_policy.byte_stored),
                 operation: operation_price.unwrap_or(existing_policy.operation),
                 operation_byte: operation_byte_price.unwrap_or(existing_policy.operation_byte),
                 message: message_price.unwrap_or(existing_policy.message),

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1283,7 +1283,6 @@ impl ClientWrapper {
             blob_published,
             blob_byte_read,
             blob_byte_published,
-            byte_stored,
             operation,
             operation_byte,
             message,
@@ -1338,9 +1337,6 @@ impl ClientWrapper {
         }
         if let Some(value) = blob_byte_published {
             command.args(["--blob-byte-published", &value.to_string()]);
-        }
-        if let Some(value) = byte_stored {
-            command.args(["--byte-stored", &value.to_string()]);
         }
         if let Some(value) = operation {
             command.args(["--operation", &value.to_string()]);

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -18,19 +18,17 @@ use std::{collections::BTreeMap, fmt::Debug, ops::Bound::Included, sync::Mutex};
 use allocative::Allocative;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
-use linera_base::{data_types::ArithmeticError, ensure, visit_allocative_simple};
-use serde::{Deserialize, Serialize};
+use linera_base::{ensure, visit_allocative_simple};
 
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        from_bytes_option, from_bytes_option_or_default, get_key_range_for_prefix, get_upper_bound,
-        DeletionSet, HasherOutput, SuffixClosedSetIterator, Update,
+        from_bytes_option, get_key_range_for_prefix, get_upper_bound, DeletionSet, HasherOutput,
+        SuffixClosedSetIterator, Update,
     },
     context::Context,
     hashable_wrapper::WrappedHashableContainerView,
     historical_hash_wrapper::HistoricallyHashableView,
-    map_view::ByteMapView,
     store::ReadableKeyValueStore,
     views::{ClonableView, HashableView, Hasher, ReplaceContext, View, ViewError, MIN_VIEW_TAG},
 };
@@ -141,47 +139,8 @@ use {
 enum KeyTag {
     /// Prefix for the indices of the view.
     Index = MIN_VIEW_TAG,
-    /// The total stored size
-    TotalSize,
-    /// The prefix where the sizes are being stored
-    Sizes,
     /// Prefix for the hash.
     Hash,
-}
-
-/// A pair containing the key and value size.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, Allocative)]
-pub struct SizeData {
-    /// The size of the key
-    pub key: u32,
-    /// The size of the value
-    pub value: u32,
-}
-
-impl SizeData {
-    /// Sums both terms
-    pub fn sum(&mut self) -> u32 {
-        self.key + self.value
-    }
-
-    /// Adds a size to `self`
-    pub fn add_assign(&mut self, size: SizeData) -> Result<(), ViewError> {
-        self.key = self
-            .key
-            .checked_add(size.key)
-            .ok_or(ViewError::ArithmeticError(ArithmeticError::Overflow))?;
-        self.value = self
-            .value
-            .checked_add(size.value)
-            .ok_or(ViewError::ArithmeticError(ArithmeticError::Overflow))?;
-        Ok(())
-    }
-
-    /// Subtracts a size from `self`
-    pub fn sub_assign(&mut self, size: SizeData) {
-        self.key -= size.key;
-        self.value -= size.value;
-    }
 }
 
 /// A view that represents the functions of `KeyValueStore`.
@@ -211,12 +170,6 @@ pub struct KeyValueStoreView<C> {
     deletion_set: DeletionSet,
     /// Pending changes not yet persisted to storage.
     updates: BTreeMap<Vec<u8>, Update<Vec<u8>>>,
-    /// The total size of keys and values persisted in storage.
-    stored_total_size: SizeData,
-    /// The total size of keys and values including pending changes.
-    total_size: SizeData,
-    /// Map of key to value size for tracking storage usage.
-    sizes: ByteMapView<C, u32>,
     /// The hash persisted in storage.
     #[allocative(visit = visit_allocative_simple)]
     stored_hash: Option<HasherOutput>,
@@ -237,9 +190,6 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for KeyValueStoreView<C> {
             context: ctx.clone()(&self.context),
             deletion_set: self.deletion_set.clone(),
             updates: self.updates.clone(),
-            stored_total_size: self.stored_total_size,
-            total_size: self.total_size,
-            sizes: self.sizes.with_context(ctx.clone()).await,
             stored_hash: self.stored_hash,
             hash: Mutex::new(hash),
         }
@@ -247,7 +197,7 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for KeyValueStoreView<C> {
 }
 
 impl<C: Context> View for KeyValueStoreView<C> {
-    const NUM_INIT_KEYS: usize = 2 + ByteMapView::<C, u32>::NUM_INIT_KEYS;
+    const NUM_INIT_KEYS: usize = 1;
 
     type Context = C;
 
@@ -257,31 +207,15 @@ impl<C: Context> View for KeyValueStoreView<C> {
 
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
         let key_hash = context.base_key().base_tag(KeyTag::Hash as u8);
-        let key_total_size = context.base_key().base_tag(KeyTag::TotalSize as u8);
-        let mut v = vec![key_hash, key_total_size];
-        let base_key = context.base_key().base_tag(KeyTag::Sizes as u8);
-        let context_sizes = context.clone_with_base_key(base_key);
-        v.extend(ByteMapView::<C, u32>::pre_load(&context_sizes)?);
-        Ok(v)
+        Ok(vec![key_hash])
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         let hash = from_bytes_option(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
-        let total_size =
-            from_bytes_option_or_default(values.get(1).ok_or(ViewError::PostLoadValuesError)?)?;
-        let base_key = context.base_key().base_tag(KeyTag::Sizes as u8);
-        let context_sizes = context.clone_with_base_key(base_key);
-        let sizes = ByteMapView::post_load(
-            context_sizes,
-            values.get(2..).ok_or(ViewError::PostLoadValuesError)?,
-        )?;
         Ok(Self {
             context,
             deletion_set: DeletionSet::new(),
             updates: BTreeMap::new(),
-            stored_total_size: total_size,
-            total_size,
-            sizes,
             stored_hash: hash,
             hash: Mutex::new(hash),
         })
@@ -290,8 +224,6 @@ impl<C: Context> View for KeyValueStoreView<C> {
     fn rollback(&mut self) {
         self.deletion_set.rollback();
         self.updates.clear();
-        self.total_size = self.stored_total_size;
-        self.sizes.rollback();
         *self.hash.get_mut().unwrap() = self.stored_hash;
     }
 
@@ -300,12 +232,6 @@ impl<C: Context> View for KeyValueStoreView<C> {
             return true;
         }
         if !self.updates.is_empty() {
-            return true;
-        }
-        if self.stored_total_size != self.total_size {
-            return true;
-        }
-        if self.sizes.has_pending_changes().await {
             return true;
         }
         let hash = self.hash.lock().unwrap();
@@ -346,7 +272,6 @@ impl<C: Context> View for KeyValueStoreView<C> {
                 }
             }
         }
-        self.sizes.pre_save(batch)?;
         let hash = *self.hash.lock().unwrap();
         if self.stored_hash != hash {
             let key = self.context.base_key().base_tag(KeyTag::Hash as u8);
@@ -355,10 +280,6 @@ impl<C: Context> View for KeyValueStoreView<C> {
                 Some(hash) => batch.put_key_value(key, &hash)?,
             }
         }
-        if self.stored_total_size != self.total_size {
-            let key = self.context.base_key().base_tag(KeyTag::TotalSize as u8);
-            batch.put_key_value(key, &self.total_size)?;
-        }
         Ok(delete_view)
     }
 
@@ -366,17 +287,13 @@ impl<C: Context> View for KeyValueStoreView<C> {
         self.deletion_set.delete_storage_first = false;
         self.deletion_set.deleted_prefixes.clear();
         self.updates.clear();
-        self.sizes.post_save();
         let hash = *self.hash.lock().unwrap();
         self.stored_hash = hash;
-        self.stored_total_size = self.total_size;
     }
 
     fn clear(&mut self) {
         self.deletion_set.clear();
         self.updates.clear();
-        self.total_size = SizeData::default();
-        self.sizes.clear();
         *self.hash.get_mut().unwrap() = None;
     }
 }
@@ -387,9 +304,6 @@ impl<C: Context> ClonableView for KeyValueStoreView<C> {
             context: self.context.clone(),
             deletion_set: self.deletion_set.clone(),
             updates: self.updates.clone(),
-            stored_total_size: self.stored_total_size,
-            total_size: self.total_size,
-            sizes: self.sizes.clone_unchecked()?,
             stored_hash: self.stored_hash,
             hash: Mutex::new(*self.hash.get_mut().unwrap()),
         })
@@ -400,23 +314,6 @@ impl<C: Context> KeyValueStoreView<C> {
     fn max_key_size(&self) -> usize {
         let prefix_len = self.context.base_key().bytes.len();
         <C::Store as ReadableKeyValueStore>::MAX_KEY_SIZE - 1 - prefix_len
-    }
-
-    /// Getting the total sizes that will be used for keys and values when stored
-    /// ```rust
-    /// # tokio_test::block_on(async {
-    /// # use linera_views::context::MemoryContext;
-    /// # use linera_views::key_value_store_view::{KeyValueStoreView, SizeData};
-    /// # use linera_views::views::View;
-    /// # let context = MemoryContext::new_for_testing(());
-    /// let mut view = KeyValueStoreView::load(context).await.unwrap();
-    /// view.insert(vec![0, 1], vec![0, 1, 2, 3, 4]).await.unwrap();
-    /// let total_size = view.total_size();
-    /// assert_eq!(total_size, SizeData { key: 2, value: 5 });
-    /// # })
-    /// ```
-    pub fn total_size(&self) -> SizeData {
-        self.total_size
     }
 
     /// Applies the function f over all indices. If the function f returns
@@ -878,12 +775,12 @@ impl<C: Context> KeyValueStoreView<C> {
     /// view.insert(vec![3, 4], vec![42]).await.unwrap();
     /// let mut batch = Batch::new();
     /// batch.delete_key_prefix(vec![0]);
-    /// view.write_batch(batch).await.unwrap();
+    /// view.write_batch(batch).unwrap();
     /// let key_values = view.find_key_values_by_prefix(&[0]).await.unwrap();
     /// assert_eq!(key_values, vec![]);
     /// # })
     /// ```
-    pub async fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
+    pub fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
         let _latency = metrics::KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY.measure_latency();
         *self.hash.get_mut().unwrap() = None;
@@ -892,14 +789,6 @@ impl<C: Context> KeyValueStoreView<C> {
             match operation {
                 WriteOperation::Delete { key } => {
                     ensure!(key.len() <= max_key_size, ViewError::KeyTooLong);
-                    if let Some(value) = self.sizes.get(&key).await? {
-                        let entry_size = SizeData {
-                            key: u32::try_from(key.len()).map_err(|_| ArithmeticError::Overflow)?,
-                            value,
-                        };
-                        self.total_size.sub_assign(entry_size);
-                    }
-                    self.sizes.remove(key.clone());
                     if self.deletion_set.contains_prefix_of(&key) {
                         // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
                         self.updates.remove(&key);
@@ -909,19 +798,6 @@ impl<C: Context> KeyValueStoreView<C> {
                 }
                 WriteOperation::Put { key, value } => {
                     ensure!(key.len() <= max_key_size, ViewError::KeyTooLong);
-                    let entry_size = SizeData {
-                        key: key.len() as u32,
-                        value: value.len() as u32,
-                    };
-                    self.total_size.add_assign(entry_size)?;
-                    if let Some(value) = self.sizes.get(&key).await? {
-                        let entry_size = SizeData {
-                            key: key.len() as u32,
-                            value,
-                        };
-                        self.total_size.sub_assign(entry_size);
-                    }
-                    self.sizes.insert(key.clone(), entry_size.value);
                     self.updates.insert(key, Update::Set(value));
                 }
                 WriteOperation::DeletePrefix { key_prefix } => {
@@ -934,16 +810,6 @@ impl<C: Context> KeyValueStoreView<C> {
                     for key in key_list {
                         self.updates.remove(&key);
                     }
-                    let key_values = self.sizes.key_values_by_prefix(key_prefix.clone()).await?;
-                    for (key, value) in key_values {
-                        let entry_size = SizeData {
-                            key: key.len() as u32,
-                            value,
-                        };
-                        self.total_size.sub_assign(entry_size);
-                        self.sizes.remove(key);
-                    }
-                    self.sizes.remove_by_prefix(key_prefix.clone());
                     self.deletion_set.insert_key_prefix(key_prefix);
                 }
             }
@@ -966,7 +832,7 @@ impl<C: Context> KeyValueStoreView<C> {
     pub async fn insert(&mut self, index: Vec<u8>, value: Vec<u8>) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.put_key_value_bytes(index, value);
-        self.write_batch(batch).await
+        self.write_batch(batch)
     }
 
     /// Removes a value. If absent then the action has no effect.
@@ -985,7 +851,7 @@ impl<C: Context> KeyValueStoreView<C> {
     pub async fn remove(&mut self, index: Vec<u8>) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.delete_key(index);
-        self.write_batch(batch).await
+        self.write_batch(batch)
     }
 
     /// Deletes a key prefix.
@@ -1004,7 +870,7 @@ impl<C: Context> KeyValueStoreView<C> {
     pub async fn remove_by_prefix(&mut self, key_prefix: Vec<u8>) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         batch.delete_key_prefix(key_prefix);
-        self.write_batch(batch).await
+        self.write_batch(batch)
     }
 
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
@@ -1306,7 +1172,7 @@ impl<C: Context> WritableKeyValueStore for ViewContainer<C> {
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewContainerError> {
         let mut view = self.view.write().await;
-        view.write_batch(batch).await?;
+        view.write_batch(batch)?;
         let mut batch = Batch::new();
         view.pre_save(&mut batch)?;
         view.post_save();

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -8,7 +8,7 @@ use linera_views::{
     bucket_queue_view::HashedBucketQueueView,
     collection_view::{CollectionView, HashedCollectionView},
     context::{Context, MemoryContext},
-    key_value_store_view::{KeyValueStoreView, SizeData},
+    key_value_store_view::KeyValueStoreView,
     map_view::{HashedByteMapView, MapView},
     queue_view::HashedQueueView,
     random::make_deterministic_rng,
@@ -140,19 +140,6 @@ fn remove_by_prefix<V>(map: &mut BTreeMap<Vec<u8>, V>, key_prefix: &[u8]) {
     map.retain(|key, _| !key.starts_with(key_prefix));
 }
 
-fn total_size(vec: &Vec<(Vec<u8>, Vec<u8>)>) -> SizeData {
-    let mut total_key_size = 0;
-    let mut total_value_size = 0;
-    for (key, value) in vec {
-        total_key_size += key.len();
-        total_value_size += value.len();
-    }
-    SizeData {
-        key: total_key_size as u32,
-        value: total_value_size as u32,
-    }
-}
-
 #[tokio::test]
 async fn key_value_store_view_mutability() -> Result<()> {
     let context = MemoryContext::new_for_testing(());
@@ -166,7 +153,6 @@ async fn key_value_store_view_mutability() -> Result<()> {
         let read_state = view.store.index_values().await?;
         let state_vec = state_map.clone().into_iter().collect::<Vec<_>>();
         assert!(read_state.iter().map(|kv| (&kv.0, &kv.1)).eq(&state_map));
-        assert_eq!(total_size(&state_vec), view.store.total_size());
 
         let count_oper = rng.gen_range(0..15);
         let mut new_state_map = state_map.clone();
@@ -191,7 +177,6 @@ async fn key_value_store_view_mutability() -> Result<()> {
                     new_state_vec = new_state_map.clone().into_iter().collect();
                     let new_key_values = view.store.index_values().await?;
                     assert_eq!(new_state_vec, new_key_values);
-                    assert_eq!(total_size(&new_state_vec), view.store.total_size());
                 }
             }
             if choice == 1 && entry_count > 0 {
@@ -225,7 +210,6 @@ async fn key_value_store_view_mutability() -> Result<()> {
             new_state_vec = new_state_map.clone().into_iter().collect();
             let new_key_values = view.store.index_values().await?;
             assert_eq!(new_state_vec, new_key_values);
-            assert_eq!(total_size(&new_state_vec), view.store.total_size());
             let all_keys_vec = all_keys.clone().into_iter().collect::<Vec<_>>();
             let tests_multi_get = view.store.multi_get(&all_keys_vec).await?;
             for (i, key) in all_keys.clone().into_iter().enumerate() {


### PR DESCRIPTION
## Motivation

It is actually somewhat impossible to keep track of the total size without doubling the runtime of the operations.

## Proposal

Remove the size entries from the `KeyValueStoreView` and also the corresponding refund entries that were supposed to be used for that purpose.

## Test Plan

CI

## Release Plan

It is already in `testnet_conway`.

## Links

None