### PR TITLE
Retry transient ScyllaDB read errors instead of failing the operation

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -11,11 +11,13 @@ use std::{
     collections::{BTreeSet, HashMap},
     ops::Deref,
     sync::Arc,
+    time::Duration,
 };
 
 use async_lock::{Semaphore, SemaphoreGuard};
 use futures::{future::join_all, StreamExt as _};
 use linera_base::{ensure, util::future::FutureSyncExt as _};
+use rand::Rng as _;
 use scylla::{
     client::{
         execution_profile::{ExecutionProfile, ExecutionProfileHandle},
@@ -36,6 +38,25 @@ use scylla::{
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::register_int_counter;
+    use prometheus::IntCounter;
+
+    /// Total retries triggered by transient ScyllaDB read errors.
+    /// Spikes here correlate with chain worker save failures (and previously,
+    /// poisoning storms) — a non-zero baseline is normal under load; rapid
+    /// growth means the cluster is past its read budget.
+    pub static SCYLLA_READ_RETRY_COUNT: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "scylla_read_retry_count",
+            "Number of ScyllaDB read operations retried due to transient overload",
+        )
+    });
+}
 
 #[cfg(with_metrics)]
 use crate::metering::MeteredDatabase;
@@ -115,6 +136,92 @@ struct ScyllaDbClient {
     find_key_values_by_prefix_bounded: PreparedStatement,
     multi_key_values: papaya::HashMap<usize, PreparedStatement>,
     multi_keys: papaya::HashMap<usize, PreparedStatement>,
+}
+
+/// Maximum number of attempts (initial + retries) before propagating a transient
+/// ScyllaDB read error. Reads are idempotent and safe to retry; the driver's
+/// `DefaultRetryPolicy` already retries once at the coordinator level, so this
+/// counts attempts *we* perform, with our own exponential backoff and jitter.
+const READ_MAX_ATTEMPTS: u32 = 6;
+/// Base delay (milliseconds) for the first retry. Each subsequent retry doubles
+/// the base until `READ_BACKOFF_MAX_MS`; the actual delay is uniformly sampled
+/// from `[0, base]` (full jitter) to avoid thundering-herd reconvergence after a
+/// shared overload event.
+const READ_BACKOFF_BASE_MS: u64 = 50;
+/// Cap on the per-retry backoff. With six attempts and a 50ms base, total
+/// worst-case wait is bounded near a few seconds — well above the proxy timeout,
+/// but far below the multi-minute poisoning loops that prompted this retry.
+const READ_BACKOFF_MAX_MS: u64 = 1600;
+
+/// Walks the error's `source()` chain and returns the first `DbError` found, if any.
+/// Errors from the ScyllaDB driver layer nest the `DbError` several levels deep
+/// (e.g. `PagerExecutionError → NextPageError → RequestFailure → LastAttemptError → DbError`),
+/// and the exact nesting varies by call site (`execute_iter` vs `execute_single_page`).
+/// Walking the chain is more robust than matching every possible enum path.
+fn extract_db_error<'a>(error: &'a (dyn std::error::Error + 'static)) -> Option<&'a DbError> {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(err) = current {
+        if let Some(db_error) = err.downcast_ref::<DbError>() {
+            return Some(db_error);
+        }
+        current = err.source();
+    }
+    None
+}
+
+/// True if this error indicates transient ScyllaDB overload that is safe to retry
+/// for a read operation. Reads have no observable side effects, so retrying on
+/// any timeout / overload signal is sound.
+fn is_retryable_read_error(error: &ScyllaDbStoreInternalError) -> bool {
+    let Some(db_error) = extract_db_error(error) else {
+        return false;
+    };
+    matches!(
+        db_error,
+        DbError::ReadTimeout { .. }
+            | DbError::Overloaded
+            | DbError::ServerError
+            | DbError::IsBootstrapping
+            | DbError::TruncateError,
+    )
+}
+
+/// Runs `operation` with retries on transient ScyllaDB overload signals. Each
+/// retry waits a uniformly-sampled delay in `[0, base]` milliseconds (full
+/// jitter) where `base` doubles per attempt, capped at `READ_BACKOFF_MAX_MS`.
+/// Non-retryable errors and successful results are returned immediately.
+async fn retry_read<F, Fut, T>(mut operation: F) -> Result<T, ScyllaDbStoreInternalError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, ScyllaDbStoreInternalError>>,
+{
+    let mut attempt: u32 = 0;
+    loop {
+        attempt += 1;
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                if attempt >= READ_MAX_ATTEMPTS || !is_retryable_read_error(&error) {
+                    return Err(error);
+                }
+                let exponent = attempt - 1;
+                let base_ms = READ_BACKOFF_BASE_MS
+                    .saturating_mul(1u64 << exponent.min(16))
+                    .min(READ_BACKOFF_MAX_MS);
+                let jittered_ms = rand::thread_rng().gen_range(0..=base_ms);
+                #[cfg(with_metrics)]
+                metrics::SCYLLA_READ_RETRY_COUNT.inc();
+                tracing::warn!(
+                    attempt,
+                    max_attempts = READ_MAX_ATTEMPTS,
+                    delay_ms = jittered_ms,
+                    error = %error,
+                    "Retrying transient ScyllaDB read error",
+                );
+                linera_base::time::timer::sleep(Duration::from_millis(jittered_ms)).await;
+            }
+        }
+    }
 }
 
 impl ScyllaDbClient {
@@ -303,19 +410,20 @@ impl ScyllaDbClient {
         key: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, ScyllaDbStoreInternalError> {
         Self::check_key_size(&key)?;
-        let session = &self.session;
-        // Read the value of a key
         let values = (root_key.to_vec(), key);
-
-        let (result, _) = session
-            .execute_single_page(&self.read_value, &values, PagingState::start())
-            .await?;
-        let rows = result.into_rows_result()?;
-        let mut rows = rows.rows::<(Vec<u8>,)>()?;
-        Ok(match rows.next() {
-            Some(row) => Some(row?.0),
-            None => None,
+        retry_read(|| async {
+            let (result, _) = self
+                .session
+                .execute_single_page(&self.read_value, &values, PagingState::start())
+                .await?;
+            let rows = result.into_rows_result()?;
+            let mut rows = rows.rows::<(Vec<u8>,)>()?;
+            Ok(match rows.next() {
+                Some(row) => Some(row?.0),
+                None => None,
+            })
         })
+        .await
     }
 
     fn get_occurrences_map(
@@ -334,25 +442,28 @@ impl ScyllaDbClient {
         root_key: &[u8],
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, ScyllaDbStoreInternalError> {
-        let mut values = vec![None; keys.len()];
+        let num_keys = keys.len();
         let map = Self::get_occurrences_map(keys)?;
         let statement = self.get_multi_key_values_statement(map.len()).await?;
         let mut inputs = vec![root_key.to_vec()];
         inputs.extend(map.keys().cloned());
-        let mut rows = Box::pin(self.session.execute_iter(statement, &inputs))
-            .await?
-            .rows_stream::<(Vec<u8>, Vec<u8>)>()?;
-
-        while let Some(row) = rows.next().await {
-            let (key, value) = row?;
-            if let Some((&last, rest)) = map[&key].split_last() {
-                for position in rest {
-                    values[*position] = Some(value.clone());
+        retry_read(|| async {
+            let mut values = vec![None; num_keys];
+            let mut rows = Box::pin(self.session.execute_iter(statement.clone(), &inputs))
+                .await?
+                .rows_stream::<(Vec<u8>, Vec<u8>)>()?;
+            while let Some(row) = rows.next().await {
+                let (key, value) = row?;
+                if let Some((&last, rest)) = map[&key].split_last() {
+                    for position in rest {
+                        values[*position] = Some(value.clone());
+                    }
+                    values[last] = Some(value);
                 }
-                values[last] = Some(value);
             }
-        }
-        Ok(values)
+            Ok(values)
+        })
+        .await
     }
 
     async fn contains_keys_internal(
@@ -360,23 +471,25 @@ impl ScyllaDbClient {
         root_key: &[u8],
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<bool>, ScyllaDbStoreInternalError> {
-        let mut values = vec![false; keys.len()];
+        let num_keys = keys.len();
         let map = Self::get_occurrences_map(keys)?;
         let statement = self.get_multi_keys_statement(map.len()).await?;
         let mut inputs = vec![root_key.to_vec()];
         inputs.extend(map.keys().cloned());
-        let mut rows = Box::pin(self.session.execute_iter(statement, &inputs))
-            .await?
-            .rows_stream::<(Vec<u8>,)>()?;
-
-        while let Some(row) = rows.next().await {
-            let (key,) = row?;
-            for i_key in &map[&key] {
-                values[*i_key] = true;
+        retry_read(|| async {
+            let mut values = vec![false; num_keys];
+            let mut rows = Box::pin(self.session.execute_iter(statement.clone(), &inputs))
+                .await?
+                .rows_stream::<(Vec<u8>,)>()?;
+            while let Some(row) = rows.next().await {
+                let (key,) = row?;
+                for i_key in &map[&key] {
+                    values[*i_key] = true;
+                }
             }
-        }
-
-        Ok(values)
+            Ok(values)
+        })
+        .await
     }
 
     async fn contains_key_internal(
@@ -385,16 +498,17 @@ impl ScyllaDbClient {
         key: Vec<u8>,
     ) -> Result<bool, ScyllaDbStoreInternalError> {
         Self::check_key_size(&key)?;
-        let session = &self.session;
-        // Read the value of a key
         let values = (root_key.to_vec(), key);
-
-        let (result, _) = session
-            .execute_single_page(&self.contains_key, &values, PagingState::start())
-            .await?;
-        let rows = result.into_rows_result()?;
-        let mut rows = rows.rows::<(Vec<u8>,)>()?;
-        Ok(rows.next().is_some())
+        retry_read(|| async {
+            let (result, _) = self
+                .session
+                .execute_single_page(&self.contains_key, &values, PagingState::start())
+                .await?;
+            let rows = result.into_rows_result()?;
+            let mut rows = rows.rows::<(Vec<u8>,)>()?;
+            Ok(rows.next().is_some())
+        })
+        .await
     }
 
     async fn write_batch_internal(
@@ -448,29 +562,37 @@ impl ScyllaDbClient {
         key_prefix: Vec<u8>,
     ) -> Result<Vec<Vec<u8>>, ScyllaDbStoreInternalError> {
         Self::check_key_size(&key_prefix)?;
-        let session = &self.session;
-        // Read the value of a key
         let len = key_prefix.len();
-        let query_unbounded = &self.find_keys_by_prefix_unbounded;
-        let query_bounded = &self.find_keys_by_prefix_bounded;
-        let rows = match get_upper_bound_option(&key_prefix) {
-            None => {
-                let values = (root_key.to_vec(), key_prefix.clone());
-                Box::pin(session.execute_iter(query_unbounded.clone(), values)).await?
+        let upper_bound = get_upper_bound_option(&key_prefix);
+        retry_read(|| async {
+            let rows = match &upper_bound {
+                None => {
+                    let values = (root_key.to_vec(), key_prefix.clone());
+                    Box::pin(
+                        self.session
+                            .execute_iter(self.find_keys_by_prefix_unbounded.clone(), values),
+                    )
+                    .await?
+                }
+                Some(upper_bound) => {
+                    let values = (root_key.to_vec(), key_prefix.clone(), upper_bound.clone());
+                    Box::pin(
+                        self.session
+                            .execute_iter(self.find_keys_by_prefix_bounded.clone(), values),
+                    )
+                    .await?
+                }
+            };
+            let mut rows = rows.rows_stream::<(Vec<u8>,)>()?;
+            let mut keys = Vec::new();
+            while let Some(row) = rows.next().await {
+                let (key,) = row?;
+                let short_key = key[len..].to_vec();
+                keys.push(short_key);
             }
-            Some(upper_bound) => {
-                let values = (root_key.to_vec(), key_prefix.clone(), upper_bound);
-                Box::pin(session.execute_iter(query_bounded.clone(), values)).await?
-            }
-        };
-        let mut rows = rows.rows_stream::<(Vec<u8>,)>()?;
-        let mut keys = Vec::new();
-        while let Some(row) = rows.next().await {
-            let (key,) = row?;
-            let short_key = key[len..].to_vec();
-            keys.push(short_key);
-        }
-        Ok(keys)
+            Ok(keys)
+        })
+        .await
     }
 
     async fn find_key_values_by_prefix_internal(
@@ -479,29 +601,37 @@ impl ScyllaDbClient {
         key_prefix: Vec<u8>,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ScyllaDbStoreInternalError> {
         Self::check_key_size(&key_prefix)?;
-        let session = &self.session;
-        // Read the value of a key
         let len = key_prefix.len();
-        let query_unbounded = &self.find_key_values_by_prefix_unbounded;
-        let query_bounded = &self.find_key_values_by_prefix_bounded;
-        let rows = match get_upper_bound_option(&key_prefix) {
-            None => {
-                let values = (root_key.to_vec(), key_prefix.clone());
-                Box::pin(session.execute_iter(query_unbounded.clone(), values)).await?
+        let upper_bound = get_upper_bound_option(&key_prefix);
+        retry_read(|| async {
+            let rows = match &upper_bound {
+                None => {
+                    let values = (root_key.to_vec(), key_prefix.clone());
+                    Box::pin(
+                        self.session
+                            .execute_iter(self.find_key_values_by_prefix_unbounded.clone(), values),
+                    )
+                    .await?
+                }
+                Some(upper_bound) => {
+                    let values = (root_key.to_vec(), key_prefix.clone(), upper_bound.clone());
+                    Box::pin(
+                        self.session
+                            .execute_iter(self.find_key_values_by_prefix_bounded.clone(), values),
+                    )
+                    .await?
+                }
+            };
+            let mut rows = rows.rows_stream::<(Vec<u8>, Vec<u8>)>()?;
+            let mut key_values = Vec::new();
+            while let Some(row) = rows.next().await {
+                let (key, value) = row?;
+                let short_key = key[len..].to_vec();
+                key_values.push((short_key, value));
             }
-            Some(upper_bound) => {
-                let values = (root_key.to_vec(), key_prefix.clone(), upper_bound);
-                Box::pin(session.execute_iter(query_bounded.clone(), values)).await?
-            }
-        };
-        let mut rows = rows.rows_stream::<(Vec<u8>, Vec<u8>)>()?;
-        let mut key_values = Vec::new();
-        while let Some(row) = rows.next().await {
-            let (key, value) = row?;
-            let short_key = key[len..].to_vec();
-            key_values.push((short_key, value));
-        }
-        Ok(key_values)
+            Ok(key_values)
+        })
+        .await
     }
 }
 

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -142,15 +142,20 @@ struct ScyllaDbClient {
 /// ScyllaDB read error. Reads are idempotent and safe to retry; the driver's
 /// `DefaultRetryPolicy` already retries once at the coordinator level, so this
 /// counts attempts *we* perform, with our own exponential backoff and jitter.
-const READ_MAX_ATTEMPTS: u32 = 6;
+/// Eight attempts give the last retry ceiling up to 640ms, which covers most
+/// short-to-medium overload patterns (compaction blips, queue saturation, GC
+/// pauses across replicas) while keeping total worst-case wait (~1.3s) well
+/// below the upstream proxy timeout.
+const READ_MAX_ATTEMPTS: u32 = 8;
 /// Base delay (milliseconds) for the first retry. Each subsequent retry doubles
 /// the base until `READ_BACKOFF_MAX_MS`; the actual delay is uniformly sampled
 /// from `[0, base]` (full jitter) to avoid thundering-herd reconvergence after a
-/// shared overload event.
-const READ_BACKOFF_BASE_MS: u64 = 50;
-/// Cap on the per-retry backoff. With six attempts and a 50ms base, total
-/// worst-case wait is bounded near a few seconds — well above the proxy timeout,
-/// but far below the multi-minute poisoning loops that prompted this retry.
+/// shared overload event. Kept small so the first retries fire quickly on brief
+/// blips and we don't eat into the upstream proxy timeout budget unnecessarily.
+const READ_BACKOFF_BASE_MS: u64 = 10;
+/// Cap on the per-retry backoff. Eight attempts at a 10ms base never hit this
+/// cap (640ms ceiling on the last retry), but the constant is preserved as a
+/// safety net for future bumps to `READ_MAX_ATTEMPTS`.
 const READ_BACKOFF_MAX_MS: u64 = 1600;
 
 /// Walks the error's `source()` chain and returns the first `DbError` found, if any.


### PR DESCRIPTION
## Motivation

Today's pm-app rolling release (linera-infra PR #1163, 2026-05-15) triggered a sustained ScyllaDB read latency spike across all four testnet_conway validators (~280–330 MB/s for ~10 minutes, with worker poisoning logs starting ~60s before the disk read spike). This was the same failure mode the team has been chasing since PR #1041 (May 4): a feedback loop where worker restart retries hit cold validator chain workers, cold-load timeouts poison the workers, eviction triggers more cold loads, and so on.

Investigating the live error revealed:

\`\`\`
Chain save failed; marking worker as poisoned
error=StoreError { backend: \"value splitting\",
  error: InnerStoreError(Inner(PagerExecutionError(NextPageError(...
    DbError(ReadTimeout { consistency: LocalQuorum, received: 0, required: 1, data_present: false }, ...)
  )))),
  must_reload_view: false }
\`\`\`

The save path's slow side calls \`expand_delete_prefixes\` (\`linera-views/src/batch.rs:91\`) which does a \`find_keys_by_prefix\` (\`execute_iter\` paged read) **before any write is attempted**. When that read times out, the journaling layer reports \`Inner(...)\` with \`must_reload_view: false\` — i.e. \"the view is fine, nothing was written.\" Nevertheless, PR #6053 (April 19) changed \`ChainWorkerState::save()\` to poison on any save error, so the worker is evicted, the chain cold-loads on next access, and the loop tightens.

A read failure means the cluster is overloaded — it does not mean the data is unrecoverable or that the in-memory view is stale. The expensive paged reads inside the write path's preparation are idempotent and safe to retry transparently at the storage layer.

## Proposal

Adds a small retry helper in \`linera-views/src/backends/scylla_db.rs\` that wraps every read operation (\`read_value_internal\`, \`read_multi_values_internal\`, \`contains_key_internal\`, \`contains_keys_internal\`, \`find_keys_by_prefix_internal\`, \`find_key_values_by_prefix_internal\`) with:

- Up to 6 total attempts (5 retries after the initial call)
- Exponential backoff: 50ms base, doubling per attempt, capped at 1600ms
- Full jitter (\`uniform(0, capped)\`) to avoid thundering-herd reconvergence after a shared overload event
- Retries only on signals the ScyllaDB Rust driver classifies as transient overload: \`DbError::ReadTimeout\`, \`Overloaded\`, \`ServerError\`, \`IsBootstrapping\`, \`TruncateError\`
- Walks the error chain via \`std::error::Error::source()\` to extract the inner \`DbError\` regardless of wrapper layer (\`PagerExecutionError\` for \`execute_iter\`, \`ExecutionError\` for \`execute_single_page\`)

Writes are intentionally not retried at this layer — those have correctness implications (PR #6053's concern) and need separate consideration.

Adds a Prometheus counter \`scylla_read_retry_count\` for observability.

## Test Plan

- \`cargo clippy --all-targets --all-features -- -D warnings\` passes (verified on the full workspace).
- The change is contained to one file and wraps existing read paths without changing their semantics on success. Read operations are idempotent so the retry has no side-effect risk.
- Post-merge / post-backport / post-deploy: a pm-app rolling release should NOT trigger sustained Scylla read latency on validators. Compare:
  - Pre-change reference (this PR's motivation): linera-infra #1163 rollout caused ~280 MB/s sustained disk reads, ~30-60 min recovery.
  - Expected post-change: brief cold-read burst (cache warm-up), but no poisoning loop. Recovery in minutes, not hours.
- Watch the new \`scylla_read_retry_count\` metric — a non-zero baseline is normal under load; rapid growth would indicate that retries are exhausted (which is the case Change 2 below would address).

## Release Plan

- These changes should be backported to the latest \`testnet\` branch, then be released in a validator hotfix.

The testnet_conway validators are currently affected by this issue on every pm-app rolling release; backporting and deploying is the user-visible benefit.

## Links

- Motivating incident: linera-infra #1163 (2026-05-15) — pm-app rolling release caused sustained Scylla spike across all four validators
- Original poisoning-on-any-save-error change: #6053 (April 19, 2026)
- Original issue motivating #6053: #6052 — write timeouts may have partially succeeded, view could be stale. Reads (this PR's scope) do not have that concern.
- First reported worker-restart Scylla incident: #1041 (May 4, 2026, 15 days after #6053 landed)

## Follow-ups (out of scope for this PR)

A second change is worth discussing: in \`ChainWorkerState::save()\`, distinguish read-failure-during-prep (no write attempted) from write-failure (write may have succeeded). Today both poison the worker; only the latter has a correctness reason to do so. This PR reduces the rate of read failures by retrying; a follow-up could make even an exhausted-retries read failure not poison the worker. That keeps the worker loaded and lets the caller back off naturally rather than triggering a cache miss.