### PR TITLE
ci: register linera-tests in the IMAGE_VAR loop

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -67,7 +67,7 @@ jobs:
 
           REGISTRY_BASE="us-docker.pkg.dev/linera-io-dev/linera-public-registry"
 
-          for IMAGE_VAR in LINERA:linera INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter; do
+          for IMAGE_VAR in LINERA:linera LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter; do
             VAR="${IMAGE_VAR%%:*}"
             NAME="${IMAGE_VAR##*:}"
             echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_TAG}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

One-liner fix to #6350: that PR added the LineraTests `build_and_push` call and its PID handling but omitted the `LINERA_TESTS:linera-tests` entry in the `for IMAGE_VAR in …` loop that populates the `<VAR>_IMAGE_{BRANCH,SHORT,LONG}` env vars. As a result the LineraTests sub-build receives empty `-t \"\"` flags and docker rejects them with:

```
ERROR: failed to build: invalid tag "": repository name must have at least one component
```

The four production images (`linera`, `linera-indexer`, `linera-explorer`, `linera-exporter`) built and pushed normally on the #6350 merge run — only `linera-tests` failed. See linera-io/linera-protocol/actions/runs/26200303794.

Same fix is going up against `main` as #6353. Once this lands the next push to `testnet_conway` triggers a clean run and `linera-tests:testnet_conway` appears in the registry alongside the existing tags, unblocking linera-io/linera-infra#1191.

Refs: linera-io/linera-infra#1188

## Test plan

- Verified locally by re-rendering the env-vars step with the patched loop in a shell and confirming all three `LINERA_TESTS_IMAGE_*` values resolve to the expected `us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-tests:<tag>` URIs.
- Real validation happens at merge time: the `Docker Image` workflow re-fires on `testnet_conway` and either pushes a `linera-tests:testnet_conway` (and short/long sha) tag, or fails differently — at which point we'll know the loop fix was sufficient.