### PR TITLE
Protocol feature flags

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -601,6 +601,7 @@ View or update the resource control policy
 * `--http-request-timeout-ms <HTTP_REQUEST_TIMEOUT_MS>` — Set the maximum amount of time allowed to wait for an HTTP response
 * `--http-request-allow-list <HTTP_REQUEST_ALLOW_LIST>` — Set the list of hosts that contracts and services can send HTTP requests to
 * `--free-application-ids <FREE_APPLICATION_IDS>` — Set the list of application IDs for which message- and event-related fees are waived
+* `--flags <FLAGS>` — Set the protocol flags that are enabled
 
 
 
@@ -750,6 +751,7 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--http-request-timeout-ms <HTTP_REQUEST_TIMEOUT_MS>` — Set the maximum amount of time allowed to wait for an HTTP response
 * `--http-request-allow-list <HTTP_REQUEST_ALLOW_LIST>` — Set the list of hosts that contracts and services can send HTTP requests to
 * `--free-application-ids <FREE_APPLICATION_IDS>` — Set the list of application IDs for which message- and event-related fees are waived
+* `--flags <FLAGS>` — Set the protocol flags that are enabled
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 * `--network-name <NETWORK_NAME>` — A unique name to identify this network
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::{
     committee::{Committee, SharedCommittees},
     execution::{ExecutionStateView, ServiceRuntimeEndpoint},
     execution_state_actor::{ExecutionRequest, ExecutionStateActor},
-    policy::ResourceControlPolicy,
+    policy::{ProtocolFlag, ResourceControlPolicy},
     resources::{BalanceHolder, ResourceController, ResourceTracker},
     runtime::{
         ContractSyncRuntimeHandle, ServiceRuntimeRequest, ServiceSyncRuntime,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -9,7 +9,7 @@
 //! It also sets overarching limits such as the maximum fuel allowed per block,
 //! the maximum block size, and limits on concurrent operations.
 
-use std::{collections::BTreeSet, fmt, str::FromStr};
+use std::{collections::BTreeSet, fmt};
 
 use allocative::Allocative;
 use linera_base::{
@@ -19,7 +19,6 @@ use linera_base::{
     vm::VmRuntime,
 };
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 use crate::ExecutionError;
 
@@ -41,32 +40,13 @@ use crate::ExecutionError;
     Serialize,
     Deserialize,
     Allocative,
+    strum::Display,
+    strum::EnumString,
 )]
 pub enum ProtocolFlag {
     #[doc(hidden)]
     _Reserved = 0,
 }
-
-impl fmt::Display for ProtocolFlag {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ProtocolFlag::_Reserved => write!(f, "_Reserved"),
-        }
-    }
-}
-
-impl FromStr for ProtocolFlag {
-    type Err = InvalidProtocolFlag;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Err(InvalidProtocolFlag(s.to_owned()))
-    }
-}
-
-/// Error caused by an unrecognized protocol flag name.
-#[derive(Clone, Debug, Error)]
-#[error("{0:?} is not a valid protocol flag")]
-pub struct InvalidProtocolFlag(String);
 
 /// A collection of prices and limits associated with block execution.
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, Allocative)]

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -9,7 +9,7 @@
 //! It also sets overarching limits such as the maximum fuel allowed per block,
 //! the maximum block size, and limits on concurrent operations.
 
-use std::{collections::BTreeSet, fmt};
+use std::{collections::BTreeSet, fmt, str::FromStr};
 
 use allocative::Allocative;
 use linera_base::{
@@ -19,6 +19,7 @@ use linera_base::{
     vm::VmRuntime,
 };
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::ExecutionError;
 
@@ -45,6 +46,27 @@ pub enum ProtocolFlag {
     #[doc(hidden)]
     _Reserved = 0,
 }
+
+impl fmt::Display for ProtocolFlag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProtocolFlag::_Reserved => write!(f, "_Reserved"),
+        }
+    }
+}
+
+impl FromStr for ProtocolFlag {
+    type Err = InvalidProtocolFlag;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Err(InvalidProtocolFlag(s.to_owned()))
+    }
+}
+
+/// Error caused by an unrecognized protocol flag name.
+#[derive(Clone, Debug, Error)]
+#[error("{0:?} is not a valid protocol flag")]
+pub struct InvalidProtocolFlag(String);
 
 /// A collection of prices and limits associated with block execution.
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, Allocative)]

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -22,6 +22,30 @@ use serde::{Deserialize, Serialize};
 
 use crate::ExecutionError;
 
+/// A flag that enables an optional protocol feature.
+///
+/// Flags are stored in [`ResourceControlPolicy::flags`] so that new features can be activated
+/// in future testnets or on mainnet by updating the policy, without breaking compatibility
+/// with chains and validators that don't have the feature enabled.
+#[repr(u32)]
+#[derive(
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+    Deserialize,
+    Allocative,
+)]
+pub enum ProtocolFlag {
+    #[doc(hidden)]
+    _Reserved = 0,
+}
+
 /// A collection of prices and limits associated with block execution.
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, Allocative)]
 pub struct ResourceControlPolicy {
@@ -93,6 +117,8 @@ pub struct ResourceControlPolicy {
     pub http_request_allow_list: BTreeSet<String>,
     /// The list of application IDs for which all message- and event-related fees are waived.
     pub free_application_ids: BTreeSet<ApplicationId>,
+    /// The set of optional protocol features that are enabled.
+    pub flags: BTreeSet<ProtocolFlag>,
 }
 
 impl fmt::Display for ResourceControlPolicy {
@@ -130,6 +156,7 @@ impl fmt::Display for ResourceControlPolicy {
             http_request_allow_list,
             http_request_timeout_ms,
             free_application_ids,
+            flags,
         } = self;
         write!(
             f,
@@ -166,7 +193,8 @@ impl fmt::Display for ResourceControlPolicy {
             {maximum_http_response_bytes} maximum number of bytes of an HTTP response\n\
             {http_request_timeout_ms} ms timeout for HTTP requests\n\
             HTTP hosts allowed for contracts and services: {http_request_allow_list:#?}\n\
-            Free application IDs: {free_application_ids:#?}\n",
+            Free application IDs: {free_application_ids:#?}\n\
+            Enabled protocol flags: {flags:#?}\n",
         )?;
         Ok(())
     }
@@ -216,6 +244,7 @@ impl ResourceControlPolicy {
             http_request_timeout_ms: u64::MAX,
             http_request_allow_list: BTreeSet::new(),
             free_application_ids: BTreeSet::new(),
+            flags: BTreeSet::new(),
         }
     }
 
@@ -300,6 +329,7 @@ impl ResourceControlPolicy {
             http_request_timeout_ms: 20_000,
             http_request_allow_list: BTreeSet::new(),
             free_application_ids: BTreeSet::new(),
+            flags: BTreeSet::new(),
         }
     }
 

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -239,6 +239,7 @@ async fn test_fee_consumption(
         blob_byte_published: Amount::from_tokens(103),
         http_request_allow_list: BTreeSet::new(),
         free_application_ids: BTreeSet::new(),
+        flags: BTreeSet::new(),
     };
 
     let consumed_fees = spends

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -336,6 +336,10 @@ pub struct ResourceControlPolicyOverrides {
     /// Set the list of application IDs for which message- and event-related fees are waived.
     #[arg(long, value_delimiter = ',')]
     pub free_application_ids: Option<Vec<String>>,
+
+    /// Set the protocol flags that are enabled.
+    #[arg(long, value_delimiter = ',')]
+    pub flags: Option<Vec<String>>,
 }
 
 #[derive(Clone, clap::Subcommand)]
@@ -709,6 +713,10 @@ pub enum ClientCommand {
         /// Set the list of application IDs for which message- and event-related fees are waived.
         #[arg(long, value_delimiter = ',')]
         free_application_ids: Option<Vec<String>>,
+
+        /// Set the protocol flags that are enabled.
+        #[arg(long, value_delimiter = ',')]
+        flags: Option<Vec<String>>,
 
         /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
         /// TESTING ONLY.

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -595,6 +595,7 @@ impl Runnable for Job {
                                             http_request_timeout_ms,
                                             http_request_allow_list,
                                             free_application_ids,
+                                            flags,
                                         },
                                 } => {
                                     let existing_policy = policy.clone();
@@ -677,7 +678,16 @@ impl Runnable for Job {
                                             .transpose()
                                             .expect("Invalid application ID")
                                             .unwrap_or(existing_policy.free_application_ids),
-                                        flags: existing_policy.flags,
+                                        flags: flags
+                                            .map(|values| {
+                                                values
+                                                    .into_iter()
+                                                    .map(|s| s.parse())
+                                                    .collect::<Result<BTreeSet<_>, _>>()
+                                            })
+                                            .transpose()
+                                            .expect("Invalid protocol flag")
+                                            .unwrap_or(existing_policy.flags),
                                     };
                                     info!("{policy}");
                                     if committee.policy() == &policy {
@@ -2229,6 +2239,7 @@ async fn run(options: &Options) -> Result<i32, Error> {
             http_request_timeout_ms,
             http_request_allow_list,
             free_application_ids,
+            flags,
             testing_prng_seed,
             network_name,
         } => {
@@ -2295,7 +2306,17 @@ async fn run(options: &Options) -> Result<i32, Error> {
                     .transpose()
                     .expect("Invalid application ID")
                     .unwrap_or(existing_policy.free_application_ids),
-                flags: existing_policy.flags,
+                flags: flags
+                    .as_ref()
+                    .map(|values| {
+                        values
+                            .iter()
+                            .map(|s| s.parse())
+                            .collect::<Result<BTreeSet<_>, _>>()
+                    })
+                    .transpose()
+                    .expect("Invalid protocol flag")
+                    .unwrap_or(existing_policy.flags),
             };
             let timestamp = start_timestamp.map_or_else(Timestamp::now, |st| {
                 let micros =

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -677,6 +677,7 @@ impl Runnable for Job {
                                             .transpose()
                                             .expect("Invalid application ID")
                                             .unwrap_or(existing_policy.free_application_ids),
+                                        flags: existing_policy.flags,
                                     };
                                     info!("{policy}");
                                     if committee.policy() == &policy {
@@ -2294,6 +2295,7 @@ async fn run(options: &Options) -> Result<i32, Error> {
                     .transpose()
                     .expect("Invalid application ID")
                     .unwrap_or(existing_policy.free_application_ids),
+                flags: existing_policy.flags,
             };
             let timestamp = start_timestamp.map_or_else(Timestamp::now, |st| {
                 let micros =

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1320,6 +1320,7 @@ impl ClientWrapper {
             http_request_timeout_ms,
             http_request_allow_list,
             free_application_ids,
+            flags,
         } = overrides;
         if let Some(value) = wasm_fuel_unit {
             command.args(["--wasm-fuel-unit", &value.to_string()]);
@@ -1416,6 +1417,9 @@ impl ClientWrapper {
         }
         if let Some(values) = free_application_ids {
             command.args(["--free-application-ids", &values.join(",")]);
+        }
+        if let Some(values) = flags {
+            command.args(["--flags", &values.join(",")]);
         }
         command.spawn_and_wait_for_stdout().await?;
         Ok(())


### PR DESCRIPTION
## Motivation

On `testnet_conway`, we've been abusing `http_allow_list` for protocol feature flags.

## Proposal

Add an explicit list of extensible flags to the resource control policy.

## Test Plan

This is not used yet, but should make it easier to introduce new feature after launching a network.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
