### PR TITLE
[testnet] Backport style fixes from #6285 and #6286

### DIFF
--- a/examples/gen-nft/src/model.rs
+++ b/examples/gen-nft/src/model.rs
@@ -46,16 +46,15 @@ impl ModelContext {
         info!("trying to load model assuming gguf");
         let model_contents = gguf_file::Content::read(cursor)?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model_contents.tensor_infos.iter() {
+        for tensor in model_contents.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
         }
 
         info!(
-            "loaded {:?} tensors ({}B) ",
+            "loaded {:?} tensors ({total_size_in_bytes}B) ",
             model_contents.tensor_infos.len(),
-            total_size_in_bytes,
         );
 
         ModelWeights::from_gguf(model_contents, cursor, &Device::Cpu)
@@ -65,16 +64,15 @@ impl ModelContext {
         info!("trying to load model assuming ggml");
         let model_contents = ggml_file::Content::read(cursor, &Device::Cpu)?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model_contents.tensors.iter() {
+        for tensor in model_contents.tensors.values() {
             let elem_count = tensor.shape().elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.dtype().type_size() / tensor.dtype().block_size();
         }
 
         info!(
-            "loaded {:?} tensors ({}B) ",
+            "loaded {:?} tensors ({total_size_in_bytes}B) ",
             model_contents.tensors.len(),
-            total_size_in_bytes,
         );
 
         ModelWeights::from_ggml(model_contents, 1)

--- a/examples/llm/src/service.rs
+++ b/examples/llm/src/service.rs
@@ -134,16 +134,15 @@ impl ModelContext {
         debug!("trying to load model assuming gguf");
         let model_contents = gguf_file::Content::read(cursor)?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model_contents.tensor_infos.iter() {
+        for tensor in model_contents.tensor_infos.values() {
             let elem_count = tensor.shape.elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.ggml_dtype.type_size() / tensor.ggml_dtype.block_size();
         }
 
         debug!(
-            "loaded {:?} tensors ({}B) ",
+            "loaded {:?} tensors ({total_size_in_bytes}B) ",
             model_contents.tensor_infos.len(),
-            total_size_in_bytes,
         );
 
         ModelWeights::from_gguf(model_contents, cursor, &Device::Cpu)
@@ -153,16 +152,15 @@ impl ModelContext {
         debug!("trying to load model assuming ggml");
         let model_contents = ggml_file::Content::read(cursor, &Device::Cpu)?;
         let mut total_size_in_bytes = 0;
-        for (_, tensor) in model_contents.tensors.iter() {
+        for tensor in model_contents.tensors.values() {
             let elem_count = tensor.shape().elem_count();
             total_size_in_bytes +=
                 elem_count * tensor.dtype().type_size() / tensor.dtype().block_size();
         }
 
         debug!(
-            "loaded {:?} tensors ({}B) ",
+            "loaded {:?} tensors ({total_size_in_bytes}B) ",
             model_contents.tensors.len(),
-            total_size_in_bytes,
         );
 
         ModelWeights::from_ggml(model_contents, 1)

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -309,7 +309,7 @@ impl std::str::FromStr for BlobId {
                 blob_type,
             })
         } else {
-            Err(anyhow!("Invalid blob ID: {}", s))
+            Err(anyhow!("Invalid blob ID: {s}"))
         }
     }
 }
@@ -656,7 +656,7 @@ impl std::str::FromStr for StreamId {
                 stream_name,
             })
         } else {
-            Err(anyhow!("Invalid blob ID: {}", s))
+            Err(anyhow!("Invalid blob ID: {s}"))
         }
     }
 }

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -91,7 +91,7 @@ pub(crate) async fn process_pending_burns<E: linera_core::environment::Environme
             let mut hash = info.block_hash;
             loop {
                 let Some(h) = hash else {
-                    anyhow::bail!("Block at height {} not found", credit_height);
+                    anyhow::bail!("Block at height {credit_height} not found");
                 };
                 let c = linera_client.read_certificate(h).await?;
                 if c.block().header.height == credit_height {

--- a/linera-bridge/src/proof/mod.rs
+++ b/linera-bridge/src/proof/mod.rs
@@ -340,9 +340,7 @@ pub fn verify_receipt_inclusion(
     let total_bytes: usize = proof_nodes.iter().map(|n| n.len()).sum();
     ensure!(
         total_bytes <= MAX_PROOF_BYTES,
-        "proof too large: {} bytes (max {})",
-        total_bytes,
-        MAX_PROOF_BYTES
+        "proof too large: {total_bytes} bytes (max {MAX_PROOF_BYTES})",
     );
 
     let key = receipt_trie_key(tx_index);
@@ -496,7 +494,7 @@ pub fn build_receipt_proof(
         .iter()
         .map(|(idx, rlp)| (receipt_trie_key(*idx), rlp.as_slice()))
         .collect();
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries.sort_by_key(|x| x.0);
 
     let target_key = receipt_trie_key(target_tx_index);
     let retainer = ProofRetainer::new(vec![target_key]);

--- a/linera-core/src/chain_worker/handle.rs
+++ b/linera-core/src/chain_worker/handle.rs
@@ -42,8 +42,7 @@ impl AtomicTimestamp {
     fn current_micros() -> u64 {
         linera_base::time::SystemTime::now()
             .duration_since(linera_base::time::UNIX_EPOCH)
-            .map(|d| d.as_micros() as u64)
-            .unwrap_or(0)
+            .map_or(0, |d| d.as_micros() as u64)
     }
 }
 

--- a/linera-core/src/client/requests_scheduler/request.rs
+++ b/linera-core/src/client/requests_scheduler/request.rs
@@ -183,13 +183,13 @@ impl SubsumingKey<RequestResult> for super::request::RequestKey {
         let mut certificates_iter = certificates.iter();
         let mut collected = vec![];
         while let Some(height) = requested_heights.first() {
-            // Remove certs below the requested height.
-            if let Some(cert) = certificates_iter.find(|cert| &cert.value().height() == height) {
-                collected.push(cert.clone());
-                requested_heights.remove(0);
-            } else {
-                return None; // Missing a requested height
-            }
+            // Remove certs below the requested height, if present.
+            collected.push(
+                certificates_iter
+                    .find(|cert| &cert.value().height() == height)?
+                    .clone(),
+            );
+            requested_heights.remove(0);
         }
 
         Some(RequestResult::Certificates(collected))

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -686,9 +686,11 @@ impl<'a, Runtime: ContractRuntime> PrecompileProvider<Ctx<'a, Runtime>> for Cont
     }
 
     fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        let mut addresses = self.inner.warm_addresses().collect::<Vec<Address>>();
-        addresses.push(PRECOMPILE_ADDRESS);
-        Box::new(addresses.into_iter())
+        Box::new(
+            self.inner
+                .warm_addresses()
+                .chain(std::iter::once(PRECOMPILE_ADDRESS)),
+        )
     }
 
     fn contains(&self, address: &Address) -> bool {
@@ -866,9 +868,11 @@ impl<'a, Runtime: ServiceRuntime> PrecompileProvider<Ctx<'a, Runtime>> for Servi
     }
 
     fn warm_addresses(&self) -> Box<impl Iterator<Item = Address>> {
-        let mut addresses = self.inner.warm_addresses().collect::<Vec<Address>>();
-        addresses.push(PRECOMPILE_ADDRESS);
-        Box::new(addresses.into_iter())
+        Box::new(
+            self.inner
+                .warm_addresses()
+                .chain(std::iter::once(PRECOMPILE_ADDRESS)),
+        )
     }
 
     fn contains(&self, address: &Address) -> bool {

--- a/linera-faucet/server/src/database.rs
+++ b/linera-faucet/server/src/database.rs
@@ -146,7 +146,7 @@ impl FaucetDatabase {
                 .storage_client()
                 .read_certificate(hash)
                 .await?
-                .ok_or_else(|| anyhow::anyhow!("Certificate not found for hash {}", hash))?;
+                .ok_or_else(|| anyhow::anyhow!("Certificate not found for hash {hash}"))?;
             let current_height = certificate.block().header.height;
 
             // Check if this block's chains are already in our database
@@ -197,7 +197,7 @@ impl FaucetDatabase {
                 .storage_client()
                 .read_certificate(hash)
                 .await?
-                .ok_or_else(|| anyhow::anyhow!("Certificate not found for hash {}", hash))?;
+                .ok_or_else(|| anyhow::anyhow!("Certificate not found for hash {hash}"))?;
 
             let block_timestamp = certificate.block().header.timestamp;
             let chains_to_store = super::extract_opened_single_owner_chains(&certificate)?

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -261,7 +261,7 @@ where
             parts.len() == 3,
             "Expecting format `(tcp|udp|grpc|grpcs):host:port`"
         );
-        let protocol = parts[0].parse().map_err(|s| anyhow::anyhow!("{}", s))?;
+        let protocol = parts[0].parse().map_err(|s| anyhow::anyhow!("{s}"))?;
         let host = parts[1].to_owned();
         let port = parts[2].parse()?;
         Ok(ValidatorPublicNetworkPreConfig {

--- a/linera-rpc/src/propagation.rs
+++ b/linera-rpc/src/propagation.rs
@@ -155,10 +155,7 @@ pub fn get_context_with_traffic_type() -> Context {
 
     let cx = Context::current();
 
-    if std::env::var(TRAFFIC_TYPE_ENV_VAR)
-        .map(|v| v == TRAFFIC_TYPE_SYNTHETIC)
-        .unwrap_or(false)
-    {
+    if std::env::var(TRAFFIC_TYPE_ENV_VAR).is_ok_and(|v| v == TRAFFIC_TYPE_SYNTHETIC) {
         cx.with_baggage(vec![KeyValue::new(
             Key::new(TRAFFIC_TYPE_KEY),
             TRAFFIC_TYPE_SYNTHETIC,

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -253,9 +253,7 @@ async fn benchmark_with_fungible(
                         }
                         if i == 4 {
                             bail!(
-                                "Expected balance: {}, actual balance: {}",
-                                expected_balance,
-                                actual_balance
+                                "Expected balance: {expected_balance}, actual balance: {actual_balance}",
                             );
                         }
                     }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1134,18 +1134,18 @@ impl Runnable for Job {
                                     match result {
                                         Some(Ok(Ok((pid, status)))) => {
                                             if !status.success() {
-                                                error!("Benchmark process (pid {:?}) failed with status: {:?}", pid, status);
+                                                error!("Benchmark process (pid {pid:?}) failed with status: {status:?}");
                                                 kill_all_processes(&children_pids).await;
-                                                return Err(anyhow::anyhow!("Benchmark process (pid {:?}) failed", pid));
+                                                return Err(anyhow::anyhow!("Benchmark process (pid {pid:?}) failed"));
                                             }
                                         }
                                         Some(Ok(Err(e))) => {
-                                            error!("Benchmark process failed: {}", e);
+                                            error!("Benchmark process failed: {e}");
                                             kill_all_processes(&children_pids).await;
                                             return Err(e);
                                         }
                                         Some(Err(e)) => {
-                                            error!("Benchmark process panicked: {}", e);
+                                            error!("Benchmark process panicked: {e}");
                                             kill_all_processes(&children_pids).await;
                                             return Err(e.into());
                                         }

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -138,7 +138,7 @@ impl Project {
         ensure!(
             output.status.success(),
             "failed to initialize git repository at {}",
-            &project_root.display()
+            project_root.display()
         );
 
         Self::write_string_to_file(&project_root.join(".gitignore"), "/target")

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -208,13 +208,7 @@ where
                 storage,
                 id: context.id,
             })),
-            _ => {
-                bail!(
-                    "network protocol mismatch: cannot have {} and {} ",
-                    internal_protocol,
-                    external_protocol,
-                );
-            }
+            _ => bail!("network protocol mismatch: cannot have {internal_protocol} and {external_protocol} "),
         };
 
         Ok(proxy)
@@ -392,7 +386,7 @@ where
                 let blob = self.storage.read_blob(*blob_id).await?;
                 let blob = blob
                     .map(Arc::unwrap_or_clone)
-                    .ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                    .ok_or_else(|| anyhow!("Blob not found {blob_id}"))?;
                 let content = blob.into_content();
                 Ok(Some(RpcMessage::DownloadBlobResponse(Box::new(content))))
             }
@@ -452,10 +446,10 @@ where
             }
             BlobLastUsedBy(blob_id) => {
                 let blob_state = self.storage.read_blob_state(*blob_id).await?;
-                let blob_state = blob_state.ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                let blob_state = blob_state.ok_or_else(|| anyhow!("Blob not found {blob_id}"))?;
                 let last_used_by = blob_state
                     .last_used_by
-                    .ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                    .ok_or_else(|| anyhow!("Blob not found {blob_id}"))?;
                 Ok(Some(RpcMessage::BlobLastUsedByResponse(Box::new(
                     last_used_by,
                 ))))
@@ -465,16 +459,16 @@ where
             ))),
             BlobLastUsedByCertificate(blob_id) => {
                 let blob_state = self.storage.read_blob_state(*blob_id).await?;
-                let blob_state = blob_state.ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                let blob_state = blob_state.ok_or_else(|| anyhow!("Blob not found {blob_id}"))?;
                 let last_used_by = blob_state
                     .last_used_by
-                    .ok_or_else(|| anyhow!("Blob not found {}", blob_id))?;
+                    .ok_or_else(|| anyhow!("Blob not found {blob_id}"))?;
                 let certificate = self
                     .storage
                     .read_certificate(last_used_by)
                     .await?
                     .map(Arc::unwrap_or_clone)
-                    .ok_or_else(|| anyhow!("Certificate not found {}", last_used_by))?;
+                    .ok_or_else(|| anyhow!("Certificate not found {last_used_by}"))?;
                 Ok(Some(RpcMessage::BlobLastUsedByCertificateResponse(
                     Box::new(certificate),
                 )))

--- a/linera-service/src/task_processor.rs
+++ b/linera-service/src/task_processor.rs
@@ -307,7 +307,7 @@ impl<Env: linera_core::Environment> TaskProcessor<Env> {
     ) -> Result<TaskOutcome, anyhow::Error> {
         let binary_path = operators
             .get(&operator)
-            .ok_or_else(|| anyhow::anyhow!("unsupported operator: {}", operator))?;
+            .ok_or_else(|| anyhow::anyhow!("unsupported operator: {operator}"))?;
         debug!("Executing task {operator} ({binary_path:?}) for {application_id}");
         let mut child = Command::new(binary_path)
             .stdin(std::process::Stdio::piped())

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -35,13 +35,9 @@ pub trait ChildExt: std::fmt::Debug {
 impl ChildExt for tokio::process::Child {
     fn ensure_is_running(&mut self) -> Result<()> {
         if let Some(status) = self.try_wait().context("try_wait child process")? {
-            bail!(
-                "Child process {:?} already exited with status: {}",
-                self,
-                status
-            );
+            bail!("Child process {self:?} already exited with status: {status}");
         }
-        debug!("Child process {:?} is running as expected.", self);
+        debug!("Child process {self:?} is running as expected.");
         Ok(())
     }
 }

--- a/linera-storage-runtime/src/lib.rs
+++ b/linera-storage-runtime/src/lib.rs
@@ -340,10 +340,7 @@ example service:tcp:127.0.0.1:7878:table_do_my_test"
                     "spawn_blocking" => Ok(RocksDbSpawnMode::SpawnBlocking),
                     "block_in_place" => Ok(RocksDbSpawnMode::BlockInPlace),
                     "runtime" => Ok(RocksDbSpawnMode::get_spawn_mode_from_runtime()),
-                    _ => Err(anyhow!(
-                        "Failed to parse {} as a spawn_mode",
-                        spawn_mode_str
-                    )),
+                    _ => Err(anyhow!("Failed to parse {spawn_mode_str} as a spawn_mode")),
                 }?;
                 let namespace = if parts.len() == 2 {
                     DEFAULT_NAMESPACE.to_string()
@@ -405,7 +402,7 @@ example service:tcp:127.0.0.1:7878:table_do_my_test"
                             if uri.is_some() {
                                 bail!("The uri has already been assigned");
                             }
-                            uri = Some(format!("{}:{}", &address, port));
+                            uri = Some(format!("{address}:{port}"));
                         }
                         _ if part.starts_with("table") => {
                             if namespace.is_some() {
@@ -444,10 +441,7 @@ example service:tcp:127.0.0.1:7878:table_do_my_test"
                 "spawn_blocking" => Ok(RocksDbSpawnMode::SpawnBlocking),
                 "block_in_place" => Ok(RocksDbSpawnMode::BlockInPlace),
                 "runtime" => Ok(RocksDbSpawnMode::get_spawn_mode_from_runtime()),
-                _ => Err(anyhow!(
-                    "Failed to parse {} as a spawn_mode",
-                    spawn_mode_str
-                )),
+                _ => Err(anyhow!("Failed to parse {spawn_mode_str} as a spawn_mode",)),
             }?;
             let protocol = parts[2];
             if protocol != "tcp" {
@@ -457,7 +451,7 @@ example service:tcp:127.0.0.1:7878:table_do_my_test"
             let port_str = parts[4];
             let port = NonZeroU16::from_str(port_str)
                 .map_err(|_| anyhow!("Failed to find parse port {port_str} for {s}"))?;
-            let uri = format!("{}:{}", &address, port);
+            let uri = format!("{address}:{port}");
             let inner_storage_config = InnerStorageConfig::DualRocksDbScyllaDb {
                 path_with_guard,
                 spawn_mode,

--- a/linera-summary/src/github.rs
+++ b/linera-summary/src/github.rs
@@ -119,9 +119,9 @@ impl GithubContext {
                 env_base_branch.map_err(|_| {
                     anyhow!("GITHUB_BASE_BRANCH is not set! This must be run from within CI")
                 })?,
-                pr_string.parse().map_err(|_| {
-                    anyhow!("GITHUB_PR_NUMBER is not a valid number: {}", pr_string)
-                })?,
+                pr_string
+                    .parse()
+                    .map_err(|_| anyhow!("GITHUB_PR_NUMBER is not a valid number: {pr_string}"))?,
             )
         };
 

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -60,9 +60,7 @@ fn get_available_memory(sys: &System) -> usize {
 }
 
 fn get_available_cpus() -> i32 {
-    std::thread::available_parallelism()
-        .map(|p| p.get() as i32)
-        .unwrap_or(1)
+    std::thread::available_parallelism().map_or(1, |p| p.get() as i32)
 }
 
 const HYPER_CLOCK_CACHE_BLOCK_SIZE: usize = 8 * 1024; // 8 KiB

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -334,21 +334,25 @@ where
             self.stored_buckets[0].index = 0;
         }
         if !self.new_back_values.is_empty() {
-            let mut index = match self.stored_buckets.back() {
-                Some(bucket) => bucket.index + 1,
-                None => 0,
-            };
+            let start = self
+                .stored_buckets
+                .back()
+                .map(|bucket| bucket.index + 1)
+                .unwrap_or_default();
             let new_back_values = std::mem::take(&mut self.new_back_values);
             let new_back_values = new_back_values.into_iter().collect::<Vec<_>>();
-            for value_chunk in new_back_values.chunks(N) {
-                self.stored_buckets.push_back(Bucket {
-                    index,
-                    state: State::Loaded {
-                        data: value_chunk.to_vec(),
-                    },
-                });
-                index += 1;
-            }
+            self.stored_buckets
+                .extend(
+                    new_back_values
+                        .chunks(N)
+                        .zip(start..)
+                        .map(|(value_chunk, index)| Bucket {
+                            index,
+                            state: State::Loaded {
+                                data: value_chunk.to_vec(),
+                            },
+                        }),
+                );
             if self.cursor.is_none() {
                 self.cursor = Some(Cursor {
                     offset: 0,

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -188,7 +188,7 @@ impl<W: View> View for ByteCollectionView<W::Context, W> {
     }
 
     fn post_save(&mut self) {
-        for (_, update) in self.updates.get_mut().iter_mut() {
+        for update in self.updates.get_mut().values_mut() {
             if let Update::Set(view) = update {
                 view.post_save();
             }

--- a/linera-views/src/views/log_view.rs
+++ b/linera-views/src/views/log_view.rs
@@ -111,15 +111,14 @@ where
         }
         if !self.new_values.is_empty() {
             delete_view = false;
-            let mut count = self.stored_count;
-            for value in &self.new_values {
+            for (count, value) in (self.stored_count..).zip(&self.new_values) {
                 let key = self
                     .context
                     .base_key()
                     .derive_tag_key(KeyTag::Index as u8, &count)?;
                 batch.put_key_value(key, value)?;
-                count += 1;
             }
+            let count = self.stored_count + self.new_values.len();
             let key = self.context.base_key().base_tag(KeyTag::Count as u8);
             batch.put_key_value(key, &count)?;
         }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -929,7 +929,7 @@ where
     for key_value in key_value_vector {
         let key = key_value.0;
         let value = key_value.1;
-        let key_str = format!("{:?}", &key);
+        let key_str = format!("{key:?}");
         let value_usize = (*value.first().unwrap()) as usize;
         view.map.insert(&key_str, value_usize)?;
         view.key_value_store.insert(key, value)?;
@@ -959,7 +959,7 @@ where
     for operation in operations {
         match operation {
             Put { key, value } => {
-                let key_str = format!("{:?}", &key);
+                let key_str = format!("{key:?}");
                 let first_value = *value.first().unwrap();
                 let first_value_usize = first_value as usize;
                 let first_value_u64 = first_value as u64;
@@ -974,7 +974,7 @@ where
                 }
             }
             Delete { key } => {
-                let key_str = format!("{:?}", &key);
+                let key_str = format!("{key:?}");
                 view.map.remove(&key_str)?;
                 view.key_value_store.remove(key)?;
             }
@@ -1078,24 +1078,23 @@ where
             let view = store.load(1).await?;
             view.hash().await?
         };
-        for pair in key_value_vector {
-            let str0 = format!("{:?}", &pair.0);
-            let str1 = format!("{:?}", &pair.1);
-            let pair0_first_u8 = *pair.0.first().unwrap();
-            let pair1_first_u8 = *pair.1.first().unwrap();
+        for (key, value) in key_value_vector {
+            let str0 = format!("{key:?}");
+            let str1 = format!("{value:?}");
+            let key_first_u8 = *key.first().unwrap();
+            let value_first_u8 = *value.first().unwrap();
             let choice = rng.gen_range(0..7);
             if choice < 3 {
                 let mut view = store.load(1).await?;
-                view.x1.set(pair0_first_u8 as u64);
-                view.x2.set(pair1_first_u8 as u32);
-                view.log.push(pair0_first_u8 as u32);
-                view.log.push(pair1_first_u8 as u32);
-                view.queue.push_back(pair0_first_u8 as u64);
-                view.queue.push_back(pair1_first_u8 as u64);
-                view.map.insert(&str0, pair1_first_u8 as usize)?;
-                view.map.insert(&str1, pair0_first_u8 as usize)?;
-                view.key_value_store
-                    .insert(pair.0.clone(), pair.1.clone())?;
+                view.x1.set(key_first_u8 as u64);
+                view.x2.set(value_first_u8 as u32);
+                view.log.push(key_first_u8 as u32);
+                view.log.push(value_first_u8 as u32);
+                view.queue.push_back(key_first_u8 as u64);
+                view.queue.push_back(value_first_u8 as u64);
+                view.map.insert(&str0, value_first_u8 as usize)?;
+                view.map.insert(&str1, key_first_u8 as usize)?;
+                view.key_value_store.insert(key.clone(), value.clone())?;
                 if choice == 0 {
                     view.rollback();
                     let hash_new = view.hash().await?;
@@ -1117,7 +1116,7 @@ where
             if choice == 4 {
                 let mut view = store.load(1).await?;
                 let subview = view.collection.load_entry_mut(&str0).await?;
-                subview.push(pair1_first_u8 as u32);
+                subview.push(value_first_u8 as u32);
                 let hash_new = view.hash().await?;
                 assert_ne!(hash, hash_new);
                 view.save().await?;

--- a/linera-witty/src/wit_generation/mod.rs
+++ b/linera-witty/src/wit_generation/mod.rs
@@ -127,7 +127,7 @@ impl FileContentGenerator for WitWorldWriter {
             writeln!(writer, "package {package};\n")?;
         }
 
-        writeln!(writer, "world {} {{", &self.name)?;
+        writeln!(writer, "world {} {{", self.name)?;
 
         for import in &self.imports {
             writeln!(writer, "    import {import};")?;


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/6285 and https://github.com/linera-io/linera-protocol/pull/6286 applied several style fixes to satisfy the new Clippy and other lints that came with the Rust 1.95.0 upgrade.

## Proposal

We cannot do the upgrade on `testnet_conway`, but we can still apply the same style fixes.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Backport style fixes but not main parts of of #6285 and #6286
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
