### PR TITLE
[testnet] ScyllaDB: eliminate per-batch read in write_batch via two-phase writes

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -851,9 +851,9 @@ impl ScyllaDbStoreInternal {
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_micros() as i64)
             .unwrap_or(0);
-        // Reserve room for `T` and `T+1` of the upcoming first batch. If
-        // another caller raced ahead and set a higher floor already, leave it.
-        let seed = now_us.max(writetime + 2);
+        // `writetime` is the last batch's `T + 1`, i.e. the highest timestamp it
+        // consumed; that is exactly what `ts_floor` tracks, so seed it directly.
+        let seed = now_us.max(writetime);
         if self
             .ts_floor
             .compare_exchange(0, seed, Ordering::Relaxed, Ordering::Relaxed)
@@ -875,14 +875,15 @@ impl ScyllaDbStoreInternal {
                 .duration_since(UNIX_EPOCH)
                 .map(|d| d.as_micros() as i64)
                 .unwrap_or(prev);
-            let next = std::cmp::max(now_us, prev + 2);
+            let next = std::cmp::max(now_us, prev + 1);
+            // The batch uses `next` (`T`) and `next + 1` (`T + 1`); store the latter
+            // so the following batch starts strictly above both.
             if self
                 .ts_floor
-                .compare_exchange_weak(prev, next, Ordering::Relaxed, Ordering::Relaxed)
+                .compare_exchange_weak(prev, next + 1, Ordering::Relaxed, Ordering::Relaxed)
                 .is_ok()
             {
-                // `next` is `T + 1`; the caller's T+1 == next, base T == next - 1.
-                return Ok(next - 1);
+                return Ok(next);
             }
         }
     }

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -10,7 +10,11 @@
 use std::{
     collections::{BTreeSet, HashMap},
     ops::Deref,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    },
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use async_lock::{Semaphore, SemaphoreGuard};
@@ -42,7 +46,7 @@ use crate::metering::MeteredDatabase;
 #[cfg(with_testing)]
 use crate::store::TestKeyValueDatabase;
 use crate::{
-    batch::UnorderedBatch,
+    batch::{SimpleUnorderedBatch, UnorderedBatch},
     common::{get_uleb128_size, get_upper_bound_option},
     journaling::{JournalingError, JournalingKeyValueDatabase},
     lru_caching::{LruCachingConfig, LruCachingDatabase},
@@ -104,6 +108,7 @@ struct ScyllaDbClient {
     session: Session,
     namespace: String,
     read_value: PreparedStatement,
+    read_writetime: PreparedStatement,
     contains_key: PreparedStatement,
     write_batch_delete_prefix_unbounded: PreparedStatement,
     write_batch_delete_prefix_bounded: PreparedStatement,
@@ -123,6 +128,12 @@ impl ScyllaDbClient {
         let read_value = session
             .prepare(format!(
                 "SELECT v FROM {KEYSPACE}.{namespace} WHERE root_key = ? AND k = ?"
+            ))
+            .await?;
+
+        let read_writetime = session
+            .prepare(format!(
+                "SELECT WRITETIME(v) FROM {KEYSPACE}.{namespace} WHERE root_key = ? AND k = ?"
             ))
             .await?;
 
@@ -184,6 +195,7 @@ impl ScyllaDbClient {
             session,
             namespace,
             read_value,
+            read_writetime,
             contains_key,
             write_batch_delete_prefix_unbounded,
             write_batch_delete_prefix_bounded,
@@ -399,46 +411,107 @@ impl ScyllaDbClient {
         Ok(rows.next().is_some())
     }
 
-    async fn write_batch_internal(
+    /// Reads the write-time of a single row in microseconds since Unix epoch,
+    /// returning `None` if the row does not exist or carries no live value.
+    async fn read_writetime_internal(
         &self,
         root_key: &[u8],
-        batch: UnorderedBatch,
+        key: Vec<u8>,
+    ) -> Result<Option<i64>, ScyllaDbStoreInternalError> {
+        Self::check_key_size(&key)?;
+        let session = &self.session;
+        let values = (root_key.to_vec(), key);
+        let (result, _) = session
+            .execute_single_page(&self.read_writetime, &values, PagingState::start())
+            .await
+            .map_err(ScyllaDbStoreInternalError::ExecutionError)?;
+        let rows = result.into_rows_result()?;
+        let mut rows = rows.rows::<(Option<i64>,)>()?;
+        Ok(match rows.next() {
+            Some(row) => row?.0,
+            None => None,
+        })
+    }
+
+    /// Issues an unlogged batch that contains only prefix-delete statements.
+    /// Phase 1 of the two-phase write. If `timestamp` is `Some(t)`, the batch
+    /// carries that explicit timestamp (exclusive mode); otherwise the
+    /// coordinator picks one (shared mode). No-op when `key_prefix_deletions`
+    /// is empty.
+    async fn write_batch_prefix_deletes(
+        &self,
+        root_key: &[u8],
+        key_prefix_deletions: Vec<Vec<u8>>,
+        timestamp: Option<i64>,
     ) -> Result<(), ScyllaDbStoreInternalError> {
+        if key_prefix_deletions.is_empty() {
+            return Ok(());
+        }
         let session = &self.session;
         let mut batch_query = scylla::statement::batch::Batch::new(BatchType::Unlogged);
-        let mut batch_values = Vec::new();
-        let query1 = &self.write_batch_delete_prefix_unbounded;
-        let query2 = &self.write_batch_delete_prefix_bounded;
-        Self::check_batch_len(&batch)?;
-        for key_prefix in batch.key_prefix_deletions {
+        batch_query.set_timestamp(timestamp);
+        let mut batch_values: Vec<Vec<Vec<u8>>> = Vec::new();
+        let q_unbounded = &self.write_batch_delete_prefix_unbounded;
+        let q_bounded = &self.write_batch_delete_prefix_bounded;
+        for key_prefix in key_prefix_deletions {
             Self::check_key_size(&key_prefix)?;
             match get_upper_bound_option(&key_prefix) {
                 None => {
-                    let values = vec![root_key.to_vec(), key_prefix];
-                    batch_values.push(values);
-                    batch_query.append_statement(query1.clone());
+                    batch_values.push(vec![root_key.to_vec(), key_prefix]);
+                    batch_query.append_statement(q_unbounded.clone());
                 }
                 Some(upper_bound) => {
-                    let values = vec![root_key.to_vec(), key_prefix, upper_bound];
-                    batch_values.push(values);
-                    batch_query.append_statement(query2.clone());
+                    batch_values.push(vec![root_key.to_vec(), key_prefix, upper_bound]);
+                    batch_query.append_statement(q_bounded.clone());
                 }
             }
         }
-        let query3 = &self.write_batch_deletion;
-        for key in batch.simple_unordered_batch.deletions {
-            Self::check_key_size(&key)?;
-            let values = vec![root_key.to_vec(), key];
-            batch_values.push(values);
-            batch_query.append_statement(query3.clone());
+        session
+            .batch(&batch_query, batch_values)
+            .await
+            .map_err(ScyllaDbStoreInternalError::WriteBatchExecutionError)?;
+        Ok(())
+    }
+
+    /// Issues an unlogged batch containing the single-key deletions and the
+    /// insertions. Phase 2 of the two-phase write. If `timestamp` is
+    /// `Some(t)`, the batch carries that explicit timestamp (exclusive mode);
+    /// otherwise the coordinator picks one (shared mode). When
+    /// `write_sentinel` is true, the batch additionally writes an empty
+    /// value at the reserved sentinel clustering key (`WRITETIME_SENTINEL_KEY`) in the
+    /// same partition — used in exclusive mode so future seeding reads can
+    /// recover the maximum timestamp issued by this store.
+    async fn write_batch_data(
+        &self,
+        root_key: &[u8],
+        deletions: Vec<Vec<u8>>,
+        insertions: Vec<(Vec<u8>, Vec<u8>)>,
+        timestamp: Option<i64>,
+        write_sentinel: bool,
+    ) -> Result<(), ScyllaDbStoreInternalError> {
+        if deletions.is_empty() && insertions.is_empty() && !write_sentinel {
+            return Ok(());
         }
-        let query4 = &self.write_batch_insertion;
-        for (key, value) in batch.simple_unordered_batch.insertions {
+        let session = &self.session;
+        let mut batch_query = scylla::statement::batch::Batch::new(BatchType::Unlogged);
+        batch_query.set_timestamp(timestamp);
+        let mut batch_values: Vec<Vec<Vec<u8>>> = Vec::new();
+        let q_deletion = &self.write_batch_deletion;
+        for key in deletions {
+            Self::check_key_size(&key)?;
+            batch_values.push(vec![root_key.to_vec(), key]);
+            batch_query.append_statement(q_deletion.clone());
+        }
+        let q_insertion = &self.write_batch_insertion;
+        for (key, value) in insertions {
             Self::check_key_size(&key)?;
             Self::check_value_size(&value)?;
-            let values = vec![root_key.to_vec(), key, value];
-            batch_values.push(values);
-            batch_query.append_statement(query4.clone());
+            batch_values.push(vec![root_key.to_vec(), key, value]);
+            batch_query.append_statement(q_insertion.clone());
+        }
+        if write_sentinel {
+            batch_values.push(vec![root_key.to_vec(), WRITETIME_SENTINEL_KEY.to_vec(), Vec::new()]);
+            batch_query.append_statement(q_insertion.clone());
         }
         session
             .batch(&batch_query, batch_values)
@@ -517,6 +590,15 @@ pub struct ScyllaDbStoreInternal {
     semaphore: Option<Arc<Semaphore>>,
     max_stream_queries: usize,
     root_key: Vec<u8>,
+    /// Whether this store was opened with `open_exclusive`. When true, `write_batch`
+    /// resolves in-batch prefix/insert collisions via per-statement `USING TIMESTAMP`;
+    /// when false, it splits the batch into two sequential sub-batches with
+    /// server-side timestamps to preserve ordering across writers.
+    is_exclusive: bool,
+    /// Per-partition timestamp floor for exclusive-mode `USING TIMESTAMP` writes.
+    /// Value 0 means unseeded; populated lazily on first write by reading
+    /// `WRITETIME` of a sentinel row. Each batch reserves 2 µs (T and T+1).
+    ts_floor: Arc<AtomicI64>,
 }
 
 /// Database-level connection to ScyllaDB for managing namespaces and partitions.
@@ -703,12 +785,96 @@ impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
     // tie-breaking rule when two cells have the same write timestamp is that dead cells
     // win over live cells" from
     // https://github.com/scylladb/scylladb/blob/master/docs/dev/timestamp-conflict-resolution.md
+    //
+    // Instead, we split the batch into two CQL batches:
+    //   * Phase 1: the prefix-deletions.
+    //   * Phase 2: the single-key deletions and insertions.
+    // In exclusive mode we attach explicit client timestamps `T` and `T+1`; in
+    // shared mode we let the coordinator pick timestamps and rely on token-aware
+    // routing plus the `.await` between phases to keep them ordered.
     type Batch = UnorderedBatch;
 
     async fn write_batch(&self, batch: Self::Batch) -> Result<(), ScyllaDbStoreInternalError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
-        store.write_batch_internal(&self.root_key, batch).await
+        ScyllaDbClient::check_batch_len(&batch)?;
+        let UnorderedBatch {
+            key_prefix_deletions,
+            simple_unordered_batch:
+                SimpleUnorderedBatch {
+                    deletions,
+                    insertions,
+                },
+        } = batch;
+        let (t_prefix, t_data, write_sentinel) = if self.is_exclusive {
+            let t = self.next_batch_ts().await?;
+            (Some(t), Some(t + 1), true)
+        } else {
+            (None, None, false)
+        };
+        store
+            .write_batch_prefix_deletes(&self.root_key, key_prefix_deletions, t_prefix)
+            .await?;
+        store
+            .write_batch_data(&self.root_key, deletions, insertions, t_data, write_sentinel)
+            .await?;
+        Ok(())
+    }
+}
+
+impl ScyllaDbStoreInternal {
+    /// Seeds the per-store timestamp floor on first write in exclusive mode.
+    /// Reads `WRITETIME` of this chain's row in the reserved sentinel
+    /// partition (written by every prior exclusive batch). Falls back to the
+    /// current wall clock if the row does not yet exist. Idempotent — only
+    /// the first caller wins the compare-exchange.
+    async fn ensure_ts_seeded(&self) -> Result<(), ScyllaDbStoreInternalError> {
+        if self.ts_floor.load(Ordering::Relaxed) > 0 {
+            return Ok(());
+        }
+        let writetime = self
+            .store
+            .read_writetime_internal(&self.root_key, WRITETIME_SENTINEL_KEY.to_vec())
+            .await?
+            .unwrap_or(0);
+        let now_us = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_micros() as i64)
+            .unwrap_or(0);
+        // Reserve room for `T` and `T+1` of the upcoming first batch. If
+        // another caller raced ahead and set a higher floor already, leave it.
+        let seed = now_us.max(writetime + 2);
+        if self
+            .ts_floor
+            .compare_exchange(0, seed, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            // Another caller seeded first; their value wins.
+        }
+        Ok(())
+    }
+
+    /// Returns the base timestamp `T` for the next batch in exclusive mode.
+    /// The batch may also use `T + 1`; the generator advances by 2 per call,
+    /// preserving monotonicity across batches in this process.
+    async fn next_batch_ts(&self) -> Result<i64, ScyllaDbStoreInternalError> {
+        self.ensure_ts_seeded().await?;
+        loop {
+            let prev = self.ts_floor.load(Ordering::Relaxed);
+            let now_us = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_micros() as i64)
+                .unwrap_or(prev);
+            let next = std::cmp::max(now_us, prev + 2);
+            if self
+                .ts_floor
+                .compare_exchange_weak(prev, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                // `next` is `T + 1`; the caller's T+1 == next, base T == next - 1.
+                return Ok(next - 1);
+            }
+        }
     }
 }
 
@@ -718,6 +884,13 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
     big_key.extend(root_key);
     big_key
 }
+
+/// Reserved clustering key inside each chain's partition that holds the
+/// timestamp sentinel used to seed the per-store client timestamp generator
+/// in exclusive mode. The empty clustering key is unused by any caller:
+/// views always write keys prefixed with a tag byte (>= `MIN_VIEW_TAG`),
+/// and the journaling layer writes 6-byte keys starting with `[0, ...]`.
+const WRITETIME_SENTINEL_KEY: &[u8] = &[];
 
 /// The type for building a new ScyllaDB Key Value Store
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -769,11 +942,24 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
             semaphore,
             max_stream_queries,
             root_key,
+            is_exclusive: false,
+            ts_floor: Arc::new(AtomicI64::new(0)),
         })
     }
 
     fn open_exclusive(&self, root_key: &[u8]) -> Result<Self::Store, ScyllaDbStoreInternalError> {
-        self.open_shared(root_key)
+        let store = self.store.clone();
+        let semaphore = self.semaphore.clone();
+        let max_stream_queries = self.max_stream_queries;
+        let root_key = get_big_root_key(root_key);
+        Ok(ScyllaDbStoreInternal {
+            store,
+            semaphore,
+            max_stream_queries,
+            root_key,
+            is_exclusive: true,
+            ts_floor: Arc::new(AtomicI64::new(0)),
+        })
     }
 
     async fn list_all(config: &Self::Config) -> Result<Vec<String>, ScyllaDbStoreInternalError> {

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -510,7 +510,11 @@ impl ScyllaDbClient {
             batch_query.append_statement(q_insertion.clone());
         }
         if write_sentinel {
-            batch_values.push(vec![root_key.to_vec(), WRITETIME_SENTINEL_KEY.to_vec(), Vec::new()]);
+            batch_values.push(vec![
+                root_key.to_vec(),
+                WRITETIME_SENTINEL_KEY.to_vec(),
+                Vec::new(),
+            ]);
             batch_query.append_statement(q_insertion.clone());
         }
         session
@@ -816,7 +820,13 @@ impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
             .write_batch_prefix_deletes(&self.root_key, key_prefix_deletions, t_prefix)
             .await?;
         store
-            .write_batch_data(&self.root_key, deletions, insertions, t_data, write_sentinel)
+            .write_batch_data(
+                &self.root_key,
+                deletions,
+                insertions,
+                t_data,
+                write_sentinel,
+            )
             .await?;
         Ok(())
     }

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -82,7 +82,12 @@ pub struct SimpleUnorderedBatch {
 }
 
 /// An unordered batch of deletions and insertions, together with a set of key-prefixes to
-/// delete. Key-prefix deletions must happen before the insertions and the deletions.
+/// delete.
+///
+/// The batch may contain collisions between `key_prefix_deletions` and `insertions`: a
+/// prefix in `key_prefix_deletions` may cover one or more keys in `insertions`. Backends
+/// are responsible for ordering execution so that insertions "happen after" the prefix
+/// deletions semantically.
 #[derive(Default, Serialize, Deserialize)]
 pub struct UnorderedBatch {
     /// The key-prefix deletions.
@@ -117,44 +122,6 @@ impl UnorderedBatch {
             deletions,
             insertions,
         })
-    }
-
-    /// Modifies an [`UnorderedBatch`] so that the key-prefix deletions do not conflict
-    /// with subsequent insertions. This may require accessing the database to compute
-    /// lists of deleted keys.
-    pub async fn expand_colliding_prefix_deletions<DB: DeletePrefixExpander>(
-        &mut self,
-        db: &DB,
-    ) -> Result<(), DB::Error> {
-        if self.key_prefix_deletions.is_empty() {
-            return Ok(());
-        }
-        let inserted_keys = self
-            .simple_unordered_batch
-            .insertions
-            .iter()
-            .map(|x| x.0.clone())
-            .collect::<BTreeSet<_>>();
-        let mut key_prefix_deletions = Vec::new();
-        for key_prefix in &self.key_prefix_deletions {
-            if inserted_keys
-                .range(get_key_range_for_prefix(key_prefix.clone()))
-                .next()
-                .is_some()
-            {
-                for short_key in &db.expand_delete_prefix(key_prefix).await? {
-                    let mut key = key_prefix.clone();
-                    key.extend(short_key);
-                    if !inserted_keys.contains(&key) {
-                        self.simple_unordered_batch.deletions.push(key);
-                    }
-                }
-            } else {
-                key_prefix_deletions.push(key_prefix.to_vec());
-            }
-        }
-        self.key_prefix_deletions = key_prefix_deletions;
-        Ok(())
     }
 
     /// The total number of entries of the batch.
@@ -541,7 +508,7 @@ impl BatchValueWriter<SimpleUnorderedBatch> for SimpleUnorderedBatchIter {
     }
 }
 
-/// The iterator that corresponds to a `SimpleUnorderedBatch`
+/// The iterator that corresponds to an [`UnorderedBatch`].
 pub struct UnorderedBatchIter {
     delete_prefix_iter: Peekable<IntoIter<Vec<u8>>>,
     insert_deletion_iter: SimpleUnorderedBatchIter,
@@ -584,12 +551,11 @@ impl SimplifiedBatch for UnorderedBatch {
         self.simple_unordered_batch.add_insert(key, value)
     }
 
-    async fn from_batch<S: DeletePrefixExpander>(store: S, batch: Batch) -> Result<Self, S::Error> {
-        let mut unordered_batch = batch.simplify();
-        unordered_batch
-            .expand_colliding_prefix_deletions(&store)
-            .await?;
-        Ok(unordered_batch)
+    async fn from_batch<S: DeletePrefixExpander>(
+        _store: S,
+        batch: Batch,
+    ) -> Result<Self, S::Error> {
+        Ok(batch.simplify())
     }
 }
 
@@ -637,7 +603,7 @@ impl BatchValueWriter<UnorderedBatch> for UnorderedBatchIter {
 #[cfg(test)]
 mod tests {
     use linera_views::{
-        batch::{Batch, SimpleUnorderedBatch, UnorderedBatch},
+        batch::Batch,
         context::{Context, MemoryContext},
         store::WritableKeyValueStore as _,
     };
@@ -715,30 +681,5 @@ mod tests {
             vec![vec![1, 2, 3], vec![1, 2, 4], vec![1, 2, 5]]
         );
         assert!(simple_unordered_batch.insertions.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_simplify_batch6() {
-        let context = MemoryContext::new_for_testing(());
-        let insertions = vec![(vec![1, 2, 3], vec![])];
-        let simple_unordered_batch = SimpleUnorderedBatch {
-            insertions: insertions.clone(),
-            deletions: vec![],
-        };
-        let key_prefix_deletions = vec![vec![1, 2]];
-        let mut unordered_batch = UnorderedBatch {
-            simple_unordered_batch,
-            key_prefix_deletions,
-        };
-        unordered_batch
-            .expand_colliding_prefix_deletions(&context)
-            .await
-            .unwrap();
-        assert!(unordered_batch.simple_unordered_batch.deletions.is_empty());
-        assert_eq!(
-            unordered_batch.simple_unordered_batch.insertions,
-            insertions
-        );
-        assert!(unordered_batch.key_prefix_deletions.is_empty());
     }
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -339,6 +339,71 @@ async fn test_scylla_db_writes_from_state() {
     run_writes_from_state(&store).await;
 }
 
+// `new_test_store` opens a shared store, so the test above only exercises the
+// coordinator-timestamp path. This variant opens an exclusive store, routing the
+// same batches (including the `DeletePrefix`-overlapping-`Put` cases in
+// `generate_specific_state_batch`) through the explicit `T`/`T + 1` timestamps.
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_scylla_db_writes_from_state_exclusive() {
+    use linera_views::store::KeyValueDatabase as _;
+
+    let database = linera_views::scylla_db::ScyllaDbDatabase::connect_test_namespace()
+        .await
+        .unwrap();
+    let store = database.open_exclusive(&[]).unwrap();
+    run_writes_from_state(&store).await;
+}
+
+// Exclusive mode keeps timestamps monotonic across batches via an in-memory
+// floor seeded, on first write, from the `WRITETIME` of a persisted sentinel.
+// A reconnect resets that floor to 0, so this test checks that a "restarted"
+// store resumes strictly above the previously persisted data: the second
+// process's `DeletePrefix` + `Put` must win over the first process's value.
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_scylla_db_exclusive_seed_after_restart() {
+    use linera_views::{
+        random::generate_test_namespace, scylla_db::ScyllaDbDatabase, store::KeyValueDatabase as _,
+    };
+
+    let config = ScyllaDbDatabase::new_test_config().await.unwrap();
+    let namespace = generate_test_namespace();
+    let key = vec![42];
+
+    // First process: write an initial value through an exclusive store.
+    {
+        let database = ScyllaDbDatabase::recreate_and_connect(&config, &namespace)
+            .await
+            .unwrap();
+        let store = database.open_exclusive(&[]).unwrap();
+        let mut batch = Batch::new();
+        batch.put_key_value_bytes(key.clone(), vec![1]);
+        store.write_batch(batch).await.unwrap();
+    }
+
+    // Second process: a fresh database + store resets the timestamp floor to 0,
+    // forcing the seed to read the persisted sentinel and resume above it.
+    {
+        let database = ScyllaDbDatabase::connect(&config, &namespace)
+            .await
+            .unwrap();
+        let store = database.open_exclusive(&[]).unwrap();
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(key.clone());
+        batch.put_key_value_bytes(key.clone(), vec![2]);
+        store.write_batch(batch).await.unwrap();
+    }
+
+    // Third process: a fresh connection (empty cache) reads from the database and
+    // must observe the second write, proving it was resolved as the later one.
+    let database = ScyllaDbDatabase::connect(&config, &namespace)
+        .await
+        .unwrap();
+    let store = database.open_exclusive(&[]).unwrap();
+    assert_eq!(store.read_value_bytes(&key).await.unwrap(), Some(vec![2]));
+}
+
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylladb_access() {


### PR DESCRIPTION
## Motivation

Previously, every ScyllaDB `write_batch` containing a `DeletePrefix` that overlapped a `Put` in the same batch paid a `find_keys_by_prefix` read inside `UnorderedBatch::expand_colliding_prefix_deletions`. The expansion existed because all statements in a CQL unlogged batch share one write timestamp by default, and at equal timestamps a range tombstone shadows a same-batch insert. This fired on the hot path (notably `reset_chain_manager` clearing `pending_*_blobs` views).

## Proposal

Split the write into two sequential unlogged batches: phase 1 issues the prefix-deletes only, phase 2 issues the puts and single-key deletes. The `.await` between phases plus token-aware routing gives phase 2 a strictly later coordinator timestamp, so LWW resolves the intended ordering without any read. In exclusive mode we additionally set explicit client timestamps `T` and `T+1` (via `Batch::set_timestamp`) to keep ordering robust against client/coordinator clock interactions; the per-store timestamp floor is seeded once on first write by reading `WRITETIME` of a reserved sentinel row (empty clustering key, which is unused by views and journaling alike), then advanced monotonically by 2 µs per batch. Shared mode uses coordinator-assigned timestamps.

Drop the now-unused `expand_colliding_prefix_deletions`. Flatten `UnorderedBatch` to carry `key_prefix_deletions` + `deletions` + `insertions` directly; its `SimplifiedBatch::from_batch` becomes pure (`Ok(batch.simplify())`). `SimpleUnorderedBatch` is unchanged and continues to be used by DynamoDB, which still needs full expansion since it has no native range-delete primitive.

## Test Plan

CI

## Release Plan

front-port to `main`