### PR TITLE
Allow inactive chains on servers, too.

### DIFF
--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -96,7 +96,7 @@ impl ServerContext {
         let config = ChainWorkerConfig {
             nickname: format!("Shard {} @ {}:{}", shard_id, local_ip_addr, shard.port),
             key_pair: Some(Arc::new(self.server_config.validator_secret.copy())),
-            allow_inactive_chains: false,
+            allow_inactive_chains: true,
             block_time_grace_period: self.block_time_grace_period,
             ttl: util::non_zero_duration(self.chain_worker_ttl),
             chain_info_max_received_log_entries: self.chain_info_max_received_log_entries,


### PR DESCRIPTION
## Motivation

We are seeing lots of `Refusing to deliver messages` warnings in some validator logs, because on validators, messages to uninitialized chains are not delivered.

This could also cause problems when waiting for message delivery while submitting a certificate; and it causes lots of retries.

## Proposal

Allow inactive chains on servers, too. This creates chain states in storage and puts messages in the inbox, even if the server doesn't have a chain description.

## Test Plan

CI

## Release Plan

- Backport to `testnet_conway`.
- Hotfix validators.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
