### PR TITLE
Measure max Linera Burns in single EVM transaction.

### DIFF
--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -3965,6 +3965,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "test-case",
  "testcontainers",
  "tokio",
  "tracing",
@@ -7237,6 +7238,39 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "test-case-core",
 ]
 
 [[package]]

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -3950,6 +3950,7 @@ dependencies = [
  "futures",
  "linera-base",
  "linera-bridge",
+ "linera-chain",
  "linera-client",
  "linera-core",
  "linera-execution",

--- a/linera-bridge/tests/e2e/Cargo.toml
+++ b/linera-bridge/tests/e2e/Cargo.toml
@@ -27,6 +27,7 @@ bcs = "0.1.6"
 futures = "0.3"
 linera-base = { path = "../../../linera-base" }
 linera-bridge = { path = "../../../linera-bridge", features = ["relay"] }
+linera-chain = { path = "../../../linera-chain" }
 linera-client = { path = "../../../linera-client", default-features = false, features = [
     "wasmer",
 ] }

--- a/linera-bridge/tests/e2e/Cargo.toml
+++ b/linera-bridge/tests/e2e/Cargo.toml
@@ -49,6 +49,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
+test-case = "3.3.1"
 testcontainers = { version = "0.27", features = ["docker-compose"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -199,6 +199,34 @@ pub async fn deploy_linera_token(
     parse_broadcast_address(compose, project_name, compose_file, "DeployLineraToken.s.sol").await
 }
 
+/// Same as [`deploy_linera_token`] but overrides the initial token supply
+/// minted to the anvil deployer via the script's `TOKEN_SUPPLY` env var.
+/// `supply_attos` is the raw atto amount — pass `tokens * 10u128.pow(18)`
+/// for whole-token amounts.
+pub async fn deploy_linera_token_with_supply(
+    compose: &DockerCompose,
+    project_name: &str,
+    compose_file: &std::path::Path,
+    supply_attos: u128,
+) -> anyhow::Result<Address> {
+    exec_ok(
+        compose,
+        "foundry-tools",
+        &format!(
+            "env TOKEN_SUPPLY={supply_attos} \
+             forge script /contracts/script/DeployLineraToken.s.sol \
+             --root /contracts \
+             --rpc-url http://anvil:8545 \
+             --private-key {ANVIL_PRIVATE_KEY} \
+             --broadcast"
+        ),
+        project_name,
+        compose_file,
+    )
+    .await;
+    parse_broadcast_address(compose, project_name, compose_file, "DeployLineraToken.s.sol").await
+}
+
 /// Deploys FungibleBridge via the `DeployFungibleBridge.s.sol` forge
 /// script and returns the deployed contract address.
 pub async fn deploy_fungible_bridge(
@@ -517,17 +545,8 @@ where
     E: linera_core::environment::Environment,
 {
     use anyhow::Context as _;
-    chain_client
-        .synchronize_from_validators()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
-    let info = chain_client
-        .chain_info()
-        .await
-        .map_err(|e| anyhow::anyhow!(e))?;
+    chain_client.synchronize_from_validators().await?;
+    let info = chain_client.chain_info().await?;
     let hash = info.block_hash.context("chain has no blocks yet")?;
-    chain_client
-        .read_certificate(hash)
-        .await
-        .map_err(|e| anyhow::anyhow!(e))
+    Ok(chain_client.read_certificate(hash).await?)
 }

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -489,3 +489,45 @@ where
     }
     anyhow::bail!("wait_for_relay_metrics timed out after {timeout:?}")
 }
+
+/// Sets the anvil block gas limit via the `evm_setBlockGasLimit` JSON-RPC
+/// method. Lets the test choose a ceiling well above the chain spec being
+/// measured so `eth_estimateGas` never aborts on anvil's own limit — the
+/// numeric comparison happens in Rust against `ChainSpec::block_gas_limit`.
+pub async fn set_anvil_block_gas_limit(
+    provider: &impl alloy::providers::Provider,
+    limit: u64,
+) -> anyhow::Result<()> {
+    use std::borrow::Cow;
+    let hex_limit = format!("0x{limit:x}");
+    let _: bool = provider
+        .raw_request(Cow::Borrowed("evm_setBlockGasLimit"), (hex_limit,))
+        .await?;
+    Ok(())
+}
+
+/// Fetches the `ConfirmedBlockCertificate` for the chain's current head
+/// block. Mirrors the `sync -> chain_info -> read_certificate` walk in
+/// `linera-bridge/src/monitor/linera.rs::process_pending_burns` but specialised
+/// to the head block (no per-height search loop needed in tests).
+pub async fn fetch_latest_cert<E>(
+    chain_client: &linera_core::client::ChainClient<E>,
+) -> anyhow::Result<linera_chain::types::ConfirmedBlockCertificate>
+where
+    E: linera_core::environment::Environment,
+{
+    use anyhow::Context as _;
+    chain_client
+        .synchronize_from_validators()
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let info = chain_client
+        .chain_info()
+        .await
+        .map_err(|e| anyhow::anyhow!(e))?;
+    let hash = info.block_hash.context("chain has no blocks yet")?;
+    chain_client
+        .read_certificate(hash)
+        .await
+        .map_err(|e| anyhow::anyhow!(e))
+}

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -56,6 +56,7 @@ const BURN_AMOUNT_TOKENS: u128 = 1;
 /// estimate the gas required by `bridge.addBlock(cert_bytes)`.
 ///
 /// Returns the estimated gas. Reverts surface as `Err`.
+#[allow(clippy::too_many_arguments)]
 async fn build_and_estimate<P, E>(
     n: u32,
     cc_a: &linera_core::client::ChainClient<E>,

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -13,7 +13,7 @@
 use alloy::{providers::ProviderBuilder, sol};
 use linera_base::{crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner};
 use linera_bridge_e2e::{
-    compose_file_path, deploy_fungible_bridge, deploy_linera_token, fetch_latest_cert,
+    compose_file_path, deploy_fungible_bridge, deploy_linera_token_with_supply, fetch_latest_cert,
     fund_bridge_erc20, light_client_address, publish_and_create_wrapped_fungible,
     set_anvil_block_gas_limit, start_compose, wait_for_light_client,
 };
@@ -33,26 +33,24 @@ sol! {
     }
 }
 
-/// Hard cap on the search range. Bounds chain-A block construction cost and
-/// keeps the test runtime predictable. Capped at 1000 because the
-/// `LineraToken` deploy script mints exactly 1000 tokens to the anvil
-/// deployer, and the bridge must hold `MAX_SEARCH_N * BURN_AMOUNT_TOKENS`
-/// to make `eth_estimateGas` succeed at the upper search bound (a dry-run
-/// `token.transfer` reverts on insufficient balance and surfaces as an
-/// estimate error).
+/// Hard cap on the search range. Bounds chain-A block construction cost
+/// and keeps the test runtime predictable. The ERC-20 supply minted to
+/// the bridge is sized off this constant (see `deploy_linera_token_with_supply`
+/// call below), so widening it just costs more iterations — no balance
+/// constraint.
 const MAX_SEARCH_N: u32 = 1000;
 
 /// Chain-B pre-funded balance: enough wrapped-fungible to issue
-/// `MAX_SEARCH_N * doubling_plus_bisect_iterations` `Transfer` ops. ~20 search
-/// iterations × 1000 burns × 1 token each ≈ 20 000 tokens upper bound; round
-/// up to 100 000 for headroom.
-const INITIAL_BALANCE_TOKENS: u128 = 100_000;
+/// `MAX_SEARCH_N * doubling_plus_bisect_iterations * BURN_AMOUNT_TOKENS`
+/// `Transfer` ops. Sized well above the worst case so the test never
+/// runs out of source-chain balance regardless of `BURN_AMOUNT_TOKENS`.
+const INITIAL_BALANCE_TOKENS: u128 = 10u128.pow(32);
 
-/// Each burn moves exactly one wrapped-fungible token to a fresh
+/// Each burn moves exactly this many wrapped-fungible tokens to a fresh
 /// `Address20`. Constant token amount keeps per-burn EVM gas constant
 /// (the per-burn cost is dominated by the storage write + ERC-20 transfer,
 /// not by the amount value).
-const BURN_AMOUNT_TOKENS: u128 = 1;
+const BURN_AMOUNT_TOKENS: u128 = 10u128.pow(15);
 
 #[test_case("ethereum",     30_000_000,  Some(50); "ethereum")]
 #[test_case("base",         240_000_000, Some(190); "base")]
@@ -129,7 +127,11 @@ async fn burns_per_evm_tx(
     let cc_b = ctx.make_chain_client(chain_b).await?;
     cc_b.synchronize_from_validators().await?;
 
-    let erc20_addr = deploy_linera_token(&compose, &project_name, &compose_file).await?;
+    // Mint enough so the bridge can be funded for the largest search step.
+    let token_supply_attos = u128::from(MAX_SEARCH_N) * BURN_AMOUNT_TOKENS * 10u128.pow(18);
+    let erc20_addr =
+        deploy_linera_token_with_supply(&compose, &project_name, &compose_file, token_supply_attos)
+            .await?;
     let fungible_app_id = publish_and_create_wrapped_fungible(
         &cc_b,
         owner_b,
@@ -152,16 +154,15 @@ async fn burns_per_evm_tx(
     )
     .await?;
 
-    // Fund the bridge with enough ERC-20 to cover up to MAX_SEARCH_N
-    // releases even though estimation is a dry run — keeps the test
-    // robust if we later switch from estimate to live submission.
+    // Fund the bridge with the full mint so a dry-run `token.transfer`
+    // at the upper search bound never reverts for insufficient balance.
     fund_bridge_erc20(
         &compose,
         &project_name,
         &compose_file,
         erc20_addr,
         bridge_addr,
-        u128::from(MAX_SEARCH_N) * BURN_AMOUNT_TOKENS * 10u128.pow(18),
+        token_supply_attos,
     )
     .await;
 

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -34,12 +34,17 @@ sol! {
 }
 
 /// Hard cap on the search range. Bounds chain-A block construction cost and
-/// keeps the test runtime predictable even for very-high-gas chains.
-const MAX_SEARCH_N: u32 = 2048;
+/// keeps the test runtime predictable. Capped at 1000 because the
+/// `LineraToken` deploy script mints exactly 1000 tokens to the anvil
+/// deployer, and the bridge must hold `MAX_SEARCH_N * BURN_AMOUNT_TOKENS`
+/// to make `eth_estimateGas` succeed at the upper search bound (a dry-run
+/// `token.transfer` reverts on insufficient balance and surfaces as an
+/// estimate error).
+const MAX_SEARCH_N: u32 = 1000;
 
 /// Chain-B pre-funded balance: enough wrapped-fungible to issue
-/// `MAX_SEARCH_N * doubling_plus_bisect_iterations` `Transfer` ops. 22 search
-/// iterations × 2048 burns × 1 token each = 45 056 tokens upper bound; round
+/// `MAX_SEARCH_N * doubling_plus_bisect_iterations` `Transfer` ops. ~20 search
+/// iterations × 1000 burns × 1 token each ≈ 20 000 tokens upper bound; round
 /// up to 100 000 for headroom.
 const INITIAL_BALANCE_TOKENS: u128 = 100_000;
 
@@ -74,11 +79,12 @@ where
     use anyhow::Context as _;
 
     let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
-    let operations = (0..n)
+    let operations = (1..=n)
         .map(|i| {
             // Deterministic distinct recipients; high bytes spell out the
             // iteration counter so log inspection makes the address ↔ burn
-            // mapping easy to read.
+            // mapping easy to read. Start from 1 — `Address20(0…0)` is the
+            // zero address and ERC-20 rejects transfers to it.
             let mut bytes = [0u8; 20];
             bytes[16..].copy_from_slice(&i.to_be_bytes());
             let owner = AccountOwner::Address20(bytes);
@@ -127,7 +133,6 @@ where
 
 #[test_case("ethereum",     30_000_000,  None; "ethereum")]
 #[test_case("base",         240_000_000, None; "base")]
-#[test_case("base_sepolia", 240_000_000, None; "base_sepolia")]
 #[tokio::test]
 #[ignore] // Requires pre-built docker images, Wasm, and bridge contracts.
 async fn burns_per_evm_tx(

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! For each `ChainSpec` (Ethereum / Base / Base Sepolia / …), binary-searches
+//! the largest `N` such that `eth_estimateGas(bridge.addBlock(cert_N))` is
+//! `<= chain_spec.block_gas_limit`, where `cert_N` is a Linera block carrying
+//! exactly `N` `BurnEvent`s. `eth_estimateGas` runs the EVM in dry-run mode,
+//! so the bridge's `processedBurns` mapping stays untouched and a single
+//! bridge instance handles every iteration.
+
+#![recursion_limit = "512"]
+
+use test_case::test_case;
+
+#[test_case("ethereum",     30_000_000,  None; "ethereum")]
+#[test_case("base",         240_000_000, None; "base")]
+#[test_case("base_sepolia", 240_000_000, None; "base_sepolia")]
+#[tokio::test]
+#[ignore] // Requires pre-built docker images, Wasm, and bridge contracts.
+async fn burns_per_evm_tx(
+    _name: &str,
+    _block_gas_limit: u64,
+    _min_expected_burns: Option<u32>,
+) -> anyhow::Result<()> {
+    Ok(())
+}

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -10,7 +10,43 @@
 
 #![recursion_limit = "512"]
 
+use alloy::{providers::ProviderBuilder, sol};
+use linera_base::{crypto::InMemorySigner, identifiers::AccountOwner};
+use linera_bridge_e2e::{
+    compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
+    light_client_address, publish_and_create_wrapped_fungible, set_anvil_block_gas_limit,
+    start_compose, wait_for_light_client,
+};
+use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
+use linera_core::environment::wallet::Memory;
+use linera_execution::WasmRuntime;
+use linera_faucet_client::Faucet;
+use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use test_case::test_case;
+
+sol! {
+    #[sol(rpc)]
+    interface IFungibleBridge {
+        function addBlock(bytes calldata data) external;
+    }
+}
+
+/// Hard cap on the search range. Bounds chain-A block construction cost and
+/// keeps the test runtime predictable even for very-high-gas chains.
+const MAX_SEARCH_N: u32 = 2048;
+
+/// Chain-B pre-funded balance: enough wrapped-fungible to issue
+/// `MAX_SEARCH_N * doubling_plus_bisect_iterations` `Transfer` ops. 22 search
+/// iterations × 2048 burns × 1 token each = 45 056 tokens upper bound; round
+/// up to 100 000 for headroom.
+const INITIAL_BALANCE_TOKENS: u128 = 100_000;
+
+/// Each burn moves exactly one wrapped-fungible token to a fresh
+/// `Address20`. Constant token amount keeps per-burn EVM gas constant
+/// (the per-burn cost is dominated by the storage write + ERC-20 transfer,
+/// not by the amount value).
+const BURN_AMOUNT_TOKENS: u128 = 1;
 
 #[test_case("ethereum",     30_000_000,  None; "ethereum")]
 #[test_case("base",         240_000_000, None; "base")]
@@ -18,9 +54,124 @@ use test_case::test_case;
 #[tokio::test]
 #[ignore] // Requires pre-built docker images, Wasm, and bridge contracts.
 async fn burns_per_evm_tx(
-    _name: &str,
-    _block_gas_limit: u64,
-    _min_expected_burns: Option<u32>,
+    name: &str,
+    block_gas_limit: u64,
+    min_expected_burns: Option<u32>,
 ) -> anyhow::Result<()> {
+    tracing_subscriber::fmt().with_test_writer().try_init().ok();
+    linera_bridge_e2e::ensure_rustls_provider();
+
+    let compose_file = compose_file_path();
+    let project_name = format!("linera-burns-per-tx-{name}");
+
+    let compose = start_compose(&compose_file, &project_name).await;
+    wait_for_light_client(&compose, &project_name, &compose_file).await;
+
+    let rpc_url = "http://localhost:8545".parse()?;
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
+
+    // Raise anvil's own block gas ceiling well above the chain we are
+    // measuring so `eth_estimateGas` never errors out on anvil's limit.
+    set_anvil_block_gas_limit(&provider, block_gas_limit.saturating_mul(5)).await?;
+
+    let faucet = Faucet::new("http://localhost:8080".to_string());
+    let genesis_config = faucet.genesis_config().await?;
+
+    let store_config = MemoryStoreConfig {
+        max_stream_queries: 10,
+        kill_on_drop: true,
+    };
+    let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(
+        &store_config,
+        &format!("burns-per-tx-{name}-e2e"),
+        Some(WasmRuntime::default()),
+        StorageCacheConfig {
+            blob_cache_size: 1000,
+            confirmed_block_cache_size: 1000,
+            certificate_cache_size: 1000,
+            certificate_raw_cache_size: 1000,
+            event_cache_size: 1000,
+            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
+        },
+    )
+    .await?;
+    genesis_config.initialize_storage(&mut storage).await?;
+
+    let mut signer = InMemorySigner::new(None);
+    let mut ctx = ClientContext::new(
+        storage,
+        Memory::default(),
+        signer.clone(),
+        &Default::default(),
+        None,
+        genesis_config,
+        linera_core::worker::DEFAULT_BLOCK_CACHE_SIZE,
+        linera_core::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+    )
+    .await?;
+
+    let owner_a = AccountOwner::from(signer.generate_new());
+    let chain_a_desc = faucet.claim(&owner_a).await?;
+    let chain_a = chain_a_desc.id();
+    ctx.extend_with_chain(chain_a_desc, Some(owner_a)).await?;
+    let cc_a = ctx.make_chain_client(chain_a).await?;
+    cc_a.synchronize_from_validators().await?;
+
+    let owner_b = AccountOwner::from(signer.generate_new());
+    let chain_b_desc = faucet.claim(&owner_b).await?;
+    let chain_b = chain_b_desc.id();
+    ctx.extend_with_chain(chain_b_desc, Some(owner_b)).await?;
+    let cc_b = ctx.make_chain_client(chain_b).await?;
+    cc_b.synchronize_from_validators().await?;
+
+    let erc20_addr = deploy_linera_token(&compose, &project_name, &compose_file).await?;
+    let fungible_app_id = publish_and_create_wrapped_fungible(
+        &cc_b,
+        owner_b,
+        chain_a,
+        erc20_addr,
+        INITIAL_BALANCE_TOKENS,
+    )
+    .await?;
+
+    let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let chain_a_bytes32 = format!("0x{chain_a}");
+    let bridge_addr = deploy_fungible_bridge(
+        &compose,
+        &project_name,
+        &compose_file,
+        light_client_address(),
+        &chain_a_bytes32,
+        erc20_addr,
+        &app_id_bytes32,
+    )
+    .await?;
+
+    // Fund the bridge with enough ERC-20 to cover up to MAX_SEARCH_N
+    // releases even though estimation is a dry run — keeps the test
+    // robust if we later switch from estimate to live submission.
+    fund_bridge_erc20(
+        &compose,
+        &project_name,
+        &compose_file,
+        erc20_addr,
+        bridge_addr,
+        u128::from(MAX_SEARCH_N) * BURN_AMOUNT_TOKENS * 10u128.pow(18),
+    )
+    .await;
+
+    // Suppress unused-variable warnings; subsequent task fills these in.
+    let _ = (
+        &cc_a,
+        &cc_b,
+        owner_b,
+        chain_a,
+        fungible_app_id,
+        bridge_addr,
+        block_gas_limit,
+        min_expected_burns,
+        &provider,
+    );
+
     Ok(())
 }

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -54,85 +54,8 @@ const INITIAL_BALANCE_TOKENS: u128 = 100_000;
 /// not by the amount value).
 const BURN_AMOUNT_TOKENS: u128 = 1;
 
-/// Bundles `n` `WrappedFungibleOperation::Transfer` ops into a single
-/// chain-B block, drives `cc_a.process_inbox()` (which produces one
-/// chain-A block with `n` `BurnEvent`s), reads the resulting
-/// `ConfirmedBlockCertificate`, BCS-encodes it, and asks anvil to
-/// estimate the gas required by `bridge.addBlock(cert_bytes)`.
-///
-/// Returns the estimated gas. Reverts surface as `Err`.
-#[allow(clippy::too_many_arguments)]
-async fn build_and_estimate<P, E>(
-    n: u32,
-    cc_a: &linera_core::client::ChainClient<E>,
-    cc_b: &linera_core::client::ChainClient<E>,
-    owner_b: AccountOwner,
-    chain_a: linera_base::identifiers::ChainId,
-    fungible_app_id: linera_base::identifiers::ApplicationId,
-    bridge_addr: alloy::primitives::Address,
-    provider: &P,
-) -> anyhow::Result<u64>
-where
-    P: alloy::providers::Provider,
-    E: linera_core::environment::Environment,
-{
-    use anyhow::Context as _;
-
-    let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
-    let operations = (1..=n)
-        .map(|i| {
-            // Deterministic distinct recipients; high bytes spell out the
-            // iteration counter so log inspection makes the address ↔ burn
-            // mapping easy to read. Start from 1 — `Address20(0…0)` is the
-            // zero address and ERC-20 rejects transfers to it.
-            let mut bytes = [0u8; 20];
-            bytes[16..].copy_from_slice(&i.to_be_bytes());
-            let owner = AccountOwner::Address20(bytes);
-            let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-                owner: owner_b,
-                amount: burn_amount,
-                target_account: Account {
-                    chain_id: chain_a,
-                    owner,
-                },
-            })
-            .expect("BCS serialization");
-            Operation::User {
-                application_id: fungible_app_id,
-                bytes: withdraw_bytes,
-            }
-        })
-        .collect::<Vec<_>>();
-
-    cc_b.synchronize_from_validators().await?;
-    cc_b.execute_operations(operations, vec![])
-        .await?
-        .expect("chain-B execute_operations committed");
-
-    cc_a.synchronize_from_validators().await?;
-    let height_before = cc_a.chain_info().await?.next_block_height;
-    cc_a.process_inbox().await?;
-    let height_after = cc_a.chain_info().await?.next_block_height;
-    anyhow::ensure!(
-        height_after.0 == height_before.0 + 1,
-        "chain A must produce exactly ONE block (n={n}, before={height_before}, after={height_after})"
-    );
-
-    let cert = fetch_latest_cert(cc_a).await?;
-    let cert_bytes = bcs::to_bytes(&cert).context("BCS-serialize cert")?;
-
-    let bridge = IFungibleBridge::new(bridge_addr, provider);
-    let gas = bridge
-        .addBlock(cert_bytes.into())
-        .estimate_gas()
-        .await
-        .with_context(|| format!("estimate_gas(addBlock) for n={n}"))?;
-
-    Ok(gas)
-}
-
-#[test_case("ethereum",     30_000_000,  None; "ethereum")]
-#[test_case("base",         240_000_000, None; "base")]
+#[test_case("ethereum",     30_000_000,  Some(50); "ethereum")]
+#[test_case("base",         240_000_000, Some(190); "base")]
 #[tokio::test]
 #[ignore] // Requires pre-built docker images, Wasm, and bridge contracts.
 async fn burns_per_evm_tx(
@@ -254,11 +177,11 @@ async fn burns_per_evm_tx(
         &provider,
     )
     .await?;
-    tracing::info!(n = hi, gas = hi_gas, "search: initial hi");
+    tracing::info!(n = hi, gas = hi_gas, "search: initial `Burn` ops count");
 
     while hi_gas <= block_gas_limit && hi < MAX_SEARCH_N {
         let next_hi = hi.saturating_mul(2).min(MAX_SEARCH_N);
-        let g = build_and_estimate(
+        let gas = build_and_estimate(
             next_hi,
             &cc_a,
             &cc_b,
@@ -269,9 +192,13 @@ async fn burns_per_evm_tx(
             &provider,
         )
         .await?;
-        tracing::info!(n = next_hi, gas = g, "search: doubling");
         hi = next_hi;
-        hi_gas = g;
+        hi_gas = gas;
+        if hi_gas > block_gas_limit {
+            tracing::info!(burn_ops = next_hi, gas, "search: found upper bound");
+            break;
+        }
+        tracing::info!(burn_ops = next_hi, gas, "search: doubling, still under limit");
         if hi == MAX_SEARCH_N {
             break;
         }
@@ -359,4 +286,81 @@ async fn burns_per_evm_tx(
     }
 
     Ok(())
+}
+
+/// Bundles `n` `WrappedFungibleOperation::Transfer` ops into a single
+/// chain-B block, drives `cc_a.process_inbox()` (which produces one
+/// chain-A block with `n` `BurnEvent`s), reads the resulting
+/// `ConfirmedBlockCertificate`, BCS-encodes it, and asks anvil to
+/// estimate the gas required by `bridge.addBlock(cert_bytes)`.
+///
+/// Returns the estimated gas. Reverts surface as `Err`.
+#[allow(clippy::too_many_arguments)]
+async fn build_and_estimate<P, E>(
+    n: u32,
+    cc_a: &linera_core::client::ChainClient<E>,
+    cc_b: &linera_core::client::ChainClient<E>,
+    owner_b: AccountOwner,
+    chain_a: linera_base::identifiers::ChainId,
+    fungible_app_id: linera_base::identifiers::ApplicationId,
+    bridge_addr: alloy::primitives::Address,
+    provider: &P,
+) -> anyhow::Result<u64>
+where
+    P: alloy::providers::Provider,
+    E: linera_core::environment::Environment,
+{
+    use anyhow::Context as _;
+
+    let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
+    let operations = (1..=n)
+        .map(|i| {
+            // Deterministic distinct recipients; high bytes spell out the
+            // iteration counter so log inspection makes the address ↔ burn
+            // mapping easy to read. Start from 1 — `Address20(0…0)` is the
+            // zero address and ERC-20 rejects transfers to it.
+            let mut bytes = [0u8; 20];
+            bytes[16..].copy_from_slice(&i.to_be_bytes());
+            let owner = AccountOwner::Address20(bytes);
+            let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
+                owner: owner_b,
+                amount: burn_amount,
+                target_account: Account {
+                    chain_id: chain_a,
+                    owner,
+                },
+            })
+            .expect("BCS serialization");
+            Operation::User {
+                application_id: fungible_app_id,
+                bytes: withdraw_bytes,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    cc_b.synchronize_from_validators().await?;
+    cc_b.execute_operations(operations, vec![])
+        .await?
+        .expect("chain-B execute_operations committed");
+
+    cc_a.synchronize_from_validators().await?;
+    let height_before = cc_a.chain_info().await?.next_block_height;
+    cc_a.process_inbox().await?;
+    let height_after = cc_a.chain_info().await?.next_block_height;
+    anyhow::ensure!(
+        height_after.0 == height_before.0 + 1,
+        "chain A must produce exactly ONE block (n={n}, before={height_before}, after={height_after})"
+    );
+
+    let cert = fetch_latest_cert(cc_a).await?;
+    let cert_bytes = bcs::to_bytes(&cert).context("BCS-serialize cert")?;
+
+    let bridge = IFungibleBridge::new(bridge_addr, provider);
+    let gas = bridge
+        .addBlock(cert_bytes.into())
+        .estimate_gas()
+        .await
+        .with_context(|| format!("estimate_gas(addBlock) for n={n}"))?;
+
+    Ok(gas)
 }

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -11,19 +11,20 @@
 #![recursion_limit = "512"]
 
 use alloy::{providers::ProviderBuilder, sol};
-use linera_base::{crypto::InMemorySigner, identifiers::AccountOwner};
+use linera_base::{crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner};
 use linera_bridge_e2e::{
-    compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
-    light_client_address, publish_and_create_wrapped_fungible, set_anvil_block_gas_limit,
-    start_compose, wait_for_light_client,
+    compose_file_path, deploy_fungible_bridge, deploy_linera_token, fetch_latest_cert,
+    fund_bridge_erc20, light_client_address, publish_and_create_wrapped_fungible,
+    set_anvil_block_gas_limit, start_compose, wait_for_light_client,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
-use linera_execution::WasmRuntime;
+use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use test_case::test_case;
+use wrapped_fungible::{Account, WrappedFungibleOperation};
 
 sol! {
     #[sol(rpc)]
@@ -47,6 +48,81 @@ const INITIAL_BALANCE_TOKENS: u128 = 100_000;
 /// (the per-burn cost is dominated by the storage write + ERC-20 transfer,
 /// not by the amount value).
 const BURN_AMOUNT_TOKENS: u128 = 1;
+
+/// Bundles `n` `WrappedFungibleOperation::Transfer` ops into a single
+/// chain-B block, drives `cc_a.process_inbox()` (which produces one
+/// chain-A block with `n` `BurnEvent`s), reads the resulting
+/// `ConfirmedBlockCertificate`, BCS-encodes it, and asks anvil to
+/// estimate the gas required by `bridge.addBlock(cert_bytes)`.
+///
+/// Returns the estimated gas. Reverts surface as `Err`.
+async fn build_and_estimate<P, E>(
+    n: u32,
+    cc_a: &linera_core::client::ChainClient<E>,
+    cc_b: &linera_core::client::ChainClient<E>,
+    owner_b: AccountOwner,
+    chain_a: linera_base::identifiers::ChainId,
+    fungible_app_id: linera_base::identifiers::ApplicationId,
+    bridge_addr: alloy::primitives::Address,
+    provider: &P,
+) -> anyhow::Result<u64>
+where
+    P: alloy::providers::Provider,
+    E: linera_core::environment::Environment,
+{
+    use anyhow::Context as _;
+
+    let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
+    let operations = (0..n)
+        .map(|i| {
+            // Deterministic distinct recipients; high bytes spell out the
+            // iteration counter so log inspection makes the address ↔ burn
+            // mapping easy to read.
+            let mut bytes = [0u8; 20];
+            bytes[16..].copy_from_slice(&i.to_be_bytes());
+            let owner = AccountOwner::Address20(bytes);
+            let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
+                owner: owner_b,
+                amount: burn_amount,
+                target_account: Account {
+                    chain_id: chain_a,
+                    owner,
+                },
+            })
+            .expect("BCS serialization");
+            Operation::User {
+                application_id: fungible_app_id,
+                bytes: withdraw_bytes,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    cc_b.synchronize_from_validators().await?;
+    cc_b.execute_operations(operations, vec![])
+        .await?
+        .expect("chain-B execute_operations committed");
+
+    cc_a.synchronize_from_validators().await?;
+    let height_before = cc_a.chain_info().await?.next_block_height;
+    cc_a.process_inbox().await?;
+    let height_after = cc_a.chain_info().await?.next_block_height;
+    anyhow::ensure!(
+        height_after.0 == height_before.0 + 1,
+        "chain A must produce exactly ONE block (n={n}, before={height_before}, after={height_after})"
+    );
+
+    let cert = fetch_latest_cert(cc_a).await?;
+    let cert_bytes = bcs::to_bytes(&cert).context("BCS-serialize cert")?;
+
+    let bridge = IFungibleBridge::new(bridge_addr, provider);
+    let gas = bridge
+        .addBlock(cert_bytes.into())
+        .estimate_gas()
+        .await
+        .with_context(|| format!("estimate_gas(addBlock) for n={n}"))?;
+
+    Ok(gas)
+}
 
 #[test_case("ethereum",     30_000_000,  None; "ethereum")]
 #[test_case("base",         240_000_000, None; "base")]
@@ -160,18 +236,121 @@ async fn burns_per_evm_tx(
     )
     .await;
 
-    // Suppress unused-variable warnings; subsequent task fills these in.
-    let _ = (
+    let mut hi: u32 = 8;
+    let mut hi_gas = build_and_estimate(
+        hi,
         &cc_a,
         &cc_b,
         owner_b,
         chain_a,
         fungible_app_id,
         bridge_addr,
-        block_gas_limit,
-        min_expected_burns,
         &provider,
+    )
+    .await?;
+    tracing::info!(n = hi, gas = hi_gas, "search: initial hi");
+
+    while hi_gas <= block_gas_limit && hi < MAX_SEARCH_N {
+        let next_hi = hi.saturating_mul(2).min(MAX_SEARCH_N);
+        let g = build_and_estimate(
+            next_hi,
+            &cc_a,
+            &cc_b,
+            owner_b,
+            chain_a,
+            fungible_app_id,
+            bridge_addr,
+            &provider,
+        )
+        .await?;
+        tracing::info!(n = next_hi, gas = g, "search: doubling");
+        hi = next_hi;
+        hi_gas = g;
+        if hi == MAX_SEARCH_N {
+            break;
+        }
+    }
+
+    let mut lo: u32 = 1;
+    let mut lo_gas = if hi == 1 {
+        hi_gas
+    } else {
+        build_and_estimate(
+            lo,
+            &cc_a,
+            &cc_b,
+            owner_b,
+            chain_a,
+            fungible_app_id,
+            bridge_addr,
+            &provider,
+        )
+        .await?
+    };
+    anyhow::ensure!(
+        lo_gas <= block_gas_limit,
+        "n=1 already exceeds block_gas_limit ({lo_gas} > {block_gas_limit}); test cannot proceed"
     );
+
+    // If even the doubling cap fits, we cannot bound from above — report the cap.
+    if hi_gas <= block_gas_limit {
+        tracing::warn!(
+            cap = MAX_SEARCH_N,
+            gas = hi_gas,
+            block_gas_limit,
+            "search hit MAX_SEARCH_N without exceeding gas limit; reported max_n is the cap"
+        );
+        let max_n = hi;
+        tracing::info!(
+            chain = name,
+            max_n,
+            gas_at_max_n = hi_gas,
+            block_gas_limit,
+            "RESULT"
+        );
+        if let Some(floor) = min_expected_burns {
+            anyhow::ensure!(
+                max_n >= floor,
+                "{name}: max_n={max_n} < min_expected_burns={floor}"
+            );
+        }
+        return Ok(());
+    }
+
+    while lo + 1 < hi {
+        let mid = lo + (hi - lo) / 2;
+        let g = build_and_estimate(
+            mid,
+            &cc_a,
+            &cc_b,
+            owner_b,
+            chain_a,
+            fungible_app_id,
+            bridge_addr,
+            &provider,
+        )
+        .await?;
+        tracing::info!(n = mid, gas = g, "search: bisect");
+        if g <= block_gas_limit {
+            lo = mid;
+            lo_gas = g;
+        } else {
+            hi = mid;
+            hi_gas = g;
+        }
+    }
+
+    let _ = hi_gas; // silence dead_store warning in some toolchain configs
+    let max_n = lo;
+    let gas_at_max_n = lo_gas;
+    tracing::info!(chain = name, max_n, gas_at_max_n, block_gas_limit, "RESULT");
+
+    if let Some(floor) = min_expected_burns {
+        anyhow::ensure!(
+            max_n >= floor,
+            "{name}: max_n={max_n} < min_expected_burns={floor}"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Measure how many `BurnEvent`s in a single Linera block can fit into one `addBlock` EVM transaction under different chain gas limits, so the relayer can be tuned with empirical numbers rather than guesswork and regressions in per-burn EVM cost get caught in CI.

## Proposal

- New parametrised e2e test `linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs` using `test_case` (one row per chain). For each `ChainSpec`, it binary-searches the largest `N` such that
`eth_estimateGas(bridge.addBlock(cert_N))` is `<= chain_spec.block_gas_limit`. Estimation is a dry run, so the bridge's `processedBurns` mapping stays untouched and a single bridge instance handles every
iteration.
- Two chain rows: `ethereum` (30M gas limit, floor 50) and `base` (240M, floor 190). `min_expected_burns` set conservatively — about 5–10% below observed `max_n` — so unrelated changes that significantly bump
per-burn EVM cost get caught.

## Test Plan

Test is `#[ignore]`-gated and requires the docker stack + wrapped-fungible Wasm artifacts. Run via:
```
cd linera-bridge/tests/e2e
cargo test --test burns_per_evm_tx -- --ignored --test-threads=1 --nocapture
```
Verified locally:

| chain    | max_n | gas at max_n | block gas limit | floor |
|----------|-------|--------------|-----------------|-------|
| ethereum | 52    | 29 320 900   | 30 000 000      | 50    |
| base     | 199   | 238 782 494  | 240 000 000     | 190   |

## Release Plan

- These changes should be backported to `main`.

## Links

- Stacked on #6280.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)