### PR TITLE
[backport] Tighten URI validation in extract_grpc_method_name.

### DIFF
--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -51,15 +51,50 @@ pub const TRAFFIC_TYPE_LABEL: &str = "traffic_type";
 /// Prometheus label for the error variant name, e.g. `"WorkerError::UnexpectedBlockHeight"`.
 pub const ERROR_TYPE_LABEL: &str = "error_type";
 
+/// Maximum length of a single proto identifier accepted as a service or method name.
+/// Real proto identifiers are far shorter than this; the cap guards against attacker
+/// input being recorded verbatim as a Prometheus label value.
+const MAX_PROTO_IDENT_LEN: usize = 128;
+
+/// Returns `true` if `s` is a valid protobuf identifier (`[A-Za-z][A-Za-z0-9_]*`)
+/// within the length cap.
+fn is_proto_identifier(s: &str) -> bool {
+    if s.is_empty() || s.len() > MAX_PROTO_IDENT_LEN {
+        return false;
+    }
+    let mut bytes = s.bytes();
+    let first = bytes.next().expect("non-empty checked above");
+    first.is_ascii_alphabetic() && bytes.all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+/// Returns `true` if `s` is a fully-qualified proto Service-Name: two or more
+/// proto identifiers joined by dots, e.g. `package.Service` or `outer.inner.Service`.
+fn is_proto_service_name(s: &str) -> bool {
+    let mut parts = s.split('.');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    let Some(second) = parts.next() else {
+        return false;
+    };
+    is_proto_identifier(first) && is_proto_identifier(second) && parts.all(is_proto_identifier)
+}
+
 /// Extracts the gRPC method name from a request URI path.
 ///
-/// gRPC paths have the form `/{package}.{Service}/{Method}` — the first segment
-/// always contains a dot. Non-gRPC requests (health checks, bot probes, etc.) return
-/// `"non_grpc"` to prevent unbounded label cardinality.
+/// gRPC paths follow the HTTP/2 form `"/" Service-Name "/" {method name}`, where
+/// `Service-Name` is `{proto package} "." {service name}` and the method name is a
+/// single proto identifier. Anything that does not match this exact shape — health
+/// probes, browser requests, bot scans probing for `.env` files, etc. — is mapped
+/// to `"non_grpc"` so the value is safe to use as a Prometheus label without
+/// blowing up cardinality or label-value length.
 pub fn extract_grpc_method_name(path: &str) -> &str {
-    let parts: Vec<&str> = path.splitn(3, '/').collect();
-    if parts.len() == 3 && parts[1].contains('.') {
-        parts[2]
+    let mut parts = path.splitn(3, '/');
+    let (Some(""), Some(service), Some(method)) = (parts.next(), parts.next(), parts.next()) else {
+        return "non_grpc";
+    };
+    if is_proto_service_name(service) && is_proto_identifier(method) {
+        method
     } else {
         "non_grpc"
     }
@@ -111,5 +146,72 @@ mod method_name_tests {
     #[test]
     fn empty_path() {
         assert_eq!(extract_grpc_method_name(""), "non_grpc");
+    }
+
+    #[test]
+    fn dot_env_bot_scan_does_not_leak_into_label() {
+        assert_eq!(
+            extract_grpc_method_name(
+                "/.env.local/.env.production/.env.staging/.env.development/.env.test"
+            ),
+            "non_grpc"
+        );
+    }
+
+    #[test]
+    fn service_starting_with_dot_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/.foo.bar/Method"), "non_grpc");
+    }
+
+    #[test]
+    fn method_with_extra_path_segments_is_rejected() {
+        assert_eq!(
+            extract_grpc_method_name("/foo.bar/Method/extra"),
+            "non_grpc"
+        );
+    }
+
+    #[test]
+    fn method_with_invalid_characters_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo.bar/Method-x"), "non_grpc");
+        assert_eq!(extract_grpc_method_name("/foo.bar/Method?x"), "non_grpc");
+        assert_eq!(extract_grpc_method_name("/foo.bar/.Method"), "non_grpc");
+    }
+
+    #[test]
+    fn identifier_starting_with_underscore_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo.bar/_Method"), "non_grpc");
+        assert_eq!(extract_grpc_method_name("/_foo.bar/Method"), "non_grpc");
+        assert_eq!(
+            extract_grpc_method_name("/foo.bar/________________"),
+            "non_grpc"
+        );
+    }
+
+    #[test]
+    fn empty_method_segment_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo.bar/"), "non_grpc");
+    }
+
+    #[test]
+    fn empty_service_segment_is_rejected() {
+        assert_eq!(extract_grpc_method_name("//Method"), "non_grpc");
+    }
+
+    #[test]
+    fn service_with_consecutive_dots_is_rejected() {
+        assert_eq!(extract_grpc_method_name("/foo..bar/Method"), "non_grpc");
+    }
+
+    #[test]
+    fn overlong_method_is_rejected() {
+        let long_method = "M".repeat(MAX_PROTO_IDENT_LEN + 1);
+        let path = format!("/foo.bar/{long_method}");
+        assert_eq!(extract_grpc_method_name(&path), "non_grpc");
+    }
+
+    #[test]
+    fn path_without_leading_slash_is_rejected() {
+        assert_eq!(extract_grpc_method_name("foo.bar/Method"), "non_grpc");
     }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Motivation

Backport of #6234 to `testnet_conway`.

Bot `.env`-file probe paths were being used verbatim as `method_name` Prometheus label values, exceeding Mimir's 2048-byte label length cap and causing `prometheus_remote_storage_samples_failed_total` failures on the mimir-lt remote.

## Proposal

Cherry-pick of the squash commit from #6234 onto `testnet_conway`. No conflicts.

## Test Plan

- 17/17 unit tests pass on the `testnet_conway` base.
- Once deployed, `prometheus_remote_storage_samples_failed_total{remote_name="mimir-lt"}` for `linera_proxy_*` series should drop to ~0.

## Release Plan

- These changes should be backported to the latest `testnet_conway` branch, then
    - be released in a validator hotfix.

## Links

- Parent PR: #6234
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
EOF
)