### PR TITLE
[testnet] Use the `Epoch` type for linera epochs.

### DIFF
--- a/linera-bridge/src/evm/light_client.rs
+++ b/linera-bridge/src/evm/light_client.rs
@@ -54,7 +54,7 @@ mod tests {
             call,
         );
 
-        assert_eq!(light_client.query_current_epoch(), 1);
+        assert_eq!(light_client.query_current_epoch(), Epoch(1));
     }
 
     #[test]
@@ -471,14 +471,14 @@ mod tests {
             )
         }
 
-        fn query_current_epoch(&mut self) -> u32 {
+        fn query_current_epoch(&mut self) -> Epoch {
             let (epoch, _, _) = call_contract(
                 &mut self.db,
                 self.deployer,
                 self.contract,
                 currentEpochCall {},
             );
-            epoch
+            Epoch(epoch)
         }
 
         fn verify_block(&mut self, data: Vec<u8>) {
@@ -549,7 +549,7 @@ mod tests {
             call,
         );
 
-        assert_eq!(light_client.query_current_epoch(), 1);
+        assert_eq!(light_client.query_current_epoch(), Epoch(1));
     }
 
     #[test]
@@ -624,7 +624,7 @@ mod tests {
             call,
         );
 
-        assert_eq!(light_client.query_current_epoch(), 1);
+        assert_eq!(light_client.query_current_epoch(), Epoch(1));
     }
 
     /// Creates a committee blob with multiple validators and returns `(committee_bytes, blob_hash)`.

--- a/linera-bridge/src/relay/committee.rs
+++ b/linera-bridge/src/relay/committee.rs
@@ -75,7 +75,7 @@ where
         }
     };
     tracing::info!(
-        current_epoch,
+        %current_epoch,
         %admin_chain_id,
         %admin_chain_height,
         "Checking for missed committee updates"
@@ -95,7 +95,7 @@ where
     let mut relayed = 0u32;
     for cert in certs.into_iter().flatten() {
         if let Some((epoch, blob_hash)) = find_create_committee(&cert) {
-            if epoch.0 <= current_epoch {
+            if epoch <= current_epoch {
                 continue;
             }
             let blob_id = BlobId::new(blob_hash, BlobType::Committee);

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -11,6 +11,7 @@ use alloy::{
 };
 use alloy_sol_types::SolCall;
 use anyhow::{Context as _, Result};
+use linera_base::data_types::Epoch;
 
 use crate::proof::deposit_event_signature;
 
@@ -152,7 +153,7 @@ impl<P: Provider> EvmClient<P> {
     }
 
     /// Queries the LightClient's current epoch.
-    pub async fn get_current_epoch(&self) -> Result<u32> {
+    pub async fn get_current_epoch(&self) -> Result<Epoch> {
         let lc_addr = self.get_light_client_address().await?;
         let call = currentEpochCall {};
         let tx = alloy::rpc::types::TransactionRequest::default()
@@ -165,7 +166,7 @@ impl<P: Provider> EvmClient<P> {
             .context("failed to query LightClient.currentEpoch()")?;
         let epoch = currentEpochCall::abi_decode_returns(&result)
             .context("failed to decode currentEpoch response")?;
-        Ok(epoch)
+        Ok(Epoch(epoch))
     }
 
     /// Relays a committee update to the LightClient contract.


### PR DESCRIPTION
## Motivation

Linera epochs have their own types, "Epoch".
We can use them in `linera-bridge`.

Backport https://github.com/linera-io/linera-protocol/pull/6210

## Proposal

Do the change

## Test Plan

CI

## Release Plan

This is the backport.

## Links

None