### PR TITLE
Make "genesis" blob origin explicit.

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -16,7 +16,7 @@ use linera_base::{
     hashed::Hashed,
     identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
 };
-use linera_execution::{BlobState, Operation, OutgoingMessage};
+use linera_execution::{BlobOrigin, BlobState, Operation, OutgoingMessage};
 use serde::{ser::SerializeStruct, Deserialize, Serialize};
 use thiserror::Error;
 
@@ -146,9 +146,11 @@ impl ConfirmedBlock {
     /// Returns a blob state that applies to all blobs used by this block.
     pub fn to_blob_state(&self, is_stored_block: bool) -> BlobState {
         BlobState {
+            origin: BlobOrigin::Published {
+                chain_id: self.chain_id(),
+                block_height: self.height(),
+            },
             last_used_by: is_stored_block.then_some(self.0.hash()),
-            chain_id: self.chain_id(),
-            block_height: self.height(),
             epoch: is_stored_block.then_some(self.epoch()),
         }
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2705,6 +2705,31 @@ where
     Ok(())
 }
 
+/// On a fresh root chain whose `ChainDescription` is defined by the genesis
+/// config (not published by any block), `request_leader_timeout` must succeed
+/// once the round has timed out: collecting the timeout certificate and then
+/// broadcasting the resulting state to validators (via
+/// `send_chain_information` -> `initialize_new_chain_on_validator` ->
+/// `send_chain_info_for_blobs`) should treat the chain-description blob as
+/// known a priori rather than looking for a publishing block.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_request_leader_timeout_with_genesis_blob<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+
+    // Advance the clock past the (default 10s) round timeout.
+    clock.set(Timestamp::from(20_000_000));
+
+    client.request_leader_timeout().await?;
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -26,7 +26,7 @@ use linera_chain::{
     manager::LockingBlock,
     types::{ConfirmedBlock, GenericCertificate, ValidatedBlock, ValidatedBlockCertificate},
 };
-use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
+use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME, BlobOrigin};
 use linera_storage::{Arc as CacheArc, Clock, Storage};
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -938,12 +938,20 @@ where
 
         let mut chain_heights: BTreeMap<ChainId, BTreeSet<BlockHeight>> = BTreeMap::new();
         for blob_state in blob_states {
-            let block_chain_id = blob_state.chain_id;
-            let block_height = blob_state.block_height;
-            chain_heights
-                .entry(block_chain_id)
-                .or_default()
-                .insert(block_height);
+            match blob_state.origin {
+                // Genesis blobs aren't published by any block; the recipient has
+                // them from its own genesis config. Nothing to ship.
+                BlobOrigin::Genesis => continue,
+                BlobOrigin::Published {
+                    chain_id,
+                    block_height,
+                } => {
+                    chain_heights
+                        .entry(chain_id)
+                        .or_default()
+                        .insert(block_height);
+                }
+            }
         }
 
         self.send_chain_info_at_heights(chain_heights, delivery)

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1615,19 +1615,45 @@ impl From<Vec<u8>> for QueryResponse {
     }
 }
 
+/// Provenance of a stored blob: either defined by the genesis config (and thus
+/// known a priori to every node holding that config) or published by a confirmed
+/// block on some chain.
+#[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize, Deserialize)]
+pub enum BlobOrigin {
+    /// The blob is part of the network's genesis: it isn't published by any
+    /// block, and every node that initialized storage from the same genesis
+    /// config already holds its content. Currently only the `ChainDescription`
+    /// blobs for root chains use this variant.
+    Genesis,
+    /// The blob was published by a confirmed block on the given chain at the
+    /// given height.
+    Published {
+        chain_id: ChainId,
+        block_height: BlockHeight,
+    },
+}
+
 /// The state of a blob of binary data.
 #[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize, Deserialize)]
 pub struct BlobState {
+    /// Where the blob comes from.
+    pub origin: BlobOrigin,
     /// Hash of the last `Certificate` that published or used this blob. If empty, the
     /// blob is known to be published by a confirmed certificate but we may not have fully
     /// processed this certificate just yet.
     pub last_used_by: Option<CryptoHash>,
-    /// The `ChainId` of the chain that published the change
-    pub chain_id: ChainId,
-    /// The `BlockHeight` of the chain that published the change
-    pub block_height: BlockHeight,
     /// Epoch of the `last_used_by` certificate (if any).
     pub epoch: Option<Epoch>,
+}
+
+impl BlobState {
+    /// The state of a blob defined by the genesis config: no publishing
+    /// certificate, no epoch.
+    pub const GENESIS: BlobState = BlobState {
+        origin: BlobOrigin::Genesis,
+        last_used_by: None,
+        epoch: None,
+    };
 }
 
 /// The runtime to use for running the application.

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -263,8 +263,13 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         ChainRuntimeContext<Self>: ExecutionRuntimeContext,
     {
         let id = description.id();
-        // Store the description blob.
-        self.write_blob(&Blob::new_chain_description(&description))
+        // Store the description blob and a `Genesis` blob state for it. The blob
+        // is not published by any block, so its provenance is the genesis config
+        // rather than a particular `(chain_id, block_height)`.
+        let description_blob = Blob::new_chain_description(&description);
+        let description_blob_id = description_blob.id();
+        self.write_blob(&description_blob).await?;
+        self.maybe_write_blob_states(&[description_blob_id], BlobState::GENESIS)
             .await?;
         let mut chain = self.load_chain(id).await?;
         assert!(
@@ -661,7 +666,7 @@ mod tests {
         block::{Block, ConfirmedBlock},
         data_types::{BlockExecutionOutcome, ProposedBlock},
     };
-    use linera_execution::BlobState;
+    use linera_execution::{BlobOrigin, BlobState};
     #[cfg(feature = "scylladb")]
     use linera_views::scylla_db::ScyllaDbDatabase;
     use linera_views::{memory::MemoryDatabase, ViewError};
@@ -755,15 +760,19 @@ mod tests {
 
         // Test blob state operations
         let blob_state1 = BlobState {
+            origin: BlobOrigin::Published {
+                chain_id: ChainId(CryptoHash::test_hash("chain1")),
+                block_height: BlockHeight(0),
+            },
             last_used_by: None,
-            chain_id: ChainId(CryptoHash::test_hash("chain1")),
-            block_height: BlockHeight(0),
             epoch: Some(Epoch::ZERO),
         };
         let blob_state2 = BlobState {
+            origin: BlobOrigin::Published {
+                chain_id: ChainId(CryptoHash::test_hash("chain2")),
+                block_height: BlockHeight(1),
+            },
             last_used_by: Some(CryptoHash::test_hash("cert")),
-            chain_id: ChainId(CryptoHash::test_hash("chain2")),
-            block_height: BlockHeight(1),
             epoch: Some(Epoch::from(1)),
         };
 


### PR DESCRIPTION
## Motivation

There is another spurious "blobs not found" error: When we request a timeout certificate on a _root_ chain that does not have any blocks yet. That's because root chain descriptions are the only blobs that don't have a blob _state_.

## Proposal

Add a blob state for them, and make the "genesis" origin explicit.

## Test Plan

A regression test was added.

## Release Plan

- Would be nice to fix this on `testnet_conway` somehow, too. On the other hand, it's a very rare edge case.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
