### PR TITLE
Fix flaky changed-files CI by using full clone in path filter jobs

### DIFF
--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -32,6 +32,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v4.0.1
         id: files-changed

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -32,6 +32,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v4.0.1
         id: files-changed

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -33,6 +33,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v4.0.1
         id: files-changed

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v4.0.1
         id: files-changed
@@ -66,6 +68,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v4.0.1
         id: files-changed

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -40,6 +40,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v4.0.1
         id: files-changed


### PR DESCRIPTION
## Motivation

The `changed-files` (and related) jobs that use `dorny/paths-filter` are intermittently failing with:

```
fatal: shallow file has changed since we read it
git exit code 128
```

Root cause: `paths-filter` needs to find the merge-base between `main` and `testnet_conway` to determine what changed. It does this by progressively deepening the shallow clone (`--depth=100` → `--deepen=200` → `--deepen=400` → ...). On the third or fourth deepening, git 2.54.0 hits an internal consistency check on `.git/shallow` that fires non-deterministically depending on pack negotiation timing with GitHub's servers. The same commit SHA can succeed on one runner and fail on another running in parallel (confirmed from run logs).

## Proposal

Add `fetch-depth: 0` to the `actions/checkout` step in every `changed-files` job that feeds into `dorny/paths-filter`. With a full clone there is no `.git/shallow` file, so `paths-filter` finds the merge-base directly via `git merge-base` without any deepening loop — structurally impossible to trigger the bug.

Files changed: `rust.yml` (2 jobs), `web.yml`, `explorer.yml`, `indexer.yml`, `lint-check-all-features.yml`.

## Test Plan

The `changed-files` jobs run on every push and PR. With `fetch-depth: 0` the failure mode is eliminated by construction. The full clone adds some time to these lightweight gating jobs but no compilation is involved.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Backport: #6348
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)