### PR TITLE
Backport: Pipeline certificate batch downloads during chain sync

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -213,6 +213,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--sender-certificate-download-batch-size <SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE>` — Maximum number of sender certificates we try to download and receive in one go when syncing sender chains
 
   Default value: `20000`
+* `--max-concurrent-batch-downloads <MAX_CONCURRENT_BATCH_DOWNLOADS>` — Maximum number of certificate batches downloaded concurrently during chain sync
+
+  Default value: `1`
 * `--max-joined-tasks <MAX_JOINED_TASKS>` — Maximum number of tasks that can are joined concurrently in the client
 
   Default value: `100`

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -15,8 +15,8 @@ use linera_base::{
 use linera_core::{
     client::{
         chain_client, DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
-        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_MAX_EVENT_STREAM_QUERIES,
-        DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+        DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE, DEFAULT_MAX_CONCURRENT_BATCH_DOWNLOADS,
+        DEFAULT_MAX_EVENT_STREAM_QUERIES, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
     },
     node::CrossChainMessageDelivery,
     DEFAULT_QUORUM_GRACE_PERIOD,
@@ -248,6 +248,10 @@ pub struct Options {
     )]
     pub sender_certificate_download_batch_size: usize,
 
+    /// Maximum number of certificate batches downloaded concurrently during chain sync.
+    #[arg(long, default_value_t = DEFAULT_MAX_CONCURRENT_BATCH_DOWNLOADS)]
+    pub max_concurrent_batch_downloads: usize,
+
     /// Maximum number of tasks that can are joined concurrently in the client.
     #[arg(long, default_value = "100")]
     pub max_joined_tasks: usize,
@@ -366,6 +370,7 @@ impl Options {
             certificate_download_batch_size: self.certificate_download_batch_size,
             certificate_upload_batch_size: self.certificate_upload_batch_size,
             sender_certificate_download_batch_size: self.sender_certificate_download_batch_size,
+            max_concurrent_batch_downloads: self.max_concurrent_batch_downloads,
             max_joined_tasks: self.max_joined_tasks,
             allow_fast_blocks: self.allow_fast_blocks,
             notification_circuit_breaker_initial_probe_interval: self

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -117,6 +117,8 @@ pub struct Options {
     /// Maximum number of sender certificates we try to download and receive in one go
     /// when syncing sender chains.
     pub sender_certificate_download_batch_size: usize,
+    /// Maximum number of certificate batches downloaded concurrently during chain sync.
+    pub max_concurrent_batch_downloads: usize,
     /// Maximum number of tasks that can be joined concurrently using buffer_unordered.
     pub max_joined_tasks: usize,
     /// Whether to allow creating blocks in the fast round. Fast blocks have lower latency but
@@ -144,7 +146,8 @@ impl Options {
     pub fn test_default() -> Self {
         use super::{
             DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE, DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
-            DEFAULT_MAX_EVENT_STREAM_QUERIES, DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            DEFAULT_MAX_CONCURRENT_BATCH_DOWNLOADS, DEFAULT_MAX_EVENT_STREAM_QUERIES,
+            DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
         };
         use crate::DEFAULT_QUORUM_GRACE_PERIOD;
 
@@ -162,6 +165,7 @@ impl Options {
             certificate_download_batch_size: DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
             certificate_upload_batch_size: DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
             sender_certificate_download_batch_size: DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE,
+            max_concurrent_batch_downloads: DEFAULT_MAX_CONCURRENT_BATCH_DOWNLOADS,
             max_joined_tasks: 100,
             allow_fast_blocks: false,
             notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -12,7 +12,7 @@ use std::{
 use custom_debug_derive::Debug;
 use futures::{
     future::Future,
-    stream::{self, AbortHandle, FuturesUnordered, StreamExt},
+    stream::{self, AbortHandle, FuturesOrdered, FuturesUnordered, StreamExt},
 };
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
@@ -128,6 +128,7 @@ pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE: u64 = 500;
 pub static DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE: usize = 20_000;
 pub static DEFAULT_MAX_EVENT_STREAM_QUERIES: usize = 1000;
+pub static DEFAULT_MAX_CONCURRENT_BATCH_DOWNLOADS: usize = 1;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TimingType {
@@ -243,7 +244,7 @@ pub struct Client<Env: Environment> {
     /// tracking.
     pub local_node: LocalNodeClient<Env::Storage>,
     /// Manages the requests sent to validator nodes.
-    requests_scheduler: RequestsScheduler<Env>,
+    requests_scheduler: Arc<RequestsScheduler<Env>>,
     /// The admin chain ID.
     admin_chain_id: ChainId,
     /// Chains that should be tracked by the client, along with their listening mode.
@@ -294,7 +295,8 @@ impl<Env: Environment> Client<Env> {
             Some(chain_modes.clone()),
         );
         let local_node = LocalNodeClient::new(state);
-        let requests_scheduler = RequestsScheduler::new(vec![], requests_scheduler_config);
+        let requests_scheduler =
+            Arc::new(RequestsScheduler::new(vec![], requests_scheduler_config));
 
         Self {
             environment,
@@ -585,18 +587,65 @@ impl<Env: Environment> Client<Env> {
             .load_local_certificates(chain_id, stop, until_block_time)
             .await?;
         let mut next_height = last_info.next_block_height;
-        // Now download the rest in batches from the remote node.
-        while next_height < stop {
-            // TODO(#2045): Analyze network errors instead of using a fixed batch size.
-            let limit = u64::from(stop)
-                .checked_sub(u64::from(next_height))
-                .ok_or(ArithmeticError::Overflow)?
-                .min(self.options.certificate_download_batch_size);
 
-            let certificates = self
-                .requests_scheduler
-                .download_certificates(remote_node, chain_id, next_height, limit)
-                .await?;
+        if next_height >= stop {
+            return Ok(last_info);
+        }
+
+        // Download remaining certificates from the remote node using a pipelined
+        // sliding window. A background task downloads up to `max_concurrent_batch_downloads`
+        // batches concurrently and sends them through a channel for sequential processing.
+        let max_concurrent = self.options.max_concurrent_batch_downloads;
+        let batch_size = self.options.certificate_download_batch_size;
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(max_concurrent);
+        let scheduler = self.requests_scheduler.clone();
+        let remote = remote_node.clone();
+
+        let _download_task = linera_base::Task::spawn(async move {
+            let mut download_height = next_height;
+            let mut in_flight = FuturesOrdered::new();
+
+            let enqueue_batch = |in_flight: &mut FuturesOrdered<_>,
+                                 scheduler: &Arc<RequestsScheduler<Env>>,
+                                 remote: &RemoteNode<Env::ValidatorNode>,
+                                 height: BlockHeight,
+                                 limit: u64| {
+                let scheduler = scheduler.clone();
+                let remote = remote.clone();
+                in_flight.push_back(async move {
+                    scheduler
+                        .download_certificates(&remote, chain_id, height, limit)
+                        .await
+                });
+            };
+
+            // Fill initial window.
+            while in_flight.len() < max_concurrent && download_height < stop {
+                let limit = u64::from(stop)
+                    .saturating_sub(u64::from(download_height))
+                    .min(batch_size);
+                enqueue_batch(&mut in_flight, &scheduler, &remote, download_height, limit);
+                download_height = BlockHeight(u64::from(download_height) + limit);
+            }
+
+            // Drain completed batches and refill the window.
+            while let Some(result) = in_flight.next().await {
+                if sender.send(result).await.is_err() {
+                    break;
+                }
+                if download_height < stop {
+                    let limit = u64::from(stop)
+                        .saturating_sub(u64::from(download_height))
+                        .min(batch_size);
+                    enqueue_batch(&mut in_flight, &scheduler, &remote, download_height, limit);
+                    download_height = BlockHeight(u64::from(download_height) + limit);
+                }
+            }
+        });
+
+        // Process downloaded batches sequentially.
+        while let Some(result) = receiver.recv().await {
+            let certificates = result?;
             let Some(info) = self
                 .process_certificates(slice::from_ref(remote_node), certificates, until_block_time)
                 .await?

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -595,6 +595,15 @@ impl<Env: Environment> Client<Env> {
         // Download remaining certificates from the remote node using a pipelined
         // sliding window. A background task downloads up to `max_concurrent_batch_downloads`
         // batches concurrently and sends them through a channel for sequential processing.
+        #[cfg(not(web))]
+        type CertificateBatchFuture = std::pin::Pin<
+            Box<dyn Future<Output = Result<Vec<ConfirmedBlockCertificate>, NodeError>> + Send>,
+        >;
+        #[cfg(web)]
+        type CertificateBatchFuture = std::pin::Pin<
+            Box<dyn Future<Output = Result<Vec<ConfirmedBlockCertificate>, NodeError>>>,
+        >;
+
         let max_concurrent = self.options.max_concurrent_batch_downloads;
         let batch_size = self.options.certificate_download_batch_size;
         let (sender, mut receiver) = tokio::sync::mpsc::channel(max_concurrent);
@@ -603,43 +612,36 @@ impl<Env: Environment> Client<Env> {
 
         let _download_task = linera_base::Task::spawn(async move {
             let mut download_height = next_height;
-            let mut in_flight = FuturesOrdered::new();
+            let mut in_flight = FuturesOrdered::<CertificateBatchFuture>::new();
 
-            let enqueue_batch = |in_flight: &mut FuturesOrdered<_>,
-                                 scheduler: &Arc<RequestsScheduler<Env>>,
-                                 remote: &RemoteNode<Env::ValidatorNode>,
-                                 height: BlockHeight,
-                                 limit: u64| {
+            let try_enqueue = |in_flight: &mut FuturesOrdered<CertificateBatchFuture>,
+                               download_height: &mut BlockHeight| {
+                if *download_height >= stop {
+                    return;
+                }
+                let limit = u64::from(stop)
+                    .saturating_sub(u64::from(*download_height))
+                    .min(batch_size);
+                let height = *download_height;
                 let scheduler = scheduler.clone();
                 let remote = remote.clone();
-                in_flight.push_back(async move {
+                in_flight.push_back(Box::pin(async move {
                     scheduler
                         .download_certificates(&remote, chain_id, height, limit)
                         .await
-                });
+                }));
+                *download_height = BlockHeight(u64::from(*download_height) + limit);
             };
 
-            // Fill initial window.
             while in_flight.len() < max_concurrent && download_height < stop {
-                let limit = u64::from(stop)
-                    .saturating_sub(u64::from(download_height))
-                    .min(batch_size);
-                enqueue_batch(&mut in_flight, &scheduler, &remote, download_height, limit);
-                download_height = BlockHeight(u64::from(download_height) + limit);
+                try_enqueue(&mut in_flight, &mut download_height);
             }
 
-            // Drain completed batches and refill the window.
             while let Some(result) = in_flight.next().await {
                 if sender.send(result).await.is_err() {
                     break;
                 }
-                if download_height < stop {
-                    let limit = u64::from(stop)
-                        .saturating_sub(u64::from(download_height))
-                        .min(batch_size);
-                    enqueue_batch(&mut in_flight, &scheduler, &remote, download_height, limit);
-                    download_height = BlockHeight(u64::from(download_height) + limit);
-                }
+                try_enqueue(&mut in_flight, &mut download_height);
             }
         });
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -610,7 +610,7 @@ impl<Env: Environment> Client<Env> {
         let scheduler = self.requests_scheduler.clone();
         let remote = remote_node.clone();
 
-        let _download_task = linera_base::Task::spawn(async move {
+        let download_task = linera_base::Task::spawn(async move {
             let mut download_height = next_height;
             let mut in_flight = FuturesOrdered::<CertificateBatchFuture>::new();
 
@@ -658,6 +658,9 @@ impl<Env: Environment> Client<Env> {
             next_height = info.next_block_height;
             last_info = info;
         }
+        // Await the downloader so any panic inside the spawned task surfaces here
+        // instead of being silently swallowed when the channel closes.
+        download_task.await;
         Ok(last_info)
     }
 


### PR DESCRIPTION
## Motivation

Backport of #5954 to `testnet_conway`.

## Proposal

Cherry-pick of the three commits from #5954:
- Pipeline certificate batch downloads during chain sync
- Address review feedback: type alias and try_enqueue dedupe
- Await the downloader task to surface panics

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #5954