### PR TITLE
[testnet] Pin Node 22 in pnpm 11 workflows

### DIFF
--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -46,6 +46,9 @@ jobs:
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
     - uses: pnpm/action-setup@v4
       with:
         version: 11.0.9

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -80,6 +80,9 @@ jobs:
     - uses: jetli/wasm-bindgen-action@v0.2.0
       with:
         version: 0.2.100
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '22'
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:


### PR DESCRIPTION
## Motivation

Fix CI

## Proposal

- Adds `actions/setup-node@v4` with `node-version: '22'` to the `web` and `test-readmes` workflows so they no longer rely on the runner image's default Node.
- Fixes the CI failure introduced by #6274 on `testnet_conway`: pnpm 11 requires `node:sqlite`, which is only available on Node 22+, but `ubuntu-latest` (Ubuntu 24.04) and the self-hosted runner both default to Node 20.20.2, producing `Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite`.
- Failing run for reference: https://github.com/linera-io/linera-protocol/actions/runs/25753515401/job/75635885558

## Test plan

CI