### PR TITLE
ci: increase test-crates-and-docrs timeout to 120 minutes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
 
   test-crates-and-docrs:
     runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

The `test-crates-and-docrs` job has been timing out at the current 90-minute limit. Since it runs post-merge on `main` (not on PRs), a longer timeout is acceptable.

## Proposal

Increase `timeout-minutes` from 90 to 120 on the `test-crates-and-docrs` job in `.github/workflows/documentation.yml`.

## Test Plan

CI change only — no functional code modified.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)