### PR TITLE
wrapped-fungible: rename Mint operation to MintAndTransfer

### DIFF
--- a/examples/wrapped-fungible/src/contract.rs
+++ b/examples/wrapped-fungible/src/contract.rs
@@ -114,10 +114,10 @@ impl Contract for WrappedFungibleTokenContract {
                 FungibleResponse::Ok
             }
 
-            WrappedFungibleOperation::Mint {
+            WrappedFungibleOperation::MintAndTransfer {
                 target_account,
                 amount,
-            } => self.execute_mint(target_account, amount).await,
+            } => self.execute_mint_and_transfer(target_account, amount).await,
 
             WrappedFungibleOperation::Burn { .. } => {
                 panic!("Operation::Burn is not supported; burning happens automatically on cross-chain transfer to an Address20 on the bridge chain");
@@ -206,7 +206,11 @@ impl WrappedFungibleTokenContract {
     }
 
     /// Mints tokens to a target account (local or remote).
-    async fn execute_mint(&mut self, target_account: Account, amount: Amount) -> FungibleResponse {
+    async fn execute_mint_and_transfer(
+        &mut self,
+        target_account: Account,
+        amount: Amount,
+    ) -> FungibleResponse {
         self.require_mint_authorized();
         if target_account.chain_id == self.runtime.chain_id() {
             self.state.credit(target_account.owner, amount).await;

--- a/examples/wrapped-fungible/tests/mint_burn.rs
+++ b/examples/wrapped-fungible/tests/mint_burn.rs
@@ -80,7 +80,7 @@ async fn test_mint_from_unauthorized_signer() {
         .try_add_block(|block| {
             block.with_operation(
                 application_id,
-                WrappedFungibleOperation::Mint {
+                WrappedFungibleOperation::MintAndTransfer {
                     target_account: Account {
                         chain_id: chain.id(),
                         owner: chain_owner,
@@ -336,7 +336,7 @@ async fn test_mint_on_wrong_chain() {
         .try_add_block(|block| {
             block.with_operation(
                 application_id,
-                WrappedFungibleOperation::Mint {
+                WrappedFungibleOperation::MintAndTransfer {
                     target_account: Account {
                         chain_id: minter_chain.id(),
                         owner: minter_account,
@@ -371,7 +371,7 @@ async fn test_direct_mint_without_bridge_is_rejected() {
         .try_add_block(|block| {
             block.with_operation(
                 application_id,
-                WrappedFungibleOperation::Mint {
+                WrappedFungibleOperation::MintAndTransfer {
                     target_account: Account {
                         chain_id: minter_chain.id(),
                         owner: minter_account,

--- a/examples/wrapped-fungible/tests/snapshots/format__format.snap
+++ b/examples/wrapped-fungible/tests/snapshots/format__format.snap
@@ -126,7 +126,7 @@ REGISTRY:
             - target_account:
                 TYPENAME: Account
       6:
-        Mint:
+        MintAndTransfer:
           STRUCT:
             - target_account:
                 TYPENAME: Account

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -262,10 +262,10 @@ impl EvmBridgeContract {
                 .expect("failed to cache verified block hash");
         }
 
-        // 6. Convert deposit fields to Linera types and call Mint
+        // 6. Convert deposit fields to Linera types and call MintAndTransfer
         let amount = Amount::try_from(deposit.amount).expect("deposit amount exceeds u128");
 
-        let mint_op = WrappedFungibleOperation::Mint {
+        let mint_op = WrappedFungibleOperation::MintAndTransfer {
             target_account: Account {
                 chain_id: deposit.target_chain_id,
                 owner: deposit.target_account_owner,

--- a/linera-bridge/src/solidity/WrappedFungibleTypes.sol
+++ b/linera-bridge/src/solidity/WrappedFungibleTypes.sol
@@ -173,8 +173,8 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_TransferFrom transfer_from;
         // choice=5 corresponds to Claim
         WrappedFungibleOperation_Claim claim;
-        // choice=6 corresponds to Mint
-        WrappedFungibleOperation_Mint mint;
+        // choice=6 corresponds to MintAndTransfer
+        WrappedFungibleOperation_MintAndTransfer mint_and_transfer;
         // choice=7 corresponds to Burn
         WrappedFungibleOperation_Burn burn;
     }
@@ -188,9 +188,12 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Transfer memory transfer_;
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
-        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(0), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        return
+            WrappedFungibleOperation(
+                uint8(0), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
     function WrappedFungibleOperation_case_ticker_symbol() internal pure returns (WrappedFungibleOperation memory) {
@@ -199,9 +202,12 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Transfer memory transfer_;
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
-        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(1), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        return
+            WrappedFungibleOperation(
+                uint8(1), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
     function WrappedFungibleOperation_case_approve(WrappedFungibleOperation_Approve memory approve)
@@ -213,9 +219,12 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Transfer memory transfer_;
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
-        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(2), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        return
+            WrappedFungibleOperation(
+                uint8(2), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
     function WrappedFungibleOperation_case_transfer(WrappedFungibleOperation_Transfer memory transfer_)
@@ -227,9 +236,12 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Approve memory approve;
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
-        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(3), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        return
+            WrappedFungibleOperation(
+                uint8(3), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
     function WrappedFungibleOperation_case_transfer_from(WrappedFungibleOperation_TransferFrom memory transfer_from)
@@ -241,9 +253,12 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Approve memory approve;
         WrappedFungibleOperation_Transfer memory transfer_;
         WrappedFungibleOperation_Claim memory claim;
-        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(4), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        return
+            WrappedFungibleOperation(
+                uint8(4), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
     function WrappedFungibleOperation_case_claim(WrappedFungibleOperation_Claim memory claim)
@@ -255,12 +270,15 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Approve memory approve;
         WrappedFungibleOperation_Transfer memory transfer_;
         WrappedFungibleOperation_TransferFrom memory transfer_from;
-        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(5), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        return
+            WrappedFungibleOperation(
+                uint8(5), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
-    function WrappedFungibleOperation_case_mint(WrappedFungibleOperation_Mint memory mint)
+    function WrappedFungibleOperation_case_mint_and_transfer(WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer)
         internal
         pure
         returns (WrappedFungibleOperation memory)
@@ -271,7 +289,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(6), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        return
+            WrappedFungibleOperation(
+                uint8(6), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
     function WrappedFungibleOperation_case_burn(WrappedFungibleOperation_Burn memory burn)
@@ -284,8 +305,11 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Transfer memory transfer_;
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
-        WrappedFungibleOperation_Mint memory mint;
-        return WrappedFungibleOperation(uint8(7), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
+        return
+            WrappedFungibleOperation(
+                uint8(7), balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            );
     }
 
     function bcs_serialize_WrappedFungibleOperation(WrappedFungibleOperation memory input)
@@ -310,7 +334,9 @@ library WrappedFungibleTypes {
             return abi.encodePacked(input.choice, bcs_serialize_WrappedFungibleOperation_Claim(input.claim));
         }
         if (input.choice == 6) {
-            return abi.encodePacked(input.choice, bcs_serialize_WrappedFungibleOperation_Mint(input.mint));
+            return abi.encodePacked(
+                input.choice, bcs_serialize_WrappedFungibleOperation_MintAndTransfer(input.mint_and_transfer)
+            );
         }
         if (input.choice == 7) {
             return abi.encodePacked(input.choice, bcs_serialize_WrappedFungibleOperation_Burn(input.burn));
@@ -346,17 +372,22 @@ library WrappedFungibleTypes {
         if (choice == 5) {
             (new_pos, claim) = bcs_deserialize_offset_WrappedFungibleOperation_Claim(new_pos, input);
         }
-        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_MintAndTransfer memory mint_and_transfer;
         if (choice == 6) {
-            (new_pos, mint) = bcs_deserialize_offset_WrappedFungibleOperation_Mint(new_pos, input);
+            (new_pos, mint_and_transfer) =
+                bcs_deserialize_offset_WrappedFungibleOperation_MintAndTransfer(new_pos, input);
         }
         WrappedFungibleOperation_Burn memory burn;
         if (choice == 7) {
             (new_pos, burn) = bcs_deserialize_offset_WrappedFungibleOperation_Burn(new_pos, input);
         }
         require(choice < 8);
-        return
-            (new_pos, WrappedFungibleOperation(choice, balance_, approve, transfer_, transfer_from, claim, mint, burn));
+        return (
+            new_pos,
+            WrappedFungibleOperation(
+                choice, balance_, approve, transfer_, transfer_from, claim, mint_and_transfer, burn
+            )
+        );
     }
 
     function bcs_deserialize_WrappedFungibleOperation(bytes memory input)
@@ -531,12 +562,12 @@ library WrappedFungibleTypes {
         return value;
     }
 
-    struct WrappedFungibleOperation_Mint {
+    struct WrappedFungibleOperation_MintAndTransfer {
         BridgeTypes.Account target_account;
         BridgeTypes.Amount amount;
     }
 
-    function bcs_serialize_WrappedFungibleOperation_Mint(WrappedFungibleOperation_Mint memory input)
+    function bcs_serialize_WrappedFungibleOperation_MintAndTransfer(WrappedFungibleOperation_MintAndTransfer memory input)
         internal
         pure
         returns (bytes memory)
@@ -545,27 +576,27 @@ library WrappedFungibleTypes {
         return abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
     }
 
-    function bcs_deserialize_offset_WrappedFungibleOperation_Mint(uint256 pos, bytes memory input)
+    function bcs_deserialize_offset_WrappedFungibleOperation_MintAndTransfer(uint256 pos, bytes memory input)
         internal
         pure
-        returns (uint256, WrappedFungibleOperation_Mint memory)
+        returns (uint256, WrappedFungibleOperation_MintAndTransfer memory)
     {
         uint256 new_pos;
         BridgeTypes.Account memory target_account;
         (new_pos, target_account) = BridgeTypes.bcs_deserialize_offset_Account(pos, input);
         BridgeTypes.Amount memory amount;
         (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
-        return (new_pos, WrappedFungibleOperation_Mint(target_account, amount));
+        return (new_pos, WrappedFungibleOperation_MintAndTransfer(target_account, amount));
     }
 
-    function bcs_deserialize_WrappedFungibleOperation_Mint(bytes memory input)
+    function bcs_deserialize_WrappedFungibleOperation_MintAndTransfer(bytes memory input)
         internal
         pure
-        returns (WrappedFungibleOperation_Mint memory)
+        returns (WrappedFungibleOperation_MintAndTransfer memory)
     {
         uint256 new_pos;
-        WrappedFungibleOperation_Mint memory value;
-        (new_pos, value) = bcs_deserialize_offset_WrappedFungibleOperation_Mint(0, input);
+        WrappedFungibleOperation_MintAndTransfer memory value;
+        (new_pos, value) = bcs_deserialize_offset_WrappedFungibleOperation_MintAndTransfer(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-bridge/tests/snapshots/format_wrapped_fungible__format_wrapped_fungible.yaml.snap
+++ b/linera-bridge/tests/snapshots/format_wrapped_fungible__format_wrapped_fungible.yaml.snap
@@ -109,7 +109,7 @@ WrappedFungibleOperation:
           - target_account:
               TYPENAME: Account
     6:
-      Mint:
+      MintAndTransfer:
         STRUCT:
           - target_account:
               TYPENAME: Account

--- a/linera-sdk/src/abis/wrapped_fungible.rs
+++ b/linera-sdk/src/abis/wrapped_fungible.rs
@@ -93,8 +93,9 @@ pub enum WrappedFungibleOperation {
         /// Target account to claim the amount into
         target_account: Account,
     },
-    /// Mints new tokens to a target account. Only the authorized minter can call this.
-    Mint {
+    /// Mints new tokens and transfers them to a target account. Only the authorized
+    /// minter can call this.
+    MintAndTransfer {
         /// Account to receive the minted tokens
         target_account: Account,
         /// Amount of tokens to mint


### PR DESCRIPTION
## Motivation

The `Mint` operation in the `wrapped-fungible` ABI does more than just mint: it
mints new tokens and credits a (possibly remote) target account in the same
step. The name `Mint` suggests a purely local supply change and obscures the
implicit transfer.

## Proposal

Rename `WrappedFungibleOperation::Mint` to `MintAndTransfer`. Updates:

- the variant and its doc comment in `linera-sdk/src/abis/wrapped_fungible.rs`,
- the dispatch arm and its handler (`execute_mint` → `execute_mint_and_transfer`) in `examples/wrapped-fungible/src/contract.rs`,
- the call site in `examples/evm-bridge/src/contract.rs`,
- the three call sites in `examples/wrapped-fungible/tests/mint_burn.rs`.

No behavioral change.

## Test Plan

- `cargo check` on `linera-sdk`, `wrapped-fungible`, and `evm-bridge`.
- `cargo check --tests` on `wrapped-fungible`.
- CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)