### PR TITLE
ci: register linera-tests in the IMAGE_VAR loop

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -65,7 +65,7 @@ jobs:
 
           REGISTRY_BASE="us-docker.pkg.dev/linera-io-dev/linera-public-registry"
 
-          for IMAGE_VAR in LINERA:linera INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter BRIDGE:linera-bridge; do
+          for IMAGE_VAR in LINERA:linera LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter BRIDGE:linera-bridge; do
             VAR="${IMAGE_VAR%%:*}"
             NAME="${IMAGE_VAR##*:}"
             echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_TAG}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

One-liner fix to #6349: that PR added the LineraTests `build_and_push` call and its PID handling but omitted the `LINERA_TESTS:linera-tests` entry in the `for IMAGE_VAR in …` loop that populates the `<VAR>_IMAGE_{BRANCH,SHORT,LONG}` env vars. As a result the LineraTests sub-build receives empty `-t \"\"` flags and docker rejects them with:

```
ERROR: failed to build: invalid tag "": repository name must have at least one component
```

The four production images (`linera`, `linera-indexer`, `linera-explorer`, `linera-exporter`) build and push normally — only `linera-tests` fails. Verified on the `testnet_conway` run that fired on the #6350 merge (linera-io/linera-protocol/actions/runs/26200303794).

Same fix is going up against `testnet_conway` as #6354 so the daily `network-health-check` CronJob (linera-infra) can finally find the `linera-tests:testnet_conway_release` tag.

Refs: linera-io/linera-infra#1188

## Test plan

- Verified locally by re-rendering the env-vars step with the patched loop in a shell and confirming all three `LINERA_TESTS_IMAGE_*` values resolve to the expected `us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-tests:<tag>` URIs.
- Real validation happens at merge time: the `Docker Image` workflow re-fires on `main` and either pushes a `linera-tests:main` (and short/long sha) tag, or fails differently — at which point we'll know the loop fix was sufficient.