### PR TITLE
linera-metrics: expose stable tokio runtime metrics on /metrics

### DIFF
--- a/linera-metrics/src/lib.rs
+++ b/linera-metrics/src/lib.rs
@@ -4,6 +4,7 @@
 //! A library for Linera server metrics.
 
 pub mod monitoring_server;
+mod runtime_metrics;
 
 #[cfg(feature = "jemalloc")]
 pub mod memory_profiler;

--- a/linera-metrics/src/monitoring_server.rs
+++ b/linera-metrics/src/monitoring_server.rs
@@ -81,6 +81,7 @@ pub fn start_metrics(
     shutdown_signal: CancellationToken,
     memory_profiling: MemoryProfiling,
 ) {
+    crate::runtime_metrics::register();
     let app = metrics_router(memory_profiling);
 
     tokio::spawn(async move {

--- a/linera-metrics/src/runtime_metrics.rs
+++ b/linera-metrics/src/runtime_metrics.rs
@@ -1,0 +1,167 @@
+use std::{collections::HashMap, sync::OnceLock};
+
+use prometheus::{
+    core::{Collector, Desc},
+    proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType},
+};
+use tokio::runtime::Handle;
+
+pub(crate) struct TokioRuntimeCollector {
+    handle: Handle,
+    descs: Vec<Desc>,
+}
+
+const IDX_WORKERS: usize = 0;
+const IDX_ALIVE_TASKS: usize = 1;
+const IDX_GLOBAL_QUEUE: usize = 2;
+const IDX_BUSY_SECONDS: usize = 3;
+const IDX_PARKS: usize = 4;
+const IDX_PARK_UNPARKS: usize = 5;
+
+impl TokioRuntimeCollector {
+    fn new(handle: Handle) -> Self {
+        let descs = vec![
+            Desc::new(
+                "linera_tokio_workers".into(),
+                "Number of worker threads in the tokio runtime.".into(),
+                vec![],
+                HashMap::new(),
+            )
+            .expect("static metric descriptor is always valid"),
+            Desc::new(
+                "linera_tokio_alive_tasks".into(),
+                "Number of tasks currently alive in the tokio runtime.".into(),
+                vec![],
+                HashMap::new(),
+            )
+            .expect("static metric descriptor is always valid"),
+            Desc::new(
+                "linera_tokio_global_queue_depth".into(),
+                "Number of tasks in the runtime's global injection queue.".into(),
+                vec![],
+                HashMap::new(),
+            )
+            .expect("static metric descriptor is always valid"),
+            Desc::new(
+                "linera_tokio_worker_busy_seconds_total".into(),
+                "Cumulative time each worker has spent executing tasks, in seconds.".into(),
+                vec!["worker".to_string()],
+                HashMap::new(),
+            )
+            .expect("static metric descriptor is always valid"),
+            Desc::new(
+                "linera_tokio_worker_parks_total".into(),
+                "Cumulative number of times each worker has parked (ran out of work).".into(),
+                vec!["worker".to_string()],
+                HashMap::new(),
+            )
+            .expect("static metric descriptor is always valid"),
+            Desc::new(
+                "linera_tokio_worker_park_unparks_total".into(),
+                "Monotonically increasing count of park and unpark events combined per worker. \
+                 An odd value means the worker is currently parked."
+                    .into(),
+                vec!["worker".to_string()],
+                HashMap::new(),
+            )
+            .expect("static metric descriptor is always valid"),
+        ];
+        Self { handle, descs }
+    }
+}
+
+impl Collector for TokioRuntimeCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let m = self.handle.metrics();
+        let num_workers = m.num_workers();
+        let mut families = Vec::with_capacity(6);
+
+        families.push(gauge_family(&self.descs[IDX_WORKERS], num_workers as f64));
+        families.push(gauge_family(
+            &self.descs[IDX_ALIVE_TASKS],
+            m.num_alive_tasks() as f64,
+        ));
+        families.push(gauge_family(
+            &self.descs[IDX_GLOBAL_QUEUE],
+            m.global_queue_depth() as f64,
+        ));
+
+        #[cfg(target_has_atomic = "64")]
+        {
+            let mut busy = counter_family(&self.descs[IDX_BUSY_SECONDS]);
+            let mut parks = counter_family(&self.descs[IDX_PARKS]);
+            let mut park_unparks = counter_family(&self.descs[IDX_PARK_UNPARKS]);
+            for i in 0..num_workers {
+                let label = worker_label(i);
+                busy.mut_metric().push(counter_metric(
+                    m.worker_total_busy_duration(i).as_secs_f64(),
+                    &label,
+                ));
+                parks
+                    .mut_metric()
+                    .push(counter_metric(m.worker_park_count(i) as f64, &label));
+                park_unparks
+                    .mut_metric()
+                    .push(counter_metric(m.worker_park_unpark_count(i) as f64, &label));
+            }
+            families.push(busy);
+            families.push(parks);
+            families.push(park_unparks);
+        }
+
+        families
+    }
+}
+
+fn gauge_family(desc: &Desc, value: f64) -> MetricFamily {
+    let mut gauge = Gauge::new();
+    gauge.set_value(value);
+    let mut metric = Metric::new();
+    metric.set_gauge(gauge);
+    let mut family = MetricFamily::new();
+    family.set_name(desc.fq_name.clone());
+    family.set_help(desc.help.clone());
+    family.set_field_type(MetricType::GAUGE);
+    family.mut_metric().push(metric);
+    family
+}
+
+fn counter_family(desc: &Desc) -> MetricFamily {
+    let mut family = MetricFamily::new();
+    family.set_name(desc.fq_name.clone());
+    family.set_help(desc.help.clone());
+    family.set_field_type(MetricType::COUNTER);
+    family
+}
+
+fn counter_metric(value: f64, labels: &[LabelPair]) -> Metric {
+    let mut counter = Counter::new();
+    counter.set_value(value);
+    let mut metric = Metric::new();
+    metric.set_counter(counter);
+    metric.set_label(labels.to_vec().into());
+    metric
+}
+
+fn worker_label(i: usize) -> [LabelPair; 1] {
+    let mut lp = LabelPair::new();
+    lp.set_name("worker".into());
+    lp.set_value(i.to_string());
+    [lp]
+}
+
+/// Idempotently register the tokio runtime metrics collector with the default
+/// Prometheus registry. Must be called from within a tokio runtime context.
+pub(crate) fn register() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let collector = Box::new(TokioRuntimeCollector::new(Handle::current()));
+        if let Err(e) = prometheus::register(collector) {
+            tracing::warn!("failed to register tokio runtime metrics: {e}");
+        }
+    });
+}

--- a/linera-metrics/src/runtime_metrics.rs
+++ b/linera-metrics/src/runtime_metrics.rs
@@ -9,57 +9,56 @@ use prometheus::{
 };
 use tokio::runtime::Handle;
 
-pub(crate) struct TokioRuntimeCollector {
+struct TokioRuntimeCollector {
     handle: Handle,
-    descs: Vec<Desc>,
+    workers: Desc,
+    alive_tasks: Desc,
+    global_queue: Desc,
+    busy_seconds: Desc,
+    parks: Desc,
+    park_unparks: Desc,
 }
-
-const IDX_WORKERS: usize = 0;
-const IDX_ALIVE_TASKS: usize = 1;
-const IDX_GLOBAL_QUEUE: usize = 2;
-const IDX_BUSY_SECONDS: usize = 3;
-const IDX_PARKS: usize = 4;
-const IDX_PARK_UNPARKS: usize = 5;
 
 impl TokioRuntimeCollector {
     fn new(handle: Handle) -> Self {
-        let descs = vec![
-            Desc::new(
+        Self {
+            handle,
+            workers: Desc::new(
                 "linera_tokio_workers".into(),
                 "Number of worker threads in the tokio runtime.".into(),
                 vec![],
                 HashMap::new(),
             )
             .expect("static metric descriptor is always valid"),
-            Desc::new(
+            alive_tasks: Desc::new(
                 "linera_tokio_alive_tasks".into(),
                 "Number of tasks currently alive in the tokio runtime.".into(),
                 vec![],
                 HashMap::new(),
             )
             .expect("static metric descriptor is always valid"),
-            Desc::new(
+            global_queue: Desc::new(
                 "linera_tokio_global_queue_depth".into(),
                 "Number of tasks in the runtime's global injection queue.".into(),
                 vec![],
                 HashMap::new(),
             )
             .expect("static metric descriptor is always valid"),
-            Desc::new(
+            busy_seconds: Desc::new(
                 "linera_tokio_worker_busy_seconds_total".into(),
                 "Cumulative time each worker has spent executing tasks, in seconds.".into(),
                 vec!["worker".to_string()],
                 HashMap::new(),
             )
             .expect("static metric descriptor is always valid"),
-            Desc::new(
+            parks: Desc::new(
                 "linera_tokio_worker_parks_total".into(),
                 "Cumulative number of times each worker has parked (ran out of work).".into(),
                 vec!["worker".to_string()],
                 HashMap::new(),
             )
             .expect("static metric descriptor is always valid"),
-            Desc::new(
+            park_unparks: Desc::new(
                 "linera_tokio_worker_park_unparks_total".into(),
                 "Monotonically increasing count of park and unpark events combined per worker. \
                  An odd value means the worker is currently parked."
@@ -68,14 +67,20 @@ impl TokioRuntimeCollector {
                 HashMap::new(),
             )
             .expect("static metric descriptor is always valid"),
-        ];
-        Self { handle, descs }
+        }
     }
 }
 
 impl Collector for TokioRuntimeCollector {
     fn desc(&self) -> Vec<&Desc> {
-        self.descs.iter().collect()
+        vec![
+            &self.workers,
+            &self.alive_tasks,
+            &self.global_queue,
+            &self.busy_seconds,
+            &self.parks,
+            &self.park_unparks,
+        ]
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
@@ -83,21 +88,18 @@ impl Collector for TokioRuntimeCollector {
         let num_workers = m.num_workers();
         let mut families = Vec::with_capacity(6);
 
-        families.push(gauge_family(&self.descs[IDX_WORKERS], num_workers as f64));
+        families.push(gauge_family(&self.workers, num_workers as f64));
+        families.push(gauge_family(&self.alive_tasks, m.num_alive_tasks() as f64));
         families.push(gauge_family(
-            &self.descs[IDX_ALIVE_TASKS],
-            m.num_alive_tasks() as f64,
-        ));
-        families.push(gauge_family(
-            &self.descs[IDX_GLOBAL_QUEUE],
+            &self.global_queue,
             m.global_queue_depth() as f64,
         ));
 
         #[cfg(target_has_atomic = "64")]
         {
-            let mut busy = counter_family(&self.descs[IDX_BUSY_SECONDS]);
-            let mut parks = counter_family(&self.descs[IDX_PARKS]);
-            let mut park_unparks = counter_family(&self.descs[IDX_PARK_UNPARKS]);
+            let mut busy = counter_family(&self.busy_seconds);
+            let mut parks = counter_family(&self.parks);
+            let mut park_unparks = counter_family(&self.park_unparks);
             for i in 0..num_workers {
                 let label = worker_label(i);
                 busy.mut_metric().push(counter_metric(
@@ -157,8 +159,7 @@ fn worker_label(i: usize) -> [LabelPair; 1] {
     [lp]
 }
 
-/// Idempotently register the tokio runtime metrics collector with the default
-/// Prometheus registry. Must be called from within a tokio runtime context.
+/// Must be called from within a tokio runtime context.
 pub(crate) fn register() {
     static ONCE: OnceLock<()> = OnceLock::new();
     ONCE.get_or_init(|| {

--- a/linera-metrics/src/runtime_metrics.rs
+++ b/linera-metrics/src/runtime_metrics.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{collections::HashMap, sync::OnceLock};
 
 use prometheus::{

--- a/linera-metrics/src/runtime_metrics.rs
+++ b/linera-metrics/src/runtime_metrics.rs
@@ -21,52 +21,50 @@ struct TokioRuntimeCollector {
 
 impl TokioRuntimeCollector {
     fn new(handle: Handle) -> Self {
+        let desc = |name: &str, help: &str, labels: Vec<String>| {
+            Desc::new(name.into(), help.into(), labels, HashMap::new())
+                .expect("static metric descriptor is always valid")
+        };
+        let workers = desc(
+            "linera_tokio_workers",
+            "Number of worker threads in the tokio runtime.",
+            vec![],
+        );
+        let alive_tasks = desc(
+            "linera_tokio_alive_tasks",
+            "Number of tasks currently alive in the tokio runtime.",
+            vec![],
+        );
+        let global_queue = desc(
+            "linera_tokio_global_queue_depth",
+            "Number of tasks in the runtime's global injection queue.",
+            vec![],
+        );
+        let worker_label = vec!["worker".to_string()];
+        let busy_seconds = desc(
+            "linera_tokio_worker_busy_seconds_total",
+            "Cumulative time each worker has spent executing tasks, in seconds.",
+            worker_label.clone(),
+        );
+        let parks = desc(
+            "linera_tokio_worker_parks_total",
+            "Cumulative number of times each worker has parked (ran out of work).",
+            worker_label.clone(),
+        );
+        let park_unparks = desc(
+            "linera_tokio_worker_park_unparks_total",
+            "Monotonically increasing count of park and unpark events combined per worker. \
+             An odd value means the worker is currently parked.",
+            worker_label,
+        );
         Self {
             handle,
-            workers: Desc::new(
-                "linera_tokio_workers".into(),
-                "Number of worker threads in the tokio runtime.".into(),
-                vec![],
-                HashMap::new(),
-            )
-            .expect("static metric descriptor is always valid"),
-            alive_tasks: Desc::new(
-                "linera_tokio_alive_tasks".into(),
-                "Number of tasks currently alive in the tokio runtime.".into(),
-                vec![],
-                HashMap::new(),
-            )
-            .expect("static metric descriptor is always valid"),
-            global_queue: Desc::new(
-                "linera_tokio_global_queue_depth".into(),
-                "Number of tasks in the runtime's global injection queue.".into(),
-                vec![],
-                HashMap::new(),
-            )
-            .expect("static metric descriptor is always valid"),
-            busy_seconds: Desc::new(
-                "linera_tokio_worker_busy_seconds_total".into(),
-                "Cumulative time each worker has spent executing tasks, in seconds.".into(),
-                vec!["worker".to_string()],
-                HashMap::new(),
-            )
-            .expect("static metric descriptor is always valid"),
-            parks: Desc::new(
-                "linera_tokio_worker_parks_total".into(),
-                "Cumulative number of times each worker has parked (ran out of work).".into(),
-                vec!["worker".to_string()],
-                HashMap::new(),
-            )
-            .expect("static metric descriptor is always valid"),
-            park_unparks: Desc::new(
-                "linera_tokio_worker_park_unparks_total".into(),
-                "Monotonically increasing count of park and unpark events combined per worker. \
-                 An odd value means the worker is currently parked."
-                    .into(),
-                vec!["worker".to_string()],
-                HashMap::new(),
-            )
-            .expect("static metric descriptor is always valid"),
+            workers,
+            alive_tasks,
+            global_queue,
+            busy_seconds,
+            parks,
+            park_unparks,
         }
     }
 }


### PR DESCRIPTION
## Motivation

Operators need to answer "is the async runtime saturated?" without guessing. Currently there is no visibility into tokio scheduler health — worker utilisation, idle vs. busy ratios, queue depth, or task count.

## Proposal

Add a `TokioRuntimeCollector` that implements `prometheus::core::Collector` and pulls six metrics from tokio's stable `RuntimeMetrics` API on every `/metrics` scrape (pull-on-demand; no background task):

| Metric | Type | Description |
|--------|------|-------------|
| `linera_tokio_workers` | gauge | Number of worker threads |
| `linera_tokio_alive_tasks` | gauge | Number of alive tasks |
| `linera_tokio_global_queue_depth` | gauge | Global injection queue depth |
| `linera_tokio_worker_busy_seconds_total{worker}` | counter | Cumulative busy time per worker |
| `linera_tokio_worker_parks_total{worker}` | counter | Park count per worker |
| `linera_tokio_worker_park_unparks_total{worker}` | counter | Combined park+unpark count per worker (odd → currently parked) |

The three per-worker counters are gated on `#[cfg(target_has_atomic = "64")]` matching tokio's own gate — **no `tokio_unstable` flag required**.

`TokioRuntimeCollector::register()` is called once (via `OnceLock`) at the top of `start_metrics()`, so every binary that already exposes `/metrics` — `linera-server`, `linera-proxy`, and any future server — gets these for free with no per-binary changes.

The key derived metric for dashboards is:

```
rate(linera_tokio_worker_busy_seconds_total[1m])
```

A value near 1.0 on any worker means that thread is saturated.

## Test Plan

Built with `--features metrics` and ran a local single-validator network:

```
cargo build -p linera-service --bin linera-server --bin linera-proxy --bin linera --features metrics
linera net up --validators 1 --shards 1
curl -s http://127.0.0.1:11001/metrics | grep linera_tokio  # shard
curl -s http://127.0.0.1:12001/metrics | grep linera_tokio  # proxy
```

All 6 metric families present with real values on both endpoints. The collector contains no logic beyond atomic reads and proto construction; there is no unit-testable behaviour.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)