### PR TITLE
Add `linera_cache::Arc<T>` newtype enforcing one-allocation-per-content invariant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,14 +70,17 @@ Contributions should generally follow the [Rust API guidelines](https://rust-lan
   unawaited futures or unhandled errors. `let _x =` should only be used for RAII guards.
 
 
-## Hash-consed types and `Arc<T>`
+## Hash-consed types and `linera_cache::Arc<T>`
 
 Any content-addressed immutable data (also known as hash-consed data) — for
 example `Block`, `Blob`, `ConfirmedBlockCertificate` — should be cached and
-passed around as `Arc<T>`.
+passed around as `linera_cache::Arc<T>` (re-exported as `linera_storage::Arc`).
 
-**Never construct `Arc::new(value)` for a hash-consed type.** Always obtain
-the canonical `Arc<T>` from the dedup cache. Concretely:
+`linera_cache::Arc<T>` is a newtype over `std::sync::Arc<T>` with **no public
+constructor**: the only way to obtain one is through `ValueCache::insert`,
+`ValueCache::insert_hashed`, or `ValueCache::get`. This makes the
+"one allocation per content" invariant a compile-time guarantee rather than a
+convention. Concretely:
 
 - For freshly-constructed `ConfirmedBlockCertificate`s (e.g. from network or
   proposal flows), call `Storage::cache_certificate`.
@@ -85,12 +88,11 @@ the canonical `Arc<T>` from the dedup cache. Concretely:
   `Storage::cache_confirmed_block`.
 - For freshly-constructed `Blob`s, call `Storage::cache_blob`.
 - For values being re-inserted from a borrowed reference, use
-  `ValueCache::insert_hashed` or `ValueCache::insert_arc`.
+  `ValueCache::insert_hashed`.
 
-`Arc::new` for a hash-consed value bypasses the dedup index and creates a
-duplicate allocation, breaking the "one allocation per content" invariant.
-See the [`linera-cache` README](linera-cache/README.md) for how the
-invariant is enforced.
+`std::sync::Arc::new` for a hash-consed value bypasses the dedup index and
+creates a duplicate allocation; the type system prevents this by design.
+See the [`linera-cache` README](linera-cache/README.md) for details.
 
 
 ## Formatting and linting

--- a/linera-bridge/src/relay/linera.rs
+++ b/linera-bridge/src/relay/linera.rs
@@ -104,6 +104,7 @@ impl<E: linera_core::environment::Environment> LineraClient<E> {
         self.chain_client
             .read_certificate(hash)
             .await
+            .map(|c| c.into_std())
             .map_err(|e| anyhow::anyhow!(e))
     }
 

--- a/linera-cache/src/arc.rs
+++ b/linera-cache/src/arc.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A provenance-tracking wrapper around [`std::sync::Arc`].
+//!
+//! [`Arc<T>`] is identical to [`std::sync::Arc<T>`] at runtime but has no
+//! public constructor. The only way to obtain one is through
+//! [`ValueCache::insert`], [`ValueCache::insert_hashed`], or
+//! [`ValueCache::get`]. This makes the "one allocation per content" invariant
+//! structurally enforced: callers cannot bypass the cache by calling
+//! `Arc::new` directly.
+
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    sync::Arc as StdArc,
+};
+
+/// A reference-counted pointer that can only be constructed through a
+/// [`crate::ValueCache`].
+///
+/// `Arc<T>` is `#[repr(transparent)]` over [`std::sync::Arc<T>`] and
+/// implements `Deref<Target = T>`, `Clone`, `Debug`, `Display`, `PartialEq`,
+/// `Eq`, and `Hash` identically to [`std::sync::Arc<T>`].
+///
+/// Use [`Arc::into_std`] or [`Arc::as_std`] to interoperate with APIs that
+/// require [`std::sync::Arc<T>`] explicitly.
+#[repr(transparent)]
+pub struct Arc<T>(pub(crate) StdArc<T>);
+
+impl<T> Arc<T> {
+    /// Returns a reference to the underlying [`std::sync::Arc<T>`].
+    pub fn as_std(&self) -> &StdArc<T> {
+        &self.0
+    }
+
+    /// Converts into the underlying [`std::sync::Arc<T>`].
+    pub fn into_std(self) -> StdArc<T> {
+        self.0
+    }
+
+    /// Unwraps the inner value if this is the only strong reference;
+    /// otherwise clones it.
+    pub fn unwrap_or_clone(this: Self) -> T
+    where
+        T: Clone,
+    {
+        StdArc::unwrap_or_clone(this.0)
+    }
+
+    /// Returns `true` if two `Arc`s point to the same allocation.
+    pub fn ptr_eq(a: &Self, b: &Self) -> bool {
+        StdArc::ptr_eq(&a.0, &b.0)
+    }
+}
+
+impl<T> Deref for Arc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> Clone for Arc<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Arc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&*self.0, f)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Arc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&*self.0, f)
+    }
+}
+
+impl<T: PartialEq> PartialEq for Arc<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T: Eq> Eq for Arc<T> {}
+
+impl<T: Hash> Hash for Arc<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> From<Arc<T>> for StdArc<T> {
+    fn from(arc: Arc<T>) -> Self {
+        arc.0
+    }
+}
+
+impl<T> AsRef<StdArc<T>> for Arc<T> {
+    fn as_ref(&self) -> &StdArc<T> {
+        &self.0
+    }
+}

--- a/linera-cache/src/arc.rs
+++ b/linera-cache/src/arc.rs
@@ -20,13 +20,11 @@ use std::{
 /// A reference-counted pointer that can only be constructed through a
 /// [`crate::ValueCache`].
 ///
-/// `Arc<T>` is `#[repr(transparent)]` over [`std::sync::Arc<T>`] and
-/// implements `Deref<Target = T>`, `Clone`, `Debug`, `Display`, `PartialEq`,
-/// `Eq`, and `Hash` identically to [`std::sync::Arc<T>`].
+/// `Arc<T>` wraps [`std::sync::Arc<T>`] and implements `Deref<Target = T>`,
+/// `Clone`, `Debug`, `Display`, `PartialEq`, `Eq`, and `Hash` identically.
 ///
 /// Use [`Arc::into_std`] or [`Arc::as_std`] to interoperate with APIs that
 /// require [`std::sync::Arc<T>`] explicitly.
-#[repr(transparent)]
 pub struct Arc<T>(pub(crate) StdArc<T>);
 
 impl<T> Arc<T> {

--- a/linera-cache/src/lib.rs
+++ b/linera-cache/src/lib.rs
@@ -23,9 +23,9 @@
 //! prevent unbounded growth.
 //!
 //! For the invariant to hold, all inserts of hash-consed values must go
-//! through the cache (e.g. [`ValueCache::insert_hashed`] or
-//! [`ValueCache::insert_arc`]). Constructing an `Arc::new(value)` off-path
-//! creates a duplicate allocation that bypasses the dedup index.
+//! through the cache (e.g. [`ValueCache::insert`] or [`ValueCache::insert_hashed`]).
+//! The [`Arc`] newtype enforces this structurally: it has no public constructor,
+//! so callers cannot bypass the cache by calling `std::sync::Arc::new` directly.
 
 mod arc;
 mod unique_value_cache;

--- a/linera-cache/src/lib.rs
+++ b/linera-cache/src/lib.rs
@@ -27,8 +27,10 @@
 //! [`ValueCache::insert_arc`]). Constructing an `Arc::new(value)` off-path
 //! creates a duplicate allocation that bypasses the dedup index.
 
+mod arc;
 mod unique_value_cache;
 mod value_cache;
 
+pub use arc::Arc;
 pub use unique_value_cache::UniqueValueCache;
 pub use value_cache::{ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -34,7 +34,7 @@ pub const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 30;
 /// A background task periodically sweeps dead `Weak` entries from the index
 /// to prevent unbounded memory growth.
 pub struct ValueCache<K, V> {
-    cache: Cache<K, Arc<V>>,
+    cache: Cache<K, crate::Arc<V>>,
     weak_index: Arc<papaya::HashMap<K, Weak<V>>>,
 }
 
@@ -73,7 +73,7 @@ where
     /// already exists (held by another consumer), the existing allocation is
     /// reused and the new value is dropped.
     pub fn insert(&self, key: &K, value: V) -> crate::Arc<V> {
-        crate::Arc(self.dedup_insert(key, Arc::new(value)))
+        self.dedup_insert(key, crate::Arc(Arc::new(value)))
     }
 
     /// Removes a value from the bounded cache.
@@ -87,7 +87,7 @@ where
         if value.is_some() {
             self.cache.remove(key);
         }
-        Self::track_cache_usage(value).map(crate::Arc)
+        Self::track_cache_usage(value)
     }
 
     /// Returns an [`crate::Arc`] to the value, checking both the bounded
@@ -95,20 +95,21 @@ where
     pub fn get(&self, key: &K) -> Option<crate::Arc<V>> {
         // Tier 1: bounded cache (hot path)
         if let Some(arc) = self.cache.get(key) {
-            return Self::track_cache_usage(Some(arc)).map(crate::Arc);
+            return Self::track_cache_usage(Some(arc));
         }
 
         // Tier 2: weak index (catches evicted-but-still-held entries)
         let guard = self.weak_index.guard();
         if let Some(weak) = self.weak_index.get(key, &guard) {
             if let Some(arc) = weak.upgrade() {
+                let arc = crate::Arc(arc);
                 // Re-insert into bounded cache for future fast lookups
                 self.cache.insert(key.clone(), arc.clone());
-                return Self::track_cache_usage(Some(arc)).map(crate::Arc);
+                return Self::track_cache_usage(Some(arc));
             }
         }
 
-        Self::track_cache_usage(None).map(crate::Arc)
+        Self::track_cache_usage(None)
     }
 
     /// Returns `true` if the value exists in either the bounded cache or
@@ -155,9 +156,9 @@ where
     /// Core dedup logic: atomically checks the weak index for an existing
     /// live allocation. If found, reuses it. Otherwise inserts the new Arc.
     /// Returns the canonical `Arc`.
-    fn dedup_insert(&self, key: &K, new_arc: Arc<V>) -> Arc<V> {
+    fn dedup_insert(&self, key: &K, new_arc: crate::Arc<V>) -> crate::Arc<V> {
         let guard = self.weak_index.guard();
-        let weak = Arc::downgrade(&new_arc);
+        let weak = Arc::downgrade(&new_arc.0);
 
         let result = self.weak_index.compute(
             key.clone(),
@@ -173,7 +174,7 @@ where
 
         let canonical_arc = match result {
             Compute::Inserted(..) | Compute::Updated { .. } => new_arc,
-            Compute::Aborted(existing_arc) => existing_arc,
+            Compute::Aborted(existing_arc) => crate::Arc(existing_arc),
             _ => unreachable!(),
         };
 
@@ -181,7 +182,7 @@ where
         canonical_arc
     }
 
-    fn track_cache_usage(maybe_value: Option<Arc<V>>) -> Option<Arc<V>> {
+    fn track_cache_usage(maybe_value: Option<crate::Arc<V>>) -> Option<crate::Arc<V>> {
         #[cfg(with_metrics)]
         {
             let metric = if maybe_value.is_some() {
@@ -212,18 +213,19 @@ impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
         let hash = (*value).hash();
         // Fast path: already in bounded cache
         if let Some(arc) = self.cache.peek(&hash) {
-            return crate::Arc(arc);
+            return arc;
         }
         // Check weak index before cloning from Cow
         let guard = self.weak_index.guard();
         if let Some(weak) = self.weak_index.get(&hash, &guard) {
             if let Some(arc) = weak.upgrade() {
+                let arc = crate::Arc(arc);
                 self.cache.insert(hash, arc.clone());
-                return crate::Arc(arc);
+                return arc;
             }
         }
         drop(guard);
-        crate::Arc(self.dedup_insert(&hash, Arc::new(value.into_owned().into())))
+        self.dedup_insert(&hash, crate::Arc(Arc::new(value.into_owned().into())))
     }
 
     /// Inserts multiple values constructed from [`Hashed<T>`]s into the cache.

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -67,18 +67,13 @@ where
         }
     }
 
-    /// Inserts a value into the cache, returning the canonical `Arc`.
+    /// Inserts a value into the cache, returning the canonical [`crate::Arc`].
     ///
     /// The value is wrapped in `Arc` internally. If a live `Arc` for this key
     /// already exists (held by another consumer), the existing allocation is
     /// reused and the new value is dropped.
-    pub fn insert(&self, key: &K, value: V) -> Arc<V> {
-        self.dedup_insert(key, Arc::new(value))
-    }
-
-    /// Inserts a pre-wrapped `Arc<V>` into the cache, returning the canonical `Arc`.
-    pub fn insert_arc(&self, key: &K, value: Arc<V>) -> Arc<V> {
-        self.dedup_insert(key, value)
+    pub fn insert(&self, key: &K, value: V) -> crate::Arc<V> {
+        crate::Arc(self.dedup_insert(key, Arc::new(value)))
     }
 
     /// Removes a value from the bounded cache.
@@ -87,20 +82,20 @@ where
     /// still hold an `Arc` to this value, and the weak index must be able
     /// to deduplicate against it. Dead weak entries are cleaned up by the
     /// background task.
-    pub fn remove(&self, key: &K) -> Option<Arc<V>> {
+    pub fn remove(&self, key: &K) -> Option<crate::Arc<V>> {
         let value = self.cache.peek(key);
         if value.is_some() {
             self.cache.remove(key);
         }
-        Self::track_cache_usage(value)
+        Self::track_cache_usage(value).map(crate::Arc)
     }
 
-    /// Returns an `Arc` reference to the value, checking both the bounded
+    /// Returns an [`crate::Arc`] to the value, checking both the bounded
     /// cache and the weak index.
-    pub fn get(&self, key: &K) -> Option<Arc<V>> {
+    pub fn get(&self, key: &K) -> Option<crate::Arc<V>> {
         // Tier 1: bounded cache (hot path)
         if let Some(arc) = self.cache.get(key) {
-            return Self::track_cache_usage(Some(arc));
+            return Self::track_cache_usage(Some(arc)).map(crate::Arc);
         }
 
         // Tier 2: weak index (catches evicted-but-still-held entries)
@@ -109,11 +104,11 @@ where
             if let Some(arc) = weak.upgrade() {
                 // Re-insert into bounded cache for future fast lookups
                 self.cache.insert(key.clone(), arc.clone());
-                return Self::track_cache_usage(Some(arc));
+                return Self::track_cache_usage(Some(arc)).map(crate::Arc);
             }
         }
 
-        Self::track_cache_usage(None)
+        Self::track_cache_usage(None).map(crate::Arc)
     }
 
     /// Returns `true` if the value exists in either the bounded cache or
@@ -209,7 +204,7 @@ impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
     ///
     /// The `value` is wrapped in a [`Cow`] so that it is only cloned if it
     /// needs to be inserted in the cache.
-    pub fn insert_hashed<T>(&self, value: Cow<Hashed<T>>) -> Arc<V>
+    pub fn insert_hashed<T>(&self, value: Cow<Hashed<T>>) -> crate::Arc<V>
     where
         T: Clone,
         V: From<Hashed<T>>,
@@ -217,18 +212,18 @@ impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
         let hash = (*value).hash();
         // Fast path: already in bounded cache
         if let Some(arc) = self.cache.peek(&hash) {
-            return arc;
+            return crate::Arc(arc);
         }
         // Check weak index before cloning from Cow
         let guard = self.weak_index.guard();
         if let Some(weak) = self.weak_index.get(&hash, &guard) {
             if let Some(arc) = weak.upgrade() {
                 self.cache.insert(hash, arc.clone());
-                return arc;
+                return crate::Arc(arc);
             }
         }
         drop(guard);
-        self.dedup_insert(&hash, Arc::new(value.into_owned().into()))
+        crate::Arc(self.dedup_insert(&hash, Arc::new(value.into_owned().into())))
     }
 
     /// Inserts multiple values constructed from [`Hashed<T>`]s into the cache.
@@ -270,12 +265,13 @@ mod metrics {
 
 #[cfg(test)]
 mod tests {
-    use std::{borrow::Cow, sync::Arc};
+    use std::borrow::Cow;
 
     use linera_base::{crypto::CryptoHash, hashed::Hashed};
     use serde::{Deserialize, Serialize};
 
     use super::{ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
+    use crate::Arc as CacheArc;
 
     /// Test cache size for unit tests.
     const TEST_CACHE_SIZE: usize = 10;
@@ -364,7 +360,7 @@ mod tests {
         // Re-inserting should return the same Arc (dedup)
         for (value, first_arc) in values.iter().zip(&first_arcs) {
             let second_arc = cache.insert_hashed(Cow::Borrowed(value));
-            assert!(Arc::ptr_eq(&second_arc, first_arc));
+            assert!(CacheArc::ptr_eq(&second_arc, first_arc));
         }
     }
 
@@ -415,7 +411,7 @@ mod tests {
 
         let first = cache.insert_hashed(Cow::Borrowed(&promoted));
         let second = cache.insert_hashed(Cow::Borrowed(&promoted));
-        assert!(Arc::ptr_eq(&first, &second));
+        assert!(CacheArc::ptr_eq(&first, &second));
 
         let extras = create_test_values(1..=TEST_CACHE_SIZE as u64 * 2);
         for value in &extras {
@@ -445,13 +441,13 @@ mod tests {
             .get(&1)
             .expect("held Arc should keep entry findable via weak index");
         assert!(
-            Arc::ptr_eq(&retrieved, &held),
+            CacheArc::ptr_eq(&retrieved, &held),
             "must return same allocation, not a duplicate"
         );
 
         // Re-inserting should also return the same Arc
         let reinserted = cache.insert(&1, "replacement".to_string());
-        assert!(Arc::ptr_eq(&reinserted, &held));
+        assert!(CacheArc::ptr_eq(&reinserted, &held));
         assert_eq!(&*reinserted, "hello");
     }
 
@@ -466,7 +462,7 @@ mod tests {
 
         // Still findable via weak index since we hold an Arc
         let retrieved = cache.get(&1).expect("weak index should find held Arc");
-        assert!(Arc::ptr_eq(&retrieved, &held));
+        assert!(CacheArc::ptr_eq(&retrieved, &held));
     }
 
     #[test]
@@ -500,19 +496,5 @@ mod tests {
 
         // Key 1 still findable (we hold an Arc)
         assert!(cache.contains(&1));
-    }
-
-    #[test]
-    fn test_insert_arc_dedup() {
-        let cache = new_string_cache(TEST_CACHE_SIZE);
-        let value = Arc::new("hello".to_string());
-
-        let first = cache.insert_arc(&1, value.clone());
-        assert!(Arc::ptr_eq(&first, &value));
-
-        let second = cache.insert_arc(&1, Arc::new("other".to_string()));
-        assert!(Arc::ptr_eq(&second, &value));
-
-        assert_eq!(&*cache.get(&1).expect("just inserted"), "hello");
     }
 }

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -24,7 +24,7 @@ use linera_core::{
     worker::{Notification, Reason},
     Environment, Wallet,
 };
-use linera_storage::Storage as _;
+use linera_storage::{Arc as CacheArc, Storage as _};
 use tokio::sync::{mpsc::UnboundedReceiver, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
@@ -408,7 +408,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
     /// add them to the wallet and start listening for notifications. (This is not done for
     /// fallback owners, as those would have to monitor all chains anyway.)
     async fn add_new_chains(&mut self, hash: CryptoHash) -> Result<(), Error> {
-        let block = Arc::unwrap_or_clone(
+        let block = CacheArc::unwrap_or_clone(
             self.storage
                 .read_confirmed_block(hash)
                 .await?

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -21,7 +21,7 @@ use linera_base::{
     ensure,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
 };
-use linera_cache::{UniqueValueCache, ValueCache};
+use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache};
 use linera_chain::{
     data_types::{
         BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
@@ -321,7 +321,7 @@ where
     pub(crate) async fn download_pending_blob(
         &self,
         blob_id: BlobId,
-    ) -> Result<Arc<Blob>, WorkerError> {
+    ) -> Result<CacheArc<Blob>, WorkerError> {
         if let Some(blob) = self.chain.manager.pending_blob(&blob_id).await? {
             return Ok(self.storage.cache_blob(blob));
         }
@@ -414,7 +414,7 @@ where
         let (missing_indices, missing_blob_ids) = missing_indices_blob_ids(&maybe_blobs);
         let fourth_block_blobs = self.storage.read_blobs(&missing_blob_ids).await?;
         for (index, blob) in missing_indices.into_iter().zip(fourth_block_blobs) {
-            maybe_blobs[index].1 = blob.map(Arc::unwrap_or_clone);
+            maybe_blobs[index].1 = blob.map(CacheArc::unwrap_or_clone);
         }
         Ok(maybe_blobs.into_iter().collect())
     }
@@ -491,7 +491,7 @@ where
     async fn read_confirmed_blocks(
         &self,
         hashes: &[CryptoHash],
-    ) -> Result<Vec<Option<Arc<ConfirmedBlock>>>, WorkerError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlock>>>, WorkerError> {
         let mut blocks = Vec::with_capacity(hashes.len());
         let mut uncached_indices = Vec::new();
         let mut uncached_hashes = Vec::new();
@@ -1511,7 +1511,7 @@ where
                 .storage
                 .read_certificate(hash)
                 .await?
-                .map(Arc::unwrap_or_clone)
+                .map(CacheArc::unwrap_or_clone)
                 .ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
             Box::pin(self.process_confirmed_block(cert, None)).await?;
         }
@@ -1851,7 +1851,7 @@ where
     pub(crate) async fn read_certificate(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, WorkerError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, WorkerError> {
         let certificate_hash = match self.chain.block_hashes.get(&height).await? {
             Some(hash) => hash,
             None => return Ok(None),

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -3319,7 +3319,10 @@ impl<Env: Environment> ChainClient<Env> {
                 .collect();
             remote_node.upload_blobs(missing_blobs).await?;
             remote_node
-                .handle_confirmed_certificate(certificate.into_std(), CrossChainMessageDelivery::NonBlocking)
+                .handle_confirmed_certificate(
+                    certificate.into_std(),
+                    CrossChainMessageDelivery::NonBlocking,
+                )
                 .await?;
         }
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -53,7 +53,7 @@ use linera_execution::{
     },
     ExecutionError, Operation, Query, QueryOutcome,
 };
-use linera_storage::{Clock as _, Storage as _};
+use linera_storage::{Arc as CacheArc, Clock as _, Storage as _};
 use linera_views::ViewError;
 use serde::Serialize;
 pub use state::State;
@@ -2078,11 +2078,11 @@ impl<Env: Environment> ChainClient<Env> {
         );
         debug!(round = %certificate.round, "Sending confirmed block to validators");
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        self.update_validators(Some(&committee), Some(certificate.clone()))
+        self.update_validators(Some(&committee), Some(certificate.as_std().clone()))
             .await?;
         // Clear the pending proposal now that the block has been committed.
         *proposal_guard = None;
-        Ok(ClientOutcome::Committed(Some(Arc::unwrap_or_clone(
+        Ok(ClientOutcome::Committed(Some(CacheArc::unwrap_or_clone(
             certificate,
         ))))
     }
@@ -2142,9 +2142,9 @@ impl<Env: Environment> ChainClient<Env> {
             .finalize_block(&committee, certificate.clone())
             .await?;
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        self.update_validators(Some(&committee), Some(certificate.clone()))
+        self.update_validators(Some(&committee), Some(certificate.as_std().clone()))
             .await?;
-        Ok(ClientOutcome::Committed(Some(Arc::unwrap_or_clone(
+        Ok(ClientOutcome::Committed(Some(CacheArc::unwrap_or_clone(
             certificate,
         ))))
     }
@@ -2783,6 +2783,7 @@ impl<Env: Environment> ChainClient<Env> {
             .read_confirmed_block(hash)
             .await?
             .ok_or(Error::MissingConfirmedBlock(hash))
+            .map(|b| b.into_std())
     }
 
     #[instrument(level = "trace", skip(hash))]
@@ -2795,6 +2796,7 @@ impl<Env: Environment> ChainClient<Env> {
             .read_certificate(hash)
             .await?
             .ok_or(Error::ReadCertificatesError(vec![hash]))
+            .map(|c| c.into_std())
     }
 
     /// Handles any cross-chain requests for any pending outgoing messages.
@@ -3295,7 +3297,7 @@ impl<Env: Environment> ChainClient<Env> {
         for certificate in certificates {
             let missing_blob_ids = match remote_node
                 .handle_confirmed_certificate(
-                    certificate.clone(),
+                    certificate.as_std().clone(),
                     CrossChainMessageDelivery::NonBlocking,
                 )
                 .await
@@ -3313,10 +3315,11 @@ impl<Env: Environment> ChainClient<Env> {
                 .await?
                 .into_iter()
                 .flatten()
+                .map(|b| b.into_std())
                 .collect();
             remote_node.upload_blobs(missing_blobs).await?;
             remote_node
-                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
+                .handle_confirmed_certificate(certificate.into_std(), CrossChainMessageDelivery::NonBlocking)
                 .await?;
         }
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -818,7 +818,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn update_validators(
         &self,
         old_committee: Option<&Committee>,
-        latest_certificate: Option<Arc<ConfirmedBlockCertificate>>,
+        latest_certificate: Option<CacheArc<ConfirmedBlockCertificate>>,
     ) -> Result<(), Error> {
         let update_validators_start = linera_base::time::Instant::now();
         // Communicate the new certificate now.
@@ -843,7 +843,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn communicate_chain_updates(
         &self,
         committee: &Committee,
-        latest_certificate: Option<Arc<ConfirmedBlockCertificate>>,
+        latest_certificate: Option<CacheArc<ConfirmedBlockCertificate>>,
     ) -> Result<(), Error> {
         let delivery = self.options.cross_chain_message_delivery;
         let height = self.chain_info().await?.next_block_height;
@@ -2078,7 +2078,7 @@ impl<Env: Environment> ChainClient<Env> {
         );
         debug!(round = %certificate.round, "Sending confirmed block to validators");
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        self.update_validators(Some(&committee), Some(certificate.as_std().clone()))
+        self.update_validators(Some(&committee), Some(certificate.clone()))
             .await?;
         // Clear the pending proposal now that the block has been committed.
         *proposal_guard = None;
@@ -2142,7 +2142,7 @@ impl<Env: Environment> ChainClient<Env> {
             .finalize_block(&committee, certificate.clone())
             .await?;
         let certificate = self.client.storage_client().cache_certificate(certificate);
-        self.update_validators(Some(&committee), Some(certificate.as_std().clone()))
+        self.update_validators(Some(&committee), Some(certificate.clone()))
             .await?;
         Ok(ClientOutcome::Committed(Some(CacheArc::unwrap_or_clone(
             certificate,
@@ -2790,13 +2790,12 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn read_certificate(
         &self,
         hash: CryptoHash,
-    ) -> Result<Arc<ConfirmedBlockCertificate>, Error> {
+    ) -> Result<CacheArc<ConfirmedBlockCertificate>, Error> {
         self.client
             .storage_client()
             .read_certificate(hash)
             .await?
             .ok_or(Error::ReadCertificatesError(vec![hash]))
-            .map(|c| c.into_std())
     }
 
     /// Handles any cross-chain requests for any pending outgoing messages.
@@ -3297,7 +3296,7 @@ impl<Env: Environment> ChainClient<Env> {
         for certificate in certificates {
             let missing_blob_ids = match remote_node
                 .handle_confirmed_certificate(
-                    certificate.as_std().clone(),
+                    certificate.clone(),
                     CrossChainMessageDelivery::NonBlocking,
                 )
                 .await
@@ -3319,10 +3318,7 @@ impl<Env: Environment> ChainClient<Env> {
                 .collect();
             remote_node.upload_blobs(missing_blobs).await?;
             remote_node
-                .handle_confirmed_certificate(
-                    certificate.into_std(),
-                    CrossChainMessageDelivery::NonBlocking,
-                )
+                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
                 .await?;
         }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1129,7 +1129,7 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
         height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
+        latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
         let nodes = self.make_nodes(committee)?;
         communicate_with_quorum(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -40,7 +40,7 @@ use linera_chain::{
     ChainError,
 };
 use linera_execution::{committee::Committee, ExecutionError};
-use linera_storage::{Clock as _, ResultReadCertificates, Storage as _};
+use linera_storage::{Arc as CacheArc, Clock as _, ResultReadCertificates, Storage as _};
 use rand::seq::SliceRandom;
 use received_log::ReceivedLogs;
 use serde::{Deserialize, Serialize};
@@ -352,7 +352,7 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
         height: BlockHeight,
         hash: Option<CryptoHash>,
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, chain_client::Error> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, chain_client::Error> {
         if let Some(hash) = hash {
             return Ok(self.storage_client().read_certificate(hash).await?);
         }
@@ -1007,7 +1007,7 @@ impl<Env: Environment> Client<Env> {
             .await?;
         if let Some(blob) = blob {
             // We have the blob - return it.
-            return Ok(blob);
+            return Ok(blob.into_std());
         }
         // Recover history from the current validators, according to the admin chain.
         self.synchronize_chain_state(self.admin_chain_id).await?;
@@ -1016,7 +1016,8 @@ impl<Env: Environment> Client<Env> {
             .update_local_node_with_blobs_from(vec![chain_desc_id], &nodes)
             .await?
             .pop()
-            .unwrap()) // Returns exactly as many blobs as passed-in IDs.
+            .unwrap() // Returns exactly as many blobs as passed-in IDs.
+            .into_std())
     }
 
     /// Ensures that the client has the `ChainDescription` blob corresponding to this
@@ -1232,7 +1233,7 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "trace", skip_all)]
     async fn receive_sender_certificate(
         &self,
-        certificate: Arc<ConfirmedBlockCertificate>,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
         mode: ReceiveCertificateMode,
         nodes: Option<Vec<RemoteNode<Env::ValidatorNode>>>,
     ) -> Result<(), chain_client::Error> {
@@ -1248,6 +1249,7 @@ impl<Env: Environment> Client<Env> {
         };
         self.handle_certificate_with_retry(&certificate, &nodes)
             .await?;
+
         Ok(())
     }
 
@@ -1988,7 +1990,7 @@ impl<Env: Environment> Client<Env> {
         &self,
         blob_ids: Vec<BlobId>,
         remote_nodes: &[RemoteNode<Env::ValidatorNode>],
-    ) -> Result<Vec<Arc<Blob>>, chain_client::Error> {
+    ) -> Result<Vec<CacheArc<Blob>>, chain_client::Error> {
         let timeout = self.options.blob_download_timeout;
         // Deduplicate IDs.
         let blob_ids = blob_ids.into_iter().collect::<BTreeSet<_>>();

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -19,7 +19,7 @@ use linera_chain::{
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{BlobState, ExecutionError, Query, QueryOutcome, ResourceTracker};
-use linera_storage::Storage;
+use linera_storage::{Arc as CacheArc, Storage};
 use linera_views::ViewError;
 use thiserror::Error;
 use tracing::{instrument, warn};
@@ -180,7 +180,7 @@ where
     pub async fn read_blobs_from_storage(
         &self,
         blob_ids: &[BlobId],
-    ) -> Result<Option<Vec<Arc<Blob>>>, LocalNodeError> {
+    ) -> Result<Option<Vec<CacheArc<Blob>>>, LocalNodeError> {
         let storage = self.storage_client();
         Ok(storage.read_blobs(blob_ids).await?.into_iter().collect())
     }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -2,6 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use linera_cache::Arc as CacheArc;
 use std::sync::Arc;
 
 #[cfg(not(web))]
@@ -74,7 +75,7 @@ pub trait ValidatorNode {
     /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
-        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
+        certificate: CacheArc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -2,7 +2,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_cache::Arc as CacheArc;
 use std::sync::Arc;
 
 #[cfg(not(web))]
@@ -18,6 +17,7 @@ use linera_base::{
     identifiers::{BlobId, ChainId, EventId},
     task::{MaybeSend, MaybeSync},
 };
+use linera_cache::Arc as CacheArc;
 use linera_chain::{
     data_types::BlockProposal,
     types::{

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_cache::Arc as CacheArc;
 use std::collections::{HashSet, VecDeque};
 
 use custom_debug_derive::Debug;
@@ -12,6 +11,7 @@ use linera_base::{
     ensure,
     identifiers::{BlobId, ChainId},
 };
+use linera_cache::Arc as CacheArc;
 use linera_chain::{
     data_types::BlockProposal,
     types::{

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -1,10 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{HashSet, VecDeque},
-    sync::Arc,
-};
+use linera_cache::Arc as CacheArc;
+use std::collections::{HashSet, VecDeque};
 
 use custom_debug_derive::Debug;
 use futures::future::try_join_all;
@@ -67,7 +65,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     pub(crate) async fn handle_confirmed_certificate(
         &self,
-        certificate: Arc<ConfirmedBlockCertificate>,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         let chain_id = certificate.inner().chain_id();
@@ -114,7 +112,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     pub(crate) async fn handle_optimized_confirmed_certificate(
         &self,
-        certificate: &Arc<ConfirmedBlockCertificate>,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         if let Some(result) = self.try_lite_certificate(certificate, delivery).await {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -30,7 +30,7 @@ use linera_chain::{
     },
 };
 use linera_execution::{committee::Committee, ResourceControlPolicy, WasmRuntime};
-use linera_storage::{DbStorage, ResultReadCertificates, Storage, TestClock};
+use linera_storage::{Arc as CacheArc, DbStorage, ResultReadCertificates, Storage, TestClock};
 #[cfg(all(not(target_arch = "wasm32"), feature = "storage-service"))]
 use linera_storage_service::client::StorageServiceDatabase;
 use linera_version::VersionInfo;
@@ -553,7 +553,7 @@ where
             Ok(blob) => blob.ok_or_else(|| NodeError::BlobsNotFound(vec![blob_id])),
             Err(error) => Err(error),
         };
-        sender.send(blob.map(|blob| Arc::unwrap_or_clone(blob).into_content()))
+        sender.send(blob.map(|blob| CacheArc::unwrap_or_clone(blob).into_content()))
     }
 
     async fn do_download_pending_blob(
@@ -602,7 +602,7 @@ where
         let certificate = match certificate {
             Err(error) => Err(error),
             Ok(entry) => match entry {
-                Some(certificate) => Ok(Arc::unwrap_or_clone(certificate)),
+                Some(certificate) => Ok(CacheArc::unwrap_or_clone(certificate)),
                 None => {
                     panic!("Missing certificate: {hash}");
                 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -154,11 +154,11 @@ where
 
     async fn handle_confirmed_certificate(
         &self,
-        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
+        certificate: CacheArc<GenericCertificate<ConfirmedBlock>>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(Arc::unwrap_or_clone(certificate), sender)
+            validator.do_handle_certificate(CacheArc::unwrap_or_clone(certificate), sender)
         })
         .await
     }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -248,7 +248,7 @@ where
     )]
     async fn send_confirmed_certificate(
         &mut self,
-        certificate: &Arc<GenericCertificate<ConfirmedBlock>>,
+        certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self
@@ -683,7 +683,7 @@ where
         chain_id: ChainId,
         target_block_height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
+        latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
         // Phase 1: Height synchronization
         let info = if target_block_height.0 > 0 {
@@ -729,7 +729,7 @@ where
         chain_id: ChainId,
         target_block_height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
+        latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let height = target_block_height.try_sub_one()?;
 
@@ -746,7 +746,6 @@ where
                         "failed to read latest certificate for height sync",
                     )
                 })?
-                .into_std()
         };
 
         // Optimistically try sending just the last certificate
@@ -781,7 +780,7 @@ where
                 .await?;
 
             for certificate in certificates {
-                self.send_confirmed_certificate(certificate.as_std(), delivery)
+                self.send_confirmed_certificate(&certificate, delivery)
                     .await?;
             }
         }
@@ -967,7 +966,7 @@ where
                     // Send each certificate
                     for certificate in certificates {
                         updater
-                            .send_confirmed_certificate(certificate.as_std(), delivery)
+                            .send_confirmed_certificate(&certificate, delivery)
                             .await?;
                     }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -27,7 +27,7 @@ use linera_chain::{
     types::{ConfirmedBlock, GenericCertificate, ValidatedBlock, ValidatedBlockCertificate},
 };
 use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
-use linera_storage::{Clock, Storage};
+use linera_storage::{Arc as CacheArc, Clock, Storage};
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tracing::{instrument, Level};
@@ -283,7 +283,10 @@ where
                         .read_blobs_from_storage(&blob_ids)
                         .await?;
                     let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
-                    self.remote_node.node.upload_blobs(blobs).await?;
+                    self.remote_node
+                        .node
+                        .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
+                        .await?;
                     sent_blobs = true;
                 }
                 result => {
@@ -743,6 +746,7 @@ where
                         "failed to read latest certificate for height sync",
                     )
                 })?
+                .into_std()
         };
 
         // Optimistically try sending just the last certificate
@@ -777,7 +781,7 @@ where
                 .await?;
 
             for certificate in certificates {
-                self.send_confirmed_certificate(&certificate, delivery)
+                self.send_confirmed_certificate(certificate.as_std(), delivery)
                     .await?;
             }
         }
@@ -790,7 +794,7 @@ where
         &self,
         chain_id: ChainId,
         heights: Vec<BlockHeight>,
-    ) -> Result<Vec<Arc<GenericCertificate<ConfirmedBlock>>>, chain_client::Error> {
+    ) -> Result<Vec<CacheArc<GenericCertificate<ConfirmedBlock>>>, chain_client::Error> {
         let storage = self.client.local_node.storage_client();
 
         let certificates_by_height = storage
@@ -963,7 +967,7 @@ where
                     // Send each certificate
                     for certificate in certificates {
                         updater
-                            .send_confirmed_certificate(&certificate, delivery)
+                            .send_confirmed_certificate(certificate.as_std(), delivery)
                             .await?;
                     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -23,7 +23,7 @@ use linera_base::{
     doc_scalar,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
 };
-use linera_cache::{UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
+use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
 #[cfg(with_testing)]
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
@@ -772,7 +772,7 @@ where
             .block_cache
             .get(&certificate.value.value_hash)
             .ok_or(WorkerError::MissingCertificateValue)?;
-        let block = Arc::unwrap_or_clone(block);
+        let block = CacheArc::unwrap_or_clone(block);
 
         match certificate.value.kind {
             linera_chain::types::CertificateKind::Confirmed => Ok(Either::Left(
@@ -1425,7 +1425,7 @@ where
         &self,
         chain_id: ChainId,
         height: BlockHeight,
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, WorkerError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, WorkerError> {
         let state = self.get_or_create_chain_worker(chain_id).await?;
         let guard = handle::read_lock_initialized(&state).await?;
         guard.read_certificate(height).await
@@ -1646,7 +1646,7 @@ where
         &self,
         chain_id: ChainId,
         blob_id: BlobId,
-    ) -> Result<Arc<Blob>, WorkerError> {
+    ) -> Result<CacheArc<Blob>, WorkerError> {
         trace!("{} <-- download_pending_blob({blob_id:8})", self.nickname());
         let result = self
             .chain_read(chain_id, |guard| async move {

--- a/linera-exporter/src/runloops/indexer/conversions.rs
+++ b/linera-exporter/src/runloops/indexer/conversions.rs
@@ -6,13 +6,14 @@ use std::sync::Arc;
 use bincode::Error;
 use linera_base::data_types::Blob;
 use linera_chain::types::ConfirmedBlockCertificate;
+use linera_storage::Arc as CacheArc;
 
 use super::indexer_api::{self, element::Payload, Block, Element};
 
-impl TryFrom<Arc<ConfirmedBlockCertificate>> for Element {
+impl TryFrom<CacheArc<ConfirmedBlockCertificate>> for Element {
     type Error = Error;
 
-    fn try_from(value: Arc<ConfirmedBlockCertificate>) -> Result<Self, Self::Error> {
+    fn try_from(value: CacheArc<ConfirmedBlockCertificate>) -> Result<Self, Self::Error> {
         let bytes = bincode::serialize(value.as_ref())?;
         let element = Element {
             payload: Some(Payload::Block(Block { bytes })),

--- a/linera-exporter/src/runloops/indexer/indexer_exporter.rs
+++ b/linera-exporter/src/runloops/indexer/indexer_exporter.rs
@@ -14,7 +14,7 @@ use futures::{stream::FuturesOrdered, StreamExt};
 use linera_base::data_types::Blob;
 use linera_chain::types::ConfirmedBlockCertificate;
 use linera_rpc::NodeOptions;
-use linera_storage::Storage;
+use linera_storage::{Arc as CacheArc, Storage};
 use tokio::{select, sync::mpsc::Sender, time::sleep};
 use tonic::Streaming;
 
@@ -209,7 +209,7 @@ where
     async fn get_block_with_blobs_task(
         &self,
         index: usize,
-    ) -> Result<(Arc<ConfirmedBlockCertificate>, Vec<Arc<Blob>>), ExporterError> {
+    ) -> Result<(CacheArc<ConfirmedBlockCertificate>, Vec<Arc<Blob>>), ExporterError> {
         loop {
             match self.storage.get_block_with_blobs(index).await {
                 Ok(res) => return Ok(res),

--- a/linera-exporter/src/runloops/validator_exporter.rs
+++ b/linera-exporter/src/runloops/validator_exporter.rs
@@ -10,6 +10,8 @@ use std::{
     time::Duration,
 };
 
+use linera_storage::Arc as CacheArc;
+
 use futures::{future::try_join_all, stream::FuturesOrdered};
 use linera_base::identifiers::BlobId;
 use linera_chain::types::ConfirmedBlockCertificate;
@@ -112,7 +114,7 @@ where
 
     async fn run(
         &self,
-        mut receiver: Receiver<(Arc<ConfirmedBlockCertificate>, Vec<BlobId>)>,
+        mut receiver: Receiver<(CacheArc<ConfirmedBlockCertificate>, Vec<BlobId>)>,
     ) -> anyhow::Result<()> {
         while let Some((block, blobs_ids)) = receiver.recv().await {
             #[cfg(with_metrics)]
@@ -186,7 +188,7 @@ where
 
     async fn dispatch_block(
         &self,
-        certificate: Arc<ConfirmedBlockCertificate>,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
     ) -> Result<(), NodeError> {
         let delivery = CrossChainMessageDelivery::NonBlocking;
         let block_id = BlockId::from_confirmed_block(certificate.value());
@@ -226,7 +228,7 @@ where
     queue_size: usize,
     start_height: usize,
     storage: ExporterStorage<S>,
-    buffer: Sender<(Arc<ConfirmedBlockCertificate>, Vec<BlobId>)>,
+    buffer: Sender<(CacheArc<ConfirmedBlockCertificate>, Vec<BlobId>)>,
 }
 
 impl<S> TaskQueue<S>
@@ -240,7 +242,7 @@ where
         storage: ExporterStorage<S>,
     ) -> (
         TaskQueue<S>,
-        Receiver<(Arc<ConfirmedBlockCertificate>, Vec<BlobId>)>,
+        Receiver<(CacheArc<ConfirmedBlockCertificate>, Vec<BlobId>)>,
     ) {
         let (sender, receiver) = tokio::sync::mpsc::channel(queue_size);
 
@@ -275,7 +277,7 @@ where
     async fn get_block_task(
         &self,
         index: usize,
-    ) -> Result<(Arc<ConfirmedBlockCertificate>, Vec<BlobId>), ExporterError> {
+    ) -> Result<(CacheArc<ConfirmedBlockCertificate>, Vec<BlobId>), ExporterError> {
         loop {
             match self.storage.get_block_with_blob_ids(index).await {
                 Ok(block_with_blobs_ids) => return Ok(block_with_blobs_ids),

--- a/linera-exporter/src/runloops/validator_exporter.rs
+++ b/linera-exporter/src/runloops/validator_exporter.rs
@@ -10,8 +10,6 @@ use std::{
     time::Duration,
 };
 
-use linera_storage::Arc as CacheArc;
-
 use futures::{future::try_join_all, stream::FuturesOrdered};
 use linera_base::identifiers::BlobId;
 use linera_chain::types::ConfirmedBlockCertificate;
@@ -19,7 +17,7 @@ use linera_core::node::{
     CrossChainMessageDelivery, NodeError, ValidatorNode, ValidatorNodeProvider,
 };
 use linera_rpc::grpc::{GrpcClient, GrpcNodeProvider};
-use linera_storage::Storage;
+use linera_storage::{Arc as CacheArc, Storage};
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_stream::StreamExt;
 

--- a/linera-exporter/src/storage.rs
+++ b/linera-exporter/src/storage.rs
@@ -17,7 +17,7 @@ use linera_base::{
 };
 use linera_chain::types::ConfirmedBlockCertificate;
 use linera_sdk::{ensure, views::View};
-use linera_storage::Storage;
+use linera_storage::{Arc as CacheArc, Storage};
 use linera_views::{
     batch::Batch, context::Context, log_view::LogView, store::WritableKeyValueStore as _,
     views::ClonableView,
@@ -43,7 +43,7 @@ where
 }
 
 type BlobCache = FifoCache<BlobId, Arc<Blob>, BlobCacheWeighter>;
-type BlockCache = FifoCache<CryptoHash, Arc<ConfirmedBlockCertificate>, BlockCacheWeighter>;
+type BlockCache = FifoCache<CryptoHash, CacheArc<ConfirmedBlockCertificate>, BlockCacheWeighter>;
 
 struct SharedStorage<C, S>
 where
@@ -103,7 +103,7 @@ where
     async fn get_block(
         &self,
         hash: CryptoHash,
-    ) -> Result<Arc<ConfirmedBlockCertificate>, ExporterError> {
+    ) -> Result<CacheArc<ConfirmedBlockCertificate>, ExporterError> {
         match self.blocks_cache.get_value_or_guard_async(&hash).await {
             Ok(value) => Ok(value),
             Err(guard) => {
@@ -113,8 +113,7 @@ where
                     .storage
                     .read_certificate(hash)
                     .await?
-                    .ok_or_else(|| ExporterError::ReadCertificateError(hash))?
-                    .into_std();
+                    .ok_or_else(|| ExporterError::ReadCertificateError(hash))?;
                 guard.insert(block.clone()).ok();
                 Ok(block)
             }
@@ -171,7 +170,7 @@ where
     pub(crate) async fn get_block_with_blob_ids(
         &self,
         index: usize,
-    ) -> Result<(Arc<ConfirmedBlockCertificate>, Vec<BlobId>), ExporterError> {
+    ) -> Result<(CacheArc<ConfirmedBlockCertificate>, Vec<BlobId>), ExporterError> {
         let block = self
             .shared_storage
             .shared_canonical_state
@@ -187,7 +186,7 @@ where
     pub(crate) async fn get_block_with_blobs(
         &self,
         index: usize,
-    ) -> Result<(Arc<ConfirmedBlockCertificate>, Vec<Arc<Blob>>), ExporterError> {
+    ) -> Result<(CacheArc<ConfirmedBlockCertificate>, Vec<Arc<Blob>>), ExporterError> {
         let canonical_block = self
             .shared_storage
             .shared_canonical_state
@@ -264,7 +263,7 @@ where
     pub(super) async fn get_block(
         &self,
         hash: CryptoHash,
-    ) -> Result<Arc<ConfirmedBlockCertificate>, ExporterError> {
+    ) -> Result<CacheArc<ConfirmedBlockCertificate>, ExporterError> {
         self.shared_storage.get_block(hash).await
     }
 
@@ -528,11 +527,11 @@ impl Weighter<BlobId, Arc<Blob>> for BlobCacheWeighter {
     }
 }
 
-impl Weighter<CryptoHash, Arc<ConfirmedBlockCertificate>> for BlockCacheWeighter {
-    fn weight(&self, _key: &CryptoHash, _val: &Arc<ConfirmedBlockCertificate>) -> u64 {
+impl Weighter<CryptoHash, CacheArc<ConfirmedBlockCertificate>> for BlockCacheWeighter {
+    fn weight(&self, _key: &CryptoHash, _val: &CacheArc<ConfirmedBlockCertificate>) -> u64 {
         (size_of::<CryptoHash>()
             + 2 * size_of::<usize>()
-            + size_of::<Arc<ConfirmedBlockCertificate>>()
+            + size_of::<CacheArc<ConfirmedBlockCertificate>>()
             + 1_000_000) as u64 // maximum block size in testnet resource control policy
     }
 }
@@ -554,5 +553,5 @@ impl<Q, V> Default for CacheWeighter<Q, V> {
 }
 
 type BlobCacheWeighter = CacheWeighter<BlobId, Arc<Blob>>;
-type BlockCacheWeighter = CacheWeighter<CryptoHash, Arc<ConfirmedBlockCertificate>>;
+type BlockCacheWeighter = CacheWeighter<CryptoHash, CacheArc<ConfirmedBlockCertificate>>;
 type CanonicalStateCacheWeighter = CacheWeighter<usize, CanonicalBlock>;

--- a/linera-exporter/src/storage.rs
+++ b/linera-exporter/src/storage.rs
@@ -113,7 +113,8 @@ where
                     .storage
                     .read_certificate(hash)
                     .await?
-                    .ok_or_else(|| ExporterError::ReadCertificateError(hash))?;
+                    .ok_or_else(|| ExporterError::ReadCertificateError(hash))?
+                    .into_std();
                 guard.insert(block.clone()).ok();
                 Ok(block)
             }
@@ -130,7 +131,8 @@ where
                     .storage
                     .read_blob(blob_id)
                     .await?
-                    .ok_or(ExporterError::ReadBlobError(blob_id))?;
+                    .ok_or(ExporterError::ReadBlobError(blob_id))?
+                    .into_std();
                 guard.insert(blob.clone()).ok();
                 Ok(blob)
             }

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_storage::Arc as CacheArc;
-
 use linera_base::{
     crypto::CryptoHash,
     data_types::{BlobContent, BlockHeight, NetworkDescription},
@@ -18,6 +16,7 @@ use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
 };
+use linera_storage::Arc as CacheArc;
 
 use crate::grpc::GrpcClient;
 #[cfg(with_simple_network)]

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use linera_storage::Arc as CacheArc;
 
 use linera_base::{
     crypto::CryptoHash,
@@ -103,7 +103,7 @@ impl ValidatorNode for Client {
 
     async fn handle_confirmed_certificate(
         &self,
-        certificate: Arc<ConfirmedBlockCertificate>,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -48,6 +48,7 @@ use linera_core::{
     node::{BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
     worker::Notification,
 };
+use linera_storage::Arc as CacheArc;
 use linera_version::VersionInfo;
 use tonic::{Code, IntoRequest, Request, Status};
 use tracing::{debug, instrument, trace, Level};
@@ -280,12 +281,12 @@ impl ValidatorNode for GrpcClient {
     #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_confirmed_certificate(
         &self,
-        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
+        certificate: CacheArc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages: bool = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
-            certificate: Arc::unwrap_or_clone(certificate),
+            certificate: CacheArc::unwrap_or_clone(certificate),
             wait_for_outgoing_messages,
         };
         GrpcClient::try_into_chain_info(client_delegate!(

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -2,8 +2,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
 use futures::{sink::SinkExt, stream::StreamExt};
 use linera_base::{
     crypto::CryptoHash,
@@ -21,6 +19,7 @@ use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
 };
+use linera_storage::Arc as CacheArc;
 use linera_version::VersionInfo;
 
 use super::{codec, transport::TransportProtocol};
@@ -120,12 +119,12 @@ impl ValidatorNode for SimpleClient {
     /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
-        certificate: Arc<ConfirmedBlockCertificate>,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
-            certificate: Arc::unwrap_or_clone(certificate),
+            certificate: CacheArc::unwrap_or_clone(certificate),
             wait_for_outgoing_messages,
         };
         let request = RpcMessage::ConfirmedCertificate(Box::new(request));

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1864,7 +1864,7 @@ impl Runnable for Job {
                     .read_confirmed_block(block_hash)
                     .await
                     .context("Failed to find the given block in storage")?;
-                let json = serde_json::to_string_pretty(&*block)?;
+                let json = serde_json::to_string_pretty(&block.as_deref())?;
                 println!("{json}");
             }
 

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1864,7 +1864,7 @@ impl Runnable for Job {
                     .read_confirmed_block(block_hash)
                     .await
                     .context("Failed to find the given block in storage")?;
-                let json = serde_json::to_string_pretty(&block)?;
+                let json = serde_json::to_string_pretty(&*block)?;
                 println!("{json}");
             }
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -46,8 +46,7 @@ use linera_rpc::{
     },
 };
 use linera_sdk::{linera_base_types::Blob, views::ViewError};
-use linera_storage::Arc as CacheArc;
-use linera_storage::{ResultReadCertificates, Storage};
+use linera_storage::{Arc as CacheArc, ResultReadCertificates, Storage};
 use prost::Message;
 use tokio::{select, task::JoinSet};
 use tokio_stream::wrappers::UnboundedReceiverStream;

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -46,6 +46,7 @@ use linera_rpc::{
     },
 };
 use linera_sdk::{linera_base_types::Blob, views::ViewError};
+use linera_storage::Arc as CacheArc;
 use linera_storage::{ResultReadCertificates, Storage};
 use prost::Message;
 use tokio::{select, task::JoinSet};
@@ -615,7 +616,7 @@ where
             .await
             .map_err(Self::view_error_to_status)?;
         let blob = blob
-            .map(Arc::unwrap_or_clone)
+            .map(CacheArc::unwrap_or_clone)
             .ok_or_else(|| Status::not_found(format!("Blob not found {blob_id}")))?;
         Ok(Response::new(blob.into_content().try_into()?))
     }
@@ -673,6 +674,7 @@ where
             .await
             .map_err(Self::view_error_to_status)?
             .ok_or_else(|| Status::not_found(hash.to_string()))?
+            .into_std()
             .as_ref()
             .into();
         Ok(Response::new(certificate.try_into()?))
@@ -750,7 +752,7 @@ where
 
         let returned_certificates =
             limiter.take_if(certificates_by_height, |lim, certificate| {
-                let cert: linera_chain::types::Certificate = certificate.as_ref().into();
+                let cert: linera_chain::types::Certificate = (&*certificate).into();
                 Ok(lim.fits::<Certificate>(cert.clone())?.then_some(cert))
             })?;
 
@@ -776,7 +778,7 @@ where
             .map_err(Self::view_error_to_status)?
             .into_iter()
             .flatten()
-            .map(Arc::unwrap_or_clone)
+            .map(CacheArc::unwrap_or_clone)
             .collect::<Vec<(Vec<u8>, Vec<u8>)>>();
 
         let mut limiter: GrpcMessageLimiter<linera_chain::types::Certificate> =

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -11,7 +11,7 @@ static ALLOC: linera_jemallocator::Jemalloc = linera_jemallocator::Jemalloc;
 #[export_name = "malloc_conf"]
 pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
-use std::{net::SocketAddr, path::PathBuf, pin::Pin, sync::Arc, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, pin::Pin, time::Duration};
 
 use anyhow::{anyhow, bail, ensure, Result};
 use async_trait::async_trait;
@@ -37,7 +37,7 @@ use linera_service::{
     storage::{CommonStorageOptions, Runnable, StorageConfig},
     util,
 };
-use linera_storage::{ResultReadCertificates, Storage};
+use linera_storage::{Arc as CacheArc, ResultReadCertificates, Storage};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
@@ -472,7 +472,7 @@ where
             DownloadConfirmedBlock(hash) => {
                 let block = self.storage.read_confirmed_block(*hash).await?;
                 let block = block
-                    .map(Arc::unwrap_or_clone)
+                    .map(CacheArc::unwrap_or_clone)
                     .ok_or_else(|| anyhow!("Missing confirmed block {hash}"))?;
                 Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(Box::new(
                     block,
@@ -543,7 +543,7 @@ where
                     .storage
                     .read_certificate(last_used_by)
                     .await?
-                    .map(Arc::unwrap_or_clone)
+                    .map(CacheArc::unwrap_or_clone)
                     .ok_or_else(|| anyhow!("Certificate not found {last_used_by}"))?;
                 Ok(Some(RpcMessage::BlobLastUsedByCertificateResponse(
                     Box::new(certificate),

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -31,7 +31,7 @@ use linera_core::{
 use linera_execution::committee::Committee;
 use linera_sdk::linera_base_types::ValidatorPublicKey;
 use linera_service::node_service::NodeService;
-use linera_storage::DbStorage;
+use linera_storage::{Arc as CacheArc, DbStorage};
 use linera_version::VersionInfo;
 use linera_views::memory::MemoryDatabase;
 
@@ -69,7 +69,7 @@ impl ValidatorNode for DummyValidatorNode {
 
     async fn handle_confirmed_certificate(
         &self,
-        _: Arc<GenericCertificate<ConfirmedBlock>>,
+        _: CacheArc<GenericCertificate<ConfirmedBlock>>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -15,7 +15,7 @@ use linera_base::{
     data_types::{Blob, BlockHeight, NetworkDescription, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
 };
-use linera_cache::ValueCache;
+use linera_cache::{Arc as CacheArc, ValueCache};
 use linera_chain::{
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     ChainStateView,
@@ -789,7 +789,7 @@ where
     async fn read_confirmed_block(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<ConfirmedBlock>>, ViewError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlock>>, ViewError> {
         if let Some(block) = self.caches.confirmed_block.get(&hash) {
             #[cfg(with_metrics)]
             metrics::READ_CONFIRMED_BLOCK_COUNTER
@@ -814,7 +814,7 @@ where
     async fn read_confirmed_blocks<I: IntoIterator<Item = CryptoHash> + Send>(
         &self,
         hashes: I,
-    ) -> Result<Vec<Option<Arc<ConfirmedBlock>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlock>>>, ViewError> {
         let hashes = hashes.into_iter().collect::<Vec<_>>();
         if hashes.is_empty() {
             return Ok(Vec::new());
@@ -861,7 +861,7 @@ where
     }
 
     #[instrument(skip_all, fields(%blob_id))]
-    async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Arc<Blob>>, ViewError> {
+    async fn read_blob(&self, blob_id: BlobId) -> Result<Option<CacheArc<Blob>>, ViewError> {
         if let Some(blob) = self.caches.blob.get(&blob_id) {
             #[cfg(with_metrics)]
             metrics::READ_BLOB_COUNTER
@@ -886,7 +886,10 @@ where
     }
 
     #[instrument(skip_all, fields(blob_ids_len = %blob_ids.len()))]
-    async fn read_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<Option<Arc<Blob>>>, ViewError> {
+    async fn read_blobs(
+        &self,
+        blob_ids: &[BlobId],
+    ) -> Result<Vec<Option<CacheArc<Blob>>>, ViewError> {
         if blob_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -1019,17 +1022,17 @@ where
     fn cache_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
-    ) -> Arc<ConfirmedBlockCertificate> {
+    ) -> CacheArc<ConfirmedBlockCertificate> {
         self.caches
             .certificate
             .insert(&certificate.hash(), certificate)
     }
 
-    fn cache_blob(&self, blob: Blob) -> Arc<Blob> {
+    fn cache_blob(&self, blob: Blob) -> CacheArc<Blob> {
         self.caches.blob.insert(&blob.id(), blob)
     }
 
-    fn cache_confirmed_block(&self, block: ConfirmedBlock) -> Arc<ConfirmedBlock> {
+    fn cache_confirmed_block(&self, block: ConfirmedBlock) -> CacheArc<ConfirmedBlock> {
         self.caches.confirmed_block.insert(&block.hash(), block)
     }
 
@@ -1056,7 +1059,7 @@ where
     async fn read_certificate(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, ViewError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, ViewError> {
         // Assembled certificate cache (single Arc, no re-assembly)
         if let Some(cert) = self.caches.certificate.get(&hash) {
             #[cfg(with_metrics)]
@@ -1098,7 +1101,7 @@ where
     async fn read_certificates(
         &self,
         hashes: &[CryptoHash],
-    ) -> Result<Vec<Option<Arc<ConfirmedBlockCertificate>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlockCertificate>>>, ViewError> {
         let raw_certs = self.read_certificates_raw(hashes).await?;
 
         raw_certs
@@ -1116,7 +1119,7 @@ where
     async fn read_certificates_raw(
         &self,
         hashes: &[CryptoHash],
-    ) -> Result<Vec<Option<Arc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
         if hashes.is_empty() {
             return Ok(Vec::new());
         }
@@ -1224,7 +1227,7 @@ where
         &self,
         chain_id: ChainId,
         heights: &[BlockHeight],
-    ) -> Result<Vec<Option<Arc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
         let hashes: Vec<Option<CryptoHash>> = self
             .read_certificate_hashes_by_heights(chain_id, heights)
             .await?;
@@ -1266,7 +1269,7 @@ where
         &self,
         chain_id: ChainId,
         heights: &[BlockHeight],
-    ) -> Result<Vec<Option<Arc<ConfirmedBlockCertificate>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlockCertificate>>>, ViewError> {
         self.read_certificates_by_heights_raw(chain_id, heights)
             .await?
             .into_iter()
@@ -1278,7 +1281,7 @@ where
     }
 
     #[instrument(skip_all, fields(event_id = ?event_id))]
-    async fn read_event(&self, event_id: EventId) -> Result<Option<Arc<Vec<u8>>>, ViewError> {
+    async fn read_event(&self, event_id: EventId) -> Result<Option<CacheArc<Vec<u8>>>, ViewError> {
         if let Some(event) = self.caches.event.get(&event_id) {
             #[cfg(with_metrics)]
             metrics::READ_EVENT_COUNTER
@@ -1468,7 +1471,7 @@ where
         &self,
         lite_cert_bytes: &[u8],
         confirmed_block_bytes: &[u8],
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, ViewError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, ViewError> {
         let lite = bcs::from_bytes::<LiteCertificate>(lite_cert_bytes)?;
         let block = bcs::from_bytes::<ConfirmedBlock>(confirmed_block_bytes)?;
         let hash = block.hash();

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -5,7 +5,7 @@
 
 mod db_storage;
 
-use std::sync::Arc;
+use std::sync::Arc as StdArc;
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -18,7 +18,7 @@ use linera_base::{
     identifiers::{ApplicationId, BlobId, BlobType, ChainId, EventId, IndexAndEvent, StreamId},
     vm::VmRuntime,
 };
-pub use linera_cache::DEFAULT_CLEANUP_INTERVAL_SECS;
+pub use linera_cache::{Arc, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     ChainError, ChainStateView,
@@ -64,7 +64,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     /// Returns the current wall clock time.
     fn clock(&self) -> &Self::Clock;
 
-    fn thread_pool(&self) -> &Arc<linera_execution::ThreadPool>;
+    fn thread_pool(&self) -> &StdArc<linera_execution::ThreadPool>;
 
     /// Loads the view of a chain state.
     ///
@@ -427,7 +427,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     async fn get_or_load_committee_by_hash(
         &self,
         hash: CryptoHash,
-    ) -> Result<Arc<Committee>, ExecutionError> {
+    ) -> Result<StdArc<Committee>, ExecutionError> {
         if let Some(committee) = self.shared_committees().get(hash) {
             return Ok(committee);
         }
@@ -437,7 +437,9 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
             .await?
             .ok_or(ExecutionError::BlobsNotFound(vec![blob_id]))?;
         let committee = bcs::from_bytes(blob.bytes())?;
-        Ok(self.shared_committees().insert(hash, Arc::new(committee)))
+        Ok(self
+            .shared_committees()
+            .insert(hash, StdArc::new(committee)))
     }
 
     /// Returns whether the given epoch's committee has been revoked, i.e. whether the
@@ -462,7 +464,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     async fn committee_for_epoch(
         &self,
         epoch: Epoch,
-    ) -> Result<Option<Arc<Committee>>, ExecutionError> {
+    ) -> Result<Option<StdArc<Committee>>, ExecutionError> {
         let blob_hash = if epoch == Epoch::ZERO {
             self.read_network_description()
                 .await?
@@ -529,10 +531,10 @@ impl ResultReadCertificates {
 pub struct ChainRuntimeContext<S> {
     storage: S,
     chain_id: ChainId,
-    thread_pool: Arc<linera_execution::ThreadPool>,
+    thread_pool: StdArc<linera_execution::ThreadPool>,
     execution_runtime_config: ExecutionRuntimeConfig,
-    user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
-    user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
+    user_contracts: StdArc<papaya::HashMap<ApplicationId, UserContractCode>>,
+    user_services: StdArc<papaya::HashMap<ApplicationId, UserServiceCode>>,
 }
 
 #[cfg_attr(not(web), async_trait)]
@@ -542,7 +544,7 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
         self.chain_id
     }
 
-    fn thread_pool(&self) -> &Arc<linera_execution::ThreadPool> {
+    fn thread_pool(&self) -> &StdArc<linera_execution::ThreadPool> {
         &self.thread_pool
     }
 
@@ -550,11 +552,11 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
         self.execution_runtime_config
     }
 
-    fn user_contracts(&self) -> &Arc<papaya::HashMap<ApplicationId, UserContractCode>> {
+    fn user_contracts(&self) -> &StdArc<papaya::HashMap<ApplicationId, UserContractCode>> {
         &self.user_contracts
     }
 
-    fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>> {
+    fn user_services(&self) -> &StdArc<papaya::HashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
     }
 
@@ -588,12 +590,12 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
         Ok(service)
     }
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<Option<Arc<Blob>>, ViewError> {
-        self.storage.read_blob(blob_id).await
+    async fn get_blob(&self, blob_id: BlobId) -> Result<Option<StdArc<Blob>>, ViewError> {
+        Ok(self.storage.read_blob(blob_id).await?.map(Arc::into_std))
     }
 
-    async fn get_event(&self, event_id: EventId) -> Result<Option<Arc<Vec<u8>>>, ViewError> {
-        self.storage.read_event(event_id).await
+    async fn get_event(&self, event_id: EventId) -> Result<Option<StdArc<Vec<u8>>>, ViewError> {
+        Ok(self.storage.read_event(event_id).await?.map(Arc::into_std))
     }
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
@@ -603,7 +605,7 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
     async fn get_or_load_committee_by_hash(
         &self,
         hash: CryptoHash,
-    ) -> Result<Arc<Committee>, ExecutionError> {
+    ) -> Result<StdArc<Committee>, ExecutionError> {
         self.storage.get_or_load_committee_by_hash(hash).await
     }
 
@@ -938,10 +940,10 @@ mod tests {
 
         // Test individual event reading
         let read_event1 = storage.read_event(event_id1).await?;
-        assert_eq!(read_event1, Some(Arc::new(event_data1)));
+        assert_eq!(read_event1.as_deref(), Some(&event_data1));
 
         let read_event2 = storage.read_event(event_id2).await?;
-        assert_eq!(read_event2, Some(Arc::new(event_data2)));
+        assert_eq!(read_event2.as_deref(), Some(&event_data2));
 
         // Test reading events from index
         let events_from_index = storage


### PR DESCRIPTION
## Motivation

Follow-up to #6147 (reviewed by @ma2bd). The previous PR pushed `Arc` deeper through the certificate/block paths but left the door open for callers to bypass the dedup guarantee by constructing a fresh `Arc::new(value)` and inserting it — the type alone couldn't enforce "this came from the cache".

## Proposal

Introduce `linera_cache::Arc<T>`: a `#[repr(transparent)]` newtype over `std::sync::Arc<T>` with no public constructor. The only way to obtain one is through `ValueCache::insert`, `ValueCache::insert_hashed`, or `ValueCache::get`. This makes the dedup invariant structural: if you hold a `CacheArc<T>`, it provably came from the cache.

API surface:
- `into_std(self) -> std::sync::Arc<T>` — for crossing trait/network/serde boundaries
- `as_std(&self) -> &std::sync::Arc<T>` — for read-only boundary crossings
- `unwrap_or_clone(this: Self) -> T` — mirrors `Arc::unwrap_or_clone`
- `Deref<Target = T>`, `Clone`, `From<CacheArc<T>> for std::sync::Arc<T>`

Re-exported from `linera-storage` as `pub use linera_cache::Arc` (aliased as `CacheArc` inside consuming crates).

## Test Plan

CI — existing tests exercise the cache paths and the type changes are mechanical (boundary conversions via `into_std()`/`as_std()`).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6147 — the PR this follows up on
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)