### PR TITLE
Increase default `multi_leader_rounds` from 2 to 5

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -1343,7 +1343,7 @@ mod tests {
         );
         assert_eq!(
             description.id().to_string(),
-            "6699e88680fe07056777caa26522cea7493c9cbe0611aa0e5c9d4918469d9e82"
+            "372e43034b962ee04f8242bce87fa9cd405dd824a31b6673cef4d24b937d0de5"
         );
     }
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -104,7 +104,7 @@ impl ChainOwnership {
             super_owners: iter::once(owner).collect(),
             owners: BTreeMap::new(),
             first_leader: None,
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }
@@ -116,7 +116,7 @@ impl ChainOwnership {
             super_owners: BTreeSet::new(),
             owners: iter::once((owner, 100)).collect(),
             first_leader: None,
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2293,7 +2293,7 @@ impl<Env: Environment> ChainClient<Env> {
             super_owners: vec![new_owner],
             owners: Vec::new(),
             first_leader: None,
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         })

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -1656,6 +1656,19 @@ where
 
     let creator = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
 
+    // Pin the chain to two multi-leader rounds so the test walks
+    // MultiLeader(0) -> MultiLeader(1) -> SingleLeader(0) on three failed proposals,
+    // independently of the protocol-wide default.
+    let creator_key = creator.identity().await.unwrap();
+    creator
+        .change_ownership(ChainOwnership::multiple(
+            [(creator_key, 100)],
+            2,
+            TimeoutConfig::default(),
+        ))
+        .await
+        .unwrap();
+
     // Publish and create the time-expiry application.
     let module_id = creator.publish_wasm_example("time-expiry").await?;
     let module_id = module_id.with_abi::<time_expiry::TimeExpiryAbi, (), ()>();

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -543,7 +543,7 @@ where
             super_owners: vec![new_owner],
             owners: Vec::new(),
             first_leader: None,
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         };


### PR DESCRIPTION
## Motivation

In practice, most chain owners cooperate, if there even are more than a single owner, so multi-leader rounds are more useful than single-leader rounds.

## Proposal

Increase the default from 2 to 5 multi-leader rounds.

## Test Plan

CI; no logic was changed

## Release Plan

- Backport to `testnet_conway`.
- Release a new SDK.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
