### PR TITLE
[testnet] Fix bridge e2e build after CacheArc rollout

### DIFF
--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -540,7 +540,7 @@ pub async fn set_anvil_block_gas_limit(
 /// to the head block (no per-height search loop needed in tests).
 pub async fn fetch_latest_cert<E>(
     chain_client: &linera_core::client::ChainClient<E>,
-) -> anyhow::Result<linera_chain::types::ConfirmedBlockCertificate>
+) -> anyhow::Result<linera_storage::Arc<linera_chain::types::ConfirmedBlockCertificate>>
 where
     E: linera_core::environment::Environment,
 {

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -355,7 +355,7 @@ where
     );
 
     let cert = fetch_latest_cert(cc_a).await?;
-    let cert_bytes = bcs::to_bytes(&cert).context("BCS-serialize cert")?;
+    let cert_bytes = bcs::to_bytes(&*cert).context("BCS-serialize cert")?;
 
     let bridge = IFungibleBridge::new(bridge_addr, provider);
     let gas = bridge


### PR DESCRIPTION
## Motivation

CI bridge-tests broke on `testnet_conway` (run 26322243134) after the `CacheArc` rollout (#6147 / #6249 backport `c7852f547f`) changed `ChainClient::read_certificate` to return `Result<CacheArc<ConfirmedBlockCertificate>>`. Production callers were updated, but `linera-bridge/tests/e2e` lives in its own sub-workspace, so the compile breakage didn't show up in the top-level `cargo build` / `cargo clippy` and slipped past the regular `Rust` workflow.

## Proposal

- `fetch_latest_cert` in `linera-bridge/tests/e2e/src/lib.rs` now returns `linera_storage::Arc<ConfirmedBlockCertificate>` (the production re-export of `CacheArc`), passing `read_certificate` through unchanged.
- Its one caller in `linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs` switches from `bcs::to_bytes(&cert)` to `bcs::to_bytes(&*cert)`. `CacheArc` is a newtype that does not forward `Serialize` (unlike `std::sync::Arc`), so the explicit deref through to the inner certificate is required.

## Test Plan

- `cd linera-bridge/tests/e2e && cargo check --tests` clean.
- `cargo test --no-run` clean (test binaries link).
- Bridge e2e ignored tests require docker images + Wasm artifacts (`make -C linera-bridge build-all`); not run here. Re-run on CI once this lands.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- CI failure: https://github.com/linera-io/linera-protocol/actions/runs/26322243134
- Root-cause commit: c7852f547f