### PR TITLE
Allow rolling back chain-worker views (again) on certain save errors

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -109,7 +109,8 @@ where
     chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
     delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
-    /// Set to `true` if a journal resolution failure has left storage potentially inconsistent.
+    /// Set to `true` if a database `save` failure has left storage potentially
+    /// inconsistent.
     poisoned: bool,
 }
 
@@ -195,8 +196,8 @@ where
         self.chain.rollback();
     }
 
-    /// Returns `WorkerError::PoisonedWorker` if the worker is poisoned due to a journal
-    /// resolution failure.
+    /// Returns `WorkerError::PoisonedWorker` if the worker is poisoned due to a database
+    /// `save` failure.
     pub(crate) fn check_not_poisoned(&self) -> Result<(), WorkerError> {
         ensure!(!self.poisoned, WorkerError::PoisonedWorker);
         Ok(())
@@ -2263,13 +2264,15 @@ where
     ))]
     pub(crate) async fn save(&mut self) -> Result<(), WorkerError> {
         if let Err(error) = self.chain.save().await {
-            tracing::error!(
-                ?error,
-                chain_id = %self.chain_id(),
-                "Chain save failed; marking worker as poisoned"
-            );
-            self.poisoned = true;
-            return Err(WorkerError::PoisonedWorker);
+            if error.must_reload_view() {
+                tracing::error!(
+                    ?error,
+                    chain_id = %self.chain_id(),
+                    "Chain save failed with a nonrecoverable error; marking worker as poisoned"
+                );
+                self.poisoned = true;
+            }
+            return Err(WorkerError::ViewError(error));
         }
         // Committee lookups go through the process-global SharedCommittees cache, so the
         // chain-local `committees` map doesn't need to sit in memory across worker calls.

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -987,6 +987,12 @@ impl DynamoDbStoreInternalError {
 
 impl KeyValueStoreError for DynamoDbStoreInternalError {
     const BACKEND: &'static str = "dynamo_db";
+
+    fn must_reload_view(&self) -> bool {
+        // A failed `TransactWriteItems` call (notably on timeout) may leave the view in
+        // an undetermined state where the transaction may or may not have been applied.
+        matches!(self, Self::TransactWriteItem(_))
+    }
 }
 
 #[cfg(with_testing)]

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -548,6 +548,7 @@ where
                 transaction_size = 0;
             }
         }
+        // Until the journal header is written nothing is committed.
         let header = JournalHeader { block_count };
         if block_count > 0 {
             let value = bcs::to_bytes(&header)?;

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -24,7 +24,7 @@ use scylla::{
     },
     deserialize::{DeserializationError, TypeCheckError},
     errors::{
-        DbError, ExecutionError, IntoRowsResultError, NextPageError, NextRowError,
+        DbError, ExecutionError, IntoRowsResultError, NewSessionError, NextPageError, NextRowError,
         PagerExecutionError, PrepareError, RequestAttemptError, RequestError, RowsError,
     },
     policies::{
@@ -569,6 +569,10 @@ pub enum ScyllaDbStoreInternalError {
     /// An execution error during a write-batch operation.
     #[error(transparent)]
     WriteBatchExecutionError(ExecutionError),
+
+    /// A session creation error
+    #[error(transparent)]
+    NewSessionError(#[from] NewSessionError),
 
     /// A next row error in ScyllaDB
     #[error(transparent)]

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -24,7 +24,7 @@ use scylla::{
     },
     deserialize::{DeserializationError, TypeCheckError},
     errors::{
-        DbError, ExecutionError, IntoRowsResultError, NewSessionError, NextPageError, NextRowError,
+        DbError, ExecutionError, IntoRowsResultError, NextPageError, NextRowError,
         PagerExecutionError, PrepareError, RequestAttemptError, RequestError, RowsError,
     },
     policies::{
@@ -309,7 +309,8 @@ impl ScyllaDbClient {
 
         let (result, _) = session
             .execute_single_page(&self.read_value, &values, PagingState::start())
-            .await?;
+            .await
+            .map_err(ScyllaDbStoreInternalError::ExecutionError)?;
         let rows = result.into_rows_result()?;
         let mut rows = rows.rows::<(Vec<u8>,)>()?;
         Ok(match rows.next() {
@@ -391,7 +392,8 @@ impl ScyllaDbClient {
 
         let (result, _) = session
             .execute_single_page(&self.contains_key, &values, PagingState::start())
-            .await?;
+            .await
+            .map_err(ScyllaDbStoreInternalError::ExecutionError)?;
         let rows = result.into_rows_result()?;
         let mut rows = rows.rows::<(Vec<u8>,)>()?;
         Ok(rows.next().is_some())
@@ -438,7 +440,10 @@ impl ScyllaDbClient {
             batch_values.push(values);
             batch_query.append_statement(query4.clone());
         }
-        session.batch(&batch_query, batch_values).await?;
+        session
+            .batch(&batch_query, batch_values)
+            .await
+            .map_err(ScyllaDbStoreInternalError::WriteBatchExecutionError)?;
         Ok(())
     }
 
@@ -533,6 +538,46 @@ pub enum ScyllaDbStoreInternalError {
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 
+    /// A deserialization error
+    #[error(transparent)]
+    DeserializationError(#[from] DeserializationError),
+
+    /// A row error
+    #[error(transparent)]
+    RowsError(#[from] RowsError),
+
+    /// A conversion error in the accessed data
+    #[error(transparent)]
+    IntoRowsResultError(#[from] IntoRowsResultError),
+
+    /// A type check error
+    #[error(transparent)]
+    TypeCheckError(#[from] TypeCheckError),
+
+    /// A pager execution error
+    #[error(transparent)]
+    PagerExecutionError(#[from] PagerExecutionError),
+
+    /// A prepare error
+    #[error(transparent)]
+    PrepareError(#[from] PrepareError),
+
+    /// An execution error during a query (except write-batch).
+    #[error(transparent)]
+    ExecutionError(ExecutionError),
+
+    /// An execution error during a write-batch operation.
+    #[error(transparent)]
+    WriteBatchExecutionError(ExecutionError),
+
+    /// A next row error in ScyllaDB
+    #[error(transparent)]
+    NextRowError(#[from] NextRowError),
+
+    /// Namespace contains forbidden characters
+    #[error("Namespace contains forbidden characters")]
+    InvalidNamespace,
+
     /// The key must have at most `MAX_KEY_SIZE` bytes
     #[error("The key must have at most MAX_KEY_SIZE")]
     KeyTooLong,
@@ -541,53 +586,19 @@ pub enum ScyllaDbStoreInternalError {
     #[error("The value must have at most RAW_MAX_VALUE_SIZE")]
     ValueTooLong,
 
-    /// A deserialization error in ScyllaDB
-    #[error(transparent)]
-    DeserializationError(#[from] DeserializationError),
-
-    /// A row error in ScyllaDB
-    #[error(transparent)]
-    RowsError(#[from] RowsError),
-
-    /// A type error in the accessed data in ScyllaDB
-    #[error(transparent)]
-    IntoRowsResultError(#[from] IntoRowsResultError),
-
-    /// A type check error in ScyllaDB
-    #[error(transparent)]
-    TypeCheckError(#[from] TypeCheckError),
-
-    /// A query error in ScyllaDB
-    #[error(transparent)]
-    PagerExecutionError(#[from] PagerExecutionError),
-
-    /// A query error in ScyllaDB
-    #[error(transparent)]
-    ScyllaDbNewSessionError(#[from] NewSessionError),
-
-    /// Namespace contains forbidden characters
-    #[error("Namespace contains forbidden characters")]
-    InvalidNamespace,
-
     /// The batch is too long to be written
     #[error("The batch is too long to be written")]
     BatchTooLong,
-
-    /// A prepare error in ScyllaDB
-    #[error(transparent)]
-    PrepareError(#[from] PrepareError),
-
-    /// An execution error in ScyllaDB
-    #[error(transparent)]
-    ExecutionError(#[from] ExecutionError),
-
-    /// A next row error in ScyllaDB
-    #[error(transparent)]
-    NextRowError(#[from] NextRowError),
 }
 
 impl KeyValueStoreError for ScyllaDbStoreInternalError {
     const BACKEND: &'static str = "scylla_db";
+
+    fn must_reload_view(&self) -> bool {
+        // Errors (notably timeouts) during a `write_batch` may leave the view in a
+        // undetermined state where the batch may or may not have happened.
+        matches!(self, Self::WriteBatchExecutionError(_))
+    }
 }
 
 impl WithError for ScyllaDbStoreInternal {
@@ -825,7 +836,8 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
 
         session
             .execute_single_page(&statement, &[], PagingState::start())
-            .await?;
+            .await
+            .map_err(ScyllaDbStoreInternalError::ExecutionError)?;
         Ok(())
     }
 
@@ -892,7 +904,8 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
             .await?;
         session
             .execute_single_page(&statement, &[], PagingState::start())
-            .await?;
+            .await
+            .map_err(ScyllaDbStoreInternalError::ExecutionError)?;
 
         // This explicitly sets a lot of default parameters for clarity and for making future
         // changes easier.
@@ -921,7 +934,8 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
             .await?;
         session
             .execute_single_page(&statement, &[], PagingState::start())
-            .await?;
+            .await
+            .map_err(ScyllaDbStoreInternalError::ExecutionError)?;
         Ok(())
     }
 
@@ -936,7 +950,8 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
             .await?;
         session
             .execute_single_page(&statement, &[], PagingState::start())
-            .await?;
+            .await
+            .map_err(ScyllaDbStoreInternalError::ExecutionError)?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

For performance reasons, especially under heavy load, we would like to distinguish two types of errors during `save` operations:

1. **Recoverable** failures (e.g. transient errors on a read or a single-row write) where the on-disk state hasn't moved and the in-memory view can safely be rolled back to its prior contents.
2. **Non-recoverable** failures where the in-memory view can no longer be trusted, either because the write is *ambiguous* (write-batch timeouts: we don't know if the write reached the database) or because the write is *partially applied* (journal-resolution failures: journal blocks were written but the live keys haven't been replayed yet, so reads would see stale data).

## Proposal

| Backend / wrapper | Reason for `must_reload_view` |
|---|---|
| ScyllaDB    | `WriteBatchExecutionError` — batch timeout, write may or may not have reached the database |
| DynamoDB    | `TransactWriteItem` — transaction timeout, same ambiguity |
| Journaling  | `JournalResolutionFailed` — journal blocks were written but live keys not yet replayed; reads would see stale data |
| RocksDB / IndexedDB / Memory | none — local backends, no in-doubt or partially-applied writes |

## Test Plan

CI

## Release Plan

To be front-ported to `main`

## References

Lightweight Transactions — ScyllaDB Docs (https://opensource.docs.scylladb.com/stable/using-scylla/lwt.html)

> Error executing a conditional statement (LWT) does not necessarily mean it failed. […] The coordinator may fail or timeout after a write has succeeded at the majority of the participants and thus has de-facto committed. To know for sure, a client must read the value back or retry the operation until it succeeds.
