### PR TITLE
ci: skip infra-only PRs in docker-compose, long-faucet, test-readmes workflows

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -1,6 +1,7 @@
 name: Bridge E2E
 
 on:
+  pull_request:
   merge_group:
   workflow_dispatch:
   push:
@@ -26,6 +27,7 @@ permissions:
 
 jobs:
   bridge-e2e:
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: linera-io-self-hosted-ci
     timeout-minutes: 60
 

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: ["devnet_*", "testnet_*"]
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [ 'devnet_*', 'testnet_*' ]
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
## Motivation

PRs that only touch `kubernetes/` or `docker/dashboards/` (e.g., Grafana dashboard JSON updates) were triggering Rust CI workflows unnecessarily. `indexer.yml`, `dynamodb.yml`, `lint-check-all-features.yml`, and `scylladb.yml` were already fixed on `main` (via `changed-files` jobs or positive `paths:` filters). The three remaining workflows had no path filter at all.

## Proposal

Add `paths-ignore` for `kubernetes/**` and `docker/dashboards/**` (alongside the existing `docs/**` and `mdbook/**` exclusions) to `docker-compose.yml`, `long_faucet_chain_test.yml`, and `test-readmes.yml`.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)