### PR TITLE
Require docs on 7 small library crates with #![deny(missing_docs)] (testnet_conway)

### DIFF
--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -38,8 +38,9 @@ pub use error::Error;
 
 mod error {
     // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempt from the crate's `missing_docs` policy.
-    #![allow(missing_docs)]
+    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
+    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
+    #![expect(missing_docs)]
 
     use thiserror_context::Context;
 

--- a/linera-faucet/client/src/lib.rs
+++ b/linera-faucet/client/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! The client component of the Linera faucet.
 
+#![deny(missing_docs)]
+
 // TODO(#3362): generate this code
 
 use std::collections::BTreeMap;
@@ -17,18 +19,34 @@ use linera_execution::{committee::ValidatorState, Committee, ResourceControlPoli
 use linera_version::VersionInfo;
 use thiserror_context::Context;
 
+/// The kinds of error that the faucet client can return.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum ErrorInner {
+    /// A response from the faucet could not be parsed as JSON.
     #[error("JSON parsing error: {0:?}")]
     Json(#[from] serde_json::Error),
+    /// The faucet returned one or more GraphQL errors.
     #[error("GraphQL error: {0:?}")]
     GraphQl(Vec<serde_json::Value>),
+    /// An HTTP request to the faucet failed.
     #[error("HTTP error: {0:?}")]
     Http(#[from] reqwest::Error),
 }
 
-thiserror_context::impl_context!(Error(ErrorInner));
+pub use error::Error;
+
+mod error {
+    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
+    // doc comments, so this wrapper module is exempt from the crate's `missing_docs` policy.
+    #![allow(missing_docs)]
+
+    use thiserror_context::Context;
+
+    use super::ErrorInner;
+
+    thiserror_context::impl_context!(Error(ErrorInner));
+}
 
 /// The result of a successful claim mutation.
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -59,10 +77,12 @@ pub struct Faucet {
 }
 
 impl Faucet {
+    /// Creates a faucet client querying the faucet service at the given URL.
     pub fn new(url: String) -> Self {
         Self { url }
     }
 
+    /// Returns the URL of the faucet service.
     pub fn url(&self) -> &str {
         &self.url
     }
@@ -107,6 +127,7 @@ impl Faucet {
         }
     }
 
+    /// Fetches the network's genesis configuration from the faucet.
     pub async fn genesis_config(&self) -> Result<GenesisConfig, Error> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
@@ -120,6 +141,7 @@ impl Faucet {
             .genesis_config)
     }
 
+    /// Fetches the faucet's version information.
     pub async fn version_info(&self) -> Result<VersionInfo, Error> {
         #[derive(serde::Deserialize)]
         struct Response {
@@ -129,6 +151,7 @@ impl Faucet {
         Ok(self.query::<Response>("query { version }").await?.version)
     }
 
+    /// Claims a new chain for the given owner, returning its chain description.
     pub async fn claim(
         &self,
         owner: &linera_base::identifiers::AccountOwner,
@@ -201,6 +224,7 @@ impl Faucet {
             .next_daily_claim)
     }
 
+    /// Returns the current validators' public keys and network addresses.
     pub async fn current_validators(&self) -> Result<Vec<(ValidatorPublicKey, String)>, Error> {
         #[derive(serde::Deserialize)]
         #[serde(rename_all = "camelCase")]
@@ -224,6 +248,7 @@ impl Faucet {
             .collect())
     }
 
+    /// Returns the current committee: its validators and resource-control policy.
     pub async fn current_committee(&self) -> Result<Committee, Error> {
         #[derive(serde::Deserialize)]
         struct CommitteeResponse {

--- a/linera-indexer/graphql-client/gql/operations_schema.graphql
+++ b/linera-indexer/graphql-client/gql/operations_schema.graphql
@@ -3,6 +3,9 @@ The unique identifier (UID) of a chain. This is currently computed as the hash v
 """
 scalar ChainId
 
+"""
+An indexed operation together with the location of the previous one on the same chain.
+"""
 type ChainOperation {
 	key: OperationKey!
 	previousOperation: OperationKey
@@ -26,8 +29,17 @@ An operation key to index operations
 """
 scalar OperationKey
 
+"""
+A way to refer to an operation: either by its exact key, or as the last operation on a chain.
+"""
 input OperationKeyKind @oneOf {
+	"""
+	Refers to the operation with this exact key.
+	"""
 	key: OperationKey
+	"""
+	Refers to the last operation registered for this chain.
+	"""
 	last: ChainId
 }
 

--- a/linera-indexer/graphql-client/src/indexer.rs
+++ b/linera-indexer/graphql-client/src/indexer.rs
@@ -1,9 +1,18 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! GraphQL queries against the indexer's main API.
+
+// The `GraphQLQuery` derive macro generates public items (per-query modules,
+// `Variables` and `ResponseData` structs, etc.) that cannot carry doc comments,
+// so this module of generated bindings is exempt from the crate's `missing_docs`
+// policy. The hand-written query structs are still documented below.
+#![allow(missing_docs)]
+
 use graphql_client::GraphQLQuery;
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
 
+/// GraphQL query returning the list of plugins registered with the indexer.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/indexer_schema.graphql",
@@ -12,6 +21,7 @@ use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::Chai
 )]
 pub struct Plugins;
 
+/// GraphQL query returning the indexer's current state (chain, block and height).
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/indexer_schema.graphql",

--- a/linera-indexer/graphql-client/src/indexer.rs
+++ b/linera-indexer/graphql-client/src/indexer.rs
@@ -5,9 +5,10 @@
 
 // The `GraphQLQuery` derive macro generates public items (per-query modules,
 // `Variables` and `ResponseData` structs, etc.) that cannot carry doc comments,
-// so this module of generated bindings is exempt from the crate's `missing_docs`
-// policy. The hand-written query structs are still documented below.
-#![allow(missing_docs)]
+// so this module of generated bindings is exempted from the crate's `missing_docs`
+// policy. `expect` (rather than `allow`) flags this if the generated code ever stops
+// producing undocumented items. The hand-written query structs are still documented below.
+#![expect(missing_docs)]
 
 use graphql_client::GraphQLQuery;
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};

--- a/linera-indexer/graphql-client/src/lib.rs
+++ b/linera-indexer/graphql-client/src/lib.rs
@@ -3,5 +3,7 @@
 
 //! A GraphQL client for the indexer.
 
+#![deny(missing_docs)]
+
 pub mod indexer;
 pub mod operations;

--- a/linera-indexer/graphql-client/src/operations.rs
+++ b/linera-indexer/graphql-client/src/operations.rs
@@ -5,9 +5,10 @@
 
 // The `GraphQLQuery` derive macro generates public items (per-query modules,
 // `Variables` and `ResponseData` structs, etc.) that cannot carry doc comments,
-// so this module of generated bindings is exempt from the crate's `missing_docs`
-// policy. The hand-written types and query structs are still documented below.
-#![allow(missing_docs)]
+// so this module of generated bindings is exempted from the crate's `missing_docs`
+// policy. `expect` (rather than `allow`) flags this if the generated code ever stops
+// producing undocumented items. The hand-written types and queries are still documented below.
+#![expect(missing_docs)]
 
 use graphql_client::GraphQLQuery;
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};

--- a/linera-indexer/graphql-client/src/operations.rs
+++ b/linera-indexer/graphql-client/src/operations.rs
@@ -1,6 +1,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! GraphQL queries against the indexer's operations API, and supporting types.
+
+// The `GraphQLQuery` derive macro generates public items (per-query modules,
+// `Variables` and `ResponseData` structs, etc.) that cannot carry doc comments,
+// so this module of generated bindings is exempt from the crate's `missing_docs`
+// policy. The hand-written types and query structs are still documented below.
+#![allow(missing_docs)]
+
 use graphql_client::GraphQLQuery;
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
 use serde::{Deserialize, Serialize};
@@ -11,13 +19,19 @@ pub type Operation = serde_json::Value;
 #[cfg(not(target_arch = "wasm32"))]
 pub use linera_execution::Operation;
 
+/// The key identifying an operation: the chain it ran on, the height of the block
+/// that contains it, and its index within that block.
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct OperationKey {
+    /// The chain on which the operation was executed.
     pub chain_id: ChainId,
+    /// The height of the block containing the operation.
     pub height: BlockHeight,
+    /// The index of the operation within the block.
     pub index: usize,
 }
 
+/// GraphQL query returning a range of operations starting from a given key.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/operations_schema.graphql",
@@ -26,6 +40,7 @@ pub struct OperationKey {
 )]
 pub struct Operations;
 
+/// GraphQL query returning the number of operations on a chain.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/operations_schema.graphql",
@@ -34,6 +49,7 @@ pub struct Operations;
 )]
 pub struct OperationsCount;
 
+/// GraphQL query returning the last operation on a chain.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/operations_schema.graphql",
@@ -42,6 +58,7 @@ pub struct OperationsCount;
 )]
 pub struct LastOperation;
 
+/// GraphQL query returning a single operation identified by its key.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/operations_schema.graphql",

--- a/linera-indexer/plugins/src/lib.rs
+++ b/linera-indexer/plugins/src/lib.rs
@@ -3,4 +3,6 @@
 
 //! Plugins for Linera indexer.
 
+#![deny(missing_docs)]
+
 pub mod operations;

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! A plugin that indexes the operations executed on each chain.
+
 use std::{
     cmp::{Ordering, PartialOrd},
     sync::Arc,
@@ -28,10 +30,15 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 use tracing::info;
 
+/// The key identifying an operation: the chain it ran on, the height of the block
+/// that contains it, and its index within that block.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct OperationKey {
+    /// The chain on which the operation was executed.
     pub chain_id: ChainId,
+    /// The height of the block containing the operation.
     pub height: BlockHeight,
+    /// The index of the operation within the block.
     pub index: usize,
 }
 
@@ -47,6 +54,7 @@ impl PartialOrd for OperationKey {
     }
 }
 
+/// An indexed operation together with the location of the previous one on the same chain.
 #[derive(Deserialize, Serialize, Clone, SimpleObject, Debug)]
 pub struct ChainOperation {
     key: OperationKey,
@@ -56,6 +64,7 @@ pub struct ChainOperation {
     content: Operation,
 }
 
+/// The persistent state of the operations plugin: per-chain operation indices.
 #[derive(RootView)]
 pub struct Operations<C> {
     last: MapView<C, ChainId, OperationKey>,
@@ -64,9 +73,12 @@ pub struct Operations<C> {
     operations: MapView<C, OperationKey, ChainOperation>,
 }
 
+/// A way to refer to an operation: either by its exact key, or as the last operation on a chain.
 #[derive(OneofObject)]
 pub enum OperationKeyKind {
+    /// Refers to the operation with this exact key.
     Key(OperationKey),
+    /// Refers to the last operation registered for this chain.
     Last(ChainId),
 }
 
@@ -106,6 +118,7 @@ where
     }
 }
 
+/// The operations plugin: indexes executed operations and serves them over GraphQL.
 #[derive(Clone)]
 pub struct OperationsPlugin<C>(Arc<Mutex<Operations<C>>>);
 

--- a/linera-metrics/src/lib.rs
+++ b/linera-metrics/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! A library for Linera server metrics.
 
+#![deny(missing_docs)]
+
 pub mod monitoring_server;
 
 #[cfg(feature = "jemalloc")]

--- a/linera-metrics/src/memory_profiler.rs
+++ b/linera-metrics/src/memory_profiler.rs
@@ -25,14 +25,19 @@ use thiserror::Error;
 use tokio::sync::Mutex;
 use tracing::{error, info, trace};
 
+/// An error that can occur while activating or querying jemalloc memory profiling.
 #[derive(Debug, Error)]
 pub enum MemoryProfilerError {
+    /// jemalloc profiling is not activated; check the `malloc_conf` configuration.
     #[error("jemalloc profiling not activated - check malloc_conf configuration")]
     JemallocProfilingNotActivated,
+    /// The jemalloc profiling control is unavailable; jemalloc was not built with profiling.
     #[error("PROF_CTL not available - ensure jemalloc is built with profiling support")]
     ProfCtlNotAvailable,
+    /// Another profiler currently holds the profiling control.
     #[error("another profiler is already running")]
     AnotherProfilerAlreadyRunning,
+    /// Activating jemalloc profiling failed.
     #[error("failed to activate jemalloc profiling: {0}")]
     ActivationFailed(String),
 }
@@ -119,6 +124,7 @@ impl MemoryProfiler {
         }
     }
 
+    /// Checks that jemalloc profiling is available and currently activated.
     pub fn check_prof_ctl() -> Result<(), MemoryProfilerError> {
         if let Some(prof_ctl) = PROF_CTL.as_ref() {
             let prof_ctl = prof_ctl

--- a/linera-metrics/src/monitoring_server.rs
+++ b/linera-metrics/src/monitoring_server.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! An HTTP server exposing Prometheus metrics, optionally with memory-profiling endpoints.
+
 use std::fmt::Debug;
 
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
@@ -14,7 +16,9 @@ use crate::memory_profiler::MemoryProfiler;
 /// Whether memory profiling endpoints should be enabled on the metrics server.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MemoryProfiling {
+    /// Memory-profiling endpoints are served.
     Enabled,
+    /// Memory-profiling endpoints are not served.
     Disabled,
 }
 
@@ -76,6 +80,8 @@ pub async fn start_metrics_with_profiling(
     start_metrics(address, shutdown_signal, memory_profiling);
 }
 
+/// Starts the metrics HTTP server on `address`, serving `/metrics` and, when profiling is
+/// enabled and available, the memory-profiling endpoints. Runs until `shutdown_signal` fires.
 pub fn start_metrics(
     address: impl ToSocketAddrs + Debug + Send + 'static,
     shutdown_signal: CancellationToken,

--- a/linera-metrics/src/monitoring_server.rs
+++ b/linera-metrics/src/monitoring_server.rs
@@ -90,6 +90,8 @@ pub fn start_metrics(
     start_metrics_with_extras(address, shutdown_signal, memory_profiling, None);
 }
 
+/// Like `start_metrics`, but additionally merges `extra_routes` into the metrics server's
+/// router before serving.
 pub fn start_metrics_with_extras(
     address: impl ToSocketAddrs + Debug + Send + 'static,
     shutdown_signal: CancellationToken,

--- a/linera-persistent/src/file.rs
+++ b/linera-persistent/src/file.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! A [`Persist`] backend that atomically saves the value to a locked file on disk.
+
 use std::{
     io::{self, BufRead as _, Write as _},
     path::Path,
@@ -22,7 +24,19 @@ enum ErrorInner {
     JsonError(#[from] serde_json::Error),
 }
 
-thiserror_context::impl_context!(Error(ErrorInner));
+pub use error::Error;
+
+mod error {
+    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
+    // doc comments, so this wrapper module is exempt from the crate's `missing_docs` policy.
+    #![allow(missing_docs)]
+
+    use thiserror_context::Context;
+
+    use super::ErrorInner;
+
+    thiserror_context::impl_context!(Error(ErrorInner));
+}
 
 /// Utility: run a fallible cleanup function if an operation failed, attaching the
 /// original operation as context to its error.
@@ -165,6 +179,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> File<T> {
         Ok(me)
     }
 
+    /// Atomically writes the current value to the file, via a temporary staging file.
     pub fn save(&self) -> Result<(), Error> {
         let mut temp_file_path = self.path.clone();
         temp_file_path.set_extension("json.new");

--- a/linera-persistent/src/file.rs
+++ b/linera-persistent/src/file.rs
@@ -28,8 +28,9 @@ pub use error::Error;
 
 mod error {
     // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
-    // doc comments, so this wrapper module is exempt from the crate's `missing_docs` policy.
-    #![allow(missing_docs)]
+    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
+    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
+    #![expect(missing_docs)]
 
     use thiserror_context::Context;
 

--- a/linera-persistent/src/lib.rs
+++ b/linera-persistent/src/lib.rs
@@ -5,6 +5,7 @@
 This crate handles persisting data types to disk with a variety of backends.
 */
 
+#![deny(missing_docs)]
 #![allow(async_fn_in_trait)]
 
 cfg_if::cfg_if! {
@@ -25,6 +26,7 @@ pub use memory::Memory;
 /// the value in memory.
 #[cfg_attr(not(web), trait_variant::make(Send))]
 pub trait Persist: Deref {
+    /// The type of error that persisting the value can produce.
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Gets a mutable reference to the value. This is not expressed as a
@@ -41,6 +43,7 @@ pub trait Persist: Deref {
         Self::Target: Sized;
 }
 
+/// Extension methods provided for every [`Persist`] implementation.
 pub trait PersistExt: Persist {
     /// Applies a mutation to the value, persisting when done.
     async fn mutate<R>(

--- a/linera-persistent/src/memory.rs
+++ b/linera-persistent/src/memory.rs
@@ -1,8 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! An in-memory [`Persist`] backend that holds the value without writing it anywhere.
+
 use super::Persist;
 
+/// The error type of the in-memory backend: persisting can never fail.
 pub type Error = std::convert::Infallible;
 
 /// A dummy [`Persist`] implementation that doesn't persist anything, but holds the value
@@ -14,6 +17,7 @@ pub struct Memory<T> {
 }
 
 impl<T> Memory<T> {
+    /// Wraps a value in an in-memory backend.
     pub fn new(value: T) -> Self {
         Self { value }
     }

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! The procedural macros for the crate `linera-sdk`.
 
+#![deny(missing_docs)]
+
 mod utils;
 
 use proc_macro::TokenStream;
@@ -14,12 +16,17 @@ use syn::{
 
 use crate::utils::{concat, snakify};
 
+/// Derives `GraphQLMutationRoot` for an operation enum, generating a GraphQL mutation root
+/// whose mutations each schedule the corresponding operation. SDK paths in the generated code
+/// are resolved against the `linera_sdk` crate.
 #[proc_macro_derive(GraphQLMutationRoot)]
 pub fn derive_mutation_root(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemEnum);
     generate_mutation_root_code(input, "linera_sdk").into()
 }
 
+/// Like the `GraphQLMutationRoot` derive, but resolves SDK paths against `crate` instead of
+/// `linera_sdk`. Used within the `linera-sdk` crate itself.
 #[proc_macro_derive(GraphQLMutationRootInCrate)]
 pub fn derive_mutation_root_in_crate(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemEnum);
@@ -128,7 +135,7 @@ fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use syn::{__private::quote::quote, parse_quote, ItemEnum};
 
     use crate::generate_mutation_root_code;

--- a/linera-wallet-json/src/keystore.rs
+++ b/linera-wallet-json/src/keystore.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! A keystore backed by a JSON file holding the client's signing keys.
+
 use std::path::Path;
 
 use linera_base::{

--- a/linera-wallet-json/src/lib.rs
+++ b/linera-wallet-json/src/lib.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! A wallet and keystore for the Linera client, persisted as JSON files on disk.
+
+#![deny(missing_docs)]
+
 pub mod display;
 pub mod keystore;
 pub mod paths;

--- a/linera-wallet-json/src/wallet.rs
+++ b/linera-wallet-json/src/wallet.rs
@@ -196,6 +196,7 @@ impl PersistentWallet {
             .map(|opt| opt.flatten())
     }
 
+    /// Removes the chain with the given ID, saving if it was present, and returns it.
     pub fn forget_chain(
         &self,
         chain_id: ChainId,
@@ -222,6 +223,7 @@ impl PersistentWallet {
         self.0.chains.chain_ids()
     }
 
+    /// Returns the list of all chain IDs for which we have a secret key.
     pub fn owned_chain_ids(&self) -> Vec<ChainId> {
         self.0.chains.owned_chain_ids()
     }

--- a/linera-wallet-json/src/wallet.rs
+++ b/linera-wallet-json/src/wallet.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! A wallet persisted as a JSON file, tracking the client's chains and default chain.
+
 use std::{
     iter::IntoIterator,
     sync::{Arc, RwLock},
@@ -18,6 +20,7 @@ struct Data {
     genesis_config: GenesisConfig,
 }
 
+/// A wallet backed by a JSON file, holding the client's chains and which one is the default.
 pub struct PersistentWallet(persistent::File<Data>);
 
 // TODO(#5081): `persistent` is no longer necessary here, we can move the locking
@@ -68,10 +71,12 @@ impl Extend<(ChainId, Chain)> for PersistentWallet {
 }
 
 impl PersistentWallet {
+    /// Returns the chain with the given ID, if it is in the wallet.
     pub fn get(&self, id: ChainId) -> Option<Chain> {
         self.0.chains.get(id)
     }
 
+    /// Removes the chain with the given ID, adjusting the default chain if needed, and saves.
     pub fn remove(&self, id: ChainId) -> Result<Option<Chain>, persistent::file::Error> {
         let chain = self.0.chains.remove(id);
         {
@@ -84,6 +89,7 @@ impl PersistentWallet {
         Ok(chain)
     }
 
+    /// Returns all `(chain ID, chain)` pairs held by the wallet.
     pub fn items(&self) -> Vec<(ChainId, Chain)> {
         self.0.chains.items()
     }
@@ -95,6 +101,7 @@ impl PersistentWallet {
         }
     }
 
+    /// Inserts or replaces a chain, making it the default chain if it has an owner, and saves.
     pub fn insert(
         &self,
         id: ChainId,
@@ -109,6 +116,8 @@ impl PersistentWallet {
         Ok(old_chain)
     }
 
+    /// Inserts a chain only if its ID is not already present, making it the default if it is
+    /// the first chain, and saves.
     pub fn try_insert(
         &self,
         id: ChainId,
@@ -122,6 +131,7 @@ impl PersistentWallet {
         Ok(chain)
     }
 
+    /// Creates a new wallet file at `path` for the given genesis configuration.
     pub fn create(
         path: &std::path::Path,
         genesis_config: GenesisConfig,
@@ -136,28 +146,35 @@ impl PersistentWallet {
         )?))
     }
 
+    /// Reads an existing wallet from the file at `path`.
     pub fn read(path: &std::path::Path) -> Result<Self, persistent::file::Error> {
         Ok(Self(persistent::File::read(path)?))
     }
 
+    /// Returns the network's genesis configuration.
     pub fn genesis_config(&self) -> &GenesisConfig {
         &self.0.genesis_config
     }
 
+    /// Returns the admin chain ID from the genesis configuration.
     pub fn genesis_admin_chain_id(&self) -> ChainId {
         self.0.genesis_config.admin_chain_id()
     }
 
+    /// Returns the default chain, if one is set.
     pub fn default_chain(&self) -> Option<ChainId> {
         *self.0.default.read().unwrap()
     }
 
+    /// Sets the default chain, which must already be in the wallet, and saves.
     pub fn set_default_chain(&mut self, id: ChainId) -> Result<(), persistent::file::Error> {
         assert!(self.0.chains.get(id).is_some());
         *self.0.default.write().unwrap() = Some(id);
         self.0.save()
     }
 
+    /// Applies a mutation to the chain with the given ID, saving afterwards. Returns `None`
+    /// if the chain is not in the wallet.
     pub fn mutate<R>(
         &self,
         chain_id: ChainId,
@@ -169,6 +186,7 @@ impl PersistentWallet {
             .map(|outcome| self.0.save().map(|()| outcome))
     }
 
+    /// Removes and returns the owner of the given chain, if the chain and its owner are present.
     pub fn forget_keys(
         &self,
         chain_id: ChainId,
@@ -189,14 +207,17 @@ impl PersistentWallet {
         Ok(chain)
     }
 
+    /// Writes the wallet to its file.
     pub fn save(&self) -> Result<(), persistent::file::Error> {
         self.0.save()
     }
 
+    /// Returns the number of chains in the wallet.
     pub fn num_chains(&self) -> usize {
         self.0.chains.items().len()
     }
 
+    /// Returns the IDs of all chains in the wallet.
     pub fn chain_ids(&self) -> Vec<ChainId> {
         self.0.chains.chain_ids()
     }


### PR DESCRIPTION
## Motivation

`testnet_conway` counterpart of #6395. We are progressively requiring documentation on the
library crates via `#![deny(missing_docs)]`, mirroring the work on both `main` and
`testnet_conway` to keep the branches in sync and ease backports.

## Proposal

Same seven crates as #6395, documented identically where the code is identical:

- `linera-indexer-graphql-client`, `linera-sdk-derive`, `linera-faucet-client`,
  `linera-indexer-plugins`, `linera-persistent`, `linera-metrics`, `linera-wallet-json`.

The first seven commits mirror #6395 (cherry-picked). Where the branches' code already
diverges, docs were adjusted to match `testnet_conway`'s actual API rather than `main`'s
(e.g. `faucet-client`'s `ErrorInner` has no `ArithmeticError` variant here; `wallet-json`'s
`forget_keys` has a different signature). A final commit documents the public items that
exist only on `testnet_conway` (`forget_chain`, `start_metrics_with_extras`,
`owned_chain_ids`), isolated so the cherry-picked commits stay a clean mirror of `main`.

Same codegen conventions as #6395 (`GraphQLQuery`/async-graphql → module-level allow;
`impl_context!` → wrapper module + re-export).

## Test Plan

For each crate: `cargo check -p <crate> --all-features --all-targets` is clean under the new
lint, and `cargo +nightly fmt -p <crate> -- --check` passes.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- `main` counterpart: #6395
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
