### PR TITLE
docker: produce `linera-tests` image with remote-net test binary

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -86,11 +86,12 @@ jobs:
             local IMAGE_SHORT=$3
             local IMAGE_LONG=$4
             local BUILD_NAME=$5
+            local TARGET=$6
             local LOG_FILE="/tmp/${BUILD_NAME}.log"
 
             {
               echo "========================================"
-              echo "Building ${BUILD_NAME} (${DOCKERFILE})"
+              echo "Building ${BUILD_NAME} (${DOCKERFILE}${TARGET:+ target=$TARGET})"
               echo "========================================"
 
               DOCKER_BUILDKIT=1 docker build \
@@ -98,6 +99,7 @@ jobs:
                 -t "${IMAGE_SHORT}" \
                 -t "${IMAGE_LONG}" \
                 -f "${DOCKERFILE}" \
+                ${TARGET:+--target "${TARGET}"} \
                 --build-arg "git_commit=${GIT_COMMIT_LONG}" \
                 --build-arg "build_date=${BUILD_DATE}" \
                 --build-arg "build_flag=--release" \
@@ -116,28 +118,35 @@ jobs:
           echo "Starting parallel builds..."
 
           build_and_push "docker/Dockerfile" \
-            "${LINERA_IMAGE_BRANCH}" "${LINERA_IMAGE_SHORT}" "${LINERA_IMAGE_LONG}" "Linera" &
+            "${LINERA_IMAGE_BRANCH}" "${LINERA_IMAGE_SHORT}" "${LINERA_IMAGE_LONG}" "Linera" "runtime" &
           PID_LINERA=$!
 
+          # linera-tests shares the Dockerfile and chef cache mounts with
+          # linera; --target tests builds the overlay stage that bundles
+          # the remote-net integration test binary on top of the runtime.
+          build_and_push "docker/Dockerfile" \
+            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" &
+          PID_LINERA_TESTS=$!
+
           build_and_push "docker/Dockerfile.indexer" \
-            "${INDEXER_IMAGE_BRANCH}" "${INDEXER_IMAGE_SHORT}" "${INDEXER_IMAGE_LONG}" "Indexer" &
+            "${INDEXER_IMAGE_BRANCH}" "${INDEXER_IMAGE_SHORT}" "${INDEXER_IMAGE_LONG}" "Indexer" "" &
           PID_INDEXER=$!
 
           build_and_push "docker/Dockerfile.explorer" \
-            "${EXPLORER_IMAGE_BRANCH}" "${EXPLORER_IMAGE_SHORT}" "${EXPLORER_IMAGE_LONG}" "Explorer" &
+            "${EXPLORER_IMAGE_BRANCH}" "${EXPLORER_IMAGE_SHORT}" "${EXPLORER_IMAGE_LONG}" "Explorer" "" &
           PID_EXPLORER=$!
 
           build_and_push "docker/Dockerfile.exporter" \
-            "${EXPORTER_IMAGE_BRANCH}" "${EXPORTER_IMAGE_SHORT}" "${EXPORTER_IMAGE_LONG}" "Exporter" &
+            "${EXPORTER_IMAGE_BRANCH}" "${EXPORTER_IMAGE_SHORT}" "${EXPORTER_IMAGE_LONG}" "Exporter" "" &
           PID_EXPORTER=$!
 
           build_and_push "docker/Dockerfile.bridge" \
-            "${BRIDGE_IMAGE_BRANCH}" "${BRIDGE_IMAGE_SHORT}" "${BRIDGE_IMAGE_LONG}" "Bridge" &
+            "${BRIDGE_IMAGE_BRANCH}" "${BRIDGE_IMAGE_SHORT}" "${BRIDGE_IMAGE_LONG}" "Bridge" "" &
           PID_BRIDGE=$!
 
           SUCCESS_NAMES=""
           FAILED_NAMES=""
-          for NAME_PID in Linera:$PID_LINERA Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Bridge:$PID_BRIDGE; do
+          for NAME_PID in Linera:$PID_LINERA LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Bridge:$PID_BRIDGE; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
             if wait "$PID"; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,7 +41,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libprotobuf-dev \
     clang \
     make \
-    libunwind-dev
+    libunwind-dev \
+    jq
 
 WORKDIR /app
 
@@ -150,7 +151,7 @@ COPY \
 FROM builder_src$copy AS binaries
 
 # ── Stage 3: runtime ──
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim AS runtime
 
 ARG git_commit
 LABEL git_commit=$git_commit
@@ -170,3 +171,33 @@ COPY --from=binaries \
     /linera-server \
     /linera-proxy \
     ./
+
+# ── Stage 4: tests-builder — compile the remote-net integration test ──
+# Builds /linera_net_tests by parsing cargo's JSON output for the executable
+# path; the underlying binary lives in /app/target/release/deps/ which is a
+# cache mount and won't persist past this RUN, hence the explicit cp.
+
+FROM builder_src AS tests-builder
+ARG build_flag
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo test --no-run ${build_flag:+"$build_flag"} \
+        -p linera-service \
+        --features remote-net \
+        --test linera_net_tests \
+        --message-format=json-render-diagnostics > /tmp/cargo-tests.json \
+    && jq -r 'select(.executable != null) | .executable' /tmp/cargo-tests.json \
+        | grep '/linera_net_tests-' \
+        | head -1 \
+        | xargs -I{} cp {} /linera_net_tests
+
+# ── Stage 5: tests runtime — runtime image + remote-net test binary ──
+# Used by linera-infra's network-health-check CronJob; production image
+# `linera:<tag>` (target=runtime) is unchanged. The test binary spawns
+# the linera CLI via PATH, so /linera is symlinked into /usr/local/bin.
+
+FROM runtime AS tests
+RUN ln -s /linera /usr/local/bin/linera
+COPY --from=tests-builder /linera_net_tests /usr/local/bin/linera-net-tests


### PR DESCRIPTION
## Summary

- New Dockerfile stages: `tests-builder` runs `cargo test --no-run -p linera-service --features remote-net --test linera_net_tests` and extracts the executable from cargo's JSON output; `tests` is built `FROM runtime` and bundles the test binary alongside the CLI (symlinked into PATH so `Command::new("linera")` resolves).
- Workflow `docker_image.yml` builds and pushes `linera-tests:{branch,sha_short,sha_long}` in parallel via `--target tests`. BuildKit dedups the shared chef/planner/builder_src stages between the two builds.
- Production `linera:<tag>` image (target=runtime) is unchanged.

Refs: linera-io/linera-infra#1188

## Test plan

- `docker buildx build --check --target tests`: clean (no warnings).
- Verified the existing `runtime` stage is byte-identical: only new stages added after it, no edits to its COPY/RUN steps.
- The added `jq` apt package in the chef stage is the only delta to the production build path; chef cache key is still cargo-chef's `recipe.json`, so unchanged.
- End-to-end validation (image pushed by this workflow → consumed by the linera-infra CronJob) happens when this lands and triggers the `Docker Image` workflow.