### PR TITLE
Fix e2e bridge tests.

### DIFF
--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -462,7 +462,7 @@ where
     chain_client.synchronize_from_validators().await?;
     chain_client.process_inbox().await?;
 
-    let initial_balance = U128(initial_balance_tokens * 10u128.pow(18));
+    let initial_balance = U128(initial_balance_tokens);
     let (fungible_app_id, _) = chain_client
         .create_application_untyped(
             wf_module_id,

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -125,7 +125,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     // (`SYNTHETIC_APP_ID_BYTES32`) below so `_onBlock` rejects every
     // burn event the relayer forwards.
     let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
     let real_app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     assert_ne!(
         real_app_id_bytes32, SYNTHETIC_APP_ID_BYTES32,

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -40,11 +40,10 @@ sol! {
 /// constraint.
 const MAX_SEARCH_N: u32 = 1000;
 
-/// Chain-B pre-funded balance: enough wrapped-fungible to issue
-/// `MAX_SEARCH_N * doubling_plus_bisect_iterations * BURN_AMOUNT_TOKENS`
-/// `Transfer` ops. Sized well above the worst case so the test never
-/// runs out of source-chain balance regardless of `BURN_AMOUNT_TOKENS`.
-const INITIAL_BALANCE_TOKENS: u128 = 10u128.pow(32);
+/// Chain-B pre-funded balance in raw ERC-20 sub-units. Worst-case burn
+/// total is `MAX_SEARCH_N * ~10 iterations * BURN_AMOUNT_TOKENS * 10^18`
+/// ≈ 10^37 raw; 10^38 gives 10× headroom and still fits in `u128`.
+const INITIAL_BALANCE_TOKENS: u128 = 10u128.pow(38);
 
 /// Each burn moves exactly this many wrapped-fungible tokens to a fresh
 /// `Address20`. Constant token amount keeps per-burn EVM gas constant

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -126,7 +126,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
     let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
 
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -108,7 +108,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
 
     let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
 
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -116,7 +116,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
 
     let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
 
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");


### PR DESCRIPTION
## Motivation

Bridge e2e tests are failing. The `U128` migration removed the `Amount` scaling but kept the `* 10^18`
multiplication in the helper, causing a `u128` overflow panic at runtime when `INITIAL_BALANCE_TOKENS = 10^32`.

## Proposal

- lib.rs: drop the * 10^18; callers now pass raw sub-units directly
- burns_per_evm_tx: INITIAL_BALANCE_TOKENS → 10^38 raw (10× headroom over the ~10^37 raw worst-case burn total; fits in u128)
- four test callers: 1_000 → 1_000 * 10^18 to preserve 1000-token initial balance semantics

## Test Plan

CI

## Release Plan

- None.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
