### PR TITLE
[testnet] template: pin `allocative_derive < 0.3.5`

### DIFF
--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -12,6 +12,7 @@ serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = {{ version = "1.0" }}
 
 # TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
+allocative_derive = {{ version = ">=0.3, <0.3.5" }}
 darling = {{ version = ">=0.20, <0.23" }}
 ruint = {{ version = ">=1, <1.18" }}
 serde_with = {{ version = ">=3, <3.18" }}


### PR DESCRIPTION
## Motivation

`allocative_derive` 0.3.5 and 0.3.6 (published 2026-05-20) use `if let` chain expressions that require Rust 1.88+. The project template still pins Rust 1.86, so a fresh `linera project new` followed by `cargo build --release --target wasm32-unknown-unknown` fails with E0658, breaking the `test_project_new` integration test.

## Proposal

Add the pin alongside the existing TODO(#4742) version constraints.

## Test Plan

I reproduced the failure and verified the fix locally. So this should fix CI, too.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
