### PR TITLE
ci: increase test-crates-and-docrs timeout to 120 minutes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,7 +57,7 @@ jobs:
 
   test-crates-and-docrs:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

The `test-crates-and-docrs` job has been consistently hitting the 90-minute timeout on `testnet_conway` (ubuntu-latest). The `Generate packages` step runs for the full 90 minutes and gets killed. This does not happen on `main`, which uses the self-hosted runner and completes in ~45 minutes.

## Proposal

Increase `timeout-minutes` from 90 to 120 on `test-crates-and-docrs` in `.github/workflows/documentation.yml`.

## Test Plan

CI change only — no functional code modified. Verified by checking recent workflow run durations via the GitHub Actions API: testnet_conway runs consistently show ~5400–5500s (≈90 min) before being cancelled, while main runs finish in ~45 min.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)