### PR TITLE
Simplify `communicate_concurrently` to return per-validator errors; log

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -11,7 +11,7 @@ use std::{
 
 use custom_debug_derive::Debug;
 use futures::{
-    future::Future,
+    future::{Future, TryFutureExt as _},
     stream::{self, AbortHandle, FuturesOrdered, FuturesUnordered, StreamExt},
 };
 #[cfg(with_metrics)]
@@ -812,12 +812,6 @@ impl<Env: Environment> Client<Env> {
                         Ok((checked_certificates, unresolved, validator_key))
                     })
                 },
-                |errors| {
-                    errors
-                        .into_iter()
-                        .map(|(validator, _error)| validator)
-                        .collect::<BTreeSet<_>>()
-                },
                 timeout,
             )
             .await;
@@ -836,7 +830,14 @@ impl<Env: Environment> Client<Env> {
                     validators.retain(|node| node.public_key != validator_key);
                     remaining_event_ids = unresolved;
                 }
-                Err(_) => {
+                Err(errors) => {
+                    for (validator, error) in &errors {
+                        warn!(
+                            %validator,
+                            %error,
+                            "failed to download event certificates from validator",
+                        );
+                    }
                     // All validators failed; no point retrying.
                     return Err(NodeError::EventsNotFound(remaining_event_ids).into());
                 }
@@ -1379,18 +1380,24 @@ impl<Env: Environment> Client<Env> {
                     }
                     Ok(certificates_with_check_results)
                 },
-                |errors| {
-                    errors
-                        .into_iter()
-                        .map(|(validator, _error)| validator)
-                        .collect::<BTreeSet<_>>()
-                },
                 self.options.certificate_batch_download_timeout,
             )
             .await
             {
                 Ok(certificates_with_check_results) => certificates_with_check_results,
-                Err(faulty_validators) => {
+                Err(errors) => {
+                    let faulty_validators = errors
+                        .into_iter()
+                        .map(|(validator, error)| {
+                            warn!(
+                                %validator,
+                                %sender_chain_id,
+                                %error,
+                                "failed to download certificates from validator",
+                            );
+                            validator
+                        })
+                        .collect::<BTreeSet<_>>();
                     // filter out faulty validators and retry if any are left
                     nodes.retain(|node| !faulty_validators.contains(&node.public_key));
                     if nodes.is_empty() {
@@ -2068,9 +2075,19 @@ impl<Env: Environment> Client<Env> {
                         .ok_or_else(|| LocalNodeError::BlobsNotFound(vec![blob_id]))?;
                     Result::<_, chain_client::Error>::Ok(blob)
                 },
-                move |_| chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id])),
                 timeout,
             )
+            .map_err(move |errors| {
+                for (validator, error) in &errors {
+                    warn!(
+                        %validator,
+                        %blob_id,
+                        %error,
+                        "failed to download certificate-for-blob from validator",
+                    );
+                }
+                chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id]))
+            })
         }))
         .buffer_unordered(self.options.max_joined_tasks)
         .collect::<Vec<_>>()
@@ -2189,19 +2206,18 @@ impl<'a, Env: Environment> EventSetDownloader<'a, Env> {
     }
 }
 
-/// Performs `f` in parallel on multiple nodes, starting with a quadratically increasing delay on
-/// each subsequent node. Returns error `err` if all of the nodes fail.
-async fn communicate_concurrently<'a, A, E1, E2, F, G, R, V>(
+/// Performs `f` in parallel on multiple nodes, starting with a quadratically increasing delay
+/// on each subsequent node. Returns the first `Ok` result; if all of the nodes fail, returns
+/// the collected `(validator, error)` pairs.
+async fn communicate_concurrently<'a, A, E, F, R, V>(
     nodes: &[RemoteNode<A>],
     f: F,
-    err: G,
     timeout: Duration,
-) -> Result<V, E2>
+) -> Result<V, Vec<(ValidatorPublicKey, E)>>
 where
     F: Clone + FnOnce(RemoteNode<A>) -> R,
     RemoteNode<A>: Clone,
-    G: FnOnce(Vec<(ValidatorPublicKey, E1)>) -> E2,
-    R: Future<Output = Result<V, E1>> + 'a,
+    R: Future<Output = Result<V, E>> + 'a,
 {
     let mut nodes = nodes.to_vec();
     nodes.shuffle(&mut rand::thread_rng());
@@ -2224,7 +2240,7 @@ where
             Err(error) => errors.push(error),
         };
     }
-    Err(err(errors))
+    Err(errors)
 }
 
 /// Wrapper for `AbortHandle` that aborts when its dropped.

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -20,7 +20,7 @@ use linera_base::{
 };
 use linera_chain::types::ConfirmedBlockCertificate;
 use rand::distributions::{Distribution, WeightedIndex};
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use super::{
     cache::{RequestsCache, SubsumingKey},
@@ -314,11 +314,23 @@ impl<Env: Environment> RequestsScheduler<Env> {
                 })
                 .await
             },
-            |errors| errors.last().cloned().unwrap(),
             timeout,
         )
         .await
-        .map_err(|(_validator, error)| error)
+        .map_err(|errors| {
+            for (validator, error) in &errors {
+                warn!(
+                    %validator,
+                    %blob_id,
+                    %error,
+                    "failed to download blob from validator",
+                );
+            }
+            errors
+                .into_iter()
+                .last()
+                .map_or(NodeError::NoValidators, |(_, error)| error)
+        })
     }
 
     /// Downloads the blobs with the given IDs. This is done in one concurrent task per blob.
@@ -400,11 +412,23 @@ impl<Env: Environment> RequestsScheduler<Env> {
                 })
                 .await
             },
-            |errors| errors.last().cloned().unwrap(),
             timeout,
         )
         .await
-        .map_err(|(_validator, error)| error)
+        .map_err(|errors| {
+            for (validator, error) in &errors {
+                warn!(
+                    %validator,
+                    %chain_id,
+                    %error,
+                    "failed to download certificates from validator",
+                );
+            }
+            errors
+                .into_iter()
+                .last()
+                .map_or(NodeError::NoValidators, |(_, error)| error)
+        })
     }
 
     pub async fn download_certificates_by_heights(


### PR DESCRIPTION
## Motivation

In many `communicate_concurrently` call sites, we simply replace the validators' errors with a single new error. This makes it hard to debug the root cause.

## Proposal

Drop the `err` closure parameter. `communicate_concurrently` can only fail when all validators returned an error, so the natural return type is `Result<V, Vec<(ValidatorPublicKey, E)>>` — let each call site own the conversion (and warn-logging) it needs.

This also surfaces an empty-validators case explicitly. The two scheduler sites previously used `errors.last().unwrap()`, which would panic if peers was empty; they now map that to `NodeError::NoValidators`.

Add logging.

## Test Plan

CI

## Release Plan

- We could backport the refactoring to `testnet_conway`, if we prefer it over #6391.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
