### PR TITLE
Require docs on 6 more library crates with #![deny(missing_docs)]

### DIFF
--- a/linera-cache/src/lib.rs
+++ b/linera-cache/src/lib.rs
@@ -27,6 +27,8 @@
 //! The [`Arc`] newtype enforces this structurally: it has no public constructor,
 //! so callers cannot bypass the cache by calling `std::sync::Arc::new` directly.
 
+#![deny(missing_docs)]
+
 mod arc;
 mod unique_value_cache;
 mod value_cache;

--- a/linera-ethereum/src/client.rs
+++ b/linera-ethereum/src/client.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! RPC client traits for querying an Ethereum node.
+
 use std::fmt::Debug;
 
 use alloy::rpc::types::eth::{
@@ -20,6 +22,7 @@ use crate::common::{
 /// A basic RPC client for making JSON queries
 #[async_trait]
 pub trait JsonRpcClient {
+    /// The error type returned by the client's requests.
     type Error: From<serde_json::Error> + From<EthereumQueryError>;
 
     /// The inner function that has to be implemented and access the client
@@ -70,6 +73,7 @@ impl<'a, T> JsonRpcRequest<'a, T> {
     }
 }
 
+/// A JSON-RPC response as returned by an Ethereum node.
 #[derive(Debug, Deserialize)]
 pub struct JsonRpcResponse {
     id: u64,
@@ -81,6 +85,7 @@ pub struct JsonRpcResponse {
 /// gas to be executed.
 #[async_trait]
 pub trait EthereumQueries {
+    /// The error type returned by the queries.
     type Error;
 
     /// Lists all the accounts of the Ethereum node.

--- a/linera-ethereum/src/common.rs
+++ b/linera-ethereum/src/common.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Common types and helpers shared across the crate, including error types and
+//! Ethereum event parsing.
+
 use std::num::ParseIntError;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -12,6 +15,7 @@ use num_traits::cast::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// An error that occurs when validating a JSON-RPC response.
 #[derive(Error, Debug)]
 pub enum EthereumQueryError {
     /// The ID should be matching
@@ -23,6 +27,7 @@ pub enum EthereumQueryError {
     WrongJsonRpcVersion,
 }
 
+/// An error that occurs while accessing or parsing data from an Ethereum node.
 #[derive(Debug, Error)]
 pub enum EthereumServiceError {
     /// The database is not coherent
@@ -33,9 +38,11 @@ pub enum EthereumServiceError {
     #[error(transparent)]
     ParseIntError(#[from] ParseIntError),
 
+    /// Unsupported Ethereum type
     #[error("Unsupported Ethereum type")]
     UnsupportedEthereumTypeError,
 
+    /// Event parsing error
     #[error("Event parsing error")]
     EventParsingError,
 
@@ -83,16 +90,27 @@ pub enum EthereumServiceError {
 /// entries of Ethereum events.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EthereumDataType {
+    /// An Ethereum address, rendered as a hexadecimal string.
     Address(String),
+    /// A 256-bit unsigned integer.
     Uint256(U256),
+    /// A 64-bit unsigned integer.
     Uint64(u64),
+    /// A 64-bit signed integer.
     Int64(i64),
+    /// A 32-bit unsigned integer.
     Uint32(u32),
+    /// A 32-bit signed integer.
     Int32(i32),
+    /// A 16-bit unsigned integer.
     Uint16(u16),
+    /// A 16-bit signed integer.
     Int16(i16),
+    /// An 8-bit unsigned integer.
     Uint8(u8),
+    /// An 8-bit signed integer.
     Int8(i8),
+    /// A boolean.
     Bool(bool),
 }
 
@@ -171,7 +189,9 @@ fn parse_entry(entry: B256, ethereum_type: &str) -> Result<EthereumDataType, Eth
 /// The data type for an Ethereum event emitted by a smart contract
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EthereumEvent {
+    /// The decoded values of the event's parameters.
     pub values: Vec<EthereumDataType>,
+    /// The number of the block in which the event was emitted.
     pub block_number: u64,
 }
 
@@ -186,6 +206,8 @@ fn get_inner_event_type(event_name_expanded: &str) -> Result<String, EthereumSer
     Err(EthereumServiceError::EventParsingError)
 }
 
+/// Parses a `log` into an [`EthereumEvent`] using the expanded event signature
+/// `event_name_expanded` (e.g. `MyEvent(type1 indexed,type2)`).
 pub fn parse_log(
     event_name_expanded: &str,
     log: &Log,

--- a/linera-ethereum/src/lib.rs
+++ b/linera-ethereum/src/lib.rs
@@ -8,6 +8,8 @@
 //! [FOUNDRY]: https://book.getfoundry.sh/
 //! [SOLC]: https://soliditylang.org/
 
+#![deny(missing_docs)]
+
 pub mod client;
 pub mod common;
 

--- a/linera-ethereum/src/provider.rs
+++ b/linera-ethereum/src/provider.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! A simplified JSON-RPC provider for accessing an Ethereum node over HTTP.
+
 use alloy::transports::http::reqwest::{header::CONTENT_TYPE, Client};
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -9,7 +11,9 @@ use crate::{client::JsonRpcClient, common::EthereumServiceError};
 
 /// The Ethereum endpoint and its provider used for accessing the Ethereum node.
 pub struct EthereumClientSimplified {
+    /// The URL of the Ethereum node.
     pub url: String,
+    /// The counter used to generate JSON-RPC request IDs.
     pub id: Mutex<u64>,
 }
 

--- a/linera-ethereum/src/test_utils/mod.rs
+++ b/linera-ethereum/src/test_utils/mod.rs
@@ -36,9 +36,11 @@ sol!(
     "./contracts/EventNumerics.json"
 );
 
+/// An Ethereum client wrapping a configured `alloy` provider, used in tests.
 #[expect(clippy::type_complexity)]
 #[derive(Clone)]
 pub struct EthereumClient {
+    /// The underlying `alloy` provider used to talk to the node.
     pub provider: FillProvider<
         JoinFill<
             JoinFill<
@@ -70,13 +72,19 @@ impl EthereumClient {
     }
 }
 
+/// A running Anvil node together with a client connected to it, for tests.
 pub struct AnvilTest {
+    /// The running Anvil instance.
     pub anvil_instance: AnvilInstance,
+    /// The HTTP endpoint of the Anvil node.
     pub endpoint: String,
+    /// A client connected to the Anvil node.
     pub ethereum_client: EthereumClient,
+    /// The parsed RPC URL of the Anvil node.
     pub rpc_url: Url,
 }
 
+/// Spawns a fresh Anvil node and returns an [`AnvilTest`] connected to it.
 pub async fn get_anvil() -> anyhow::Result<AnvilTest> {
     let port = get_free_port().await?;
     let anvil_instance = Anvil::new().port(port).try_spawn()?;
@@ -92,18 +100,23 @@ pub async fn get_anvil() -> anyhow::Result<AnvilTest> {
 }
 
 impl AnvilTest {
+    /// Returns the Anvil account address at the given `index` as a hexadecimal string.
     pub fn get_address(&self, index: usize) -> String {
         let address = self.anvil_instance.addresses()[index];
         format!("{address:?}")
     }
 }
 
+/// A deployed `SimpleToken` contract together with the Anvil node it lives on.
 pub struct SimpleTokenContractFunction {
+    /// The address of the deployed contract.
     pub contract_address: String,
+    /// The Anvil node hosting the contract.
     pub anvil_test: AnvilTest,
 }
 
 impl SimpleTokenContractFunction {
+    /// Deploys a new `SimpleToken` contract on `anvil_test` and returns a handle to it.
     pub async fn new(anvil_test: AnvilTest) -> anyhow::Result<Self> {
         // 2: initializing the contract
         let initial_supply = U256::from(1000);
@@ -118,6 +131,7 @@ impl SimpleTokenContractFunction {
         })
     }
 
+    /// Returns the token balance of address `to` at the given `block`.
     // Only the balanceOf operation is of interest for this contract
     pub async fn balance_of(&self, to: &str, block: u64) -> anyhow::Result<U256> {
         // Getting the simple_token
@@ -143,6 +157,7 @@ impl SimpleTokenContractFunction {
         Ok(balance)
     }
 
+    /// Transfers `value` tokens from address `from` to address `to`.
     pub async fn transfer(&self, from: &str, to: &str, value: U256) -> anyhow::Result<()> {
         // Getting the simple_token
         let contract_address = self.contract_address.parse::<Address>()?;
@@ -159,12 +174,16 @@ impl SimpleTokenContractFunction {
     }
 }
 
+/// A deployed `EventNumerics` contract together with the Anvil node it lives on.
 pub struct EventNumericsContractFunction {
+    /// The address of the deployed contract.
     pub contract_address: String,
+    /// The Anvil node hosting the contract.
     pub anvil_test: AnvilTest,
 }
 
 impl EventNumericsContractFunction {
+    /// Deploys a new `EventNumerics` contract on `anvil_test` and returns a handle to it.
     pub async fn new(anvil_test: AnvilTest) -> anyhow::Result<Self> {
         // Deploying the event numerics contract
         let initial_supply = U256::from(0);

--- a/linera-service-graphql-client/src/lib.rs
+++ b/linera-service-graphql-client/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! A GraphQL client for the node service.
 
+#![deny(missing_docs)]
+
 mod service;
 pub mod utils;
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -8,6 +8,9 @@
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap
 )]
+// The `GraphQLQuery` derives and the `pub use types::*` re-exports generate
+// public items that cannot carry doc comments.
+#![expect(missing_docs)]
 
 use graphql_client::GraphQLQuery;
 use linera_base::{
@@ -17,6 +20,7 @@ use linera_base::{
 };
 use thiserror::Error;
 
+/// The GraphQL `JSONObject` scalar, represented as an arbitrary JSON value.
 pub type JSONObject = serde_json::Value;
 
 #[cfg(target_arch = "wasm32")]
@@ -92,8 +96,10 @@ mod types {
 }
 
 pub use types::*;
+/// The GraphQL representation of an application ID, as a string.
 pub type ApplicationId = String;
 
+/// GraphQL query for a single chain.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/service_schema.graphql",
@@ -102,6 +108,7 @@ pub type ApplicationId = String;
 )]
 pub struct Chain;
 
+/// GraphQL query for the list of chains.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/service_schema.graphql",
@@ -110,6 +117,7 @@ pub struct Chain;
 )]
 pub struct Chains;
 
+/// GraphQL query for the applications on a chain.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/service_schema.graphql",
@@ -118,6 +126,7 @@ pub struct Chains;
 )]
 pub struct Applications;
 
+/// GraphQL query for a range of blocks.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/service_schema.graphql",
@@ -126,6 +135,7 @@ pub struct Applications;
 )]
 pub struct Blocks;
 
+/// GraphQL query for a single block.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/service_schema.graphql",
@@ -134,6 +144,7 @@ pub struct Blocks;
 )]
 pub struct Block;
 
+/// GraphQL subscription for node notifications.
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/service_schema.graphql",
@@ -150,10 +161,13 @@ pub struct Notifications;
 )]
 pub struct Transfer;
 
+/// An error that occurs while converting GraphQL responses into native types.
 #[derive(Error, Debug)]
 pub enum ConversionError {
+    /// A `serde_json` error.
     #[error(transparent)]
     Serde(#[from] serde_json::Error),
+    /// The response contained an unexpected or unknown certificate type.
     #[error("Unexpected certificate type: {0}")]
     UnexpectedCertificateType(String),
 }

--- a/linera-service-graphql-client/src/utils.rs
+++ b/linera-service-graphql-client/src/utils.rs
@@ -1,14 +1,19 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Helpers for sending GraphQL requests to the node service.
+
 use graphql_client::{reqwest::post_graphql, GraphQLQuery};
 use reqwest::Client;
 use thiserror::Error;
 
+/// An error that occurs while performing a GraphQL request.
 #[derive(Error, Debug)]
 pub enum Error {
+    /// An HTTP transport error from `reqwest`.
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
+    /// The response contained GraphQL errors.
     #[error("GraphQL errors: {0:?}")]
     GraphQLError(Vec<graphql_client::Error>),
 }
@@ -19,6 +24,8 @@ impl From<Option<Vec<graphql_client::Error>>> for Error {
     }
 }
 
+/// Sends the GraphQL query `T` with the given `variables` to `url` and returns
+/// its response data.
 pub async fn request<T, V>(
     client: &Client,
     url: &str,

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -4,6 +4,8 @@
 use linera_storage::{StorageCacheConfig, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_views::lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig;
 
+/// Command-line options shared by all storage backends, controlling concurrency
+/// limits and cache sizes.
 #[derive(Clone, Debug, clap::Parser)]
 pub struct CommonStorageOptions {
     /// The maximal number of simultaneous queries to the database
@@ -76,11 +78,13 @@ pub struct CommonStorageOptions {
 }
 
 impl CommonStorageOptions {
+    /// Returns the options with their default values.
     pub fn with_defaults() -> Self {
         use clap::Parser as _;
         Self::parse_from(std::iter::empty::<String>())
     }
 
+    /// Builds the storage cache configuration from these options.
     pub fn storage_cache_config(&self) -> StorageCacheConfig {
         StorageCacheConfig {
             blob_cache_size: self.blob_cache_size,
@@ -92,6 +96,7 @@ impl CommonStorageOptions {
         }
     }
 
+    /// Builds the views storage cache configuration from these options.
     pub fn views_storage_cache_config(&self) -> ViewsStorageCacheConfig {
         ViewsStorageCacheConfig {
             max_cache_size: self.storage_max_cache_size,

--- a/linera-storage-runtime/src/lib.rs
+++ b/linera-storage-runtime/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Storage configuration and runtime infrastructure for the Linera protocol.
 
+#![deny(missing_docs)]
+
 mod common_options;
 mod storage_config;
 mod store_config;

--- a/linera-storage-runtime/src/storage_config.rs
+++ b/linera-storage-runtime/src/storage_config.rs
@@ -45,6 +45,7 @@ pub enum InnerStorageConfig {
         /// The URI for accessing the database.
         uri: String,
     },
+    /// The dual RocksDB / ScyllaDB description.
     #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
     DualRocksDbScyllaDb {
         /// The path used.
@@ -279,6 +280,7 @@ example service:tcp:127.0.0.1:7878:table_do_my_test"
 }
 
 impl StorageConfig {
+    /// Appends a shard-specific subdirectory to the storage path, if applicable.
     #[allow(unused_variables)]
     pub fn maybe_append_shard_path(&mut self, shard: usize) -> std::io::Result<()> {
         match &mut self.inner_storage_config {

--- a/linera-storage-runtime/src/store_config.rs
+++ b/linera-storage-runtime/src/store_config.rs
@@ -27,51 +27,69 @@ use {linera_storage::ChainStatesFirstAssignment, linera_views::backends::dual::D
 pub enum StoreConfig {
     /// The memory key value store
     Memory {
+        /// The store configuration.
         config: linera_views::memory::MemoryStoreConfig,
+        /// The namespace used.
         namespace: String,
+        /// The path to the genesis configuration used to initialize the store.
         genesis_path: PathBuf,
     },
     /// The storage service key-value store
     #[cfg(feature = "storage-service")]
     StorageService {
+        /// The store configuration.
         config: linera_storage_service::common::StorageServiceStoreConfig,
+        /// The namespace used.
         namespace: String,
     },
     /// The RocksDB key value store
     #[cfg(feature = "rocksdb")]
     RocksDb {
+        /// The store configuration.
         config: linera_views::rocks_db::RocksDbStoreConfig,
+        /// The namespace used.
         namespace: String,
     },
     /// The ScyllaDB key value store
     #[cfg(feature = "scylladb")]
     ScyllaDb {
+        /// The store configuration.
         config: linera_views::scylla_db::ScyllaDbStoreConfig,
+        /// The namespace used.
         namespace: String,
     },
+    /// The dual RocksDB / ScyllaDB key value store
     #[cfg(all(feature = "rocksdb", feature = "scylladb"))]
     DualRocksDbScyllaDb {
+        /// The store configuration.
         config: linera_views::backends::dual::DualStoreConfig<
             linera_views::rocks_db::RocksDbStoreConfig,
             linera_views::scylla_db::ScyllaDbStoreConfig,
         >,
+        /// The namespace used.
         namespace: String,
     },
 }
 
+/// A job that can be run against a high-level [`Storage`].
 #[async_trait]
 pub trait Runnable {
+    /// The type produced by running the job.
     type Output;
 
+    /// Runs the job against the given `storage`.
     async fn run<S>(self, storage: S) -> Self::Output
     where
         S: Storage + Clone + Send + Sync + 'static;
 }
 
+/// A job that can be run against a low-level key-value store.
 #[async_trait]
 pub trait RunnableWithStore {
+    /// The type produced by running the job.
     type Output;
 
+    /// Runs the job against a store built from the given configuration.
     async fn run<D>(
         self,
         config: D::Config,
@@ -90,6 +108,7 @@ fn read_json<T: serde::de::DeserializeOwned>(path: impl Into<PathBuf>) -> anyhow
 }
 
 impl StoreConfig {
+    /// Connects to the configured storage and runs the given [`Runnable`] job against it.
     pub async fn run_with_storage<Job>(
         self,
         wasm_runtime: Option<WasmRuntime>,
@@ -169,6 +188,8 @@ impl StoreConfig {
         }
     }
 
+    /// Connects to the configured key-value store and runs the given
+    /// [`RunnableWithStore`] job against it.
     #[allow(unused_variables)]
     pub async fn run_with_store<Job>(
         self,
@@ -206,6 +227,7 @@ impl StoreConfig {
     }
 }
 
+/// A [`RunnableWithStore`] job that migrates the storage schema.
 pub struct StorageMigration;
 
 #[async_trait]
@@ -228,6 +250,7 @@ impl RunnableWithStore for StorageMigration {
     }
 }
 
+/// A [`RunnableWithStore`] job that asserts the storage is at schema version 1.
 pub struct AssertStorageV1;
 
 #[async_trait]

--- a/linera-summary/src/ci_runtime_comparison.rs
+++ b/linera-summary/src/ci_runtime_comparison.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Comparison of per-job CI runtimes between a PR and its base branch.
+
 use std::collections::BTreeMap;
 
 use anyhow::{ensure, Result};
@@ -10,6 +12,7 @@ use tracing::warn;
 
 type WorkflowName = String;
 
+/// The runtime comparison for a single CI job between the base branch and the PR.
 #[derive(Serialize)]
 pub struct WorkflowJobRuntimeComparison {
     name: String,
@@ -20,30 +23,38 @@ pub struct WorkflowJobRuntimeComparison {
 }
 
 impl WorkflowJobRuntimeComparison {
+    /// Returns the job name.
     pub fn name(&self) -> &str {
         &self.name
     }
 
+    /// Returns the name of the workflow the job belongs to.
     pub fn workflow_name(&self) -> &str {
         &self.workflow_name
     }
 
+    /// Returns the job's runtime on the base branch, in seconds.
     pub fn base_runtime(&self) -> u64 {
         self.base_runtime
     }
 
+    /// Returns the job's runtime on the PR, in seconds.
     pub fn pr_runtime(&self) -> u64 {
         self.pr_runtime
     }
 
+    /// Returns the PR runtime relative to the base, as a percentage difference.
     pub fn runtime_difference_pct(&self) -> f64 {
         self.runtime_difference_pct
     }
 }
 
-// The key is the name of the workflow, and the value is a list of per job comparisons.
+/// Per-job runtime comparisons, keyed by workflow name.
 #[derive(Serialize)]
-pub struct CiRuntimeComparison(pub BTreeMap<WorkflowName, Vec<WorkflowJobRuntimeComparison>>);
+pub struct CiRuntimeComparison(
+    /// The comparisons for each workflow's jobs, keyed by workflow name.
+    pub BTreeMap<WorkflowName, Vec<WorkflowJobRuntimeComparison>>,
+);
 
 impl CiRuntimeComparison {
     fn get_runtimes(jobs: Vec<Job>) -> Result<BTreeMap<String, BTreeMap<String, u64>>> {
@@ -66,6 +77,8 @@ impl CiRuntimeComparison {
         Ok(runtimes)
     }
 
+    /// Builds the comparison from the base-branch jobs and the PR jobs, matching them by
+    /// workflow and job name.
     pub fn from_jobs(base_jobs: Vec<Job>, pr_jobs: Vec<Job>) -> Result<Self> {
         let base_runtimes = Self::get_runtimes(base_jobs)?;
         let pr_runtimes = Self::get_runtimes(pr_jobs)?;

--- a/linera-summary/src/github.rs
+++ b/linera-summary/src/github.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! GitHub access: resolving the repository and PR context, and querying workflow runs and jobs.
+
 use std::env;
 
 use anyhow::{anyhow, Context, Result};
@@ -17,16 +19,19 @@ use crate::performance_summary::PR_COMMENT_HEADER;
 const API_REQUEST_DELAY_MS: u64 = 100;
 const IGNORED_JOB_PREFIXES: &[&str] = &["lint-", "check-outdated-cli-md"];
 
+/// A GitHub repository, identified by its owner and name.
 pub struct GithubRepository {
     owner: String,
     name: String,
 }
 
 impl GithubRepository {
+    /// Returns the repository owner.
     pub fn owner(&self) -> &str {
         &self.owner
     }
 
+    /// Returns the repository name.
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -48,6 +53,7 @@ impl GithubRepository {
     }
 }
 
+/// The GitHub context for the PR being analyzed: repository, branches, commit and PR number.
 pub struct GithubContext {
     repository: GithubRepository,
     pr_commit_hash: String,
@@ -57,18 +63,22 @@ pub struct GithubContext {
 }
 
 impl GithubContext {
+    /// Returns the base branch the PR is targeting.
     pub fn base_branch(&self) -> &str {
         &self.base_branch
     }
 
+    /// Returns the PR's head branch.
     pub fn pr_branch(&self) -> &str {
         &self.pr_branch
     }
 
+    /// Returns the commit hash at the PR's head.
     pub fn pr_commit_hash(&self) -> &str {
         &self.pr_commit_hash
     }
 
+    /// Returns the repository the PR belongs to.
     pub fn repository(&self) -> &GithubRepository {
         &self.repository
     }
@@ -135,6 +145,7 @@ impl GithubContext {
     }
 }
 
+/// A GitHub client bound to a PR context, used to query workflow runs/jobs and post comments.
 pub struct Github {
     octocrab: Octocrab,
     context: GithubContext,
@@ -142,6 +153,7 @@ pub struct Github {
 }
 
 impl Github {
+    /// Builds a client from the environment, in local or CI mode, for the given PR number.
     pub fn new(is_local: bool, pr_number: Option<u64>) -> Result<Self> {
         let octocrab_builder = Octocrab::builder();
         let octocrab =
@@ -162,11 +174,12 @@ impl Github {
         })
     }
 
+    /// Returns the PR context this client is bound to.
     pub fn context(&self) -> &GithubContext {
         &self.context
     }
 
-    // Updates an existing comment or creates a new one in the PR.
+    /// Updates the tool's existing summary comment on the PR, or creates one if absent.
     pub async fn upsert_pr_comment(&self, body: String) -> Result<()> {
         let issue_handler = self.octocrab.issues(
             self.context.repository.owner.clone(),
@@ -268,6 +281,8 @@ impl Github {
         Ok(latest_runs)
     }
 
+    /// Returns the jobs of the latest successful run of each workflow on `branch` for `event`,
+    /// excluding jobs with ignored name prefixes.
     pub async fn latest_jobs(
         &self,
         branch: &str,
@@ -310,6 +325,7 @@ impl Github {
         Ok(jobs_filtered)
     }
 
+    /// Returns a workflows handler scoped to this client's repository.
     pub fn workflows_handler(&self) -> WorkflowsHandler<'_> {
         self.octocrab.workflows(
             self.context.repository.owner.clone(),
@@ -317,6 +333,7 @@ impl Github {
         )
     }
 
+    /// Lists all workflows defined in the repository.
     pub async fn workflows(
         &self,
         workflows_handler: &WorkflowsHandler<'_>,

--- a/linera-summary/src/lib.rs
+++ b/linera-summary/src/lib.rs
@@ -3,7 +3,7 @@
 
 //! This crate provides the internal tool to summarize performance changes in PRs.
 
-#![allow(missing_docs)]
+#![deny(missing_docs)]
 
 pub mod ci_runtime_comparison;
 pub mod github;

--- a/linera-summary/src/performance_summary.rs
+++ b/linera-summary/src/performance_summary.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Building the performance summary and rendering it as a PR comment.
+
 use std::{collections::HashSet, time::Duration};
 
 use anyhow::{bail, Result};
@@ -9,8 +11,10 @@ use serde::Serialize;
 
 use crate::{ci_runtime_comparison::CiRuntimeComparison, github::Github};
 
+/// The Markdown header that identifies the tool's PR comment so it can be found and updated.
 pub const PR_COMMENT_HEADER: &str = "## Performance Summary for commit";
 
+/// A performance summary for a PR: the CI runtime comparison plus the GitHub client to post it.
 #[derive(Serialize)]
 pub struct PerformanceSummary {
     #[serde(skip_serializing)]
@@ -19,6 +23,8 @@ pub struct PerformanceSummary {
 }
 
 impl PerformanceSummary {
+    /// Fetches the latest base-branch and PR jobs for the tracked workflows and builds the
+    /// runtime comparison.
     pub async fn init(github: Github, tracked_workflows: HashSet<String>) -> Result<Self> {
         let workflows_handler = github.workflows_handler();
         let workflows = github
@@ -97,7 +103,7 @@ impl PerformanceSummary {
         markdown_content
     }
 
-    // Updates an existing comment or creates a new one in the PR.
+    /// Renders the summary as Markdown and posts it to the PR, updating any existing comment.
     pub async fn upsert_pr_comment(&self) -> Result<()> {
         self.github
             .upsert_pr_comment(self.format_comment_body())

--- a/linera-summary/src/summary_options.rs
+++ b/linera-summary/src/summary_options.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Command-line options for the performance-summary tool.
+
 use std::collections::HashSet;
 
 use linera_version::VersionInfo;
@@ -11,6 +13,7 @@ use linera_version::VersionInfo;
     version = VersionInfo::default_clap_str(),
     about = "Executable for performance summary generation.",
 )]
+/// Parsed command-line options for the `linera-summary` executable.
 pub struct SummaryOptions {
     #[command(subcommand)]
     command: Command,
@@ -33,14 +36,18 @@ enum Command {
 }
 
 impl SummaryOptions {
+    /// Parses the options from the process command-line arguments.
     pub fn init() -> Self {
         <SummaryOptions as clap::Parser>::parse()
     }
 
+    /// Returns whether the tool is running in local mode (printing to stdout instead of
+    /// commenting on the PR).
     pub fn is_local(&self) -> bool {
         matches!(self.command, Command::Local { .. })
     }
 
+    /// Returns the PR number to analyze in local mode, or `None` in CI mode.
     pub fn pr_number(&self) -> Option<u64> {
         match self.command {
             Command::Local { pr } => Some(pr),
@@ -48,6 +55,7 @@ impl SummaryOptions {
         }
     }
 
+    /// Returns the set of workflow names to track.
     pub fn workflows(&self) -> HashSet<String> {
         self.workflows.split(',').map(str::to_string).collect()
     }

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! The procedural macros for the crate `linera-views`.
 
+#![deny(missing_docs)]
 #![allow(clippy::cast_possible_truncation)]
 
 use proc_macro::TokenStream;
@@ -459,6 +460,7 @@ fn to_token_stream(input: Result<TokenStream2, Error>) -> TokenStream {
     }
 }
 
+/// Derives the `View` trait for a struct whose fields are themselves views.
 #[proc_macro_derive(View, attributes(view))]
 pub fn derive_view(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -472,6 +474,7 @@ fn derive_hash_view_token_stream2(input: &ItemStruct) -> Result<TokenStream2, Er
     Ok(stream)
 }
 
+/// Derives the `View` and `HashableView` traits for a struct.
 #[proc_macro_derive(HashableView, attributes(view))]
 pub fn derive_hash_view(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -486,6 +489,7 @@ fn derive_root_view_token_stream2(input: &ItemStruct) -> Result<TokenStream2, Er
     Ok(stream)
 }
 
+/// Derives the `View` and `RootView` traits for a struct.
 #[proc_macro_derive(RootView, attributes(view))]
 pub fn derive_root_view(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -501,6 +505,7 @@ fn derive_crypto_hash_view_token_stream2(input: &ItemStruct) -> Result<TokenStre
     Ok(stream)
 }
 
+/// Derives the `View`, `HashableView` and `CryptoHashView` traits for a struct.
 #[proc_macro_derive(CryptoHashView, attributes(view))]
 pub fn derive_crypto_hash_view(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -517,6 +522,7 @@ fn derive_crypto_hash_root_view_token_stream2(input: &ItemStruct) -> Result<Toke
     Ok(stream)
 }
 
+/// Derives the `View`, `RootView`, `HashableView` and `CryptoHashView` traits for a struct.
 #[proc_macro_derive(CryptoHashRootView, attributes(view))]
 pub fn derive_crypto_hash_root_view(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -533,6 +539,7 @@ fn derive_hashable_root_view_token_stream2(input: &ItemStruct) -> Result<TokenSt
     Ok(stream)
 }
 
+/// Derives the `View`, `RootView` and `HashableView` traits for a struct (used in tests).
 #[proc_macro_derive(HashableRootView, attributes(view))]
 #[cfg(test)]
 pub fn derive_hashable_root_view(input: TokenStream) -> TokenStream {
@@ -542,6 +549,7 @@ pub fn derive_hashable_root_view(input: TokenStream) -> TokenStream {
     to_token_stream(stream)
 }
 
+/// Derives the `ClonableView` trait for a struct whose fields are clonable views.
 #[proc_macro_derive(ClonableView, attributes(view))]
 pub fn derive_clonable_view(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -552,7 +560,7 @@ pub fn derive_clonable_view(input: TokenStream) -> TokenStream {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
 
     use quote::quote;
     use syn::{parse_quote, AngleBracketedGenericArguments};


### PR DESCRIPTION
## Motivation

Second batch of the effort to require documentation on the library crates of the main
workspace via `#![deny(missing_docs)]` (follows #6395 / #6396). Mirrored on `testnet_conway`
(see Links) to keep the branches in sync and ease backports.

## Proposal

Add `#![deny(missing_docs)]` and document every public item in six more library crates:

- `linera-summary` (flips its existing `#![allow(missing_docs)]` to `deny`)
- `linera-ethereum`
- `linera-cache`
- `linera-views-derive`
- `linera-storage-runtime`
- `linera-service-graphql-client`

Generated public items that cannot carry doc comments are exempted narrowly with a
documented module-level `#![expect(missing_docs)]` (`expect` flags the exemption if the
generated code ever stops producing undocumented items): `linera-service-graphql-client`'s
`#[derive(GraphQLQuery)]` bindings in `service.rs`. (`linera-ethereum`'s `sol!`-generated
code already carries its own `#[allow(missing_docs)]`.)

One non-doc change: `linera-views-derive`'s `#[cfg(test)] pub mod tests` becomes a private
`mod tests` (the `pub` was gratuitous and tripped `missing_docs` under `--all-targets`).

## Test Plan

For each crate: `cargo check -p <crate> --all-features --all-targets` is clean under the new
lint, and `cargo +nightly fmt -p <crate> -- --check` passes.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- testnet_conway counterpart: (to be linked)
- previous batch: #6395
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
