### PR TITLE
Expose the message timestamp in the contract runtime API.

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -205,6 +205,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         let context = MessageContext {
             chain_id: self.chain_id,
             origin: incoming_bundle.origin,
+            origin_timestamp: incoming_bundle.bundle.timestamp,
             is_bouncing: posted_message.is_bouncing(),
             height: self.block_height,
             round,

--- a/linera-execution/solidity/Linera.sol
+++ b/linera-execution/solidity/Linera.sol
@@ -225,6 +225,11 @@ library Linera {
         ChainId value;
     }
 
+    struct opt_Timestamp {
+        bool has_value;
+        uint64 value;
+    }
+
     function opt_account_owner_from(LineraTypes.opt_AccountOwner memory entry)
         internal
         pure
@@ -247,6 +252,14 @@ library Linera {
         returns (opt_ChainId memory)
     {
         return opt_ChainId(false, ChainId(bytes32(0)));
+    }
+
+    function opt_timestamp_from(LineraTypes.opt_Timestamp memory entry)
+        internal
+        pure
+        returns (opt_Timestamp memory)
+    {
+        return opt_Timestamp(entry.has_value, entry.value.value);
     }
 
     enum OptionBool { None, True, False }
@@ -461,6 +474,17 @@ library Linera {
         require(success);
         LineraTypes.MessageIsBouncing memory output2 = LineraTypes.bcs_deserialize_MessageIsBouncing(output1);
         return optionbool_from(output2);
+    }
+
+    function message_origin_timestamp() internal returns (opt_Timestamp memory) {
+        address precompile = address(0x0b);
+        LineraTypes.ContractRuntimePrecompile memory contract_ = LineraTypes.ContractRuntimePrecompile_case_message_origin_timestamp();
+        LineraTypes.RuntimePrecompile memory input1 = LineraTypes.RuntimePrecompile_case_contract(contract_);
+        bytes memory input2 = LineraTypes.bcs_serialize_RuntimePrecompile(input1);
+        (bool success, bytes memory output1) = precompile.call(input2);
+        require(success);
+        LineraTypes.opt_Timestamp memory output2 = LineraTypes.bcs_deserialize_opt_Timestamp(output1);
+        return opt_timestamp_from(output2);
     }
 
     function authenticated_caller_id() internal returns (Linera.opt_ApplicationId memory) {

--- a/linera-execution/solidity/LineraTypes.sol
+++ b/linera-execution/solidity/LineraTypes.sol
@@ -1581,6 +1581,41 @@ library LineraTypes {
         return value;
     }
 
+    struct OptionTimestamp {
+        opt_Timestamp value;
+    }
+
+    function bcs_serialize_OptionTimestamp(OptionTimestamp memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_opt_Timestamp(input.value);
+    }
+
+    function bcs_deserialize_offset_OptionTimestamp(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, OptionTimestamp memory)
+    {
+        uint256 new_pos;
+        opt_Timestamp memory value;
+        (new_pos, value) = bcs_deserialize_offset_opt_Timestamp(pos, input);
+        return (new_pos, OptionTimestamp(value));
+    }
+
+    function bcs_deserialize_OptionTimestamp(bytes memory input)
+        internal
+        pure
+        returns (OptionTimestamp memory)
+    {
+        uint256 new_pos;
+        OptionTimestamp memory value;
+        (new_pos, value) = bcs_deserialize_offset_OptionTimestamp(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
     struct OptionU32 {
         opt_uint32 value;
     }

--- a/linera-execution/solidity/LineraTypes.sol
+++ b/linera-execution/solidity/LineraTypes.sol
@@ -629,6 +629,7 @@ library LineraTypes {
         // choice=11 corresponds to ValidationRound
         // choice=12 corresponds to Transfer
         ContractRuntimePrecompile_Transfer transfer_;
+        // choice=13 corresponds to MessageOriginTimestamp
     }
 
     function ContractRuntimePrecompile_case_authenticated_owner()
@@ -831,6 +832,22 @@ library LineraTypes {
         return ContractRuntimePrecompile(uint8(12), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service, transfer_);
     }
 
+    function ContractRuntimePrecompile_case_message_origin_timestamp()
+        internal
+        pure
+        returns (ContractRuntimePrecompile memory)
+    {
+        ContractRuntimePrecompile_SendMessage memory send_message;
+        ContractRuntimePrecompile_TryCallApplication memory try_call_application;
+        ContractRuntimePrecompile_Emit memory emit_;
+        ContractRuntimePrecompile_ReadEvent memory read_event;
+        ContractRuntimePrecompile_SubscribeToEvents memory subscribe_to_events;
+        ContractRuntimePrecompile_UnsubscribeFromEvents memory unsubscribe_from_events;
+        ContractRuntimePrecompile_QueryService memory query_service;
+        ContractRuntimePrecompile_Transfer memory transfer_;
+        return ContractRuntimePrecompile(uint8(13), send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service, transfer_);
+    }
+
     function bcs_serialize_ContractRuntimePrecompile(ContractRuntimePrecompile memory input)
         internal
         pure
@@ -903,7 +920,7 @@ library LineraTypes {
         if (choice == 12) {
             (new_pos, transfer_) = bcs_deserialize_offset_ContractRuntimePrecompile_Transfer(new_pos, input);
         }
-        require(choice < 13);
+        require(choice < 14);
         return (new_pos, ContractRuntimePrecompile(choice, send_message, try_call_application, emit_, read_event, subscribe_to_events, unsubscribe_from_events, query_service, transfer_));
     }
 
@@ -2450,6 +2467,50 @@ library LineraTypes {
         uint256 new_pos;
         opt_TimeDelta memory value;
         (new_pos, value) = bcs_deserialize_offset_opt_TimeDelta(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct opt_Timestamp {
+        bool has_value;
+        Timestamp value;
+    }
+
+    function bcs_serialize_opt_Timestamp(opt_Timestamp memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        if (input.has_value) {
+            return abi.encodePacked(uint8(1), bcs_serialize_Timestamp(input.value));
+        } else {
+            return abi.encodePacked(uint8(0));
+        }
+    }
+
+    function bcs_deserialize_offset_opt_Timestamp(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, opt_Timestamp memory)
+    {
+        uint256 new_pos;
+        bool has_value;
+        (new_pos, has_value) = bcs_deserialize_offset_bool(pos, input);
+        Timestamp memory value;
+        if (has_value) {
+            (new_pos, value) = bcs_deserialize_offset_Timestamp(new_pos, input);
+        }
+        return (new_pos, opt_Timestamp(has_value, value));
+    }
+
+    function bcs_deserialize_opt_Timestamp(bytes memory input)
+        internal
+        pure
+        returns (opt_Timestamp memory)
+    {
+        uint256 new_pos;
+        opt_Timestamp memory value;
+        (new_pos, value) = bcs_deserialize_offset_opt_Timestamp(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-execution/solidity/LineraTypes.yaml
+++ b/linera-execution/solidity/LineraTypes.yaml
@@ -106,6 +106,10 @@ OptionChainId:
   NEWTYPESTRUCT:
     OPTION:
       TYPENAME: ChainId
+OptionTimestamp:
+  NEWTYPESTRUCT:
+    OPTION:
+      TYPENAME: Timestamp
 StreamName:
   NEWTYPESTRUCT: BYTES
 ApplicationId:
@@ -211,6 +215,8 @@ ContractRuntimePrecompile:
               TYPENAME: Account
           - amount:
               TYPENAME: Amount
+    13:
+      MessageOriginTimestamp: UNIT
 ServiceRuntimePrecompile:
   ENUM:
     0:

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -350,6 +350,8 @@ enum ContractRuntimePrecompile {
         account: Account,
         amount: AmountU256,
     },
+    /// Calling `message_origin_timestamp` of `ContractRuntime`
+    MessageOriginTimestamp,
 }
 
 /// Some functionalities from the ServiceRuntime not in BaseRuntime
@@ -573,6 +575,11 @@ impl<'a> ContractPrecompile {
             ContractRuntimePrecompile::MessageIsBouncing => {
                 let mut runtime = context.db().0.lock_runtime();
                 let result = runtime.message_is_bouncing()?;
+                Ok(bcs::to_bytes(&result)?)
+            }
+            ContractRuntimePrecompile::MessageOriginTimestamp => {
+                let mut runtime = context.db().0.lock_runtime();
+                let result = runtime.message_origin_timestamp()?;
                 Ok(bcs::to_bytes(&result)?)
             }
             ContractRuntimePrecompile::AuthenticatedCallerId => {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -643,6 +643,8 @@ pub struct MessageContext {
     pub chain_id: ChainId,
     /// The chain ID where the message originated from.
     pub origin: ChainId,
+    /// The timestamp of the block on the origin chain that sent the message.
+    pub origin_timestamp: Timestamp,
     /// Whether the message was rejected by the original receiver and is now bouncing back.
     pub is_bouncing: bool,
     /// The authenticated owner of the operation that created the message, if any.
@@ -948,6 +950,10 @@ pub trait ContractRuntime: BaseRuntime {
 
     /// The chain ID where the current message originated from, if there is one.
     fn message_origin_chain_id(&mut self) -> Result<Option<ChainId>, ExecutionError>;
+
+    /// The timestamp of the block on the origin chain that sent the current message, if there
+    /// is one.
+    fn message_origin_timestamp(&mut self) -> Result<Option<Timestamp>, ExecutionError>;
 
     /// The optional authenticated caller application ID, if it was provided and if there is one
     /// based on the execution context.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1226,6 +1226,13 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .map(|metadata| metadata.origin))
     }
 
+    fn message_origin_timestamp(&mut self) -> Result<Option<Timestamp>, ExecutionError> {
+        Ok(self
+            .inner()
+            .executing_message
+            .map(|metadata| metadata.origin_timestamp))
+    }
+
     fn authenticated_caller_id(&mut self) -> Result<Option<ApplicationId>, ExecutionError> {
         let this = self.inner();
         if this.call_stack.len() <= 1 {
@@ -1923,6 +1930,7 @@ pub enum ServiceRuntimeRequest {
 struct ExecutingMessage {
     is_bouncing: bool,
     origin: ChainId,
+    origin_timestamp: Timestamp,
 }
 
 impl From<&MessageContext> for ExecutingMessage {
@@ -1930,6 +1938,7 @@ impl From<&MessageContext> for ExecutingMessage {
         ExecutingMessage {
             is_bouncing: context.is_bouncing,
             origin: context.origin,
+            origin_timestamp: context.origin_timestamp,
         }
     }
 }

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -122,6 +122,7 @@ pub fn create_dummy_message_context(
     MessageContext {
         chain_id,
         origin: chain_id,
+        origin_timestamp: Default::default(),
         is_bouncing: false,
         authenticated_owner,
         refund_grant_to: None,

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -491,6 +491,16 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Returns the timestamp of the block on the origin chain that sent the current message,
+    /// or [`None`] if not executing an incoming message.
+    fn message_origin_timestamp(caller: &mut Caller) -> Result<Option<Timestamp>, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .message_origin_timestamp()
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Returns the authenticated caller ID, if the caller configured it and if the current context.
     fn authenticated_caller_id(caller: &mut Caller) -> Result<Option<ApplicationId>, RuntimeError> {
         caller

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -277,6 +277,7 @@ async fn test_fee_consumption(
     let context = MessageContext {
         chain_id,
         origin: chain_id,
+        origin_timestamp: Timestamp::default(),
         is_bouncing: false,
         authenticated_owner,
         refund_grant_to,
@@ -476,6 +477,7 @@ async fn test_free_app_message_no_fees() -> anyhow::Result<()> {
     let context = MessageContext {
         chain_id,
         origin: chain_id,
+        origin_timestamp: Timestamp::default(),
         is_bouncing: false,
         authenticated_owner: Some(signer),
         refund_grant_to,

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -75,6 +75,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     let context = MessageContext {
         chain_id,
         origin: chain_id,
+        origin_timestamp: Default::default(),
         is_bouncing: false,
         height: BlockHeight(0),
         round: Some(0),

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, StreamUpdate},
+    data_types::{Amount, StreamUpdate, Timestamp},
     identifiers::{
         AccountOwner, ApplicationId, ChainId, DataBlobHash, GenericApplicationId, ModuleId,
         StreamId, StreamName,
@@ -89,6 +89,12 @@ impl From<wit_contract_api::ApplicationId> for ApplicationId {
 impl From<wit_contract_api::ChainId> for ChainId {
     fn from(chain_id: wit_contract_api::ChainId) -> Self {
         ChainId(chain_id.inner0.into())
+    }
+}
+
+impl From<wit_contract_api::Timestamp> for Timestamp {
+    fn from(timestamp: wit_contract_api::Timestamp) -> Self {
+        Timestamp::from(timestamp.inner0)
     }
 }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -36,6 +36,7 @@ where
     block_height: Option<BlockHeight>,
     message_is_bouncing: Option<Option<bool>>,
     message_origin_chain_id: Option<Option<ChainId>>,
+    message_origin_timestamp: Option<Option<Timestamp>>,
     timestamp: Option<Timestamp>,
 }
 
@@ -53,6 +54,7 @@ where
             block_height: None,
             message_is_bouncing: None,
             message_origin_chain_id: None,
+            message_origin_timestamp: None,
             timestamp: None,
         }
     }
@@ -210,6 +212,14 @@ where
         *self
             .message_origin_chain_id
             .get_or_insert_with(|| contract_wit::message_origin_chain_id().map(ChainId::from))
+    }
+
+    /// Returns the timestamp of the block on the origin chain that sent the incoming message,
+    /// or [`None`] if not executing an incoming message.
+    pub fn message_origin_timestamp(&mut self) -> Option<Timestamp> {
+        *self
+            .message_origin_timestamp
+            .get_or_insert_with(|| contract_wit::message_origin_timestamp().map(Timestamp::from))
     }
 
     /// Returns the authenticated caller ID, if the caller configured it and if the current context

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -62,6 +62,7 @@ where
     round: Option<u32>,
     message_is_bouncing: Option<Option<bool>>,
     message_origin_chain_id: Option<Option<ChainId>>,
+    message_origin_timestamp: Option<Option<Timestamp>>,
     authenticated_caller_id: Option<Option<ApplicationId>>,
     timestamp: Option<Timestamp>,
     chain_balance: Option<Amount>,
@@ -115,6 +116,7 @@ where
             round: None,
             message_is_bouncing: None,
             message_origin_chain_id: None,
+            message_origin_timestamp: None,
             authenticated_caller_id: None,
             timestamp: None,
             chain_balance: None,
@@ -380,6 +382,24 @@ where
         self.message_origin_chain_id.expect(
             "`message_origin_chain_id` has not been mocked, \
             please call `MockContractRuntime::set_message_origin_chain_id` first",
+        )
+    }
+
+    /// Configures the `message_origin_timestamp` to return during the test.
+    pub fn set_message_origin_timestamp(
+        &mut self,
+        message_origin_timestamp: impl Into<Option<Timestamp>>,
+    ) -> &mut Self {
+        self.message_origin_timestamp = Some(message_origin_timestamp.into());
+        self
+    }
+
+    /// Returns the timestamp of the block on the origin chain that sent the incoming message,
+    /// or [`None`] if not executing an incoming message.
+    pub fn message_origin_timestamp(&mut self) -> Option<Timestamp> {
+        self.message_origin_timestamp.expect(
+            "`message_origin_timestamp` has not been mocked, \
+            please call `MockContractRuntime::set_message_origin_timestamp` first",
         )
     }
 

--- a/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
+++ b/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
@@ -50,6 +50,10 @@ impl Contract for MetaCounterContract {
 
     async fn execute_operation(&mut self, operation: Operation) {
         log::trace!("operation: {:?}", operation);
+        assert!(
+            self.runtime.message_origin_timestamp().is_none(),
+            "Origin timestamp must not be set when executing an operation"
+        );
         let Operation {
             recipient_id,
             authenticated,

--- a/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
+++ b/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
@@ -83,6 +83,14 @@ impl Contract for MetaCounterContract {
             .runtime
             .message_is_bouncing()
             .expect("Message delivery status has to be available when executing a message");
+        let origin_timestamp = self
+            .runtime
+            .message_origin_timestamp()
+            .expect("Origin timestamp has to be available when executing a message");
+        assert!(
+            origin_timestamp <= self.runtime.system_time(),
+            "Origin timestamp must not be in the future"
+        );
         if is_bouncing {
             log::trace!("receiving a bouncing message {message:?}");
             return;

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -4,6 +4,7 @@ interface contract-runtime-api {
     authenticated-owner: func() -> option<account-owner>;
     message-is-bouncing: func() -> option<bool>;
     message-origin-chain-id: func() -> option<chain-id>;
+    message-origin-timestamp: func() -> option<timestamp>;
     authenticated-caller-id: func() -> option<application-id>;
     send-message: func(message: send-message-request);
     transfer: func(source: account-owner, destination: account, amount: amount);
@@ -140,6 +141,10 @@ interface contract-runtime-api {
         base-timeout: time-delta,
         timeout-increment: time-delta,
         fallback-duration: time-delta,
+    }
+
+    record timestamp {
+        inner0: u64,
     }
 
     type u128 = tuple<u64, u64>;


### PR DESCRIPTION
## Motivation

It's useful for contracts to be able to see the timestamp of the message they are handling.

## Proposal

Add `message_origin_timestamp`.

## Test Plan

The `meta-counter` contract was extended to assert basic invariants.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Closes #5647.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
