### PR TITLE
Drop Rust 1.86.0 workarounds now that we're on 1.95.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,9 +241,7 @@ revm-state = { version = "4.0.1", default-features = false, features = [
     "serde",
 ] }
 rocksdb = "0.24.0"
-# 0.8.2 doesn't build with Rust 1.87. Remove `=` once
-# https://github.com/linera-io/linera-protocol/issues/4742 is resolved.
-ruzstd = "=0.8.1"
+ruzstd = "0.8.1"
 scylla = "~1.1.0"
 semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }

--- a/docs/developers/backend/creating_a_project.md
+++ b/docs/developers/backend/creating_a_project.md
@@ -14,10 +14,6 @@ files:
 - `Cargo.toml`: your project's manifest filled with the necessary dependencies
   to create an app;
 - `rust-toolchain.toml`: a file with configuration for Rust compiler.
-
-> **NOTE:** currently the latest Rust version compatible with our network is
-> `1.86.0`. Make sure it's the one used by your project.
-
 - `src/lib.rs`: the application's ABI definition;
 - `src/state.rs`: the application's state;
 - `src/contract.rs`: the application's contract, and the binary target for the

--- a/linera-bridge/contracts/evm-bridge/rust-toolchain.toml
+++ b/linera-bridge/contracts/evm-bridge/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.95.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/linera-bridge/rust-toolchain.toml
+++ b/linera-bridge/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-06-10"
+channel = "nightly-2026-05-11"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/linera-bridge/tests/e2e/rust-toolchain.toml
+++ b/linera-bridge/tests/e2e/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.95.0"
 profile = "minimal"

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -11,23 +11,9 @@ futures = {{ version = "0.3 "}}
 serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = {{ version = "1.0" }}
 
-# TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
-darling = {{ version = ">=0.20, <0.23" }}
-ruint = {{ version = ">=1, <1.18" }}
-serde_with = {{ version = ">=3, <3.18" }}
-time = {{ version = ">=0.3, <0.3.47" }}
-time-core = {{ version = ">=0.1, <0.1.8" }}
-unicode-segmentation = {{ version = ">=1, <1.13" }}
-
 [dev-dependencies]
 {linera_sdk_dev_dep}
 tokio = {{ version = "1.40", features = ["rt", "sync"] }}
-
-# TODO(#4742): Remove the pinned versions once the `linera-*` crates work with Rust > 1.86.0.
-tonic = {{ version = ">=0.14, <0.14.6", default-features = false }}
-tonic-build = {{ version = ">=0.14, <0.14.6", default-features = false }}
-tonic-prost = {{ version = ">=0.14, <0.14.6", default-features = false }}
-tonic-prost-build = {{ version = ">=0.14, <0.14.6", default-features = false }}
 
 [[bin]]
 name = "{contract_binary_name}"


### PR DESCRIPTION
## Motivation

We upgraded Rust to 1.95.0, so all the pinned dependencies and related comments and notes in the docs can go. Also, there were some missed toolchain updates in `linera-bridge`.

## Proposal

Remove pinned dependencies, comments, and do the missed upgrades.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #4742, #5264, #6286
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
