### PR TITLE
[testnet] Handle `EventsNotFound` on admin chain `EPOCH_STREAM_NAME` in committee lookup and cert processing

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -712,7 +712,7 @@ impl<Env: Environment> ChainClient<Env> {
 
     /// Obtains the committee for the latest epoch on the admin chain.
     #[instrument(level = "trace")]
-    pub async fn admin_committee(&self) -> Result<(Epoch, Arc<Committee>), LocalNodeError> {
+    pub async fn admin_committee(&self) -> Result<(Epoch, Arc<Committee>), Error> {
         self.client.admin_committee().await
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -747,16 +747,33 @@ impl<Env: Environment> Client<Env> {
                     break;
                 }
             }
-            info = Some(
+            // Track event IDs we've already tried to download to avoid looping
+            // forever when a publisher chain refuses to serve them.
+            let mut downloaded_events = HashSet::<EventId>::new();
+            let response = loop {
                 match self.handle_certificate(certificate.clone()).await {
                     Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
                         self.download_blobs(remote_nodes, &blob_ids).await?;
-                        self.handle_certificate(certificate).await?
+                        continue;
                     }
-                    x => x?,
+                    Err(LocalNodeError::EventsNotFound(event_ids)) => {
+                        let new_events = event_ids
+                            .iter()
+                            .filter(|id| !downloaded_events.contains(id))
+                            .cloned()
+                            .collect::<Vec<_>>();
+                        if new_events.is_empty() {
+                            // Already tried to download these; don't loop forever.
+                            return Err(NodeError::EventsNotFound(event_ids).into());
+                        }
+                        Box::pin(self.download_certificates_for_events(&new_events)).await?;
+                        downloaded_events.extend(new_events);
+                        continue;
+                    }
+                    other => break other?,
                 }
-                .info,
-            );
+            };
+            info = Some(response.info);
         }
 
         Ok(info)

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -36,7 +36,7 @@ use linera_chain::{
     },
     ChainError,
 };
-use linera_execution::committee::Committee;
+use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
 use linera_storage::{Clock as _, ResultReadCertificates, Storage as _};
 use rand::prelude::SliceRandom as _;
 use received_log::ReceivedLogs;
@@ -818,9 +818,8 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "trace", skip_all)]
     async fn admin_committees(
         &self,
-    ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), LocalNodeError> {
-        let query = ChainInfoQuery::new(self.admin_chain_id);
-        let info = self.local_node.handle_chain_info_query(query).await?.info;
+    ) -> Result<(Epoch, BTreeMap<Epoch, Committee>), chain_client::Error> {
+        let info = self.admin_chain_info(false).await?;
         let max_epoch = info.epoch;
         let mut committees = BTreeMap::new();
         let mut needs_fallback = false;
@@ -833,7 +832,7 @@ impl<Env: Environment> Client<Env> {
             }
         }
         if needs_fallback {
-            let info = self.chain_info_with_committees(self.admin_chain_id).await?;
+            let info = self.admin_chain_info(true).await?;
             if let Some(chain_state) = info.requested_committees.as_ref() {
                 for (epoch, committee) in chain_state {
                     if !committees.contains_key(epoch) {
@@ -851,9 +850,8 @@ impl<Env: Environment> Client<Env> {
     /// Obtains the committee for the latest epoch on the admin chain.
     ///
     /// See `admin_committees` for the fallback rationale (transitional).
-    pub async fn admin_committee(&self) -> Result<(Epoch, Arc<Committee>), LocalNodeError> {
-        let query = ChainInfoQuery::new(self.admin_chain_id);
-        let info = self.local_node.handle_chain_info_query(query).await?.info;
+    pub async fn admin_committee(&self) -> Result<(Epoch, Arc<Committee>), chain_client::Error> {
+        let info = self.admin_chain_info(false).await?;
         let epoch = info.epoch;
         if let Some(committee) = self.storage_client().get_or_load_committee(epoch).await? {
             return Ok((epoch, committee));
@@ -861,7 +859,7 @@ impl<Env: Environment> Client<Env> {
         // Slow path: events/blob missing in storage. Use the admin chain's own
         // `committees` view (still populated on testnet — #6114 is not being
         // ported) and seed the shared cache so subsequent calls hit the fast path.
-        let info = self.chain_info_with_committees(self.admin_chain_id).await?;
+        let info = self.admin_chain_info(true).await?;
         let committee = info
             .requested_committees
             .as_ref()
@@ -872,6 +870,62 @@ impl<Env: Environment> Client<Env> {
             .shared_committees()
             .insert(epoch, Arc::new(committee));
         Ok((epoch, arc_committee))
+    }
+
+    /// Queries the local node for the admin chain's info. If the chain isn't yet
+    /// initialized locally and the worker raises `EventsNotFound` on admin
+    /// `EPOCH_STREAM_NAME` events (initialization couldn't load the committees
+    /// for the admin chain's `min_active_epoch..=max_active_epoch` range), bootstrap
+    /// by syncing the admin chain from the genesis committee in storage and retry.
+    ///
+    /// Goes straight to `synchronize_chain_state_from_committee` rather than
+    /// `synchronize_chain_state`, which would re-enter `admin_committee` and recurse.
+    async fn admin_chain_info(
+        &self,
+        with_committees: bool,
+    ) -> Result<Box<ChainInfo>, chain_client::Error> {
+        let make_query = || {
+            let q = ChainInfoQuery::new(self.admin_chain_id);
+            if with_committees {
+                q.with_committees()
+            } else {
+                q
+            }
+        };
+        match self.local_node.handle_chain_info_query(make_query()).await {
+            Ok(response) => Ok(response.info),
+            Err(LocalNodeError::EventsNotFound(event_ids))
+                if event_ids.iter().all(|id| {
+                    id.chain_id == self.admin_chain_id
+                        && id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
+                }) =>
+            {
+                self.bootstrap_admin_chain_from_genesis().await?;
+                Ok(self
+                    .local_node
+                    .handle_chain_info_query(make_query())
+                    .await?
+                    .info)
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Loads the genesis committee from storage (via the genesis committee blob,
+    /// which doesn't require any synced events) and uses it to sync the admin
+    /// chain. Used when the admin chain isn't initialized locally and we can't
+    /// yet get a committee via the normal `admin_committee` path.
+    async fn bootstrap_admin_chain_from_genesis(&self) -> Result<(), chain_client::Error> {
+        let genesis_committee = self
+            .storage_client()
+            .get_or_load_committee(Epoch::ZERO)
+            .await?
+            .ok_or(LocalNodeError::InactiveChain(self.admin_chain_id))?;
+        Box::pin(
+            self.synchronize_chain_state_from_committee(self.admin_chain_id, genesis_committee),
+        )
+        .await?;
+        Ok(())
     }
 
     /// Obtains the validators for the latest epoch.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -585,7 +585,7 @@ impl<Env: Environment> Client<Env> {
         loop {
             match self.handle_certificate(certificate.clone()).await {
                 Err(LocalNodeError::BlobsNotFound(blob_ids)) if !remote_nodes.is_empty() => {
-                    tracing::warn!(
+                    tracing::error!(
                         ?blob_ids,
                         "FIX_LOCAL_EVENT_NOT_FOUND: retrying handle_certificate after BlobsNotFound"
                     );
@@ -599,14 +599,14 @@ impl<Env: Environment> Client<Env> {
                         .cloned()
                         .collect::<Vec<_>>();
                     if new_events.is_empty() {
-                        tracing::warn!(
+                        tracing::error!(
                             ?event_ids,
                             "FIX_LOCAL_EVENT_NOT_FOUND: giving up — events not retrievable"
                         );
                         // Already tried to download these; don't loop forever.
                         return Err(NodeError::EventsNotFound(event_ids).into());
                     }
-                    tracing::warn!(
+                    tracing::error!(
                         ?new_events,
                         "FIX_LOCAL_EVENT_NOT_FOUND: downloading certs for missing events and retrying handle_certificate"
                     );
@@ -961,7 +961,7 @@ impl<Env: Environment> Client<Env> {
     /// chain. Used when the admin chain isn't initialized locally and we can't
     /// yet get a committee via the normal `admin_committee` path.
     async fn bootstrap_admin_chain_from_genesis(&self) -> Result<(), chain_client::Error> {
-        tracing::warn!(
+        tracing::error!(
             admin_chain_id = %self.admin_chain_id,
             "FIX_LOCAL_EVENT_NOT_FOUND: bootstrapping admin chain from genesis committee"
         );
@@ -1787,6 +1787,11 @@ impl<Env: Environment> Client<Env> {
         remote_node: &RemoteNode<Env::ValidatorNode>,
         chain_id: ChainId,
     ) -> Result<(), chain_client::Error> {
+        tracing::error!(
+            %chain_id,
+            remote_node = remote_node.address(),
+            "FIX_LOCAL_EVENT_NOT_FOUND: entered synchronize_chain_state_from"
+        );
         let with_manager_values = !self.is_chain_follow_only(chain_id).await;
         let query = if with_manager_values {
             ChainInfoQuery::new(chain_id).with_manager_values()

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -585,6 +585,10 @@ impl<Env: Environment> Client<Env> {
         loop {
             match self.handle_certificate(certificate.clone()).await {
                 Err(LocalNodeError::BlobsNotFound(blob_ids)) if !remote_nodes.is_empty() => {
+                    tracing::warn!(
+                        ?blob_ids,
+                        "FIX_LOCAL_EVENT_NOT_FOUND: retrying handle_certificate after BlobsNotFound"
+                    );
                     self.download_blobs(remote_nodes, &blob_ids).await?;
                     continue;
                 }
@@ -595,9 +599,17 @@ impl<Env: Environment> Client<Env> {
                         .cloned()
                         .collect::<Vec<_>>();
                     if new_events.is_empty() {
+                        tracing::warn!(
+                            ?event_ids,
+                            "FIX_LOCAL_EVENT_NOT_FOUND: giving up — events not retrievable"
+                        );
                         // Already tried to download these; don't loop forever.
                         return Err(NodeError::EventsNotFound(event_ids).into());
                     }
+                    tracing::warn!(
+                        ?new_events,
+                        "FIX_LOCAL_EVENT_NOT_FOUND: downloading certs for missing events and retrying handle_certificate"
+                    );
                     Box::pin(self.download_certificates_for_events(&new_events)).await?;
                     downloaded_events.extend(new_events);
                     continue;
@@ -949,6 +961,10 @@ impl<Env: Environment> Client<Env> {
     /// chain. Used when the admin chain isn't initialized locally and we can't
     /// yet get a committee via the normal `admin_committee` path.
     async fn bootstrap_admin_chain_from_genesis(&self) -> Result<(), chain_client::Error> {
+        tracing::warn!(
+            admin_chain_id = %self.admin_chain_id,
+            "FIX_LOCAL_EVENT_NOT_FOUND: bootstrapping admin chain from genesis committee"
+        );
         let genesis_committee = self
             .storage_client()
             .get_or_load_committee(Epoch::ZERO)

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -563,9 +563,48 @@ impl<Env: Environment> Client<Env> {
                     break;
                 }
             }
-            last_info = self.handle_certificate(certificate).await?.info;
+            last_info = self
+                .handle_certificate_with_event_retries(certificate, &[])
+                .await?
+                .info;
         }
         Ok(last_info)
+    }
+
+    /// Wraps `handle_certificate` with retries for `EventsNotFound` (downloading the
+    /// publisher-chain certificates that contain the missing events) and, when
+    /// `remote_nodes` is non-empty, for `BlobsNotFound` (downloading the missing
+    /// blobs from the given validators). Prevents infinite retry loops by tracking
+    /// events that have already been requested.
+    async fn handle_certificate_with_event_retries<T: ProcessableCertificate + Clone>(
+        &self,
+        certificate: GenericCertificate<T>,
+        remote_nodes: &[RemoteNode<Env::ValidatorNode>],
+    ) -> Result<ChainInfoResponse, chain_client::Error> {
+        let mut downloaded_events = HashSet::<EventId>::new();
+        loop {
+            match self.handle_certificate(certificate.clone()).await {
+                Err(LocalNodeError::BlobsNotFound(blob_ids)) if !remote_nodes.is_empty() => {
+                    self.download_blobs(remote_nodes, &blob_ids).await?;
+                    continue;
+                }
+                Err(LocalNodeError::EventsNotFound(event_ids)) => {
+                    let new_events = event_ids
+                        .iter()
+                        .filter(|id| !downloaded_events.contains(id))
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    if new_events.is_empty() {
+                        // Already tried to download these; don't loop forever.
+                        return Err(NodeError::EventsNotFound(event_ids).into());
+                    }
+                    Box::pin(self.download_certificates_for_events(&new_events)).await?;
+                    downloaded_events.extend(new_events);
+                    continue;
+                }
+                other => return Ok(other?),
+            }
+        }
     }
 
     /// Downloads and processes certificates from the given validator.
@@ -747,32 +786,9 @@ impl<Env: Environment> Client<Env> {
                     break;
                 }
             }
-            // Track event IDs we've already tried to download to avoid looping
-            // forever when a publisher chain refuses to serve them.
-            let mut downloaded_events = HashSet::<EventId>::new();
-            let response = loop {
-                match self.handle_certificate(certificate.clone()).await {
-                    Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
-                        self.download_blobs(remote_nodes, &blob_ids).await?;
-                        continue;
-                    }
-                    Err(LocalNodeError::EventsNotFound(event_ids)) => {
-                        let new_events = event_ids
-                            .iter()
-                            .filter(|id| !downloaded_events.contains(id))
-                            .cloned()
-                            .collect::<Vec<_>>();
-                        if new_events.is_empty() {
-                            // Already tried to download these; don't loop forever.
-                            return Err(NodeError::EventsNotFound(event_ids).into());
-                        }
-                        Box::pin(self.download_certificates_for_events(&new_events)).await?;
-                        downloaded_events.extend(new_events);
-                        continue;
-                    }
-                    other => break other?,
-                }
-            };
+            let response = self
+                .handle_certificate_with_event_retries(certificate, remote_nodes)
+                .await?;
             info = Some(response.info);
         }
 
@@ -1783,7 +1799,8 @@ impl<Env: Environment> Client<Env> {
         };
 
         if let Some(timeout) = remote_info.manager.timeout {
-            self.handle_certificate(*timeout).await?;
+            self.handle_certificate_with_event_retries(*timeout, slice::from_ref(remote_node))
+                .await?;
         }
         let mut proposals = Vec::new();
         if let Some(proposal) = remote_info.manager.requested_signed_proposal {

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 packages:
-- '@linera/client'
-- '@linera/metamask'
+  - '@linera/client'
+  - '@linera/metamask'
+allowBuilds:
+  esbuild: true
 publishBranch: testnet_conway


### PR DESCRIPTION
## Motivation

The web client surfaces this error from `chain.synchronize_from_validators()`:

```
chain client error: Failed to communicate with a quorum of validators:
Local error handling validator response:
Local node operation failed: Events not found:
    [EventId { chain_id: <admin>, stream_id: StreamName(00), index: 46 }]
```

`stream_name: 00` is `EPOCH_STREAM_NAME`. `index: 46` means the admin chain's `NewCommittee` event for epoch 46 isn't in local storage. After the shared committee map landed in #6122 / #6131 and the chain-state fallback in #6186, there are still two `EventsNotFound` paths that bubble straight out instead of recovering:

1. `Client::admin_committee` / `admin_committees` call `handle_chain_info_query(admin_chain_id)` directly. If the admin chain has never been initialized locally and its description's `min_active_epoch..=max_active_epoch` range needs events that aren't synced, this errors out without trying to bootstrap.
2. `Client::process_certificates` only retries on `BlobsNotFound`. When applying a downloaded certificate for the user's chain, the worker calls `initialize_chain` → `get_committees(min..=max_active_epoch)` and raises `EventsNotFound` for admin `EPOCH_STREAM_NAME` events covering the chain's active epochs. That bubbles out of `synchronize_chain_state_from` and is wrapped as `NodeError::ResponseHandlingError` by `communicate_with_quorum` — matching the stack trace above.

The retry in `ChainClient::local_committee` from #6122 doesn't help with either: (1) is reached through callers like `validator_nodes()` that go through `admin_committee` directly, and (2) happens after `admin_committee` has already returned successfully, deep inside `communicate_with_quorum`.

## Proposal

**Commit 1 — `admin_committee` / `admin_committees` bootstrap.** Route both through a new helper `admin_chain_info(with_committees)` that catches `LocalNodeError::EventsNotFound` when **all** missing event IDs are on the admin chain's `EPOCH_STREAM_NAME`. On a hit it calls `bootstrap_admin_chain_from_genesis`, then retries the query.

`bootstrap_admin_chain_from_genesis` reads the genesis committee directly from storage via `Storage::get_or_load_committee(Epoch::ZERO)` — that path resolves through `NetworkDescription::genesis_committee_blob_hash` and does not require any synced events. It then calls `synchronize_chain_state_from_committee(admin_chain_id, genesis_committee)` (deliberately **not** `synchronize_chain_state`, which would re-enter `admin_committee` and recurse).

Both call sites in `admin_committees` — the initial query and the chain-state-fallback `chain_info_with_committees(admin_chain_id)` — share this retry.

Return types of `admin_committee` / `admin_committees` change from `LocalNodeError` to `chain_client::Error` so we can call `synchronize_chain_state_from_committee` (which uses that error type). The wrapper `ChainClient::admin_committee` was updated to match; all other callsites already used `?` to convert.

**Commit 2 — `EventsNotFound` retry in `process_certificates`.** Mirror the existing `EventsNotFound` retry from `stage_block_execution`: when `handle_certificate` raises `LocalNodeError::EventsNotFound`, call `download_certificates_for_events` to fetch the publisher-chain certificates that contain those events, then retry the handler. A per-iteration `downloaded_events` set prevents looping forever if the events truly can't be fetched.

This is the change that addresses the reported web-client error directly.

## Test Plan

- `cargo check --workspace --exclude linera-web` passes.
- The existing regression test `test_local_committee_syncs_admin_chain` (added in #6122) still passes against the new return types.
- Manual verification in the web client by the reporter is required to confirm the original `EventsNotFound` no longer surfaces.

A dedicated regression test for the `process_certificates` path (downloading admin-chain certificates to satisfy `NewCommittee` event lookups during certificate processing) and for the `admin_committee` bootstrap path (uninitialized admin chain) are not included yet and can be added in a follow-up.

## Release Plan

- These changes should be backported to the latest \`testnet\` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Original PR: #6122 (backport #6131)
- Follow-up chain-state fallback: #6186
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)