### PR TITLE
Use the correct signer for pending blocks.

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1937,12 +1937,12 @@ impl<Env: Environment> ChainClient<Env> {
         {
             return self.finalize_locking_block(info).await;
         }
-        let owner = self.identity().await?;
+        let identity = self.identity().await?;
 
         let local_node = &self.client.local_node;
         // Otherwise we have to re-propose the highest validated block, if there is one.
-        let (block, blobs) = if let Some(locking) = &info.manager.requested_locking {
-            match &**locking {
+        let (block, blobs, owner) = if let Some(locking) = &info.manager.requested_locking {
+            let (block, blobs) = match &**locking {
                 LockingBlock::Regular(certificate) => {
                     let blob_ids = certificate.block().required_blob_ids();
                     let blobs = local_node
@@ -1971,9 +1971,30 @@ impl<Env: Environment> ChainClient<Env> {
                     debug!("Retrying locking block from fast round.");
                     (block, blobs)
                 }
-            }
+            };
+            (block, blobs, identity)
         } else if let Some(pending) = proposal_guard.as_ref() {
-            // Otherwise we are free to propose our own pending block.
+            // Otherwise we are free to propose our own pending block. Sign it as the owner
+            // that staged it: the block's operations are authenticated by that owner, and
+            // validators reject the proposal with `WorkerError::InvalidSigner` if we re-sign
+            // it as someone else (which would happen if `preferred_owner` changed since the
+            // block was staged). The signer is global to the client, so we can sign as the
+            // original author as long as we still hold their key. If we don't, the pending
+            // block is unfinishable and we drop it.
+            let owner = match pending.block.authenticated_owner {
+                Some(staged_owner) if staged_owner != identity => {
+                    if !self.has_key_for(&staged_owner).await? {
+                        warn!(
+                            ?staged_owner, %identity,
+                            "Discarding pending block: no signer key for its authenticated owner",
+                        );
+                        *proposal_guard = None;
+                        return Ok(ClientOutcome::Committed(None));
+                    }
+                    staged_owner
+                }
+                _ => identity,
+            };
             let proposed_block = pending.block.clone();
             let blobs = pending.blobs.clone();
             let staging_outcome = pending.auto_retry_outcome.as_ref();
@@ -1997,7 +2018,7 @@ impl<Env: Environment> ChainClient<Env> {
                 );
             }
             debug!("Proposing the local pending block.");
-            (block, blobs)
+            (block, blobs, owner)
         } else {
             return Ok(ClientOutcome::Committed(None)); // Nothing to do.
         };

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1979,11 +1979,23 @@ impl<Env: Environment> ChainClient<Env> {
             // validators reject the proposal with `WorkerError::InvalidSigner` if we re-sign
             // it as someone else (which would happen if `preferred_owner` changed since the
             // block was staged). The signer is global to the client, so we can sign as the
-            // original author as long as we still hold their key. If we don't, the pending
-            // block is unfinishable and we drop it.
+            // original author as long as we still hold their key.
             let owner = match pending.block.authenticated_owner {
                 Some(staged_owner) if staged_owner != identity => {
                     if !self.has_key_for(&staged_owner).await? {
+                        // If a fast-round proposal was already submitted, we can't safely
+                        // drop it and propose a conflicting fast block: fast rounds skip
+                        // the validation step and rely on the super owner not forking
+                        // itself, so a second proposal could split votes between f+1 and
+                        // 2f and wedge the round until it times out. Surface an error so
+                        // the caller can recover the key or wait for the timeout.
+                        if pending.round.is_some_and(|round| round.is_fast()) {
+                            return Err(Error::BlockProposalError(
+                                "pending fast block was signed by an owner whose key is no \
+                                 longer available; recover the key or wait for the round to \
+                                 time out before retrying",
+                            ));
+                        }
                         warn!(
                             ?staged_owner, %identity,
                             "Discarding pending block: no signer key for its authenticated owner",

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -910,9 +910,7 @@ where
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
-async fn test_pending_block_is_signed_by_original_owner<B>(
-    storage_builder: B,
-) -> anyhow::Result<()>
+async fn test_pending_block_is_signed_by_original_owner<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
 {
@@ -954,7 +952,10 @@ where
         .await
         .unwrap_ok_committed()
         .expect("the pending block should be committed");
-    assert_eq!(certificate.block().header.authenticated_owner, Some(owner_a));
+    assert_eq!(
+        certificate.block().header.authenticated_owner,
+        Some(owner_a)
+    );
     assert!(client.pending_proposal().await.is_none());
 
     Ok(())

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -900,6 +900,66 @@ where
     Ok(())
 }
 
+/// Regression test: when the preferred owner changes while a pending proposal exists, the
+/// next call to `process_pending_block` must sign the proposal as the original author (the
+/// owner that staged it), not as the new preferred owner. Otherwise the worker rejects the
+/// proposal with `WorkerError::InvalidSigner` because the operations in the block are
+/// authenticated by the original owner.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_pending_block_is_signed_by_original_owner<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let owner_a = client.identity().await?;
+
+    // Co-own the chain with a second owner `b` and no super-owner, so it runs in
+    // multi-leader rounds — mirroring a chain shared by a wallet key and an autosigner.
+    let owner_b: AccountOwner = builder.signer.generate_new().into();
+    let ownership =
+        ChainOwnership::multiple([(owner_a, 50), (owner_b, 50)], 10, TimeoutConfig::default());
+    client.change_ownership(ownership).await?;
+
+    // Stage a block as owner `a` that can't reach a quorum, so it stays pending in the
+    // shared per-chain queue, authenticated by `a`.
+    builder.set_fault_type([0, 1], FaultType::Offline);
+    assert_matches!(
+        client.burn(AccountOwner::CHAIN, Amount::ONE).await,
+        Err(_),
+        "the burn should fail to commit with only two of four validators online"
+    );
+    let pending = client
+        .pending_proposal()
+        .await
+        .expect("a pending proposal authored by owner `a` should remain");
+    assert_eq!(pending.block.authenticated_owner, Some(owner_a));
+
+    // Bring the validators back and act as owner `b` on the same shared queue.
+    builder.set_fault_type([0, 1], FaultType::Honest);
+    client.synchronize_from_validators().await?;
+    client.set_preferred_owner(owner_b);
+
+    // Owner `b`'s client retries the pending block. The signer still holds owner `a`'s key,
+    // so the proposal is signed as `a` and the worker accepts it.
+    let certificate = client
+        .process_pending_block()
+        .await
+        .unwrap_ok_committed()
+        .expect("the pending block should be committed");
+    assert_eq!(certificate.block().header.authenticated_owner, Some(owner_a));
+    assert!(client.pending_proposal().await.is_none());
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]


### PR DESCRIPTION
## Motivation

`process_pending_block_without_prepare` calls `self.identity()` _again_, rather than taking the identity from the pending block. This can make the client submit a block signed by the wrong key, which is invalid.

## Proposal

Sign with the correct key.

## Test Plan

A regression test was added.

## Release Plan

- Could be backported, but https://github.com/linera-io/linera-protocol/pull/6371 already works around it.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
