### PR TITLE
bridge-e2e: declare bridge-init as service_completed_successfully in compose

### DIFF
--- a/docker/docker-compose.bridge-test.yml
+++ b/docker/docker-compose.bridge-test.yml
@@ -265,6 +265,8 @@ services:
     depends_on:
       bridge-chain-init:
         condition: service_completed_successfully
+      bridge-init:
+        condition: service_completed_successfully
       anvil:
         condition: service_healthy
 


### PR DESCRIPTION
## Motivation

The `burns_per_evm_tx::base` e2e test was failing in CI because `docker compose up --wait` exited with code 1 when `bridge-init` (the one-shot forge deployment container) exited with code 0.

The testcontainers `DockerCompose` helper defaults to `--wait --wait-timeout 60`. Docker compose `--wait` monitors all services; when a container transitions from running to exited during the monitoring window, compose treats it as a failure **unless** the service is declared as a `service_completed_successfully` dependency of another service — that declaration is what tells compose an exit is expected.

`bridge-chain-init`, `scylla-setup`, and `bridge-args-init` were all already declared this way. `bridge-init` was the only one-shot container that was not, so its ~27-second forge compilation + deployment caused a spurious exit-1 when monitored.

The `burns_per_evm_tx::ethereum` test was passing because it runs after `base` (both are `#[serial]`), and by then forge compilation artifacts are cached — `bridge-init` exits in ~1-2 seconds, before the monitoring window fully starts.

## Proposal

Add `bridge-init: condition: service_completed_successfully` to `linera-relay`'s `depends_on`, alongside the existing `bridge-chain-init` entry. This is exactly the same pattern already used for every other one-shot container in the compose file.

## Test Plan

CI: the `burns_per_evm_tx::base` test was failing at the `docker compose up` phase (exit status 1). This fix aligns `bridge-init` with the established pattern for all other one-shot containers.

NOT YET END-TO-END VERIFIED locally — reproducing requires a full bridge e2e environment.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes merge-queue CI failure in job https://github.com/linera-io/linera-protocol/actions/runs/26251898193/job/77264886720
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)