### PR TITLE
Log per-validator errors in communicate_concurrently call sites

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -729,7 +729,17 @@ impl<Env: Environment> Client<Env> {
                         }
                     })
                 },
-                |_| chain_client::Error::InternalError("missing events"),
+                |errors| {
+                    for (validator, error) in &errors {
+                        warn!(
+                            %validator,
+                            %chain_id,
+                            %error,
+                            "failed to sync events from validator",
+                        );
+                    }
+                    chain_client::Error::InternalError("missing events")
+                },
                 timeout,
             )
             .await;
@@ -1317,7 +1327,15 @@ impl<Env: Environment> Client<Env> {
                 |errors| {
                     errors
                         .into_iter()
-                        .map(|(validator, _error)| validator)
+                        .map(|(validator, error)| {
+                            warn!(
+                                %validator,
+                                %sender_chain_id,
+                                %error,
+                                "failed to download certificates from validator",
+                            );
+                            validator
+                        })
                         .collect::<BTreeSet<_>>()
                 },
                 self.options.certificate_batch_download_timeout,
@@ -1989,7 +2007,17 @@ impl<Env: Environment> Client<Env> {
                         .ok_or_else(|| LocalNodeError::BlobsNotFound(vec![blob_id]))?;
                     Result::<_, chain_client::Error>::Ok(blob)
                 },
-                move |_| chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id])),
+                move |errors| {
+                    for (validator, error) in &errors {
+                        warn!(
+                            %validator,
+                            %blob_id,
+                            %error,
+                            "failed to download certificate-for-blob from validator",
+                        );
+                    }
+                    chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id]))
+                },
                 timeout,
             )
         }))

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -20,7 +20,7 @@ use linera_base::{
 };
 use linera_chain::types::ConfirmedBlockCertificate;
 use rand::distributions::{Distribution, WeightedIndex};
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use super::{
     cache::{RequestsCache, SubsumingKey},
@@ -314,7 +314,17 @@ impl<Env: Environment> RequestsScheduler<Env> {
                 })
                 .await
             },
-            |errors| errors.last().cloned().unwrap(),
+            |errors| {
+                for (validator, error) in &errors {
+                    warn!(
+                        %validator,
+                        %blob_id,
+                        %error,
+                        "failed to download blob from validator",
+                    );
+                }
+                errors.last().cloned().unwrap()
+            },
             timeout,
         )
         .await
@@ -397,7 +407,17 @@ impl<Env: Environment> RequestsScheduler<Env> {
                 })
                 .await
             },
-            |errors| errors.last().cloned().unwrap(),
+            |errors| {
+                for (validator, error) in &errors {
+                    warn!(
+                        %validator,
+                        %chain_id,
+                        %error,
+                        "failed to download certificates from validator",
+                    );
+                }
+                errors.last().cloned().unwrap()
+            },
             timeout,
         )
         .await


### PR DESCRIPTION
## Motivation

The err closures for the five `communicate_concurrently` call sites in `linera-core` are swallowing the per-validator errors, leaving only a synthesized "Blobs not found" / "missing events" with no indication of why each validator actually failed.

## Proposal

Log them at `warn!` before producing the fallback so we can learn more about the actual cause.

## Test Plan

CI

## Release Plan

- Port to `main`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
