### PR TITLE
Fix linera-bridge e2e after backports; require --locked in CI

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -98,21 +98,21 @@ jobs:
           docker push "${GCP_REGISTRY}/linera-bridge:${{ github.ref_name }}"
 
       - name: Build evm-bridge Wasm module
-        run: cargo build --release --target wasm32-unknown-unknown
+        run: cargo build --locked --release --target wasm32-unknown-unknown
         working-directory: linera-bridge/contracts/evm-bridge
 
       - name: Build wrapped-fungible Wasm module
-        run: cargo build --release --target wasm32-unknown-unknown -p wrapped-fungible
+        run: cargo build --locked --release --target wasm32-unknown-unknown -p wrapped-fungible
         working-directory: examples
 
       - name: Build linera-bridge binary for local relay tests
-        run: cargo build -p linera-bridge --features linera-bridge/relay
+        run: cargo build --locked -p linera-bridge --features linera-bridge/relay
 
       - name: Run bridge E2E test
         working-directory: linera-bridge/tests/e2e
         env:
           RUSTFLAGS: ""
-        run: cargo test -- --ignored --nocapture
+        run: cargo test --locked -- --ignored --nocapture
 
       - name: Install Foundry (provides `anvil`)
         uses: foundry-rs/foundry-toolchain@v1
@@ -142,4 +142,4 @@ jobs:
         working-directory: linera-bridge
         env:
           RUSTFLAGS: ""
-        run: cargo test -p linera-bridge --test anvil_deposit_proof -- --ignored --nocapture
+        run: cargo test --locked -p linera-bridge --test anvil_deposit_proof -- --ignored --nocapture

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -2516,6 +2516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-discriminant"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a6df962265a53221f29081896c412ef325c17fa7d638cd9578febe53d3c82c"
+dependencies = [
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2824,6 +2833,7 @@ dependencies = [
  "futures",
  "linera-sdk",
  "serde",
+ "serde-reflection",
 ]
 
 [[package]]
@@ -4192,6 +4202,7 @@ dependencies = [
  "log",
  "papaya",
  "serde",
+ "serde-reflection",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -6399,6 +6410,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-reflection"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68fb2363ca88876b3e16442b02dde5305646fd50df297c79a4b54fc5f5cf51d4"
+dependencies = [
+ "erased-discriminant",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "typeid",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7844,6 +7869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8971,6 +9002,7 @@ dependencies = [
  "fungible",
  "hex",
  "linera-sdk",
+ "serde-reflection",
 ]
 
 [[package]]

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -403,10 +403,12 @@ where
         .context("manifest dir has fewer than 3 ancestors")?
         .to_path_buf();
     let wasm_dir = repo_root.join("examples/target/wasm32-unknown-unknown/release");
-    let wf_contract = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm"))?;
-    let wf_service = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_service.wasm"))?;
+    let wf_contract =
+        Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm")).await?;
+    let wf_service =
+        Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_service.wasm")).await?;
     let (wf_module_id, _) = chain_client
-        .publish_module(wf_contract, wf_service, VmRuntime::Wasm)
+        .publish_module(wf_contract, wf_service, VmRuntime::Wasm, None)
         .await?
         .expect("publish wrapped-fungible module committed");
     chain_client.synchronize_from_validators().await?;
@@ -543,7 +545,7 @@ pub async fn set_anvil_block_gas_limit(
 /// to the head block (no per-height search loop needed in tests).
 pub async fn fetch_latest_cert<E>(
     chain_client: &linera_core::client::ChainClient<E>,
-) -> anyhow::Result<linera_chain::types::ConfirmedBlockCertificate>
+) -> anyhow::Result<std::sync::Arc<linera_chain::types::ConfirmedBlockCertificate>>
 where
     E: linera_core::environment::Environment,
 {

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -16,11 +16,7 @@
 
 #![recursion_limit = "512"]
 
-use std::{
-    collections::BTreeMap,
-    path::PathBuf,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
 use alloy::{
     primitives::U256,
@@ -28,7 +24,6 @@ use alloy::{
     signers::local::PrivateKeySigner,
     sol,
 };
-use anyhow::Context as _;
 use linera_base::{
     crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner,
 };
@@ -210,7 +205,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
-            &linera_storage_runtime::CommonStorageOptions::with_defaults(),
+            linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
             Duration::from_secs(2),
             0,
             5,

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -220,7 +220,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
-            &linera_storage_runtime::CommonStorageOptions::with_defaults(),
+            linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
             Duration::from_secs(2),
             0,
             5,

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -204,7 +204,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
-            &linera_storage_runtime::CommonStorageOptions::with_defaults(),
+            linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
             Duration::from_secs(2),
             0,
             5,


### PR DESCRIPTION
## Motivation

Bridge e2e job is still broken and merge queue does not fail with it.

## Proposal

The `linera-bridge` e2e crate (`linera-bridge/tests/e2e/`) is a separate Cargo workspace and was missed by the previous backport fix-up. Bring its callsites in line with the post-backport APIs:

- `Bytecode::load_from_file` is now async — add `.await`.
- `ChainClient::publish_module` gained a `formats: Option<Vec<u8>>` parameter — pass `None`.
- `ChainClient::read_certificate` now returns `Arc<ConfirmedBlockCertificate>`; propagate the `Arc` through `fetch_latest_cert`.
- `relay::run` takes `StorageCacheConfig`, not `&CommonStorageOptions`. Switch the three remaining callsites to `CommonStorageOptions::with_defaults().storage_cache_config()`, matching the already-correct callsite in `auto_deposit_scan.rs`.
- Drop now-unused imports in `burn_completion_requires_on_chain_evidence.rs`.
- Regenerate `linera-bridge/tests/e2e/Cargo.lock` for the new transitive `serde-reflection` dep pulled in via path-deps.

Also add `--locked` to every cargo invocation in
`.github/workflows/bridge-e2e.yml` so a stale e2e lockfile fails CI instead of being silently rewritten — the gap that hid this break.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
