### PR TITLE
Fix burn completion false positive via per-burn on-chain dedup

### DIFF
--- a/linera-bridge/src/monitor/db.rs
+++ b/linera-bridge/src/monitor/db.rs
@@ -100,12 +100,12 @@ impl BridgeDb {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS pending_burns (
                 linera_height     INTEGER NOT NULL,
-                burn_index        INTEGER NOT NULL,
+                event_index        INTEGER NOT NULL,
                 evm_recipient     TEXT NOT NULL,
                 amount            TEXT NOT NULL,
                 raw_cert          BLOB,
                 created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                PRIMARY KEY (linera_height, burn_index)
+                PRIMARY KEY (linera_height, event_index)
             )",
         )
         .execute(&self.pool)
@@ -114,14 +114,14 @@ impl BridgeDb {
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS finished_burns (
                 linera_height     INTEGER NOT NULL,
-                burn_index        INTEGER NOT NULL,
+                event_index        INTEGER NOT NULL,
                 evm_recipient     TEXT NOT NULL,
                 amount            TEXT NOT NULL,
                 raw_cert          BLOB,
                 status            TEXT NOT NULL,
                 created_at        TEXT NOT NULL,
                 finished_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                PRIMARY KEY (linera_height, burn_index)
+                PRIMARY KEY (linera_height, event_index)
             )",
         )
         .execute(&self.pool)
@@ -217,11 +217,11 @@ impl BridgeDb {
     /// Inserts a new pending burn. Ignores duplicates (idempotent).
     pub async fn insert_burn(&self, burn: &PendingBurn) -> Result<()> {
         sqlx::query(
-            "INSERT OR IGNORE INTO pending_burns (linera_height, burn_index, evm_recipient, amount)
+            "INSERT OR IGNORE INTO pending_burns (linera_height, event_index, evm_recipient, amount)
              VALUES (?, ?, ?, ?)",
         )
         .bind(burn.height.0 as i64)
-        .bind(burn.burn_index as i64)
+        .bind(burn.event_index as i64)
         .bind(format!("{:#x}", burn.evm_recipient))
         .bind(burn.amount.to_string())
         .execute(&self.pool)
@@ -238,18 +238,18 @@ impl BridgeDb {
     pub async fn update_burn_status(
         &self,
         height: BlockHeight,
-        index: usize,
+        index: u32,
         status: &str,
     ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
         let inserted = sqlx::query(
             "INSERT OR IGNORE INTO finished_burns
-                (linera_height, burn_index, evm_recipient, amount, raw_cert,
+                (linera_height, event_index, evm_recipient, amount, raw_cert,
                  status, created_at)
-             SELECT linera_height, burn_index, evm_recipient, amount, raw_cert,
+             SELECT linera_height, event_index, evm_recipient, amount, raw_cert,
                     ?, created_at
              FROM pending_burns
-             WHERE linera_height = ? AND burn_index = ?",
+             WHERE linera_height = ? AND event_index = ?",
         )
         .bind(status)
         .bind(height.0 as i64)
@@ -258,7 +258,7 @@ impl BridgeDb {
         .await?
         .rows_affected();
         let deleted =
-            sqlx::query("DELETE FROM pending_burns WHERE linera_height = ? AND burn_index = ?")
+            sqlx::query("DELETE FROM pending_burns WHERE linera_height = ? AND event_index = ?")
                 .bind(height.0 as i64)
                 .bind(index as i64)
                 .execute(&mut *tx)
@@ -268,7 +268,7 @@ impl BridgeDb {
         if deleted > 0 && inserted == 0 {
             tracing::warn!(
                 ?height,
-                burn_index = index,
+                event_index = index,
                 "Replay detected: burn already in finished_burns, original record kept"
             );
         }
@@ -321,7 +321,7 @@ impl BridgeDb {
     /// in-memory `MonitorState`.
     pub async fn load_pending_burns(&self) -> Result<Vec<PendingBurn>> {
         let rows = sqlx::query(
-            "SELECT linera_height, burn_index, evm_recipient, amount
+            "SELECT linera_height, event_index, evm_recipient, amount
              FROM pending_burns",
         )
         .fetch_all(&self.pool)
@@ -330,13 +330,13 @@ impl BridgeDb {
         let mut out = Vec::with_capacity(rows.len());
         for row in rows {
             let height: i64 = row.get(0);
-            let burn_index: i64 = row.get(1);
+            let event_index: i64 = row.get(1);
             let evm_recipient: String = row.get(2);
             let amount: String = row.get(3);
 
             out.push(PendingBurn {
                 height: BlockHeight(height as u64),
-                burn_index: burn_index as usize,
+                event_index: event_index as u32,
                 evm_recipient: evm_recipient
                     .parse()
                     .context("invalid evm_recipient in burns row")?,
@@ -363,15 +363,10 @@ impl BridgeDb {
     }
 
     /// Stores raw BCS-serialized certificate bytes on the pending burn row.
-    pub async fn store_burn_raw(
-        &self,
-        height: BlockHeight,
-        index: usize,
-        raw: &[u8],
-    ) -> Result<()> {
+    pub async fn store_burn_raw(&self, height: BlockHeight, index: u32, raw: &[u8]) -> Result<()> {
         sqlx::query(
             "UPDATE pending_burns SET raw_cert = ?
-             WHERE linera_height = ? AND burn_index = ?",
+             WHERE linera_height = ? AND event_index = ?",
         )
         .bind(raw)
         .bind(height.0 as i64)
@@ -427,7 +422,7 @@ mod tests {
     fn test_burn() -> PendingBurn {
         PendingBurn {
             height: BlockHeight(100),
-            burn_index: 0,
+            event_index: 0,
             evm_recipient: "0xabcdef1234567890abcdef1234567890abcdef12"
                 .parse()
                 .unwrap(),
@@ -713,7 +708,7 @@ mod tests {
     async fn test_load_pending_excludes_finished_burns(use_file: bool) -> Result<()> {
         let db = open_db(use_file).await?;
         let mut second = test_burn();
-        second.burn_index = 1;
+        second.event_index = 1;
         db.insert_burn(&test_burn()).await?;
         db.insert_burn(&second).await?;
         db.update_burn_status(BlockHeight(100), 0, "completed")
@@ -721,7 +716,7 @@ mod tests {
 
         let pending = db.load_pending_burns().await?;
         assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].burn_index, 1);
+        assert_eq!(pending[0].event_index, 1);
         Ok(())
     }
 

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -81,8 +81,8 @@ pub(crate) async fn process_pending_burns<E: linera_core::environment::Environme
         };
 
         let credit_height = pending.height;
-        let burn_index = pending.burn_index;
-        tracing::info!(?credit_height, burn_index, "Processing burn...");
+        let event_index = pending.event_index;
+        tracing::info!(?credit_height, event_index, "Processing burn...");
 
         // Read the certificate at the burn's block height (already contains the auto-burn).
         let cert = match async {
@@ -106,13 +106,13 @@ pub(crate) async fn process_pending_burns<E: linera_core::environment::Environme
             Err(e) => {
                 tracing::warn!(
                     ?credit_height,
-                    burn_index,
+                    event_index,
                     "Failed to read certificate: {e:#}"
                 );
                 monitor
                     .write()
                     .await
-                    .mark_burn_retried(credit_height, burn_index);
+                    .mark_burn_retried(credit_height, event_index);
                 continue;
             }
         };
@@ -122,12 +122,12 @@ pub(crate) async fn process_pending_burns<E: linera_core::environment::Environme
             bcs::to_bytes(&cert).expect("failed to BCS-serialize ConfirmedBlockCertificate");
         if let Some(db) = monitor.read().await.db() {
             if let Err(e) = db
-                .store_burn_raw(credit_height, burn_index, &cert_bytes)
+                .store_burn_raw(credit_height, event_index, &cert_bytes)
                 .await
             {
                 tracing::warn!(
                     ?credit_height,
-                    burn_index,
+                    event_index,
                     "Failed to store burn raw bytes: {e:#}"
                 );
             }
@@ -141,15 +141,15 @@ pub(crate) async fn process_pending_burns<E: linera_core::environment::Environme
         // on-chain state. Here we only forward and retry.
         match evm_client.forward_cert(&cert).await {
             Ok(()) => {
-                tracing::info!(?credit_height, burn_index, "Burn forwarded to EVM");
+                tracing::info!(?credit_height, event_index, "Burn forwarded to EVM");
                 relay::update_balance_metrics(evm_client, linera_client).await;
             }
             Err(e) => {
                 let msg = format!("{e:#}");
                 if msg.contains("already verified") {
-                    tracing::trace!(?credit_height, burn_index, "Block already verified on EVM");
+                    tracing::trace!(?credit_height, event_index, "Block already verified on EVM");
                 } else {
-                    tracing::warn!(?credit_height, burn_index, "EVM forwarding failed: {e:#}");
+                    tracing::warn!(?credit_height, event_index, "EVM forwarding failed: {e:#}");
                 }
             }
         }
@@ -157,7 +157,7 @@ pub(crate) async fn process_pending_burns<E: linera_core::environment::Environme
         monitor
             .write()
             .await
-            .mark_burn_retried(credit_height, burn_index);
+            .mark_burn_retried(credit_height, event_index);
     }
 }
 
@@ -194,10 +194,10 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
     for block in &blocks {
         let height = block.block().header.height;
         let burn_events = find_burn_events(&block.block().body.events, fungible_app_id);
-        for (burn_index, burn_event) in burn_events.into_iter().enumerate() {
+        for (event_index, burn_event) in burn_events {
             new_burns.push((
                 height,
-                burn_index,
+                event_index,
                 Address::from(burn_event.target),
                 burn_event.amount,
             ));
@@ -205,14 +205,14 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
     }
 
     let mut tracked_any = false;
-    for (height, burn_index, recipient, amount) in &new_burns {
-        tracing::info!(?height, burn_index, %recipient, %amount, "Discovered burn");
+    for (height, event_index, recipient, amount) in &new_burns {
+        tracing::info!(?height, event_index, %recipient, %amount, "Discovered burn");
         let was_new = monitor
             .write()
             .await
             .track_burn(PendingBurn {
                 height: *height,
-                burn_index: *burn_index,
+                event_index: *event_index,
                 evm_recipient: *recipient,
                 amount: *amount,
             })
@@ -232,16 +232,20 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
     Ok(())
 }
 
+/// Polls the FungibleBridge per pending burn and marks any that the EVM
+/// has already released. Per-burn rather than per-recipient — the previous
+/// `Transfer`-log filter would mark every pending burn for a recipient
+/// complete the moment ANY transfer to that recipient was observed.
 async fn check_burn_completion(
     monitor: &RwLock<MonitorState>,
     evm_client: &EvmClient<impl Provider>,
 ) -> anyhow::Result<()> {
-    let pending: Vec<(BlockHeight, usize, Address)> = {
+    let pending: Vec<(BlockHeight, u32)> = {
         let state = monitor.read().await;
         state
             .pending_burns()
             .into_iter()
-            .map(|b| (b.value.height, b.value.burn_index, b.value.evm_recipient))
+            .map(|b| (b.value.height, b.value.event_index))
             .collect()
     };
 
@@ -249,14 +253,23 @@ async fn check_burn_completion(
         return Ok(());
     }
 
-    for (height, burn_index, recipient) in pending {
-        let logs = evm_client.get_transfer_logs(recipient).await?;
-        if !logs.is_empty() {
-            monitor
-                .write()
-                .await
-                .complete_burn(height, burn_index)
-                .await;
+    for (height, event_index) in pending {
+        match evm_client.is_burn_processed(height, event_index).await {
+            Ok(true) => {
+                monitor
+                    .write()
+                    .await
+                    .complete_burn(height, event_index)
+                    .await;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    ?height,
+                    event_index,
+                    "is_burn_processed query failed: {e:#}"
+                );
+            }
         }
     }
 

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -233,9 +233,7 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
 }
 
 /// Polls the FungibleBridge per pending burn and marks any that the EVM
-/// has already released. Per-burn rather than per-recipient — the previous
-/// `Transfer`-log filter would mark every pending burn for a recipient
-/// complete the moment ANY transfer to that recipient was observed.
+/// has already released.
 async fn check_burn_completion(
     monitor: &RwLock<MonitorState>,
     evm_client: &EvmClient<impl Provider>,

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -57,10 +57,15 @@ pub struct PendingDeposit {
 }
 
 /// A pending burn detected by the Linera scanner, sent to the retry loop.
+///
+/// `event_index` is the underlying Linera `Event.index` — the position of
+/// the burn event within its stream ("burns" on the configured fungible
+/// application). Used both as the dedup key off-chain and as the value
+/// the `FungibleBridge.isBurnProcessed(height, eventIndex)` view consumes.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PendingBurn {
     pub height: BlockHeight,
-    pub burn_index: usize,
+    pub event_index: u32,
     pub evm_recipient: Address,
     pub amount: Amount,
 }
@@ -96,7 +101,7 @@ pub type TrackedBurn = Tracked<PendingBurn>;
 /// In-memory monitoring state shared across scan loops and HTTP handlers.
 pub struct MonitorState {
     pub(crate) deposits: HashMap<DepositKey, TrackedDeposit>,
-    pub(crate) burns: HashMap<(BlockHeight, usize), TrackedBurn>,
+    pub(crate) burns: HashMap<(BlockHeight, u32), TrackedBurn>,
     pub(crate) last_scanned_evm_block: u64,
     pub(crate) last_scanned_linera_height: BlockHeight,
     db: Option<db::BridgeDb>,
@@ -160,7 +165,7 @@ impl MonitorState {
     /// Uses Entry API instead of insert() to avoid overwriting existing entries
     /// that may have accumulated retry state.
     pub async fn track_burn(&mut self, pending: PendingBurn) -> bool {
-        let key = (pending.height, pending.burn_index);
+        let key = (pending.height, pending.event_index);
         match self.burns.entry(key) {
             Entry::Occupied(_) => false,
             Entry::Vacant(e) => {
@@ -176,21 +181,24 @@ impl MonitorState {
         }
     }
 
-    pub async fn complete_burn(&mut self, height: BlockHeight, burn_index: usize) {
-        if let Some(b) = self.burns.get_mut(&(height, burn_index)) {
+    pub async fn complete_burn(&mut self, height: BlockHeight, event_index: u32) {
+        if let Some(b) = self.burns.get_mut(&(height, event_index)) {
             b.forwarded = true;
             crate::relay::metrics::burn_completed();
             if let Some(db) = &self.db {
-                if let Err(e) = db.update_burn_status(height, burn_index, "completed").await {
+                if let Err(e) = db
+                    .update_burn_status(height, event_index, "completed")
+                    .await
+                {
                     tracing::warn!(
                         ?height,
-                        burn_index,
+                        event_index,
                         "Failed to update burn status in SQLite: {e:#}"
                     );
                 }
             }
         } else {
-            tracing::warn!(?height, burn_index, "Attempted to complete unknown burn");
+            tracing::warn!(?height, event_index, "Attempted to complete unknown burn");
         }
     }
 
@@ -282,7 +290,8 @@ impl MonitorState {
             self.deposits.insert(d.key.clone(), Tracked::new(d));
         }
         for b in burns {
-            self.burns.insert((b.height, b.burn_index), Tracked::new(b));
+            self.burns
+                .insert((b.height, b.event_index), Tracked::new(b));
         }
         tracing::info!(
             deposits = n_deposits,
@@ -311,22 +320,22 @@ impl MonitorState {
         }
     }
 
-    pub fn mark_burn_retried(&mut self, height: BlockHeight, burn_index: usize) {
-        if let Some(b) = self.burns.get_mut(&(height, burn_index)) {
+    pub fn mark_burn_retried(&mut self, height: BlockHeight, event_index: u32) {
+        if let Some(b) = self.burns.get_mut(&(height, event_index)) {
             b.retry_count += 1;
             b.last_retry_at = Some(Instant::now());
         }
     }
 
-    pub async fn mark_burn_failed(&mut self, height: BlockHeight, burn_index: usize) {
-        if let Some(b) = self.burns.get_mut(&(height, burn_index)) {
+    pub async fn mark_burn_failed(&mut self, height: BlockHeight, event_index: u32) {
+        if let Some(b) = self.burns.get_mut(&(height, event_index)) {
             b.failed = true;
             crate::relay::metrics::burn_failed();
             if let Some(db) = &self.db {
-                if let Err(e) = db.update_burn_status(height, burn_index, "failed").await {
+                if let Err(e) = db.update_burn_status(height, event_index, "failed").await {
                     tracing::warn!(
                         ?height,
-                        burn_index,
+                        event_index,
                         "Failed to update burn status in SQLite: {e:#}"
                     );
                 }
@@ -473,7 +482,7 @@ mod tests {
         state
             .track_burn(PendingBurn {
                 height: BlockHeight(10),
-                burn_index: 0,
+                event_index: 0,
                 evm_recipient: Address::from([0xab; 20]),
                 amount: Amount::from_attos(500),
             })
@@ -510,7 +519,7 @@ mod tests {
         state
             .track_burn(PendingBurn {
                 height: BlockHeight(5),
-                burn_index: 0,
+                event_index: 0,
                 evm_recipient: Address::from([0x12; 20]),
                 amount: Amount::from_attos(100),
             })
@@ -662,7 +671,7 @@ mod tests {
         .unwrap();
         db.insert_burn(&PendingBurn {
             height: BlockHeight(99),
-            burn_index: 2,
+            event_index: 2,
             evm_recipient: Address::from([0xDD; 20]),
             amount: Amount::from_attos(7),
         })
@@ -688,7 +697,7 @@ mod tests {
         state
             .track_burn(PendingBurn {
                 height,
-                burn_index: 0,
+                event_index: 0,
                 evm_recipient: Address::from([0xab; 20]),
                 amount: Amount::from_attos(500),
             })

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -11,7 +11,7 @@ use alloy::{
 };
 use alloy_sol_types::SolCall;
 use anyhow::{Context as _, Result};
-use linera_base::data_types::Epoch;
+use linera_base::data_types::{BlockHeight, Epoch};
 
 use crate::proof::deposit_event_signature;
 
@@ -20,7 +20,7 @@ sol! {
     interface IFungibleBridge {
         function addBlock(bytes calldata data) external;
         function lightClient() external view returns (address);
-        function token() external view returns (address);
+        function isBurnProcessed(uint64 height, uint32 eventIndex) external view returns (bool);
     }
 }
 
@@ -44,7 +44,6 @@ pub struct EvmClient<P> {
     relayer_addr: Address,
     deposit_event_sig: B256,
     light_client_addr: tokio::sync::OnceCell<Address>,
-    token_addr: tokio::sync::OnceCell<Address>,
 }
 
 impl<P: Provider> EvmClient<P> {
@@ -64,7 +63,6 @@ impl<P: Provider> EvmClient<P> {
             relayer_addr,
             deposit_event_sig: deposit_event_signature(),
             light_client_addr,
-            token_addr: tokio::sync::OnceCell::new(),
         }
     }
 
@@ -99,36 +97,14 @@ impl<P: Provider> EvmClient<P> {
         Ok(all_logs)
     }
 
-    /// Queries ERC-20 `Transfer` events emitted by the bridged token
-    /// contract, with the bridge as the sender (`from`) and `recipient`
-    /// as the receiver (`to`). The events come from `address(token)`,
-    /// not from the bridge itself, because `FungibleBridge._onBlock`
-    /// releases tokens by calling `token.transfer(target, ...)`.
-    pub async fn get_transfer_logs(&self, recipient: Address) -> Result<Vec<Log>> {
-        let token_addr = self.get_token_address().await?;
-        let transfer_sig = alloy::primitives::keccak256("Transfer(address,address,uint256)");
-        let filter = Filter::new()
-            .address(token_addr)
-            .event_signature(transfer_sig)
-            .topic1(B256::left_padding_from(self.bridge_addr.as_slice()))
-            .topic2(B256::left_padding_from(recipient.as_slice()));
-        Ok(self.provider.get_logs(&filter).await?)
-    }
-
-    /// Discovers the bridged ERC-20 token address from the FungibleBridge.
-    pub async fn get_token_address(&self) -> Result<Address> {
-        self.token_addr
-            .get_or_try_init(|| async {
-                let bridge = IFungibleBridge::new(self.bridge_addr, &self.provider);
-                let addr = bridge
-                    .token()
-                    .call()
-                    .await
-                    .context("failed to query FungibleBridge.token()")?;
-                Ok(addr)
-            })
-            .await
-            .copied()
+    /// Returns whether the FungibleBridge has already released the burn
+    /// at `(height, event_index)` — i.e. whether the corresponding
+    /// `_onBlock` loop iteration ran to completion in some prior `addBlock`
+    /// transaction. `event_index` is the underlying Linera `Event.index`.
+    /// Per-burn (not per-block, not per-recipient).
+    pub async fn is_burn_processed(&self, height: BlockHeight, event_index: u32) -> Result<bool> {
+        let bridge = IFungibleBridge::new(self.bridge_addr, &self.provider);
+        Ok(bridge.isBurnProcessed(height.0, event_index).call().await?)
     }
 
     /// BCS-serialize and forward a certified block to FungibleBridge on EVM.

--- a/linera-bridge/src/relay/linera.rs
+++ b/linera-bridge/src/relay/linera.rs
@@ -142,7 +142,7 @@ impl<E: linera_core::environment::Environment> Clone for LineraClient<E> {
     }
 }
 
-/// Finds all BurnEvents in a block's event streams for a given application,
+/// Finds all `BurnEvent`s in a block's event streams for a given application,
 /// returning each burn paired with the underlying `Event.index` — the
 /// position of the event within its stream. That index is what the
 /// `FungibleBridge` contract keys its per-burn dedup mapping on.

--- a/linera-bridge/src/relay/linera.rs
+++ b/linera-bridge/src/relay/linera.rs
@@ -142,11 +142,14 @@ impl<E: linera_core::environment::Environment> Clone for LineraClient<E> {
     }
 }
 
-/// Find all BurnEvents in a block's event streams for a given application.
+/// Finds all BurnEvents in a block's event streams for a given application,
+/// returning each burn paired with the underlying `Event.index` — the
+/// position of the event within its stream. That index is what the
+/// `FungibleBridge` contract keys its per-burn dedup mapping on.
 pub(crate) fn find_burn_events(
     events: &[Vec<Event>],
     fungible_app_id: ApplicationId,
-) -> Vec<wrapped_fungible::BurnEvent> {
+) -> Vec<(u32, wrapped_fungible::BurnEvent)> {
     let mut result = Vec::new();
     for tx_events in events {
         for event in tx_events {
@@ -157,7 +160,7 @@ pub(crate) fn find_burn_events(
                 continue;
             }
             if let Ok(burn) = bcs::from_bytes::<wrapped_fungible::BurnEvent>(&event.value) {
-                result.push(burn);
+                result.push((event.index, burn));
             }
         }
     }

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -36,12 +36,26 @@ contract FungibleBridge is Microchain {
     IERC20 public immutable token;
     uint256 public depositNonce;
 
+    /// Per-burn dedup keyed by `keccak256(abi.encode(height, eventIndex))`
+    /// where `eventIndex` is the underlying Linera `Event.index` — the
+    /// position of the burn event within its stream. Set inside
+    /// `_onBlock` after the burn's `token.transfer` succeeds.
+    mapping(bytes32 => bool) internal processedBurns;
+
     constructor(address _lightClient, bytes32 _chainId, address _token, bytes32 _fungibleApplicationId)
         Microchain(_lightClient, _chainId)
     {
         require(_fungibleApplicationId != bytes32(0), "fungibleApplicationId must be non-zero");
         token = IERC20(_token);
         fungibleApplicationId = _fungibleApplicationId;
+    }
+
+    /// Returns whether the burn at `(height, eventIndex)` has already been
+    /// released by a prior `addBlock` call. `eventIndex` matches
+    /// `Event.index` from the Linera block body — the same value the
+    /// off-chain relayer pulls from the certificate.
+    function isBurnProcessed(uint64 height, uint32 eventIndex) external view returns (bool) {
+        return processedBurns[keccak256(abi.encode(height, eventIndex))];
     }
 
     /// Locks ERC-20 tokens in the bridge and emits a DepositInitiated event.
@@ -78,8 +92,13 @@ contract FungibleBridge is Microchain {
 
     /// Processes a Linera block and releases ERC-20 tokens for any BurnEvent
     /// events on the "burns" stream from the wrapped-fungible application.
+    /// Idempotent: each burn's release is gated on
+    /// `processedBurns[keccak256(abi.encode(height, evt.index))]`, so
+    /// re-submitting the same cert is a no-op for burns already released
+    /// by a prior call.
     function _onBlock(BridgeTypes.Block memory blockValue) internal override {
         bytes32 burnsHash = keccak256("burns");
+        uint64 height = blockValue.header.height.value;
         for (uint256 i = 0; i < blockValue.body.events.length; i++) {
             BridgeTypes.Event[] memory txEvents = blockValue.body.events[i];
             for (uint256 j = 0; j < txEvents.length; j++) {
@@ -94,11 +113,14 @@ contract FungibleBridge is Microchain {
                 // Check stream name is "burns"
                 if (keccak256(evt.stream_id.stream_name.value) != burnsHash) continue;
 
+                bytes32 key = keccak256(abi.encode(height, evt.index));
+                if (processedBurns[key]) continue;
+
                 WrappedFungibleTypes.BurnEvent memory burnEvt =
                     WrappedFungibleTypes.bcs_deserialize_BurnEvent(evt.value);
-
                 address target = address(burnEvt.target);
                 require(token.transfer(target, burnEvt.amount.value), "token transfer failed");
+                processedBurns[key] = true;
             }
         }
     }

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -432,6 +432,30 @@ pub async fn fund_bridge_erc20(
     .await;
 }
 
+/// Polls the relayer's `/metrics` endpoint until it responds (any HTTP
+/// status), indicating the embedded server is up and the spawned relay
+/// task is past its boot phase. Bails on `timeout`. Call after
+/// `tokio::spawn`-ing `relay::run` to gate test traffic on readiness.
+pub async fn wait_for_relay_http_ready(
+    http: &reqwest::Client,
+    relay_url: &str,
+    timeout: std::time::Duration,
+) -> anyhow::Result<()> {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        if http
+            .get(format!("{relay_url}/metrics"))
+            .send()
+            .await
+            .is_ok()
+        {
+            return Ok(());
+        }
+    }
+    anyhow::bail!("relay did not become ready within {timeout:?}")
+}
+
 /// Polls the relayer's `/metrics` endpoint every 2s and returns
 /// `Ok(())` once `predicate(detected, completed, pending, failed)`
 /// returns true. Bails on `timeout`. The poll interval matches the

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -328,3 +328,140 @@ pub async fn start_compose(compose_file: &std::path::Path, project_name: &str) -
 
     compose
 }
+
+/// Parses a Prometheus text-format response and returns the integer
+/// value of the metric named `name`. Returns 0 if the metric is absent
+/// (a counter never incremented).
+pub fn parse_metric_value(body: &str, name: &str) -> i64 {
+    for line in body.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        let Some((metric, value)) = line.split_once(' ') else {
+            continue;
+        };
+        if metric.trim() == name {
+            return value.trim().parse::<f64>().unwrap_or(0.0) as i64;
+        }
+    }
+    0
+}
+
+/// Publishes the wrapped-fungible Wasm module on `chain_client` and
+/// creates an application instance with the given `mint_chain_id` and
+/// an initial `initial_balance_tokens` balance for `initial_holder`.
+/// Returns the resulting `application_id`. The Wasm artifacts are
+/// loaded from `examples/target/wasm32-unknown-unknown/release/` —
+/// bridge tests must build the examples crate before invoking this.
+pub async fn publish_and_create_wrapped_fungible<E>(
+    chain_client: &linera_core::client::ChainClient<E>,
+    initial_holder: linera_base::identifiers::AccountOwner,
+    mint_chain_id: linera_base::identifiers::ChainId,
+    erc20_addr: Address,
+    initial_balance_tokens: u128,
+) -> anyhow::Result<linera_base::identifiers::ApplicationId>
+where
+    E: linera_core::environment::Environment,
+{
+    use anyhow::Context as _;
+    use linera_base::{data_types::Bytecode, vm::VmRuntime};
+
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .context("manifest dir has fewer than 3 ancestors")?
+        .to_path_buf();
+    let wasm_dir = repo_root.join("examples/target/wasm32-unknown-unknown/release");
+    let wf_contract = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm"))?;
+    let wf_service = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_service.wasm"))?;
+    let (wf_module_id, _) = chain_client
+        .publish_module(wf_contract, wf_service, VmRuntime::Wasm)
+        .await?
+        .expect("publish wrapped-fungible module committed");
+    chain_client.synchronize_from_validators().await?;
+    chain_client.process_inbox().await?;
+
+    let initial_balance = linera_base::data_types::Amount::from_tokens(initial_balance_tokens);
+    let (fungible_app_id, _) = chain_client
+        .create_application_untyped(
+            wf_module_id,
+            serde_json::to_vec(&wrapped_fungible::WrappedParameters {
+                ticker_symbol: "wTEST".to_string(),
+                minter: None,
+                mint_chain_id: Some(mint_chain_id),
+                evm_token_address: erc20_addr.0 .0,
+                evm_source_chain_id: 31337,
+                bridge_app_id: None,
+            })?,
+            serde_json::to_vec(&wrapped_fungible::InitialState {
+                accounts: std::collections::BTreeMap::from([(initial_holder, initial_balance)]),
+            })?,
+            vec![],
+        )
+        .await?
+        .expect("create wrapped-fungible app committed");
+    Ok(fungible_app_id)
+}
+
+/// Transfers `amount` ERC-20 attos from the deployer (Anvil account 0)
+/// to the bridge contract via `cast send` inside the foundry-tools
+/// service. Used to seed the bridge with enough liquidity to release
+/// burned tokens.
+pub async fn fund_bridge_erc20(
+    compose: &DockerCompose,
+    project_name: &str,
+    compose_file: &std::path::Path,
+    erc20: Address,
+    bridge: Address,
+    amount: u128,
+) {
+    exec_ok(
+        compose,
+        "foundry-tools",
+        &format!(
+            "cast send --rpc-url http://anvil:8545 \
+             --private-key {ANVIL_PRIVATE_KEY} \
+             {erc20} \
+             'transfer(address,uint256)(bool)' \
+             {bridge} \
+             {amount}"
+        ),
+        project_name,
+        compose_file,
+    )
+    .await;
+}
+
+/// Polls the relayer's `/metrics` endpoint every 2s and returns
+/// `Ok(())` once `predicate(detected, completed, pending, failed)`
+/// returns true. Bails on `timeout`. The poll interval matches the
+/// relayer's own scan loop so callers don't redundantly hammer the
+/// endpoint between iterations.
+pub async fn wait_for_relay_metrics<F>(
+    http: &reqwest::Client,
+    relay_url: &str,
+    mut predicate: F,
+    timeout: std::time::Duration,
+) -> anyhow::Result<()>
+where
+    F: FnMut(i64, i64, i64, i64) -> bool,
+{
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        let body = http
+            .get(format!("{relay_url}/metrics"))
+            .send()
+            .await?
+            .text()
+            .await?;
+        let detected = parse_metric_value(&body, "linera_bridge_burns_detected");
+        let completed = parse_metric_value(&body, "linera_bridge_burns_completed");
+        let pending = parse_metric_value(&body, "linera_bridge_burns_pending");
+        let failed = parse_metric_value(&body, "linera_bridge_burns_failed");
+        if predicate(detected, completed, pending, failed) {
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+    anyhow::bail!("wait_for_relay_metrics timed out after {timeout:?}")
+}

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -160,7 +160,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
         &compose_file,
         erc20_addr,
         bridge_addr,
-        500_000_000_000_000_000_000u128,
+        500 * 10u128.pow(18),
     )
     .await;
 

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -35,7 +35,7 @@ use linera_base::{
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
-    wait_for_light_client, ANVIL_PRIVATE_KEY,
+    wait_for_light_client, wait_for_relay_http_ready, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -221,20 +221,10 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
 
     let relay_url = format!("http://localhost:{relay_port}");
     let http = reqwest::Client::new();
-    for attempt in 0..30 {
-        tokio::time::sleep(Duration::from_secs(2)).await;
-        if http
-            .get(format!("{relay_url}/metrics"))
-            .send()
-            .await
-            .is_ok()
-        {
-            break;
-        }
-        if attempt == 29 {
-            relay_handle.abort();
-            anyhow::bail!("Relay did not become ready");
-        }
+    if let Err(error) = wait_for_relay_http_ready(&http, &relay_url, Duration::from_secs(60)).await
+    {
+        relay_handle.abort();
+        return Err(error);
     }
 
     // Trigger a single burn: chain B transfers wrapped tokens to an

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -30,14 +30,12 @@ use alloy::{
 };
 use anyhow::Context as _;
 use linera_base::{
-    crypto::InMemorySigner,
-    data_types::{Amount, Bytecode},
-    identifiers::AccountOwner,
-    vm::VmRuntime,
+    crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner,
 };
 use linera_bridge_e2e::{
-    compose_file_path, deploy_fungible_bridge, deploy_linera_token, exec_ok, light_client_address,
-    start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
+    compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
+    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
+    wait_for_light_client, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -45,7 +43,7 @@ use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use wrapped_fungible::{Account, InitialState, WrappedFungibleOperation, WrappedParameters};
+use wrapped_fungible::{Account, WrappedFungibleOperation};
 
 sol! {
     #[sol(rpc)]
@@ -128,48 +126,13 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
 
-    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(3)
-        .context("manifest dir has fewer than 3 ancestors")?
-        .to_path_buf();
-    let wasm_dir = repo_root.join("examples/target/wasm32-unknown-unknown/release");
-
-    // Publish + create the wrapped-fungible application on chain B (the
-    // user chain) with `mint_chain_id = chain_a` (the bridge / relayer
-    // chain). Initial balance goes to `owner_b`, the user. The created
-    // app's `application_description_hash` is the *real* fungible_app_id
-    // the scanner will see in burn events. The deployed `FungibleBridge`
-    // is given a *different* id (`SYNTHETIC_APP_ID_BYTES32`) below so
-    // `_onBlock` rejects every burn event the relayer forwards.
-    let wf_contract = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm"))?;
-    let wf_service = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_service.wasm"))?;
-    let (wf_module_id, _) = cc_b
-        .publish_module(wf_contract, wf_service, VmRuntime::Wasm)
-        .await?
-        .expect("publish wrapped-fungible module committed");
-    cc_b.synchronize_from_validators().await?;
-    cc_b.process_inbox().await?;
-
-    let initial_balance = Amount::from_tokens(1_000);
-    let (fungible_app_id, _) = cc_b
-        .create_application_untyped(
-            wf_module_id,
-            serde_json::to_vec(&WrappedParameters {
-                ticker_symbol: "wTEST".to_string(),
-                minter: None,
-                mint_chain_id: Some(chain_a),
-                evm_token_address: erc20_addr.0 .0,
-                evm_source_chain_id: 31337,
-                bridge_app_id: None,
-            })?,
-            serde_json::to_vec(&InitialState {
-                accounts: BTreeMap::from([(owner_b, initial_balance)]),
-            })?,
-            vec![],
-        )
-        .await?
-        .expect("create wrapped-fungible app committed");
+    // The created app's `application_description_hash` is the *real*
+    // fungible_app_id the scanner will see in burn events. The deployed
+    // `FungibleBridge` is given a *different* id
+    // (`SYNTHETIC_APP_ID_BYTES32`) below so `_onBlock` rejects every
+    // burn event the relayer forwards.
+    let fungible_app_id =
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
     let real_app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     assert_ne!(
         real_app_id_bytes32, SYNTHETIC_APP_ID_BYTES32,
@@ -191,19 +154,13 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     // Fund the bridge so that a `token.transfer` inside `_onBlock` would
     // succeed if it ever ran. Eliminates "insufficient balance" as an
     // alternative explanation for the missing on-chain Transfer.
-    exec_ok(
+    fund_bridge_erc20(
         &compose,
-        "foundry-tools",
-        &format!(
-            "cast send --rpc-url http://anvil:8545 \
-             --private-key {ANVIL_PRIVATE_KEY} \
-             {erc20_addr} \
-             'transfer(address,uint256)(bool)' \
-             {bridge_addr} \
-             500000000000000000000"
-        ),
         project_name,
         &compose_file,
+        erc20_addr,
+        bridge_addr,
+        500_000_000_000_000_000_000u128,
     )
     .await;
 
@@ -324,7 +281,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
             .await?
             .text()
             .await?;
-        if metric_value(&body, "linera_bridge_burns_detected") >= 1 {
+        if parse_metric_value(&body, "linera_bridge_burns_detected") >= 1 {
             detected = true;
             tracing::info!(attempt, "Burn detected by scanner");
             break;
@@ -361,10 +318,10 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
         .await?
         .text()
         .await?;
-    let burns_detected = metric_value(&metrics_body, "linera_bridge_burns_detected");
-    let burns_completed = metric_value(&metrics_body, "linera_bridge_burns_completed");
-    let burns_failed = metric_value(&metrics_body, "linera_bridge_burns_failed");
-    let burns_pending = metric_value(&metrics_body, "linera_bridge_burns_pending");
+    let burns_detected = parse_metric_value(&metrics_body, "linera_bridge_burns_detected");
+    let burns_completed = parse_metric_value(&metrics_body, "linera_bridge_burns_completed");
+    let burns_failed = parse_metric_value(&metrics_body, "linera_bridge_burns_failed");
+    let burns_pending = parse_metric_value(&metrics_body, "linera_bridge_burns_pending");
 
     let evm_recipient: alloy::primitives::Address = format!("0x{evm_recipient_hex}").parse()?;
     let token_balance = IERC20::new(erc20_addr, &provider)
@@ -402,22 +359,4 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     );
 
     Ok(())
-}
-
-/// Parses a Prometheus text-format response and returns the integer value
-/// associated with a metric name. Returns 0 if the metric is absent
-/// (counters are reported only after their first increment).
-fn metric_value(body: &str, name: &str) -> i64 {
-    for line in body.lines() {
-        if line.starts_with('#') {
-            continue;
-        }
-        let Some((metric, value)) = line.split_once(' ') else {
-            continue;
-        };
-        if metric.trim() == name {
-            return value.trim().parse::<f64>().unwrap_or(0.0) as i64;
-        }
-    }
-    0
 }

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -1,32 +1,25 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Reproduces the UI-demo bug: many burns to the same EVM recipient
-//! across separate Linera blocks. The pre-fix relayer's
-//! `check_burn_completion` used a recipient-only ERC-20 `Transfer`-log
-//! filter, so once any pending burn for a recipient saw an on-chain
-//! transfer, every other pending burn for that same recipient flipped
-//! to completed regardless of whether its own `token.transfer` ran.
-//! With the per-burn `isBurnProcessed(height, eventIndex)` query,
-//! completion is decided per burn and the relayer must actually
-//! release every one before marking them done.
+//! Verifies that multiple BurnEvents in a single Linera block are all
+//! relayed and completed on the EVM side. The user chain submits one
+//! block carrying N Transfer operations to N distinct Address20
+//! recipients on the bridge chain. The test process drives the inbox
+//! processing on the bridge chain so the resulting Credit messages
+//! all land in one chain-A block — a single cert with N BurnEvents.
+//! After the relayer is spawned, exactly one `addBlock` call should
+//! release all N tokens (one `token.transfer` per burn in `_onBlock`)
+//! and the relayer must mark every pending burn complete.
 //!
-//! Setup: 5 burns to the same EVM recipient, materialised as 5
-//! separate Linera blocks on the bridge chain BEFORE the relayer is
-//! spawned. The test process drives both the cross-chain Transfer on
-//! the user chain and the inbox processing on the bridge chain, so
-//! each Credit lands in its own block deterministically (no race with
-//! the relayer's notification loop batching multiple Credits into one
-//! block). When the relayer starts, its first scan iteration finds
-//! all 5 pending burns at once — the multi-pending shape required to
-//! reproduce the mark-by-existence false positive.
-//!
-//! Expected outcome on the pre-fix code: only some `addBlock` calls
-//! complete before `check_burn_completion` false-marks every pending
-//! burn complete; the recipient's ERC-20 balance ends up below
-//! `5 * amount` while `linera_bridge_burns_completed == 5`. The
-//! balance assertion fails. Post-fix: per-burn dedup forces the
-//! relayer to forward every burn, balance reaches the full amount.
+//! Expected outcome on the pre-fix code: `_onBlock` atomically
+//! transfers all N tokens in the single `addBlock` call (recipient
+//! balances are correct), but the off-chain `check_burn_completion`'s
+//! Transfer-log filter does not mark these burns complete —
+//! `linera_bridge_burns_completed` stays at 0. The
+//! `burns_completed == NUM_BURNS` assertion fails. Post-fix: per-burn
+//! `isBurnProcessed(height, eventIndex)` returns true for every flag
+//! written inside the same `_onBlock` call, so all N entries flip
+//! to complete on the next `check_burn_completion` iteration.
 
 #![recursion_limit = "512"]
 
@@ -56,16 +49,16 @@ sol! {
     }
 }
 
-const NUM_BURNS: u32 = 5;
+const NUM_BURNS: usize = 4;
 const BURN_AMOUNT_TOKENS: u128 = 1;
 
 #[tokio::test]
 #[ignore] // Requires pre-built docker images, Wasm, and relay binary.
-async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> {
+async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_test_writer().try_init().ok();
     linera_bridge_e2e::ensure_rustls_provider();
     let compose_file = compose_file_path();
-    let project_name = "linera-multi-burn-same-recipient-test";
+    let project_name = "linera-multi-burn-same-block-test";
 
     let compose = start_compose(&compose_file, project_name).await;
     wait_for_light_client(&compose, project_name, &compose_file).await;
@@ -80,7 +73,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(
         &store_config,
-        "multi-burn-same-recipient-e2e",
+        "multi-burn-same-block-e2e",
         Some(WasmRuntime::default()),
         StorageCacheConfig {
             blob_cache_size: 1000,
@@ -107,7 +100,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     )
     .await?;
 
-    // Chain A hosts the bridge contract
+    // Chain A hosts the bridge contract.
     let owner_a = AccountOwner::from(signer.generate_new());
     let chain_a_desc = faucet.claim(&owner_a).await?;
     let chain_a = chain_a_desc.id();
@@ -151,34 +144,60 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     )
     .await;
 
-    let evm_recipient: alloy::primitives::Address =
-        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?;
-    let receiver = AccountOwner::Address20(evm_recipient.0 .0);
+    // NUM_BURNS Address20 recipients in the order they appear in the
+    // block. One address is intentionally repeated to exercise per-burn
+    // accounting independently of the recipient; `_onBlock` must release
+    // tokens for each occurrence even though the dedup key shares no
+    // recipient bits.
+    let recipients: [alloy::primitives::Address; NUM_BURNS] = [
+        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?,
+        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?,
+        "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC".parse()?,
+        "0x90F79bf6EB2c4f870365E785982E1f101E93b906".parse()?,
+    ];
     let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
 
-    for _ in 0..NUM_BURNS {
-        cc_b.synchronize_from_validators().await?;
-        let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-            owner: owner_b,
-            amount: burn_amount,
-            target_account: Account {
-                chain_id: chain_a,
-                owner: receiver,
-            },
-        })?;
-        cc_b.execute_operations(
-            vec![Operation::User {
+    // Bundle every Transfer into a SINGLE chain-B block, then drive
+    // chain A's inbox once. The N Credit messages travel together
+    // and `process_inbox` materialises one chain-A block containing
+    // all N BurnEvents.
+    let operations: Vec<Operation> = recipients
+        .iter()
+        .map(|recipient| {
+            let owner = AccountOwner::Address20(recipient.0 .0);
+            let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
+                owner: owner_b,
+                amount: burn_amount,
+                target_account: Account {
+                    chain_id: chain_a,
+                    owner,
+                },
+            })
+            .expect("BCS serialization");
+            Operation::User {
                 application_id: fungible_app_id,
                 bytes: withdraw_bytes,
-            }],
-            vec![],
-        )
-        .await?
-        .expect("cross-chain withdrawal committed on chain B");
+            }
+        })
+        .collect();
 
-        cc_a.synchronize_from_validators().await?;
-        cc_a.process_inbox().await?;
-    }
+    cc_b.synchronize_from_validators().await?;
+    cc_b.execute_operations(operations, vec![])
+        .await?
+        .expect("multi-burn block committed on chain B");
+
+    cc_a.synchronize_from_validators().await?;
+    let height_before_inbox = cc_a.chain_info().await?.next_block_height;
+    cc_a.process_inbox().await?;
+    let height_after_inbox = cc_a.chain_info().await?.next_block_height;
+    assert_eq!(
+        height_after_inbox.0,
+        height_before_inbox.0 + 1,
+        "chain A must produce exactly ONE block carrying all {NUM_BURNS} BurnEvents \
+         (before={}, after={})",
+        height_before_inbox.0,
+        height_after_inbox.0,
+    );
 
     let relay_dir = tempfile::tempdir()?;
     let wallet_path = relay_dir.path().join("wallet.json");
@@ -193,7 +212,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     }
     linera_wallet_json::PersistentWallet::create(&wallet_path, relay_genesis_config)?;
 
-    let relay_port = 3004u16;
+    let relay_port = 3005u16;
     let bridge_addr_str = format!("{bridge_addr}");
     let bridge_app_str = format!("{fungible_app_id}");
     let fungible_app_str = format!("{fungible_app_id}");
@@ -229,35 +248,49 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
         return Err(error);
     }
 
-    // Wait until the relayer has finished work: pending drops to 0 and
-    // all NUM_BURNS appear in burns_completed. Pre-fix gets there via
-    // mark-by-existence flipping every pending burn complete after the
-    // first transfer lands; post-fix gets there via per-burn
-    // `isBurnProcessed` flipping each entry only as its own `addBlock`
-    // confirms.
-    let settle_result = wait_for_relay_metrics(
+    let num_burns_i64 = i64::try_from(NUM_BURNS).unwrap();
+    // Gate on the scanner having found every burn; we deliberately do
+    // NOT wait for `pending == 0` because the failure mode we want to
+    // surface is a balance / counter discrepancy, not a timeout —
+    // assertions below catch the actual state.
+    if let Err(error) = wait_for_relay_metrics(
         &http,
         &relay_url,
-        |_detected, completed, pending, _failed| {
-            pending == 0 && completed >= i64::from(NUM_BURNS)
-        },
-        Duration::from_secs(240),
+        |detected, _completed, _pending, _failed| detected >= num_burns_i64,
+        Duration::from_secs(60),
     )
-    .await;
-    if let Err(error) = settle_result {
+    .await
+    {
         relay_handle.abort();
         return Err(error);
     }
+    // One addBlock processes all N burns in `_onBlock`; allow the
+    // relayer enough time to call it and for the post-tx settle path
+    // (check_burn_completion / per-burn isBurnProcessed query) to run
+    // at least one iteration.
+    tokio::time::sleep(Duration::from_secs(30)).await;
 
     let rpc_url = "http://localhost:8545".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
-    let token_balance = IERC20::new(erc20_addr, &provider)
-        .balanceOf(evm_recipient)
-        .call()
-        .await?;
+    let token = IERC20::new(erc20_addr, &provider);
 
-    // Scrape the final metric values once for diagnostic clarity in
-    // both pass and fail cases.
+    // Each occurrence in `recipients` is one expected transfer. A
+    // recipient listed twice should accumulate two transfers, etc.
+    let mut expected_per_recipient: std::collections::BTreeMap<
+        alloy::primitives::Address,
+        U256,
+    > = std::collections::BTreeMap::new();
+    let one_burn = U256::from(BURN_AMOUNT_TOKENS) * U256::from(10u128.pow(18));
+    for recipient in &recipients {
+        *expected_per_recipient.entry(*recipient).or_insert(U256::ZERO) += one_burn;
+    }
+
+    let mut observed_balances = Vec::with_capacity(expected_per_recipient.len());
+    for (recipient, expected) in &expected_per_recipient {
+        let balance = token.balanceOf(*recipient).call().await?;
+        observed_balances.push((*recipient, balance, *expected));
+    }
+
     let final_metrics = http
         .get(format!("{relay_url}/metrics"))
         .send()
@@ -265,35 +298,37 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
         .text()
         .await?;
     let burns_detected = parse_metric_value(&final_metrics, "linera_bridge_burns_detected");
+    let burns_completed = parse_metric_value(&final_metrics, "linera_bridge_burns_completed");
 
     relay_handle.abort();
 
-    let expected_balance =
-        U256::from(BURN_AMOUNT_TOKENS) * U256::from(NUM_BURNS) * U256::from(10u128.pow(18));
     tracing::info!(
-        ?token_balance,
-        ?expected_balance,
+        ?observed_balances,
         burns_detected,
+        burns_completed,
         "Final state"
     );
 
-    // Sanity check: every burn must have reached the scanner. A drop
-    // here would mean the test failed to pre-populate chain A
-    // properly, not the bug we are reproducing.
+    // Sanity: the scanner must have picked up all NUM_BURNS as separate
+    // PendingBurns even though they share a Linera block.
     assert_eq!(
-        burns_detected,
-        i64::from(NUM_BURNS),
+        burns_detected, num_burns_i64,
         "relayer must have detected all {NUM_BURNS} burns; got {burns_detected}"
     );
-
-    // The recipient's balance must reflect every burn. Anything less
-    // means at least one `PendingBurn` was marked complete without
-    // its `token.transfer` actually landing on-chain — the UI-demo bug.
     assert_eq!(
-        token_balance,
-        expected_balance,
-        "recipient must accumulate every burn; got {token_balance}, expected {expected_balance}"
+        burns_completed, num_burns_i64,
+        "relayer must have completed all {NUM_BURNS} burns; got {burns_completed}"
     );
+
+    // Each unique recipient must hold exactly the sum of their
+    // occurrences in `recipients`. Anything less means a per-burn
+    // release was dropped; anything more means double-spend.
+    for (recipient, balance, expected) in &observed_balances {
+        assert_eq!(
+            *balance, *expected,
+            "recipient {recipient:?} balance {balance}, expected {expected}"
+        );
+    }
 
     Ok(())
 }

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -1,25 +1,16 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verifies that multiple BurnEvents in a single Linera block are all
+//! Verifies that multiple `BurnEvent`s in a single Linera block are all
 //! relayed and completed on the EVM side. The user chain submits one
-//! block carrying N Transfer operations to N distinct Address20
+//! block carrying N `Transfer` operations to N distinct `Address20`
 //! recipients on the bridge chain. The test process drives the inbox
-//! processing on the bridge chain so the resulting Credit messages
-//! all land in one chain-A block — a single cert with N BurnEvents.
+//! processing on the bridge chain so the resulting `Credit` messages
+//! all land in one chain-A block — a single cert with N `BurnEvent`s.
 //! After the relayer is spawned, exactly one `addBlock` call should
 //! release all N tokens (one `token.transfer` per burn in `_onBlock`)
-//! and the relayer must mark every pending burn complete.
-//!
-//! Expected outcome on the pre-fix code: `_onBlock` atomically
-//! transfers all N tokens in the single `addBlock` call (recipient
-//! balances are correct), but the off-chain `check_burn_completion`'s
-//! Transfer-log filter does not mark these burns complete —
-//! `linera_bridge_burns_completed` stays at 0. The
-//! `burns_completed == NUM_BURNS` assertion fails. Post-fix: per-burn
-//! `isBurnProcessed(height, eventIndex)` returns true for every flag
-//! written inside the same `_onBlock` call, so all N entries flip
-//! to complete on the next `check_burn_completion` iteration.
+//! and the relayer must mark every pending burn complete via the
+//! per-burn `isBurnProcessed(height, eventIndex)` view.
 
 #![recursion_limit = "512"]
 
@@ -161,7 +152,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     // chain A's inbox once. The N Credit messages travel together
     // and `process_inbox` materialises one chain-A block containing
     // all N BurnEvents.
-    let operations: Vec<Operation> = recipients
+    let operations = recipients
         .iter()
         .map(|recipient| {
             let owner = AccountOwner::Address20(recipient.0 .0);
@@ -194,9 +185,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         height_after_inbox.0,
         height_before_inbox.0 + 1,
         "chain A must produce exactly ONE block carrying all {NUM_BURNS} BurnEvents \
-         (before={}, after={})",
-        height_before_inbox.0,
-        height_after_inbox.0,
+         (before={height_before_inbox}, after={height_after_inbox})",
     );
 
     let relay_dir = tempfile::tempdir()?;
@@ -264,11 +253,20 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         relay_handle.abort();
         return Err(error);
     }
-    // One addBlock processes all N burns in `_onBlock`; allow the
-    // relayer enough time to call it and for the post-tx settle path
-    // (check_burn_completion / per-burn isBurnProcessed query) to run
-    // at least one iteration.
-    tokio::time::sleep(Duration::from_secs(30)).await;
+    // Wait for the relayer to finish: one `addBlock` releases all N
+    // tokens inside `_onBlock`, then `check_burn_completion`'s per-burn
+    // `isBurnProcessed` query flips every entry to completed.
+    if let Err(error) = wait_for_relay_metrics(
+        &http,
+        &relay_url,
+        |_detected, completed, _pending, _failed| completed >= num_burns_i64,
+        Duration::from_secs(60),
+    )
+    .await
+    {
+        relay_handle.abort();
+        return Err(error);
+    }
 
     let rpc_url = "http://localhost:8545".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -1,32 +1,24 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Reproduces the UI-demo bug: many burns to the same EVM recipient
-//! across separate Linera blocks. The pre-fix relayer's
-//! `check_burn_completion` used a recipient-only ERC-20 `Transfer`-log
-//! filter, so once any pending burn for a recipient saw an on-chain
-//! transfer, every other pending burn for that same recipient flipped
-//! to completed regardless of whether its own `token.transfer` ran.
-//! With the per-burn `isBurnProcessed(height, eventIndex)` query,
-//! completion is decided per burn and the relayer must actually
-//! release every one before marking them done.
+//! Verifies that the relayer decides burn completion per burn rather
+//! than per recipient: many burns to the same EVM recipient, spread
+//! across separate Linera blocks, must each be released on-chain
+//! before the relayer marks them complete.
 //!
 //! Setup: 5 burns to the same EVM recipient, materialised as 5
 //! separate Linera blocks on the bridge chain BEFORE the relayer is
-//! spawned. The test process drives both the cross-chain Transfer on
-//! the user chain and the inbox processing on the bridge chain, so
-//! each Credit lands in its own block deterministically (no race with
-//! the relayer's notification loop batching multiple Credits into one
-//! block). When the relayer starts, its first scan iteration finds
-//! all 5 pending burns at once — the multi-pending shape required to
-//! reproduce the mark-by-existence false positive.
+//! spawned. The test process drives both the cross-chain `Transfer`
+//! on the user chain and the inbox processing on the bridge chain,
+//! so each `Credit` lands in its own block deterministically (no
+//! race with the relayer's notification loop batching multiple
+//! `Credit`s into one block). When the relayer starts, its first
+//! scan iteration finds all 5 pending burns at once.
 //!
-//! Expected outcome on the pre-fix code: only some `addBlock` calls
-//! complete before `check_burn_completion` false-marks every pending
-//! burn complete; the recipient's ERC-20 balance ends up below
-//! `5 * amount` while `linera_bridge_burns_completed == 5`. The
-//! balance assertion fails. Post-fix: per-burn dedup forces the
-//! relayer to forward every burn, balance reaches the full amount.
+//! The relayer must forward every burn via `addBlock` and the
+//! per-burn `isBurnProcessed(height, eventIndex)` query must return
+//! true for every entry; the recipient's ERC-20 balance must equal
+//! `5 * amount`.
 
 #![recursion_limit = "512"]
 

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -1,0 +1,309 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reproduces the UI-demo bug: many burns to the same EVM recipient
+//! across separate Linera blocks. The pre-fix relayer's
+//! `check_burn_completion` used a recipient-only ERC-20 `Transfer`-log
+//! filter, so once any pending burn for a recipient saw an on-chain
+//! transfer, every other pending burn for that same recipient flipped
+//! to completed regardless of whether its own `token.transfer` ran.
+//! With the per-burn `isBurnProcessed(height, eventIndex)` query,
+//! completion is decided per burn and the relayer must actually
+//! release every one before marking them done.
+//!
+//! Setup: 5 burns to the same EVM recipient, materialised as 5
+//! separate Linera blocks on the bridge chain BEFORE the relayer is
+//! spawned. The test process drives both the cross-chain Transfer on
+//! the user chain and the inbox processing on the bridge chain, so
+//! each Credit lands in its own block deterministically (no race with
+//! the relayer's notification loop batching multiple Credits into one
+//! block). When the relayer starts, its first scan iteration finds
+//! all 5 pending burns at once — the multi-pending shape required to
+//! reproduce the mark-by-existence false positive.
+//!
+//! Expected outcome on the pre-fix code: only some `addBlock` calls
+//! complete before `check_burn_completion` false-marks every pending
+//! burn complete; the recipient's ERC-20 balance ends up below
+//! `5 * amount` while `linera_bridge_burns_completed == 5`. The
+//! balance assertion fails. Post-fix: per-burn dedup forces the
+//! relayer to forward every burn, balance reaches the full amount.
+
+#![recursion_limit = "512"]
+
+use std::time::Duration;
+
+use alloy::{primitives::U256, providers::ProviderBuilder, sol};
+use linera_base::{
+    crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner,
+};
+use linera_bridge_e2e::{
+    compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
+    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
+    wait_for_light_client, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
+};
+use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
+use linera_core::environment::wallet::Memory;
+use linera_execution::{Operation, WasmRuntime};
+use linera_faucet_client::Faucet;
+use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
+use wrapped_fungible::{Account, WrappedFungibleOperation};
+
+sol! {
+    #[sol(rpc)]
+    interface IERC20 {
+        function balanceOf(address account) external view returns (uint256);
+    }
+}
+
+const NUM_BURNS: u32 = 5;
+const BURN_AMOUNT_TOKENS: u128 = 1;
+
+#[tokio::test]
+#[ignore] // Requires pre-built docker images, Wasm, and relay binary.
+async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> {
+    tracing_subscriber::fmt().with_test_writer().try_init().ok();
+    linera_bridge_e2e::ensure_rustls_provider();
+    let compose_file = compose_file_path();
+    let project_name = "linera-multi-burn-same-recipient-test";
+
+    let compose = start_compose(&compose_file, project_name).await;
+    wait_for_light_client(&compose, project_name, &compose_file).await;
+
+    let faucet = Faucet::new("http://localhost:8080".to_string());
+    let genesis_config = faucet.genesis_config().await?;
+    let relay_genesis_config = genesis_config.clone();
+
+    let store_config = MemoryStoreConfig {
+        max_stream_queries: 10,
+        kill_on_drop: true,
+    };
+    let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(
+        &store_config,
+        "multi-burn-same-recipient-e2e",
+        Some(WasmRuntime::default()),
+        StorageCacheConfig {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
+        },
+    )
+    .await?;
+    genesis_config.initialize_storage(&mut storage).await?;
+
+    let mut signer = InMemorySigner::new(None);
+    let mut ctx = ClientContext::new(
+        storage,
+        Memory::default(),
+        signer.clone(),
+        &Default::default(),
+        None,
+        genesis_config,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+    )
+    .await?;
+
+    // Chain A hosts the bridge contract
+    let owner_a = AccountOwner::from(signer.generate_new());
+    let chain_a_desc = faucet.claim(&owner_a).await?;
+    let chain_a = chain_a_desc.id();
+    ctx.extend_with_chain(chain_a_desc, Some(owner_a)).await?;
+    let cc_a = ctx.make_chain_client(chain_a).await?;
+    cc_a.synchronize_from_validators().await?;
+
+    // Chain B is the user.
+    let owner_b = AccountOwner::from(signer.generate_new());
+    let chain_b_desc = faucet.claim(&owner_b).await?;
+    let chain_b = chain_b_desc.id();
+    ctx.extend_with_chain(chain_b_desc, Some(owner_b)).await?;
+    let cc_b = ctx.make_chain_client(chain_b).await?;
+    cc_b.synchronize_from_validators().await?;
+
+    let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
+
+    let fungible_app_id =
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
+
+    let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let chain_a_bytes32 = format!("0x{chain_a}");
+    let bridge_addr = deploy_fungible_bridge(
+        &compose,
+        project_name,
+        &compose_file,
+        light_client_address(),
+        &chain_a_bytes32,
+        erc20_addr,
+        &app_id_bytes32,
+    )
+    .await?;
+
+    fund_bridge_erc20(
+        &compose,
+        project_name,
+        &compose_file,
+        erc20_addr,
+        bridge_addr,
+        1_000_000_000_000_000_000_000u128,
+    )
+    .await;
+
+    let evm_recipient: alloy::primitives::Address =
+        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?;
+    let receiver = AccountOwner::Address20(evm_recipient.0 .0);
+    let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
+
+    for _ in 0..NUM_BURNS {
+        cc_b.synchronize_from_validators().await?;
+        let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
+            owner: owner_b,
+            amount: burn_amount,
+            target_account: Account {
+                chain_id: chain_a,
+                owner: receiver,
+            },
+        })?;
+        cc_b.execute_operations(
+            vec![Operation::User {
+                application_id: fungible_app_id,
+                bytes: withdraw_bytes,
+            }],
+            vec![],
+        )
+        .await?
+        .expect("cross-chain withdrawal committed on chain B");
+
+        cc_a.synchronize_from_validators().await?;
+        cc_a.process_inbox().await?;
+    }
+
+    let relay_dir = tempfile::tempdir()?;
+    let wallet_path = relay_dir.path().join("wallet.json");
+    let keystore_path = relay_dir.path().join("keystore.json");
+    let storage_config = format!("rocksdb:{}", relay_dir.path().join("client.db").display());
+    let sqlite_path = relay_dir.path().join("relay.sqlite3");
+
+    {
+        use linera_persistent::Persist;
+        let mut ks = linera_persistent::File::new(&keystore_path, signer.clone())?;
+        ks.persist().await?;
+    }
+    linera_wallet_json::PersistentWallet::create(&wallet_path, relay_genesis_config)?;
+
+    let relay_port = 3004u16;
+    let bridge_addr_str = format!("{bridge_addr}");
+    let bridge_app_str = format!("{fungible_app_id}");
+    let fungible_app_str = format!("{fungible_app_id}");
+    let sqlite_path_for_relay = sqlite_path.clone();
+    let relay_handle = tokio::spawn(async move {
+        Box::pin(linera_bridge::relay::run(
+            "http://localhost:8545",
+            Some(wallet_path.as_path()),
+            Some(keystore_path.as_path()),
+            Some(&storage_config),
+            chain_a,
+            owner_a,
+            &bridge_addr_str,
+            &bridge_app_str,
+            &fungible_app_str,
+            ANVIL_PRIVATE_KEY,
+            None,
+            relay_port,
+            &linera_storage_runtime::CommonStorageOptions::with_defaults(),
+            Duration::from_secs(2),
+            0,
+            5,
+            Some(sqlite_path_for_relay.as_path()),
+        ))
+        .await
+    });
+
+    let relay_url = format!("http://localhost:{relay_port}");
+    let http = reqwest::Client::new();
+    for attempt in 0..30 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        if http
+            .get(format!("{relay_url}/metrics"))
+            .send()
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        if attempt == 29 {
+            relay_handle.abort();
+            anyhow::bail!("Relay did not become ready");
+        }
+    }
+
+    // Wait until the relayer has finished work: pending drops to 0 and
+    // all NUM_BURNS appear in burns_completed. Pre-fix gets there via
+    // mark-by-existence flipping every pending burn complete after the
+    // first transfer lands; post-fix gets there via per-burn
+    // `isBurnProcessed` flipping each entry only as its own `addBlock`
+    // confirms.
+    let settle_result = wait_for_relay_metrics(
+        &http,
+        &relay_url,
+        |_detected, completed, pending, _failed| {
+            pending == 0 && completed >= i64::from(NUM_BURNS)
+        },
+        Duration::from_secs(240),
+    )
+    .await;
+    if let Err(error) = settle_result {
+        relay_handle.abort();
+        return Err(error);
+    }
+
+    let rpc_url = "http://localhost:8545".parse()?;
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
+    let token_balance = IERC20::new(erc20_addr, &provider)
+        .balanceOf(evm_recipient)
+        .call()
+        .await?;
+
+    // Scrape the final metric values once for diagnostic clarity in
+    // both pass and fail cases.
+    let final_metrics = http
+        .get(format!("{relay_url}/metrics"))
+        .send()
+        .await?
+        .text()
+        .await?;
+    let burns_detected = parse_metric_value(&final_metrics, "linera_bridge_burns_detected");
+
+    relay_handle.abort();
+
+    let expected_balance =
+        U256::from(BURN_AMOUNT_TOKENS) * U256::from(NUM_BURNS) * U256::from(10u128.pow(18));
+    tracing::info!(
+        ?token_balance,
+        ?expected_balance,
+        burns_detected,
+        "Final state"
+    );
+
+    // Sanity check: every burn must have reached the scanner. A drop
+    // here would mean the test failed to pre-populate chain A
+    // properly, not the bug we are reproducing.
+    assert_eq!(
+        burns_detected,
+        i64::from(NUM_BURNS),
+        "relayer must have detected all {NUM_BURNS} burns; got {burns_detected}"
+    );
+
+    // The recipient's balance must reflect every burn. Anything less
+    // means at least one `PendingBurn` was marked complete without
+    // its `token.transfer` actually landing on-chain — the UI-demo bug.
+    assert_eq!(
+        token_balance,
+        expected_balance,
+        "recipient must accumulate every burn; got {token_balance}, expected {expected_balance}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

`check_burn_completion` used to mark a `PendingBurn` complete when ANY ERC-20 `Transfer` to the recipient existed. Multiple burns to the same recipient (a common pattern — a user repeatedly burning to their own
EVM address) collapsed to a single signal: once one transfer landed, every pending burn for that recipient flipped to completed regardless of whether its own `token.transfer` had actually run inside `_onBlock`. A
UI demo reproduced the failure exactly — 11 burns submitted, only 3 actually transferred on EVM, all 11 reported complete by the relayer.

## Proposal

- Add an on-chain per-burn flag. `FungibleBridge` writes `processedBurns[keccak256(abi.encode(height, evt.index))] = true` after each successful `token.transfer` inside `_onBlock`, and exposes an
`isBurnProcessed(uint64 height, uint32 eventIndex)` view.
- The relayer's `check_burn_completion` queries `isBurnProcessed` per pending burn instead of inspecting ERC-20 `Transfer` logs by recipient. Mark-by-existence is gone.
- `eventIndex` is the underlying Linera `Event.index` — the same value the off-chain scanner sees. `PendingBurn.burn_index: usize` (a synthetic flat counter) is renamed to `event_index: u32` and sourced from
`Event.index`. SQLite column, in-memory `HashMap` key, and metric labels updated.
- `Microchain.verifiedBlocks` is untouched. Multi-tx burn submission (splitting a single Linera block across several `addBlock` calls) needs that gate relaxed and is left for a follow-up.

Two new e2e tests reproduce the bug end-to-end and verify the fix:

- `multiple_burns_same_recipient_across_blocks` — 5 burns to the same EVM recipient pre-populated as separate Linera blocks before the relayer is spawned. Pre-fix: only some `addBlock` calls land;
`check_burn_completion`'s recipient-only filter false-marks every pending burn; the ERC-20 balance falls short of `5 * amount`. Post-fix: per-burn dedup forces each `addBlock`, balance reaches the full amount.
- `multiple_burns_same_block` — 4 burns (one recipient repeated) bundled into a single chain B block and absorbed into one chain A block carrying all 4 BurnEvents. Pre-fix: `_onBlock` transfers correctly but the
off-chain `check_burn_completion` never marks the burns complete (`burns_completed` stays at 0). Post-fix: per-burn `isBurnProcessed` returns true for every flag written in the same `_onBlock` call.

## Test Plan

- New e2e tests under `linera-bridge/tests/e2e/tests/`. Run with `cargo test --manifest-path linera-bridge/tests/e2e/Cargo.toml -- --ignored`. Both verified locally against the docker-compose stack: each fails on
the prior code with the expected diagnostic (`balance == 2e18, expected 5e18` and `burns_completed == 0, expected 4`) and passes with the fix.
- Existing `linera-bridge` unit tests (73 tests) continue to pass.
- CI.

## Release Plan

- These changes should be backported to the `main` branch

## Links

- Supersedes #6258 and stacks on #6276.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)