### PR TITLE
[testnet] Increase default `multi_leader_rounds` from 2 to 5 (#6359)

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -1231,7 +1231,7 @@ mod tests {
         );
         assert_eq!(
             description.id().to_string(),
-            "fe947fddf2735224d01eb9d56580109f2d9d02397dc5ddd748ef9beeb38d9caa"
+            "0b87a7cba23cf0d634a1f8eace084acb8fa110b8017db71a7f1bb159e4c752dd"
         );
     }
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -100,7 +100,7 @@ impl ChainOwnership {
         ChainOwnership {
             super_owners: iter::once(owner).collect(),
             owners: BTreeMap::new(),
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }
@@ -111,7 +111,7 @@ impl ChainOwnership {
         ChainOwnership {
             super_owners: BTreeSet::new(),
             owners: iter::once((owner, 100)).collect(),
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2332,7 +2332,7 @@ impl<Env: Environment> ChainClient<Env> {
         Box::pin(self.execute_operation(SystemOperation::ChangeOwnership {
             super_owners: vec![new_owner],
             owners: Vec::new(),
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         }))

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -1764,6 +1764,19 @@ where
 
     let creator = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
 
+    // Pin the chain to two multi-leader rounds so the test walks
+    // MultiLeader(0) -> MultiLeader(1) -> SingleLeader(0) on three failed proposals,
+    // independently of the protocol-wide default.
+    let creator_key = creator.identity().await.unwrap();
+    creator
+        .change_ownership(ChainOwnership::multiple(
+            [(creator_key, 100)],
+            2,
+            TimeoutConfig::default(),
+        ))
+        .await
+        .unwrap();
+
     // Publish and create the time-expiry application.
     let module_id = creator.publish_wasm_example("time-expiry").await?;
     let module_id = module_id.with_abi::<time_expiry::TimeExpiryAbi, (), ()>();

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -536,7 +536,7 @@ where
         let operation = SystemOperation::ChangeOwnership {
             super_owners: vec![new_owner],
             owners: Vec::new(),
-            multi_leader_rounds: 2,
+            multi_leader_rounds: 5,
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig::default(),
         };


### PR DESCRIPTION
Backport of #6359.

## Motivation

In practice, most chain owners cooperate, if there even are more than a single owner, so multi-leader rounds are more useful than single-leader rounds.

## Proposal

Increase the default from 2 to 5 multi-leader rounds.

## Test Plan

CI; no logic was changed

## Release Plan

- Release SDK.

## Links

- PR to `main`: #6359
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
