### PR TITLE
Run (non e2e) linera-bridge tests in CI.

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -162,6 +162,12 @@ jobs:
         run: cargo build --release --target wasm32-unknown-unknown -p wrapped-fungible
         working-directory: examples
 
+      - name: Run evm-bridge contract integration tests
+        working-directory: linera-bridge/contracts/evm-bridge
+        env:
+          RUSTFLAGS: ""
+        run: cargo test
+
       - name: Build linera-bridge binary for local relay tests
         run: cargo build -p linera-bridge --features linera-bridge/relay
 
@@ -200,3 +206,9 @@ jobs:
         env:
           RUSTFLAGS: ""
         run: cargo test -p linera-bridge --test anvil_deposit_proof -- --ignored --nocapture
+
+      - name: Run evm-bridge contract integration tests (anvil)
+        working-directory: linera-bridge/contracts/evm-bridge
+        env:
+          RUSTFLAGS: ""
+        run: cargo test -- --ignored --nocapture

--- a/linera-bridge/contracts/evm-bridge/Cargo.lock
+++ b/linera-bridge/contracts/evm-bridge/Cargo.lock
@@ -3220,7 +3220,7 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linera-base"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "allocative",
  "alloy-primitives",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "linera-bridge"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3284,7 +3284,7 @@ dependencies = [
 
 [[package]]
 name = "linera-cache"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "cfg_aliases",
  "linera-base",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3323,7 +3323,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "linera-ethereum"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3432,7 +3432,7 @@ checksum = "c9198100e9ce61acd3c714a2e61eb19fc5b8e2178dd645e2d9061e61e6e1feef"
 
 [[package]]
 name = "linera-sdk"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage-service"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "linera-version"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "allocative",
  "anyhow",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "cfg_aliases",
  "deluxe",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "anyhow",
  "cfg_aliases",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-macros"
-version = "0.15.17"
+version = "0.15.18"
 dependencies = [
  "cfg_aliases",
  "heck 0.4.1",

--- a/linera-bridge/contracts/evm-bridge/tests/process_deposit.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/process_deposit.rs
@@ -6,7 +6,7 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use alloy_primitives::{Address, B256, U256};
-use evm_bridge::{BridgeOperation, BridgeParameters, EvmBridgeAbi};
+use evm_bridge::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters, EvmBridgeAbi};
 use fungible::{InitialState, InitialStateBuilder};
 use linera_bridge::proof::{
     deposit_event_signature,
@@ -16,7 +16,7 @@ use linera_bridge::proof::{
     ReceiptLog,
 };
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId},
+    linera_base_types::{AccountOwner, ApplicationId, U128},
     test::{ActiveChain, TestValidator},
 };
 use serde::Deserialize;
@@ -27,7 +27,7 @@ async fn query_balance(
     app_id: ApplicationId<WrappedFungibleTokenAbi>,
     chain: &ActiveChain,
     owner: AccountOwner,
-) -> Option<Amount> {
+) -> Option<U128> {
     use async_graphql::InputType;
     use linera_sdk::test::QueryOutcome;
 
@@ -37,11 +37,11 @@ async fn query_balance(
     );
     let QueryOutcome { response, .. } = chain.graphql_query(app_id, query).await;
     let balance = response["accounts"]["entry"]["value"].as_str()?;
-    Some(
+    Some(U128(
         balance
             .parse()
-            .expect("balance cannot be parsed as a number"),
-    )
+            .expect("balance cannot be parsed as u128"),
+    ))
 }
 
 /// Common setup for bridge integration tests.
@@ -60,7 +60,7 @@ struct TestBridge {
 impl TestBridge {
     async fn setup() -> Self {
         let (validator, bridge_module_id) =
-            TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, ()>().await;
+            TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
         let mut chain = validator.new_chain().await;
         let chain_owner = AccountOwner::from(chain.public_key());
 
@@ -71,16 +71,15 @@ impl TestBridge {
         let bridge_params = BridgeParameters {
             source_chain_id,
             token_address,
-            rpc_endpoint: String::new(),
         };
         let bridge_app_id = chain
-            .create_application(bridge_module_id, bridge_params, (), vec![])
+            .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument::default(), vec![])
             .await;
 
         // 2. Deploy wrapped-fungible with the bridge's app ID
         let fungible_module_id = chain
             .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
-                "../wrapped-fungible",
+                "../../../examples/wrapped-fungible",
             )
             .await;
         let wrapped_params = WrappedParameters {
@@ -200,7 +199,7 @@ impl TestBridge {
     /// can verify that `ProcessDeposit` panics when the address has not been set.
     async fn setup_without_bridge_address() -> Self {
         let (validator, bridge_module_id) =
-            TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, ()>().await;
+            TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
         let mut chain = validator.new_chain().await;
         let chain_owner = AccountOwner::from(chain.public_key());
 
@@ -210,15 +209,14 @@ impl TestBridge {
         let bridge_params = BridgeParameters {
             source_chain_id,
             token_address,
-            rpc_endpoint: String::new(),
         };
         let bridge_app_id = chain
-            .create_application(bridge_module_id, bridge_params, (), vec![])
+            .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument::default(), vec![])
             .await;
 
         let fungible_module_id = chain
             .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
-                "../wrapped-fungible",
+                "../../../examples/wrapped-fungible",
             )
             .await;
         let wrapped_params = WrappedParameters {
@@ -302,7 +300,7 @@ async fn test_process_deposit() {
     // Verify tokens were minted
     assert_eq!(
         query_balance(tb.fungible_app_id, &tb.chain, tb.chain_owner).await,
-        Some(Amount::from_attos(1_000_000u128)),
+        Some(U128(1_000_000)),
     );
 
     // Second deposit with same proof should fail (replay)
@@ -637,7 +635,7 @@ async fn test_replay_different_log_index_succeeds() {
 
     assert_eq!(
         query_balance(tb.fungible_app_id, &tb.chain, tb.chain_owner).await,
-        Some(Amount::from_attos(1_000_000u128)),
+        Some(U128(1_000_000)),
     );
 
     // Process log_index: 1 — should also succeed (different DepositKey)
@@ -659,7 +657,7 @@ async fn test_replay_different_log_index_succeeds() {
     // Both deposits should have been minted
     assert_eq!(
         query_balance(tb.fungible_app_id, &tb.chain, tb.chain_owner).await,
-        Some(Amount::from_attos(2_000_000u128)),
+        Some(U128(2_000_000)),
     );
 }
 
@@ -670,7 +668,7 @@ async fn test_replay_different_log_index_succeeds() {
 #[tokio::test]
 async fn test_instantiation_fails_with_unreachable_endpoint() {
     let (validator, bridge_module_id) =
-        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, ()>().await;
+        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
     let mut chain = validator.new_chain().await;
 
     let token_address = [0xA0; 20];
@@ -680,10 +678,9 @@ async fn test_instantiation_fails_with_unreachable_endpoint() {
     let bridge_params = BridgeParameters {
         source_chain_id,
         token_address,
-        rpc_endpoint: "http://localhost:8545".to_string(),
     };
     let result = chain
-        .try_create_application(bridge_module_id, bridge_params, (), vec![])
+        .try_create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument { rpc_endpoint: "http://localhost:8545".to_string() }, vec![])
         .await;
 
     assert!(
@@ -723,7 +720,7 @@ async fn setup_bridge_with_anvil(
     ApplicationId<WrappedFungibleTokenAbi>,
 ) {
     let (mut validator, bridge_module_id) =
-        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, ()>().await;
+        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
 
     // Allow the contract to make HTTP requests to the Anvil host.
     validator
@@ -745,16 +742,15 @@ async fn setup_bridge_with_anvil(
     let bridge_params = BridgeParameters {
         source_chain_id,
         token_address,
-        rpc_endpoint: anvil_endpoint.to_string(),
     };
     let bridge_app_id = chain
-        .create_application(bridge_module_id, bridge_params, (), vec![])
+        .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument { rpc_endpoint: anvil_endpoint.to_string() }, vec![])
         .await;
 
     // 2. Deploy wrapped-fungible with bridge's app ID
     let fungible_module_id = chain
         .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
-            "../wrapped-fungible",
+            "../../../examples/wrapped-fungible",
         )
         .await;
     let wrapped_params = WrappedParameters {
@@ -914,16 +910,15 @@ async fn test_process_deposit_rejects_when_bridge_address_unregistered() {
 #[tokio::test]
 async fn test_register_fungible_bridge_is_one_shot() {
     let (validator, bridge_module_id) =
-        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, ()>().await;
+        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
     let mut chain = validator.new_chain().await;
 
     let bridge_params = BridgeParameters {
         source_chain_id: 8453u64,
         token_address: [0xA0; 20],
-        rpc_endpoint: String::new(),
     };
     let bridge_app_id = chain
-        .create_application(bridge_module_id, bridge_params, (), vec![])
+        .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument::default(), vec![])
         .await;
 
     chain

--- a/linera-bridge/contracts/evm-bridge/tests/set_rpc_endpoint.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/set_rpc_endpoint.rs
@@ -25,7 +25,6 @@ async fn setup_bridge() -> (ActiveChain, ApplicationId<EvmBridgeAbi>) {
     let bridge_params = BridgeParameters {
         source_chain_id: 8453u64,
         token_address: [0xA0; 20],
-        rpc_endpoint: String::new(),
     };
     let bridge_app_id = chain
         .create_application(


### PR DESCRIPTION
## Motivation

I missed those from the CI job where only e2e tests were running.

## Proposal

Add them to the CI in two steps:
1.  Unit tests in one job
2. Anvil-based tests in a second job

## Test Plan

CI. Manual verification they're running now.

## Release Plan

These changes should be backported to `main`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
