### PR TITLE
monitoring: add CPU steal time panel to validator General dashboard

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/general.json
@@ -4062,6 +4062,55 @@
       ],
       "title": "Top Server Error Pairs (method \u00d7 error_type)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 99
+      },
+      "id": 63,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "expr": "avg by (cluster) (rate(node_cpu_seconds_total{mode=\"steal\", cluster=~\"gke-testnet-conway-validator-.*\"}[5m]))",
+          "legendFormat": "{{cluster}}"
+        }
+      ],
+      "title": "CPU Steal Time (per validator cluster)",
+      "type": "timeseries"
     }
   ],
   "preload": false,


### PR DESCRIPTION
## Motivation

CPU steal time is a hypervisor-level signal invisible to cgroup metrics like CFS throttling. It tells us whether the node is being starved by the hypervisor, distinct from our own CPU pressure.

## Proposal

Adds a "CPU Steal Time (per validator cluster)" panel to the **Cluster Info** section of the General validator dashboard, half-width (w=12) alongside the existing "Shards FS written bytes per second" panel. Queries \`node_cpu_seconds_total{mode="steal", cluster=~"gke-testnet-conway-validator-.*"}\` averaged per cluster.

Backport of linera-io/linera-protocol#6299.

## Test Plan

CI.

## Release Plan

- These changes should be backported to the latest \`testnet\` branch.