### PR TITLE
Add Scylla Wasm UDFs to decode RootKey partition keys in cqlsh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4195a29a4b87137b2bb02105e746102873bc03561805cf45c0e510c961f160e6"
 dependencies = [
  "alloy-primitives",
- "num_enum",
+ "num_enum 0.7.4",
  "strum 0.27.2",
 ]
 
@@ -1811,6 +1811,17 @@ checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1e50562e37200edf7c6c43e54a08e64a5553bfb59d9c297d5572512aa517256"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -6291,6 +6302,7 @@ dependencies = [
  "linera-chain",
  "linera-execution",
  "linera-storage",
+ "linera-storage-udf",
  "linera-views",
  "papaya",
  "prometheus",
@@ -6348,6 +6360,17 @@ dependencies = [
  "tonic-prost-build",
  "tracing",
  "tracing-subscriber 0.3.19",
+]
+
+[[package]]
+name = "linera-storage-udf"
+version = "0.16.0"
+dependencies = [
+ "bcs",
+ "hex",
+ "linera-base",
+ "scylla-udf",
+ "serde",
 ]
 
 [[package]]
@@ -6747,11 +6770,20 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8cbbb2831780bc3b9c15a41f5b49222ef756b6730a95f3decfdd15903eb5a3"
+dependencies = [
+ "twox-hash 1.6.3",
+]
+
+[[package]]
+name = "lz4_flex"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.1",
 ]
 
 [[package]]
@@ -7165,12 +7197,33 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive 0.5.11",
+]
+
+[[package]]
+name = "num_enum"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.7.4",
  "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8913,7 +8966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1588093530ec4442461163be49c433c07a3235d1ca6f6799fef338dacc50d3"
 dependencies = [
  "alloy-primitives",
- "num_enum",
+ "num_enum 0.7.4",
  "serde",
 ]
 
@@ -9259,7 +9312,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.1",
 ]
 
 [[package]]
@@ -9348,16 +9401,37 @@ dependencies = [
  "hashbrown 0.14.5",
  "itertools 0.14.0",
  "lazy_static",
- "lz4_flex",
+ "lz4_flex 0.11.5",
  "rand 0.9.2",
  "rand_pcg",
- "scylla-cql",
+ "scylla-cql 1.3.1",
  "smallvec",
  "snap",
  "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "scylla-cql"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6615b8ff55a3bd86c8ad259560a05548f2b73cc0cf610564369dcea7aff91c"
+dependencies = [
+ "async-trait",
+ "bigdecimal",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "lz4_flex 0.9.5",
+ "num-bigint 0.3.3",
+ "num_enum 0.5.11",
+ "scylla-macros 0.2.3",
+ "snap",
+ "thiserror 1.0.69",
+ "tokio",
  "uuid",
 ]
 
@@ -9371,14 +9445,25 @@ dependencies = [
  "bytes",
  "chrono",
  "itertools 0.14.0",
- "lz4_flex",
- "scylla-macros",
+ "lz4_flex 0.11.5",
+ "scylla-macros 1.3.1",
  "snap",
  "stable_deref_trait",
  "thiserror 2.0.17",
  "tokio",
  "uuid",
  "yoke",
+]
+
+[[package]]
+name = "scylla-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bbac3874ee838894b5a82c5833c2b0b29d39ca5ad486d982ee434177b2cc57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -9391,6 +9476,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.105",
+]
+
+[[package]]
+name = "scylla-udf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3106371ad805ed4a23a0957076c427c5e0f48bfd0f11bc4c118833490e88a5"
+dependencies = [
+ "bigdecimal",
+ "bytes",
+ "chrono",
+ "libc",
+ "num-bigint 0.3.3",
+ "scylla-cql 0.0.4",
+ "scylla-udf-macros",
+ "uuid",
+]
+
+[[package]]
+name = "scylla-udf-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4522f3a23a979a6e26a4bcad36342fb1007c437ba4b11b34415cd663721d08"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -11464,6 +11576,16 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "linera-storage",
     "linera-storage-runtime",
     "linera-storage-service",
+    "linera-storage/udf",
     "linera-summary",
     "linera-views",
     "linera-views-derive",
@@ -240,6 +241,7 @@ rocksdb = "0.24.0"
 # https://github.com/linera-io/linera-protocol/issues/4742 is resolved.
 ruzstd = "=0.8.1"
 scylla = "~1.1.0"
+scylla-udf = "0.1.0"
 semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }
 serde-command-opts = "0.1.1"
@@ -381,6 +383,18 @@ version = "1.88.0"
 [profile.release]
 lto = "thin"
 debug = true
+
+# Used by `linera-storage-udf` when building the Scylla Wasm UDF binary, where every kilobyte
+# counts because the WAT source is embedded as a string literal inside a CQL CREATE FUNCTION
+# statement.
+[profile.wasm-udf]
+inherits = "release"
+debug = false
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
 
 [profile.bench]
 debug = true

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -56,7 +56,9 @@ serde.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+linera-base = { workspace = true, features = ["test"] }
 linera-storage = { path = ".", default-features = false, features = ["test"] }
+linera-storage-udf = { path = "udf" }
 test-case.workspace = true
 test-log = { workspace = true, features = ["trace"] }
 tokio.workspace = true

--- a/linera-storage/tests/root_key_drift.rs
+++ b/linera-storage/tests/root_key_drift.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Drift-detection between the canonical `RootKey` in `linera-storage` and the mirrored copy in
+//! `linera-storage-udf`. Both must BCS-encode identically; otherwise the deployed Wasm UDFs will
+//! mis-decode partition keys written by validators.
+
+use linera_base::{
+    crypto::CryptoHash,
+    identifiers::{BlobId, BlobType, ChainId},
+};
+use linera_storage::RootKey;
+use linera_storage_udf::RootKey as UdfRootKey;
+
+fn check<F>(canonical: RootKey, mirror: F)
+where
+    F: FnOnce() -> UdfRootKey,
+{
+    assert_eq!(
+        canonical.bytes(),
+        mirror().bytes(),
+        "BCS encoding diverged for {canonical:?}"
+    );
+}
+
+#[test]
+fn every_variant_encodes_identically() {
+    let chain_id = ChainId(CryptoHash::test_hash("drift"));
+    let other_hash = CryptoHash::test_hash("drift-2");
+    let blob_id = BlobId::new(other_hash, BlobType::Data);
+
+    check(RootKey::NetworkDescription, || {
+        UdfRootKey::NetworkDescription
+    });
+    check(RootKey::BlockExporterState(42), || {
+        UdfRootKey::BlockExporterState(42)
+    });
+    check(RootKey::ChainState(chain_id), || {
+        UdfRootKey::ChainState(chain_id)
+    });
+    check(RootKey::BlockHash(other_hash), || {
+        UdfRootKey::BlockHash(other_hash)
+    });
+    check(RootKey::BlobId(blob_id), || UdfRootKey::BlobId(blob_id));
+    check(RootKey::Event(chain_id), || UdfRootKey::Event(chain_id));
+    check(RootKey::BlockByHeight(chain_id), || {
+        UdfRootKey::BlockByHeight(chain_id)
+    });
+    check(RootKey::EventBlockHeight(chain_id), || {
+        UdfRootKey::EventBlockHeight(chain_id)
+    });
+}

--- a/linera-storage/udf/Cargo.toml
+++ b/linera-storage/udf/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "linera-storage-udf"
+description = "ScyllaDB Wasm UDFs to decode and encode Linera RootKey partition keys."
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+bcs.workspace = true
+hex.workspace = true
+linera-base.workspace = true
+scylla-udf.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+linera-base = { workspace = true, features = ["test"] }

--- a/linera-storage/udf/README.md
+++ b/linera-storage/udf/README.md
@@ -1,0 +1,93 @@
+# linera-storage-udf
+
+ScyllaDB Wasm UDFs that decode and encode Linera `RootKey` partition keys so engineers can
+inspect raw `system.large_partitions` output, or query for a specific chain by ID, directly
+in `cqlsh`.
+
+## What's in here
+
+Two UDFs:
+
+- `decode_root_key(raw blob) RETURNS text` — given a `root_key` column value, return the
+  `Debug` representation of the BCS-encoded `RootKey` (e.g. `ChainState(ChainId(...))`).
+- `encode_root_key(variant text, payload_hex text) RETURNS blob` — given a variant name and
+  hex payload, return the partition key blob, suitable for `WHERE root_key = ?`.
+
+Both transparently handle the leading `0x00` tag byte that
+`linera-views::backends::scylla_db::get_big_root_key` prepends.
+
+## Building
+
+```bash
+./linera-storage/udf/build.sh
+```
+
+Requires `cargo`, `rustup` (with the `wasm32-wasip1` target), and `wasm2wat` (`npm i -g wabt`).
+
+Output:
+- `target/wasm32-wasip1/wasm-udf/linera_storage_udf.wasm` — the binary
+- `target/wasm32-wasip1/wasm-udf/linera_storage_udf.wat` — text format, ready for CQL
+
+## Registering
+
+ScyllaDB Wasm UDFs are still experimental, so each node's `scylla.yaml` must include
+`udf` in `experimental_features`. Then:
+
+```bash
+WAT=$(sed "s/'/''/g" target/wasm32-wasip1/wasm-udf/linera_storage_udf.wat)
+cqlsh -e "
+  CREATE OR REPLACE FUNCTION linera.decode_root_key(raw blob)
+    RETURNS NULL ON NULL INPUT
+    RETURNS text
+    LANGUAGE wasm
+    AS '${WAT}';
+"
+```
+
+Same for `encode_root_key`.
+
+## Example queries
+
+Top partitions by size, decoded:
+
+```sql
+SELECT decode_root_key(partition_key) AS what, partition_size
+FROM system.large_partitions
+WHERE keyspace_name = 'linera'
+ORDER BY partition_size DESC
+LIMIT 20;
+```
+
+All rows for a known chain, across the four `ChainId`-wrapping variants:
+
+```sql
+SELECT decode_root_key(root_key), length(k), length(v)
+FROM linera."ns_42"
+WHERE root_key IN (
+  encode_root_key('ChainState',       '7a3f1c4d...4b9c'),
+  encode_root_key('Event',            '7a3f1c4d...4b9c'),
+  encode_root_key('BlockByHeight',    '7a3f1c4d...4b9c'),
+  encode_root_key('EventBlockHeight', '7a3f1c4d...4b9c')
+);
+```
+
+## Payload format for `encode_root_key`
+
+| Variant | payload_hex |
+|---|---|
+| `NetworkDescription` | empty |
+| `BlockExporterState` | 4 bytes (u32, little-endian) |
+| `ChainState` / `Event` / `BlockByHeight` / `EventBlockHeight` | 32 bytes (CryptoHash) |
+| `BlockHash` | 32 bytes (CryptoHash) |
+| `BlobId` | 32 bytes (CryptoHash) + 1 byte (BlobType BCS variant tag) |
+
+A `0x` prefix is accepted and stripped. Unknown variants or wrong payload lengths return an
+empty blob, which causes `WHERE` clauses to match nothing (rather than the wrong rows).
+
+## Source-of-truth note
+
+`RootKey` is mirrored here from `linera-storage::db_storage` because compiling the full
+`linera-storage` crate to `wasm32-wasip1` would drag in the validator dependency tree. The
+test in `linera-storage/tests/root_key_drift.rs` asserts that the two definitions BCS-encode
+identically. If you change the canonical `RootKey`, update this crate's mirror too — the
+drift test will fail otherwise.

--- a/linera-storage/udf/build.sh
+++ b/linera-storage/udf/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Build linera-storage-udf for ScyllaDB Wasm UDF registration.
+#
+# Produces a `.wat` file that can be embedded directly into a CQL `CREATE FUNCTION` statement.
+# Run from the repository root.
+set -euo pipefail
+
+BIN_NAME=linera_storage_udf
+TARGET=wasm32-wasip1
+PROFILE=wasm-udf
+OUT_DIR=target/${TARGET}/${PROFILE}
+
+for tool in cargo wasm2wat; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "error: missing $tool" >&2
+        exit 1
+    fi
+done
+
+if ! rustup target list --installed 2>/dev/null | grep -q "^${TARGET}$"; then
+    rustup target add "$TARGET"
+fi
+
+# scylla-rust-udf README: WASI default stack of 1MB causes Scylla warnings; keep 128KB.
+RUSTFLAGS="-C link-args=-zstack-size=131072" \
+    cargo build -p linera-storage-udf --target "$TARGET" --profile "$PROFILE"
+
+if command -v wasm-strip >/dev/null 2>&1; then
+    wasm-strip "${OUT_DIR}/${BIN_NAME}.wasm"
+fi
+
+wasm2wat "${OUT_DIR}/${BIN_NAME}.wasm" > "${OUT_DIR}/${BIN_NAME}.wat"
+
+echo
+echo "Built: ${OUT_DIR}/${BIN_NAME}.wasm ($(stat -c%s "${OUT_DIR}/${BIN_NAME}.wasm") bytes)"
+echo "WAT:   ${OUT_DIR}/${BIN_NAME}.wat ($(wc -l < "${OUT_DIR}/${BIN_NAME}.wat") lines)"

--- a/linera-storage/udf/src/lib.rs
+++ b/linera-storage/udf/src/lib.rs
@@ -1,0 +1,228 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ScyllaDB Wasm UDFs to decode and encode Linera `RootKey` partition keys directly in cqlsh.
+//!
+//! The ScyllaDB backend wraps every root key with a single `0x00` tag byte (see
+//! `get_big_root_key` in `linera-views::backends::scylla_db`); both UDFs handle that wrapping
+//! transparently.
+//!
+//! `RootKey` is mirrored here from `linera-storage::db_storage` because compiling the full
+//! `linera-storage` crate to `wasm32-wasip1` would drag in the validator dependency tree. The
+//! `roundtrip` test in `linera-storage/src/db_storage.rs` (added in the same change) asserts
+//! that the two definitions encode to the same bytes.
+
+use linera_base::{
+    crypto::CryptoHash,
+    identifiers::{BlobId, BlobType, ChainId},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum RootKey {
+    NetworkDescription,
+    BlockExporterState(u32),
+    ChainState(ChainId),
+    BlockHash(CryptoHash),
+    BlobId(BlobId),
+    Event(ChainId),
+    BlockByHeight(ChainId),
+    EventBlockHeight(ChainId),
+}
+
+const SCYLLA_TAG: u8 = 0x00;
+
+/// Decode a `RootKey` partition key blob into its `Debug` representation.
+///
+/// Expects the ScyllaDB `0x00` tag byte at the start (every `root_key` column in
+/// `linera-views::backends::scylla_db` is wrapped this way). Returns an `ERR:` prefix on
+/// failure so `cqlsh` shows useful output instead of NULL.
+#[scylla_udf::export_udf]
+fn decode_root_key(raw: Vec<u8>) -> String {
+    decode_root_key_impl(&raw)
+}
+
+/// Encode a `RootKey` partition key from a variant name and a hex payload.
+///
+/// Output includes the ScyllaDB `0x00` tag byte so the result can be used directly as a
+/// `root_key` value in `WHERE root_key = ?` clauses. Returns an empty blob on error so
+/// `WHERE` clauses fail explicitly rather than silently matching the wrong rows.
+///
+/// Payload format per variant:
+/// - `NetworkDescription`: empty
+/// - `BlockExporterState`: 4 bytes (u32, little-endian)
+/// - `ChainState` / `Event` / `BlockByHeight` / `EventBlockHeight`: 32 bytes (CryptoHash)
+/// - `BlockHash`: 32 bytes (CryptoHash)
+/// - `BlobId`: 32 bytes (CryptoHash) + 1 byte (BlobType BCS variant tag)
+#[scylla_udf::export_udf]
+fn encode_root_key(variant: String, payload_hex: String) -> Vec<u8> {
+    encode_root_key_impl(&variant, &payload_hex)
+}
+
+fn decode_root_key_impl(raw: &[u8]) -> String {
+    let Some((&SCYLLA_TAG, payload)) = raw.split_first() else {
+        return "ERR: missing ScyllaDB tag byte".to_string();
+    };
+    match bcs::from_bytes::<RootKey>(payload) {
+        Ok(key) => format!("{key:?}"),
+        Err(error) => format!("ERR: {error}"),
+    }
+}
+
+fn encode_root_key_impl(variant: &str, payload_hex: &str) -> Vec<u8> {
+    let Ok(key) = build_root_key(variant, payload_hex) else {
+        return Vec::new();
+    };
+    let mut bytes = vec![SCYLLA_TAG];
+    bytes.extend(key.bytes());
+    bytes
+}
+
+impl RootKey {
+    pub fn bytes(&self) -> Vec<u8> {
+        bcs::to_bytes(self).expect("BCS encoding of RootKey cannot fail")
+    }
+}
+
+fn build_root_key(variant: &str, payload_hex: &str) -> Result<RootKey, BuildError> {
+    let payload = hex::decode(payload_hex.strip_prefix("0x").unwrap_or(payload_hex))
+        .map_err(|_| BuildError::Hex)?;
+    match variant {
+        "NetworkDescription" => {
+            require_len(&payload, 0)?;
+            Ok(RootKey::NetworkDescription)
+        }
+        "BlockExporterState" => {
+            require_len(&payload, 4)?;
+            let mut buf = [0u8; 4];
+            buf.copy_from_slice(&payload);
+            Ok(RootKey::BlockExporterState(u32::from_le_bytes(buf)))
+        }
+        "ChainState" => Ok(RootKey::ChainState(ChainId(read_hash(&payload)?))),
+        "BlockHash" => Ok(RootKey::BlockHash(read_hash(&payload)?)),
+        "Event" => Ok(RootKey::Event(ChainId(read_hash(&payload)?))),
+        "BlockByHeight" => Ok(RootKey::BlockByHeight(ChainId(read_hash(&payload)?))),
+        "EventBlockHeight" => Ok(RootKey::EventBlockHeight(ChainId(read_hash(&payload)?))),
+        "BlobId" => {
+            require_len(&payload, 33)?;
+            let hash = read_hash(&payload[..32])?;
+            let blob_type =
+                bcs::from_bytes::<BlobType>(&payload[32..]).map_err(|_| BuildError::Payload)?;
+            Ok(RootKey::BlobId(BlobId::new(hash, blob_type)))
+        }
+        _ => Err(BuildError::Variant),
+    }
+}
+
+fn read_hash(payload: &[u8]) -> Result<CryptoHash, BuildError> {
+    require_len(payload, 32)?;
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(payload);
+    Ok(CryptoHash::from(bytes))
+}
+
+fn require_len(payload: &[u8], expected: usize) -> Result<(), BuildError> {
+    if payload.len() == expected {
+        Ok(())
+    } else {
+        Err(BuildError::Payload)
+    }
+}
+
+#[derive(Debug)]
+enum BuildError {
+    Hex,
+    Variant,
+    Payload,
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::{crypto::CryptoHash, identifiers::BlobType};
+
+    use super::*;
+
+    fn wrap(bytes: Vec<u8>) -> Vec<u8> {
+        let mut out = vec![SCYLLA_TAG];
+        out.extend(bytes);
+        out
+    }
+
+    #[test]
+    fn decode_network_description() {
+        let raw = wrap(RootKey::NetworkDescription.bytes());
+        assert_eq!(decode_root_key_impl(&raw), "NetworkDescription");
+    }
+
+    #[test]
+    fn decode_block_exporter_state() {
+        let raw = wrap(RootKey::BlockExporterState(42).bytes());
+        assert_eq!(decode_root_key_impl(&raw), "BlockExporterState(42)");
+    }
+
+    #[test]
+    fn decode_chain_state_includes_hash() {
+        let hash = CryptoHash::test_hash("udf");
+        let raw = wrap(RootKey::ChainState(ChainId(hash)).bytes());
+        let decoded = decode_root_key_impl(&raw);
+        assert!(decoded.starts_with("ChainState("), "{decoded}");
+        assert!(decoded.contains(&hash.to_string()), "{decoded}");
+    }
+
+    #[test]
+    fn decode_without_scylla_tag_errors() {
+        let result = decode_root_key_impl(&[]);
+        assert!(result.starts_with("ERR:"), "{result}");
+    }
+
+    #[test]
+    fn decode_garbage_returns_error_string() {
+        let result = decode_root_key_impl(&wrap(vec![0xff, 0xff]));
+        assert!(result.starts_with("ERR:"), "{result}");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_chain_state() {
+        let hash = CryptoHash::test_hash("roundtrip");
+        let encoded = encode_root_key_impl("ChainState", &hex::encode(hash.as_bytes()));
+        let decoded = decode_root_key_impl(&encoded);
+        assert!(decoded.starts_with("ChainState("), "{decoded}");
+        assert!(decoded.contains(&hash.to_string()), "{decoded}");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_block_exporter_state() {
+        let encoded = encode_root_key_impl("BlockExporterState", &hex::encode(42u32.to_le_bytes()));
+        assert_eq!(decode_root_key_impl(&encoded), "BlockExporterState(42)");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_network_description() {
+        let encoded = encode_root_key_impl("NetworkDescription", "");
+        assert_eq!(decode_root_key_impl(&encoded), "NetworkDescription");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip_blob_id() {
+        let hash = CryptoHash::test_hash("blob");
+        let mut payload = hex::encode(hash.as_bytes());
+        payload.push_str(&hex::encode(bcs::to_bytes(&BlobType::Data).unwrap()));
+        let encoded = encode_root_key_impl("BlobId", &payload);
+        let decoded = decode_root_key_impl(&encoded);
+        assert!(decoded.starts_with("BlobId("), "{decoded}");
+    }
+
+    #[test]
+    fn encode_unknown_variant_returns_empty() {
+        assert!(encode_root_key_impl("NotARealVariant", "").is_empty());
+    }
+
+    #[test]
+    fn encode_accepts_0x_prefix() {
+        let hash = CryptoHash::test_hash("prefix");
+        let encoded =
+            encode_root_key_impl("ChainState", &format!("0x{}", hex::encode(hash.as_bytes())));
+        let decoded = decode_root_key_impl(&encoded);
+        assert!(decoded.contains(&hash.to_string()), "{decoded}");
+    }
+}


### PR DESCRIPTION
## Motivation

`linera-storage-decode-key` (#6263) is great for offline decoding of `RootKey` partition keys, but you still have to copy hex out of `cqlsh`, pipe it through, and copy results back. Moving the decoder into ScyllaDB itself as a Wasm UDF eliminates the pipe and unlocks queries like:

```sql
SELECT decode_root_key(partition_key) AS what, partition_size
FROM system.large_partitions
WHERE keyspace_name = 'linera'
ORDER BY partition_size DESC
LIMIT 20;
```

and

```sql
SELECT decode_root_key(root_key), length(k), length(v)
FROM linera."ns_42"
WHERE root_key IN (
  encode_root_key('ChainState',       '7a3f...'),
  encode_root_key('BlockByHeight',    '7a3f...'),
  encode_root_key('Event',            '7a3f...'),
  encode_root_key('EventBlockHeight', '7a3f...')
);
```

## Proposal

New crate `linera-storage/udf/` (workspace member, not in `default-members`) targeting `wasm32-wasip1`. Two `#[scylla_udf::export_udf]` functions: `decode_root_key(blob) -> text` and `encode_root_key(text, text) -> blob`. Both transparently handle the leading `0x00` tag byte that `linera-views::backends::scylla_db::get_big_root_key` prepends.

`RootKey` is mirrored locally because compiling `linera-storage` to `wasm32-wasip1` would drag in the validator dependency tree. A drift-detection test (`linera-storage/tests/root_key_drift.rs`) asserts the mirrored enum BCS-encodes identically to the canonical one — it will fail loudly if `RootKey` changes here without the mirror being updated.

Build script at `linera-storage/udf/build.sh` produces the optimized `.wasm` (~145 KB) and the `.wat` ready to embed in a CQL `CREATE FUNCTION` statement. Full registration workflow documented in `linera-storage/udf/README.md`.

Includes a custom `[profile.wasm-udf]` in the workspace `Cargo.toml` (inherits release; strip; LTO; opt-level z; panic abort) because WAT source size matters: it is embedded as a string literal in the CQL statement.

Will be backported to `testnet_conway` (which has a different `RootKey` schema) as a separate PR.

## Test Plan

CI. Additionally locally:

- `cargo check -p linera-storage-udf`
- `cargo clippy -p linera-storage-udf --all-targets -- -D warnings`
- `cargo clippy -p linera-storage --all-targets -- -D warnings`
- `cargo test -p linera-storage-udf` — 11/11 passing
- `cargo test -p linera-storage --test root_key_drift` — 1/1 passing
- `RUSTFLAGS=... cargo build -p linera-storage-udf --target wasm32-wasip1 --profile wasm-udf` produces a 148 KB binary
- `wasm2wat` produces 55,587 lines of WAT ready for CQL embedding

End-to-end registration against a real Scylla instance is deferred until the operator workflow is in place; ScyllaDB Wasm UDFs are still experimental and require `udf` in `experimental_features` in `scylla.yaml`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.