### PR TITLE
[testnet] Fix chain manager issues with locking block and current round.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -180,6 +180,9 @@ impl ValidatorQueryResults {
                 }) {
                     println!("Round: {}", info.manager.current_round);
                 }
+                if let Some(leader) = info.manager.leader {
+                    println!("Leader: {leader}");
+                }
                 if let Some(locking) = &info.manager.requested_locking {
                     match &**locking {
                         LockingBlock::Fast(proposal) => {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1929,11 +1929,40 @@ where
     }
 
     /// Validates and executes a block proposed to extend this chain.
+    ///
+    /// Returns network actions alongside the result so the caller can dispatch them
+    /// even when the proposal is rejected: a `HasIncompatibleConfirmedVote` rejection
+    /// can still advance `current_round` via `update_signed_proposal`, and subscribers
+    /// need the resulting `NewRound` notification.
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
         block_height = %proposal.content.block.height
     ))]
     pub(crate) async fn handle_block_proposal(
+        &mut self,
+        proposal: BlockProposal,
+    ) -> (Result<ChainInfoResponse, WorkerError>, NetworkActions) {
+        let old_round = self.chain.manager.current_round();
+        match self.try_handle_block_proposal(proposal).await {
+            Ok((response, actions)) => (Ok(response), actions),
+            Err(err) => {
+                // Even on error, the manager's `current_round` may have advanced
+                // (the `HasIncompatibleConfirmedVote` recovery path calls
+                // `update_signed_proposal`). Surface the resulting `NewRound`
+                // notification so subscribers can react.
+                let actions = if self.chain.manager.current_round() != old_round {
+                    self.create_network_actions(Some(old_round))
+                        .await
+                        .unwrap_or_default()
+                } else {
+                    NetworkActions::default()
+                };
+                (Err(err), actions)
+            }
+        }
+    }
+
+    async fn try_handle_block_proposal(
         &mut self,
         proposal: BlockProposal,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2001,11 +2001,27 @@ where
                 original_proposal.check_signature()?;
             }
         }
-        if chain.manager.check_proposed_block(&proposal)? == manager::Outcome::Skip {
-            // We already voted for this block.
-            return Ok((self.chain_info_response().await?, NetworkActions::default()));
-        }
         let local_time = self.storage.clock().current_time();
+        match chain.manager.check_proposed_block(&proposal) {
+            Ok(manager::Outcome::Skip) => {
+                // We already voted for this block.
+                return Ok((self.chain_info_response().await?, NetworkActions::default()));
+            }
+            Ok(manager::Outcome::Accept) => {}
+            Err(err) => {
+                // The proposal is correctly signed and at a legitimate round, but our
+                // local state means we won't vote on it. Record it so `current_round`
+                // still tracks the round the proposer is in.
+                if self
+                    .chain
+                    .manager
+                    .update_signed_proposal(&proposal, local_time)
+                {
+                    self.save().await?;
+                }
+                return Err(err.into());
+            }
+        }
 
         // Make sure we remember that a proposal was signed, to determine the correct round to
         // propose in.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2009,13 +2009,18 @@ where
             }
             Ok(manager::Outcome::Accept) => {}
             Err(err) => {
-                // The proposal is correctly signed and at a legitimate round, but our
-                // local state means we won't vote on it. Record it so `current_round`
-                // still tracks the round the proposer is in.
-                if self
-                    .chain
-                    .manager
-                    .update_signed_proposal(&proposal, local_time)
+                // A `HasIncompatibleConfirmedVote` rejection means the proposer is at a
+                // round we'd otherwise be happy to sign at; only our prior confirmed vote
+                // prevents us from voting. Record the proposal so `current_round` still
+                // tracks the round the proposer is in — without it, the chain can wedge.
+                // Other rejections (e.g. `WrongRound`, `InsufficientRound`) mean the
+                // proposal is not actually valid for the chain's current state, so we
+                // shouldn't let it advance our round.
+                if matches!(err, ChainError::HasIncompatibleConfirmedVote(_, _))
+                    && self
+                        .chain
+                        .manager
+                        .update_signed_proposal(&proposal, local_time)
                 {
                     self.save().await?;
                 }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -3006,8 +3006,11 @@ impl<Env: Environment> ChainClient<Env> {
             }
             Reason::NewRound { height, round } => {
                 let chain_id = notification.chain_id;
+                // The validator may hold a locking block whose round is below both its
+                // current round and ours, so we only short-circuit when strictly past its
+                // height.
                 if let Some(info) = self.maybe_local_chain_info(chain_id, &local_node).await? {
-                    if (info.next_block_height, info.manager.current_round) >= (height, round) {
+                    if info.next_block_height > height {
                         debug!(
                             chain_id = %self.chain_id,
                             "Accepting redundant notification for new round"

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -92,8 +92,8 @@ where
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         // In local nodes, cross-chain actions will be handled internally, so we discard them.
         let (response, _actions) =
-            Box::pin(self.node.state.handle_block_proposal(proposal)).await?;
-        Ok(response)
+            Box::pin(self.node.state.handle_block_proposal(proposal)).await;
+        Ok(response?)
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -91,8 +91,7 @@ where
         proposal: BlockProposal,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         // In local nodes, cross-chain actions will be handled internally, so we discard them.
-        let (response, _actions) =
-            Box::pin(self.node.state.handle_block_proposal(proposal)).await;
+        let (response, _actions) = Box::pin(self.node.state.handle_block_proposal(proposal)).await;
         Ok(response?)
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2276,6 +2276,129 @@ where
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
+async fn test_new_round_notification_pulls_lower_round_locking_block<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let client_a = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = client_a.chain_id();
+    let recipient_id = recipient.chain_id();
+    let owner_a = client_a.identity().await?;
+    let owner_b: AccountOwner = builder.signer.generate_new().into();
+
+    // Single multi-leader round, so ML(0) has a non-`None` round duration and times out
+    // into SL(0).
+    let owners = [(owner_a, 100), (owner_b, 100)];
+    let ownership = ChainOwnership::multiple(owners, 1, TimeoutConfig::default());
+    client_a.change_ownership(ownership).await?;
+
+    let info = client_a.chain_info().await?;
+    let mut client_b = builder
+        .make_client(chain_id, info.block_hash, info.next_block_height)
+        .await?;
+    client_b.set_preferred_owner(owner_b);
+
+    // client_b proposes at MultiLeader(0). All four validators vote validate, but
+    // validators 0 and 1 refuse to absorb the resulting certificate and validator 3
+    // refuses to confirm: validators 2 and 3 end up holding a `LockingBlock::Regular @
+    // MultiLeader(0)` and a `confirmed_vote` for it, while the block never reaches a
+    // confirmation quorum and stays uncommitted.
+    builder.set_fault_type([0, 1], FaultType::DontProcessValidated);
+    builder.set_fault_type([3], FaultType::DontSendConfirmVote);
+    client_b.synchronize_from_validators().await?;
+    let b_result = client_b
+        .transfer(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient_id),
+        )
+        .await;
+    assert!(b_result.is_err());
+
+    let manager_v2 = builder
+        .node(2)
+        .chain_info_with_manager_values(chain_id)
+        .await?
+        .manager;
+    let v2_locking = *manager_v2
+        .requested_locking
+        .expect("validator 2 should hold a locking block");
+    let LockingBlock::Regular(v2_validated) = v2_locking else {
+        panic!("expected a Regular locking block on validator 2");
+    };
+    assert_eq!(v2_validated.round, Round::MultiLeader(0));
+
+    // Restore honest behavior and drive timeout certificates until client_a is the leader
+    // of the current round. request_leader_timeout only fetches the timeout cert, not
+    // manager values, so client_a advances rounds without absorbing the locking block.
+    builder.set_fault_type([0, 1, 2, 3], FaultType::Honest);
+    let target_round = loop {
+        let manager = client_a.chain_info().await?.manager;
+        if manager.leader == Some(owner_a) {
+            break manager.current_round;
+        }
+        clock.set(
+            manager
+                .round_timeout
+                .expect("round_timeout should be set outside the early multi-leader rounds"),
+        );
+        client_a.request_leader_timeout().await?;
+    };
+    assert!(
+        client_a
+            .chain_info_with_manager_values()
+            .await?
+            .manager
+            .requested_locking
+            .is_none(),
+        "client_a must not yet hold a locking block"
+    );
+
+    // Validator 2 delivers a NewRound notification reporting that it is in the current
+    // round. The resulting `synchronize_chain_state_from` pulls validator 2's locking
+    // block into client_a.
+    let pk_v2 = builder.node(2).name();
+    let validator_2 = builder
+        .initial_committee
+        .validator_addresses()
+        .find(|(pk, _)| *pk == pk_v2)
+        .expect("validator 2 should be in the committee");
+    let notification = Notification {
+        chain_id,
+        reason: Reason::NewRound {
+            height: BlockHeight::from(1),
+            round: target_round,
+        },
+    };
+    client_a
+        .process_notification_from(notification, validator_2)
+        .await;
+
+    // Now client_a can drive the chain forward. The locking block (owner_b's transfer)
+    // is finalized — classified as a Conflict because the authenticated signer doesn't
+    // match owner_a's intended burn — and the chain advances to height 2.
+    let burn_result = client_a.burn(AccountOwner::CHAIN, Amount::ONE).await?;
+    assert_matches!(burn_result, ClientOutcome::Conflict(_));
+    assert_eq!(
+        client_a.chain_info().await?.next_block_height,
+        BlockHeight::from(2)
+    );
+
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
 async fn test_finalize_validated<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2399,6 +2399,144 @@ where
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
+async fn test_sync_consensus_round_pushes_locking_below_current_round<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let client_a = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = client_a.chain_id();
+    let recipient_id = recipient.chain_id();
+    let owner_a = client_a.identity().await?;
+    let owner_b: AccountOwner = builder.signer.generate_new().into();
+
+    let owners = [(owner_a, 100), (owner_b, 100)];
+    let ownership = ChainOwnership::multiple(owners, 1, TimeoutConfig::default());
+    client_a.change_ownership(ownership).await?;
+
+    let info = client_a.chain_info().await?;
+    let mut client_b = builder
+        .make_client(chain_id, info.block_hash, info.next_block_height)
+        .await?;
+    client_b.set_preferred_owner(owner_b);
+
+    // client_b proposes at MultiLeader(0). All four validators vote validate, but only
+    // validator 2 absorbs the resulting certificate: validators 0, 1, 3 refuse to process
+    // it. So validator 2 ends up holding a `LockingBlock::Regular @ MultiLeader(0)` and
+    // `confirmed_vote @ MultiLeader(0)`; the other three hold neither.
+    builder.set_fault_type([0, 1, 3], FaultType::DontProcessValidated);
+    client_b.synchronize_from_validators().await?;
+    let b_result = client_b
+        .transfer(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient_id),
+        )
+        .await;
+    assert!(b_result.is_err());
+    assert!(
+        builder
+            .node(2)
+            .chain_info_with_manager_values(chain_id)
+            .await?
+            .manager
+            .requested_locking
+            .is_some(),
+        "validator 2 should hold the locking block",
+    );
+
+    // Take validator 1 offline and let the other three timeout out of MultiLeader(0) into
+    // SingleLeader(0). Validator 1 stays at MultiLeader(0) without any locking block.
+    builder.set_fault_type([0, 2, 3], FaultType::Honest);
+    builder.set_fault_type([1], FaultType::OfflineWithInfo);
+    let manager_a = client_a.chain_info().await?.manager;
+    clock.set(manager_a.round_timeout.expect("round_timeout"));
+    client_a.request_leader_timeout().await?;
+    assert_eq!(
+        client_a.chain_info().await?.manager.current_round,
+        Round::SingleLeader(0)
+    );
+
+    builder.set_fault_type([1], FaultType::Honest);
+    let manager_v1 = builder
+        .node(1)
+        .chain_info_with_manager_values(chain_id)
+        .await?
+        .manager;
+    assert_eq!(manager_v1.current_round, Round::MultiLeader(0));
+    assert!(manager_v1.requested_locking.is_none());
+
+    // Pull validator 2's locking block into client_a via a NewRound notification (the
+    // mechanism added by the same branch).
+    let pk_v2 = builder.node(2).name();
+    let validator_2 = builder
+        .initial_committee
+        .validator_addresses()
+        .find(|(pk, _)| *pk == pk_v2)
+        .expect("validator 2 should be in the committee");
+    let notification = Notification {
+        chain_id,
+        reason: Reason::NewRound {
+            height: BlockHeight::from(1),
+            round: Round::SingleLeader(0),
+        },
+    };
+    client_a
+        .process_notification_from(notification, validator_2)
+        .await;
+    let info_a = client_a.chain_info_with_manager_values().await?;
+    let locking = *info_a
+        .manager
+        .requested_locking
+        .expect("client_a should hold the locking block");
+    let LockingBlock::Regular(client_locking_cert) = locking else {
+        panic!("expected Regular locking block on client_a");
+    };
+
+    // Advance the clock past the SingleLeader(0) round_timeout and call
+    // `request_leader_timeout` again. The per-validator request for validator 1 hits the
+    // `WrongRound(MultiLeader(0))` path, which routes through `send_chain_information` →
+    // `sync_consensus_round`. Branch 2 of that function now pushes the locking
+    // certificate because its round (`MultiLeader(0)`) is at least the remote validator's
+    // current round (`MultiLeader(0)`).
+    clock.set(
+        client_a
+            .chain_info()
+            .await?
+            .manager
+            .round_timeout
+            .expect("round_timeout for SingleLeader(0)"),
+    );
+    client_a.request_leader_timeout().await?;
+
+    let manager_v1_after = builder
+        .node(1)
+        .chain_info_with_manager_values(chain_id)
+        .await?
+        .manager;
+    let v1_locking = *manager_v1_after
+        .requested_locking
+        .expect("validator 1 should have absorbed the pushed locking block");
+    let LockingBlock::Regular(v1_validated) = v1_locking else {
+        panic!("expected Regular locking block on validator 1");
+    };
+    assert_eq!(v1_validated.round, Round::MultiLeader(0));
+    assert_eq!(v1_validated.hash(), client_locking_cert.hash());
+
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
 async fn test_finalize_validated<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -377,14 +377,14 @@ where
             | FaultType::Honest
             | FaultType::DontSendConfirmVote
             | FaultType::DontProcessValidated => {
-                let result = self
+                let (response_result, _actions) = self
                     .client
                     .lock()
                     .await
                     .state
                     .handle_block_proposal(proposal)
-                    .await
-                    .map_err(Into::into);
+                    .await;
+                let result = response_result.map_err(NodeError::from);
                 if self.fault_type == FaultType::DontSendValidateVote {
                     Err(NodeError::ClientIoError {
                         error: "refusing to validate".to_string(),
@@ -395,7 +395,7 @@ where
             }
         };
         // In a local node cross-chain messages can't get lost, so we can ignore the actions here.
-        sender.send(result.map(|(info, _actions)| info))
+        sender.send(result)
     }
 
     async fn do_handle_lite_certificate(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -601,7 +601,7 @@ where
     assert_matches!(
         env.worker()
             .handle_block_proposal(bad_signature_block_proposal)
-            .await,
+            .await.0,
             Err(WorkerError::CryptoError(error))
                 if matches!(error, linera_base::crypto::CryptoError::InvalidSignature {..})
     );
@@ -642,7 +642,7 @@ where
     assert_matches!(
     env.worker()
         .handle_block_proposal(zero_amount_block_proposal)
-        .await,
+        .await.0,
         Err(
             WorkerError::ChainError(error)
         ) if matches!(&*error, ChainError::ExecutionError(
@@ -690,7 +690,7 @@ where
             .unwrap();
         // Timestamp too far in the future
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await.0,
             Err(WorkerError::InvalidTimestamp { .. })
         );
     }
@@ -708,7 +708,7 @@ where
             .unwrap();
         let future = env.worker().handle_block_proposal(block_proposal);
         clock.set(block_0_time);
-        future.await?;
+        future.await.0?;
 
         let system_state = SystemExecutionState {
             balance: balance - small_transfer,
@@ -742,7 +742,7 @@ where
             .unwrap();
         // Timestamp older than previous one
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await.0,
             Err(WorkerError::ChainError(error))
                 if matches!(*error, ChainError::InvalidBlockTimestamp { .. })
         );
@@ -805,7 +805,7 @@ where
         )
         .await?;
     // Past timestamp should be handled immediately (and succeed).
-    let result = env.worker().handle_block_proposal(block_proposal).await;
+    let result = env.worker().handle_block_proposal(block_proposal).await.0;
     assert!(result.is_ok(), "Past timestamp should be accepted");
     let certificate = env.make_certificate(ConfirmedBlock::new(block));
     env.worker()
@@ -833,7 +833,7 @@ where
             BundleExecutionPolicy::committed(),
         )
         .await?;
-    let result = env.worker().handle_block_proposal(block_proposal).await;
+    let result = env.worker().handle_block_proposal(block_proposal).await.0;
     assert!(result.is_ok(), "Current timestamp should be accepted");
     let certificate = env.make_certificate(ConfirmedBlock::new(block));
     env.worker()
@@ -881,7 +881,7 @@ where
     clock.set(future_timestamp);
 
     // Now the future should complete.
-    let result = future.as_mut().await;
+    let (result, _actions) = future.as_mut().await;
     assert!(
         result.is_ok(),
         "Future timestamp within grace period should succeed after delay"
@@ -904,7 +904,7 @@ where
         .unwrap();
     // Far-future timestamp should be rejected immediately.
     assert_matches!(
-        env.worker().handle_block_proposal(block_proposal).await,
+        env.worker().handle_block_proposal(block_proposal).await.0,
         Err(WorkerError::InvalidTimestamp { .. })
     );
 
@@ -942,7 +942,7 @@ where
     assert_matches!(
         env.worker()
             .handle_block_proposal(unknown_sender_block_proposal)
-            .await,
+            .await.0,
         Err(WorkerError::InvalidOwner)
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
@@ -994,7 +994,7 @@ where
         .unwrap();
 
     assert_matches!(
-        env.worker().handle_block_proposal(block_proposal1.clone()).await,
+        env.worker().handle_block_proposal(block_proposal1.clone()).await.0,
         Err(WorkerError::ChainError(error)) if matches!(
             *error,
             ChainError::UnexpectedBlockHeight {
@@ -1010,7 +1010,7 @@ where
     drop(chain);
     env.worker()
         .handle_block_proposal(block_proposal0.clone())
-        .await?;
+        .await.0?;
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
     let block = chain.manager.validated_vote().unwrap().value().block();
@@ -1038,7 +1038,7 @@ where
     drop(chain);
     env.worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await?;
+        .await.0?;
 
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
@@ -1047,7 +1047,7 @@ where
     assert!(chain.manager.confirmed_vote().is_none());
     drop(chain);
     assert_matches!(
-        env.worker().handle_block_proposal(block_proposal0).await,
+        env.worker().handle_block_proposal(block_proposal0).await.0,
         Err(WorkerError::ChainError(error)) if matches!(
             *error,
             ChainError::UnexpectedBlockHeight {
@@ -1143,7 +1143,7 @@ where
     let proposal_result = env
         .worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await;
+        .await.0;
     assert_matches!(
         proposal_result,
         Err(WorkerError::ChainError(err)) if matches!(*err, ChainError::UnexpectedBlockHeight {
@@ -1179,7 +1179,7 @@ where
     let proposal_result = env
         .worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await;
+        .await.0;
     assert_matches!(proposal_result, Ok(_));
 
     Ok(())
@@ -1322,7 +1322,7 @@ where
             .unwrap();
         // Insufficient funding
         assert_matches!(
-                env.worker().handle_block_proposal(block_proposal).await,
+                env.worker().handle_block_proposal(block_proposal).await.0,
                 Err(
                     WorkerError::ChainError(error)
                 ) if matches!(&*error, ChainError::ExecutionError(
@@ -1378,7 +1378,7 @@ where
             .unwrap();
         // Inconsistent received messages.
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await.0,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::UnexpectedMessage { .. })
         );
@@ -1404,7 +1404,7 @@ where
             .unwrap();
         // Skipped message.
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await.0,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::CannotSkipMessage { .. })
         );
@@ -1455,7 +1455,7 @@ where
             .unwrap();
         // Inconsistent order in received messages (heights).
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await,
+            env.worker().handle_block_proposal(block_proposal).await.0,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::CannotSkipMessage { .. })
         );
@@ -1483,7 +1483,7 @@ where
         // Taking the first message only is ok.
         env.worker()
             .handle_block_proposal(block_proposal.clone())
-            .await?;
+            .await.0?;
         let certificate: ConfirmedBlockCertificate = env.make_certificate(ConfirmedBlock::new(
             BlockExecutionOutcome {
                 messages: vec![
@@ -1539,7 +1539,7 @@ where
             .unwrap();
         env.worker()
             .handle_block_proposal(block_proposal.clone())
-            .await?;
+            .await.0?;
     }
     Ok(())
 }
@@ -1571,7 +1571,7 @@ where
         .await
         .unwrap();
     assert_matches!(
-        env.worker().handle_block_proposal(block_proposal).await,
+        env.worker().handle_block_proposal(block_proposal).await.0,
         Err(
             WorkerError::ChainError(error)
         ) if matches!(&*error, ChainError::ExecutionError(
@@ -1612,8 +1612,7 @@ where
         .await
         .unwrap();
 
-    let (chain_info_response, _actions) =
-        env.worker().handle_block_proposal(block_proposal).await?;
+    let chain_info_response = env.worker().handle_block_proposal(block_proposal).await.0?;
     chain_info_response.check(env.worker().public_key())?;
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
@@ -1666,12 +1665,13 @@ where
         .await
         .unwrap();
 
-    let (response, _actions) = env
+    let response = env
         .worker()
         .handle_block_proposal(block_proposal.clone())
-        .await?;
+        .await
+        .0?;
     response.check(env.worker().public_key())?;
-    let (replay_response, _actions) = env.worker().handle_block_proposal(block_proposal).await?;
+    let replay_response = env.worker().handle_block_proposal(block_proposal).await.0?;
     // Workaround lack of equality.
     assert_eq!(
         CryptoHash::new(&*response.info),
@@ -3609,14 +3609,14 @@ where
         .into_proposal_with_round(owner0, &signer, Round::SingleLeader(0))
         .await
         .unwrap();
-    let result = env.worker().handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await.0;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal = make_child_block(&value0)
         .with_simple_transfer(chain_1, small_transfer)
         .into_proposal_with_round(owner0, &signer, Round::SingleLeader(1))
         .await
         .unwrap();
-    let result = env.worker().handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await.0;
 
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::SingleLeader(0)))
@@ -3669,14 +3669,14 @@ where
     let result = env
         .worker()
         .handle_block_proposal(proposal1_wrong_owner)
-        .await;
+        .await.0;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal1 = proposed_block1
         .clone()
         .into_proposal_with_round(owner0, &signer, Round::SingleLeader(1))
         .await
         .unwrap();
-    let (response, _) = env.worker().handle_block_proposal(proposal1).await?;
+    let response = env.worker().handle_block_proposal(proposal1).await.0?;
     let value1 = ValidatedBlock::new(block1.clone());
 
     // If we send the validated block certificate to the worker, it votes to confirm.
@@ -3740,7 +3740,7 @@ where
         .into_proposal_with_round(owner1, &signer, Round::SingleLeader(5))
         .await
         .unwrap();
-    let result = env.worker().handle_block_proposal(proposal.clone()).await;
+    let result = env.worker().handle_block_proposal(proposal.clone()).await.0;
     assert_matches!(result, Err(WorkerError::ChainError(error))
          if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
     );
@@ -3757,7 +3757,7 @@ where
     .await
     .unwrap();
     let lite_value2 = LiteValue::new(&value2);
-    let (_, _) = env.worker().handle_block_proposal(proposal).await?;
+    env.worker().handle_block_proposal(proposal).await.0?;
     let (response, _) = env
         .worker()
         .handle_chain_info_query(query_values.clone())
@@ -3785,7 +3785,7 @@ where
         .into_proposal_with_round(owner0, &signer, Round::SingleLeader(6))
         .await
         .unwrap();
-    let result = env.worker().handle_block_proposal(proposal.clone()).await;
+    let result = env.worker().handle_block_proposal(proposal.clone()).await.0;
     assert_matches!(result, Err(WorkerError::ChainError(error))
          if matches!(*error, ChainError::HasIncompatibleConfirmedVote(_, _))
     );
@@ -3876,13 +3876,13 @@ where
         .into_proposal_with_round(owner1, &signer, Round::Fast)
         .await
         .unwrap();
-    let result = env.worker().handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await.0;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal = make_child_block(&value0)
         .into_proposal_with_round(owner1, &signer, Round::MultiLeader(0))
         .await
         .unwrap();
-    let result = env.worker().handle_block_proposal(proposal).await;
+    let result = env.worker().handle_block_proposal(proposal).await.0;
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::Fast))
     );
@@ -3922,7 +3922,8 @@ where
         .into_proposal_with_round(owner1, &signer, Round::MultiLeader(1))
         .await
         .unwrap();
-    let (_, actions) = env.worker().handle_block_proposal(proposal1).await?;
+    let (result, actions) = env.worker().handle_block_proposal(proposal1).await;
+    result?;
     assert_matches!(actions.notifications[0].reason, Reason::NewRound { .. });
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
@@ -4010,10 +4011,11 @@ where
         )
         .await?;
     let value1 = ConfirmedBlock::new(block1);
-    let (response, _) = env
+    let response = env
         .worker()
         .handle_block_proposal(proposal1.clone())
-        .await?;
+        .await
+        .0?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.round, Round::Fast);
     assert_eq!(vote.value.value_hash, value1.hash());
@@ -4036,7 +4038,7 @@ where
         BlockProposal::new_retry_fast(owner1, Round::MultiLeader(0), proposal1.clone(), &signer)
             .await
             .unwrap();
-    let (response, _) = env.worker().handle_block_proposal(proposal1b).await?;
+    let response = env.worker().handle_block_proposal(proposal1b).await.0?;
 
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.round, Round::MultiLeader(0));
@@ -4051,7 +4053,7 @@ where
         .into_proposal_with_round(owner1, &signer, Round::MultiLeader(1))
         .await
         .unwrap();
-    let result = env.worker().handle_block_proposal(proposal2).await;
+    let result = env.worker().handle_block_proposal(proposal2).await.0;
     assert_matches!(result, Err(WorkerError::ChainError(err))
         if matches!(*err, ChainError::HasIncompatibleConfirmedVote(_, Round::Fast))
     );
@@ -4059,7 +4061,7 @@ where
         BlockProposal::new_retry_fast(owner0, Round::MultiLeader(2), proposal1.clone(), &signer)
             .await
             .unwrap();
-    env.worker().handle_block_proposal(proposal3).await?;
+    env.worker().handle_block_proposal(proposal3).await.0?;
 
     // A validated block certificate from a later round can override the locked fast block.
     let (_, block2, _, _, _) = env
@@ -4082,7 +4084,7 @@ where
     .await
     .unwrap();
     let lite_value2 = LiteValue::new(&value2);
-    let (_, _) = env.worker().handle_block_proposal(proposal).await?;
+    env.worker().handle_block_proposal(proposal).await.0?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = env.worker().handle_chain_info_query(query_values).await?;
     assert_eq!(
@@ -4276,7 +4278,7 @@ where
         .into_first_proposal(owner, &signer)
         .await
         .unwrap();
-    env.worker().handle_block_proposal(block_proposal).await?;
+    env.worker().handle_block_proposal(block_proposal).await.0?;
 
     for local_time in queries_before_confirmation {
         clock.set(local_time);
@@ -4448,7 +4450,7 @@ where
         .unwrap();
 
     assert_matches!(
-        env.worker().handle_block_proposal(bad_proposal).await,
+        env.worker().handle_block_proposal(bad_proposal).await.0,
         Err(WorkerError::ChainError(chain_error))
             if matches!(*chain_error, ChainError::IncorrectMessageOrder { .. })
     );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -942,7 +942,8 @@ where
     assert_matches!(
         env.worker()
             .handle_block_proposal(unknown_sender_block_proposal)
-            .await.0,
+            .await
+            .0,
         Err(WorkerError::InvalidOwner)
     );
     let chain = env.worker().chain_state_view(chain_1).await?;
@@ -1010,7 +1011,8 @@ where
     drop(chain);
     env.worker()
         .handle_block_proposal(block_proposal0.clone())
-        .await.0?;
+        .await
+        .0?;
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
     let block = chain.manager.validated_vote().unwrap().value().block();
@@ -1038,7 +1040,8 @@ where
     drop(chain);
     env.worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await.0?;
+        .await
+        .0?;
 
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
@@ -1143,7 +1146,8 @@ where
     let proposal_result = env
         .worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await.0;
+        .await
+        .0;
     assert_matches!(
         proposal_result,
         Err(WorkerError::ChainError(err)) if matches!(*err, ChainError::UnexpectedBlockHeight {
@@ -1179,7 +1183,8 @@ where
     let proposal_result = env
         .worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await.0;
+        .await
+        .0;
     assert_matches!(proposal_result, Ok(_));
 
     Ok(())
@@ -1483,7 +1488,8 @@ where
         // Taking the first message only is ok.
         env.worker()
             .handle_block_proposal(block_proposal.clone())
-            .await.0?;
+            .await
+            .0?;
         let certificate: ConfirmedBlockCertificate = env.make_certificate(ConfirmedBlock::new(
             BlockExecutionOutcome {
                 messages: vec![
@@ -1539,7 +1545,8 @@ where
             .unwrap();
         env.worker()
             .handle_block_proposal(block_proposal.clone())
-            .await.0?;
+            .await
+            .0?;
     }
     Ok(())
 }
@@ -3669,7 +3676,8 @@ where
     let result = env
         .worker()
         .handle_block_proposal(proposal1_wrong_owner)
-        .await.0;
+        .await
+        .0;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal1 = proposed_block1
         .clone()

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -887,41 +887,14 @@ where
         remote_round: Round,
         manager: &linera_chain::manager::ChainManagerInfo,
     ) -> Result<(), chain_client::Error> {
-        // Each of the three pieces below (proposal, validated cert, timeout cert) advances a
-        // different aspect of the remote validator's state — its proposal record, its
-        // locking block, and its current round — so we push everything we have. A success
-        // reply on one doesn't prove the remote actually changed state (e.g. the validated
-        // cert may already be its lock and `process_validated_block` returns `Skip`), so
-        // we can't early-return without risking leaving the validator wedged at an older
-        // round.
+        let target_round = manager.current_round;
 
-        // Try to send a proposal for the current round.
-        for proposal in manager
-            .requested_proposed
-            .iter()
-            .chain(manager.requested_signed_proposal.iter())
-        {
-            if proposal.content.round == manager.current_round {
-                match self
-                    .remote_node
-                    .handle_block_proposal(proposal.clone())
-                    .await
-                {
-                    Ok(_) => {
-                        tracing::debug!("successfully sent block proposal for round sync");
-                        break;
-                    }
-                    Err(error) => {
-                        tracing::debug!(%error, "failed to send block proposal");
-                    }
-                }
-            }
-        }
-
-        // Try to send a validated block. Its round can be below our `current_round` and
-        // still be useful: a validator with a lock at an even older round will rotate to
-        // this cert, and one with a `confirmed_vote` at this round will then accept a
-        // future proposal carrying it.
+        // First, push the locking certificate. A remote with an older lock rotates to this
+        // one (and one already locked at this round becomes able to accept a proposal
+        // carrying the cert). Pushing it does not necessarily advance the remote's current
+        // round — e.g. if the remote already holds this exact cert as its lock,
+        // `process_validated_block` returns `Skip` — so only early-return when the
+        // response shows the remote has actually reached our current round.
         if let Some(LockingBlock::Regular(validated)) = manager.requested_locking.as_deref() {
             if validated.round >= remote_round {
                 match self
@@ -932,8 +905,11 @@ where
                     )
                     .await
                 {
-                    Ok(_) => {
+                    Ok(info) => {
                         tracing::debug!("successfully sent validated block for round sync");
+                        if info.manager.current_round >= target_round {
+                            return Ok(());
+                        }
                     }
                     Err(error) => {
                         tracing::debug!(%error, "failed to send validated block");
@@ -942,7 +918,8 @@ where
             }
         }
 
-        // Try to send a timeout certificate.
+        // Try to send a timeout certificate. The remote applies `next_round(cert.round)`
+        // to its current round, which (for the cert we hold) lands at our current round.
         if let Some(cert) = &manager.timeout {
             if cert.round >= remote_round {
                 match self
@@ -950,11 +927,39 @@ where
                     .handle_timeout_certificate(cert.as_ref().clone())
                     .await
                 {
-                    Ok(_) => {
+                    Ok(info) => {
                         tracing::debug!(round = %cert.round, "successfully sent timeout certificate");
+                        if info.manager.current_round >= target_round {
+                            return Ok(());
+                        }
                     }
                     Err(error) => {
                         tracing::debug!(%error, round = %cert.round, "failed to send timeout certificate");
+                    }
+                }
+            }
+        }
+
+        // Finally, try to push a proposal at the current round.
+        for proposal in manager
+            .requested_proposed
+            .iter()
+            .chain(manager.requested_signed_proposal.iter())
+        {
+            if proposal.content.round == target_round {
+                match self
+                    .remote_node
+                    .handle_block_proposal(proposal.clone())
+                    .await
+                {
+                    Ok(info) => {
+                        tracing::debug!("successfully sent block proposal for round sync");
+                        if info.manager.current_round >= target_round {
+                            return Ok(());
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(%error, "failed to send block proposal");
                     }
                 }
             }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -887,7 +887,15 @@ where
         remote_round: Round,
         manager: &linera_chain::manager::ChainManagerInfo,
     ) -> Result<(), chain_client::Error> {
-        // Try to send a proposal for the current round
+        // Each of the three pieces below (proposal, validated cert, timeout cert) advances a
+        // different aspect of the remote validator's state — its proposal record, its
+        // locking block, and its current round — so we push everything we have. A success
+        // reply on one doesn't prove the remote actually changed state (e.g. the validated
+        // cert may already be its lock and `process_validated_block` returns `Skip`), so
+        // we can't early-return without risking leaving the validator wedged at an older
+        // round.
+
+        // Try to send a proposal for the current round.
         for proposal in manager
             .requested_proposed
             .iter()
@@ -901,7 +909,7 @@ where
                 {
                     Ok(_) => {
                         tracing::debug!("successfully sent block proposal for round sync");
-                        return Ok(());
+                        break;
                     }
                     Err(error) => {
                         tracing::debug!(%error, "failed to send block proposal");
@@ -926,7 +934,6 @@ where
                 {
                     Ok(_) => {
                         tracing::debug!("successfully sent validated block for round sync");
-                        return Ok(());
                     }
                     Err(error) => {
                         tracing::debug!(%error, "failed to send validated block");
@@ -935,7 +942,7 @@ where
             }
         }
 
-        // Try to send a timeout certificate
+        // Try to send a timeout certificate.
         if let Some(cert) = &manager.timeout {
             if cert.round >= remote_round {
                 match self
@@ -945,7 +952,6 @@ where
                 {
                     Ok(_) => {
                         tracing::debug!(round = %cert.round, "successfully sent timeout certificate");
-                        return Ok(());
                     }
                     Err(error) => {
                         tracing::debug!(%error, round = %cert.round, "failed to send timeout certificate");
@@ -954,9 +960,6 @@ where
             }
         }
 
-        // If we reach here, either we had no round sync data to send, or all attempts failed.
-        // This is not a fatal error - height sync succeeded which is the primary goal.
-        tracing::debug!("round sync not performed: no applicable data or all attempts failed");
         Ok(())
     }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -910,9 +910,12 @@ where
             }
         }
 
-        // Try to send a validated block for the current round
+        // Try to send a validated block. Its round can be below our `current_round` and
+        // still be useful: a validator with a lock at an even older round will rotate to
+        // this cert, and one with a `confirmed_vote` at this round will then accept a
+        // future proposal carrying it.
         if let Some(LockingBlock::Regular(validated)) = manager.requested_locking.as_deref() {
-            if validated.round == manager.current_round {
+            if validated.round >= remote_round {
                 match self
                     .remote_node
                     .handle_optimized_validated_certificate(

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -965,6 +965,9 @@ where
             }
         }
 
+        // If we reach here, either we had no round sync data to send, or all attempts failed.
+        // This is not a fatal error - height sync succeeded which is the primary goal.
+        tracing::debug!("round sync not performed: no applicable data or all attempts failed");
         Ok(())
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1467,7 +1467,7 @@ where
     pub async fn handle_block_proposal(
         &self,
         proposal: BlockProposal,
-    ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
+    ) -> (Result<ChainInfoResponse, WorkerError>, NetworkActions) {
         trace!("{} <-- {:?}", self.nickname(), proposal);
         #[cfg(with_metrics)]
         let round = proposal.content.round;
@@ -1485,16 +1485,22 @@ where
             self.storage.clock().sleep_until(block_timestamp).await;
         }
 
-        let response = self
+        let outcome = self
             .chain_write(chain_id, move |mut guard| async move {
-                guard.handle_block_proposal(proposal).await
+                Ok::<_, WorkerError>(guard.handle_block_proposal(proposal).await)
             })
-            .await?;
+            .await;
+        let (result, actions) = match outcome {
+            Ok((result, actions)) => (result, actions),
+            Err(err) => (Err(err), NetworkActions::default()),
+        };
         #[cfg(with_metrics)]
-        metrics::NUM_ROUNDS_IN_BLOCK_PROPOSAL
-            .with_label_values(&[round.type_name()])
-            .observe(round.number() as f64);
-        Ok(response)
+        if result.is_ok() {
+            metrics::NUM_ROUNDS_IN_BLOCK_PROPOSAL
+                .with_label_values(&[round.type_name()])
+                .observe(round.number() as f64);
+        }
+        (result, actions)
     }
 
     /// Processes a certificate, e.g. to extend a chain with a confirmed block.

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -750,11 +750,7 @@ where
                 info.try_into()?
             }
             Err(error) => {
-                Self::log_request_error(
-                    "handle_block_proposal",
-                    traffic_type,
-                    &error.error_type(),
-                );
+                Self::log_request_error("handle_block_proposal", traffic_type, &error.error_type());
                 self.log_error(&error, "Failed to handle block proposal");
                 NodeError::from(error).try_into()?
             }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -738,24 +738,27 @@ where
         let traffic_type = Self::get_traffic_type(&request);
         let proposal = request.into_inner().try_into()?;
         trace!(?proposal, "Handling block proposal");
-        Ok(Response::new(
-            match self.state.clone().handle_block_proposal(proposal).await {
-                Ok((info, actions)) => {
-                    Self::log_request_success("handle_block_proposal", traffic_type);
-                    self.handle_network_actions(actions);
-                    info.try_into()?
-                }
-                Err(error) => {
-                    Self::log_request_error(
-                        "handle_block_proposal",
-                        traffic_type,
-                        &error.error_type(),
-                    );
-                    self.log_error(&error, "Failed to handle block proposal");
-                    NodeError::from(error).try_into()?
-                }
-            },
-        ))
+        let (result, actions) = self.state.clone().handle_block_proposal(proposal).await;
+        // Dispatch actions whether or not the proposal was accepted: a rejected
+        // proposal can still advance the manager's `current_round` (via
+        // `update_signed_proposal` on the `HasIncompatibleConfirmedVote` recovery
+        // path), and subscribers need the resulting `NewRound` notification.
+        self.handle_network_actions(actions);
+        Ok(Response::new(match result {
+            Ok(info) => {
+                Self::log_request_success("handle_block_proposal", traffic_type);
+                info.try_into()?
+            }
+            Err(error) => {
+                Self::log_request_error(
+                    "handle_block_proposal",
+                    traffic_type,
+                    &error.error_type(),
+                );
+                self.log_error(&error, "Failed to handle block proposal");
+                NodeError::from(error).try_into()?
+            }
+        }))
     }
 
     #[instrument(

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -200,13 +200,15 @@ where
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
         let reply = match message {
             RpcMessage::BlockProposal(message) => {
-                match self.server.state.handle_block_proposal(*message).await {
-                    Ok((info, actions)) => {
-                        // Cross-shard requests
-                        self.handle_network_actions(actions);
-                        // Response
-                        Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
-                    }
+                let (result, actions) = self.server.state.handle_block_proposal(*message).await;
+                // Dispatch actions whether or not the proposal was accepted: a
+                // rejected proposal can still advance the manager's `current_round`
+                // (via `update_signed_proposal` on the `HasIncompatibleConfirmedVote`
+                // recovery path), and subscribers need the resulting `NewRound`
+                // notification.
+                self.handle_network_actions(actions);
+                match result {
+                    Ok(info) => Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info)))),
                     Err(error) => {
                         self.log_error(&error, "Failed to handle block proposal");
                         Err(error.into())


### PR DESCRIPTION
## Motivation

There are a few bugs in several consensus protocol edge cases:

- `NewRound` notifications for round `r` can be relevant for a client even if it is already in round `>= r`, since they could contain locking blocks. The client currently ignores them.
- When updating a validator about a new round, we only send our local locking block if it's from our own current round. It can still be relevant for the validator, however, if it's from an earlier round.
- `update_signed_proposal` isn't called if `check_proposed_block` fails, e.g. due to a conflicting locked block. But the point of `signed_proposal` is only to make a note of the proposal (whether we accepted it or not) that was signed by a chain owner, because for multi-leader rounds the presence of such a proposal determines the current round.
- The worker fails to send a `NewRound` notification if the reason for the new round is an updated `signed_proposal`, because in that case it returns an error and doesn't `create_network_actions`.

## Proposal

- Only ignore `NewRound` notifications if we're already at a greater _height_, not just _round_.
- Always send the locking block to a validator if it's at least in _their_ current round (even if it's below _our_ current round).
- Call `update_signed_proposal` if `check_proposed_block` fails.
- `create_network_actions` even in the error case.

## Test Plan

Two regression tests were added.

(The second and third point above fix the same scenario; I'd say the third point is the proper fix and the second one more of a nice-to-have. However, the second point should unblock users in some cases even before the validators have been updated.)

## Release Plan

- Port to `main`.
- Hotfix validators.
- Release SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
