### PR TITLE
Fetch and bind GCP Secrets at startup

### DIFF
--- a/docker/docker-compose.bridge-testnet.yml
+++ b/docker/docker-compose.bridge-testnet.yml
@@ -1,29 +1,69 @@
 # Long-running linera-bridge relayer.
 #
 # Defaults match the testnet host layout (env at /etc/linera-bridge,
-# data at /var/lib/linera-bridge). Override RELAYER_ENV_FILE,
-# RELAYER_ENV_SECRET, RELAYER_DATA_DIR to reuse this compose file
-# from a developer machine pointing at a real network — see
-# examples/bridge-demo/spawn-relayer.sh.
+# data at /var/lib/linera-bridge, runtime secret cache at /run/linera-bridge).
+# The EVM signing key is fetched from GCP Secret Manager on every start
+# rather than read from a long-lived /etc/linera-bridge/.env.secret file.
 #
 # Prerequisites (testnet operator does this once on the VM):
-#   1. Create /var/lib/linera-bridge (data) and /etc/linera-bridge (env)
-#   2. Populate /etc/linera-bridge/.env with the keys consumed by
-#      bridge-entrypoint.sh (RPC_URL, FAUCET_URL, EVM_BRIDGE_ADDRESS,
-#      LINERA_BRIDGE_APP, LINERA_FUNGIBLE_APP, LINERA_BRIDGE_CHAIN_ID,
-#      LINERA_BRIDGE_CHAIN_OWNER, LINERA_WALLET, LINERA_KEYSTORE,
-#      LINERA_STORAGE, MONITOR_*, MAX_RETRIES, PORT)
-#   3. Drop the EVM signing key in /etc/linera-bridge/.env.secret
-#      (mode 0600, root:root): EVM_PRIVATE_KEY=0x...
+# 1. Create /var/lib/linera-bridge (data) and /etc/linera-bridge (env).
+# 2. Populate /etc/linera-bridge/.env with the keys consumed by
+#    bridge-entrypoint.sh (RPC_URL, FAUCET_URL, EVM_BRIDGE_ADDRESS,
+#    LINERA_BRIDGE_APP, LINERA_FUNGIBLE_APP, LINERA_BRIDGE_CHAIN_ID,
+#    LINERA_BRIDGE_CHAIN_OWNER, LINERA_WALLET, LINERA_KEYSTORE,
+#    LINERA_STORAGE, MONITOR_*, MAX_RETRIES, PORT). EVM_PRIVATE_KEY
+#    is NOT in this file anymore.
+# 3. Store the EVM signing key in GCP Secret Manager (default secret
+#    name: linera-bridge-evm-key; override via EVM_KEY_SECRET). Grant
+#    roles/secretmanager.secretAccessor to the principal used at runtime
+#    (VM service account, or the SA whose key file is mounted) on that
+#    specific secret.
+# 4. Ensure the tmpfs cache dir exists, owned root and mode 0700:
+#      install -d -m 0700 -o root -g root /run/linera-bridge
+#    /run is tmpfs on systemd hosts, so the materialised key never
+#    touches disk and is gone after reboot.
+#
+# Authentication for the fetcher: by default we rely on the GCE metadata
+# server (the VM's attached service account). To use a service account
+# key file instead, set GCP_KEY_FILE=/path/to/key.json on the host before
+# `docker compose up`. GCP_PROJECT_ID is required either way.
 #
 # See docker/README.testnet.md for the full procedure.
+
 services:
+  fetch-evm-key:
+    image: google/cloud-sdk:slim
+    restart: "no"
+    volumes:
+      - ${EVM_KEY_TMP_DIR:-/run/linera-bridge}:/out
+      # Mounting /dev/null when GCP_KEY_FILE is unset is a no-op; the
+      # GOOGLE_APPLICATION_CREDENTIALS var below is also empty in that
+      # case, so gcloud falls back to the GCE metadata server.
+      - ${GCP_KEY_FILE:-/dev/null}:/gcp-key.json:ro
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: ${GCP_KEY_FILE:+/gcp-key.json}
+      GCP_PROJECT_ID: ${GCP_PROJECT_ID:?GCP_PROJECT_ID must be set}
+      EVM_KEY_SECRET: ${EVM_KEY_SECRET:-linera-bridge-evm-key}
+      EVM_KEY_VERSION: ${EVM_KEY_VERSION:-latest}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        KEY=$$(gcloud secrets versions access "$$EVM_KEY_VERSION" \
+          --secret="$$EVM_KEY_SECRET" \
+          --project="$$GCP_PROJECT_ID")
+        umask 077
+        printf 'EVM_PRIVATE_KEY=%s\n' "$$KEY" > /out/evm.env
+
   relayer:
     image: us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-bridge:testnet_conway_internal
     restart: unless-stopped
+    depends_on:
+      fetch-evm-key:
+        condition: service_completed_successfully
     env_file:
       - ${RELAYER_ENV_FILE:-/etc/linera-bridge/.env}
-      - ${RELAYER_ENV_SECRET:-/etc/linera-bridge/.env.secret}
+      - ${EVM_KEY_TMP_DIR:-/run/linera-bridge}/evm.env
     ports:
       # Loopback only — /metrics and /health are not public-facing.
       # Scrape via SSH tunnel or VPN from the ops network.


### PR DESCRIPTION
## Motivation

The relayer's EVM signing key currently lives in `/etc/linera-bridge/.env.secret` on the testnet VM — a long-lived plaintext file owned by root. Operators must hand-place it during provisioning and manually rotate it. Backups and snapshots that include `/etc/` carry the key. There is no audit trail of who/when read it.

Move the secret to GCP Secret Manager and fetch it at startup into a tmpfs (`/run/linera-bridge`) that disappears on reboot.

## Proposal

- New `fetch-evm-key` compose service runs `gcloud secrets versions access` on every `up`, writes `EVM_PRIVATE_KEY=...` to `/run/linera-bridge/evm.env`, exits.
- `relayer` service `depends_on: fetch-evm-key (service_completed_successfully)` and reads the key via `env_file: /run/linera-bridge/evm.env`. The long-lived `.env.secret` `env_file` entry is removed.
- Authentication: defaults to the GCE metadata server (VM's attached service account). `GCP_KEY_FILE=/path/to/key.json` on the host switches to a mounted SA-key file for non-GCE environments.
- Configurable via env vars: `GCP_PROJECT_ID` (required), `EVM_KEY_SECRET` (default `linera-bridge-evm-key`), `EVM_KEY_VERSION` (default `latest`), `EVM_KEY_TMP_DIR` (default `/run/linera-bridge`).
- Header comment in the compose file documents the operator runbook (create tmpfs dir mode 0700, store secret in GCP, grant `roles/secretmanager.secretAccessor`).

## Test Plan

- Manual: on the testnet VM, store the existing key in Secret Manager, grant the VM SA `secretAccessor`, `docker compose up -d`, verify `fetch-evm-key` exits 0 and `relayer` starts healthy with metrics on `:3001`.
- Verify `/run/linera-bridge/evm.env` exists with mode 0600 while the relayer runs and is gone after reboot.
- Negative: missing/wrong `GCP_PROJECT_ID` makes compose fail loud before the relayer starts (compose `?` substitution).
- Negative: insufficient IAM produces a clear gcloud error from `fetch-evm-key`; the relayer never starts.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)