### PR TITLE
[testnet_conway] Add NonCanonicalBTreeMap to skip BCS map re-sorting in value position (backport of #6373)

### DIFF
--- a/examples/gen-nft/src/state.rs
+++ b/examples/gen-nft/src/state.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
-
 use async_graphql::SimpleObject;
 use gen_nft::{Nft, TokenId};
 use linera_sdk::{
-    linera_base_types::AccountOwner,
+    linera_base_types::{AccountOwner, NonCanonicalBTreeSet},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 
@@ -17,7 +15,7 @@ pub struct GenNftState {
     // Map from token ID to the NFT data
     pub nfts: MapView<TokenId, Nft>,
     // Map from owners to the set of NFT token IDs they own
-    pub owned_token_ids: MapView<AccountOwner, BTreeSet<TokenId>>,
+    pub owned_token_ids: MapView<AccountOwner, NonCanonicalBTreeSet<TokenId>>,
     // Counter of NFTs minted in this chain, used for hash uniqueness
     pub num_minted_nfts: RegisterView<u64>,
 }

--- a/examples/hex-game/src/state.rs
+++ b/examples/hex-game/src/state.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
-
 use async_graphql::SimpleObject;
 use hex_game::{Board, Clock, Timeouts};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, ChainId},
+    linera_base_types::{AccountOwner, ChainId, NonCanonicalBTreeSet},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use serde::{Deserialize, Serialize};
@@ -32,5 +30,5 @@ pub struct HexState {
     /// The timeouts.
     pub timeouts: RegisterView<Timeouts>,
     /// Temporary chains for individual games, by player.
-    pub game_chains: MapView<AccountOwner, BTreeSet<GameChain>>,
+    pub game_chains: MapView<AccountOwner, NonCanonicalBTreeSet<GameChain>>,
 }

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -1,12 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
-
 use async_graphql::SimpleObject;
 use fungible::Account;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount},
+    linera_base_types::{AccountOwner, Amount, NonCanonicalBTreeSet},
     views::{
         linera_views, CustomCollectionView, MapView, QueueView, RegisterView, RootView, View,
         ViewStorageContext,
@@ -43,7 +41,7 @@ pub struct KeyBook {
 #[derive(Default, Clone, Debug, Serialize, Deserialize, SimpleObject)]
 pub struct AccountInfo {
     /// The list of orders
-    pub orders: BTreeSet<OrderId>,
+    pub orders: NonCanonicalBTreeSet<OrderId>,
 }
 
 /// The price level is contained in a QueueView

--- a/examples/non-fungible/src/state.rs
+++ b/examples/non-fungible/src/state.rs
@@ -1,11 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeSet;
-
 use async_graphql::SimpleObject;
 use linera_sdk::{
-    linera_base_types::AccountOwner,
+    linera_base_types::{AccountOwner, NonCanonicalBTreeSet},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use non_fungible::{Nft, TokenId};
@@ -17,7 +15,7 @@ pub struct NonFungibleTokenState {
     // Map from token ID to the NFT data
     pub nfts: MapView<TokenId, Nft>,
     // Map from owners to the set of NFT token IDs they own
-    pub owned_token_ids: MapView<AccountOwner, BTreeSet<TokenId>>,
+    pub owned_token_ids: MapView<AccountOwner, NonCanonicalBTreeSet<TokenId>>,
     // Counter of NFTs minted in this chain, used for hash uniqueness
     pub num_minted_nfts: RegisterView<u64>,
 }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -7,7 +7,7 @@
 #[cfg(with_testing)]
 use std::ops;
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, BTreeSet, HashSet},
     fmt::{self, Display},
     fs,
     hash::Hash,
@@ -40,6 +40,257 @@ use crate::{
     time::{Duration, SystemTime},
     vm::VmRuntime,
 };
+
+/// A [`BTreeMap`] that serializes like a `Vec<(K, V)>` instead of using BCS's canonical
+/// map encoding.
+///
+/// BCS serializes a [`BTreeMap`] in *canonical* form: on every `serialize` call it re-sorts the
+/// entries by their serialized-key bytes (an `O(n log n)` sort) and verifies that ordering again
+/// on `deserialize`. Since a [`BTreeMap`] already keeps its entries ordered, this is wasted work.
+/// `NonCanonicalBTreeMap` instead (de)serializes the entries as a plain sequence of pairs, exactly
+/// like `Vec<(K, V)>`, trading the canonical wire format for speed.
+///
+/// Use it in *value* position — the value of a `RegisterView<Value>` or `MapView<_, Value>` — so
+/// that `save()` does not pay the canonical sort. Never use it in *key* position
+/// (`MapView<Key, _>`): keys rely on the canonical encoding that this type skips, so use
+/// [`CanonicalBTreeMap`] there instead.
+///
+/// It otherwise behaves like a [`BTreeMap`]: it derefs to one, so all the usual methods are
+/// available.
+#[derive(Debug, Clone, PartialEq, Eq, Allocative)]
+pub struct NonCanonicalBTreeMap<K, V>(BTreeMap<K, V>);
+
+impl<K, V> Default for NonCanonicalBTreeMap<K, V> {
+    fn default() -> Self {
+        Self(BTreeMap::new())
+    }
+}
+
+impl<K, V> std::ops::Deref for NonCanonicalBTreeMap<K, V> {
+    type Target = BTreeMap<K, V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<K, V> std::ops::DerefMut for NonCanonicalBTreeMap<K, V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<K, V> From<BTreeMap<K, V>> for NonCanonicalBTreeMap<K, V> {
+    fn from(map: BTreeMap<K, V>) -> Self {
+        Self(map)
+    }
+}
+
+impl<K, V> From<NonCanonicalBTreeMap<K, V>> for BTreeMap<K, V> {
+    fn from(map: NonCanonicalBTreeMap<K, V>) -> Self {
+        map.0
+    }
+}
+
+impl<K: Ord, V> FromIterator<(K, V)> for NonCanonicalBTreeMap<K, V> {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self(BTreeMap::from_iter(iter))
+    }
+}
+
+impl<K, V> IntoIterator for NonCanonicalBTreeMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::collections::btree_map::IntoIter<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a NonCanonicalBTreeMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = std::collections::btree_map::Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<K, V> Serialize for NonCanonicalBTreeMap<K, V>
+where
+    K: Serialize,
+    V: Serialize,
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Serialize as a sequence of pairs, exactly like `Vec<(K, V)>`. The entries are already
+        // in key order, so this avoids the canonical re-sorting that BCS does for maps.
+        serializer.collect_seq(self.0.iter())
+    }
+}
+
+impl<'de, K, V> Deserialize<'de> for NonCanonicalBTreeMap<K, V>
+where
+    K: Deserialize<'de> + Ord,
+    V: Deserialize<'de>,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let entries = Vec::<(K, V)>::deserialize(deserializer)?;
+        Ok(Self(entries.into_iter().collect()))
+    }
+}
+
+impl<K, V> async_graphql::OutputType for NonCanonicalBTreeMap<K, V>
+where
+    BTreeMap<K, V>: async_graphql::OutputType,
+{
+    fn type_name() -> std::borrow::Cow<'static, str> {
+        <BTreeMap<K, V> as async_graphql::OutputType>::type_name()
+    }
+
+    fn create_type_info(registry: &mut async_graphql::registry::Registry) -> String {
+        <BTreeMap<K, V> as async_graphql::OutputType>::create_type_info(registry)
+    }
+
+    async fn resolve(
+        &self,
+        ctx: &async_graphql::ContextSelectionSet<'_>,
+        field: &async_graphql::Positioned<async_graphql::parser::types::Field>,
+    ) -> async_graphql::ServerResult<async_graphql::Value> {
+        self.0.resolve(ctx, field).await
+    }
+}
+
+/// A [`BTreeSet`] used in value position; the counterpart to [`NonCanonicalBTreeMap`].
+///
+/// Unlike maps, serde already serializes a [`BTreeSet`] as a plain sequence (it never goes through
+/// `serialize_map`), so BCS does not re-sort it. A type alias is therefore enough; no wrapper is
+/// needed.
+///
+/// Use it in *value* position (`RegisterView<Value>` or `MapView<_, Value>`). In *key* position
+/// (`MapView<Key, _>`) use [`CanonicalBTreeSet`] instead, which enforces the canonical ordering
+/// that keys require.
+pub type NonCanonicalBTreeSet<T> = BTreeSet<T>;
+
+/// A [`BTreeMap`] suitable for *key* position; an alias for [`BTreeMap`] itself.
+///
+/// In key position the canonical BCS encoding is exactly what is wanted — keys are ordered and
+/// compared by their serialized bytes — so no wrapper is needed. Use it for the key type of a
+/// `MapView<Key, _>`. In *value* position prefer [`NonCanonicalBTreeMap`], which skips the
+/// per-`save()` canonical sort. This alias exists to make that intent explicit and to pair with
+/// [`NonCanonicalBTreeMap`].
+pub type CanonicalBTreeMap<K, V> = BTreeMap<K, V>;
+
+/// A [`BTreeSet`] that serializes canonically, like a `BTreeMap<T, ()>`.
+///
+/// A plain [`BTreeSet`] serializes as a serde *sequence*, so BCS keeps the in-memory (Rust `Ord`)
+/// order without enforcing canonical ordering of the serialized elements. That is fine in value
+/// position, but in *key* position the canonical encoding matters. `CanonicalBTreeSet` therefore
+/// (de)serializes through a map of `T -> ()`, so that BCS sorts the elements by their serialized
+/// bytes, exactly as it does for [`BTreeMap`] keys.
+///
+/// Use it for the key type of a `MapView<Key, _>`. In *value* position use
+/// [`NonCanonicalBTreeSet`] instead. It otherwise behaves like a [`BTreeSet`]: it derefs to one,
+/// so all the usual methods are available.
+#[derive(Debug, Clone, PartialEq, Eq, Allocative)]
+pub struct CanonicalBTreeSet<T>(BTreeSet<T>);
+
+impl<T> Default for CanonicalBTreeSet<T> {
+    fn default() -> Self {
+        Self(BTreeSet::new())
+    }
+}
+
+impl<T> std::ops::Deref for CanonicalBTreeSet<T> {
+    type Target = BTreeSet<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for CanonicalBTreeSet<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<BTreeSet<T>> for CanonicalBTreeSet<T> {
+    fn from(set: BTreeSet<T>) -> Self {
+        Self(set)
+    }
+}
+
+impl<T> From<CanonicalBTreeSet<T>> for BTreeSet<T> {
+    fn from(set: CanonicalBTreeSet<T>) -> Self {
+        set.0
+    }
+}
+
+impl<T: Ord> FromIterator<T> for CanonicalBTreeSet<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(BTreeSet::from_iter(iter))
+    }
+}
+
+impl<T> IntoIterator for CanonicalBTreeSet<T> {
+    type Item = T;
+    type IntoIter = std::collections::btree_set::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a CanonicalBTreeSet<T> {
+    type Item = &'a T;
+    type IntoIter = std::collections::btree_set::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<T> Serialize for CanonicalBTreeSet<T>
+where
+    T: Serialize,
+{
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Serialize as a `BTreeMap<T, ()>`: going through `serialize_map` lets BCS sort the
+        // elements canonically by their serialized bytes, as required in key position.
+        serializer.collect_map(self.0.iter().map(|element| (element, ())))
+    }
+}
+
+impl<'de, T> Deserialize<'de> for CanonicalBTreeSet<T>
+where
+    T: Deserialize<'de> + Ord,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let map = BTreeMap::<T, ()>::deserialize(deserializer)?;
+        Ok(Self(map.into_keys().collect()))
+    }
+}
+
+impl<T> async_graphql::OutputType for CanonicalBTreeSet<T>
+where
+    BTreeSet<T>: async_graphql::OutputType,
+{
+    fn type_name() -> std::borrow::Cow<'static, str> {
+        <BTreeSet<T> as async_graphql::OutputType>::type_name()
+    }
+
+    fn create_type_info(registry: &mut async_graphql::registry::Registry) -> String {
+        <BTreeSet<T> as async_graphql::OutputType>::create_type_info(registry)
+    }
+
+    async fn resolve(
+        &self,
+        ctx: &async_graphql::ContextSelectionSet<'_>,
+        field: &async_graphql::Positioned<async_graphql::parser::types::Field>,
+    ) -> async_graphql::ServerResult<async_graphql::Value> {
+        self.0.resolve(ctx, field).await
+    }
+}
 
 /// A non-negative amount of tokens.
 ///
@@ -1736,6 +1987,71 @@ mod tests {
         identifiers::{BlobType, ChainId, ModuleId},
         vm::VmRuntime,
     };
+
+    #[test]
+    fn non_canonical_btree_map_serializes_like_vec() {
+        use std::collections::BTreeMap;
+
+        use super::NonCanonicalBTreeMap;
+
+        // `256u32` is chosen so that its little-endian BCS bytes sort *before* `1u32`'s,
+        // i.e. the canonical (serialized-byte) order differs from the numeric `Ord` order.
+        let map = NonCanonicalBTreeMap::from(BTreeMap::from([
+            (1u32, 10u8),
+            (256u32, 20u8),
+            (2u32, 30u8),
+        ]));
+
+        // It serializes as a plain `Vec<(K, V)>` in the map's `Ord` key order, with no canonical
+        // re-sorting.
+        let entries = map
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect::<Vec<(u32, u8)>>();
+        assert_eq!(
+            bcs::to_bytes(&map).unwrap(),
+            bcs::to_bytes(&entries).unwrap()
+        );
+
+        // ... which differs from the canonical `BTreeMap` encoding that re-sorts by serialized key.
+        let canonical = map
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .collect::<BTreeMap<u32, u8>>();
+        assert_ne!(
+            bcs::to_bytes(&map).unwrap(),
+            bcs::to_bytes(&canonical).unwrap()
+        );
+
+        // It round-trips.
+        let deserialized: NonCanonicalBTreeMap<u32, u8> =
+            bcs::from_bytes(&bcs::to_bytes(&map).unwrap()).unwrap();
+        assert_eq!(map, deserialized);
+    }
+
+    #[test]
+    fn canonical_btree_set_serializes_like_map() {
+        use std::collections::{BTreeMap, BTreeSet};
+
+        use super::CanonicalBTreeSet;
+
+        let set = CanonicalBTreeSet::from(BTreeSet::from([1u32, 256u32, 2u32]));
+
+        // It serializes exactly like a `BTreeMap<T, ()>`, i.e. canonically sorted by serialized
+        // bytes.
+        let map = set.iter().map(|t| (*t, ())).collect::<BTreeMap<u32, ()>>();
+        assert_eq!(bcs::to_bytes(&set).unwrap(), bcs::to_bytes(&map).unwrap());
+
+        // That canonical order differs from a plain `BTreeSet`'s sequence encoding, which keeps
+        // the numeric `Ord` order.
+        let plain = set.iter().copied().collect::<BTreeSet<u32>>();
+        assert_ne!(bcs::to_bytes(&set).unwrap(), bcs::to_bytes(&plain).unwrap());
+
+        // It round-trips.
+        let deserialized: CanonicalBTreeSet<u32> =
+            bcs::from_bytes(&bcs::to_bytes(&set).unwrap()).unwrap();
+        assert_eq!(set, deserialized);
+    }
 
     #[test]
     fn display_amount() {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -11,7 +11,7 @@ use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
         ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Epoch,
-        OracleResponse, Timestamp,
+        NonCanonicalBTreeMap, NonCanonicalBTreeSet, OracleResponse, Timestamp,
     },
     ensure,
     identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, StreamId},
@@ -262,9 +262,9 @@ where
     pub outboxes: ReentrantCollectionView<C, ChainId, OutboxStateView<C>>,
     /// Number of outgoing messages in flight for each block height.
     /// We use a `RegisterView` to prioritize speed for small maps.
-    pub outbox_counters: RegisterView<C, BTreeMap<BlockHeight, u32>>,
+    pub outbox_counters: RegisterView<C, NonCanonicalBTreeMap<BlockHeight, u32>>,
     /// Outboxes with at least one pending message. This allows us to avoid loading all outboxes.
-    pub nonempty_outboxes: RegisterView<C, BTreeSet<ChainId>>,
+    pub nonempty_outboxes: RegisterView<C, NonCanonicalBTreeSet<ChainId>>,
 
     /// Blocks that have been verified but not executed yet, and that may not be contiguous.
     pub preprocessed_blocks: MapView<C, BlockHeight, CryptoHash>,
@@ -276,7 +276,7 @@ where
     /// Inboxes with at least one pending added bundle. This allows us to avoid loading all
     /// inboxes. `None` means the set hasn't been computed yet for this chain (backwards
     /// compatibility with pre-existing database entries).
-    pub nonempty_inboxes: RegisterView<C, Option<BTreeSet<ChainId>>>,
+    pub nonempty_inboxes: RegisterView<C, Option<NonCanonicalBTreeSet<ChainId>>>,
 
     /// The local wall-clock time when block 0 was last executed. Used to prevent
     /// reset-on-incorrect-outcome from looping: if not enough time has elapsed since

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -75,7 +75,7 @@ use custom_debug_derive::Debug;
 use futures::future::Either;
 use linera_base::{
     crypto::{AccountPublicKey, CryptoError, ValidatorSecretKey},
-    data_types::{Blob, BlockHeight, Epoch, Round, Timestamp},
+    data_types::{Blob, BlockHeight, Epoch, NonCanonicalBTreeMap, Round, Timestamp},
     ensure,
     identifiers::{AccountOwner, BlobId, ChainId},
     ownership::ChainOwnership,
@@ -202,7 +202,7 @@ where
     #[cfg_attr(with_graphql, graphql(skip))]
     pub current_round: RegisterView<C, Round>,
     /// The owners that take over in fallback mode.
-    pub fallback_owners: RegisterView<C, BTreeMap<AccountOwner, u64>>,
+    pub fallback_owners: RegisterView<C, NonCanonicalBTreeMap<AccountOwner, u64>>,
 }
 
 #[cfg(with_graphql)]
@@ -239,7 +239,7 @@ where
 
         let fallback_owners = fallback_owners
             .map(|(pub_key, weight)| (AccountOwner::from(pub_key), weight))
-            .collect::<BTreeMap<_, _>>();
+            .collect::<NonCanonicalBTreeMap<_, _>>();
         let fallback_distribution = calculate_distribution(fallback_owners.iter());
 
         let current_round = ownership.first_round();

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -47,7 +47,10 @@ use std::fmt::Debug;
 pub use bcs;
 pub use linera_base::{
     abi,
-    data_types::{Resources, SendMessageRequest},
+    data_types::{
+        CanonicalBTreeMap, CanonicalBTreeSet, NonCanonicalBTreeMap, NonCanonicalBTreeSet,
+        Resources, SendMessageRequest,
+    },
     ensure, http, task_processor,
 };
 use linera_base::{


### PR DESCRIPTION
## Motivation

BCS serializes a `BTreeMap` in *canonical* form: on every `serialize` call it re-sorts the
entries by their serialized-key bytes (an `O(n log n)` sort), and on `deserialize` it re-checks
that ordering. For maps kept in *value* position of a `RegisterView`/`MapView`, this extra work
is unnecessary.

## Proposal

Backport of #6373 to `testnet_conway`.

Introduce a small family of map/set wrappers in `linera-base` that make the (de)serialization
behavior explicit, and use them where it matters:

- `NonCanonicalBTreeMap<K, V>`: a `BTreeMap` newtype whose `serde` impl treats it as a
  `Vec<(K, V)>` — entries are serialized as a plain sequence in the map's existing key order,
  with no canonical re-sort. It derefs to `BTreeMap`, so it is a drop-in replacement.
- `NonCanonicalBTreeSet<T> = BTreeSet<T>`: an alias (sets already serialize as a sequence, so
  BCS never re-sorts them).
- `CanonicalBTreeMap<K, V> = BTreeMap<K, V>`: an alias (the canonical encoding is exactly what
  keys need).
- `CanonicalBTreeSet<T>`: a `BTreeSet` newtype that (de)serializes as a `BTreeMap<T, ()>`, so
  BCS sorts the elements canonically by their serialized bytes — for use in key position.

Note for the backport: on `testnet_conway`, `nonempty_inboxes` keeps its existing
`Option<…>` backwards-compatibility wrapper, so the field becomes
`RegisterView<C, Option<NonCanonicalBTreeSet<ChainId>>>`. Since `NonCanonicalBTreeSet` is a type
alias for `BTreeSet`, this is wire-identical to the previous field — only the map fields
(`outbox_counters`, `fallback_owners`) actually change encoding.

## Test Plan

CI.

Locally verified `cargo check` for `linera-base`, `linera-chain`, `linera-core`, `linera-sdk`,
and the affected example apps (`matching-engine`, `hex-game`, `gen-nft`, `non-fungible`).

## Release Plan

This PR is itself the backport of #6373 to `testnet_conway`. The change alters the storage
encoding of the affected map views, so the upgrade is a one-way door that cannot be reverted.

## Links

- Upstream PR: #6373
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
