### PR TITLE
Set new gas floors - main is more expensive

### DIFF
--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -52,8 +52,8 @@ const INITIAL_BALANCE_TOKENS: u128 = 10u128.pow(32);
 /// not by the amount value).
 const BURN_AMOUNT_TOKENS: u128 = 10u128.pow(15);
 
-#[test_case("ethereum",     30_000_000,  Some(50); "ethereum")]
-#[test_case("base",         240_000_000, Some(190); "base")]
+#[test_case("ethereum",     30_000_000,  Some(45); "ethereum")]
+#[test_case("base",         240_000_000, Some(175); "base")]
 #[tokio::test]
 #[serial_test::serial]
 #[ignore] // Requires pre-built docker images, Wasm, and bridge contracts.


### PR DESCRIPTION
## Motivation

bridge-e2e tests are failing on the `burns_per_evm_tx` – seems like costs of deserializing certificates on `main` branch is higher than on `testnet_conway`.

## Proposal

Set new floors lower but high enough to catch 10% regressions.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
