### PR TITLE
Ensure checkpoint-bootstrapped nodes have all referenced blobs.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1072,6 +1072,11 @@ pub enum OracleResponse {
     Checkpoint {
         /// Content hashes of the execution-state-dump blobs, in restore order.
         execution_state_blobs: Vec<CryptoHash>,
+        /// All blobs the chain references in its `used_blobs` set at the time of the
+        /// checkpoint. A bootstrapping node must have each of these in shared blob
+        /// storage before applying the checkpoint, otherwise subsequent operations on
+        /// the chain could try to read blob content the node doesn't actually have.
+        used_blobs: Vec<BlobId>,
     },
 }
 

--- a/linera-bridge/src/solidity/BridgeTypes.sol
+++ b/linera-bridge/src/solidity/BridgeTypes.sol
@@ -1820,6 +1820,7 @@ library BridgeTypes {
 
     struct OracleResponse_Checkpoint {
         CryptoHash[] execution_state_blobs;
+        BlobId[] used_blobs;
     }
 
     function bcs_serialize_OracleResponse_Checkpoint(OracleResponse_Checkpoint memory input)
@@ -1827,7 +1828,8 @@ library BridgeTypes {
         pure
         returns (bytes memory)
     {
-        return bcs_serialize_seq_CryptoHash(input.execution_state_blobs);
+        bytes memory result = bcs_serialize_seq_CryptoHash(input.execution_state_blobs);
+        return abi.encodePacked(result, bcs_serialize_seq_BlobId(input.used_blobs));
     }
 
     function bcs_deserialize_offset_OracleResponse_Checkpoint(uint256 pos, bytes memory input)
@@ -1838,7 +1840,9 @@ library BridgeTypes {
         uint256 new_pos;
         CryptoHash[] memory execution_state_blobs;
         (new_pos, execution_state_blobs) = bcs_deserialize_offset_seq_CryptoHash(pos, input);
-        return (new_pos, OracleResponse_Checkpoint(execution_state_blobs));
+        BlobId[] memory used_blobs;
+        (new_pos, used_blobs) = bcs_deserialize_offset_seq_BlobId(new_pos, input);
+        return (new_pos, OracleResponse_Checkpoint(execution_state_blobs, used_blobs));
     }
 
     function bcs_deserialize_OracleResponse_Checkpoint(bytes memory input)
@@ -4075,6 +4079,41 @@ library BridgeTypes {
         uint256 new_pos;
         BlobContent[] memory value;
         (new_pos, value) = bcs_deserialize_offset_seq_BlobContent(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    function bcs_serialize_seq_BlobId(BlobId[] memory input) internal pure returns (bytes memory) {
+        uint256 len = input.length;
+        bytes memory result = bcs_serialize_len(len);
+        for (uint256 i = 0; i < len; i++) {
+            result = abi.encodePacked(result, bcs_serialize_BlobId(input[i]));
+        }
+        return result;
+    }
+
+    function bcs_deserialize_offset_seq_BlobId(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, BlobId[] memory)
+    {
+        uint256 len;
+        uint256 new_pos;
+        (new_pos, len) = bcs_deserialize_offset_len(pos, input);
+        BlobId[] memory result;
+        result = new BlobId[](len);
+        BlobId memory value;
+        for (uint256 i = 0; i < len; i++) {
+            (new_pos, value) = bcs_deserialize_offset_BlobId(new_pos, input);
+            result[i] = value;
+        }
+        return (new_pos, result);
+    }
+
+    function bcs_deserialize_seq_BlobId(bytes memory input) internal pure returns (BlobId[] memory) {
+        uint256 new_pos;
+        BlobId[] memory value;
+        (new_pos, value) = bcs_deserialize_offset_seq_BlobId(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-bridge/tests/snapshots/format__format.yaml.snap
+++ b/linera-bridge/tests/snapshots/format__format.yaml.snap
@@ -361,6 +361,9 @@ OracleResponse:
           - execution_state_blobs:
               SEQ:
                 TYPENAME: CryptoHash
+          - used_blobs:
+              SEQ:
+                TYPENAME: BlobId
 OutgoingMessage:
   STRUCT:
     - destination:

--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -566,8 +566,14 @@ impl Block {
         let mut required_blob_ids = BTreeSet::new();
         for responses in &self.body.oracle_responses {
             for response in responses {
-                if let OracleResponse::Blob(blob_id) = response {
-                    required_blob_ids.insert(*blob_id);
+                match response {
+                    OracleResponse::Blob(blob_id) => {
+                        required_blob_ids.insert(*blob_id);
+                    }
+                    OracleResponse::Checkpoint { used_blobs, .. } => {
+                        required_blob_ids.extend(used_blobs.iter().copied());
+                    }
+                    _ => {}
                 }
             }
         }

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -682,8 +682,14 @@ impl BlockExecutionOutcome {
         let mut required_blob_ids = HashSet::new();
         for responses in &self.oracle_responses {
             for response in responses {
-                if let OracleResponse::Blob(blob_id) = response {
-                    required_blob_ids.insert(*blob_id);
+                match response {
+                    OracleResponse::Blob(blob_id) => {
+                        required_blob_ids.insert(*blob_id);
+                    }
+                    OracleResponse::Checkpoint { used_blobs, .. } => {
+                        required_blob_ids.extend(used_blobs.iter().copied());
+                    }
+                    _ => {}
                 }
             }
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -915,6 +915,7 @@ where
             if block.starts_with_checkpoint() {
                 let Some(OracleResponse::Checkpoint {
                     execution_state_blobs,
+                    ..
                 }) = block.body.oracle_responses.first().and_then(|r| r.first())
                 else {
                     return Err(ChainError::InternalError(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4248,6 +4248,7 @@ where
     let execution_state_blobs = match block.body.oracle_responses.first().and_then(|t| t.first()) {
         Some(OracleResponse::Checkpoint {
             execution_state_blobs,
+            used_blobs: _,
         }) => execution_state_blobs.clone(),
         other => panic!("Expected OracleResponse::Checkpoint as the first response, got {other:?}"),
     };

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -162,18 +162,23 @@ where
     }
 
     /// Registers the checkpoint blobs (produced by [`Self::prepare_checkpoint`]) with the
-    /// transaction tracker and records the matching [`OracleResponse::Checkpoint`].
-    pub fn apply_checkpoint(
+    /// transaction tracker and records the matching [`OracleResponse::Checkpoint`]. The
+    /// oracle response also lists every blob the chain currently references in its
+    /// `used_blobs` set: a bootstrapping node restores those references from the dump but
+    /// must independently ensure each blob's content is present in shared storage.
+    pub async fn apply_checkpoint(
         &self,
         blobs: Vec<Blob>,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(), ExecutionError> {
         let execution_state_blobs = blobs.iter().map(|blob| blob.id().hash).collect();
+        let used_blobs = self.system.used_blobs.indices().await?;
         for blob in blobs {
             txn_tracker.add_created_blob(blob);
         }
         txn_tracker.replay_oracle_response(OracleResponse::Checkpoint {
             execution_state_blobs,
+            used_blobs,
         })?;
         Ok(())
     }
@@ -190,7 +195,7 @@ where
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(), ExecutionError> {
         let blobs = self.prepare_checkpoint(maximum_blob_size).await?;
-        self.apply_checkpoint(blobs, txn_tracker)
+        self.apply_checkpoint(blobs, txn_tracker).await
     }
 
     /// Replaces the persisted execution state with the content of a checkpoint blob,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -1072,9 +1072,7 @@ where
                              the chain-level pre-block hook must run prepare_checkpoint first",
                         ),
                     )?;
-                    self.state
-                        .apply_checkpoint(blobs, self.txn_tracker)
-                        .await?;
+                    self.state.apply_checkpoint(blobs, self.txn_tracker).await?;
                 }
                 op => {
                     let new_application = self

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -1072,7 +1072,9 @@ where
                              the chain-level pre-block hook must run prepare_checkpoint first",
                         ),
                     )?;
-                    self.state.apply_checkpoint(blobs, self.txn_tracker)?;
+                    self.state
+                        .apply_checkpoint(blobs, self.txn_tracker)
+                        .await?;
                 }
                 op => {
                     let new_application = self

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -170,6 +170,7 @@ async fn execute_checkpoint_publishes_blob_and_records_oracle_response() -> anyh
         outcome.oracle_responses[0],
         OracleResponse::Checkpoint {
             execution_state_blobs: vec![blob.id().hash],
+            used_blobs: vec![],
         }
     );
 
@@ -221,7 +222,7 @@ async fn checkpoint_roundtrip_via_separate_view_yields_matching_hash() -> anyhow
         .flat_map(|blob| blob.bytes().iter().copied())
         .collect::<Vec<u8>>();
     let mut txn_tracker = TransactionTracker::default();
-    producer.apply_checkpoint(blobs, &mut txn_tracker)?;
+    producer.apply_checkpoint(blobs, &mut txn_tracker).await?;
     let mut batch = Batch::new();
     producer.pre_save(&mut batch)?;
     producer.context().store().write_batch(batch).await?;

--- a/linera-indexer/lib/src/db/postgres/mod.rs
+++ b/linera-indexer/lib/src/db/postgres/mod.rs
@@ -450,10 +450,14 @@ impl PostgresDatabase {
                 }
                 OracleResponse::Checkpoint {
                     execution_state_blobs,
+                    used_blobs,
                 } => {
-                    let serialized = bincode::serialize(execution_state_blobs).map_err(|e| {
-                        PostgresError::Serialization(format!("Failed to serialize checkpoint: {e}"))
-                    })?;
+                    let serialized =
+                        bincode::serialize(&(execution_state_blobs, used_blobs)).map_err(|e| {
+                            PostgresError::Serialization(format!(
+                                "Failed to serialize checkpoint: {e}"
+                            ))
+                        })?;
                     ("Checkpoint", None, Some(serialized))
                 }
             };

--- a/linera-indexer/lib/src/db/postgres/mod.rs
+++ b/linera-indexer/lib/src/db/postgres/mod.rs
@@ -452,8 +452,8 @@ impl PostgresDatabase {
                     execution_state_blobs,
                     used_blobs,
                 } => {
-                    let serialized =
-                        bincode::serialize(&(execution_state_blobs, used_blobs)).map_err(|e| {
+                    let serialized = bincode::serialize(&(execution_state_blobs, used_blobs))
+                        .map_err(|e| {
                             PostgresError::Serialization(format!(
                                 "Failed to serialize checkpoint: {e}"
                             ))

--- a/linera-indexer/lib/src/db/sqlite/mod.rs
+++ b/linera-indexer/lib/src/db/sqlite/mod.rs
@@ -450,8 +450,8 @@ impl SqliteDatabase {
                     execution_state_blobs,
                     used_blobs,
                 } => {
-                    let serialized =
-                        bincode::serialize(&(execution_state_blobs, used_blobs)).map_err(|e| {
+                    let serialized = bincode::serialize(&(execution_state_blobs, used_blobs))
+                        .map_err(|e| {
                             SqliteError::Serialization(format!(
                                 "Failed to serialize checkpoint: {e}"
                             ))

--- a/linera-indexer/lib/src/db/sqlite/mod.rs
+++ b/linera-indexer/lib/src/db/sqlite/mod.rs
@@ -448,10 +448,14 @@ impl SqliteDatabase {
                 }
                 OracleResponse::Checkpoint {
                     execution_state_blobs,
+                    used_blobs,
                 } => {
-                    let serialized = bincode::serialize(execution_state_blobs).map_err(|e| {
-                        SqliteError::Serialization(format!("Failed to serialize checkpoint: {e}"))
-                    })?;
+                    let serialized =
+                        bincode::serialize(&(execution_state_blobs, used_blobs)).map_err(|e| {
+                            SqliteError::Serialization(format!(
+                                "Failed to serialize checkpoint: {e}"
+                            ))
+                        })?;
                     ("Checkpoint", None, Some(serialized))
                 }
             };

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -886,6 +886,9 @@ OracleResponse:
           - execution_state_blobs:
               SEQ:
                 TYPENAME: CryptoHash
+          - used_blobs:
+              SEQ:
+                TYPENAME: BlobId
 OriginalProposal:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

The dumped execution state restores the chain's `used_blobs` set by ID, but the corresponding blob contents live in shared blob storage and may be absent on a bootstrapping node.

## Proposal

List the chain's `used_blobs` in `OracleResponse::Checkpoint` and surface them through `oracle_blob_ids` so the existing required-blob plumbing fetches or fails as usual.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
