### PR TITLE
[testnet] Only preprocess sender blocks, even if contiguous (#6328)

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -20,7 +20,7 @@ mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 
-pub use chain::ChainStateView;
+pub use chain::{ChainStateView, ChainTipState};
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -8,8 +8,8 @@ mod delivery_notifier;
 pub(crate) mod handle;
 pub(crate) mod state;
 
-pub use self::config::ChainWorkerConfig;
 pub(super) use self::delivery_notifier::DeliveryNotifier;
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::state::{BlockOutcome, CrossChainUpdateResult, EventSubscriptionsResult};
+pub use self::{config::ChainWorkerConfig, state::ProcessConfirmedBlockMode};

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -31,7 +31,7 @@ use linera_chain::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
         ValidatedBlockCertificate,
     },
-    ChainError, ChainExecutionContext, ChainStateView, ExecutionResultExt as _,
+    ChainError, ChainExecutionContext, ChainStateView, ChainTipState, ExecutionResultExt as _,
 };
 use linera_execution::{
     system::EventSubscriptions, ExecutionRuntimeContext as _, ExecutionStateView, Query,
@@ -133,6 +133,23 @@ pub enum BlockOutcome {
     Processed,
     Preprocessed,
     Skipped,
+}
+
+/// How to handle a confirmed block.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProcessConfirmedBlockMode {
+    /// Execute the block if it is contiguous (or bridgeable via a checkpoint);
+    /// otherwise preprocess it. Used by validators and by any caller that
+    /// wants graceful fallback when there's a gap.
+    Auto,
+    /// Execute the block. Fail with [`WorkerError::InvalidBlockChaining`] if
+    /// there's a gap that can't be bridged. Use when the caller knows the
+    /// block must be contiguous and wants a hard error otherwise.
+    Execute,
+    /// Only preprocess the block, never execute it — even if it would be
+    /// contiguous. Used by the client for sender-chain blocks it is not
+    /// otherwise tracking, since their execution state is irrelevant.
+    Preprocess,
 }
 
 impl<StorageClient> ChainWorkerState<StorageClient>
@@ -783,10 +800,10 @@ where
     pub(crate) async fn process_confirmed_block(
         &mut self,
         certificate: ConfirmedBlockCertificate,
+        mode: ProcessConfirmedBlockMode,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
         let block = certificate.block();
-        let block_hash = certificate.hash();
         let height = block.header.height;
         let chain_id = block.header.chain_id;
 
@@ -852,42 +869,86 @@ where
             .maybe_write_blob_states(&blob_ids, blob_state)
             .await?;
 
-        let mut blobs = blobs_result?
+        let blobs = blobs_result?
             .into_iter()
             .map(|blob| (blob.id(), blob))
             .collect::<BTreeMap<_, _>>();
 
-        // If this block is higher than the next expected block in this chain, we're going
-        // to have a gap: do not execute this block, only update the outboxes and return.
-        if tip.next_block_height < height {
-            // Initialize next_expected_events for any streams that don't have entries yet.
-            if block.body.events.iter().any(|events| !events.is_empty()) {
-                self.initialize_next_expected_events().await?;
+        // Dispatch on mode + whether there's a gap:
+        //  - `Preprocess` mode, or `Auto` with a gap: preprocess.
+        //  - `Execute` mode with a gap: error.
+        //  - `Auto`/`Execute` mode + contiguous: execute directly.
+        use ProcessConfirmedBlockMode::{Auto, Execute, Preprocess};
+        let gap = tip.next_block_height < height;
+        match (mode, gap) {
+            (Preprocess, _) | (Auto, true) => {
+                self.preprocess_certified_block(certificate, notify_when_messages_are_delivered)
+                    .await
             }
-            // Update the outboxes and track emitted events.
-            let event_streams = self.chain.preprocess_block(certificate.value()).await?;
-            // Persist chain.
-            self.save().await?;
-            let mut actions = self.create_network_actions(None).await?;
-            if !event_streams.is_empty() {
-                actions.notifications.push(Notification {
-                    chain_id,
-                    reason: Reason::NewEvents {
-                        height,
-                        hash: block_hash,
-                        event_streams,
-                    },
-                });
+            (Execute, true) => Err(WorkerError::InvalidBlockChaining),
+            (Auto | Execute, false) => {
+                self.execute_contiguous_block(
+                    certificate,
+                    blobs,
+                    tip,
+                    notify_when_messages_are_delivered,
+                )
+                .await
             }
-            trace!("Preprocessed confirmed block {height}");
-            self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
-                .await;
-            return Ok((
-                self.chain_info_response().await?,
-                actions,
-                BlockOutcome::Preprocessed,
-            ));
         }
+    }
+
+    /// Preprocesses a confirmed block: updates outboxes and event streams without
+    /// executing it, and does not advance the chain tip.
+    async fn preprocess_certified_block(
+        &mut self,
+        certificate: ConfirmedBlockCertificate,
+        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
+    ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+        let block_hash = certificate.hash();
+        let block = certificate.block();
+        let chain_id = block.header.chain_id;
+        let height = block.header.height;
+
+        if block.body.events.iter().any(|events| !events.is_empty()) {
+            self.initialize_next_expected_events().await?;
+        }
+        let updated_event_streams = self.chain.preprocess_block(certificate.value()).await?;
+        self.save().await?;
+        let mut actions = self.create_network_actions(None).await?;
+        if !updated_event_streams.is_empty() {
+            actions.notifications.push(Notification {
+                chain_id,
+                reason: Reason::NewEvents {
+                    height,
+                    hash: block_hash,
+                    event_streams: updated_event_streams,
+                },
+            });
+        }
+        trace!("Preprocessed confirmed block {height}");
+        self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
+            .await;
+        Ok((
+            self.chain_info_response().await?,
+            actions,
+            BlockOutcome::Preprocessed,
+        ))
+    }
+
+    /// Executes a confirmed block whose height equals `tip.next_block_height`,
+    /// updating inboxes, applying the block, and persisting the chain.
+    async fn execute_contiguous_block(
+        &mut self,
+        certificate: ConfirmedBlockCertificate,
+        mut blobs: BTreeMap<BlobId, Blob>,
+        tip: ChainTipState,
+        notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
+    ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+        let block_hash = certificate.hash();
+        let block = certificate.block();
+        let chain_id = block.header.chain_id;
+        let height = block.header.height;
 
         // This should always be true for valid certificates.
         ensure!(
@@ -895,9 +956,8 @@ where
             WorkerError::InvalidBlockChaining
         );
 
-        // If we got here, `height` is equal to `tip.next_block_height` and the block is
-        // properly chained. Verify that the chain is active and that the epoch we used for
-        // verifying the certificate is actually the active one on the chain.
+        // Verify that the chain is active and that the epoch we used for verifying
+        // the certificate is actually the active one on the chain.
         self.initialize_and_save_if_needed().await?;
         let (epoch, _) = self.chain.current_committee().await?;
         check_block_epoch(epoch, chain_id, block.header.epoch)?;
@@ -913,7 +973,6 @@ where
             self.initialize_next_expected_events().await?;
         }
 
-        // Execute the block and update inboxes.
         let local_time = self.storage.clock().current_time();
         if block.header.timestamp.duration_since(local_time) > self.config.block_time_grace_period {
             warn!(
@@ -969,7 +1028,6 @@ where
             ConfirmedBlock::new(Block::new(proposed_block, verified))
         };
 
-        // Update the rest of the chain state.
         let event_streams = chain
             .apply_confirmed_block(&confirmed_block, local_time)
             .await?;
@@ -994,7 +1052,6 @@ where
                 },
             });
         }
-        // Persist chain.
         self.save().await?;
 
         self.block_values
@@ -1415,7 +1472,8 @@ where
                 .await?
                 .map(CacheArc::unwrap_or_clone)
                 .ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
-            Box::pin(self.process_confirmed_block(cert, None)).await?;
+            Box::pin(self.process_confirmed_block(cert, ProcessConfirmedBlockMode::Execute, None))
+                .await?;
         }
         for (height, hash) in preprocessed {
             let cert = self
@@ -1424,7 +1482,12 @@ where
                 .await?
                 .map(CacheArc::unwrap_or_clone)
                 .ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
-            Box::pin(self.process_confirmed_block(cert, None)).await?;
+            Box::pin(self.process_confirmed_block(
+                cert,
+                ProcessConfirmedBlockMode::Preprocess,
+                None,
+            ))
+            .await?;
         }
 
         // 5. Restore any previously cast votes and locking block so we cannot be

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2647,12 +2647,12 @@ impl<Env: Environment> ChainClient<Env> {
         .await?
         .try_map(|certificate| {
             // The first message of the only operation created the application.
-            let mut creation: Vec<_> = certificate
+            let mut creation = certificate
                 .block()
                 .created_blob_ids()
                 .into_iter()
                 .filter(|blob_id| blob_id.blob_type == BlobType::ApplicationDescription)
-                .collect();
+                .collect::<Vec<_>>();
             if creation.len() > 1 {
                 return Err(Error::InternalError(
                     "Unexpected number of application descriptions published",
@@ -3203,11 +3203,11 @@ impl<Env: Environment> ChainClient<Env> {
             } else {
                 self.local_committee().await?
             };
-            let nodes: HashMap<_, _> = self
+            let nodes = self
                 .client
                 .validator_node_provider()
                 .make_nodes(&committee)?
-                .collect();
+                .collect::<HashMap<_, _>>();
             (nodes, self.client.local_node.clone())
         };
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -53,7 +53,7 @@ use crate::{
     remote_node::RemoteNode,
     updater::{communicate_with_quorum, CommunicateAction, ValidatorUpdater},
     worker::{Notification, ProcessableCertificate, Reason, WorkerError, WorkerState},
-    ChainWorkerConfig, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    ChainWorkerConfig, ProcessConfirmedBlockMode, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
 pub mod chain_client;
@@ -235,6 +235,15 @@ impl ListeningMode {
     pub fn is_full(&self) -> bool {
         matches!(self, ListeningMode::FullChain)
     }
+
+    /// Returns whether the client should fully synchronize the chain's execution state.
+    /// `EventsOnly` chains do not need execution state, only events.
+    pub fn should_sync_chain_state(&self) -> bool {
+        match self {
+            ListeningMode::FullChain | ListeningMode::FollowChain => true,
+            ListeningMode::EventsOnly(_) => false,
+        }
+    }
 }
 
 /// A builder that creates [`ChainClient`]s which share the cache and notifiers.
@@ -276,7 +285,15 @@ impl<Env: Environment> Client<Env> {
         block_cache_size: usize,
         execution_state_cache_size: usize,
     ) -> Self {
-        let chain_modes = Arc::new(RwLock::new(chain_modes.into_iter().collect()));
+        let mut chain_modes = chain_modes.into_iter().collect::<BTreeMap<_, _>>();
+        // The client needs the admin chain fully synced for epoch tracking, so
+        // promote it (or insert) into `FullChain`. `extend` is monotonic in the
+        // listening mode order, so this never weakens an existing entry.
+        chain_modes
+            .entry(admin_chain_id)
+            .or_insert(ListeningMode::FullChain)
+            .extend(Some(ListeningMode::FullChain));
+        let chain_modes = Arc::new(RwLock::new(chain_modes));
         let config = ChainWorkerConfig {
             nickname: name.into(),
             long_lived_services,
@@ -516,7 +533,12 @@ impl<Env: Environment> Client<Env> {
                 )
                 .await?;
             let Some(new_info) = self
-                .process_certificates(&validators, certificates, None)
+                .process_certificates(
+                    &validators,
+                    certificates,
+                    None,
+                    ProcessConfirmedBlockMode::Execute,
+                )
                 .await?
             else {
                 break;
@@ -648,7 +670,12 @@ impl<Env: Environment> Client<Env> {
         while let Some(result) = receiver.recv().await {
             let certificates = result?;
             let Some(info) = self
-                .process_certificates(slice::from_ref(remote_node), certificates, until_block_time)
+                .process_certificates(
+                    slice::from_ref(remote_node),
+                    certificates,
+                    until_block_time,
+                    ProcessConfirmedBlockMode::Execute,
+                )
                 .await?
             else {
                 break;
@@ -775,6 +802,7 @@ impl<Env: Environment> Client<Env> {
         remote_nodes: &[RemoteNode<Env::ValidatorNode>],
         certificates: Vec<ConfirmedBlockCertificate>,
         until_block_time: Option<Timestamp>,
+        mode: ProcessConfirmedBlockMode,
     ) -> Result<Option<Box<ChainInfo>>, chain_client::Error> {
         let mut info = None;
         // Blobs created by these certs are already embedded in the downloaded
@@ -811,7 +839,7 @@ impl<Env: Environment> Client<Env> {
                 }
             }
             let response = self
-                .handle_certificate_with_retry(&certificate, remote_nodes)
+                .handle_certificate_with_retry(&certificate, remote_nodes, mode)
                 .await?;
             info = Some(response.info);
         }
@@ -819,18 +847,21 @@ impl<Env: Environment> Client<Env> {
         Ok(info)
     }
 
-    /// Calls `handle_certificate`, retrying with any missing blobs (downloaded
+    /// Calls `handle_confirmed_certificate`, retrying with any missing blobs (downloaded
     /// from `nodes`) and any missing events (downloaded from the publisher
     /// chains via the current validators).
     async fn handle_certificate_with_retry(
         &self,
         certificate: &ConfirmedBlockCertificate,
         nodes: &[RemoteNode<Env::ValidatorNode>],
+        mode: ProcessConfirmedBlockMode,
     ) -> Result<ChainInfoResponse, chain_client::Error> {
         let mut downloaded_blobs = HashSet::<BlobId>::new();
         let mut events = EventSetDownloader::new(self);
         loop {
-            let result = self.handle_certificate(certificate.clone()).await;
+            let result = self
+                .handle_confirmed_certificate(certificate.clone(), mode)
+                .await;
             if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
                 let new_blobs = filter_new(blob_ids, &downloaded_blobs);
                 if !new_blobs.is_empty() {
@@ -934,6 +965,22 @@ impl<Env: Environment> Client<Env> {
         Ok((max_epoch, committees))
     }
 
+    async fn handle_confirmed_certificate(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+        mode: ProcessConfirmedBlockMode,
+    ) -> Result<ChainInfoResponse, LocalNodeError> {
+        let chain_id = certificate.inner().chain_id();
+        let response = self
+            .local_node
+            .handle_confirmed_certificate(certificate, mode, &self.notifier)
+            .await?;
+        if self.is_tracked(chain_id) {
+            self.update_publisher_chain_modes(chain_id).await?;
+        }
+        Ok(response)
+    }
+
     /// Obtains the committee for the latest epoch on the admin chain.
     ///
     /// See `admin_committees` for the fallback rationale (transitional).
@@ -1033,8 +1080,11 @@ impl<Env: Environment> Client<Env> {
         let certificate = self
             .communicate_chain_action(committee, finalize_action, hashed_value)
             .await?;
-        self.receive_certificate_with_checked_signatures(certificate.clone())
-            .await?;
+        self.receive_certificate_with_checked_signatures(
+            certificate.clone(),
+            ProcessConfirmedBlockMode::Execute,
+        )
+        .await?;
         Ok(certificate)
     }
 
@@ -1203,6 +1253,7 @@ impl<Env: Environment> Client<Env> {
     async fn receive_certificate_with_checked_signatures(
         &self,
         certificate: ConfirmedBlockCertificate,
+        mode: ProcessConfirmedBlockMode,
     ) -> Result<(), chain_client::Error> {
         let block = certificate.block();
         // Recover history from the network.
@@ -1211,12 +1262,15 @@ impl<Env: Environment> Client<Env> {
         // Process the received operations. Download required hashed certificate values if
         // necessary.
         let nodes = self.validator_nodes().await?;
-        self.handle_certificate_with_retry(&certificate, &nodes)
+        self.handle_certificate_with_retry(&certificate, &nodes, mode)
             .await?;
         Ok(())
     }
 
-    /// Processes the confirmed block in the local node, possibly without executing it.
+    /// Processes the confirmed block in the local node. Whether it is fully
+    /// executed or only preprocessed depends on the chain's [`ListeningMode`]:
+    /// chains we follow get executed, untracked or events-only chains are only
+    /// preprocessed.
     #[instrument(level = "trace", skip_all)]
     async fn receive_sender_certificate(
         &self,
@@ -1235,7 +1289,15 @@ impl<Env: Environment> Client<Env> {
         } else {
             self.validator_nodes().await?
         };
-        self.handle_certificate_with_retry(&certificate, &nodes)
+        let processing_mode = if self
+            .chain_mode(certificate.value().chain_id())
+            .is_some_and(|m| m.should_sync_chain_state())
+        {
+            ProcessConfirmedBlockMode::Auto
+        } else {
+            ProcessConfirmedBlockMode::Preprocess
+        };
+        self.handle_certificate_with_retry(&certificate, &nodes, processing_mode)
             .await?;
 
         Ok(())
@@ -1648,7 +1710,7 @@ impl<Env: Environment> Client<Env> {
         stream_ids: &BTreeSet<StreamId>,
         remote_node: &RemoteNode<Env::ValidatorNode>,
     ) -> Result<(), chain_client::Error> {
-        let stream_ids_vec: Vec<_> = stream_ids.iter().cloned().collect();
+        let stream_ids_vec = stream_ids.iter().cloned().collect::<Vec<_>>();
         let mut initial_blocks = BTreeSet::new();
         for chunk in stream_ids_vec.chunks(self.options.max_event_stream_queries) {
             let previous_blocks = remote_node

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -9,7 +9,7 @@
 #![allow(async_fn_in_trait)]
 
 mod chain_worker;
-pub use chain_worker::ChainWorkerConfig;
+pub use chain_worker::{ChainWorkerConfig, ProcessConfirmedBlockMode};
 pub mod client;
 pub use client::Client;
 pub mod data_types;

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -15,7 +15,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, BundleExecutionPolicy, ProposedBlock},
-    types::{Block, GenericCertificate},
+    types::{Block, ConfirmedBlockCertificate, GenericCertificate},
 };
 use linera_execution::{BlobState, Query, QueryOutcome, ResourceTracker};
 use linera_storage::{Arc as CacheArc, Storage};
@@ -24,6 +24,7 @@ use thiserror::Error;
 use tracing::{instrument, warn};
 
 use crate::{
+    chain_worker::ProcessConfirmedBlockMode,
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse},
     notifier::Notifier,
     worker::{ProcessableCertificate, WorkerError, WorkerState},
@@ -108,6 +109,24 @@ where
             self.node
                 .state
                 .fully_handle_certificate_with_notifications(certificate, notifier),
+        )
+        .await?)
+    }
+
+    /// Same as [`Self::handle_certificate`] but for a confirmed block certificate
+    /// and with an explicit [`ProcessConfirmedBlockMode`]. The generic variant
+    /// always uses [`ProcessConfirmedBlockMode::Auto`].
+    #[instrument(level = "trace", skip_all)]
+    pub async fn handle_confirmed_certificate(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+        mode: ProcessConfirmedBlockMode,
+        notifier: &impl Notifier,
+    ) -> Result<ChainInfoResponse, LocalNodeError> {
+        Ok(Box::pin(
+            self.node
+                .state
+                .fully_handle_confirmed_certificate_with_notifications(certificate, mode, notifier),
         )
         .await?)
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2107,6 +2107,11 @@ where
     );
     let owner0 = client.identity().await.unwrap();
     let owner1 = AccountSecretKey::generate().public().into();
+    // The observer needs to fully execute the client's chain to see its manager
+    // state; otherwise the client chain would only be preprocessed.
+    observer
+        .client
+        .extend_chain_mode(chain_id, ListeningMode::FollowChain);
 
     let owners = [(owner0, 100), (owner1, 100)];
     let ownership = ChainOwnership::multiple(owners, 0, TimeoutConfig::default());

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -65,7 +65,7 @@ use crate::test_utils::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
 use crate::test_utils::ScyllaDbStorageBuilder;
 use crate::{
-    chain_worker::CrossChainUpdateHelper,
+    chain_worker::{CrossChainUpdateHelper, ProcessConfirmedBlockMode},
     data_types::*,
     test_utils::{MemoryStorageBuilder, StorageBuilder},
     worker::{
@@ -1034,7 +1034,7 @@ where
     drop(chain);
 
     env.worker()
-        .handle_confirmed_certificate(certificate0, None)
+        .handle_confirmed_certificate(certificate0, ProcessConfirmedBlockMode::Execute, None)
         .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
     drop(chain);
@@ -1128,11 +1128,11 @@ where
     // The worker handles certificates 0 and 2 - this should succeed, and the worker
     // should now have block 0 fully processed, and block 2 preprocessed.
     env.worker()
-        .handle_confirmed_certificate(certificate0, None)
+        .handle_confirmed_certificate(certificate0, ProcessConfirmedBlockMode::Execute, None)
         .await?;
 
     env.worker()
-        .handle_confirmed_certificate(certificate2.clone(), None)
+        .handle_confirmed_certificate(certificate2.clone(), ProcessConfirmedBlockMode::Auto, None)
         .await?;
 
     {
@@ -1158,7 +1158,7 @@ where
 
     // Handle the certificate in the gap.
     env.worker()
-        .handle_confirmed_certificate(certificate1, None)
+        .handle_confirmed_certificate(certificate1, ProcessConfirmedBlockMode::Execute, None)
         .await?;
 
     {
@@ -1170,7 +1170,7 @@ where
     // ...and the one that has been preprocessed before, again, as it is not automatically
     // re-processed.
     env.worker()
-        .handle_confirmed_certificate(certificate2, None)
+        .handle_confirmed_certificate(certificate2, ProcessConfirmedBlockMode::Execute, None)
         .await?;
 
     {
@@ -1270,7 +1270,11 @@ where
     // Missing earlier blocks, but the certificate will be preprocessed.
     assert_matches!(
         env.worker()
-            .handle_confirmed_certificate(certificate1.clone(), None)
+            .handle_confirmed_certificate(
+                certificate1.clone(),
+                ProcessConfirmedBlockMode::Auto,
+                None
+            )
             .await,
         Ok(_)
     );
@@ -1510,7 +1514,11 @@ where
             .with(block_proposal.content.block),
         ));
         env.worker()
-            .handle_confirmed_certificate(certificate.clone(), None)
+            .handle_confirmed_certificate(
+                certificate.clone(),
+                ProcessConfirmedBlockMode::Execute,
+                None,
+            )
             .await?;
 
         // Then receive the next two messages.
@@ -4327,7 +4335,7 @@ where
     );
     let certificate = env.make_certificate(value);
     env.worker()
-        .handle_confirmed_certificate(certificate, None)
+        .handle_confirmed_certificate(certificate, ProcessConfirmedBlockMode::Execute, None)
         .await?;
 
     for _ in query_contexts_after_new_block.clone() {
@@ -4421,7 +4429,11 @@ where
     ));
 
     env.worker()
-        .handle_confirmed_certificate(certificate_chain_2.clone(), None)
+        .handle_confirmed_certificate(
+            certificate_chain_2.clone(),
+            ProcessConfirmedBlockMode::Execute,
+            None,
+        )
         .await?;
 
     // Now try to stage a block with the earlier message (transaction_index: 0).
@@ -4520,10 +4532,10 @@ where
 
     // Step 2: Process both certs on chain_1 (adds heights 0, 1 to outbox for chain_2).
     env.worker()
-        .process_confirmed_block(cert_0.clone(), None)
+        .process_confirmed_block(cert_0.clone(), ProcessConfirmedBlockMode::Execute, None)
         .await?;
     env.worker()
-        .process_confirmed_block(cert_1.clone(), None)
+        .process_confirmed_block(cert_1.clone(), ProcessConfirmedBlockMode::Execute, None)
         .await?;
 
     // Step 3: Deliver height 0 to chain_2 and confirm it on chain_1.
@@ -4577,7 +4589,7 @@ where
         .await;
     // Process cert_2 on chain_1 so the block is in confirmed_log.
     env.worker()
-        .process_confirmed_block(cert_2.clone(), None)
+        .process_confirmed_block(cert_2.clone(), ProcessConfirmedBlockMode::Execute, None)
         .await?;
 
     // Now manually deliver height 2's cross-chain update to chain_2.
@@ -4906,9 +4918,16 @@ where
         .await;
 
     // Process all three blocks on chain_1.
-    env.worker().process_confirmed_block(cert_0, None).await?;
-    env.worker().process_confirmed_block(cert_1, None).await?;
-    let (_, actions, _) = env.worker().process_confirmed_block(cert_2, None).await?;
+    env.worker()
+        .process_confirmed_block(cert_0, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_1, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    let (_, actions, _) = env
+        .worker()
+        .process_confirmed_block(cert_2, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
 
     // With chunk_limit=1, only the first chunk (height 0) should be returned.
     // The remaining heights stay in the outbox for delivery after confirmation.
@@ -5024,11 +5043,13 @@ where
 
     // Process all three blocks on chain_1.
     env.worker()
-        .process_confirmed_block(cert_0.clone(), None)
+        .process_confirmed_block(cert_0.clone(), ProcessConfirmedBlockMode::Execute, None)
         .await?;
-    env.worker().process_confirmed_block(cert_1, None).await?;
     env.worker()
-        .process_confirmed_block(cert_2.clone(), None)
+        .process_confirmed_block(cert_1, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_2.clone(), ProcessConfirmedBlockMode::Execute, None)
         .await?;
 
     // Deliver height 0 to chain_2 and confirm it.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -67,6 +67,7 @@ use crate::{
         handle,
         state::{send_result, ChainWorkerState},
         BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult, DeliveryNotifier,
+        ProcessConfirmedBlockMode,
     },
     client::ListeningMode,
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -813,7 +814,12 @@ impl ProcessableCertificate for ConfirmedBlock {
         worker: &WorkerState<S>,
         certificate: ConfirmedBlockCertificate,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        Box::pin(worker.handle_confirmed_certificate(certificate, None)).await
+        Box::pin(worker.handle_confirmed_certificate(
+            certificate,
+            ProcessConfirmedBlockMode::Auto,
+            None,
+        ))
+        .await
     }
 }
 
@@ -898,6 +904,34 @@ where
         linera_base::Task::spawn(async move {
             let (response, actions) =
                 ProcessableCertificate::process_certificate(&this, certificate).await?;
+            notifications.notify(&actions.notifications);
+            let mut requests = VecDeque::from(actions.cross_chain_requests);
+            while let Some(request) = requests.pop_front() {
+                let actions = this.handle_cross_chain_request(request).await?;
+                requests.extend(actions.cross_chain_requests);
+                notifications.notify(&actions.notifications);
+            }
+            Ok(response)
+        })
+        .await
+    }
+
+    /// Same as [`Self::fully_handle_certificate_with_notifications`] but for a
+    /// confirmed block certificate and with an explicit [`ProcessConfirmedBlockMode`].
+    /// The generic variant always uses [`ProcessConfirmedBlockMode::Auto`].
+    #[instrument(level = "trace", skip(self, certificate, notifier))]
+    #[inline]
+    pub async fn fully_handle_confirmed_certificate_with_notifications(
+        &self,
+        certificate: ConfirmedBlockCertificate,
+        mode: ProcessConfirmedBlockMode,
+        notifier: &impl Notifier,
+    ) -> Result<ChainInfoResponse, WorkerError> {
+        let notifications = (*notifier).clone();
+        let this = self.clone();
+        linera_base::Task::spawn(async move {
+            let (response, actions) =
+                Box::pin(this.handle_confirmed_certificate(certificate, mode, None)).await?;
             notifications.notify(&actions.notifications);
             let mut requests = VecDeque::from(actions.cross_chain_requests);
             while let Some(request) = requests.pop_front() {
@@ -1294,12 +1328,13 @@ where
     async fn process_confirmed_block(
         &self,
         certificate: ConfirmedBlockCertificate,
+        mode: ProcessConfirmedBlockMode,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
         let chain_id = certificate.block().header.chain_id;
         self.chain_write(chain_id, move |mut guard| async move {
             guard
-                .process_confirmed_block(certificate, notify_when_messages_are_delivered)
+                .process_confirmed_block(certificate, mode, notify_when_messages_are_delivered)
                 .await
         })
         .await
@@ -1512,12 +1547,11 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         match self.full_certificate(certificate).await? {
             Either::Left(confirmed) => {
-                Box::pin(
-                    self.handle_confirmed_certificate(
-                        confirmed,
-                        notify_when_messages_are_delivered,
-                    ),
-                )
+                Box::pin(self.handle_confirmed_certificate(
+                    confirmed,
+                    ProcessConfirmedBlockMode::Auto,
+                    notify_when_messages_are_delivered,
+                ))
                 .await
             }
             Either::Right(validated) => {
@@ -1541,6 +1575,7 @@ where
     pub async fn handle_confirmed_certificate(
         &self,
         certificate: ConfirmedBlockCertificate,
+        mode: ProcessConfirmedBlockMode,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname(), certificate);
@@ -1548,9 +1583,12 @@ where
         let metrics_data = metrics::MetricsData::new(&certificate);
 
         #[allow(unused_variables)]
-        let (info, actions, outcome) =
-            Box::pin(self.process_confirmed_block(certificate, notify_when_messages_are_delivered))
-                .await?;
+        let (info, actions, outcome) = Box::pin(self.process_confirmed_block(
+            certificate,
+            mode,
+            notify_when_messages_are_delivered,
+        ))
+        .await?;
 
         #[cfg(with_metrics)]
         if matches!(outcome, BlockOutcome::Processed) {

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -17,7 +17,7 @@ use linera_core::{
     join_set_ext::JoinSet,
     node::NodeError,
     worker::{NetworkActions, Notification, Reason, WorkerState},
-    JoinSetExt as _, TaskHandle,
+    JoinSetExt as _, ProcessConfirmedBlockMode, TaskHandle,
 };
 use linera_storage::Storage;
 use tokio::sync::{broadcast::error::RecvError, oneshot};
@@ -829,7 +829,7 @@ where
         match self
             .state
             .clone()
-            .handle_confirmed_certificate(certificate, sender)
+            .handle_confirmed_certificate(certificate, ProcessConfirmedBlockMode::Auto, sender)
             .await
         {
             Ok((info, actions)) => {

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -10,7 +10,7 @@ use linera_core::{
     data_types::CrossChainRequest,
     node::NodeError,
     worker::{NetworkActions, WorkerError, WorkerState},
-    JoinSetExt as _,
+    JoinSetExt as _, ProcessConfirmedBlockMode,
 };
 use linera_storage::Storage;
 use tokio::{sync::oneshot, task::JoinSet};
@@ -295,7 +295,11 @@ where
                 match self
                     .server
                     .state
-                    .handle_confirmed_certificate(request.certificate, sender)
+                    .handle_confirmed_certificate(
+                        request.certificate,
+                        ProcessConfirmedBlockMode::Auto,
+                        sender,
+                    )
                     .await
                 {
                     Ok((info, actions)) => {


### PR DESCRIPTION
#6328 backport

## Motivation

Currently chain workers fully execute new blocks whenever they can, i.e. if they are the next one to be executed according to the chain tip state. This is wasteful for e.g. sender chains.

## Proposal

Make the mode explicit, and on the client side specify explicitly whether to fully execute or only preprocess.

Validators still execute whenever they can, since they are expected to execute every chain anyway.

## Test Plan

CI

## Release Plan

- Release SDK.
- 
## Links

- PR to main: #6328
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
