### PR TITLE
Support checkpoints that don't fit in one blob.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1065,8 +1065,14 @@ pub enum OracleResponse {
     ),
     /// An event exists.
     EventExists(EventId),
-    /// A checkpoint of the chain's execution state was published as the named blob.
-    Checkpoint(BlobId),
+    /// A checkpoint of the chain's execution state was published. The execution-state
+    /// dump is chunked into one or more `BlobType::CheckpointExecutionState` blobs whose
+    /// content hashes are listed here in restore order; a bootstrapping node concatenates
+    /// the bytes and feeds them to `ExecutionStateView::restore_from_content`.
+    Checkpoint {
+        /// Content hashes of the execution-state-dump blobs, in restore order.
+        execution_state_blobs: Vec<CryptoHash>,
+    },
 }
 
 impl BcsHashable<'_> for OracleResponse {}
@@ -1508,6 +1514,11 @@ impl Blob {
     /// Returns whether the blob is of [`BlobType::Committee`] variant.
     pub fn is_committee_blob(&self) -> bool {
         self.content().blob_type().is_committee_blob()
+    }
+
+    /// Returns whether the blob carries a chunk of a checkpoint's execution-state dump.
+    pub fn is_checkpoint_blob(&self) -> bool {
+        self.content().blob_type().is_checkpoint_blob()
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -274,25 +274,24 @@ pub enum BlobType {
     /// A blob containing the JSON-encoded `Formats` description published
     /// alongside an application's contract and service blobs.
     ApplicationFormats,
-    /// A blob containing the canonical content of a chain's execution state at a
+    /// A blob containing one ordered chunk of a chain's execution-state dump at a
     /// checkpoint, used to bootstrap a node without replaying the chain's history.
-    CheckpointContent,
+    /// A single checkpoint produces a sequence of such blobs whose content hashes
+    /// are listed in `OracleResponse::Checkpoint`.
+    CheckpointExecutionState,
 }
 
 impl BlobType {
     /// Returns whether the blob is of [`BlobType::Committee`] variant.
     pub fn is_committee_blob(&self) -> bool {
-        match self {
-            BlobType::Data
-            | BlobType::ContractBytecode
-            | BlobType::ServiceBytecode
-            | BlobType::EvmBytecode
-            | BlobType::ApplicationDescription
-            | BlobType::ApplicationFormats
-            | BlobType::ChainDescription
-            | BlobType::CheckpointContent => false,
-            BlobType::Committee => true,
-        }
+        matches!(self, BlobType::Committee)
+    }
+
+    /// Returns whether the blob carries a chunk of a checkpoint's execution-state dump.
+    /// Such blobs are produced by `ExecutionStateView::prepare_checkpoint` and exempt
+    /// from per-block published-blob counts and per-blob fees.
+    pub fn is_checkpoint_blob(&self) -> bool {
+        matches!(self, BlobType::CheckpointExecutionState)
     }
 }
 

--- a/linera-bridge/src/solidity/BridgeTypes.sol
+++ b/linera-bridge/src/solidity/BridgeTypes.sol
@@ -524,7 +524,7 @@ library BridgeTypes {
         Committee,
         ChainDescription,
         ApplicationFormats,
-        CheckpointContent
+        CheckpointExecutionState
     }
 
     function bcs_serialize_BlobType(BlobType input) internal pure returns (bytes memory) {
@@ -571,7 +571,7 @@ library BridgeTypes {
         }
 
         if (choice == 8) {
-            return (pos + 1, BlobType.CheckpointContent);
+            return (pos + 1, BlobType.CheckpointExecutionState);
         }
 
         require(choice < 9);
@@ -1649,7 +1649,7 @@ library BridgeTypes {
         // choice=6 corresponds to EventExists
         EventId event_exists;
         // choice=7 corresponds to Checkpoint
-        BlobId checkpoint;
+        OracleResponse_Checkpoint checkpoint;
     }
 
     function OracleResponse_case_service(bytes memory service) internal pure returns (OracleResponse memory) {
@@ -1658,7 +1658,7 @@ library BridgeTypes {
         opt_uint32 memory round;
         OracleResponse_Event memory event_;
         EventId memory event_exists;
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         return OracleResponse(uint8(0), service, http, blob, round, event_, event_exists, checkpoint);
     }
 
@@ -1668,7 +1668,7 @@ library BridgeTypes {
         opt_uint32 memory round;
         OracleResponse_Event memory event_;
         EventId memory event_exists;
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         return OracleResponse(uint8(1), service, http, blob, round, event_, event_exists, checkpoint);
     }
 
@@ -1678,7 +1678,7 @@ library BridgeTypes {
         opt_uint32 memory round;
         OracleResponse_Event memory event_;
         EventId memory event_exists;
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         return OracleResponse(uint8(2), service, http, blob, round, event_, event_exists, checkpoint);
     }
 
@@ -1689,7 +1689,7 @@ library BridgeTypes {
         opt_uint32 memory round;
         OracleResponse_Event memory event_;
         EventId memory event_exists;
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         return OracleResponse(uint8(3), service, http, blob, round, event_, event_exists, checkpoint);
     }
 
@@ -1699,7 +1699,7 @@ library BridgeTypes {
         BlobId memory blob;
         OracleResponse_Event memory event_;
         EventId memory event_exists;
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         return OracleResponse(uint8(4), service, http, blob, round, event_, event_exists, checkpoint);
     }
 
@@ -1713,7 +1713,7 @@ library BridgeTypes {
         BlobId memory blob;
         opt_uint32 memory round;
         EventId memory event_exists;
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         return OracleResponse(uint8(5), service, http, blob, round, event_, event_exists, checkpoint);
     }
 
@@ -1727,11 +1727,15 @@ library BridgeTypes {
         BlobId memory blob;
         opt_uint32 memory round;
         OracleResponse_Event memory event_;
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         return OracleResponse(uint8(6), service, http, blob, round, event_, event_exists, checkpoint);
     }
 
-    function OracleResponse_case_checkpoint(BlobId memory checkpoint) internal pure returns (OracleResponse memory) {
+    function OracleResponse_case_checkpoint(OracleResponse_Checkpoint memory checkpoint)
+        internal
+        pure
+        returns (OracleResponse memory)
+    {
         bytes memory service;
         Response memory http;
         BlobId memory blob;
@@ -1761,7 +1765,7 @@ library BridgeTypes {
             return abi.encodePacked(input.choice, bcs_serialize_EventId(input.event_exists));
         }
         if (input.choice == 7) {
-            return abi.encodePacked(input.choice, bcs_serialize_BlobId(input.checkpoint));
+            return abi.encodePacked(input.choice, bcs_serialize_OracleResponse_Checkpoint(input.checkpoint));
         }
         return abi.encodePacked(input.choice);
     }
@@ -1798,9 +1802,9 @@ library BridgeTypes {
         if (choice == 6) {
             (new_pos, event_exists) = bcs_deserialize_offset_EventId(new_pos, input);
         }
-        BlobId memory checkpoint;
+        OracleResponse_Checkpoint memory checkpoint;
         if (choice == 7) {
-            (new_pos, checkpoint) = bcs_deserialize_offset_BlobId(new_pos, input);
+            (new_pos, checkpoint) = bcs_deserialize_offset_OracleResponse_Checkpoint(new_pos, input);
         }
         require(choice < 8);
         return (new_pos, OracleResponse(choice, service, http, blob, round, event_, event_exists, checkpoint));
@@ -1810,6 +1814,41 @@ library BridgeTypes {
         uint256 new_pos;
         OracleResponse memory value;
         (new_pos, value) = bcs_deserialize_offset_OracleResponse(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct OracleResponse_Checkpoint {
+        CryptoHash[] execution_state_blobs;
+    }
+
+    function bcs_serialize_OracleResponse_Checkpoint(OracleResponse_Checkpoint memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_seq_CryptoHash(input.execution_state_blobs);
+    }
+
+    function bcs_deserialize_offset_OracleResponse_Checkpoint(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, OracleResponse_Checkpoint memory)
+    {
+        uint256 new_pos;
+        CryptoHash[] memory execution_state_blobs;
+        (new_pos, execution_state_blobs) = bcs_deserialize_offset_seq_CryptoHash(pos, input);
+        return (new_pos, OracleResponse_Checkpoint(execution_state_blobs));
+    }
+
+    function bcs_deserialize_OracleResponse_Checkpoint(bytes memory input)
+        internal
+        pure
+        returns (OracleResponse_Checkpoint memory)
+    {
+        uint256 new_pos;
+        OracleResponse_Checkpoint memory value;
+        (new_pos, value) = bcs_deserialize_offset_OracleResponse_Checkpoint(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }
@@ -4036,6 +4075,41 @@ library BridgeTypes {
         uint256 new_pos;
         BlobContent[] memory value;
         (new_pos, value) = bcs_deserialize_offset_seq_BlobContent(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    function bcs_serialize_seq_CryptoHash(CryptoHash[] memory input) internal pure returns (bytes memory) {
+        uint256 len = input.length;
+        bytes memory result = bcs_serialize_len(len);
+        for (uint256 i = 0; i < len; i++) {
+            result = abi.encodePacked(result, bcs_serialize_CryptoHash(input[i]));
+        }
+        return result;
+    }
+
+    function bcs_deserialize_offset_seq_CryptoHash(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, CryptoHash[] memory)
+    {
+        uint256 len;
+        uint256 new_pos;
+        (new_pos, len) = bcs_deserialize_offset_len(pos, input);
+        CryptoHash[] memory result;
+        result = new CryptoHash[](len);
+        CryptoHash memory value;
+        for (uint256 i = 0; i < len; i++) {
+            (new_pos, value) = bcs_deserialize_offset_CryptoHash(new_pos, input);
+            result[i] = value;
+        }
+        return (new_pos, result);
+    }
+
+    function bcs_deserialize_seq_CryptoHash(bytes memory input) internal pure returns (CryptoHash[] memory) {
+        uint256 new_pos;
+        CryptoHash[] memory value;
+        (new_pos, value) = bcs_deserialize_offset_seq_CryptoHash(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-bridge/tests/snapshots/format__format.yaml.snap
+++ b/linera-bridge/tests/snapshots/format__format.yaml.snap
@@ -98,7 +98,7 @@ BlobType:
     7:
       ApplicationFormats: UNIT
     8:
-      CheckpointContent: UNIT
+      CheckpointExecutionState: UNIT
 Block:
   STRUCT:
     - header:
@@ -357,8 +357,10 @@ OracleResponse:
           TYPENAME: EventId
     7:
       Checkpoint:
-        NEWTYPE:
-          TYPENAME: BlobId
+        STRUCT:
+          - execution_state_blobs:
+              SEQ:
+                TYPENAME: CryptoHash
 OutgoingMessage:
   STRUCT:
     - destination:

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -59,10 +59,11 @@ pub struct BlockExecutionTracker<'resources, 'blobs> {
     // Blobs published in the block.
     published_blobs: BTreeMap<BlobId, &'blobs Blob>,
 
-    // A checkpoint blob computed pre-block, to be handed to the matching
-    // `SystemOperation::Checkpoint` operation handler when it runs.
+    // Checkpoint blobs computed pre-block, to be handed to the matching
+    // `SystemOperation::Checkpoint` operation handler when it runs. A single dump may
+    // span multiple blobs to respect `maximum_blob_size` from the current epoch's policy.
     #[debug(skip_if = Option::is_none)]
-    prepared_checkpoint_blob: Option<Blob>,
+    prepared_checkpoint_blobs: Option<Vec<Blob>>,
 }
 
 impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
@@ -98,14 +99,14 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             operation_results: Vec::new(),
             transaction_index: 0,
             published_blobs,
-            prepared_checkpoint_blob: None,
+            prepared_checkpoint_blobs: None,
         })
     }
 
-    /// Stashes a pre-computed checkpoint blob to be handed to the matching
+    /// Stashes pre-computed checkpoint blobs to be handed to the matching
     /// `SystemOperation::Checkpoint` handler when its transaction runs.
-    pub fn set_prepared_checkpoint_blob(&mut self, blob: Blob) {
-        self.prepared_checkpoint_blob = Some(blob);
+    pub fn set_prepared_checkpoint_blobs(&mut self, blobs: Vec<Blob>) {
+        self.prepared_checkpoint_blobs = Some(blobs);
     }
 
     /// Executes a transaction in the context of the block.
@@ -190,9 +191,9 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
             self.oracle_responses()?,
             &self.blobs,
         );
-        // Cloning the blob is cheap — its bytes are behind an `Arc`.
-        if let Some(blob) = self.prepared_checkpoint_blob.as_ref() {
-            tracker.set_prepared_checkpoint_blob(blob.clone());
+        // Cloning each blob is cheap — its bytes are behind an `Arc`.
+        if let Some(blobs) = self.prepared_checkpoint_blobs.as_ref() {
+            tracker.set_prepared_checkpoint_blobs(blobs.clone());
         }
         Ok(tracker)
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -709,24 +709,10 @@ where
         #[cfg(with_metrics)]
         let _execution_latency = metrics::BLOCK_EXECUTION_LATENCY.measure_latency_us();
 
-        // Pre-block hook: if this block contains a `SystemOperation::Checkpoint`, dump the
-        // execution state from storage *now*, before any block-level mutation taints the
-        // inner view's pending-changes set. The matching operation handler will publish
-        // the resulting blob without re-dumping; subsequent fees and other state changes
-        // accumulate normally and end up persisted with the override hash on save.
-        let prepared_checkpoint_blob = if block.starts_with_checkpoint() {
-            Some(
-                chain
-                    .prepare_checkpoint()
-                    .await
-                    .with_execution_context(ChainExecutionContext::Block)?,
-            )
-        } else {
-            None
-        };
-
-        chain.system.timestamp.set(block.timestamp);
-
+        // Resolve the current epoch's resource policy first: `prepare_checkpoint` needs
+        // `maximum_blob_size` to chunk the dump, and `current_committee` is a pure read
+        // so it can run before the dump without tainting the inner view's pending-changes
+        // set.
         let committee_policy = chain
             .system
             .current_committee()
@@ -736,6 +722,24 @@ where
             .1
             .policy()
             .clone();
+
+        // Pre-block hook: if this block contains a `SystemOperation::Checkpoint`, dump the
+        // execution state from storage *now*, before any block-level mutation taints the
+        // inner view's pending-changes set. The matching operation handler will publish
+        // the resulting blobs without re-dumping; subsequent fees and other state changes
+        // accumulate normally and end up persisted with the override hash on save.
+        let prepared_checkpoint_blobs = if block.starts_with_checkpoint() {
+            Some(
+                chain
+                    .prepare_checkpoint(committee_policy.maximum_blob_size)
+                    .await
+                    .with_execution_context(ChainExecutionContext::Block)?,
+            )
+        } else {
+            None
+        };
+
+        chain.system.timestamp.set(block.timestamp);
 
         let mut resource_controller = ResourceController::new(
             Arc::new(committee_policy),
@@ -762,8 +766,8 @@ where
             replaying_oracle_responses,
             block,
         )?;
-        if let Some(blob) = prepared_checkpoint_blob {
-            block_execution_tracker.set_prepared_checkpoint_blob(blob);
+        if let Some(blobs) = prepared_checkpoint_blobs {
+            block_execution_tracker.set_prepared_checkpoint_blobs(blobs);
         }
 
         // Extract failure-policy parameters from exec_policy.
@@ -1124,7 +1128,7 @@ where
             )
         );
         if block.starts_with_checkpoint() {
-            self.check_checkpoint_preconditions(&block).await?;
+            self.check_checkpoint_preconditions().await?;
         }
 
         Self::execute_block_inner(
@@ -1253,25 +1257,16 @@ where
     }
 
     /// Validates the chain-state-level preconditions for a `SystemOperation::Checkpoint`:
-    ///   * the block contains the Checkpoint operation as its only transaction;
     ///   * no inbox has consumed any incoming bundle (every `next_cursor_to_remove` is
     ///     at default);
     ///   * no outbox has pending outgoing messages;
     ///   * no event stream tracker is set.
     ///
-    /// Sender-side conditions (no events ever published, no cross-chain messages ever
-    /// sent) are validated inside `ExecutionStateView::execute_checkpoint`.
-    async fn check_checkpoint_preconditions(
-        &self,
-        block: &ProposedBlock,
-    ) -> Result<(), ChainError> {
-        ensure!(
-            block.transactions.len() == 1,
-            ChainError::CheckpointPreconditionFailed(
-                "Checkpoint must be the only transaction in its block",
-            )
-        );
-
+    /// The structural invariant that Checkpoint must be the *first* transaction in its
+    /// block is enforced unconditionally in `execute_block`, independently of these
+    /// preconditions. Sender-side conditions (no events ever published, no cross-chain
+    /// messages ever sent) are validated inside `ExecutionStateView::prepare_checkpoint`.
+    async fn check_checkpoint_preconditions(&self) -> Result<(), ChainError> {
         let origins = self.inboxes.indices().await?;
         for origin in &origins {
             let Some(inbox) = self.inboxes.try_load_entry(origin).await? else {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -19,7 +19,7 @@ use linera_base::{
         Timestamp,
     },
     ensure,
-    identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, StreamId},
 };
 use linera_cache::{UniqueValueCache, ValueCache};
 use linera_chain::{
@@ -913,18 +913,25 @@ where
         //     so this block becomes available to clients via cross-chain syncing.
         if tip.next_block_height < height {
             if block.starts_with_checkpoint() {
-                let Some(OracleResponse::Checkpoint(blob_id)) =
-                    block.body.oracle_responses.first().and_then(|r| r.first())
+                let Some(OracleResponse::Checkpoint {
+                    execution_state_blobs,
+                }) = block.body.oracle_responses.first().and_then(|r| r.first())
                 else {
                     return Err(ChainError::InternalError(
                         "Checkpoint block missing OracleResponse::Checkpoint".into(),
                     )
                     .into());
                 };
-                let blob = blobs
-                    .get(blob_id)
-                    .ok_or_else(|| WorkerError::BlobsNotFound(vec![*blob_id]))?;
-                let bytes = blob.bytes().to_vec();
+                let mut bytes = Vec::new();
+                let mut missing = Vec::new();
+                for hash in execution_state_blobs {
+                    let blob_id = BlobId::new(*hash, BlobType::CheckpointExecutionState);
+                    match blobs.get(&blob_id) {
+                        Some(blob) => bytes.extend_from_slice(blob.bytes()),
+                        None => missing.push(blob_id),
+                    }
+                }
+                ensure!(missing.is_empty(), WorkerError::BlobsNotFound(missing));
                 self.chain
                     .execution_state
                     .restore_from_content(&bytes)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -3984,11 +3984,17 @@ where
         Transaction::ExecuteOperation(Operation::System(op)) if matches!(**op, SystemOperation::Checkpoint),
         "Unexpected first transaction",
     );
-    let blob_id = match block.body.oracle_responses.first().and_then(|t| t.first()) {
-        Some(OracleResponse::Checkpoint(id)) => *id,
+    let execution_state_blobs = match block.body.oracle_responses.first().and_then(|t| t.first())
+    {
+        Some(OracleResponse::Checkpoint {
+            execution_state_blobs,
+        }) => execution_state_blobs.clone(),
         other => panic!("Expected OracleResponse::Checkpoint as the first response, got {other:?}"),
     };
-    assert_eq!(blob_id.blob_type, BlobType::CheckpointContent);
+    assert!(
+        !execution_state_blobs.is_empty(),
+        "Checkpoint must list at least one execution-state blob",
+    );
 
     let producer_info = producer.chain_info().await?;
     assert_eq!(producer_info.next_block_height, BlockHeight::from(2));

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -3984,8 +3984,7 @@ where
         Transaction::ExecuteOperation(Operation::System(op)) if matches!(**op, SystemOperation::Checkpoint),
         "Unexpected first transaction",
     );
-    let execution_state_blobs = match block.body.oracle_responses.first().and_then(|t| t.first())
-    {
+    let execution_state_blobs = match block.body.oracle_responses.first().and_then(|t| t.first()) {
         Some(OracleResponse::Checkpoint {
             execution_state_blobs,
         }) => execution_state_blobs.clone(),

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -108,9 +108,11 @@ where
     }
 
     /// Validates the execution-state-level preconditions for a `SystemOperation::Checkpoint`
-    /// and dumps the inner view's persisted content as a [`Blob`]. The blob is not yet
-    /// published; the caller is expected to register it during transaction execution via
-    /// [`Self::apply_checkpoint`].
+    /// and dumps the inner view's persisted content as one or more [`Blob`]s. The dump is
+    /// split into chunks of at most `maximum_blob_size` bytes (from the current epoch's
+    /// resource policy) so each chunk respects the per-blob size limit even for very
+    /// large states. The blobs are not yet published; the caller is expected to register
+    /// them during transaction execution via [`Self::apply_checkpoint`].
     ///
     /// This is a *pre-block* operation: it must run before the block-level setup mutates
     /// the chain state (e.g. setting `system.timestamp`), because `dump_content` reads
@@ -118,7 +120,10 @@ where
     /// dump out of the operation handler also guarantees the captured bytes represent
     /// the chain's pre-block state, which is exactly what a bootstrapping node will
     /// `restore_from_content` from before re-applying the certified checkpoint block.
-    pub async fn prepare_checkpoint(&mut self) -> Result<Blob, ExecutionError> {
+    pub async fn prepare_checkpoint(
+        &mut self,
+        maximum_blob_size: u64,
+    ) -> Result<Vec<Blob>, ExecutionError> {
         let mut had_event_block = false;
         self.previous_event_blocks
             .for_each_index_while(|_| {
@@ -144,22 +149,32 @@ where
         );
 
         let (bytes, _content_hash) = self.inner.dump_content().await?;
-        Ok(Blob::new(BlobContent::new(
-            BlobType::CheckpointContent,
-            bytes,
-        )))
+        let chunk_size = usize::try_from(maximum_blob_size).unwrap_or(usize::MAX);
+        Ok(bytes
+            .chunks(chunk_size)
+            .map(|chunk| {
+                Blob::new(BlobContent::new(
+                    BlobType::CheckpointExecutionState,
+                    chunk.to_vec(),
+                ))
+            })
+            .collect())
     }
 
-    /// Registers the checkpoint blob (produced by [`Self::prepare_checkpoint`]) with the
+    /// Registers the checkpoint blobs (produced by [`Self::prepare_checkpoint`]) with the
     /// transaction tracker and records the matching [`OracleResponse::Checkpoint`].
     pub fn apply_checkpoint(
         &self,
-        blob: Blob,
+        blobs: Vec<Blob>,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(), ExecutionError> {
-        let blob_id = blob.id();
-        txn_tracker.add_created_blob(blob);
-        txn_tracker.replay_oracle_response(OracleResponse::Checkpoint(blob_id))?;
+        let execution_state_blobs = blobs.iter().map(|blob| blob.id().hash).collect();
+        for blob in blobs {
+            txn_tracker.add_created_blob(blob);
+        }
+        txn_tracker.replay_oracle_response(OracleResponse::Checkpoint {
+            execution_state_blobs,
+        })?;
         Ok(())
     }
 
@@ -171,10 +186,11 @@ where
     #[cfg(test)]
     pub async fn execute_checkpoint(
         &mut self,
+        maximum_blob_size: u64,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(), ExecutionError> {
-        let blob = self.prepare_checkpoint().await?;
-        self.apply_checkpoint(blob, txn_tracker)
+        let blobs = self.prepare_checkpoint(maximum_blob_size).await?;
+        self.apply_checkpoint(blobs, txn_tracker)
     }
 
     /// Replaces the persisted execution state with the content of a checkpoint blob,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -1066,13 +1066,13 @@ where
         match operation {
             Operation::System(op) => match *op {
                 SystemOperation::Checkpoint => {
-                    let blob = self.txn_tracker.take_prepared_checkpoint_blob().ok_or(
+                    let blobs = self.txn_tracker.take_prepared_checkpoint_blobs().ok_or(
                         ExecutionError::CheckpointPreconditionFailed(
-                            "Checkpoint operation reached the actor without a prepared blob; \
+                            "Checkpoint operation reached the actor without prepared blobs; \
                              the chain-level pre-block hook must run prepare_checkpoint first",
                         ),
                     )?;
-                    self.state.apply_checkpoint(blob, self.txn_tracker)?;
+                    self.state.apply_checkpoint(blobs, self.txn_tracker)?;
                 }
                 op => {
                     let new_application = self

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -461,7 +461,7 @@ impl ResourceControlPolicy {
             | BlobType::ApplicationFormats
             | BlobType::Committee
             | BlobType::ChainDescription
-            | BlobType::CheckpointContent => {}
+            | BlobType::CheckpointExecutionState => {}
         }
         Ok(())
     }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -700,7 +700,11 @@ where
     pub fn track_blob_published(&mut self, blob: &Blob) -> Result<(), ExecutionError> {
         self.policy.check_blob_size(blob.content())?;
         let size = blob.content().bytes().len() as u64;
-        if blob.is_committee_blob() {
+        // Committee and checkpoint-execution-state blobs are exempt from fees and the
+        // per-block published-blob limit. Committee blobs are produced by network-level
+        // governance; checkpoint blobs are produced by `SystemOperation::Checkpoint`
+        // and their size is bounded by the policy's `maximum_blob_size` per chunk.
+        if blob.is_committee_blob() || blob.is_checkpoint_blob() {
             return Ok(());
         }
         {

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -56,12 +56,14 @@ pub struct TransactionTracker {
     blobs_published: BTreeSet<BlobId>,
     /// Blob IDs created or published by free apps (fees waived).
     free_blob_ids: BTreeSet<BlobId>,
-    /// A checkpoint blob computed pre-block by `ExecutionStateView::prepare_checkpoint`,
+    /// Checkpoint blobs computed pre-block by `ExecutionStateView::prepare_checkpoint`,
     /// stashed here so that the matching `SystemOperation::Checkpoint` operation handler
-    /// can publish it without re-dumping mid-block (which would fail because the inner
-    /// view has by then accumulated pending changes from block-level setup).
+    /// can publish them without re-dumping mid-block (which would fail because the inner
+    /// view has by then accumulated pending changes from block-level setup). The dump is
+    /// chunked at the current epoch's `maximum_blob_size`, so even a large state respects
+    /// the per-blob size limit.
     #[debug(skip_if = Option::is_none)]
-    prepared_checkpoint_blob: Option<Blob>,
+    prepared_checkpoint_blobs: Option<Vec<Blob>>,
 }
 
 /// The [`TransactionTracker`] contents after a transaction has finished.
@@ -116,16 +118,16 @@ impl TransactionTracker {
         self
     }
 
-    /// Stashes a pre-block-computed checkpoint blob on the tracker. The matching
-    /// `SystemOperation::Checkpoint` operation handler will retrieve it via
-    /// [`Self::take_prepared_checkpoint_blob`] when the operation runs.
-    pub fn set_prepared_checkpoint_blob(&mut self, blob: Blob) {
-        self.prepared_checkpoint_blob = Some(blob);
+    /// Stashes pre-block-computed checkpoint blobs on the tracker. The matching
+    /// `SystemOperation::Checkpoint` operation handler will retrieve them via
+    /// [`Self::take_prepared_checkpoint_blobs`] when the operation runs.
+    pub fn set_prepared_checkpoint_blobs(&mut self, blobs: Vec<Blob>) {
+        self.prepared_checkpoint_blobs = Some(blobs);
     }
 
-    /// Takes the pre-block-computed checkpoint blob, if one was stashed.
-    pub fn take_prepared_checkpoint_blob(&mut self) -> Option<Blob> {
-        self.prepared_checkpoint_blob.take()
+    /// Takes the pre-block-computed checkpoint blobs, if any were stashed.
+    pub fn take_prepared_checkpoint_blobs(&mut self) -> Option<Vec<Blob>> {
+        self.prepared_checkpoint_blobs.take()
     }
 
     pub fn local_time(&self) -> Timestamp {
@@ -326,7 +328,7 @@ impl TransactionTracker {
             streams_to_process,
             blobs_published,
             free_blob_ids,
-            prepared_checkpoint_blob: _,
+            prepared_checkpoint_blobs: _,
         } = self;
         ensure!(
             streams_to_process.is_empty(),

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -154,7 +154,7 @@ async fn execute_checkpoint_publishes_blob_and_records_oracle_response() -> anyh
     let pre_checkpoint_hash = view.crypto_hash_mut().await?;
 
     let mut txn_tracker = TransactionTracker::default();
-    view.execute_checkpoint(&mut txn_tracker).await?;
+    view.execute_checkpoint(u64::MAX, &mut txn_tracker).await?;
 
     // The override hash takes effect immediately for the in-memory view.
     let post_checkpoint_hash = view.crypto_hash_mut().await?;
@@ -163,12 +163,14 @@ async fn execute_checkpoint_publishes_blob_and_records_oracle_response() -> anyh
     let outcome = txn_tracker.into_outcome()?;
     assert_eq!(outcome.blobs.len(), 1);
     let blob = &outcome.blobs[0];
-    assert_eq!(blob.id().blob_type, BlobType::CheckpointContent);
+    assert_eq!(blob.id().blob_type, BlobType::CheckpointExecutionState);
     assert!(outcome.blobs_published.is_empty());
     assert_eq!(outcome.oracle_responses.len(), 1);
     assert_eq!(
         outcome.oracle_responses[0],
-        OracleResponse::Checkpoint(blob.id())
+        OracleResponse::Checkpoint {
+            execution_state_blobs: vec![blob.id().hash],
+        }
     );
 
     // Saving the chain commits the override; the persisted hash now matches the content hash.
@@ -203,10 +205,23 @@ async fn checkpoint_roundtrip_via_separate_view_yields_matching_hash() -> anyhow
     producer.context().store().write_batch(batch).await?;
     producer.post_save();
 
-    let blob = producer.prepare_checkpoint().await?;
-    let blob_bytes = blob.bytes().to_vec();
+    // Use a small chunk size so the dump spans multiple `CheckpointExecutionState`
+    // blobs. The bootstrap side concatenates them in restore order.
+    const CHUNK_SIZE: usize = 32;
+    let blobs = producer.prepare_checkpoint(CHUNK_SIZE as u64).await?;
+    assert!(
+        blobs.len() > 1,
+        "Test state should be large enough to span multiple chunks",
+    );
+    for blob in &blobs {
+        assert!(blob.bytes().len() <= CHUNK_SIZE);
+    }
+    let blob_bytes = blobs
+        .iter()
+        .flat_map(|blob| blob.bytes().iter().copied())
+        .collect::<Vec<u8>>();
     let mut txn_tracker = TransactionTracker::default();
-    producer.apply_checkpoint(blob, &mut txn_tracker)?;
+    producer.apply_checkpoint(blobs, &mut txn_tracker)?;
     let mut batch = Batch::new();
     producer.pre_save(&mut batch)?;
     producer.context().store().write_batch(batch).await?;
@@ -248,7 +263,7 @@ async fn execute_checkpoint_rejects_chain_with_published_events() -> anyhow::Res
         .insert(&StreamId::system(b"events"), BlockHeight::from(0))?;
 
     let mut txn_tracker = TransactionTracker::default();
-    let result = view.execute_checkpoint(&mut txn_tracker).await;
+    let result = view.execute_checkpoint(u64::MAX, &mut txn_tracker).await;
     assert!(matches!(
         result,
         Err(crate::ExecutionError::CheckpointPreconditionFailed(_))

--- a/linera-indexer/lib/src/db/postgres/mod.rs
+++ b/linera-indexer/lib/src/db/postgres/mod.rs
@@ -448,8 +448,15 @@ impl PostgresDatabase {
                     })?;
                     ("EventExists", None, Some(serialized))
                 }
-                OracleResponse::Checkpoint(blob_id) => {
-                    ("Checkpoint", Some(blob_id.hash.to_string()), None)
+                OracleResponse::Checkpoint {
+                    execution_state_blobs,
+                } => {
+                    let serialized = bincode::serialize(execution_state_blobs).map_err(|e| {
+                        PostgresError::Serialization(format!(
+                            "Failed to serialize checkpoint: {e}"
+                        ))
+                    })?;
+                    ("Checkpoint", None, Some(serialized))
                 }
             };
 

--- a/linera-indexer/lib/src/db/postgres/mod.rs
+++ b/linera-indexer/lib/src/db/postgres/mod.rs
@@ -452,9 +452,7 @@ impl PostgresDatabase {
                     execution_state_blobs,
                 } => {
                     let serialized = bincode::serialize(execution_state_blobs).map_err(|e| {
-                        PostgresError::Serialization(format!(
-                            "Failed to serialize checkpoint: {e}"
-                        ))
+                        PostgresError::Serialization(format!("Failed to serialize checkpoint: {e}"))
                     })?;
                     ("Checkpoint", None, Some(serialized))
                 }

--- a/linera-indexer/lib/src/db/sqlite/mod.rs
+++ b/linera-indexer/lib/src/db/sqlite/mod.rs
@@ -446,8 +446,13 @@ impl SqliteDatabase {
                     })?;
                     ("EventExists", None, Some(serialized))
                 }
-                OracleResponse::Checkpoint(blob_id) => {
-                    ("Checkpoint", Some(blob_id.hash.to_string()), None)
+                OracleResponse::Checkpoint {
+                    execution_state_blobs,
+                } => {
+                    let serialized = bincode::serialize(execution_state_blobs).map_err(|e| {
+                        SqliteError::Serialization(format!("Failed to serialize checkpoint: {e}"))
+                    })?;
+                    ("Checkpoint", None, Some(serialized))
                 }
             };
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -137,7 +137,7 @@ BlobType:
     7:
       ApplicationFormats: UNIT
     8:
-      CheckpointContent: UNIT
+      CheckpointExecutionState: UNIT
 Block:
   STRUCT:
     - header:
@@ -882,8 +882,10 @@ OracleResponse:
           TYPENAME: EventId
     7:
       Checkpoint:
-        NEWTYPE:
-          TYPENAME: BlobId
+        STRUCT:
+          - execution_state_blobs:
+              SEQ:
+                TYPENAME: CryptoHash
 OriginalProposal:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

Saving the checkpoint state in a blob can exceed the blob size limit.

## Proposal

Split checkpoints into multiple execution state blobs.

## Test Plan

Tests were updated.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Part of https://github.com/linera-io/linera-protocol/issues/460
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
