### PR TITLE
dashboard: sync bundled JSONs — multi-select validator var + Loki perf fixes

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/execution.json
@@ -6424,7 +6424,8 @@
         },
         "refresh": 1,
         "regex": "",
-        "type": "query"
+        "type": "query",
+        "multi": true
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/logs.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/logs.json
@@ -181,7 +181,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} |~ \" ERROR \" [$__interval]))",
+          "expr": "sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} |= \" ERROR \" [$__interval]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -243,7 +243,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} |~ \" WARN \" [$__interval]))",
+          "expr": "sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} |= \" WARN \" [$__interval]))",
           "queryType": "range",
           "refId": "A"
         }
@@ -309,7 +309,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} |~ \" ERROR \" [$__interval])) / sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} [$__interval])) * 100",
+          "expr": "sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} |= \" ERROR \" [$__interval])) / sum(count_over_time({validator=~\"$validator\", container=~\"$container\"} [$__interval])) * 100",
           "queryType": "range",
           "refId": "A"
         }
@@ -473,7 +473,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum by (level, validator) (count_over_time({validator=~\"$validator\", container=~\"$container\"} | regexp \"(?P<level>ERROR|WARN|INFO|DEBUG|TRACE)\" [$__interval]))",
+          "expr": "sum by (level, validator) (count_over_time({validator=~\"$validator\", container=~\"$container\"} | pattern `<_>  <level> <_>` | level=~\"ERROR|WARN|INFO|DEBUG|TRACE\" [$__interval]))",
           "legendFormat": "{{level}} - {{validator}}",
           "queryType": "range",
           "refId": "A"
@@ -565,7 +565,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "sum by (validator) (count_over_time({validator=~\"$validator\", container=~\"$container\"} |~ \" ERROR \" [$__interval]))",
+          "expr": "sum by (validator) (count_over_time({validator=~\"$validator\", container=~\"$container\"} |= \" ERROR \" [$__interval]))",
           "legendFormat": "{{validator}}",
           "queryType": "range",
           "refId": "A"
@@ -615,7 +615,7 @@
             "uid": "loki"
           },
           "editorMode": "code",
-          "expr": "{validator=~\"$validator\", container=~\"$container\"} |~ \"$level\" |~ \"$search\"",
+          "expr": "{validator=~\"$validator\", container=~\"$container\"} |= \"$level\" |~ \"$search\"",
           "queryType": "range",
           "refId": "A"
         }

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/scylladb.json
@@ -2883,7 +2883,8 @@
         "refresh": 2,
         "regex": "",
         "sort": 1,
-        "type": "query"
+        "type": "query",
+        "multi": true
       },
       {
         "allValue": ".*",

--- a/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/storage/storage.json
@@ -3732,7 +3732,8 @@
         "refresh": 2,
         "regex": "",
         "sort": 1,
-        "type": "query"
+        "type": "query",
+        "multi": true
       }
     ]
   },

--- a/kubernetes/linera-validator/grafana-dashboards/linera/views.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera/views.json
@@ -1301,7 +1301,7 @@
         "hide": 0,
         "includeAll": true,
         "label": "Validator",
-        "multi": false,
+        "multi": true,
         "name": "validator",
         "options": [],
         "query": {


### PR DESCRIPTION
## Motivation

Backport of #6310 to `testnet_conway`.

Bundled Grafana dashboard JSON files drifted from the live central monitoring instance. Two categories of fixes:

1. **Multi-select validator variable** — `execution.json`, `views.json`, `storage/scylladb.json`, `storage/storage.json` had `multi: false` or missing `multi` on the validator template variable. `general.json` already had `multi: true`; these four dashboards now match.

2. **Loki performance fixes for `logs.json`** — Replace `|~` regex filters with `|=` literal filters for fixed strings (` ERROR `, ` WARN `); replace `| regexp` with `| pattern` for the Log Volume by Level panel.

## Proposal

Cherry-pick of the commit from #6310.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6310
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)