### PR TITLE
Silence delivery warning in logs

### DIFF
--- a/linera-core/src/chain_worker/delivery_notifier.rs
+++ b/linera-core/src/chain_worker/delivery_notifier.rs
@@ -15,7 +15,7 @@ use std::{
 
 use linera_base::data_types::BlockHeight;
 use tokio::sync::oneshot;
-use tracing::warn;
+use tracing::debug;
 
 /// A set of pending listeners waiting to be notified about the delivery of messages sent
 /// from specific [`BlockHeight`]s.
@@ -57,7 +57,7 @@ impl DeliveryNotifier {
 
         for notifier in relevant_notifiers.into_values().flatten() {
             if let Err(()) = notifier.send(()) {
-                warn!("Failed to notify message delivery to caller");
+                debug!("Failed to notify message delivery to caller");
             }
         }
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -994,7 +994,7 @@ where
                 // No need to wait. Also, cross-chain requests may not trigger the
                 // notifier later, even if we register it.
                 if let Err(()) = notifier.send(()) {
-                    warn!("Failed to notify message delivery to caller");
+                    debug!("Failed to notify message delivery to caller (early case)");
                 }
             }
         }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -40,7 +40,7 @@ use linera_views::{context::InactiveContext, ViewError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
-use tracing::{instrument, trace, warn};
+use tracing::{debug, instrument, trace, warn};
 
 /// A read guard providing access to a chain's [`ChainStateView`].
 ///
@@ -1529,7 +1529,7 @@ where
                 if let Some(notifier) = notify_when_messages_are_delivered {
                     // Nothing to wait for.
                     if let Err(()) = notifier.send(()) {
-                        warn!("Failed to notify message delivery to caller");
+                        debug!("Failed to notify message delivery to caller (validation cert)");
                     }
                 }
                 Box::pin(self.handle_validated_certificate(validated)).await


### PR DESCRIPTION
## Motivation

Reduce noise in validator logs

## Proposal

* Switch these 3 warnings to debug
* Add text to differentiate the cases

## Test Plan

CI

## Release Plan

To be backported to testnet branch