### PR TITLE
[testnet_conway] Fix flaky changed-files CI by using full clone in path filter jobs

### DIFF
--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -32,6 +32,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v3
         id: files-changed

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v3
         id: files-changed

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -40,6 +40,8 @@ jobs:
       should-run: ${{ steps.files-changed.outputs.paths }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Filter paths
         uses: dorny/paths-filter@v3
         id: files-changed


### PR DESCRIPTION
## Motivation

Backport of #6346 to `testnet_conway`. This is where the failures are currently happening.

The `changed-files` jobs using `dorny/paths-filter` intermittently fail with:

```
fatal: shallow file has changed since we read it
git exit code 128
```

See #6346 for the full root cause analysis.

## Proposal

Add `fetch-depth: 0` to the `actions/checkout` step in every `changed-files` job that feeds into `dorny/paths-filter` in `testnet_conway` workflows.

Files changed: `rust.yml`, `web.yml`, `explorer.yml`.

## Test Plan

Same as #6346. Eliminates the shallow clone deepening loop by construction.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Main branch PR: #6346
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)