### PR TITLE
ci: skip infra-only PRs in workflows

### DIFF
--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -8,12 +8,14 @@ on:
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -6,10 +6,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -45,6 +45,7 @@ jobs:
               - '!INSTALL.md'
               - '!docs/**'
               - '!mdbook/**'
+              - '!.github/workflows/**'
 
   test:
     needs: changed-files

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -9,6 +9,7 @@ on:
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -8,12 +8,14 @@ on:
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -6,10 +6,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -8,12 +8,14 @@ on:
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -6,10 +6,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/remote_compatibility.yml
+++ b/.github/workflows/remote_compatibility.yml
@@ -16,6 +16,8 @@ on:
       - 'docker_scylla/**'
       - 'configuration/**'
       - 'kubernetes/**'
+      - 'docker/dashboards/**'
+      - '.github/workflows/**'
       - 'scripts/**'
 
   workflow_dispatch:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,7 @@ jobs:
               - '!INSTALL.md'
               - '!docs/**'
               - '!mdbook/**'
+              - '!.github/workflows/**'
   remote-net-test:
     needs: changed-files
     if: needs.changed-files.outputs.should-run == 'true'

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -6,6 +6,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -8,12 +8,14 @@ on:
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
       - 'kubernetes/**'
       - 'docker/dashboards/**'
+      - '.github/workflows/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -6,10 +6,14 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -55,6 +55,7 @@ jobs:
               - '!INSTALL.md'
               - '!docs/**'
               - '!mdbook/**'
+              - '!.github/workflows/**'
 
   web:
     needs: changed-files


### PR DESCRIPTION
## Motivation

PRs that only touch `kubernetes/` or `docker/dashboards/` (e.g., Grafana dashboard JSON updates, Helm chart config) were triggering all Rust CI workflows. All 7 affected workflows on `testnet_conway` still used `paths-ignore: docs/**, mdbook/**` only, so any infra-only PR ran the full test suite for no reason.

## Proposal

Add `kubernetes/**` and `docker/dashboards/**` to `paths-ignore` in all 7 affected workflows: `indexer.yml`, `docker-compose.yml`, `dynamodb.yml`, `lint-check-all-features.yml`, `long_faucet_chain_test.yml`, `scylladb.yml`, `test-readmes.yml`.

## Test Plan

CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6318 (main counterpart)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)