### PR TITLE
[testnet] Retry on `EventsNotFound` (#6278)

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -692,17 +692,6 @@ impl<Env: Environment> ChainClient<Env> {
                 self.synchronize_chain_state(self.chain_id).await?;
                 self.chain_info().await?
             }
-            Err(LocalNodeError::EventsNotFound(event_ids))
-                if event_ids
-                    .iter()
-                    .all(|event_id| event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)) =>
-            {
-                // `initialize_and_save_if_needed` couldn't start the chain because
-                // the admin chain's epoch events aren't synced yet.
-                self.synchronize_chain_state(self.client.admin_chain_id)
-                    .await?;
-                self.chain_info().await?
-            }
             Err(err) => return Err(err.into()),
         };
         let committee = self
@@ -1592,6 +1581,8 @@ impl<Env: Environment> ChainClient<Env> {
         query: Query,
         block_hash: Option<CryptoHash>,
     ) -> Result<(QueryOutcome, BlockHeight), Error> {
+        let mut downloaded_blobs = HashSet::<BlobId>::new();
+        let mut events = super::EventSetDownloader::new(&self.client);
         loop {
             let result = self
                 .client
@@ -1599,11 +1590,20 @@ impl<Env: Environment> ChainClient<Env> {
                 .query_application(self.chain_id, query.clone(), block_hash)
                 .await;
             if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
-                let validators = self.client.validator_nodes().await?;
-                self.client
-                    .update_local_node_with_blobs_from(blob_ids.clone(), &validators)
-                    .await?;
-                continue; // We found the missing blob: retry.
+                let new_blobs = super::filter_new(blob_ids, &downloaded_blobs);
+                if !new_blobs.is_empty() {
+                    let validators = self.client.validator_nodes().await?;
+                    self.client
+                        .update_local_node_with_blobs_from(new_blobs.clone(), &validators)
+                        .await?;
+                    downloaded_blobs.extend(new_blobs);
+                    continue;
+                }
+            }
+            if let Err(LocalNodeError::EventsNotFound(event_ids)) = &result {
+                if events.download_new(event_ids).await? {
+                    continue;
+                }
             }
             return Ok(result?);
         }
@@ -2765,7 +2765,7 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     #[instrument(level = "trace", skip(local_node))]
-    async fn local_chain_info(
+    async fn maybe_local_chain_info(
         &self,
         chain_id: ChainId,
         local_node: &LocalNodeClient<Env::Storage>,
@@ -2784,7 +2784,7 @@ impl<Env: Environment> ChainClient<Env> {
         local_node: &LocalNodeClient<Env::Storage>,
     ) -> Result<BlockHeight, Error> {
         Ok(self
-            .local_chain_info(chain_id, local_node)
+            .maybe_local_chain_info(chain_id, local_node)
             .await?
             .map_or(BlockHeight::ZERO, |info| info.next_block_height))
     }
@@ -2920,7 +2920,7 @@ impl<Env: Environment> ChainClient<Env> {
             }
             Reason::NewRound { height, round } => {
                 let chain_id = notification.chain_id;
-                if let Some(info) = self.local_chain_info(chain_id, &local_node).await? {
+                if let Some(info) = self.maybe_local_chain_info(chain_id, &local_node).await? {
                     if (info.next_block_height, info.manager.current_round) >= (height, round) {
                         debug!(
                             chain_id = %self.chain_id,
@@ -2932,7 +2932,7 @@ impl<Env: Environment> ChainClient<Env> {
                 self.client
                     .synchronize_chain_state_from(&remote_node, chain_id)
                     .await?;
-                let Some(info) = self.local_chain_info(chain_id, &local_node).await? else {
+                let Some(info) = self.maybe_local_chain_info(chain_id, &local_node).await? else {
                     error!(
                         chain_id = %self.chain_id,
                         "NewRound: Fail to read local chain info for {chain_id}"
@@ -3239,6 +3239,7 @@ impl<Env: Environment> ChainClient<Env> {
             .await
         {
             Ok(info) => info.info.next_block_height,
+            // The validator doesn't have this chain's description blob yet.
             Err(NodeError::BlobsNotFound(_)) => BlockHeight::ZERO,
             Err(err) => return Err(err.into()),
         };
@@ -3249,9 +3250,9 @@ impl<Env: Environment> ChainClient<Env> {
             return Ok(());
         }
 
-        let heights: Vec<_> = (validator_next_block_height.0..local_next_block_height.0)
+        let heights = (validator_next_block_height.0..local_next_block_height.0)
             .map(BlockHeight)
-            .collect();
+            .collect::<Vec<_>>();
 
         let certificates = self
             .client
@@ -3260,39 +3261,35 @@ impl<Env: Environment> ChainClient<Env> {
             .await?
             .into_iter()
             .flatten()
-            .map(Arc::unwrap_or_clone)
-            .collect::<Vec<_>>();
+            .map(Arc::unwrap_or_clone);
 
         for certificate in certificates {
-            match remote_node
+            let missing_blob_ids = match remote_node
                 .handle_confirmed_certificate(
                     certificate.clone(),
                     CrossChainMessageDelivery::NonBlocking,
                 )
                 .await
             {
-                Ok(_) => (),
-                Err(NodeError::BlobsNotFound(missing_blob_ids)) => {
-                    // Upload the missing blobs we have and retry.
-                    let missing_blobs: Vec<_> = self
-                        .client
-                        .storage_client()
-                        .read_blobs(&missing_blob_ids)
-                        .await?
-                        .into_iter()
-                        .flatten()
-                        .map(Arc::unwrap_or_clone)
-                        .collect();
-                    remote_node.upload_blobs(missing_blobs).await?;
-                    remote_node
-                        .handle_confirmed_certificate(
-                            certificate,
-                            CrossChainMessageDelivery::NonBlocking,
-                        )
-                        .await?;
-                }
+                Ok(_) => continue,
+                Err(NodeError::BlobsNotFound(missing_blob_ids)) => missing_blob_ids,
                 Err(err) => return Err(err.into()),
-            }
+            };
+            // The validator is missing blobs the certificate depends on
+            // (including possibly the chain description). Upload and retry.
+            let missing_blobs = self
+                .client
+                .storage_client()
+                .read_blobs(&missing_blob_ids)
+                .await?
+                .into_iter()
+                .flatten()
+                .map(Arc::unwrap_or_clone)
+                .collect();
+            remote_node.upload_blobs(missing_blobs).await?;
+            remote_node
+                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
+                .await?;
         }
 
         Ok(())

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -472,10 +472,9 @@ impl<Env: Environment> Client<Env> {
         match self.local_node.chain_info(chain_id).await {
             Ok(info) => Ok(info),
             Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
-                // Make sure the admin chain is up to date.
+                // Make sure the admin chain is up to date so we can validate the
+                // certificate that creates this chain's description blob.
                 Box::pin(self.synchronize_chain_state(self.admin_chain_id)).await?;
-                // If the chain is missing then the error is a WorkerError
-                // and so a BlobsNotFound
                 self.update_local_node_with_blobs_from(blob_ids, validators)
                     .await?;
                 Ok(self.local_node.chain_info(chain_id).await?)
@@ -684,7 +683,7 @@ impl<Env: Environment> Client<Env> {
     /// the block heights, downloads those certificates, and processes them — all
     /// as one atomic unit per validator attempt, with staggered fallback.
     #[instrument(level = "trace", skip_all)]
-    async fn download_certificates_for_events(
+    pub(crate) async fn download_certificates_for_events(
         &self,
         event_ids: &[EventId],
     ) -> Result<(), chain_client::Error> {
@@ -801,19 +800,42 @@ impl<Env: Environment> Client<Env> {
                     break;
                 }
             }
-            info = Some(
-                match self.handle_certificate(certificate.clone()).await {
-                    Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
-                        self.download_blobs(remote_nodes, &blob_ids).await?;
-                        self.handle_certificate(certificate).await?
-                    }
-                    x => x?,
-                }
-                .info,
-            );
+            let response = self
+                .handle_certificate_with_retry(&certificate, remote_nodes)
+                .await?;
+            info = Some(response.info);
         }
 
         Ok(info)
+    }
+
+    /// Calls `handle_certificate`, retrying with any missing blobs (downloaded
+    /// from `nodes`) and any missing events (downloaded from the publisher
+    /// chains via the current validators).
+    async fn handle_certificate_with_retry(
+        &self,
+        certificate: &ConfirmedBlockCertificate,
+        nodes: &[RemoteNode<Env::ValidatorNode>],
+    ) -> Result<ChainInfoResponse, chain_client::Error> {
+        let mut downloaded_blobs = HashSet::<BlobId>::new();
+        let mut events = EventSetDownloader::new(self);
+        loop {
+            let result = self.handle_certificate(certificate.clone()).await;
+            if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
+                let new_blobs = filter_new(blob_ids, &downloaded_blobs);
+                if !new_blobs.is_empty() {
+                    self.download_blobs(nodes, &new_blobs).await?;
+                    downloaded_blobs.extend(new_blobs);
+                    continue;
+                }
+            }
+            if let Err(LocalNodeError::EventsNotFound(event_ids)) = &result {
+                if events.download_new(event_ids).await? {
+                    continue;
+                }
+            }
+            return Ok(result?);
+        }
     }
 
     async fn handle_certificate<T: ProcessableCertificate>(
@@ -1177,22 +1199,9 @@ impl<Env: Environment> Client<Env> {
             .await?;
         // Process the received operations. Download required hashed certificate values if
         // necessary.
-        if let Err(err) = self.handle_certificate(certificate.clone()).await {
-            match &err {
-                LocalNodeError::BlobsNotFound(blob_ids) => {
-                    self.download_blobs(&self.validator_nodes().await?, blob_ids)
-                        .await
-                        .map_err(|_| err)?;
-                    self.handle_certificate(certificate).await?;
-                }
-                _ => {
-                    // The certificate is not as expected. Give up.
-                    warn!("Failed to process network hashed certificate value");
-                    return Err(err.into());
-                }
-            }
-        }
-
+        let nodes = self.validator_nodes().await?;
+        self.handle_certificate_with_retry(&certificate, &nodes)
+            .await?;
         Ok(())
     }
 
@@ -1215,20 +1224,8 @@ impl<Env: Environment> Client<Env> {
         } else {
             self.validator_nodes().await?
         };
-        if let Err(err) = self.handle_certificate(certificate.clone()).await {
-            match &err {
-                LocalNodeError::BlobsNotFound(blob_ids) => {
-                    self.download_blobs(&nodes, blob_ids).await?;
-                    self.handle_certificate(certificate.clone()).await?;
-                }
-                _ => {
-                    // The certificate is not as expected. Give up.
-                    warn!("Failed to process network hashed certificate value");
-                    return Err(err.into());
-                }
-            }
-        }
-
+        self.handle_certificate_with_retry(&certificate, &nodes)
+            .await?;
         Ok(())
     }
 
@@ -1853,6 +1850,30 @@ impl<Env: Environment> Client<Env> {
                         }
                     }
                 }
+                if let LocalNodeError::EventsNotFound(event_ids) = &err {
+                    if let Err(error) =
+                        Box::pin(self.download_certificates_for_events(event_ids)).await
+                    {
+                        info!(
+                            remote_node = remote_node.address(),
+                            height = %local_height,
+                            proposer = %owner,
+                            %error,
+                            "skipping proposal from validator; failed to download events",
+                        );
+                        continue 'proposal_loop;
+                    }
+                    // We found the missing publisher chain data: retry.
+                    if let Err(new_err) = self
+                        .local_node
+                        .handle_block_proposal(proposal.clone())
+                        .await
+                    {
+                        err = new_err;
+                    } else {
+                        continue;
+                    }
+                }
                 while let LocalNodeError::WorkerError(WorkerError::ChainError(chain_err)) = &err {
                     if let ChainError::MissingCrossChainUpdate {
                         chain_id,
@@ -1898,24 +1919,35 @@ impl<Env: Environment> Client<Env> {
         certificate: GenericCertificate<ValidatedBlock>,
     ) -> Result<(), chain_client::Error> {
         let chain_id = certificate.inner().chain_id();
-        match self.handle_certificate(certificate.clone()).await {
-            Err(LocalNodeError::BlobsNotFound(blob_ids)) => {
-                let mut blobs = Vec::new();
-                for blob_id in blob_ids {
-                    let blob_content = self
-                        .requests_scheduler
-                        .download_pending_blob(remote_node, chain_id, blob_id)
+        let mut downloaded_blobs = HashSet::<BlobId>::new();
+        let mut events = EventSetDownloader::new(self);
+        loop {
+            let result = self.handle_certificate(certificate.clone()).await;
+            if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
+                let new_blobs = filter_new(blob_ids, &downloaded_blobs);
+                if !new_blobs.is_empty() {
+                    let mut blobs = Vec::new();
+                    for blob_id in &new_blobs {
+                        let blob_content = self
+                            .requests_scheduler
+                            .download_pending_blob(remote_node, chain_id, *blob_id)
+                            .await?;
+                        blobs.push(Blob::new(blob_content));
+                    }
+                    self.local_node
+                        .handle_pending_blobs(chain_id, blobs)
                         .await?;
-                    blobs.push(Blob::new(blob_content));
+                    downloaded_blobs.extend(new_blobs);
+                    continue;
                 }
-                self.local_node
-                    .handle_pending_blobs(chain_id, blobs)
-                    .await?;
-                self.handle_certificate(certificate).await?;
-                Ok(())
             }
-            Err(err) => Err(err.into()),
-            Ok(_) => Ok(()),
+            if let Err(LocalNodeError::EventsNotFound(event_ids)) = &result {
+                if events.download_new(event_ids).await? {
+                    continue;
+                }
+            }
+            result?;
+            return Ok(());
         }
     }
 
@@ -1980,7 +2012,7 @@ impl<Env: Environment> Client<Env> {
         published_blobs: Vec<Blob>,
         policy: BundleExecutionPolicy,
     ) -> Result<(Block, ChainInfoResponse, HashSet<ChainId>), chain_client::Error> {
-        let mut downloaded_events = HashSet::<EventId>::new();
+        let mut events = EventSetDownloader::new(self);
         loop {
             let result = self
                 .local_node
@@ -1998,14 +2030,7 @@ impl<Env: Environment> Client<Env> {
                 continue; // We found the missing blob: retry.
             }
             if let Err(LocalNodeError::EventsNotFound(event_ids)) = &result {
-                let new_events = event_ids
-                    .iter()
-                    .filter(|id| !downloaded_events.contains(id))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                if !new_events.is_empty() {
-                    Box::pin(self.download_certificates_for_events(&new_events)).await?;
-                    downloaded_events.extend(new_events);
+                if events.download_new(event_ids).await? {
                     continue; // We downloaded new publisher chain data: retry.
                 }
                 // All reported events were already downloaded; don't loop forever.
@@ -2030,6 +2055,53 @@ impl<Env: Environment> Client<Env> {
             ) = result?;
             return Ok((executed_block, response, never_reject_origins));
         }
+    }
+}
+
+/// Returns the items in `ids` that are not yet present in `already_downloaded`.
+fn filter_new<T: Clone + Eq + std::hash::Hash>(
+    ids: &[T],
+    already_downloaded: &HashSet<T>,
+) -> Vec<T> {
+    ids.iter()
+        .filter(|id| !already_downloaded.contains(*id))
+        .cloned()
+        .collect()
+}
+
+/// Per-call deduplication for an event-download retry loop. Holds the set of
+/// events the loop has already downloaded and the [`Client`] used to fetch new
+/// ones — call `download_new` each time the inner operation reports
+/// `EventsNotFound` and continue the loop only if it returns `true`.
+pub(crate) struct EventSetDownloader<'a, Env: Environment> {
+    client: &'a Client<Env>,
+    downloaded: HashSet<EventId>,
+}
+
+impl<'a, Env: Environment> EventSetDownloader<'a, Env> {
+    pub(crate) fn new(client: &'a Client<Env>) -> Self {
+        Self {
+            client,
+            downloaded: HashSet::new(),
+        }
+    }
+
+    /// If any of `event_ids` haven't been downloaded yet, fetches the publisher
+    /// certificates that contain them and returns `true`. Returns `false`
+    /// (without downloading) if every reported event has already been
+    /// downloaded — that prevents an infinite retry loop when the events are
+    /// genuinely unavailable.
+    pub(crate) async fn download_new(
+        &mut self,
+        event_ids: &[EventId],
+    ) -> Result<bool, chain_client::Error> {
+        let new_events = filter_new(event_ids, &self.downloaded);
+        if new_events.is_empty() {
+            return Ok(false);
+        }
+        Box::pin(self.client.download_certificates_for_events(&new_events)).await?;
+        self.downloaded.extend(new_events);
+        Ok(true)
     }
 }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -3185,68 +3185,61 @@ where
     Ok(())
 }
 
-/// Regression test: a client whose local node has the chain's description blob but
-/// hasn't yet synced the admin chain's `NewCommittee` event for the chain's active
-/// epoch must still be able to fetch its own committee — `local_committee` syncs the
-/// admin chain on its own rather than failing with `EventsNotFound` or `InactiveChain`.
+/// Regression test: when a fresh client syncs a chain that has a block at a
+/// non-genesis epoch, `process_certificates` must download the admin chain's
+/// `NewCommittee` event for that epoch — cert verification calls
+/// `get_committee_hashes` which reads the event. Without the fix this surfaces
+/// as `Events not found` for `StreamName(00)` rather than recovering.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
-async fn test_local_committee_syncs_admin_chain<B>(storage_builder: B) -> anyhow::Result<()>
+async fn test_synchronize_downloads_admin_chain_events<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
 {
-    let mut signer = InMemorySigner::new(None);
-    let new_public_key = signer.generate_new();
+    let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
 
     let admin_client = builder.add_root_chain(0, Amount::from_tokens(1000)).await?;
     let parent = builder.add_root_chain(1, Amount::from_tokens(1000)).await?;
 
-    // Create a new epoch on the admin chain.
+    // Create a new epoch on the admin chain and migrate `parent` to it.
     admin_client
         .stage_new_committee(builder.initial_committee.clone())
         .await
         .unwrap();
-
-    // Migrate `parent` to the new epoch and open a child chain at that epoch.
     parent.synchronize_from_validators().await.unwrap();
     parent.process_inbox().await.unwrap();
-    let (child_desc, certificate) = Box::pin(parent.open_chain(
-        ChainOwnership::single(new_public_key.into()),
-        ApplicationPermissions::default(),
-        Amount::from_tokens(10),
-    ))
-    .await
-    .unwrap_ok_committed();
-    assert_eq!(certificate.block().header.epoch, Epoch::from(1));
+    // The migration block itself is at epoch 0 (the chain's epoch before
+    // `ProcessNewEpoch` executes). To make `process_certificates` actually
+    // verify against the new committee, the chain must have a follow-up block
+    // *at* epoch 1 — its cert's `get_committee_hashes(1..=1)` then reads the
+    // admin event during cert verification.
+    let cert = parent
+        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(cert.block().header.epoch, Epoch::from(1));
+    let parent_info = parent.chain_info().await?;
 
-    // A fresh client with genesis-only storage: no admin-chain events past epoch 0.
-    let mut child_client = builder
-        .make_client(child_desc.id(), None, BlockHeight::ZERO)
-        .await?;
-    child_client.set_preferred_owner(new_public_key.into());
-    // Pre-seed the child's description blob so that the first `chain_info()` call
-    // makes it past the blob-lookup and triggers initialization, which needs the
-    // admin chain's epoch events to load the committee for epoch 1. This is the
-    // exact state a web client ends up in after receiving the chain description
-    // but before syncing the admin chain.
-    child_client
-        .storage_client()
-        .write_blob(&Blob::new_chain_description(&child_desc))
+    // A fresh client (its genesis storage has `parent`'s description blob but
+    // no admin-chain events).
+    let fresh_client = builder
+        .make_client(parent.chain_id(), None, BlockHeight::ZERO)
         .await?;
 
-    // Before the fix, this returned `EventsNotFound` because
-    // `initialize_and_save_if_needed` couldn't find the admin chain's
-    // `NewCommittee` event for epoch 1. `local_committee` must sync
-    // the admin chain on its own and succeed.
-    let committee = child_client.local_committee().await?;
+    // Before the fix, `process_certificates` propagated `EventsNotFound` for
+    // the epoch-1 transfer cert because cert verification couldn't load the
+    // admin chain's `NewCommittee` event. The fix retries after downloading
+    // the publisher certificates that contain the missing event.
+    fresh_client.synchronize_from_validators().await?;
+
     assert_eq!(
-        committee.validators.len(),
-        builder.initial_committee.validators.len()
+        fresh_client.chain_info().await?.next_block_height,
+        parent_info.next_block_height,
     );
 
     Ok(())

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -334,8 +334,6 @@ pub enum ExecutionError {
     InvalidUrlForHttpRequest(#[from] url::ParseError),
     #[error("Worker thread failure: {0:?}")]
     Thread(#[from] web_thread::Error),
-    #[error("The chain being queried is not active {0}")]
-    InactiveChain(ChainId),
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     #[error("Events not found: {0:?}")]
@@ -414,7 +412,6 @@ impl ExecutionError {
             | ExecutionError::BytecodeTooLarge
             | ExecutionError::UnauthorizedHttpRequest(_)
             | ExecutionError::InvalidUrlForHttpRequest(_)
-            | ExecutionError::InactiveChain(_)
             | ExecutionError::BlobsNotFound(_)
             | ExecutionError::EventsNotFound(_)
             | ExecutionError::InvalidHeaderName(_)

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -482,10 +482,11 @@ where
             }
             ProcessNewEpoch(epoch) => {
                 self.check_next_epoch(epoch)?;
-                let admin_chain_id = self
-                    .admin_chain_id
-                    .get()
-                    .ok_or_else(|| ExecutionError::InactiveChain(context.chain_id))?;
+                let admin_chain_id = self.admin_chain_id.get().ok_or_else(|| {
+                    ExecutionError::InternalError(
+                        "execute_operation called for uninitialized chain",
+                    )
+                })?;
                 let event_id = EventId {
                     chain_id: admin_chain_id,
                     stream_id: StreamId::system(EPOCH_STREAM_NAME),
@@ -512,10 +513,11 @@ where
                     self.committees.get_mut().await?.remove(&epoch).is_some(),
                     ExecutionError::InvalidCommitteeRemoval
                 );
-                let admin_chain_id = self
-                    .admin_chain_id
-                    .get()
-                    .ok_or_else(|| ExecutionError::InactiveChain(context.chain_id))?;
+                let admin_chain_id = self.admin_chain_id.get().ok_or_else(|| {
+                    ExecutionError::InternalError(
+                        "execute_operation called for uninitialized chain",
+                    )
+                })?;
                 let event_id = EventId {
                     chain_id: admin_chain_id,
                     stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),


### PR DESCRIPTION
Backport of #6278.

## Motivation

There are still some places missing where we retry on `BlobsNotFound` but not on `EventsNotFound`, specifically when it comes to missing epoch events.

## Proposal

Fix those; deduplicate some of the code. Regarding the backport:

```
Conflicts resolved:
  - chain_client/mod.rs local_committee: dropped testnet_conway's EventsNotFound/EPOCH_STREAM_NAME special-case (the commit centralizes EventsNotFound retry into other paths).
  - chain_client/mod.rs sync_validator: kept Arc::unwrap_or_clone on cert + blob iterators — testnet_conway's handle_confirmed_certificate takes owned ConfirmedBlockCertificate and upload_blobs takes Vec<Blob> (on main both take Arc-wrapped).
  - client/mod.rs fetch_chain_info: kept Box::pin(...) around synchronize_chain_state (testnet_conway needs it for clippy::large_futures).
  - client/mod.rs receive_sender_certificate: accepted the commit's handle_certificate_with_retry call.
  - system.rs extra fix: testnet_conway has a parallel ProcessRemovedEpoch branch (not on main) that referenced the now-deleted ExecutionError::InactiveChain — extended the same InternalError swap to keep it compiling.
```

## Test Plan

A test was extended.

## Release Plan

- Release SDK.

## Links

- PR to `main`: #6278
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
