### PR TITLE
docker: bundle pre-compiled Wasm contracts and linera-benchmark in linera-tests image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -173,17 +173,21 @@ COPY --from=binaries \
     ./
 
 # ── Stage 4: tests-builder — compile the remote-net integration test ──
-# Builds /linera_net_tests by parsing cargo's JSON output for the executable
-# path; the underlying binary lives in /app/target/release/deps/ which is a
-# cache mount and won't persist past this RUN, hence the explicit cp.
+# Builds /linera_net_tests and /linera-benchmark; also pre-compiles all
+# example Wasm contracts so the test binary can publish them without needing
+# cargo or source code at runtime.  The test binary lives in
+# /app/target/release/deps/ (a cache mount) so it must be copied out in the
+# same RUN.
 
 FROM builder_src AS tests-builder
 ARG build_flag
+ARG build_folder
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
-    cargo test --no-run ${build_flag:+"$build_flag"} \
+    cargo build ${build_flag:+"$build_flag"} --bin linera-benchmark \
+    && cargo test --no-run ${build_flag:+"$build_flag"} \
         -p linera-service \
         --features remote-net \
         --test linera_net_tests \
@@ -191,7 +195,26 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     && jq -r 'select(.executable != null) | .executable' /tmp/cargo-tests.json \
         | grep '/linera_net_tests-' \
         | head -1 \
-        | xargs -I{} cp {} /linera_net_tests
+        | xargs -I{} cp {} /linera_net_tests \
+    && cp target/"${build_folder}"/linera-benchmark /linera-benchmark
+
+# Build every example contract exactly the way CI does (.github/workflows/
+# scylladb.yml: `cd examples && cargo build --locked --release --target
+# wasm32-unknown-unknown`). Building the whole examples workspace guarantees
+# every `<name>_contract.wasm` / `<name>_service.wasm` the tests publish is
+# produced — an explicit `-p` list silently misses contracts.
+#
+# No cache mount on examples/target: the wasm must persist into this image
+# layer for the `tests` stage to copy, and building into a real dir (as CI
+# does) avoids any cache-mount visibility ambiguity.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cd examples \
+    && cargo build --locked --release --target wasm32-unknown-unknown \
+    && mkdir -p /wasm-examples \
+    && find target/wasm32-unknown-unknown/release \
+        -maxdepth 1 -name "*.wasm" \
+        -exec cp {} /wasm-examples/ \;
 
 # ── Stage 5: tests runtime — runtime image + remote-net test binary ──
 # Used by linera-infra's network-health-check CronJob; production image
@@ -201,3 +224,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 FROM runtime AS tests
 RUN ln -s /linera /usr/local/bin/linera
 COPY --from=tests-builder /linera_net_tests /usr/local/bin/linera-net-tests
+COPY --from=tests-builder /linera-benchmark /usr/local/bin/linera-benchmark
+# Stub cargo so build_application() succeeds without a Rust toolchain: it calls
+# `cargo build`, the stub exits 0, then reads the pre-built .wasm files below.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/cargo && chmod +x /usr/local/bin/cargo
+# The remote-net tests run from `/` and treat `/examples` as a linera-protocol
+# checkout: they read contract sources and snapshot fixtures (e.g.
+# examples/counter/tests/snapshots/format__format.snap), resolve each contract
+# via `…/examples/<name>/../target/…/release/<name>_contract.wasm` (needs the
+# real `/examples/<name>` dir to exist for the `..` to collapse), and
+# linera-benchmark canonicalize()s `/examples/fungible`. Ship the examples
+# source tree (.dockerignore strips target/) and overlay the pre-built wasm.
+COPY examples /examples
+COPY --from=tests-builder /wasm-examples/ /examples/target/wasm32-unknown-unknown/release/


### PR DESCRIPTION
## Motivation

The `linera-tests` Docker image (consumed by the `network-health-check` CronJob
in `linera-infra`) had never worked since the health-check migrated from
building tests at runtime to a pre-built `linera-net-tests` binary. The binary
expects to run inside a linera-protocol checkout, but the image shipped only the
test binary — so every wasm-publishing test failed. Concretely:

1. `build_application()` shells out to `cargo build --release --target
   wasm32-unknown-unknown` and then reads the resulting `.wasm` — the image had
   no Rust toolchain, no example sources, and no compiled wasm.
2. The benchmark test calls `resolve_binary("linera-benchmark")` — that binary
   was never copied into the image.
3. Tests also read example **source** fixtures (e.g.
   `examples/counter/tests/snapshots/format__format.snap`).

Builds on #6362, which stopped building `linera-tests` with the `metrics`
feature (so `linera service` no longer requires `--metrics-port`).

## Proposal

All changes are in `docker/Dockerfile`; no Rust code is touched.

**`tests-builder` stage**
- Build `linera-benchmark` alongside `linera_net_tests` and copy both out of the
  cargo cache mount.
- Add a second `RUN` that builds the **entire** examples workspace exactly as CI
  does (`.github/workflows/scylladb.yml`: `cd examples && cargo build --locked
  --release --target wasm32-unknown-unknown`) and stages every `.wasm` under
  `/wasm-examples/`.

**`tests` stage**
- Copy in `linera-benchmark`.
- Install a stub `/usr/local/bin/cargo` that exits 0. `build_application()` still
  runs `cargo build`, the stub succeeds without a toolchain, and the code falls
  through to reading the pre-built wasm.
- `COPY examples /examples` — ship the real examples source tree (`.dockerignore`
  strips `target/`), then overlay the pre-built wasm at
  `/examples/target/wasm32-unknown-unknown/release/`.

**Why the source tree, not just the wasm:** the tests run from `/` and resolve
each contract via a literal
`…/examples/<name>/../target/wasm32-unknown-unknown/release/<name>_contract.wasm`
path. The kernel only collapses the `<name>/..` segment if `/examples/<name>`
actually exists — so the wasm being present is not enough; every example
directory must exist on disk. Shipping the source tree makes every example dir
real **and** provides the snapshot fixtures the tests read, and gives
`linera-benchmark` the `/examples/fungible` dir it `canonicalize()`s.

## Test Plan

Verified end-to-end against the live `testnet-conway` network by building this
image and triggering the `network-health-check` e2e CronJob one-off
(`trigger-healthcheck-job.sh testnet-conway e2e`):

- Before: `14 passed; 14 failed` (only `fungible` resolved — its dir happened to exist).
- After this change: **`test result: ok. 28 passed; 0 failed; 1 ignored`**, Slack
  posts :white_check_mark: "succeeded on first attempt". Zero `failed to query metadata` /
  `No such file` / `Cannot find a binary` errors.

(A single intermittent failure observed on one run was a live-network flake — a
different, previously-passing test, no file errors — and cleared on re-run with
the identical image.)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- Note: this fix should also be forward-ported to `main` (main's
  `docker_image.yml` and `docker/Dockerfile` still carry both the `metrics` and
  the packaging bugs), so branches cut from `main` don't reintroduce it.

## Links

- Builds on #6362 (metrics feature fix)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
