### PR TITLE
Skip no-op tombstones when clearing already-empty MapViews

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -36,6 +36,10 @@ pub enum Update<T> {
 pub(crate) struct DeletionSet {
     pub(crate) delete_storage_first: bool,
     pub(crate) deleted_prefixes: BTreeSet<Vec<u8>>,
+    /// True when storage under this prefix is confirmed empty (set after a successful
+    /// full-clear save with no subsequent inserts). Allows `clear()` to skip emitting
+    /// a range tombstone when the storage is already empty.
+    pub(crate) storage_is_empty: bool,
 }
 
 impl DeletionSet {
@@ -43,11 +47,14 @@ impl DeletionSet {
         Self {
             delete_storage_first: false,
             deleted_prefixes: BTreeSet::new(),
+            storage_is_empty: false,
         }
     }
 
     pub(crate) fn clear(&mut self) {
-        self.delete_storage_first = true;
+        if !self.storage_is_empty {
+            self.delete_storage_first = true;
+        }
         self.deleted_prefixes.clear();
     }
 

--- a/linera-views/src/views/map_view.rs
+++ b/linera-views/src/views/map_view.rs
@@ -187,9 +187,15 @@ where
     }
 
     fn post_save(&mut self) {
+        let had_full_clear = self.deletion_set.delete_storage_first;
+        let storage_now_empty =
+            had_full_clear && !self.updates.values().any(|u| matches!(u, Update::Set(_)));
         self.updates.clear();
         self.deletion_set.delete_storage_first = false;
         self.deletion_set.deleted_prefixes.clear();
+        if had_full_clear {
+            self.deletion_set.storage_is_empty = storage_now_empty;
+        }
     }
 
     fn clear(&mut self) {
@@ -228,6 +234,7 @@ where
     /// # })
     /// ```
     pub fn insert(&mut self, short_key: Vec<u8>, value: V) {
+        self.deletion_set.storage_is_empty = false;
         self.updates.insert(short_key, Update::Set(value));
     }
 


### PR DESCRIPTION
## Motivation

`MapView::clear()` on an already-empty view still emits a Scylla range tombstone on every call. In production, `reset_chain_manager()` invokes `clear()` on 3 `MapView`s that are essentially always empty — `proposed_blobs`, `locking_blobs`, and the `pending_blobs` inside `PendingBlobsView` — once per block processed.

At ~1000 blocks/sec this generates thousands of unnecessary tombstones/second in ScyllaDB, which:

1. Accumulates in the LCS L0 SSTable tier until the compaction backlog triggers expensive STCS-in-L0 fallback bursts every ~22-25 minutes.
2. Evicts keys from the `linera-shard` LRU cache via `WriteOperation::DeletePrefix`. Absent keys cannot be re-cached in shared mode, so the cache hit rate decays monotonically after every node restart (observed: 49% -> 13% over 5 days on testnet_conway).

## Proposal

Add `storage_is_empty: bool` to `DeletionSet`. After a successful full-clear save where no data was written back (`ByteMapView::post_save` detects this via `delete_storage_first && no Update::Set in updates`), the flag is set to `true`. Subsequent `clear()` calls skip setting `delete_storage_first` — and therefore emit no tombstone — when storage is already known to be empty. Any `insert()` resets the flag to `false`, preserving correctness when data is later written.

The change is conservative:
- `rollback()` preserves `storage_is_empty` (rollback reverts in-memory changes only; storage state is unchanged).
- On fresh load, `storage_is_empty = false` (unknown state, assume non-empty).
- Only a confirmed full-clear save transitions the flag to `true`.
- Same behavior for non-empty views: the optimization only activates on the second+ `clear()` after a full-clear save with no subsequent writes.

This is `linera-views`-internal and crate-private (`pub(crate)`), so no public API change.

## Test Plan

- Existing `linera-views` unit tests cover `ByteMapView` lifecycle (clear/insert/rollback/save cycles).
- `cargo clippy -p linera-views` and `cargo clippy -p linera-views --all-features` clean (exit 0).
- **Production validation (post-deploy):** the ~4000 tombstones/sec rate should drop to near zero within one compaction cycle. Tracked via Scylla SSTable count per pod and L0 backlog metrics.

**NOT YET END-TO-END VERIFIED on a live network.** Logic reviewed manually; CI will catch any test regressions before merge.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Investigation context: production Scylla LCS L0 backlog accumulation post-restart, correlated with `linera-shard` cache hit rate drain.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
