### PR TITLE
Fix `next_height` assertions.

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -653,7 +653,7 @@ impl<Env: Environment> Client<Env> {
             else {
                 break;
             };
-            assert!(info.next_block_height > next_height);
+            assert!(info.next_block_height >= next_height);
             next_height = info.next_block_height;
             last_info = info;
         }


### PR DESCRIPTION
## Motivation

We are downloading certificates in parallel from different validators, and sometimes the same certificate from different sources. So the certificates are not necessarily distinct, and some of them are a no-op, not increasing the chain height.

## Proposal

Only assert that the chain height does not _decrease_.

## Test Plan

CI

## Release Plan

- Port to `main`.
- Release SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
