### PR TITLE
[testnet] multi-leader jitter and conflict-detection fix

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -173,6 +173,7 @@ Client implementation and command-line tool for the Linera blockchain
   Default value: `3600000`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
 * `--allow-fast-blocks` — Whether to allow creating blocks in the fast round. Fast blocks have lower latency but must be used carefully so that there are never any conflicting fast block proposals
+* `--disable-multi-leader-jitter` — Disable the multi-leader jitter delay. By default, when proposing in a multi-leader round with index `>= 1`, the client waits a deterministic delay derived from the owner and round before re-proposing. This spreads out concurrent proposals from honest clients; the owner with the lowest `hash(owner, round)` still proposes immediately
 * `--long-lived-services` — (EXPERIMENTAL) Whether application services can persist in some cases between queries
 * `--blanket-message-policy <BLANKET_MESSAGE_POLICY>` — The policy for handling incoming messages
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
+    crypto::{BcsHashable, CryptoHash},
     data_types::{Round, TimeDelta},
     doc_scalar,
     identifiers::AccountOwner,
@@ -216,7 +217,78 @@ impl ChainOwnership {
     pub fn is_super_owner_no_regular_owners(&self, owner: &AccountOwner) -> bool {
         self.owners.is_empty() && self.super_owners.contains(owner)
     }
+
+    /// Returns whether `owner` has the lowest `hash(owner, round)` among the eligible
+    /// multi-leader proposers, and should therefore propose immediately rather than wait
+    /// out a jitter delay. Returns `false` for `open_multi_leader_rounds`, where the set
+    /// of proposers is unbounded.
+    ///
+    /// This is a gentle-clients convention; it is not enforced by the protocol.
+    fn is_preferred_multi_leader_proposer(&self, owner: &AccountOwner, round_index: u32) -> bool {
+        if self.open_multi_leader_rounds || !self.can_propose_in_multi_leader_round(owner) {
+            return false;
+        }
+        let our_priority = multi_leader_priority(owner, round_index);
+        self.all_owners().all(|other| {
+            other == owner || multi_leader_priority(other, round_index) >= our_priority
+        })
+    }
+
+    /// Returns the deterministic delay this owner should wait before proposing in `round`,
+    /// to spread out concurrent proposals from honest clients. The preferred owner returns
+    /// `TimeDelta::ZERO`; others return `hash(owner, round) mod round_duration`. Returns
+    /// `None` outside of multi-leader rounds, in the first multi-leader round (where
+    /// honest clients all attempt to propose immediately), and `Some(ZERO)` if the round
+    /// has no configured timeout.
+    ///
+    /// The duration used to bound the jitter is taken from the single-leader round with
+    /// the same index, so the jitter remains active even for multi-leader rounds whose
+    /// own timeout is not configured.
+    pub fn multi_leader_proposal_delay(
+        &self,
+        owner: &AccountOwner,
+        round: Round,
+    ) -> Option<TimeDelta> {
+        let Round::MultiLeader(round_index) = round else {
+            return None;
+        };
+        if round_index == 0 {
+            return None;
+        }
+        let round_duration = self
+            .round_timeout(Round::SingleLeader(round_index))
+            .unwrap_or(TimeDelta::ZERO);
+        if round_duration == TimeDelta::ZERO
+            || self.is_preferred_multi_leader_proposer(owner, round_index)
+        {
+            return Some(TimeDelta::ZERO);
+        }
+        let priority = multi_leader_priority(owner, round_index);
+        let prefix = <[u8; 8]>::try_from(&priority.as_bytes().as_slice()[..8])
+            .expect("hash is at least 8 bytes long");
+        let hash_u64 = u64::from_le_bytes(prefix);
+        Some(TimeDelta::from_micros(
+            hash_u64 % round_duration.as_micros(),
+        ))
+    }
 }
+
+/// Returns the deterministic priority of `owner` in the multi-leader round with the
+/// given index. The owner with the lowest priority is preferred to propose first.
+fn multi_leader_priority(owner: &AccountOwner, round_index: u32) -> CryptoHash {
+    CryptoHash::new(&MultiLeaderPriorityInput {
+        round: round_index,
+        owner: *owner,
+    })
+}
+
+#[derive(Serialize, Deserialize)]
+struct MultiLeaderPriorityInput {
+    round: u32,
+    owner: AccountOwner,
+}
+
+impl BcsHashable<'_> for MultiLeaderPriorityInput {}
 
 /// Errors that can happen when attempting to close a chain.
 #[derive(Clone, Copy, Debug, Error, WitStore, WitType)]
@@ -297,6 +369,64 @@ mod tests {
             ownership.round_timeout(Round::SingleLeader(8)),
             Some(TimeDelta::from_secs(18))
         );
+    }
+
+    #[test]
+    fn test_multi_leader_proposal_delay() {
+        let owner_a = AccountOwner::from(Ed25519SecretKey::generate().public());
+        let owner_b = AccountOwner::from(Ed25519SecretKey::generate().public());
+        let owner_c = AccountOwner::from(Ed25519SecretKey::generate().public());
+        let mut ownership = ChainOwnership::multiple(
+            [(owner_a, 100), (owner_b, 100), (owner_c, 100)],
+            10,
+            TimeoutConfig {
+                fast_round_duration: None,
+                base_timeout: TimeDelta::from_secs(10),
+                timeout_increment: TimeDelta::ZERO,
+                fallback_duration: TimeDelta::MAX,
+            },
+        );
+
+        // No jitter in MultiLeader(0): all clients race; lowest-hash recovery kicks in
+        // only from MultiLeader(1) onwards.
+        for owner in [owner_a, owner_b, owner_c] {
+            assert_eq!(
+                ownership.multi_leader_proposal_delay(&owner, Round::MultiLeader(0)),
+                None
+            );
+        }
+
+        // Outside multi-leader rounds, no delay is computed.
+        assert_eq!(
+            ownership.multi_leader_proposal_delay(&owner_a, Round::SingleLeader(1)),
+            None
+        );
+
+        // In MultiLeader(1) exactly one owner is preferred (delay = 0); the others
+        // get a deterministic, bounded delay.
+        let delays = [owner_a, owner_b, owner_c].map(|owner| {
+            ownership
+                .multi_leader_proposal_delay(&owner, Round::MultiLeader(1))
+                .expect("delay should be defined in a multi-leader round")
+        });
+        let zero_count = delays.iter().filter(|d| **d == TimeDelta::ZERO).count();
+        assert_eq!(
+            zero_count, 1,
+            "exactly one owner should be the preferred proposer"
+        );
+        for delay in delays {
+            assert!(delay < TimeDelta::from_secs(10));
+        }
+
+        // Open multi-leader rounds have no fixed proposer set; nobody is preferred,
+        // so every owner waits its own deterministic jitter.
+        ownership.open_multi_leader_rounds = true;
+        for owner in [owner_a, owner_b, owner_c] {
+            let delay = ownership
+                .multi_leader_proposal_delay(&owner, Round::MultiLeader(1))
+                .expect("delay should be defined in a multi-leader round");
+            assert!(delay > TimeDelta::ZERO && delay < TimeDelta::from_secs(10));
+        }
     }
 }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -154,6 +154,14 @@ pub struct Options {
     #[arg(long)]
     pub allow_fast_blocks: bool,
 
+    /// Disable the multi-leader jitter delay. By default, when proposing in a multi-leader
+    /// round with index `>= 1`, the client waits a deterministic delay derived from the
+    /// owner and round before re-proposing. This spreads out concurrent proposals from
+    /// honest clients; the owner with the lowest `hash(owner, round)` still proposes
+    /// immediately.
+    #[arg(long)]
+    pub disable_multi_leader_jitter: bool,
+
     /// (EXPERIMENTAL) Whether application services can persist in some cases between queries.
     #[arg(long)]
     pub long_lived_services: bool,
@@ -373,6 +381,7 @@ impl Options {
             max_concurrent_batch_downloads: self.max_concurrent_batch_downloads,
             max_joined_tasks: self.max_joined_tasks,
             allow_fast_blocks: self.allow_fast_blocks,
+            multi_leader_jitter: !self.disable_multi_leader_jitter,
             notification_circuit_breaker_initial_probe_interval: self
                 .notification_circuit_breaker_initial_probe_interval,
             notification_circuit_breaker_max_probe_interval: self

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -21,7 +21,7 @@ use linera_base::{
     crypto::{signer, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
-        ChainDescription, Epoch, MessagePolicy, Round, Timestamp,
+        ChainDescription, Epoch, MessagePolicy, Round, TimeDelta, Timestamp,
     },
     ensure,
     identifiers::{
@@ -124,6 +124,10 @@ pub struct Options {
     /// Whether to allow creating blocks in the fast round. Fast blocks have lower latency but
     /// must be used carefully so that there are never any conflicting fast block proposals.
     pub allow_fast_blocks: bool,
+    /// Whether to apply the multi-leader jitter delay before proposing in a multi-leader
+    /// round with index `>= 1`, to spread out concurrent proposals across honest clients.
+    /// The owner with the lowest `hash(owner, round)` still proposes immediately.
+    pub multi_leader_jitter: bool,
     /// Initial probe interval for the notification circuit breaker. When a validator's
     /// notification stream exhausts retries, the circuit breaker waits this long before
     /// probing again. Doubles on each failed probe.
@@ -168,6 +172,7 @@ impl Options {
             max_concurrent_batch_downloads: DEFAULT_MAX_CONCURRENT_BATCH_DOWNLOADS,
             max_joined_tasks: 100,
             allow_fast_blocks: false,
+            multi_leader_jitter: false,
             notification_circuit_breaker_initial_probe_interval: Duration::from_secs(300),
             notification_circuit_breaker_max_probe_interval: Duration::from_secs(3600),
             max_event_stream_queries: DEFAULT_MAX_EVENT_STREAM_QUERIES,
@@ -1423,7 +1428,7 @@ impl<Env: Environment> ChainClient<Env> {
             .await?
         {
             ClientOutcome::Committed(Some(certificate)) => {
-                return Ok(ClientOutcome::Conflict(Box::new(certificate)))
+                return Ok(self.classify_committed(certificate, &operations));
             }
             ClientOutcome::WaitForTimeout(timeout) => {
                 return Ok(ClientOutcome::WaitForTimeout(timeout))
@@ -1437,7 +1442,9 @@ impl<Env: Environment> ChainClient<Env> {
         // Collect pending messages and epoch changes after acquiring the lock to avoid
         // race conditions where messages valid for one block height are proposed at a
         // different height.
-        let transactions = self.prepend_epochs_messages_and_events(operations).await?;
+        let transactions = self
+            .prepend_epochs_messages_and_events(operations.clone())
+            .await?;
 
         if transactions.is_empty() {
             return Err(Error::LocalNodeError(LocalNodeError::WorkerError(
@@ -1445,19 +1452,15 @@ impl<Env: Environment> ChainClient<Env> {
             )));
         }
 
-        let block = self
-            .new_pending_block(transactions, blobs, &mut proposal_guard)
+        self.new_pending_block(transactions, blobs, &mut proposal_guard)
             .await?;
 
         match self
             .process_pending_block_without_prepare(&mut proposal_guard)
             .await?
         {
-            ClientOutcome::Committed(Some(certificate)) if certificate.block() == &block => {
-                Ok(ClientOutcome::Committed(certificate))
-            }
             ClientOutcome::Committed(Some(certificate)) => {
-                Ok(ClientOutcome::Conflict(Box::new(certificate)))
+                Ok(self.classify_committed(certificate, &operations))
             }
             // Unreachable: We just set the pending proposal in the guard.
             ClientOutcome::Committed(None) => {
@@ -1465,6 +1468,47 @@ impl<Env: Environment> ChainClient<Env> {
             }
             ClientOutcome::WaitForTimeout(timeout) => Ok(ClientOutcome::WaitForTimeout(timeout)),
             ClientOutcome::Conflict(certificate) => Ok(ClientOutcome::Conflict(certificate)),
+        }
+    }
+
+    /// Returns `Committed` if the committed block reflects our request — same
+    /// authenticated signer, and our `operations`. All other transactions must be ones that
+    /// are added automatically, to process messages, streams or new epochs.
+    fn classify_committed(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+        operations: &[Operation],
+    ) -> ClientOutcome<ConfirmedBlockCertificate> {
+        let block = certificate.block();
+        if self.preferred_owner.is_none()
+            || block.header.authenticated_signer != self.preferred_owner
+        {
+            return ClientOutcome::Conflict(Box::new(certificate));
+        }
+        let mut operations_iter = operations.iter().peekable();
+        for tx in &block.body.transactions {
+            let is_expected = match tx {
+                Transaction::ReceiveMessages(_) => true,
+                Transaction::ExecuteOperation(op) if Some(&op) == operations_iter.peek() => {
+                    operations_iter.next();
+                    true
+                }
+                Transaction::ExecuteOperation(Operation::System(op)) => matches!(
+                    **op,
+                    SystemOperation::ProcessNewEpoch(_)
+                        | SystemOperation::ProcessRemovedEpoch(_)
+                        | SystemOperation::UpdateStreams(_)
+                ),
+                Transaction::ExecuteOperation(Operation::User { .. }) => false,
+            };
+            if !is_expected {
+                return ClientOutcome::Conflict(Box::new(certificate));
+            }
+        }
+        if operations_iter.next().is_some() {
+            ClientOutcome::Conflict(Box::new(certificate))
+        } else {
+            ClientOutcome::Committed(certificate)
         }
     }
 
@@ -2202,6 +2246,13 @@ impl<Env: Environment> ChainClient<Env> {
             .map(|v| (AccountOwner::from(v.account_public_key), v.votes))
             .collect();
         if manager.should_propose(identity, round, seed, &current_committee) {
+            if let Some(wait_until) = self.multi_leader_jitter_target(info, identity, round) {
+                return Ok(Either::Right(RoundTimeout {
+                    timestamp: wait_until,
+                    current_round: round,
+                    next_block_height: info.next_block_height,
+                }));
+            }
             return Ok(Either::Left(round));
         }
         if let Some(timeout) = info.round_timeout() {
@@ -2210,6 +2261,41 @@ impl<Env: Environment> ChainClient<Env> {
         Err(Error::BlockProposalError(
             "Not a leader in the current round",
         ))
+    }
+
+    /// Returns the timestamp at which `owner` should propose in `round`, to spread out
+    /// concurrent proposals from honest clients in a multi-leader round. Returns `None` if
+    /// the owner should propose immediately (either because the round is not a multi-leader
+    /// round, the owner is the preferred proposer, or the jitter target is already in the past).
+    ///
+    /// The delay is deterministic per `(owner, round)` and is anchored at the round's start
+    /// time when known, so that retrying after an interrupting notification does not extend
+    /// the wait further.
+    fn multi_leader_jitter_target(
+        &self,
+        info: &ChainInfo,
+        owner: &AccountOwner,
+        round: Round,
+    ) -> Option<Timestamp> {
+        if !self.options.multi_leader_jitter {
+            return None;
+        }
+        let ownership = &info.manager.ownership;
+        let delay = ownership.multi_leader_proposal_delay(owner, round)?;
+        if delay == TimeDelta::ZERO {
+            return None;
+        }
+        let now = self.storage_client().clock().current_time();
+        let round_start = if round == info.manager.current_round {
+            match (info.manager.round_timeout, ownership.round_timeout(round)) {
+                (Some(end), Some(duration)) => end.saturating_sub(duration),
+                _ => now,
+            }
+        } else {
+            now
+        };
+        let propose_at = round_start.saturating_add(delay);
+        (propose_at > now).then_some(propose_at)
     }
 
     /// Clears the information on any operation that previously failed.

--- a/web/@linera/client/src/client.rs
+++ b/web/@linera/client/src/client.rs
@@ -57,7 +57,10 @@ impl Client {
         signer: Signer,
         options: Option<linera_client::Options>,
     ) -> Result<Client> {
-        let options = options.unwrap_or_default();
+        let mut options = options.unwrap_or_default();
+        if crate::multi_leader_jitter_disabled() {
+            options.disable_multi_leader_jitter = true;
+        }
 
         wallet.lock().await?;
         let mut storage = storage::get_storage(&wallet.name()).await?;

--- a/web/@linera/client/src/index.ts
+++ b/web/@linera/client/src/index.ts
@@ -16,13 +16,16 @@ function isBrokenSafari(): boolean {
 
 export async function initialize(options?: wasm.InitializeOptions) {
   if (window.location) {
-    // Allow overriding the application's log filters using the `LINERA_LOG` and
-    // `LINERA_PROFILING` search params, for debugging.
+    // Allow overriding the application's log filters using the `LINERA_LOG`,
+    // `LINERA_PROFILING`, and `LINERA_DISABLE_MULTI_LEADER_JITTER` search params,
+    // for debugging.
     const params = new URL(window.location.href).searchParams;
     const log = params.get('LINERA_LOG');
 
     if (!options) options = {};
     if (params.get('LINERA_PROFILING')) options.profiling = true;
+    if (params.get('LINERA_DISABLE_MULTI_LEADER_JITTER'))
+      options.disableMultiLeaderJitter = true;
     if (log) options.log = log;
   }
 

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -58,9 +58,20 @@ pub struct InitializeOptions {
     pub log: String,
     /// Whether to enable performance reporting through the Performance API.
     pub profiling: bool,
+    /// Disable the multi-leader jitter delay applied by clients before re-proposing
+    /// in multi-leader rounds with index `>= 1`. Settable via the
+    /// `LINERA_DISABLE_MULTI_LEADER_JITTER` URL search param for debugging.
+    pub disable_multi_leader_jitter: bool,
 }
 
 static INITIALIZED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+static DISABLE_MULTI_LEADER_JITTER: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+
+/// Returns whether the multi-leader jitter delay should be disabled for all chain
+/// clients in this session, as configured by [`initialize`]. Defaults to `false`.
+pub(crate) fn multi_leader_jitter_disabled() -> bool {
+    DISABLE_MULTI_LEADER_JITTER.get().copied().unwrap_or(false)
+}
 
 #[wasm_bindgen]
 pub fn initialize(options: Option<InitializeOptions>) {
@@ -74,6 +85,9 @@ pub fn initialize(options: Option<InitializeOptions>) {
     }
 
     let options = options.unwrap_or_default();
+    DISABLE_MULTI_LEADER_JITTER
+        .set(options.disable_multi_leader_jitter)
+        .ok();
     // If no log filter is provided, disable the user application log by default, to avoid
     // overwhelming the console with logs from the client library itself.
     let log_filter = if options.log.is_empty() {


### PR DESCRIPTION
Backport of the client-side parts of #6289

## Motivation

If there are conflicting proposals in the first multi-leader round that probably means that several clients are trying to make a proposal at the same time. When they see the conflict, they would currently propose immediately in the next round, and likely cause a conflict again.

Sometimes retried proposals are considered "conflicts", even though they match what the user was attempting to do.

## Proposal

- Clients randomly delay re-proposing in multi-leader rounds to reduce the chance of conflicting again. Disabled with `--disable-multi-leader-jitter` (or `LINERA_DISABLE_MULTI_LEADER_JITTER` in the web client).
- Better distinguish `Committed` vs. `Conflict` outcomes.

## Test Plan

A unit test was added for the delay computation.

## Release Plan

- Release SDK.

## Links

- PR to `main`: #6289
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
