### PR TITLE
Harden Solidity contracts of the bridge

### DIFF
--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -29,6 +29,16 @@ contract FungibleBridge is Microchain {
         uint256 nonce
     );
 
+    /// Emitted when a Linera burn is released as an ERC-20 transfer to
+    /// `target`. `height` and `eventIndex` together identify the burn in
+    /// the source Linera block (matches the on-chain dedup key).
+    event BurnReleased(
+        uint64 indexed height,
+        uint32 indexed eventIndex,
+        address indexed target,
+        uint256 amount
+    );
+
     // WrappedFungible application ID on Linera,
     // used to identify Burn events in the block stream.
     bytes32 public immutable fungibleApplicationId;
@@ -108,7 +118,7 @@ contract FungibleBridge is Microchain {
                 bytes32 key = _burnKey(height, evt.index);
                 if (processedBurns[key]) continue;
 
-                _releaseBurn(evt, key);
+                _releaseBurn(evt, key, height);
             }
         }
     }
@@ -152,7 +162,7 @@ contract FungibleBridge is Microchain {
             bytes32 key = _burnKey(height, evt.index);
             if (processedBurns[key]) continue;
 
-            _releaseBurn(evt, key);
+            _releaseBurn(evt, key, height);
         }
     }
 
@@ -178,10 +188,13 @@ contract FungibleBridge is Microchain {
     /// the dedup flag BEFORE the external `token.transfer` call
     /// (checks-effects-interactions) so a malicious token that re-enters
     /// `addBlock` / `processBurns` cannot trigger a second release.
-    function _releaseBurn(BridgeTypes.Event memory evt, bytes32 key) private {
+    function _releaseBurn(BridgeTypes.Event memory evt, bytes32 key, uint64 height) private {
         WrappedFungibleTypes.BurnEvent memory burnEvt = WrappedFungibleTypes.bcs_deserialize_BurnEvent(evt.value);
         processedBurns[key] = true;
-        _safeTransfer(address(burnEvt.target), burnEvt.amount.value);
+        address target = address(burnEvt.target);
+        uint256 amount = burnEvt.amount.value;
+        _safeTransfer(target, amount);
+        emit BurnReleased(height, evt.index, target, amount);
     }
 
     /// @dev Calls transfer and handles tokens that don't return a boolean.

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -132,7 +132,7 @@ contract FungibleBridge is Microchain {
     /// - any position out of range (`"eventPos out of range"`)
     /// - any position whose event is not a matching burn for this app
     ///   (`"not a matching burn"`)
-    /// - any failed `token.transfer` (`"token transfer failed"`)
+    /// - any failed `token.transfer` (`"safeTransfer failed"`)
     function processBurns(bytes calldata data, uint32 txIndex, uint32[] calldata eventPositionsInTx) external {
         require(eventPositionsInTx.length > 0, "empty positions");
         (BridgeTypes.Block memory blockValue,) = lightClient.verifyBlock(data);
@@ -181,7 +181,14 @@ contract FungibleBridge is Microchain {
     function _releaseBurn(BridgeTypes.Event memory evt, bytes32 key) private {
         WrappedFungibleTypes.BurnEvent memory burnEvt = WrappedFungibleTypes.bcs_deserialize_BurnEvent(evt.value);
         processedBurns[key] = true;
-        require(token.transfer(address(burnEvt.target), burnEvt.amount), "token transfer failed");
+        _safeTransfer(address(burnEvt.target), burnEvt.amount.value);
+    }
+
+    /// @dev Calls transfer and handles tokens that don't return a boolean.
+    function _safeTransfer(address to, uint256 amount_) internal {
+        (bool success, bytes memory data) =
+            address(token).call(abi.encodeWithSelector(token.transfer.selector, to, amount_));
+        require(success && (data.length == 0 || abi.decode(data, (bool))), "safeTransfer failed");
     }
 
     /// @dev Calls transferFrom and handles tokens that don't return a boolean.

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -32,12 +32,7 @@ contract FungibleBridge is Microchain {
     /// Emitted when a Linera burn is released as an ERC-20 transfer to
     /// `target`. `height` and `eventIndex` together identify the burn in
     /// the source Linera block (matches the on-chain dedup key).
-    event BurnReleased(
-        uint64 indexed height,
-        uint32 indexed eventIndex,
-        address indexed target,
-        uint256 amount
-    );
+    event BurnReleased(uint64 indexed height, uint32 indexed eventIndex, address indexed target, uint256 amount);
 
     // WrappedFungible application ID on Linera,
     // used to identify Burn events in the block stream.

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -187,7 +187,7 @@ contract FungibleBridge is Microchain {
         WrappedFungibleTypes.BurnEvent memory burnEvt = WrappedFungibleTypes.bcs_deserialize_BurnEvent(evt.value);
         processedBurns[key] = true;
         address target = address(burnEvt.target);
-        uint256 amount = burnEvt.amount.value;
+        uint256 amount = burnEvt.amount;
         _safeTransfer(target, amount);
         emit BurnReleased(height, evt.index, target, amount);
     }

--- a/linera-bridge/src/solidity/test/FungibleBridge.t.sol
+++ b/linera-bridge/src/solidity/test/FungibleBridge.t.sol
@@ -149,6 +149,8 @@ function _u32s_single(uint32 a) pure returns (uint32[] memory) {
 // ------------------------------------------------------------------
 
 contract FungibleBridgeProcessBurnsTest is Test {
+    event BurnReleased(uint64 indexed height, uint32 indexed eventIndex, address indexed target, uint256 amount);
+
     // Deploy a bridge backed by `lc`, with a LineraToken that has
     // `supply` tokens pre-minted to the bridge.
     function _deployBridge(address lc, uint256 supply) internal returns (FungibleBridge bridge, LineraToken tok) {
@@ -238,6 +240,23 @@ contract FungibleBridgeProcessBurnsTest is Test {
         uint32[] memory empty = new uint32[](0);
         vm.expectRevert(bytes("empty positions"));
         bridge.processBurns(hex"deadbeef", TX, empty);
+    }
+
+    function test_processBurns_emits_BurnReleased() public {
+        // Settle two burns; each release emits BurnReleased with
+        // (height, evt.index, target, amount). Recipients are
+        // RECIP_0 and RECIP_0+1; stream indices are 5 and 6.
+        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 2, AMOUNT, RECIP_0);
+        (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
+
+        address recip1 = address(uint160(RECIP_0) + 1);
+
+        vm.expectEmit(true, true, true, true, address(bridge));
+        emit BurnReleased(HEIGHT, 5, RECIP_0, AMOUNT);
+        vm.expectEmit(true, true, true, true, address(bridge));
+        emit BurnReleased(HEIGHT, 6, recip1, AMOUNT);
+
+        bridge.processBurns(hex"deadbeef", TX, _u32s(0, 1));
     }
 
     function test_processBurns_partial_overlap_releases_remaining() public {


### PR DESCRIPTION
## Motivation

  Three small hardening / observability changes to `FungibleBridge.sol`:

  - The bridge currently uses bare `token.transfer(...)` to release burns. That breaks for non-bool-returning ERC-20s (USDT, BNB, …) because the `require(token.transfer(...))` decode reverts on empty return data.
  `_safeTransferFrom` already handles this pattern on the deposit side; the release side should match.
  - Burn settlements emit no log, so off-chain consumers (relayer telemetry, indexers, user-facing UIs) have to scan `processedBurns` storage or watch raw ERC-20 `Transfer` events from the bridge address to learn a
   burn settled. Symmetric to `DepositInitiated` on the deposit side, the release path should emit its own typed event.

  ## Proposal

  - `_releaseBurn` now calls a new internal `_safeTransfer(address,uint256)` helper that mirrors the existing `_safeTransferFrom`: raw call into the token, success + (empty-return || abi.decode(bool)) check,
  `"safeTransfer failed"` on revert.
  - New event `BurnReleased(uint64 indexed height, uint32 indexed eventIndex, address indexed target, uint256 amount)`. Emitted from `_releaseBurn` after the safeTransfer succeeds, on both the `addBlock` and
  `processBurns` settlement paths. `height` is threaded through `_releaseBurn(evt, key, height)` since `evt` does not carry it.

  ## Test Plan

  Forge tests on `linera-bridge/src/solidity/` (`forge test --match-path test/FungibleBridge.t.sol` — 14 cases pass):

  - `test_processBurns_emits_BurnReleased` — settles two burns, asserts both `BurnReleased` events with indexed `(height, eventIndex, target)` and `amount`.

  `safeTransfer` change: no existing test or Rust call site pinned `"token transfer failed"`, so the only observable diff is the revert string when a non-conformant token is wired up. Full forge suite: 18/18.

  ## Release Plan

  - These changes should be backported to the `main` branch.

  ## Links

  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)