### PR TITLE
Move rpc_endpoint setting (EVM rpc node) from bridge parameters to instantiation.

### DIFF
--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -231,7 +231,6 @@ echo "Publishing and creating evm-bridge app..."
 BRIDGE_PARAMS=$(
     CHAIN_ID="$EVM_CHAIN_ID" \
     TOKEN_HEX="$TOKEN_ADDR_HEX" \
-    EVM_RPC_URL="$EVM_RPC_URL" \
     python3 -c "
 import json, os
 def hex_to_array(h):
@@ -239,9 +238,13 @@ def hex_to_array(h):
 params = {
     'source_chain_id': int(os.environ['CHAIN_ID']),
     'token_address': hex_to_array(os.environ['TOKEN_HEX']),
-    'rpc_endpoint': os.environ.get('EVM_RPC_URL', ''),
 }
 print(json.dumps(params))
+")
+
+BRIDGE_ARGUMENT=$(EVM_RPC_URL="$EVM_RPC_URL" python3 -c "
+import json, os
+print(json.dumps({'rpc_endpoint': os.environ.get('EVM_RPC_URL', '')}))
 ")
 
 for attempt in 1 2 3; do
@@ -249,7 +252,7 @@ for attempt in 1 2 3; do
         "$EVM_BRIDGE_WASM_DIR/evm_bridge_contract.wasm" \
         "$EVM_BRIDGE_WASM_DIR/evm_bridge_service.wasm" \
         --json-parameters "$BRIDGE_PARAMS" \
-        --json-argument 'null' 2>&1) && break
+        --json-argument "$BRIDGE_ARGUMENT" 2>&1) && break
     echo "  Attempt $attempt failed:" >&2
     echo "$BRIDGE_APP_OUTPUT" >&2
     sleep 2

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -4,7 +4,9 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 use alloy_primitives::Bytes;
-use evm_bridge::{BridgeOperation, BridgeParameters, DepositKey, EvmBridgeAbi};
+use evm_bridge::{
+    BridgeInstantiationArgument, BridgeOperation, BridgeParameters, DepositKey, EvmBridgeAbi,
+};
 use fungible::Account;
 use linera_bridge::proof;
 use linera_sdk::{
@@ -25,6 +27,7 @@ pub struct BridgeState {
     pub verified_block_hashes: SetView<[u8; 32]>,
     pub fungible_app_id: RegisterView<Option<ApplicationId>>,
     pub bridge_contract_address: RegisterView<Option<[u8; 20]>>,
+    pub rpc_endpoint: RegisterView<String>,
 }
 
 pub struct EvmBridgeContract {
@@ -41,7 +44,7 @@ impl WithContractAbi for EvmBridgeContract {
 impl Contract for EvmBridgeContract {
     type Message = ();
     type Parameters = BridgeParameters;
-    type InstantiationArgument = ();
+    type InstantiationArgument = BridgeInstantiationArgument;
     type EventValue = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
@@ -51,10 +54,10 @@ impl Contract for EvmBridgeContract {
         EvmBridgeContract { state, runtime }
     }
 
-    async fn instantiate(&mut self, _argument: ()) {
+    async fn instantiate(&mut self, argument: BridgeInstantiationArgument) {
         let params = self.runtime.application_parameters();
-        if !params.rpc_endpoint.is_empty() {
-            let client = ContractEthereumClient::new(params.rpc_endpoint.clone());
+        if !argument.rpc_endpoint.is_empty() {
+            let client = ContractEthereumClient::new(argument.rpc_endpoint.clone());
             let chain_id = client
                 .get_chain_id()
                 .await
@@ -65,6 +68,7 @@ impl Contract for EvmBridgeContract {
                 params.source_chain_id
             );
         }
+        self.state.rpc_endpoint.set(argument.rpc_endpoint);
     }
 
     async fn execute_operation(&mut self, operation: BridgeOperation) {

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -121,6 +121,12 @@ impl Contract for EvmBridgeContract {
                 );
                 self.state.bridge_contract_address.set(Some(address));
             }
+            BridgeOperation::SetRpcEndpoint { rpc_endpoint } => {
+                self.runtime
+                    .authenticated_signer()
+                    .expect("SetRpcEndpoint requires an authenticated signer");
+                self.state.rpc_endpoint.set(rpc_endpoint);
+            }
         }
     }
 

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -136,9 +136,9 @@ impl Contract for EvmBridgeContract {
 
 impl EvmBridgeContract {
     async fn verify_block_hash(&mut self, block_hash: [u8; 32]) {
-        let params = self.runtime.application_parameters();
+        let rpc_endpoint = self.state.rpc_endpoint.get();
         assert!(
-            !params.rpc_endpoint.is_empty(),
+            !rpc_endpoint.is_empty(),
             "rpc_endpoint must be configured to verify block hashes"
         );
 
@@ -181,7 +181,7 @@ impl EvmBridgeContract {
         // 1b. Finality check: when an endpoint is configured, verify the block hash
         //     is finalized. Uses cached result if a previous deposit from this block
         //     was already processed.
-        if params.rpc_endpoint.is_empty() {
+        if self.state.rpc_endpoint.get().is_empty() {
             log::warn!("rpc_endpoint is empty — skipping block finality verification.");
         } else if !self
             .state
@@ -253,7 +253,7 @@ impl EvmBridgeContract {
 
         // 5b. Cache the verified block hash so subsequent deposits from the same
         //     block skip the RPC finality check.
-        if !params.rpc_endpoint.is_empty() {
+        if !self.state.rpc_endpoint.get().is_empty() {
             self.state
                 .verified_block_hashes
                 .insert(&block_hash.0)

--- a/linera-bridge/contracts/evm-bridge/src/lib.rs
+++ b/linera-bridge/contracts/evm-bridge/src/lib.rs
@@ -8,7 +8,7 @@
 
 use async_graphql::{Request, Response};
 pub use linera_bridge::{
-    abi::{BridgeOperation, BridgeParameters},
+    abi::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters},
     proof::DepositKey,
 };
 use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};

--- a/linera-bridge/contracts/evm-bridge/src/service.rs
+++ b/linera-bridge/contracts/evm-bridge/src/service.rs
@@ -10,17 +10,22 @@ use async_graphql::{EmptyMutation, EmptySubscription, Object, Request, Response,
 use evm_bridge::{BridgeParameters, EvmBridgeAbi};
 use linera_sdk::{
     ethereum::{EthereumQueries, ServiceEthereumClient},
-    linera_base_types::WithServiceAbi,
+    linera_base_types::{ApplicationId, WithServiceAbi},
     views::{linera_views, RegisterView, RootView, SetView, View, ViewStorageContext},
     Service, ServiceRuntime,
 };
 
-/// On-chain state (mirrors contract state).
+/// On-chain state (mirrors contract state). Field order MUST match
+/// `BridgeState` in `contract.rs` because `RootView` keys are derived
+/// from field position.
 #[derive(RootView)]
 #[view(context = ViewStorageContext)]
 pub struct BridgeState {
     pub processed_deposits: SetView<[u8; 32]>,
+    pub verified_block_hashes: SetView<[u8; 32]>,
+    pub fungible_app_id: RegisterView<Option<ApplicationId>>,
     pub bridge_contract_address: RegisterView<Option<[u8; 20]>>,
+    pub rpc_endpoint: RegisterView<String>,
 }
 
 #[derive(Clone)]
@@ -78,6 +83,12 @@ impl EvmBridgeService {
         format!("0x{}", hex::encode(params.token_address))
     }
 
+    /// The configured EVM JSON-RPC endpoint, or empty if finality verification
+    /// is disabled.
+    async fn rpc_endpoint(&self) -> String {
+        self.state.rpc_endpoint.get().clone()
+    }
+
     /// Whether a deposit with the given hash has been processed.
     ///
     /// The hash is the hex-encoded keccak-256 of the deposit key
@@ -104,12 +115,12 @@ impl EvmBridgeService {
             .expect("invalid hex")
             .try_into()
             .expect("hash must be 32 bytes");
-        let params: BridgeParameters = self.runtime.application_parameters();
+        let rpc_endpoint = self.state.rpc_endpoint.get().clone();
         assert!(
-            !params.rpc_endpoint.is_empty(),
+            !rpc_endpoint.is_empty(),
             "rpc_endpoint must be configured to verify block hashes"
         );
-        let client = ServiceEthereumClient::new(params.rpc_endpoint);
+        let client = ServiceEthereumClient::new(rpc_endpoint);
         client
             .is_block_hash_finalized(B256::from(bytes))
             .await

--- a/linera-bridge/contracts/evm-bridge/tests/set_rpc_endpoint.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/set_rpc_endpoint.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the EVM bridge app's SetRpcEndpoint operation.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use evm_bridge::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters, EvmBridgeAbi};
+use linera_sdk::{
+    linera_base_types::ApplicationId,
+    test::{ActiveChain, QueryOutcome, TestValidator},
+};
+
+/// Boots a TestValidator with the bridge module and instantiates a fresh
+/// bridge application with finality verification disabled (empty RPC endpoint).
+async fn setup_bridge() -> (ActiveChain, ApplicationId<EvmBridgeAbi>) {
+    let (validator, bridge_module_id) = TestValidator::with_current_module::<
+        EvmBridgeAbi,
+        BridgeParameters,
+        BridgeInstantiationArgument,
+    >()
+    .await;
+    let mut chain = validator.new_chain().await;
+
+    let bridge_params = BridgeParameters {
+        source_chain_id: 8453u64,
+        token_address: [0xA0; 20],
+        rpc_endpoint: String::new(),
+    };
+    let bridge_app_id = chain
+        .create_application(
+            bridge_module_id,
+            bridge_params,
+            BridgeInstantiationArgument::default(),
+            vec![],
+        )
+        .await;
+
+    (chain, bridge_app_id)
+}
+
+/// Reads the bridge service's `rpcEndpoint` GraphQL field.
+async fn query_rpc_endpoint(chain: &ActiveChain, app_id: ApplicationId<EvmBridgeAbi>) -> String {
+    let QueryOutcome { response, .. } = chain.graphql_query(app_id, "query { rpcEndpoint }").await;
+    response["rpcEndpoint"]
+        .as_str()
+        .expect("rpcEndpoint should be a string")
+        .to_string()
+}
+
+#[tokio::test]
+async fn test_set_rpc_endpoint_updates_state() {
+    let (chain, bridge_app_id) = setup_bridge().await;
+
+    // Initially the endpoint is empty (finality verification disabled).
+    assert_eq!(query_rpc_endpoint(&chain, bridge_app_id).await, "");
+
+    let new_endpoint = "https://rpc.example.com".to_string();
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::SetRpcEndpoint {
+                    rpc_endpoint: new_endpoint.clone(),
+                },
+            );
+        })
+        .await;
+
+    // The new endpoint must be observable on the service, which reads from state.
+    assert_eq!(
+        query_rpc_endpoint(&chain, bridge_app_id).await,
+        new_endpoint,
+    );
+
+    // Empty string is a valid value (disables finality verification).
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::SetRpcEndpoint {
+                    rpc_endpoint: String::new(),
+                },
+            );
+        })
+        .await;
+
+    assert_eq!(query_rpc_endpoint(&chain, bridge_app_id).await, "");
+}

--- a/linera-bridge/src/abi.rs
+++ b/linera-bridge/src/abi.rs
@@ -45,12 +45,7 @@ pub enum BridgeOperation {
     SetRpcEndpoint { rpc_endpoint: String },
 }
 
-/// Initial mutable state passed at `create_application`.
-///
-/// Distinct from `BridgeParameters` (immutable, part of the ApplicationId
-/// hash). Fields here are written to the contract's state during
-/// `instantiate` and may be mutated later by operations such as
-/// `SetRpcEndpoint`.
+/// Initial state passed at `create_application`.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BridgeInstantiationArgument {
     /// JSON-RPC endpoint of the source EVM chain for finality verification.

--- a/linera-bridge/src/abi.rs
+++ b/linera-bridge/src/abi.rs
@@ -44,6 +44,9 @@ pub enum BridgeOperation {
     /// Can only be called once, by the chain owner.
     /// Must be set before ProcessDeposit can succeed.
     RegisterFungibleBridge { address: [u8; 20] },
+    /// Replace the bridge's RPC endpoint. Chain-owner-only.
+    /// Empty string disables finality verification.
+    SetRpcEndpoint { rpc_endpoint: String },
 }
 
 /// Initial mutable state passed at `create_application`.

--- a/linera-bridge/src/abi.rs
+++ b/linera-bridge/src/abi.rs
@@ -18,10 +18,6 @@ pub struct BridgeParameters {
     pub source_chain_id: u64,
     /// ERC-20 token address on the source EVM chain.
     pub token_address: [u8; 20],
-    /// JSON-RPC endpoint of the source EVM chain for finality verification.
-    /// When non-empty, `ProcessDeposit` requires the block hash to be verified first
-    /// via `VerifyBlockHash`.
-    pub rpc_endpoint: String,
 }
 
 /// Operations accepted by the bridge contract.

--- a/linera-bridge/src/abi.rs
+++ b/linera-bridge/src/abi.rs
@@ -45,3 +45,36 @@ pub enum BridgeOperation {
     /// Must be set before ProcessDeposit can succeed.
     RegisterFungibleBridge { address: [u8; 20] },
 }
+
+/// Initial mutable state passed at `create_application`.
+///
+/// Distinct from `BridgeParameters` (immutable, part of the ApplicationId
+/// hash). Fields here are written to the contract's state during
+/// `instantiate` and may be mutated later by operations such as
+/// `SetRpcEndpoint`.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BridgeInstantiationArgument {
+    /// JSON-RPC endpoint of the source EVM chain for finality verification.
+    /// Empty string means "skip finality verification" (test / local-dev mode).
+    pub rpc_endpoint: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn instantiation_argument_json_roundtrip() {
+        let arg = BridgeInstantiationArgument {
+            rpc_endpoint: "https://example.com/rpc".to_string(),
+        };
+        let json = serde_json::to_string(&arg).unwrap();
+        let back: BridgeInstantiationArgument = serde_json::from_str(&json).unwrap();
+        assert_eq!(arg, back);
+
+        // Empty string is a valid value (skip-finality mode).
+        let empty = BridgeInstantiationArgument::default();
+        let json = serde_json::to_string(&empty).unwrap();
+        assert_eq!(json, r#"{"rpc_endpoint":""}"#);
+    }
+}

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -33,7 +33,7 @@ use linera_base::{
     identifiers::AccountOwner,
     vm::VmRuntime,
 };
-use linera_bridge::abi::{BridgeOperation, BridgeParameters};
+use linera_bridge::abi::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters};
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, exec_ok, light_client_address,
     start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
@@ -173,9 +173,10 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             serde_json::to_vec(&BridgeParameters {
                 source_chain_id: 31337,
                 token_address: erc20_addr.0 .0,
+            })?,
+            serde_json::to_vec(&BridgeInstantiationArgument {
                 rpc_endpoint: String::new(),
             })?,
-            serde_json::to_vec(&())?,
             vec![],
         )
         .await?

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -22,7 +22,7 @@ use linera_base::{
     vm::VmRuntime,
 };
 use linera_bridge::{
-    abi::{BridgeOperation, BridgeParameters},
+    abi::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters},
     proof::gen::{DepositProofClient as _, HttpDepositProofClient},
 };
 use linera_bridge_e2e::{
@@ -166,13 +166,14 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     let bridge_params = BridgeParameters {
         source_chain_id: 31337,
         token_address: erc20_addr.0 .0,
-        rpc_endpoint: String::new(),
     };
     let (bridge_app_id, _) = cc
         .create_application_untyped(
             eb_module_id,
             serde_json::to_vec(&bridge_params)?,
-            serde_json::to_vec(&())?,
+            serde_json::to_vec(&BridgeInstantiationArgument {
+                rpc_endpoint: String::new(),
+            })?,
             vec![],
         )
         .await?


### PR DESCRIPTION
## Motivation

`rpc_endpoint` on the EVM bridge is currently part of `BridgeParameters`,
which is the immutable Linera application-parameters slot — the value is
baked into the ApplicationId hash and can never change. Rotating an RPC
provider, switching from a public to a private node, or pointing at a
different mirror all force a fresh deployment with a new ApplicationId,
which cascades into wallet, relay, and frontend reconfiguration.

This PR moves `rpc_endpoint` from immutable parameters to mutable
per-deployment state and adds an operation to update it.

## Proposal

- New `BridgeInstantiationArgument { rpc_endpoint: String }` carrying
  the value at `create_application` time. Empty string keeps the
  existing skip-finality semantics.
- `evm-bridge` contract stores `rpc_endpoint` in a `RegisterView<String>`
  on its state. `instantiate` writes the argument's value (after the
  existing chain-ID sanity check); `process_deposit` and
  `verify_block_hash` read from state instead of `application_parameters`.
- New `BridgeOperation::SetRpcEndpoint { rpc_endpoint: String }` updates
  the state field. Gated on `authenticated_signer().is_some()` —
  chain-owner-only, mirrors `RegisterFungibleApp` /
  `RegisterFungibleBridge`. Idempotent; empty string allowed (drops back
  to skip-finality mode).
- `rpc_endpoint` is removed from `BridgeParameters`. Callers
  (`setup.sh`, the e2e tests) pass it via `--json-argument` /
  `BridgeInstantiationArgument` instead.
- Service GraphQL exposes the new state field; existing
  `isBlockHashFinalized` reads `rpc_endpoint` from state too.
- New integration test `set_rpc_endpoint`: chain-owner submits the
  operation, GraphQL query confirms state updated, then resets to empty
  string. (TestValidator hardcodes the signer, so the unauth-panic case
  isn't covered by the harness — would need an SDK-level helper.)

## Test Plan

- CI
- manually confirmed that UI demo works.

## Release Plan

- These changes should be backported to `main` 

## Links

- Stacked on top of [`evm-bridge-relocation`](https://github.com/linera-io/linera-protocol/compare/testnet_conway...evm-bridge-relocation)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)