### PR TITLE
ScyllaDB: quote the namespace in the timestamped queries

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -140,7 +140,7 @@ impl ScyllaDbClient {
 
         let read_writetime = session
             .prepare(format!(
-                "SELECT WRITETIME(v) FROM {KEYSPACE}.{namespace} WHERE root_key = ? AND k = ?"
+                "SELECT WRITETIME(v) FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k = ?"
             ))
             .await?;
 
@@ -180,26 +180,26 @@ impl ScyllaDbClient {
         // tombstone shadowing the inserts.
         let write_batch_delete_prefix_unbounded_ts = session
             .prepare(format!(
-                "DELETE FROM {KEYSPACE}.{namespace} USING TIMESTAMP ? WHERE root_key = ? AND k >= ?"
+                "DELETE FROM {KEYSPACE}.\"{namespace}\" USING TIMESTAMP ? WHERE root_key = ? AND k >= ?"
             ))
             .await?;
 
         let write_batch_delete_prefix_bounded_ts = session
             .prepare(format!(
-                "DELETE FROM {KEYSPACE}.{namespace} USING TIMESTAMP ? \
+                "DELETE FROM {KEYSPACE}.\"{namespace}\" USING TIMESTAMP ? \
                  WHERE root_key = ? AND k >= ? AND k < ?"
             ))
             .await?;
 
         let write_batch_deletion_ts = session
             .prepare(format!(
-                "DELETE FROM {KEYSPACE}.{namespace} USING TIMESTAMP ? WHERE root_key = ? AND k = ?"
+                "DELETE FROM {KEYSPACE}.\"{namespace}\" USING TIMESTAMP ? WHERE root_key = ? AND k = ?"
             ))
             .await?;
 
         let write_batch_insertion_ts = session
             .prepare(format!(
-                "INSERT INTO {KEYSPACE}.{namespace} (root_key, k, v) VALUES (?, ?, ?) \
+                "INSERT INTO {KEYSPACE}.\"{namespace}\" (root_key, k, v) VALUES (?, ?, ?) \
                  USING TIMESTAMP ?"
             ))
             .await?;


### PR DESCRIPTION
## Motivation

The exclusive-mode timestamped queries introduced in #6342 reference the table
without quoting the namespace, unlike every other statement and the
`CREATE TABLE`. CQL folds *unquoted* identifiers to lowercase, while the table
is created with a *quoted* (case-sensitive) name. So for any namespace
containing uppercase letters (allowed by `check_namespace`: ASCII alphanumeric
+ `_`, up to 48 chars), these queries would target a different, lowercased
table that does not exist — failing the exclusive-mode write/seed path. The
bug is masked today because test namespaces and `DEFAULT_NAMESPACE` are
lowercase.

## Proposal

Quote the namespace consistently (`{KEYSPACE}."{namespace}"`) in the five
affected statements:

- `SELECT WRITETIME(v) …` (the sentinel write-time read)
- the three `USING TIMESTAMP` `DELETE`s (unbounded prefix, bounded prefix,
  single key)
- the `USING TIMESTAMP` `INSERT`

## Test Plan

- `cargo check -p linera-views --features scylladb` passes.
- No behavioral change for the lowercase namespaces used by the existing
  ScyllaDB test suite; the fix only affects mixed-case namespaces.

## Release Plan

to be backported

## Links

- Follow-up to #6342.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)