### PR TITLE
Increase publish-docs CI timeout to 40 minutes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
 
   publish-docs:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
 
     # We only publish docs for the main branch.
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Motivation

The `publish-docs` job is timing out at its current 20-minute limit. See https://github.com/linera-io/linera-protocol/actions/runs/26223620144/job/77164751927.

## Proposal

Double the timeout from 20 to 40 minutes to give `cargo doc --all-features` enough headroom.

## Test Plan

CI will validate on merge. The job itself is the test — if it completes within 40 min, the fix holds.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- https://github.com/linera-io/linera-protocol/actions/runs/26223620144/job/77164751927
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)