### PR TITLE
linera-metrics: expose stable tokio runtime metrics on /metrics

### DIFF
--- a/linera-metrics/src/lib.rs
+++ b/linera-metrics/src/lib.rs
@@ -4,6 +4,7 @@
 //! A library for Linera server metrics.
 
 pub mod monitoring_server;
+mod runtime_metrics;
 
 #[cfg(feature = "jemalloc")]
 pub mod memory_profiler;

--- a/linera-metrics/src/monitoring_server.rs
+++ b/linera-metrics/src/monitoring_server.rs
@@ -90,6 +90,7 @@ pub fn start_metrics_with_extras(
     memory_profiling: MemoryProfiling,
     extra_routes: Option<Router>,
 ) {
+    crate::runtime_metrics::register();
     let mut app = metrics_router(memory_profiling);
 
     if let Some(extra) = extra_routes {

--- a/linera-metrics/src/runtime_metrics.rs
+++ b/linera-metrics/src/runtime_metrics.rs
@@ -1,0 +1,169 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, sync::OnceLock};
+
+use prometheus::{
+    core::{Collector, Desc},
+    proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType},
+};
+use tokio::runtime::Handle;
+
+struct TokioRuntimeCollector {
+    handle: Handle,
+    workers: Desc,
+    alive_tasks: Desc,
+    global_queue: Desc,
+    busy_seconds: Desc,
+    parks: Desc,
+    park_unparks: Desc,
+}
+
+impl TokioRuntimeCollector {
+    fn new(handle: Handle) -> Self {
+        let desc = |name: &str, help: &str, labels: Vec<String>| {
+            Desc::new(name.into(), help.into(), labels, HashMap::new())
+                .expect("static metric descriptor is always valid")
+        };
+        let workers = desc(
+            "linera_tokio_workers",
+            "Number of worker threads in the tokio runtime.",
+            vec![],
+        );
+        let alive_tasks = desc(
+            "linera_tokio_alive_tasks",
+            "Number of tasks currently alive in the tokio runtime.",
+            vec![],
+        );
+        let global_queue = desc(
+            "linera_tokio_global_queue_depth",
+            "Number of tasks in the runtime's global injection queue.",
+            vec![],
+        );
+        let worker_label = vec!["worker".to_string()];
+        let busy_seconds = desc(
+            "linera_tokio_worker_busy_seconds_total",
+            "Cumulative time each worker has spent executing tasks, in seconds.",
+            worker_label.clone(),
+        );
+        let parks = desc(
+            "linera_tokio_worker_parks_total",
+            "Cumulative number of times each worker has parked (ran out of work).",
+            worker_label.clone(),
+        );
+        let park_unparks = desc(
+            "linera_tokio_worker_park_unparks_total",
+            "Monotonically increasing count of park and unpark events combined per worker. \
+             An odd value means the worker is currently parked.",
+            worker_label,
+        );
+        Self {
+            handle,
+            workers,
+            alive_tasks,
+            global_queue,
+            busy_seconds,
+            parks,
+            park_unparks,
+        }
+    }
+}
+
+impl Collector for TokioRuntimeCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![
+            &self.workers,
+            &self.alive_tasks,
+            &self.global_queue,
+            &self.busy_seconds,
+            &self.parks,
+            &self.park_unparks,
+        ]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let m = self.handle.metrics();
+        let num_workers = m.num_workers();
+        let mut families = Vec::with_capacity(6);
+
+        families.push(gauge_family(&self.workers, num_workers as f64));
+        families.push(gauge_family(&self.alive_tasks, m.num_alive_tasks() as f64));
+        families.push(gauge_family(
+            &self.global_queue,
+            m.global_queue_depth() as f64,
+        ));
+
+        #[cfg(target_has_atomic = "64")]
+        {
+            let mut busy = counter_family(&self.busy_seconds);
+            let mut parks = counter_family(&self.parks);
+            let mut park_unparks = counter_family(&self.park_unparks);
+            for i in 0..num_workers {
+                let label = worker_label(i);
+                busy.mut_metric().push(counter_metric(
+                    m.worker_total_busy_duration(i).as_secs_f64(),
+                    &label,
+                ));
+                parks
+                    .mut_metric()
+                    .push(counter_metric(m.worker_park_count(i) as f64, &label));
+                park_unparks
+                    .mut_metric()
+                    .push(counter_metric(m.worker_park_unpark_count(i) as f64, &label));
+            }
+            families.push(busy);
+            families.push(parks);
+            families.push(park_unparks);
+        }
+
+        families
+    }
+}
+
+fn gauge_family(desc: &Desc, value: f64) -> MetricFamily {
+    let mut gauge = Gauge::new();
+    gauge.set_value(value);
+    let mut metric = Metric::new();
+    metric.set_gauge(gauge);
+    let mut family = MetricFamily::new();
+    family.set_name(desc.fq_name.clone());
+    family.set_help(desc.help.clone());
+    family.set_field_type(MetricType::GAUGE);
+    family.mut_metric().push(metric);
+    family
+}
+
+fn counter_family(desc: &Desc) -> MetricFamily {
+    let mut family = MetricFamily::new();
+    family.set_name(desc.fq_name.clone());
+    family.set_help(desc.help.clone());
+    family.set_field_type(MetricType::COUNTER);
+    family
+}
+
+fn counter_metric(value: f64, labels: &[LabelPair]) -> Metric {
+    let mut counter = Counter::new();
+    counter.set_value(value);
+    let mut metric = Metric::new();
+    metric.set_counter(counter);
+    metric.set_label(labels.to_vec().into());
+    metric
+}
+
+fn worker_label(i: usize) -> [LabelPair; 1] {
+    let mut lp = LabelPair::new();
+    lp.set_name("worker".into());
+    lp.set_value(i.to_string());
+    [lp]
+}
+
+/// Must be called from within a tokio runtime context.
+pub(crate) fn register() {
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        let collector = Box::new(TokioRuntimeCollector::new(Handle::current()));
+        if let Err(e) = prometheus::register(collector) {
+            tracing::warn!("failed to register tokio runtime metrics: {e}");
+        }
+    });
+}


### PR DESCRIPTION
## Motivation

Backport of #6321 to `testnet_conway`.

Operators need to answer "is the async runtime saturated?" without guessing. Currently there is no visibility into tokio scheduler health — worker utilisation, idle vs. busy ratios, queue depth, or task count.

## Proposal

Add a `TokioRuntimeCollector` that implements `prometheus::core::Collector` and pulls six metrics from tokio's stable `RuntimeMetrics` API on every `/metrics` scrape (pull-on-demand; no background task):

| Metric | Type | Description |
|--------|------|-------------|
| `linera_tokio_workers` | gauge | Number of worker threads |
| `linera_tokio_alive_tasks` | gauge | Number of alive tasks |
| `linera_tokio_global_queue_depth` | gauge | Global injection queue depth |
| `linera_tokio_worker_busy_seconds_total{worker}` | counter | Cumulative busy time per worker |
| `linera_tokio_worker_parks_total{worker}` | counter | Park count per worker |
| `linera_tokio_worker_park_unparks_total{worker}` | counter | Combined park+unpark count per worker (odd → currently parked) |

The three per-worker counters are gated on `#[cfg(target_has_atomic = "64")]` matching tokio's own gate — **no `tokio_unstable` flag required**.

`TokioRuntimeCollector::register()` is called once (via `OnceLock`) at the top of `start_metrics_with_extras()`, so every binary that already exposes `/metrics` — `linera-server`, `linera-proxy`, and any future server — gets these for free with no per-binary changes.

The conflict with `testnet_conway` was that `start_metrics` now delegates to `start_metrics_with_extras`; the `register()` call was moved there accordingly.

## Test Plan

Verified on `main` via #6321. The only testnet_conway-specific change is placing `register()` in `start_metrics_with_extras` instead of `start_metrics`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Original PR: #6321
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)