### PR TITLE
linera-storage: add in-memory caches for immutable DB reads

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -296,6 +296,12 @@ Client implementation and command-line tool for the Linera blockchain
 * `--event-cache-size <EVENT_CACHE_SIZE>` — The maximal number of entries in the event cache
 
   Default value: `1000`
+* `--block-hash-by-height-cache-size <BLOCK_HASH_BY_HEIGHT_CACHE_SIZE>` — The maximal number of entries in the block-hash-by-height cache
+
+  Default value: `1000`
+* `--event-block-height-cache-size <EVENT_BLOCK_HEIGHT_CACHE_SIZE>` — The maximal number of entries in the event-block-height cache
+
+  Default value: `1000`
 * `--cache-cleanup-interval-secs <CACHE_CLEANUP_INTERVAL_SECS>` — Interval in seconds between weak reference cleanup sweeps in value caches
 
   Default value: `30`

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -123,6 +123,14 @@ struct ServeOptions {
     #[arg(long, default_value = "1000")]
     event_cache_size: usize,
 
+    /// The maximal number of entries in the block-hash-by-height cache.
+    #[arg(long, default_value = "1000")]
+    block_hash_by_height_cache_size: usize,
+
+    /// The maximal number of entries in the event-block-height cache.
+    #[arg(long, default_value = "1000")]
+    event_block_height_cache_size: usize,
+
     /// Interval between monitor scan loops, in seconds.
     #[arg(long, default_value = "30")]
     monitor_scan_interval: u64,
@@ -184,6 +192,8 @@ impl ServeOptions {
                 certificate_cache_size: self.certificate_cache_size,
                 certificate_raw_cache_size: self.certificate_raw_cache_size,
                 event_cache_size: self.event_cache_size,
+                block_hash_by_height_cache_size: self.block_hash_by_height_cache_size,
+                event_block_height_cache_size: self.event_block_height_cache_size,
                 cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
             },
             std::time::Duration::from_secs(self.monitor_scan_interval),

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -561,9 +561,11 @@ where
     E: linera_core::environment::Environment,
 {
     use linera_execution::Operation;
-    let bytes = bcs::to_bytes(&wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
-        app_id: bridge_app_id,
-    })?;
+    let bytes = bcs::to_bytes(
+        &wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
+            app_id: bridge_app_id,
+        },
+    )?;
     chain_client
         .execute_operations(
             vec![Operation::User {
@@ -697,4 +699,18 @@ where
     let info = chain_client.chain_info().await?;
     let hash = info.block_hash.context("chain has no blocks yet")?;
     Ok(chain_client.read_certificate(hash).await?)
+}
+
+/// Storage cache configuration used by the e2e tests.
+pub fn test_storage_cache_config() -> linera_storage::StorageCacheConfig {
+    linera_storage::StorageCacheConfig {
+        blob_cache_size: 1000,
+        confirmed_block_cache_size: 1000,
+        certificate_cache_size: 1000,
+        certificate_raw_cache_size: 1000,
+        event_cache_size: 1000,
+        block_hash_by_height_cache_size: 1000,
+        event_block_height_cache_size: 1000,
+        cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
+    }
 }

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -42,7 +42,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use wrapped_fungible::{InitialState, WrappedParameters};
 
@@ -91,16 +91,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         &config,
         "auto-scan-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
 
@@ -225,9 +216,11 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
 
     // ── Phase 6: Register app IDs on both sides ──
     tracing::info!("Registering bridge app in wrapped-fungible...");
-    let register_bytes = bcs::to_bytes(&wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
-        app_id: bridge_app_id,
-    })?;
+    let register_bytes = bcs::to_bytes(
+        &wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
+            app_id: bridge_app_id,
+        },
+    )?;
     let register_operation = Operation::User {
         application_id: fungible_app_id,
         bytes: register_bytes,
@@ -328,9 +321,9 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             relay_port,
             0, // admin port (unused in e2e)
             linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
-            std::time::Duration::from_secs(5),  // monitor_scan_interval
-            0,  // monitor_start_block
-            5,  // max_retries
+            std::time::Duration::from_secs(5), // monitor_scan_interval
+            0,                                 // monitor_start_block
+            5,                                 // max_retries
             None,
         ))
         .await

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -97,6 +97,8 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -29,14 +29,14 @@ use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_evm_bridge,
-    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
-    wait_for_light_client, wait_for_relay_http_ready, ANVIL_PRIVATE_KEY,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose, wait_for_light_client,
+    wait_for_relay_http_ready, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -79,16 +79,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
         &store_config,
         "burn-false-positive-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;
@@ -141,7 +132,8 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     )
     .await?;
 
-    let bridge_app_id = publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
 
     // Register the wrapped-fungible app with the evm-bridge so it can drive
     // the escrow transfer + burn.

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -85,6 +85,8 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -99,6 +99,8 @@ async fn burns_per_evm_tx(
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -23,7 +23,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use test_case::test_case;
 
@@ -93,16 +93,7 @@ async fn burns_per_evm_tx(
         &store_config,
         &format!("burns-per-tx-{name}-e2e"),
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;
@@ -186,28 +177,14 @@ async fn burns_per_evm_tx(
     .await;
 
     let mut hi: u32 = 8;
-    let mut hi_gas = build_and_estimate(
-        hi,
-        &cc_a,
-        &cc_b,
-        bridge_app_id,
-        bridge_addr,
-        &provider,
-    )
-    .await?;
+    let mut hi_gas =
+        build_and_estimate(hi, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider).await?;
     tracing::info!(n = hi, gas = hi_gas, "search: initial `Burn` ops count");
 
     while hi_gas <= block_gas_limit && hi < MAX_SEARCH_N {
         let next_hi = hi.saturating_mul(2).min(MAX_SEARCH_N);
-        let gas = build_and_estimate(
-            next_hi,
-            &cc_a,
-            &cc_b,
-            bridge_app_id,
-            bridge_addr,
-            &provider,
-        )
-        .await?;
+        let gas = build_and_estimate(next_hi, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider)
+            .await?;
         hi = next_hi;
         hi_gas = gas;
         if hi_gas > block_gas_limit {
@@ -228,15 +205,7 @@ async fn burns_per_evm_tx(
     let mut lo_gas = if hi == 1 {
         hi_gas
     } else {
-        build_and_estimate(
-            lo,
-            &cc_a,
-            &cc_b,
-            bridge_app_id,
-            bridge_addr,
-            &provider,
-        )
-        .await?
+        build_and_estimate(lo, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider).await?
     };
     anyhow::ensure!(
         lo_gas <= block_gas_limit,
@@ -270,15 +239,8 @@ async fn burns_per_evm_tx(
 
     while lo + 1 < hi {
         let mid = lo + (hi - lo) / 2;
-        let g = build_and_estimate(
-            mid,
-            &cc_a,
-            &cc_b,
-            bridge_app_id,
-            bridge_addr,
-            &provider,
-        )
-        .await?;
+        let g =
+            build_and_estimate(mid, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider).await?;
         tracing::info!(n = mid, gas = g, "search: bisect");
         if g <= block_gas_limit {
             lo = mid;

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -80,6 +80,8 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -23,7 +23,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::WasmRuntime;
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -74,16 +74,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
         &config,
         "committee-rotation-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;
@@ -188,9 +179,9 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             relay_port,
             0, // admin port (unused in e2e)
             linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
-            std::time::Duration::from_secs(5),  // monitor_scan_interval
-            0,  // monitor_start_block
-            5,  // max_retries
+            std::time::Duration::from_secs(5), // monitor_scan_interval
+            0,                                 // monitor_start_block
+            5,                                 // max_retries
             None,
         ))
         .await

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -90,6 +90,8 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -35,7 +35,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, Query, QueryResponse, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use serde::Serialize;
 use wrapped_fungible::{InitialState, WrappedParameters};
@@ -84,16 +84,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &config,
         "e2l-bridge-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
 
@@ -142,8 +133,10 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
 
     // 4a. Publish and create wrapped-fungible app
     tracing::info!("Publishing wrapped-fungible module...");
-    let wf_contract = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm")).await?;
-    let wf_service = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_service.wasm")).await?;
+    let wf_contract =
+        Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm")).await?;
+    let wf_service =
+        Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_service.wasm")).await?;
 
     let (wf_module_id, _) = cc
         .publish_module(wf_contract, wf_service, VmRuntime::Wasm, None)

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -83,6 +83,8 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -20,7 +20,7 @@ use futures::StreamExt as _;
 use linera_base::{
     crypto::InMemorySigner,
     data_types::{Bytecode, U128},
-    identifiers::AccountOwner,
+    identifiers::{Account, AccountOwner},
     vm::VmRuntime,
 };
 use linera_bridge::abi::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters};
@@ -32,12 +32,11 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::{environment::wallet::Memory, worker::Reason};
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_base::identifiers::Account;
+use linera_storage::DbStorage;
+use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use wrapped_fungible::{
     InitialState, WrappedFungibleOperation, WrappedFungibleTokenAbi, WrappedParameters,
 };
-use linera_storage::{DbStorage, StorageCacheConfig};
-use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
     #[sol(rpc)]
@@ -77,16 +76,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &config,
         "bridge-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -42,7 +42,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -91,16 +91,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
         &store_config,
         "multi-tx-burn-chunking-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;
@@ -145,7 +136,8 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
     )
     .await?;
 
-    let bridge_app_id = publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
 
     // Register the wrapped-fungible app with the evm-bridge so it can drive
     // the escrow transfer + burn.

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -97,6 +97,8 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -24,14 +24,14 @@ use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_evm_bridge,
-    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
-    wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose, wait_for_light_client,
+    wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -67,16 +67,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         &store_config,
         "multi-burn-same-block-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -73,6 +73,8 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -32,14 +32,14 @@ use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_evm_bridge,
-    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
-    wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose, wait_for_light_client,
+    wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -75,16 +75,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
         &store_config,
         "multi-burn-same-recipient-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            event_block_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -81,6 +81,8 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -68,6 +68,14 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "1000", global = true)]
     pub event_cache_size: usize,
 
+    /// The maximal number of entries in the block-hash-by-height cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub block_hash_by_height_cache_size: usize,
+
+    /// The maximal number of entries in the event-block-height cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub event_block_height_cache_size: usize,
+
     /// Interval in seconds between weak reference cleanup sweeps in value caches.
     #[arg(long, default_value_t = DEFAULT_CLEANUP_INTERVAL_SECS, global = true)]
     pub cache_cleanup_interval_secs: u64,
@@ -92,6 +100,8 @@ impl CommonStorageOptions {
             certificate_cache_size: self.certificate_cache_size,
             certificate_raw_cache_size: self.certificate_raw_cache_size,
             event_cache_size: self.event_cache_size,
+            block_hash_by_height_cache_size: self.block_hash_by_height_cache_size,
+            event_block_height_cache_size: self.event_block_height_cache_size,
             cache_cleanup_interval_secs: self.cache_cleanup_interval_secs,
         }
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -4,7 +4,7 @@
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use async_trait::async_trait;
@@ -252,6 +252,28 @@ pub mod metrics {
         )
     });
 
+    /// The metric counting how often a block hash is read by height from storage.
+    #[doc(hidden)]
+    pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "read_block_hash_by_height",
+                "The metric counting how often a block hash is read by height from storage",
+                &[SOURCE_LABEL],
+            )
+        });
+
+    /// The metric counting how often an event block height is read from storage.
+    #[doc(hidden)]
+    pub(super) static READ_EVENT_BLOCK_HEIGHT_COUNTER: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "read_event_block_height",
+                "The metric counting how often an event block height is read from storage",
+                &[SOURCE_LABEL],
+            )
+        });
+
     /// The metric counting how often the network description is read from storage.
     #[doc(hidden)]
     pub(super) static READ_NETWORK_DESCRIPTION: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -423,6 +445,10 @@ pub struct StorageCacheConfig {
     pub certificate_raw_cache_size: usize,
     /// The maximum number of events to cache.
     pub event_cache_size: usize,
+    /// The maximum number of block hashes to cache, keyed by `(chain, height)`.
+    pub block_hash_by_height_cache_size: usize,
+    /// The maximum number of event-to-block-height index entries to cache.
+    pub event_block_height_cache_size: usize,
     /// The interval, in seconds, between cache cleanup passes.
     pub cache_cleanup_interval_secs: u64,
 }
@@ -435,6 +461,8 @@ pub const DEFAULT_STORAGE_CACHE_CONFIG: StorageCacheConfig = StorageCacheConfig 
     certificate_cache_size: 1000,
     certificate_raw_cache_size: 1000,
     event_cache_size: 1000,
+    block_hash_by_height_cache_size: 1000,
+    event_block_height_cache_size: 1000,
     cache_cleanup_interval_secs: linera_cache::DEFAULT_CLEANUP_INTERVAL_SECS,
 };
 
@@ -453,6 +481,9 @@ pub struct StorageCaches {
     pub(crate) certificate: Arc<ValueCache<CryptoHash, ConfirmedBlockCertificate>>,
     pub(crate) certificate_raw: Arc<ValueCache<CryptoHash, RawCertificate>>,
     pub(crate) event: Arc<ValueCache<EventId, Vec<u8>>>,
+    pub(crate) block_hash_by_height: Arc<ValueCache<(ChainId, BlockHeight), CryptoHash>>,
+    pub(crate) event_block_height: Arc<ValueCache<EventId, BlockHeight>>,
+    pub(crate) network_description: Arc<OnceLock<NetworkDescription>>,
 }
 
 impl StorageCaches {
@@ -485,6 +516,17 @@ impl StorageCaches {
                 sizes.event_cache_size,
                 interval,
             )),
+            block_hash_by_height: Arc::new(ValueCache::new(
+                "storage_block_hash_by_height",
+                sizes.block_hash_by_height_cache_size,
+                interval,
+            )),
+            event_block_height: Arc::new(ValueCache::new(
+                "storage_event_block_height",
+                sizes.event_block_height_cache_size,
+                interval,
+            )),
+            network_description: Arc::new(OnceLock::new()),
         }
     }
 }
@@ -1053,7 +1095,24 @@ where
             batch.add_blob(blob);
         }
         batch.add_certificate(certificate)?;
-        self.write_batch(batch).await
+        self.write_batch(batch).await?;
+        // Populate immutable-data caches so subsequent reads are served from memory.
+        let block = certificate.value().block();
+        let chain_id = block.header.chain_id;
+        let height = block.header.height;
+        let hash = certificate.hash();
+        self.caches
+            .block_hash_by_height
+            .insert(&(chain_id, height), hash);
+        for event in block.body.events.iter().flatten() {
+            let event_id = EventId {
+                chain_id,
+                stream_id: event.stream_id.clone(),
+                index: event.index,
+            };
+            self.caches.event_block_height.insert(&event_id, height);
+        }
+        Ok(())
     }
 
     fn cache_certificate(
@@ -1211,19 +1270,49 @@ where
             return Ok(Vec::new());
         }
 
-        let index_root_key = RootKey::BlockByHeight(chain_id).bytes();
-        let store = self.database.open_shared(&index_root_key)?;
-        let height_keys: Vec<Vec<u8>> = heights.iter().map(|h| to_height_key(*h)).collect();
-        let hash_bytes = store.read_multi_values_bytes(&height_keys).await?;
-        let hash_options: Vec<Option<CryptoHash>> = hash_bytes
-            .into_iter()
-            .map(|opt| {
-                opt.map(|bytes| bcs::from_bytes::<CryptoHash>(&bytes))
-                    .transpose()
-            })
-            .collect::<Result<_, _>>()?;
+        let mut results = vec![None; heights.len()];
+        let mut misses = Vec::new();
+        for (i, &height) in heights.iter().enumerate() {
+            if let Some(hash) = self.caches.block_hash_by_height.get(&(chain_id, height)) {
+                results[i] = Some(*hash);
+            } else {
+                misses.push(i);
+            }
+        }
+        #[cfg(with_metrics)]
+        {
+            let cache_hits = (heights.len() - misses.len()) as u64;
+            if cache_hits > 0 {
+                metrics::READ_BLOCK_HASH_BY_HEIGHT_COUNTER
+                    .with_label_values(&[metrics::CACHE])
+                    .inc_by(cache_hits);
+            }
+        }
+        if !misses.is_empty() {
+            let miss_keys: Vec<Vec<u8>> =
+                misses.iter().map(|&i| to_height_key(heights[i])).collect();
+            let index_root_key = RootKey::BlockByHeight(chain_id).bytes();
+            let store = self.database.open_shared(&index_root_key)?;
+            let hash_bytes = store.read_multi_values_bytes(&miss_keys).await?;
+            #[cfg(with_metrics)]
+            {
+                let db_reads = misses.len() as u64;
+                metrics::READ_BLOCK_HASH_BY_HEIGHT_COUNTER
+                    .with_label_values(&[metrics::DB])
+                    .inc_by(db_reads);
+            }
+            for (miss_idx, opt_bytes) in misses.iter().zip(hash_bytes) {
+                if let Some(bytes) = opt_bytes {
+                    let hash = bcs::from_bytes::<CryptoHash>(&bytes)?;
+                    self.caches
+                        .block_hash_by_height
+                        .insert(&(chain_id, heights[*miss_idx]), hash);
+                    results[*miss_idx] = Some(hash);
+                }
+            }
+        }
 
-        Ok(hash_options)
+        Ok(results)
     }
 
     async fn read_event_block_heights(
@@ -1233,15 +1322,38 @@ where
         if event_ids.is_empty() {
             return Ok(Vec::new());
         }
-        // Group event IDs by chain ID for batch lookups per partition.
-        let mut chain_groups = BTreeMap::<_, Vec<_>>::new();
+
+        let mut results = vec![None; event_ids.len()];
+        // Check cache first; collect misses.
+        let mut misses: Vec<usize> = Vec::new();
         for (i, event_id) in event_ids.iter().enumerate() {
+            if let Some(height) = self.caches.event_block_height.get(event_id) {
+                results[i] = Some(*height);
+            } else {
+                misses.push(i);
+            }
+        }
+        #[cfg(with_metrics)]
+        {
+            let cache_hits = (event_ids.len() - misses.len()) as u64;
+            if cache_hits > 0 {
+                metrics::READ_EVENT_BLOCK_HEIGHT_COUNTER
+                    .with_label_values(&[metrics::CACHE])
+                    .inc_by(cache_hits);
+            }
+        }
+        if misses.is_empty() {
+            return Ok(results);
+        }
+        // Group cache-miss event IDs by chain ID for batch lookups per partition.
+        let mut chain_groups = BTreeMap::<_, Vec<_>>::new();
+        for &i in &misses {
+            let event_id = &event_ids[i];
             chain_groups
                 .entry(event_id.chain_id)
                 .or_default()
                 .push((i, to_event_key(event_id)));
         }
-        let mut results = vec![None; event_ids.len()];
         for (chain_id, entries) in chain_groups {
             let root_key = RootKey::EventBlockHeight(chain_id).bytes();
             let store = self.database.open_shared(&root_key)?;
@@ -1250,9 +1362,20 @@ where
                 .map(|(_, key)| key.clone())
                 .collect::<Vec<_>>();
             let values = store.read_multi_values_bytes(&keys).await?;
+            #[cfg(with_metrics)]
+            {
+                let db_reads = entries.len() as u64;
+                metrics::READ_EVENT_BLOCK_HEIGHT_COUNTER
+                    .with_label_values(&[metrics::DB])
+                    .inc_by(db_reads);
+            }
             for ((original_index, _), value) in entries.into_iter().zip(values) {
                 if let Some(bytes) = value {
-                    results[original_index] = Some(bcs::from_bytes::<BlockHeight>(&bytes)?);
+                    let height = bcs::from_bytes::<BlockHeight>(&bytes)?;
+                    self.caches
+                        .event_block_height
+                        .insert(&event_ids[original_index], height);
+                    results[original_index] = Some(height);
                 }
             }
         }
@@ -1369,24 +1492,48 @@ where
     ) -> Result<Vec<IndexAndEvent>, ViewError> {
         let root_key = RootKey::Event(*chain_id).bytes();
         let store = self.database.open_shared(&root_key)?;
-        let mut keys = Vec::new();
-        let mut indices = Vec::new();
+        let mut db_keys = Vec::new();
+        let mut db_indices = Vec::new();
+        let mut returned_values = Vec::new();
         let prefix = bcs::to_bytes(stream_id).unwrap();
         for short_key in store.find_keys_by_prefix(&prefix).await? {
             let index = bcs::from_bytes::<u32>(&short_key)?;
             if index >= start_index {
-                let mut key = prefix.clone();
-                key.extend(short_key);
-                keys.push(key);
-                indices.push(index);
+                let event_id = EventId {
+                    chain_id: *chain_id,
+                    stream_id: stream_id.clone(),
+                    index,
+                };
+                if let Some(cached) = self.caches.event.get(&event_id) {
+                    returned_values.push(IndexAndEvent {
+                        index,
+                        event: (*cached).clone(),
+                    });
+                } else {
+                    let mut key = prefix.clone();
+                    key.extend(short_key);
+                    db_keys.push(key);
+                    db_indices.push(index);
+                }
             }
         }
-        let values = store.read_multi_values_bytes(&keys).await?;
-        let mut returned_values = Vec::new();
-        for (index, value) in indices.into_iter().zip(values) {
-            let event = value.unwrap();
-            returned_values.push(IndexAndEvent { index, event });
+        if !db_keys.is_empty() {
+            let values = store.read_multi_values_bytes(&db_keys).await?;
+            for (index, value) in db_indices.into_iter().zip(values) {
+                let event_bytes = value.unwrap();
+                let event_id = EventId {
+                    chain_id: *chain_id,
+                    stream_id: stream_id.clone(),
+                    index,
+                };
+                self.caches.event.insert(&event_id, event_bytes.clone());
+                returned_values.push(IndexAndEvent {
+                    index,
+                    event: event_bytes,
+                });
+            }
         }
+        returned_values.sort_unstable_by_key(|ie| ie.index);
         Ok(returned_values)
     }
 
@@ -1404,13 +1551,25 @@ where
 
     #[instrument(skip_all)]
     async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
+        if let Some(desc) = self.caches.network_description.get() {
+            #[cfg(with_metrics)]
+            metrics::READ_NETWORK_DESCRIPTION
+                .with_label_values(&[metrics::CACHE])
+                .inc();
+            return Ok(Some(desc.clone()));
+        }
         let root_key = RootKey::NetworkDescription.bytes();
         let store = self.database.open_shared(&root_key)?;
-        let maybe_value = store.read_value(NETWORK_DESCRIPTION_KEY).await?;
+        let maybe_value: Option<NetworkDescription> =
+            store.read_value(NETWORK_DESCRIPTION_KEY).await?;
         #[cfg(with_metrics)]
         metrics::READ_NETWORK_DESCRIPTION
             .with_label_values(&[metrics::DB])
             .inc();
+        if let Some(ref desc) = maybe_value {
+            // Ignore the error: another thread may have populated the cache concurrently.
+            drop(self.caches.network_description.set(desc.clone()));
+        }
         Ok(maybe_value)
     }
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -35,7 +35,7 @@ use linera_views::{
     ViewError,
 };
 use serde::{Deserialize, Serialize};
-use tracing::instrument;
+use tracing::{debug, instrument};
 #[cfg(with_testing)]
 use {
     futures::channel::oneshot::{self, Receiver},
@@ -1492,9 +1492,10 @@ where
     ) -> Result<Vec<IndexAndEvent>, ViewError> {
         let root_key = RootKey::Event(*chain_id).bytes();
         let store = self.database.open_shared(&root_key)?;
+        // Pair each index with its cached value, or `None` for a cache miss to be
+        // read from the database, so results keep the key-scan order.
+        let mut entries = Vec::new();
         let mut db_keys = Vec::new();
-        let mut db_indices = Vec::new();
-        let mut returned_values = Vec::new();
         let prefix = bcs::to_bytes(stream_id).unwrap();
         for short_key in store.find_keys_by_prefix(&prefix).await? {
             let index = bcs::from_bytes::<u32>(&short_key)?;
@@ -1504,36 +1505,41 @@ where
                     stream_id: stream_id.clone(),
                     index,
                 };
-                if let Some(cached) = self.caches.event.get(&event_id) {
-                    returned_values.push(IndexAndEvent {
-                        index,
-                        event: (*cached).clone(),
-                    });
-                } else {
+                let cached = self.caches.event.get(&event_id).map(|arc| (*arc).clone());
+                if cached.is_none() {
                     let mut key = prefix.clone();
                     key.extend(short_key);
                     db_keys.push(key);
-                    db_indices.push(index);
                 }
+                entries.push((index, cached));
             }
         }
-        if !db_keys.is_empty() {
-            let values = store.read_multi_values_bytes(&db_keys).await?;
-            for (index, value) in db_indices.into_iter().zip(values) {
-                let event_bytes = value.unwrap();
-                let event_id = EventId {
-                    chain_id: *chain_id,
-                    stream_id: stream_id.clone(),
-                    index,
-                };
-                self.caches.event.insert(&event_id, event_bytes.clone());
-                returned_values.push(IndexAndEvent {
-                    index,
-                    event: event_bytes,
-                });
-            }
+        let mut db_values = if db_keys.is_empty() {
+            Vec::new()
+        } else {
+            store.read_multi_values_bytes(&db_keys).await?
         }
-        returned_values.sort_unstable_by_key(|ie| ie.index);
+        .into_iter();
+        let mut returned_values = Vec::with_capacity(entries.len());
+        for (index, cached) in entries {
+            let event = match cached {
+                Some(event) => event,
+                None => {
+                    let event_bytes = db_values
+                        .next()
+                        .expect("one database value per cache miss")
+                        .unwrap();
+                    let event_id = EventId {
+                        chain_id: *chain_id,
+                        stream_id: stream_id.clone(),
+                        index,
+                    };
+                    self.caches.event.insert(&event_id, event_bytes.clone());
+                    event_bytes
+                }
+            };
+            returned_values.push(IndexAndEvent { index, event });
+        }
         Ok(returned_values)
     }
 
@@ -1567,8 +1573,9 @@ where
             .with_label_values(&[metrics::DB])
             .inc();
         if let Some(ref desc) = maybe_value {
-            // Ignore the error: another thread may have populated the cache concurrently.
-            drop(self.caches.network_description.set(desc.clone()));
+            if self.caches.network_description.set(desc.clone()).is_err() {
+                debug!("network description cache was already populated concurrently");
+            }
         }
         Ok(maybe_value)
     }

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -25,6 +25,8 @@ pub async fn get_storage(
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
+            event_block_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )


### PR DESCRIPTION
## Motivation

`DbStorage` pays a full Scylla/RocksDB round-trip on every call to four read methods that return permanently immutable data. On busy validators this contributes directly to Scylla read pressure (one node sustained ~7-8s p99 read spikes, with cache storms making it worse).

The four uncached paths:
- `read_certificate_hashes_by_heights` — `(ChainId, BlockHeight) → CryptoHash`
- `read_event_block_heights` — `EventId → BlockHeight`
- `read_events_from_index` — per-event bytes (keys still require a DB scan, but values now hit the cache)
- `read_network_description` — single `NetworkDescription` value

All four are permanently immutable once written. They are safe to cache indefinitely.

## Proposal

Add three new caches to `StorageCaches`:

- `block_hash_by_height: Arc<ValueCache<(ChainId, BlockHeight), CryptoHash>>` — S3-FIFO bounded, consistent with the existing five caches
- `event_block_height: Arc<ValueCache<EventId, BlockHeight>>` — same
- `network_description: Arc<OnceLock<NetworkDescription>>` — single-value, zero overhead after first read

Read path: check-then-populate pattern (same as `read_certificates_raw`). Misses batch to DB; hits short-circuit. Write path: caches are populated in `write_blobs_and_certificate` at write time so write-then-read (the common path) is immediately cached.

`read_events_from_index` still scans DB for the key list (unavoidable), but now checks the existing `event` cache before bulk-reading values.

New CLI flags with conservative defaults (1 000 entries), overridden to larger values in the validator `values.yaml`:
- `--block-hash-by-height-cache-size` (validator: 100 000)
- `--event-block-height-cache-size` (validator: 50 000)

New Prometheus counters: `READ_BLOCK_HASH_BY_HEIGHT_COUNTER`, `READ_EVENT_BLOCK_HEIGHT_COUNTER` (labeled `[CACHE]`/`[DB]`). `read_network_description` gets `[CACHE]`/`[DB]` on the existing `READ_NETWORK_DESCRIPTION_COUNTER`.

## Test Plan

- `cargo clippy` clean on `--all-targets --all-features` and `--no-default-features`
- Covered by existing integration tests exercising `read_certificate_hashes_by_heights` and `read_events_from_index` for the full round-trip

## Release Plan

- These changes should be backported to the latest `testnet` branch, then be released in a validator hotfix.

## Links

- Prerequisite backport (index to testnet_conway): #6393
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)