### PR TITLE
docker: build linera-tests without metrics feature

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -89,6 +89,7 @@ jobs:
             local IMAGE_LONG=$4
             local BUILD_NAME=$5
             local TARGET=$6
+            local BUILD_FEATURES=${7:-}
             local LOG_FILE="/tmp/${BUILD_NAME}.log"
 
             {
@@ -106,6 +107,7 @@ jobs:
                 --build-arg "build_date=${BUILD_DATE}" \
                 --build-arg "build_flag=--release" \
                 --build-arg "build_folder=release" \
+                ${BUILD_FEATURES:+--build-arg "build_features=${BUILD_FEATURES}"} \
                 .
 
               echo "Pushing ${BUILD_NAME} images..."
@@ -126,8 +128,11 @@ jobs:
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
           # the remote-net integration test binary on top of the runtime.
+          # Build without the `metrics` feature: tests spawn `linera service`
+          # internally and the test harness does not pass --metrics-port, so
+          # including `metrics` would make every node-service call fail.
           build_and_push "docker/Dockerfile" \
-            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" &
+            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" "scylladb,jemalloc" &
           PID_LINERA_TESTS=$!
 
           build_and_push "docker/Dockerfile.indexer" \

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -89,9 +89,14 @@ jobs:
             local IMAGE_LONG=$4
             local BUILD_NAME=$5
             local TARGET=$6
-            local OVERRIDE_BUILD_FEATURES=${7+set}
-            local BUILD_FEATURES=${7:-}
             local LOG_FILE="/tmp/${BUILD_NAME}.log"
+            # Only pass --build-arg build_features when a 7th arg is given (even
+            # if empty), so callers can override the Dockerfile default of
+            # scylladb,metrics,opentelemetry,jemalloc with a smaller feature set.
+            local features_arg=()
+            if [[ $# -ge 7 ]]; then
+                features_arg=(--build-arg "build_features=${7}")
+            fi
 
             {
               echo "========================================"
@@ -108,7 +113,7 @@ jobs:
                 --build-arg "build_date=${BUILD_DATE}" \
                 --build-arg "build_flag=--release" \
                 --build-arg "build_folder=release" \
-                ${OVERRIDE_BUILD_FEATURES:+--build-arg "build_features=${BUILD_FEATURES}"} \
+                "${features_arg[@]+"${features_arg[@]}"}" \
                 .
 
               echo "Pushing ${BUILD_NAME} images..."
@@ -129,12 +134,10 @@ jobs:
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
           # the remote-net integration test binary on top of the runtime.
-          # Build with only the default Cargo features (no scylladb/metrics/
-          # opentelemetry/jemalloc extras): the linera binary in this image is a
-          # client-side tool used by the test harness; it does not need a DB
-          # backend, tracing, or a custom allocator. Crucially, omitting
-          # `metrics` means `linera service` does not require --metrics-port,
-          # which the test harness does not pass.
+          # Build with no extra features: the linera binary here is a client-side
+          # tool used by the test harness and does not need a DB backend,
+          # metrics, or a custom allocator. Without `metrics`, `linera service`
+          # does not require --metrics-port, which the test harness does not pass.
           build_and_push "docker/Dockerfile" \
             "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" "" &
           PID_LINERA_TESTS=$!

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -132,7 +132,7 @@ jobs:
           # internally and the test harness does not pass --metrics-port, so
           # including `metrics` would make every node-service call fail.
           build_and_push "docker/Dockerfile" \
-            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" "scylladb,jemalloc" &
+            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" "scylladb,opentelemetry,jemalloc" &
           PID_LINERA_TESTS=$!
 
           build_and_push "docker/Dockerfile.indexer" \

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -89,6 +89,7 @@ jobs:
             local IMAGE_LONG=$4
             local BUILD_NAME=$5
             local TARGET=$6
+            local OVERRIDE_BUILD_FEATURES=${7+set}
             local BUILD_FEATURES=${7:-}
             local LOG_FILE="/tmp/${BUILD_NAME}.log"
 
@@ -107,7 +108,7 @@ jobs:
                 --build-arg "build_date=${BUILD_DATE}" \
                 --build-arg "build_flag=--release" \
                 --build-arg "build_folder=release" \
-                ${BUILD_FEATURES:+--build-arg "build_features=${BUILD_FEATURES}"} \
+                ${OVERRIDE_BUILD_FEATURES:+--build-arg "build_features=${BUILD_FEATURES}"} \
                 .
 
               echo "Pushing ${BUILD_NAME} images..."
@@ -128,11 +129,14 @@ jobs:
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
           # the remote-net integration test binary on top of the runtime.
-          # Build without the `metrics` feature: tests spawn `linera service`
-          # internally and the test harness does not pass --metrics-port, so
-          # including `metrics` would make every node-service call fail.
+          # Build with only the default Cargo features (no scylladb/metrics/
+          # opentelemetry/jemalloc extras): the linera binary in this image is a
+          # client-side tool used by the test harness; it does not need a DB
+          # backend, tracing, or a custom allocator. Crucially, omitting
+          # `metrics` means `linera service` does not require --metrics-port,
+          # which the test harness does not pass.
           build_and_push "docker/Dockerfile" \
-            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" "scylladb,opentelemetry,jemalloc" &
+            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" "" &
           PID_LINERA_TESTS=$!
 
           build_and_push "docker/Dockerfile.indexer" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --bin linera-proxy \
     --bin linera-server \
     --bin linera \
-    --features $build_features
+    ${build_features:+--features $build_features}
 
 # Copy full source and build (only changed crates recompile).
 COPY . .
@@ -132,7 +132,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         --bin linera-proxy \
         --bin linera-server \
         --bin linera \
-        --features $build_features \
+        ${build_features:+--features $build_features} \
     && cp \
         target/"$build_folder"/linera \
         target/"$build_folder"/linera-proxy \


### PR DESCRIPTION
## Motivation

The `linera-tests` image was being built with the `metrics` feature enabled (the Dockerfile default: `scylladb,metrics,jemalloc`). With `metrics`, `linera service` requires `--metrics-port` as a mandatory argument. The test harness (`run_node_service_with_all_options` in `cli_wrappers/wallet.rs`) spawns `linera service` without passing `--metrics-port`, so every test that starts a node service was failing.

This broke the `testnet-conway-healthcheck` CronJob: 21/29 E2E tests failed.

## Proposal

Add an optional 7th parameter `BUILD_FEATURES` to the `build_and_push` shell function in `docker_image.yml`. When set, it overrides the Dockerfile's default `build_features` ARG via `--build-arg`.

For `linera-tests`, pass `scylladb,jemalloc` (dropping `metrics`). The `linera` binary embedded in the test image no longer requires `--metrics-port`, so the test harness can spawn it without changes.

All other images (`linera`, indexer, explorer, exporter) continue using the Dockerfile default and are unaffected.

## Test Plan

NOT YET END-TO-END VERIFIED — the fix needs to land on `testnet_conway`, trigger a CI image rebuild, and then the health-check CronJob re-run to confirm all 29 tests pass.

Logic verification:
- `build_and_push` with no 7th arg: `BUILD_FEATURES` is empty, `${BUILD_FEATURES:+...}` expands to nothing → Dockerfile default unchanged ✓
- `build_and_push ... "scylladb,jemalloc"`: adds `--build-arg build_features=scylladb,jemalloc` → `metrics` excluded → `--metrics-port` not required ✓

## Release Plan

- These changes should be backported to the latest `testnet` branch.

(This PR already targets `testnet_conway`. Also needs a forward-port to `main`.)

## Links

- Companion infra fix: linera-io/linera-infra#1195 (validator check image tag)
