### PR TITLE
Backport to testnet_conway: Arc deeper through certificate/block paths + Arc newtype (#6147 + #6330)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,29 @@ Contributions should generally follow the [Rust API guidelines](https://rust-lan
   unawaited futures or unhandled errors. `let _x =` should only be used for RAII guards.
 
 
+## Hash-consed types and `Arc<T>`
+
+Any content-addressed immutable data (also known as hash-consed data) — for
+example `Block`, `Blob`, `ConfirmedBlockCertificate` — should be cached and
+passed around as `Arc<T>`.
+
+**Never construct `Arc::new(value)` for a hash-consed type.** Always obtain
+the canonical `Arc<T>` from the dedup cache. Concretely:
+
+- For freshly-constructed `ConfirmedBlockCertificate`s (e.g. from network or
+  proposal flows), call `Storage::cache_certificate`.
+- For freshly-constructed `ConfirmedBlock`s, call
+  `Storage::cache_confirmed_block`.
+- For freshly-constructed `Blob`s, call `Storage::cache_blob`.
+- For values being re-inserted from a borrowed reference, use
+  `ValueCache::insert_hashed` or `ValueCache::insert_arc`.
+
+`Arc::new` for a hash-consed value bypasses the dedup index and creates a
+duplicate allocation, breaking the "one allocation per content" invariant.
+See the [`linera-cache` README](linera-cache/README.md) for how the
+invariant is enforced.
+
+
 ## Formatting and linting
 
 Make sure to fix the lint errors reported by

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1378,6 +1378,12 @@ impl From<Blob> for BlobContent {
     }
 }
 
+impl From<Arc<Blob>> for BlobContent {
+    fn from(blob: Arc<Blob>) -> BlobContent {
+        blob.content().clone()
+    }
+}
+
 /// A blob of binary data, with its hash.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Allocative)]
 pub struct Blob {

--- a/linera-bridge/src/relay/linera.rs
+++ b/linera-bridge/src/relay/linera.rs
@@ -3,6 +3,8 @@
 
 //! Centralized Linera client for all bridge chain interactions.
 
+use std::sync::Arc;
+
 use anyhow::{Context as _, Result};
 use linera_base::{
     crypto::CryptoHash,
@@ -88,14 +90,17 @@ impl<E: linera_core::environment::Environment> LineraClient<E> {
     pub async fn read_confirmed_block(
         &self,
         hash: CryptoHash,
-    ) -> Result<linera_chain::block::ConfirmedBlock> {
+    ) -> Result<Arc<linera_chain::block::ConfirmedBlock>> {
         self.chain_client
             .read_confirmed_block(hash)
             .await
             .map_err(|e| anyhow::anyhow!(e))
     }
 
-    pub async fn read_certificate(&self, hash: CryptoHash) -> Result<ConfirmedBlockCertificate> {
+    pub async fn read_certificate(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Arc<ConfirmedBlockCertificate>> {
         self.chain_client
             .read_certificate(hash)
             .await

--- a/linera-cache/README.md
+++ b/linera-cache/README.md
@@ -2,6 +2,30 @@
 
 Caching utilities for the Linera protocol.
 
+## Hash-consing and the "one allocation per content" invariant
+
+[`ValueCache`] is the canonical home for content-addressed immutable data
+(also known as hash-consed data) such as `Block`, `Blob`, and
+`ConfirmedBlockCertificate`. For such types the cache guarantees that at
+most one allocation exists per distinct content at any time, and all
+consumers share the same `Arc<T>`.
+
+The guarantee is implemented by combining two structures:
+
+- A bounded `quick_cache` (S3-FIFO eviction) for hot-path lookups.
+- A lock-free `papaya::HashMap<K, Weak<V>>` weak index that survives bounded
+  eviction. If the bounded cache evicts an entry while a consumer still
+  holds an `Arc`, re-requesting the same key returns the existing
+  allocation instead of creating a duplicate.
+
+A background task periodically sweeps dead `Weak` entries from the index to
+prevent unbounded growth.
+
+For the invariant to hold, all inserts of hash-consed values must go
+through the cache (e.g. [`ValueCache::insert_hashed`] or
+[`ValueCache::insert_arc`]). Constructing an `Arc::new(value)` off-path
+creates a duplicate allocation that bypasses the dedup index.
+
 <!-- cargo-rdme end -->
 
 ## Contributing

--- a/linera-cache/src/arc.rs
+++ b/linera-cache/src/arc.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A provenance-tracking wrapper around [`std::sync::Arc`].
+//!
+//! [`Arc<T>`] is identical to [`std::sync::Arc<T>`] at runtime but has no
+//! public constructor. The only way to obtain one is through
+//! [`ValueCache::insert`], [`ValueCache::insert_hashed`], or
+//! [`ValueCache::get`]. This makes the "one allocation per content" invariant
+//! structurally enforced: callers cannot bypass the cache by calling
+//! `Arc::new` directly.
+
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    sync::Arc as StdArc,
+};
+
+/// A reference-counted pointer that can only be constructed through a
+/// [`crate::ValueCache`].
+///
+/// `Arc<T>` is `#[repr(transparent)]` over [`std::sync::Arc<T>`] and
+/// implements `Deref<Target = T>`, `Clone`, `Debug`, `Display`, `PartialEq`,
+/// `Eq`, and `Hash` identically to [`std::sync::Arc<T>`].
+///
+/// Use [`Arc::into_std`] or [`Arc::as_std`] to interoperate with APIs that
+/// require [`std::sync::Arc<T>`] explicitly.
+#[repr(transparent)]
+pub struct Arc<T>(pub(crate) StdArc<T>);
+
+impl<T> Arc<T> {
+    /// Returns a reference to the underlying [`std::sync::Arc<T>`].
+    pub fn as_std(&self) -> &StdArc<T> {
+        &self.0
+    }
+
+    /// Converts into the underlying [`std::sync::Arc<T>`].
+    pub fn into_std(self) -> StdArc<T> {
+        self.0
+    }
+
+    /// Unwraps the inner value if this is the only strong reference;
+    /// otherwise clones it.
+    pub fn unwrap_or_clone(this: Self) -> T
+    where
+        T: Clone,
+    {
+        StdArc::unwrap_or_clone(this.0)
+    }
+
+    /// Returns `true` if two `Arc`s point to the same allocation.
+    pub fn ptr_eq(a: &Self, b: &Self) -> bool {
+        StdArc::ptr_eq(&a.0, &b.0)
+    }
+}
+
+impl<T> Deref for Arc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> Clone for Arc<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Arc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&*self.0, f)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Arc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&*self.0, f)
+    }
+}
+
+impl<T: PartialEq> PartialEq for Arc<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<T: Eq> Eq for Arc<T> {}
+
+impl<T: Hash> Hash for Arc<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl<T> From<Arc<T>> for StdArc<T> {
+    fn from(arc: Arc<T>) -> Self {
+        arc.0
+    }
+}
+
+impl<T> AsRef<StdArc<T>> for Arc<T> {
+    fn as_ref(&self) -> &StdArc<T> {
+        &self.0
+    }
+}

--- a/linera-cache/src/lib.rs
+++ b/linera-cache/src/lib.rs
@@ -2,9 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Caching utilities for the Linera protocol.
+//!
+//! ## Hash-consing and the "one allocation per content" invariant
+//!
+//! [`ValueCache`] is the canonical home for content-addressed immutable data
+//! (also known as hash-consed data) such as `Block`, `Blob`, and
+//! `ConfirmedBlockCertificate`. For such types the cache guarantees that at
+//! most one allocation exists per distinct content at any time, and all
+//! consumers share the same `Arc<T>`.
+//!
+//! The guarantee is implemented by combining two structures:
+//!
+//! - A bounded `quick_cache` (S3-FIFO eviction) for hot-path lookups.
+//! - A lock-free `papaya::HashMap<K, Weak<V>>` weak index that survives bounded
+//!   eviction. If the bounded cache evicts an entry while a consumer still
+//!   holds an `Arc`, re-requesting the same key returns the existing
+//!   allocation instead of creating a duplicate.
+//!
+//! A background task periodically sweeps dead `Weak` entries from the index to
+//! prevent unbounded growth.
+//!
+//! For the invariant to hold, all inserts of hash-consed values must go
+//! through the cache (e.g. [`ValueCache::insert_hashed`] or
+//! [`ValueCache::insert_arc`]). Constructing an `Arc::new(value)` off-path
+//! creates a duplicate allocation that bypasses the dedup index.
 
+mod arc;
 mod unique_value_cache;
 mod value_cache;
 
+pub use arc::Arc;
 pub use unique_value_cache::UniqueValueCache;
 pub use value_cache::{ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -67,19 +67,13 @@ where
         }
     }
 
-    /// Inserts a value into the cache, returning the canonical `Arc`.
+    /// Inserts a value into the cache, returning the canonical [`crate::Arc`].
     ///
     /// The value is wrapped in `Arc` internally. If a live `Arc` for this key
     /// already exists (held by another consumer), the existing allocation is
     /// reused and the new value is dropped.
-    pub fn insert(&self, key: &K, value: V) -> Arc<V> {
-        self.dedup_insert(key, Arc::new(value))
-    }
-
-    /// Inserts a pre-wrapped `Arc<V>` into the cache, returning the canonical `Arc`.
-    #[cfg(with_testing)]
-    pub fn insert_arc(&self, key: &K, value: Arc<V>) -> Arc<V> {
-        self.dedup_insert(key, value)
+    pub fn insert(&self, key: &K, value: V) -> crate::Arc<V> {
+        crate::Arc(self.dedup_insert(key, Arc::new(value)))
     }
 
     /// Removes a value from the bounded cache.
@@ -88,20 +82,20 @@ where
     /// still hold an `Arc` to this value, and the weak index must be able
     /// to deduplicate against it. Dead weak entries are cleaned up by the
     /// background task.
-    pub fn remove(&self, key: &K) -> Option<Arc<V>> {
+    pub fn remove(&self, key: &K) -> Option<crate::Arc<V>> {
         let value = self.cache.peek(key);
         if value.is_some() {
             self.cache.remove(key);
         }
-        Self::track_cache_usage(value)
+        Self::track_cache_usage(value).map(crate::Arc)
     }
 
-    /// Returns an `Arc` reference to the value, checking both the bounded
+    /// Returns an [`crate::Arc`] to the value, checking both the bounded
     /// cache and the weak index.
-    pub fn get(&self, key: &K) -> Option<Arc<V>> {
+    pub fn get(&self, key: &K) -> Option<crate::Arc<V>> {
         // Tier 1: bounded cache (hot path)
         if let Some(arc) = self.cache.get(key) {
-            return Self::track_cache_usage(Some(arc));
+            return Self::track_cache_usage(Some(arc)).map(crate::Arc);
         }
 
         // Tier 2: weak index (catches evicted-but-still-held entries)
@@ -110,11 +104,11 @@ where
             if let Some(arc) = weak.upgrade() {
                 // Re-insert into bounded cache for future fast lookups
                 self.cache.insert(key.clone(), arc.clone());
-                return Self::track_cache_usage(Some(arc));
+                return Self::track_cache_usage(Some(arc)).map(crate::Arc);
             }
         }
 
-        Self::track_cache_usage(None)
+        Self::track_cache_usage(None).map(crate::Arc)
     }
 
     /// Returns `true` if the value exists in either the bounded cache or
@@ -204,37 +198,40 @@ where
     }
 }
 
-impl<T: Send + Sync + 'static> ValueCache<CryptoHash, Hashed<T>> {
-    /// Inserts a [`Hashed<T>`] into the cache, returning the canonical `Arc`.
+impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
+    /// Inserts a value constructed from a [`Hashed<T>`] into the cache, keyed
+    /// by its hash, returning the canonical `Arc<V>`.
     ///
     /// The `value` is wrapped in a [`Cow`] so that it is only cloned if it
     /// needs to be inserted in the cache.
-    pub fn insert_hashed(&self, value: Cow<Hashed<T>>) -> Arc<Hashed<T>>
+    pub fn insert_hashed<T>(&self, value: Cow<Hashed<T>>) -> crate::Arc<V>
     where
         T: Clone,
+        V: From<Hashed<T>>,
     {
         let hash = (*value).hash();
         // Fast path: already in bounded cache
         if let Some(arc) = self.cache.peek(&hash) {
-            return arc;
+            return crate::Arc(arc);
         }
         // Check weak index before cloning from Cow
         let guard = self.weak_index.guard();
         if let Some(weak) = self.weak_index.get(&hash, &guard) {
             if let Some(arc) = weak.upgrade() {
                 self.cache.insert(hash, arc.clone());
-                return arc;
+                return crate::Arc(arc);
             }
         }
         drop(guard);
-        self.dedup_insert(&hash, Arc::new(value.into_owned()))
+        crate::Arc(self.dedup_insert(&hash, Arc::new(value.into_owned().into())))
     }
 
-    /// Inserts multiple [`Hashed<T>`]s into the cache.
+    /// Inserts multiple values constructed from [`Hashed<T>`]s into the cache.
     #[cfg(with_testing)]
-    pub fn insert_all_hashed<'a>(&self, values: impl IntoIterator<Item = Cow<'a, Hashed<T>>>)
+    pub fn insert_all_hashed<'a, T>(&self, values: impl IntoIterator<Item = Cow<'a, Hashed<T>>>)
     where
         T: Clone + 'a,
+        V: From<Hashed<T>>,
     {
         for value in values {
             self.insert_hashed(value);
@@ -268,12 +265,13 @@ mod metrics {
 
 #[cfg(test)]
 mod tests {
-    use std::{borrow::Cow, sync::Arc};
+    use std::borrow::Cow;
 
     use linera_base::{crypto::CryptoHash, hashed::Hashed};
     use serde::{Deserialize, Serialize};
 
     use super::{ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
+    use crate::Arc as CacheArc;
 
     /// Test cache size for unit tests.
     const TEST_CACHE_SIZE: usize = 10;
@@ -284,6 +282,12 @@ mod tests {
 
     impl linera_base::crypto::BcsHashable<'_> for TestValue {}
 
+    impl From<Hashed<TestValue>> for TestValue {
+        fn from(value: Hashed<TestValue>) -> Self {
+            value.into_inner()
+        }
+    }
+
     fn create_test_value(n: u64) -> Hashed<TestValue> {
         Hashed::new(TestValue(n))
     }
@@ -292,7 +296,7 @@ mod tests {
         iter.into_iter().map(create_test_value).collect()
     }
 
-    fn new_hashed_cache(size: usize) -> ValueCache<CryptoHash, Hashed<TestValue>> {
+    fn new_hashed_cache(size: usize) -> ValueCache<CryptoHash, TestValue> {
         ValueCache::new(size, DEFAULT_CLEANUP_INTERVAL_SECS)
     }
 
@@ -317,7 +321,7 @@ mod tests {
 
         cache.insert_hashed(Cow::Borrowed(&value));
         assert!(cache.contains(&hash));
-        assert_eq!(cache.get(&hash).as_deref(), Some(&value));
+        assert_eq!(cache.get(&hash).as_deref(), Some(value.inner()));
     }
 
     #[test]
@@ -331,14 +335,14 @@ mod tests {
 
         for value in &values {
             assert!(cache.contains(&value.hash()));
-            assert_eq!(cache.get(&value.hash()).as_deref(), Some(value));
+            assert_eq!(cache.get(&value.hash()).as_deref(), Some(value.inner()));
         }
 
         // Batch insert
         let cache2 = new_hashed_cache(TEST_CACHE_SIZE);
         cache2.insert_all_hashed(values.iter().map(Cow::Borrowed));
         for value in &values {
-            assert_eq!(cache2.get(&value.hash()).as_deref(), Some(value));
+            assert_eq!(cache2.get(&value.hash()).as_deref(), Some(value.inner()));
         }
     }
 
@@ -356,7 +360,7 @@ mod tests {
         // Re-inserting should return the same Arc (dedup)
         for (value, first_arc) in values.iter().zip(&first_arcs) {
             let second_arc = cache.insert_hashed(Cow::Borrowed(value));
-            assert!(Arc::ptr_eq(&second_arc, first_arc));
+            assert!(CacheArc::ptr_eq(&second_arc, first_arc));
         }
     }
 
@@ -407,7 +411,7 @@ mod tests {
 
         let first = cache.insert_hashed(Cow::Borrowed(&promoted));
         let second = cache.insert_hashed(Cow::Borrowed(&promoted));
-        assert!(Arc::ptr_eq(&first, &second));
+        assert!(CacheArc::ptr_eq(&first, &second));
 
         let extras = create_test_values(1..=TEST_CACHE_SIZE as u64 * 2);
         for value in &extras {
@@ -437,13 +441,13 @@ mod tests {
             .get(&1)
             .expect("held Arc should keep entry findable via weak index");
         assert!(
-            Arc::ptr_eq(&retrieved, &held),
+            CacheArc::ptr_eq(&retrieved, &held),
             "must return same allocation, not a duplicate"
         );
 
         // Re-inserting should also return the same Arc
         let reinserted = cache.insert(&1, "replacement".to_string());
-        assert!(Arc::ptr_eq(&reinserted, &held));
+        assert!(CacheArc::ptr_eq(&reinserted, &held));
         assert_eq!(&*reinserted, "hello");
     }
 
@@ -458,7 +462,7 @@ mod tests {
 
         // Still findable via weak index since we hold an Arc
         let retrieved = cache.get(&1).expect("weak index should find held Arc");
-        assert!(Arc::ptr_eq(&retrieved, &held));
+        assert!(CacheArc::ptr_eq(&retrieved, &held));
     }
 
     #[test]
@@ -492,19 +496,5 @@ mod tests {
 
         // Key 1 still findable (we hold an Arc)
         assert!(cache.contains(&1));
-    }
-
-    #[test]
-    fn test_insert_arc_dedup() {
-        let cache = new_string_cache(TEST_CACHE_SIZE);
-        let value = Arc::new("hello".to_string());
-
-        let first = cache.insert_arc(&1, value.clone());
-        assert!(Arc::ptr_eq(&first, &value));
-
-        let second = cache.insert_arc(&1, Arc::new("other".to_string()));
-        assert!(Arc::ptr_eq(&second, &value));
-
-        assert_eq!(&*cache.get(&1).expect("just inserted"), "hello");
     }
 }

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -154,6 +154,18 @@ impl ConfirmedBlock {
     }
 }
 
+impl From<Hashed<Block>> for ConfirmedBlock {
+    fn from(block: Hashed<Block>) -> Self {
+        Self::from_hashed(block)
+    }
+}
+
+impl From<Hashed<Block>> for ValidatedBlock {
+    fn from(block: Hashed<Block>) -> Self {
+        Self::from_hashed(block)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Allocative)]
 #[serde(transparent)]
 pub struct Timeout(Hashed<TimeoutInner>);

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -56,6 +56,12 @@ impl From<GenericCertificate<ConfirmedBlock>> for Certificate {
     }
 }
 
+impl From<&GenericCertificate<ConfirmedBlock>> for Certificate {
+    fn from(cert: &GenericCertificate<ConfirmedBlock>) -> Certificate {
+        Certificate::Confirmed(cert.clone())
+    }
+}
+
 impl Serialize for GenericCertificate<ConfirmedBlock> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -21,7 +21,7 @@ use linera_core::{
     worker::{Notification, Reason},
     Environment, Wallet,
 };
-use linera_storage::Storage as _;
+use linera_storage::{Arc as CacheArc, Storage as _};
 use tokio::sync::{mpsc::UnboundedReceiver, Notify};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
@@ -406,7 +406,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
     /// If any new chains were created by the given block, and we have a key pair for them,
     /// add them to the wallet and start listening for notifications.
     async fn add_new_chains(&mut self, hash: CryptoHash) -> Result<(), Error> {
-        let block = Arc::unwrap_or_clone(
+        let block = CacheArc::unwrap_or_clone(
             self.storage
                 .read_confirmed_block(hash)
                 .await?

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -18,10 +18,9 @@ use linera_base::{
         ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round, Timestamp,
     },
     ensure,
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, StreamId},
 };
-use linera_cache::{UniqueValueCache, ValueCache};
+use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache};
 use linera_chain::{
     data_types::{
         BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
@@ -103,7 +102,7 @@ where
     /// Wrapped in `Arc` so the keep-alive task can read it without acquiring
     /// the `RwLock`.
     last_access: Arc<AtomicTimestamp>,
-    block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+    block_values: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
     chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
@@ -147,7 +146,7 @@ where
     pub(crate) async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
-        block_values: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+        block_values: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
         execution_state_cache: Option<
             Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>,
         >,
@@ -256,12 +255,16 @@ where
         chain_id = %self.chain_id(),
         blob_id = %blob_id
     ))]
-    pub(crate) async fn download_pending_blob(&self, blob_id: BlobId) -> Result<Blob, WorkerError> {
+    pub(crate) async fn download_pending_blob(
+        &self,
+        blob_id: BlobId,
+    ) -> Result<CacheArc<Blob>, WorkerError> {
         if let Some(blob) = self.chain.manager.pending_blob(&blob_id).await? {
-            return Ok(blob);
+            return Ok(self.storage.cache_blob(blob));
         }
-        let blob = self.storage.read_blob(blob_id).await?;
-        blob.map(Arc::unwrap_or_clone)
+        self.storage
+            .read_blob(blob_id)
+            .await?
             .ok_or(WorkerError::BlobsNotFound(vec![blob_id]))
     }
 
@@ -348,7 +351,7 @@ where
         let (missing_indices, missing_blob_ids) = missing_indices_blob_ids(&maybe_blobs);
         let fourth_block_blobs = self.storage.read_blobs(&missing_blob_ids).await?;
         for (index, blob) in missing_indices.into_iter().zip(fourth_block_blobs) {
-            maybe_blobs[index].1 = blob.map(Arc::unwrap_or_clone);
+            maybe_blobs[index].1 = blob.map(CacheArc::unwrap_or_clone);
         }
         Ok(maybe_blobs.into_iter().collect())
     }
@@ -425,16 +428,14 @@ where
     async fn read_confirmed_blocks(
         &self,
         hashes: Vec<CryptoHash>,
-    ) -> Result<Vec<Option<Arc<ConfirmedBlock>>>, WorkerError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlock>>>, WorkerError> {
         let mut blocks = Vec::with_capacity(hashes.len());
         let mut uncached_indices = Vec::new();
         let mut uncached_hashes = Vec::new();
 
         for (i, hash) in hashes.iter().enumerate() {
-            if let Some(hashed_block) = self.block_values.get(hash) {
-                blocks.push(Some(Arc::new(ConfirmedBlock::from_hashed(
-                    Arc::unwrap_or_clone(hashed_block),
-                ))));
+            if let Some(block) = self.block_values.get(hash) {
+                blocks.push(Some(block));
             } else {
                 blocks.push(None);
                 uncached_indices.push(i);
@@ -445,10 +446,6 @@ where
         if !uncached_hashes.is_empty() {
             let from_storage = self.storage.read_confirmed_blocks(uncached_hashes).await?;
             for (i, maybe_block) in uncached_indices.into_iter().zip(from_storage) {
-                if let Some(block) = &maybe_block {
-                    self.block_values
-                        .insert_hashed(Cow::Borrowed(block.inner()));
-                }
                 blocks[i] = maybe_block;
             }
         }
@@ -477,7 +474,7 @@ where
         let mut height_to_blocks = HashMap::new();
         for (block, hash) in blocks.into_iter().zip(hashes) {
             let block = block.ok_or_else(|| WorkerError::ReadCertificatesError(vec![hash]))?;
-            let hashed_block = Arc::unwrap_or_clone(block).into_inner();
+            let hashed_block = CacheArc::unwrap_or_clone(block).into_inner();
             height_to_blocks.insert(hashed_block.inner().header.height, hashed_block);
         }
 
@@ -1415,7 +1412,7 @@ where
                 .storage
                 .read_certificate(hash)
                 .await?
-                .map(Arc::unwrap_or_clone)
+                .map(CacheArc::unwrap_or_clone)
                 .ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
             Box::pin(self.process_confirmed_block(cert, None)).await?;
         }
@@ -1424,7 +1421,7 @@ where
                 .storage
                 .read_certificate(hash)
                 .await?
-                .map(Arc::unwrap_or_clone)
+                .map(CacheArc::unwrap_or_clone)
                 .ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
             Box::pin(self.process_confirmed_block(cert, None)).await?;
         }
@@ -1771,7 +1768,7 @@ where
     pub(crate) async fn read_certificate(
         &self,
         height: BlockHeight,
-    ) -> Result<Option<ConfirmedBlockCertificate>, WorkerError> {
+    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, WorkerError> {
         let certificate_hash = match self.chain.confirmed_log.get(height.try_into()?).await? {
             Some(hash) => hash,
             None => return Ok(None),
@@ -1780,7 +1777,6 @@ where
             .storage
             .read_certificate(certificate_hash)
             .await?
-            .map(Arc::unwrap_or_clone)
             .ok_or_else(|| WorkerError::ReadCertificatesError(vec![certificate_hash]))?;
         Ok(Some(certificate))
     }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -40,8 +40,8 @@ use linera_chain::{
     },
     manager::LockingBlock,
     types::{
-        Block, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate, Timeout,
-        TimeoutCertificate, ValidatedBlock,
+        Block, ConfirmedBlock, ConfirmedBlockCertificate, Timeout, TimeoutCertificate,
+        ValidatedBlock,
     },
     ChainError, ChainExecutionContext,
 };
@@ -53,7 +53,7 @@ use linera_execution::{
     },
     ExecutionError, Operation, Query, QueryOutcome,
 };
-use linera_storage::{Clock as _, Storage as _};
+use linera_storage::{Arc as CacheArc, Clock as _, Storage as _};
 use linera_views::ViewError;
 use serde::Serialize;
 pub(crate) use state::State;
@@ -843,7 +843,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn update_validators(
         &self,
         old_committee: Option<&Committee>,
-        latest_certificate: Option<ConfirmedBlockCertificate>,
+        latest_certificate: Option<Arc<ConfirmedBlockCertificate>>,
     ) -> Result<(), Error> {
         let update_validators_start = linera_base::time::Instant::now();
         // Communicate the new certificate now.
@@ -878,7 +878,7 @@ impl<Env: Environment> ChainClient<Env> {
     pub async fn communicate_chain_updates(
         &self,
         committee: &Committee,
-        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
+        latest_certificate: Option<Arc<ConfirmedBlockCertificate>>,
     ) -> Result<(), Error> {
         let delivery = self.options.cross_chain_message_delivery;
         let height = self.chain_info().await?.next_block_height;
@@ -2072,7 +2072,9 @@ impl<Env: Environment> ChainClient<Env> {
         self.send_timing(submit_block_proposal_start, TimingType::SubmitBlockProposal);
         debug!(round = %certificate.round, "Sending confirmed block to validators");
         let update_start = linera_base::time::Instant::now();
-        Box::pin(self.update_validators(Some(&committee), Some(certificate.clone()))).await?;
+        let certificate = self.client.storage_client().cache_certificate(certificate);
+        Box::pin(self.update_validators(Some(&committee), Some(certificate.as_std().clone())))
+            .await?;
         tracing::debug!(
             update_validators_ms = update_start.elapsed().as_millis(),
             total_process_ms = process_start.elapsed().as_millis(),
@@ -2080,7 +2082,9 @@ impl<Env: Environment> ChainClient<Env> {
         );
         // Clear the pending proposal now that the block has been committed.
         *proposal_guard = None;
-        Ok(ClientOutcome::Committed(Some(certificate)))
+        Ok(ClientOutcome::Committed(Some(CacheArc::unwrap_or_clone(
+            certificate,
+        ))))
     }
 
     fn send_timing(&self, start: Instant, timing_type: TimingType) {
@@ -2131,8 +2135,12 @@ impl<Env: Environment> ChainClient<Env> {
         let committee = self.local_committee().await?;
         let certificate =
             Box::pin(self.client.finalize_block(&committee, certificate.clone())).await?;
-        Box::pin(self.update_validators(Some(&committee), Some(certificate.clone()))).await?;
-        Ok(ClientOutcome::Committed(Some(certificate)))
+        let certificate = self.client.storage_client().cache_certificate(certificate);
+        Box::pin(self.update_validators(Some(&committee), Some(certificate.as_std().clone())))
+            .await?;
+        Ok(ClientOutcome::Committed(Some(CacheArc::unwrap_or_clone(
+            certificate,
+        ))))
     }
 
     /// Returns the number for the round number oracle to use when staging a block proposal.
@@ -2733,26 +2741,29 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     #[instrument(level = "trace", skip(hash))]
-    pub async fn read_confirmed_block(&self, hash: CryptoHash) -> Result<ConfirmedBlock, Error> {
-        let block = self
-            .client
+    pub async fn read_confirmed_block(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<Arc<ConfirmedBlock>, Error> {
+        self.client
             .storage_client()
             .read_confirmed_block(hash)
-            .await?;
-        block
-            .map(Arc::unwrap_or_clone)
+            .await?
             .ok_or(Error::MissingConfirmedBlock(hash))
+            .map(|b| b.into_std())
     }
 
     #[instrument(level = "trace", skip(hash))]
     pub async fn read_certificate(
         &self,
         hash: CryptoHash,
-    ) -> Result<ConfirmedBlockCertificate, Error> {
-        let certificate = self.client.storage_client().read_certificate(hash).await?;
-        certificate
-            .map(Arc::unwrap_or_clone)
+    ) -> Result<Arc<ConfirmedBlockCertificate>, Error> {
+        self.client
+            .storage_client()
+            .read_certificate(hash)
+            .await?
             .ok_or(Error::ReadCertificatesError(vec![hash]))
+            .map(|c| c.into_std())
     }
 
     /// Handles any cross-chain requests for any pending outgoing messages.
@@ -3260,13 +3271,12 @@ impl<Env: Environment> ChainClient<Env> {
             .read_certificates_by_heights(self.chain_id, &heights)
             .await?
             .into_iter()
-            .flatten()
-            .map(Arc::unwrap_or_clone);
+            .flatten();
 
         for certificate in certificates {
             let missing_blob_ids = match remote_node
                 .handle_confirmed_certificate(
-                    certificate.clone(),
+                    certificate.as_std().clone(),
                     CrossChainMessageDelivery::NonBlocking,
                 )
                 .await
@@ -3284,11 +3294,14 @@ impl<Env: Environment> ChainClient<Env> {
                 .await?
                 .into_iter()
                 .flatten()
-                .map(Arc::unwrap_or_clone)
+                .map(|b| b.into_std())
                 .collect();
             remote_node.upload_blobs(missing_blobs).await?;
             remote_node
-                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
+                .handle_confirmed_certificate(
+                    certificate.into_std(),
+                    CrossChainMessageDelivery::NonBlocking,
+                )
                 .await?;
         }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -37,7 +37,7 @@ use linera_chain::{
     ChainError,
 };
 use linera_execution::committee::Committee;
-use linera_storage::{Clock as _, ResultReadCertificates, Storage as _};
+use linera_storage::{Arc as CacheArc, Clock as _, ResultReadCertificates, Storage as _};
 use rand::prelude::SliceRandom as _;
 use received_log::ReceivedLogs;
 use serde::{Deserialize, Serialize};
@@ -344,7 +344,7 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
         height: BlockHeight,
         hash: Option<CryptoHash>,
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, chain_client::Error> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, chain_client::Error> {
         if let Some(hash) = hash {
             return Ok(self.storage_client().read_certificate(hash).await?);
         }
@@ -975,7 +975,7 @@ impl<Env: Environment> Client<Env> {
     pub async fn get_chain_description_blob(
         &self,
         chain_id: ChainId,
-    ) -> Result<Blob, chain_client::Error> {
+    ) -> Result<Arc<Blob>, chain_client::Error> {
         let chain_desc_id = BlobId::new(chain_id.0, BlobType::ChainDescription);
         let blob = self
             .local_node
@@ -984,7 +984,7 @@ impl<Env: Environment> Client<Env> {
             .await?;
         if let Some(blob) = blob {
             // We have the blob - return it.
-            return Ok(Arc::unwrap_or_clone(blob));
+            return Ok(blob.into_std());
         }
         // Recover history from the current validators, according to the admin chain.
         Box::pin(self.synchronize_chain_state(self.admin_chain_id)).await?;
@@ -993,7 +993,8 @@ impl<Env: Environment> Client<Env> {
             .update_local_node_with_blobs_from(vec![chain_desc_id], &nodes)
             .await?
             .pop()
-            .unwrap()) // Returns exactly as many blobs as passed-in IDs.
+            .unwrap() // Returns exactly as many blobs as passed-in IDs.
+            .into_std())
     }
 
     /// Ensures that the client has the `ChainDescription` blob corresponding to this
@@ -1105,7 +1106,7 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
         height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
+        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
         let nodes = self.make_nodes(committee)?;
         communicate_with_quorum(
@@ -1209,7 +1210,7 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "trace", skip_all)]
     async fn receive_sender_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
         mode: ReceiveCertificateMode,
         nodes: Option<Vec<RemoteNode<Env::ValidatorNode>>>,
     ) -> Result<(), chain_client::Error> {
@@ -1226,6 +1227,7 @@ impl<Env: Environment> Client<Env> {
         };
         self.handle_certificate_with_retry(&certificate, &nodes)
             .await?;
+
         Ok(())
     }
 
@@ -1358,7 +1360,11 @@ impl<Env: Environment> Client<Env> {
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self
-                    .receive_sender_certificate(certificate, mode, None)
+                    .receive_sender_certificate(
+                        self.storage_client().cache_certificate(certificate),
+                        mode,
+                        None,
+                    )
                     .await
                 {
                     warn!(%error, %hash, "Received invalid certificate");
@@ -1456,7 +1462,7 @@ impl<Env: Environment> Client<Env> {
                 .try_read_local_certificate(sender_chain_id, current_height, current_hash)
                 .await?
             {
-                Arc::unwrap_or_clone(local)
+                local
             } else {
                 let downloaded = self
                     .requests_scheduler
@@ -1472,7 +1478,7 @@ impl<Env: Environment> Client<Env> {
                         height: current_height,
                     });
                 };
-                certificate
+                self.storage_client().cache_certificate(certificate)
             };
 
             // Validate the certificate.
@@ -1555,7 +1561,7 @@ impl<Env: Environment> Client<Env> {
             let certificate = if let Some(certificate) =
                 self.storage_client().read_certificate(current_hash).await?
             {
-                Arc::unwrap_or_clone(certificate)
+                certificate
             } else {
                 let downloaded = self
                     .requests_scheduler
@@ -1574,7 +1580,7 @@ impl<Env: Environment> Client<Env> {
                 Client::<Env>::check_certificate(max_epoch, &committees, &certificate)?
                     .into_result()?;
 
-                certificate
+                self.storage_client().cache_certificate(certificate)
             };
 
             let block = certificate.block();
@@ -1957,7 +1963,7 @@ impl<Env: Environment> Client<Env> {
         &self,
         blob_ids: Vec<BlobId>,
         remote_nodes: &[RemoteNode<Env::ValidatorNode>],
-    ) -> Result<Vec<Blob>, chain_client::Error> {
+    ) -> Result<Vec<CacheArc<Blob>>, chain_client::Error> {
         let timeout = self.options.blob_download_timeout;
         // Deduplicate IDs.
         let blob_ids = blob_ids.into_iter().collect::<BTreeSet<_>>();
@@ -1970,7 +1976,7 @@ impl<Env: Environment> Client<Env> {
                         .download_certificate_for_blob(&remote_node, blob_id)
                         .await?;
                     self.receive_sender_certificate(
-                        certificate,
+                        self.storage_client().cache_certificate(certificate),
                         ReceiveCertificateMode::NeedsCheck,
                         Some(vec![remote_node.clone()]),
                     )
@@ -1980,7 +1986,6 @@ impl<Env: Environment> Client<Env> {
                         .storage_client()
                         .read_blob(blob_id)
                         .await?
-                        .map(Arc::unwrap_or_clone)
                         .ok_or_else(|| LocalNodeError::BlobsNotFound(vec![blob_id]))?;
                     Result::<_, chain_client::Error>::Ok(blob)
                 },

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -18,7 +18,7 @@ use linera_chain::{
     types::{Block, GenericCertificate},
 };
 use linera_execution::{BlobState, Query, QueryOutcome, ResourceTracker};
-use linera_storage::Storage;
+use linera_storage::{Arc as CacheArc, Storage};
 use linera_views::ViewError;
 use thiserror::Error;
 use tracing::{instrument, warn};
@@ -167,14 +167,9 @@ where
     pub async fn read_blobs_from_storage(
         &self,
         blob_ids: &[BlobId],
-    ) -> Result<Option<Vec<Blob>>, LocalNodeError> {
+    ) -> Result<Option<Vec<CacheArc<Blob>>>, LocalNodeError> {
         let storage = self.storage_client();
-        Ok(storage
-            .read_blobs(blob_ids)
-            .await?
-            .into_iter()
-            .map(|opt| opt.map(Arc::unwrap_or_clone))
-            .collect())
+        Ok(storage.read_blobs(blob_ids).await?.into_iter().collect())
     }
 
     /// Reads blob states from storage.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 #[cfg(not(web))]
 use futures::stream::BoxStream;
@@ -71,7 +71,7 @@ pub trait ValidatorNode {
     /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 
@@ -112,7 +112,7 @@ pub trait ValidatorNode {
     // See also https://github.com/rust-lang/impl-trait-utils/issues/17
     fn upload_blobs(
         &self,
-        blobs: Vec<Blob>,
+        blobs: Vec<Arc<Blob>>,
     ) -> impl futures::Future<Output = Result<Vec<BlobId>, NodeError>> {
         let tasks: Vec<_> = blobs
             .into_iter()

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashSet, VecDeque};
+use std::{
+    collections::{HashSet, VecDeque},
+    sync::Arc,
+};
 
 use custom_debug_derive::Debug;
 use futures::future::try_join_all;
@@ -64,7 +67,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     pub(crate) async fn handle_confirmed_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         let chain_id = certificate.inner().chain_id();
@@ -111,7 +114,7 @@ impl<N: ValidatorNode> RemoteNode<N> {
 
     pub(crate) async fn handle_optimized_confirmed_certificate(
         &self,
-        certificate: &ConfirmedBlockCertificate,
+        certificate: &Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, NodeError> {
         if let Some(result) = self.try_lite_certificate(certificate, delivery).await {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -149,11 +149,11 @@ where
 
     async fn handle_confirmed_certificate(
         &self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, sender)
+            validator.do_handle_certificate(Arc::unwrap_or_clone(certificate), sender)
         })
         .await
     }
@@ -538,7 +538,7 @@ where
             .download_pending_blob(chain_id, blob_id)
             .await
             .map_err(Into::into);
-        sender.send(result.map(|blob| blob.into_content()))
+        sender.send(result.map(|blob| blob.content().clone()))
     }
 
     async fn do_handle_pending_blob(
@@ -851,7 +851,7 @@ impl<S: Storage + Clone + Send + Sync + 'static> ChainClient<S> {
         &self,
         from: CryptoHash,
         limit: u32,
-    ) -> anyhow::Result<Vec<ConfirmedBlock>> {
+    ) -> anyhow::Result<Vec<Arc<ConfirmedBlock>>> {
         let mut hash = Some(from);
         let mut values = Vec::new();
         for _ in 0..limit {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4896,16 +4896,9 @@ where
         .await;
 
     // Process all three blocks on chain_1.
-    env.worker()
-        .process_confirmed_block(cert_0.clone(), None)
-        .await?;
-    env.worker()
-        .process_confirmed_block(cert_1.clone(), None)
-        .await?;
-    let (_, actions, _) = env
-        .worker()
-        .process_confirmed_block(cert_2.clone(), None)
-        .await?;
+    env.worker().process_confirmed_block(cert_0, None).await?;
+    env.worker().process_confirmed_block(cert_1, None).await?;
+    let (_, actions, _) = env.worker().process_confirmed_block(cert_2, None).await?;
 
     // With chunk_limit=1, only the first chunk (height 0) should be returned.
     // The remaining heights stay in the outbox for delivery after confirmation.
@@ -5023,9 +5016,7 @@ where
     env.worker()
         .process_confirmed_block(cert_0.clone(), None)
         .await?;
-    env.worker()
-        .process_confirmed_block(cert_1.clone(), None)
-        .await?;
+    env.worker().process_confirmed_block(cert_1, None).await?;
     env.worker()
         .process_confirmed_block(cert_2.clone(), None)
         .await?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -27,7 +27,7 @@ use linera_chain::{
     types::{ConfirmedBlock, GenericCertificate, ValidatedBlock, ValidatedBlockCertificate},
 };
 use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
-use linera_storage::{Clock, ResultReadCertificates, Storage};
+use linera_storage::{Arc as CacheArc, Clock, ResultReadCertificates, Storage};
 use thiserror::Error;
 use tokio::sync::mpsc;
 use tracing::{instrument, Level};
@@ -265,12 +265,12 @@ where
     )]
     async fn send_confirmed_certificate(
         &mut self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: &Arc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self
             .remote_node
-            .handle_optimized_confirmed_certificate(&certificate, delivery)
+            .handle_optimized_confirmed_certificate(certificate, delivery)
             .await;
 
         let mut sent_admin_chain = false;
@@ -292,7 +292,7 @@ where
                 Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
                     // The validator is missing the blobs required by the certificate.
                     self.remote_node
-                        .check_blobs_not_found(&certificate, &blob_ids)?;
+                        .check_blobs_not_found(certificate, &blob_ids)?;
                     // The certificate is confirmed, so the blobs must be in storage.
                     let maybe_blobs = self
                         .client
@@ -300,7 +300,10 @@ where
                         .read_blobs_from_storage(&blob_ids)
                         .await?;
                     let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
-                    self.remote_node.node.upload_blobs(blobs).await?;
+                    self.remote_node
+                        .node
+                        .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
+                        .await?;
                     sent_blobs = true;
                 }
                 result => {
@@ -696,7 +699,7 @@ where
         chain_id: ChainId,
         target_block_height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
+        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
         // Phase 1: Height synchronization
         let info = if target_block_height.0 > 0 {
@@ -742,7 +745,7 @@ where
         chain_id: ChainId,
         target_block_height: BlockHeight,
         delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<GenericCertificate<ConfirmedBlock>>,
+        latest_certificate: Option<Arc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let height = target_block_height.try_sub_one()?;
 
@@ -759,10 +762,14 @@ where
                         "failed to read latest certificate for height sync",
                     )
                 })?
+                .into_std()
         };
 
         // Optimistically try sending just the last certificate
-        let info = match self.send_confirmed_certificate(certificate, delivery).await {
+        let info = match self
+            .send_confirmed_certificate(&certificate, delivery)
+            .await
+        {
             Ok(info) => info,
             Err(error) => {
                 tracing::debug!(
@@ -790,7 +797,7 @@ where
                 .await?;
 
             for certificate in certificates {
-                self.send_confirmed_certificate(certificate, delivery)
+                self.send_confirmed_certificate(certificate.as_std(), delivery)
                     .await?;
             }
         }
@@ -810,7 +817,7 @@ where
         &self,
         chain_id: ChainId,
         heights: Vec<BlockHeight>,
-    ) -> Result<Vec<GenericCertificate<ConfirmedBlock>>, chain_client::Error> {
+    ) -> Result<Vec<CacheArc<GenericCertificate<ConfirmedBlock>>>, chain_client::Error> {
         let storage = self.client.local_node.storage_client();
 
         // First, try the direct height-based lookup
@@ -823,11 +830,7 @@ where
             && certificates_by_height.iter().all(|c| c.is_some());
 
         if all_found {
-            return Ok(certificates_by_height
-                .into_iter()
-                .flatten()
-                .map(Arc::unwrap_or_clone)
-                .collect());
+            return Ok(certificates_by_height.into_iter().flatten().collect());
         }
 
         // Fallback to the traditional approach
@@ -846,7 +849,10 @@ where
                 storage
                     .write_certificate_height_indices(chain_id, &indices)
                     .await?;
-                Ok(certs)
+                Ok(certs
+                    .into_iter()
+                    .map(|c| storage.cache_certificate(c))
+                    .collect())
             }
             ResultReadCertificates::InvalidHashes(hashes) => {
                 Err(chain_client::Error::ReadCertificatesError(hashes))
@@ -1012,13 +1018,12 @@ where
                         .await?
                         .into_iter()
                         .flatten()
-                        .map(Arc::unwrap_or_clone)
                         .collect::<Vec<_>>();
 
                     // Send each certificate
                     for certificate in certificates {
                         updater
-                            .send_confirmed_certificate(certificate, delivery)
+                            .send_confirmed_certificate(certificate.as_std(), delivery)
                             .await?;
                     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -21,10 +21,9 @@ use linera_base::{
         Timestamp,
     },
     doc_scalar,
-    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
 };
-use linera_cache::{UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
+use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
 #[cfg(with_testing)]
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
@@ -693,7 +692,7 @@ pub struct WorkerState<StorageClient: Storage> {
     storage: StorageClient,
     /// Configuration options for chain workers.
     pub(crate) chain_worker_config: ChainWorkerConfig,
-    block_cache: Arc<ValueCache<CryptoHash, Hashed<Block>>>,
+    block_cache: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
     /// Chains tracked by a worker, along with their listening modes.
@@ -779,19 +778,16 @@ where
             .block_cache
             .get(&certificate.value.value_hash)
             .ok_or(WorkerError::MissingCertificateValue)?;
-        let block = Arc::unwrap_or_clone(block);
+        let block = CacheArc::unwrap_or_clone(block);
 
         match certificate.value.kind {
-            linera_chain::types::CertificateKind::Confirmed => {
-                let value = ConfirmedBlock::from_hashed(block);
-                Ok(Either::Left(
-                    certificate
-                        .with_value(value)
-                        .ok_or(WorkerError::InvalidLiteCertificate)?,
-                ))
-            }
+            linera_chain::types::CertificateKind::Confirmed => Ok(Either::Left(
+                certificate
+                    .with_value(block)
+                    .ok_or(WorkerError::InvalidLiteCertificate)?,
+            )),
             linera_chain::types::CertificateKind::Validated => {
-                let value = ValidatedBlock::from_hashed(block);
+                let value = ValidatedBlock::from_hashed(block.into_inner());
                 Ok(Either::Right(
                     certificate
                         .with_value(value)
@@ -1432,7 +1428,7 @@ where
         &self,
         chain_id: ChainId,
         height: BlockHeight,
-    ) -> Result<Option<ConfirmedBlockCertificate>, WorkerError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, WorkerError> {
         let state = self.get_or_create_chain_worker(chain_id).await?;
         let guard = handle::read_lock_initialized(&state).await?;
         guard.read_certificate(height).await
@@ -1630,7 +1626,7 @@ where
         &self,
         chain_id: ChainId,
         blob_id: BlobId,
-    ) -> Result<Blob, WorkerError> {
+    ) -> Result<CacheArc<Blob>, WorkerError> {
         trace!("{} <-- download_pending_blob({blob_id:8})", self.nickname());
         let result = self
             .chain_read(chain_id, |guard| async move {

--- a/linera-exporter/src/runloops/validator_exporter.rs
+++ b/linera-exporter/src/runloops/validator_exporter.rs
@@ -117,7 +117,7 @@ where
             crate::metrics::VALIDATOR_EXPORTER_QUEUE_LENGTH
                 .with_label_values(&[self.node.address()])
                 .set(receiver.len() as i64);
-            match self.dispatch_block((*block).clone()).await {
+            match self.dispatch_block(block.clone()).await {
                 Ok(_) => {}
 
                 Err(NodeError::BlobsNotFound(blobs_to_maybe_send)) => {
@@ -126,7 +126,7 @@ where
                         .filter(|id| blobs_to_maybe_send.contains(id))
                         .collect();
                     self.upload_blobs(blobs).await?;
-                    self.dispatch_block((*block).clone()).await?
+                    self.dispatch_block(block).await?
                 }
 
                 Err(e) => Err(e)?,
@@ -180,7 +180,7 @@ where
 
     async fn dispatch_block(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
     ) -> Result<(), NodeError> {
         let delivery = CrossChainMessageDelivery::NonBlocking;
         let block_id = BlockId::from_confirmed_block(certificate.value());

--- a/linera-exporter/src/storage.rs
+++ b/linera-exporter/src/storage.rs
@@ -110,7 +110,8 @@ where
                     .storage
                     .read_certificate(hash)
                     .await?
-                    .ok_or_else(|| ExporterError::ReadCertificateError(hash))?;
+                    .ok_or_else(|| ExporterError::ReadCertificateError(hash))?
+                    .into_std();
                 guard.insert(block.clone()).ok();
                 Ok(block)
             }
@@ -123,7 +124,7 @@ where
             Err(guard) => {
                 #[cfg(with_metrics)]
                 metrics::GET_BLOB_HISTOGRAM.measure_latency();
-                let blob = self.storage.read_blob(blob_id).await?.unwrap();
+                let blob = self.storage.read_blob(blob_id).await?.unwrap().into_std();
                 guard.insert(blob.clone()).ok();
                 Ok(blob)
             }

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::Arc};
 
 use linera_base::{
     crypto::CryptoHash,
@@ -103,7 +103,7 @@ impl ValidatorNode for Client {
 
     async fn handle_confirmed_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -284,12 +284,12 @@ impl ValidatorNode for GrpcClient {
     #[instrument(target = "grpc_client", skip_all, err(level = Level::DEBUG), fields(address = self.address))]
     async fn handle_confirmed_certificate(
         &self,
-        certificate: GenericCertificate<ConfirmedBlock>,
+        certificate: Arc<GenericCertificate<ConfirmedBlock>>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages: bool = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
-            certificate,
+            certificate: Arc::unwrap_or_clone(certificate),
             wait_for_outgoing_messages,
         };
         GrpcClient::try_into_chain_info(client_delegate!(

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -990,7 +990,7 @@ where
         {
             Ok(blob) => {
                 Self::log_request_success("download_pending_blob", traffic_type);
-                Ok(Response::new(blob.into_content().try_into()?))
+                Ok(Response::new(blob.content().clone().try_into()?))
             }
             Err(error) => {
                 Self::log_request_error("download_pending_blob", traffic_type, &error.error_type());

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, future::Future};
+use std::{collections::BTreeMap, future::Future, sync::Arc};
 
 use futures::{sink::SinkExt, stream::StreamExt};
 use linera_base::{
@@ -120,12 +120,12 @@ impl ValidatorNode for SimpleClient {
     /// Processes a confirmed certificate.
     async fn handle_confirmed_certificate(
         &self,
-        certificate: ConfirmedBlockCertificate,
+        certificate: Arc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleConfirmedCertificateRequest {
-            certificate,
+            certificate: Arc::unwrap_or_clone(certificate),
             wait_for_outgoing_messages,
         };
         let request = RpcMessage::ConfirmedCertificate(Box::new(request));

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -348,7 +348,7 @@ where
                     .await
                 {
                     Ok(blob) => Ok(Some(RpcMessage::DownloadPendingBlobResponse(Box::new(
-                        blob.into(),
+                        blob.content().clone(),
                     )))),
                     Err(error) => {
                         self.log_error(&error, "Failed to handle pending blob request");

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -772,7 +772,7 @@ where
         &self,
         hash: Option<CryptoHash>,
         chain_id: ChainId,
-    ) -> Result<Option<ConfirmedBlock>, Error> {
+    ) -> Result<Option<Arc<ConfirmedBlock>>, Error> {
         let client = self
             .context
             .lock()
@@ -784,8 +784,7 @@ where
             None => client.chain_info().await?.block_hash,
         };
         if let Some(hash) = hash {
-            let block = client.read_confirmed_block(hash).await?;
-            Ok(Some(block))
+            Ok(Some(client.read_confirmed_block(hash).await?))
         } else {
             Ok(None)
         }
@@ -812,7 +811,7 @@ where
         from: Option<CryptoHash>,
         chain_id: ChainId,
         limit: Option<u32>,
-    ) -> Result<Vec<ConfirmedBlock>, Error> {
+    ) -> Result<Vec<Arc<ConfirmedBlock>>, Error> {
         let client = self
             .context
             .lock()

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -51,7 +51,7 @@ use linera_rpc::{
     },
 };
 use linera_sdk::{linera_base_types::Blob, views::ViewError};
-use linera_storage::Storage;
+use linera_storage::{Arc as CacheArc, Storage};
 use prost::Message;
 use tokio::{select, task::JoinSet};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -505,7 +505,7 @@ where
                 .map_err(Self::view_error_to_status)?
                 .into_iter()
                 .flatten()
-                .map(Arc::unwrap_or_clone)
+                .map(CacheArc::unwrap_or_clone)
                 .collect();
 
             let batch_size = certificates.len();
@@ -683,7 +683,7 @@ where
             .await
             .map_err(Self::view_error_to_status)?;
         let blob = blob
-            .map(Arc::unwrap_or_clone)
+            .map(CacheArc::unwrap_or_clone)
             .ok_or_else(|| Status::not_found(format!("Blob not found {blob_id}")))?;
         Ok(Response::new(blob.into_content().try_into()?))
     }
@@ -727,15 +727,16 @@ where
         request: Request<CryptoHash>,
     ) -> Result<Response<Certificate>, Status> {
         let hash = request.into_inner().try_into()?;
-        let certificate: linera_chain::types::Certificate = Arc::unwrap_or_clone(
-            self.0
-                .storage
-                .read_certificate(hash)
-                .await
-                .map_err(Self::view_error_to_status)?
-                .ok_or_else(|| Status::not_found(hash.to_string()))?,
-        )
-        .into();
+        let certificate: linera_chain::types::Certificate = self
+            .0
+            .storage
+            .read_certificate(hash)
+            .await
+            .map_err(Self::view_error_to_status)?
+            .ok_or_else(|| Status::not_found(hash.to_string()))?
+            .into_std()
+            .as_ref()
+            .into();
         Ok(Response::new(certificate.try_into()?))
     }
 
@@ -809,8 +810,7 @@ where
 
             let returned_certificates =
                 limiter.take_if(certificates_by_height, |lim, certificate| {
-                    let cert: linera_chain::types::Certificate =
-                        Arc::unwrap_or_clone(certificate).into();
+                    let cert: linera_chain::types::Certificate = (&*certificate).into();
                     Ok(lim.fits::<Certificate>(cert.clone())?.then_some(cert))
                 })?;
 
@@ -851,7 +851,7 @@ where
             .map_err(Self::view_error_to_status)?
             .into_iter()
             .flatten()
-            .map(Arc::unwrap_or_clone)
+            .map(CacheArc::unwrap_or_clone)
             .collect::<Vec<(Vec<u8>, Vec<u8>)>>();
 
         // Check if we got all certificates.

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -11,7 +11,7 @@ static ALLOC: linera_jemallocator::Jemalloc = linera_jemallocator::Jemalloc;
 #[export_name = "malloc_conf"]
 pub static MALLOC_CONF: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
 
-use std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use anyhow::{anyhow, bail, ensure, Result};
 use async_trait::async_trait;
@@ -34,6 +34,7 @@ use linera_service::{
     storage::{AssertStorageV1, CommonStorageOptions, Runnable, StorageConfig},
     util,
 };
+use linera_storage::Arc as CacheArc;
 use linera_storage::{ResultReadCertificates, Storage};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -379,16 +380,14 @@ where
             }
             DownloadBlob(blob_id) => {
                 let blob = self.storage.read_blob(*blob_id).await?;
-                let blob = blob
-                    .map(Arc::unwrap_or_clone)
-                    .ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
-                let content = blob.into_content();
+                let blob = blob.ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                let content = blob.content().clone();
                 Ok(Some(RpcMessage::DownloadBlobResponse(Box::new(content))))
             }
             DownloadConfirmedBlock(hash) => {
                 let block = self.storage.read_confirmed_block(*hash).await?;
                 let block = block
-                    .map(Arc::unwrap_or_clone)
+                    .map(CacheArc::unwrap_or_clone)
                     .ok_or_else(|| anyhow!("Missing confirmed block {hash}"))?;
                 Ok(Some(RpcMessage::DownloadConfirmedBlockResponse(Box::new(
                     block,
@@ -462,7 +461,7 @@ where
                     .storage
                     .read_certificate(last_used_by)
                     .await?
-                    .map(Arc::unwrap_or_clone)
+                    .map(CacheArc::unwrap_or_clone)
                     .ok_or_else(|| anyhow!("Certificate not found {}", last_used_by))?;
                 Ok(Some(RpcMessage::BlobLastUsedByCertificateResponse(
                     Box::new(certificate),

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -69,7 +69,7 @@ impl ValidatorNode for DummyValidatorNode {
 
     async fn handle_confirmed_certificate(
         &self,
-        _: GenericCertificate<ConfirmedBlock>,
+        _: Arc<GenericCertificate<ConfirmedBlock>>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -11,7 +11,7 @@ use linera_base::{
     data_types::{Blob, BlockHeight, NetworkDescription, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
 };
-use linera_cache::ValueCache;
+use linera_cache::{Arc as CacheArc, ValueCache};
 use linera_chain::{
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     ChainStateView,
@@ -1278,7 +1278,7 @@ where
     async fn read_confirmed_block(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<ConfirmedBlock>>, ViewError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlock>>, ViewError> {
         if let Some(block) = self.caches.confirmed_block.get(&hash) {
             #[cfg(with_metrics)]
             metrics::READ_CONFIRMED_BLOCK_COUNTER
@@ -1303,7 +1303,7 @@ where
     async fn read_confirmed_blocks<I: IntoIterator<Item = CryptoHash> + Send>(
         &self,
         hashes: I,
-    ) -> Result<Vec<Option<Arc<ConfirmedBlock>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlock>>>, ViewError> {
         let hashes = hashes.into_iter().collect::<Vec<_>>();
         if hashes.is_empty() {
             return Ok(Vec::new());
@@ -1350,7 +1350,7 @@ where
     }
 
     #[instrument(skip_all, fields(%blob_id))]
-    async fn read_blob(&self, blob_id: BlobId) -> Result<Option<Arc<Blob>>, ViewError> {
+    async fn read_blob(&self, blob_id: BlobId) -> Result<Option<CacheArc<Blob>>, ViewError> {
         if let Some(blob) = self.caches.blob.get(&blob_id) {
             #[cfg(with_metrics)]
             metrics::READ_BLOB_COUNTER
@@ -1375,7 +1375,10 @@ where
     }
 
     #[instrument(skip_all, fields(blob_ids_len = %blob_ids.len()))]
-    async fn read_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<Option<Arc<Blob>>>, ViewError> {
+    async fn read_blobs(
+        &self,
+        blob_ids: &[BlobId],
+    ) -> Result<Vec<Option<CacheArc<Blob>>>, ViewError> {
         if blob_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -1503,6 +1506,23 @@ where
         self.write_batch(batch).await
     }
 
+    fn cache_certificate(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+    ) -> CacheArc<ConfirmedBlockCertificate> {
+        self.caches
+            .certificate
+            .insert(&certificate.hash(), certificate)
+    }
+
+    fn cache_blob(&self, blob: Blob) -> CacheArc<Blob> {
+        self.caches.blob.insert(&blob.id(), blob)
+    }
+
+    fn cache_confirmed_block(&self, block: ConfirmedBlock) -> CacheArc<ConfirmedBlock> {
+        self.caches.confirmed_block.insert(&block.hash(), block)
+    }
+
     #[instrument(skip_all, fields(%hash))]
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError> {
         if self.caches.certificate.contains(&hash) || self.caches.certificate_raw.contains(&hash) {
@@ -1526,7 +1546,7 @@ where
     async fn read_certificate(
         &self,
         hash: CryptoHash,
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, ViewError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, ViewError> {
         // Assembled certificate cache (single Arc, no re-assembly)
         if let Some(cert) = self.caches.certificate.get(&hash) {
             #[cfg(with_metrics)]
@@ -1568,7 +1588,7 @@ where
     async fn read_certificates(
         &self,
         hashes: &[CryptoHash],
-    ) -> Result<Vec<Option<Arc<ConfirmedBlockCertificate>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlockCertificate>>>, ViewError> {
         let raw_certs = self.read_certificates_raw(hashes).await?;
 
         raw_certs
@@ -1586,7 +1606,7 @@ where
     async fn read_certificates_raw(
         &self,
         hashes: &[CryptoHash],
-    ) -> Result<Vec<Option<Arc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
         if hashes.is_empty() {
             return Ok(Vec::new());
         }
@@ -1661,7 +1681,7 @@ where
         &self,
         chain_id: ChainId,
         heights: &[BlockHeight],
-    ) -> Result<Vec<Option<Arc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<(Vec<u8>, Vec<u8>)>>>, ViewError> {
         let hashes: Vec<Option<CryptoHash>> = self
             .read_certificate_hashes_by_heights(chain_id, heights)
             .await?;
@@ -1706,7 +1726,7 @@ where
         &self,
         chain_id: ChainId,
         heights: &[BlockHeight],
-    ) -> Result<Vec<Option<Arc<ConfirmedBlockCertificate>>>, ViewError> {
+    ) -> Result<Vec<Option<CacheArc<ConfirmedBlockCertificate>>>, ViewError> {
         self.read_certificates_by_heights_raw(chain_id, heights)
             .await?
             .into_iter()
@@ -1742,7 +1762,7 @@ where
     }
 
     #[instrument(skip_all, fields(event_id = ?event_id))]
-    async fn read_event(&self, event_id: EventId) -> Result<Option<Arc<Vec<u8>>>, ViewError> {
+    async fn read_event(&self, event_id: EventId) -> Result<Option<CacheArc<Vec<u8>>>, ViewError> {
         if let Some(event) = self.caches.event.get(&event_id) {
             #[cfg(with_metrics)]
             metrics::READ_EVENT_COUNTER
@@ -1887,7 +1907,7 @@ where
         &self,
         lite_cert_bytes: &[u8],
         confirmed_block_bytes: &[u8],
-    ) -> Result<Option<Arc<ConfirmedBlockCertificate>>, ViewError> {
+    ) -> Result<Option<CacheArc<ConfirmedBlockCertificate>>, ViewError> {
         let lite = bcs::from_bytes::<LiteCertificate>(lite_cert_bytes)?;
         let block = bcs::from_bytes::<ConfirmedBlock>(confirmed_block_bytes)?;
         let hash = block.hash();

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -6,7 +6,7 @@
 mod db_storage;
 mod migration;
 
-use std::sync::Arc;
+use std::sync::Arc as StdArc;
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -19,7 +19,7 @@ use linera_base::{
     identifiers::{ApplicationId, BlobId, BlobType, ChainId, EventId, IndexAndEvent, StreamId},
     vm::VmRuntime,
 };
-pub use linera_cache::DEFAULT_CLEANUP_INTERVAL_SECS;
+pub use linera_cache::{Arc, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     ChainError, ChainStateView,
@@ -65,7 +65,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     /// Returns the current wall clock time.
     fn clock(&self) -> &Self::Clock;
 
-    fn thread_pool(&self) -> &Arc<linera_execution::ThreadPool>;
+    fn thread_pool(&self) -> &StdArc<linera_execution::ThreadPool>;
 
     /// Loads the view of a chain state.
     ///
@@ -138,6 +138,33 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
 
     /// Tests existence of the certificate with the given hash.
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError>;
+
+    /// Inserts a certificate into the in-memory dedup cache and returns the
+    /// canonical [`Arc`]. If the cache already holds an `Arc` for this hash,
+    /// the passed-in `certificate` is dropped and the existing `Arc` is
+    /// returned. This must be used (rather than `Arc::new`) for any
+    /// freshly-constructed [`ConfirmedBlockCertificate`] that should
+    /// participate in the "one allocation per content" invariant.
+    fn cache_certificate(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+    ) -> Arc<ConfirmedBlockCertificate>;
+
+    /// Inserts a blob into the in-memory dedup cache and returns the canonical
+    /// [`Arc`]. If the cache already holds an `Arc` for this blob ID, the
+    /// passed-in `blob` is dropped and the existing `Arc` is returned. This
+    /// must be used (rather than `Arc::new`) for any freshly-constructed
+    /// [`Blob`] that should participate in the "one allocation per content"
+    /// invariant.
+    fn cache_blob(&self, blob: Blob) -> Arc<Blob>;
+
+    /// Inserts a confirmed block into the in-memory dedup cache and returns
+    /// the canonical [`Arc`]. If the cache already holds an `Arc` for this
+    /// hash, the passed-in `block` is dropped and the existing `Arc` is
+    /// returned. This must be used (rather than `Arc::new`) for any
+    /// freshly-constructed [`ConfirmedBlock`] that should participate in the
+    /// "one allocation per content" invariant.
+    fn cache_confirmed_block(&self, block: ConfirmedBlock) -> Arc<ConfirmedBlock>;
 
     /// Reads the certificate with the given hash.
     async fn read_certificate(
@@ -238,7 +265,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     async fn get_or_load_committee(
         &self,
         epoch: Epoch,
-    ) -> Result<Option<Arc<Committee>>, ViewError> {
+    ) -> Result<Option<StdArc<Committee>>, ViewError> {
         if let Some(committee) = self.shared_committees().get(epoch) {
             return Ok(Some(committee));
         }
@@ -280,7 +307,8 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         };
         let committee: Committee = bcs::from_bytes(blob.bytes())?;
         Ok(Some(
-            self.shared_committees().insert(epoch, Arc::new(committee)),
+            self.shared_committees()
+                .insert(epoch, StdArc::new(committee)),
         ))
     }
 
@@ -323,10 +351,14 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         let contract_bytecode_blob_id = application_description.contract_bytecode_blob_id();
         let content = match txn_tracker.get_blob_content(&contract_bytecode_blob_id) {
             Some(content) => content.clone(),
-            None => Arc::unwrap_or_clone(self.read_blob(contract_bytecode_blob_id).await?.ok_or(
-                ExecutionError::BlobsNotFound(vec![contract_bytecode_blob_id]),
-            )?)
-            .into_content(),
+            None => self
+                .read_blob(contract_bytecode_blob_id)
+                .await?
+                .ok_or(ExecutionError::BlobsNotFound(vec![
+                    contract_bytecode_blob_id,
+                ]))?
+                .content()
+                .clone(),
         };
         let compressed_contract_bytecode = CompressedBytecode {
             compressed_bytes: content.into_arc_bytes(),
@@ -386,10 +418,14 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         let service_bytecode_blob_id = application_description.service_bytecode_blob_id();
         let content = match txn_tracker.get_blob_content(&service_bytecode_blob_id) {
             Some(content) => content.clone(),
-            None => Arc::unwrap_or_clone(self.read_blob(service_bytecode_blob_id).await?.ok_or(
-                ExecutionError::BlobsNotFound(vec![service_bytecode_blob_id]),
-            )?)
-            .into_content(),
+            None => self
+                .read_blob(service_bytecode_blob_id)
+                .await?
+                .ok_or(ExecutionError::BlobsNotFound(vec![
+                    service_bytecode_blob_id,
+                ]))?
+                .content()
+                .clone(),
         };
         let compressed_service_bytecode = CompressedBytecode {
             compressed_bytes: content.into_arc_bytes(),
@@ -477,10 +513,10 @@ impl ResultReadCertificates {
 pub struct ChainRuntimeContext<S> {
     storage: S,
     chain_id: ChainId,
-    thread_pool: Arc<linera_execution::ThreadPool>,
+    thread_pool: StdArc<linera_execution::ThreadPool>,
     execution_runtime_config: ExecutionRuntimeConfig,
-    user_contracts: Arc<papaya::HashMap<ApplicationId, UserContractCode>>,
-    user_services: Arc<papaya::HashMap<ApplicationId, UserServiceCode>>,
+    user_contracts: StdArc<papaya::HashMap<ApplicationId, UserContractCode>>,
+    user_services: StdArc<papaya::HashMap<ApplicationId, UserServiceCode>>,
 }
 
 #[cfg_attr(not(web), async_trait)]
@@ -490,7 +526,7 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
         self.chain_id
     }
 
-    fn thread_pool(&self) -> &Arc<linera_execution::ThreadPool> {
+    fn thread_pool(&self) -> &StdArc<linera_execution::ThreadPool> {
         &self.thread_pool
     }
 
@@ -498,11 +534,11 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
         self.execution_runtime_config
     }
 
-    fn user_contracts(&self) -> &Arc<papaya::HashMap<ApplicationId, UserContractCode>> {
+    fn user_contracts(&self) -> &StdArc<papaya::HashMap<ApplicationId, UserContractCode>> {
         &self.user_contracts
     }
 
-    fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>> {
+    fn user_services(&self) -> &StdArc<papaya::HashMap<ApplicationId, UserServiceCode>> {
         &self.user_services
     }
 
@@ -536,12 +572,12 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
         Ok(service)
     }
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<Option<Arc<Blob>>, ViewError> {
-        self.storage.read_blob(blob_id).await
+    async fn get_blob(&self, blob_id: BlobId) -> Result<Option<StdArc<Blob>>, ViewError> {
+        Ok(self.storage.read_blob(blob_id).await?.map(Arc::into_std))
     }
 
-    async fn get_event(&self, event_id: EventId) -> Result<Option<Arc<Vec<u8>>>, ViewError> {
-        self.storage.read_event(event_id).await
+    async fn get_event(&self, event_id: EventId) -> Result<Option<StdArc<Vec<u8>>>, ViewError> {
+        Ok(self.storage.read_event(event_id).await?.map(Arc::into_std))
     }
 
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
@@ -551,7 +587,7 @@ impl<S: Storage> ExecutionRuntimeContext for ChainRuntimeContext<S> {
     async fn get_or_load_committee(
         &self,
         epoch: Epoch,
-    ) -> Result<Option<Arc<Committee>>, ViewError> {
+    ) -> Result<Option<StdArc<Committee>>, ViewError> {
         self.storage.get_or_load_committee(epoch).await
     }
 


### PR DESCRIPTION
## Motivation

Supersedes #6249 (which had accumulated merge conflicts). Backports #6147 and #6330 to `testnet_conway` in a single commit on a rebased branch.

## Proposal

Cherry-pick of #6147 rebased on current `testnet_conway` tip, with conflict resolution, plus the `linera_cache::Arc<T>` newtype from #6330.

Conflict resolution notes:
- `linera-storage/src/lib.rs`: took testnet_conway's removals (`shared_committees`, `get_or_load_committee_by_hash`, `committee_for_epoch`, test module); adjusted `get_or_load_committee` return type to `std::sync::Arc<Committee>` (Committee is not managed by value cache)
- `linera-storage/src/db_storage.rs`: took testnet_conway's structure throughout, then applied newtype return-type changes
- `linera-core/src/client/chain_client/mod.rs`: kept testnet_conway's `download_certificates_for_events` restructuring and `BlobsNotFound` handling; adapted blob/certificate boundary conversions (`into_std()`, `as_std().clone()`)
- `linera-service/src/proxy/grpc.rs`: kept testnet_conway's `if all_found` guard; used `(&*certificate).into()` to avoid `.as_ref()` ambiguity on `CacheArc`

## Test Plan

CI — `cargo check --workspace --exclude linera-web` and `cargo clippy` clean locally before pushing.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6147 — original main PR (merged)
- #6330 — the newtype follow-up on main
- #6249 — superseded backport PR
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)