### PR TITLE
ScyllaDB: quote namespace identifier in CQL to handle reserved keywords

### DIFF
--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -140,7 +140,7 @@ impl ScyllaDbClient {
 
         let read_writetime = session
             .prepare(format!(
-                "SELECT WRITETIME(v) FROM {KEYSPACE}.{namespace} WHERE root_key = ? AND k = ?"
+                "SELECT WRITETIME(v) FROM {KEYSPACE}.\"{namespace}\" WHERE root_key = ? AND k = ?"
             ))
             .await?;
 
@@ -180,26 +180,26 @@ impl ScyllaDbClient {
         // tombstone shadowing the inserts.
         let write_batch_delete_prefix_unbounded_ts = session
             .prepare(format!(
-                "DELETE FROM {KEYSPACE}.{namespace} USING TIMESTAMP ? WHERE root_key = ? AND k >= ?"
+                "DELETE FROM {KEYSPACE}.\"{namespace}\" USING TIMESTAMP ? WHERE root_key = ? AND k >= ?"
             ))
             .await?;
 
         let write_batch_delete_prefix_bounded_ts = session
             .prepare(format!(
-                "DELETE FROM {KEYSPACE}.{namespace} USING TIMESTAMP ? \
+                "DELETE FROM {KEYSPACE}.\"{namespace}\" USING TIMESTAMP ? \
                  WHERE root_key = ? AND k >= ? AND k < ?"
             ))
             .await?;
 
         let write_batch_deletion_ts = session
             .prepare(format!(
-                "DELETE FROM {KEYSPACE}.{namespace} USING TIMESTAMP ? WHERE root_key = ? AND k = ?"
+                "DELETE FROM {KEYSPACE}.\"{namespace}\" USING TIMESTAMP ? WHERE root_key = ? AND k = ?"
             ))
             .await?;
 
         let write_batch_insertion_ts = session
             .prepare(format!(
-                "INSERT INTO {KEYSPACE}.{namespace} (root_key, k, v) VALUES (?, ?, ?) \
+                "INSERT INTO {KEYSPACE}.\"{namespace}\" (root_key, k, v) VALUES (?, ?, ?) \
                  USING TIMESTAMP ?"
             ))
             .await?;


### PR DESCRIPTION
## Motivation

PR #6342 introduced five new CQL prepared statements (timestamped variants used by the exclusive-mode write path). Those statements interpolated the table name as bare `{namespace}`, which breaks when the namespace happens to be a CQL reserved keyword such as `DEFAULT`. ScyllaDB returns an error from `session.prepare()`, which `.unwrap()` turns into a panic and an exit code 101, causing the compose-based CI test to fail.

## Proposal

Double-quote the namespace identifier in all five new statements, matching the pattern already used by all the pre-existing statements in the same function:

```cql
-- before
SELECT WRITETIME(v) FROM linera.default WHERE ...
-- after
SELECT WRITETIME(v) FROM linera."default" WHERE ...
```

This is the standard CQL way to escape reserved keywords as identifiers.

## Test Plan

CI: the `docker-shard-2` compose job was exiting with code 101 (Rust panic in `scylla_db.rs`) when the namespace resolved to `default`. This fix makes all five statements match the quoting pattern of the surrounding statements.

NOT YET END-TO-END VERIFIED locally — reproducing requires a ScyllaDB instance with a `default` namespace. The root cause is unambiguous from the CQL spec and the panic stack trace.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Fixes merge-queue CI failure in job https://github.com/linera-io/linera-protocol/actions/runs/26251898227/job/77264886705
- Introduced by #6342
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)