### PR TITLE
Fix `next_height` assertions. (#6336)

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -666,7 +666,7 @@ impl<Env: Environment> Client<Env> {
             else {
                 break;
             };
-            assert!(info.next_block_height > next_height);
+            assert!(info.next_block_height >= next_height);
             next_height = info.next_block_height;
             last_info = info;
         }


### PR DESCRIPTION
Port of #6336

## Motivation

We are downloading certificates in parallel from different validators, and sometimes the same certificate from different sources. So the certificates are not necessarily distinct, and some of them are a no-op, not increasing the chain height.

## Proposal

Only assert that the chain height does not _decrease_.

## Test Plan

CI

## Release Plan

- Nothing to do

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)