### PR TITLE
Backport #6404 to main: Fix e2e bridge tests

### DIFF
--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -421,7 +421,7 @@ where
     chain_client.synchronize_from_validators().await?;
     chain_client.process_inbox().await?;
 
-    let initial_balance = linera_base::data_types::Amount::from_tokens(initial_balance_tokens);
+    let initial_balance = linera_base::data_types::Amount::from_attos(initial_balance_tokens);
     let (fungible_app_id, _) = chain_client
         .create_application_untyped(
             wf_module_id,

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -127,7 +127,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     // (`SYNTHETIC_APP_ID_BYTES32`) below so `_onBlock` rejects every
     // burn event the relayer forwards.
     let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
     let real_app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     assert_ne!(
         real_app_id_bytes32, SYNTHETIC_APP_ID_BYTES32,

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -40,11 +40,10 @@ sol! {
 /// constraint.
 const MAX_SEARCH_N: u32 = 1000;
 
-/// Chain-B pre-funded balance: enough wrapped-fungible to issue
-/// `MAX_SEARCH_N * doubling_plus_bisect_iterations * BURN_AMOUNT_TOKENS`
-/// `Transfer` ops. Sized well above the worst case so the test never
-/// runs out of source-chain balance regardless of `BURN_AMOUNT_TOKENS`.
-const INITIAL_BALANCE_TOKENS: u128 = 10u128.pow(32);
+/// Chain-B pre-funded balance in raw ERC-20 sub-units. Worst-case burn
+/// total is `MAX_SEARCH_N * ~10 iterations * BURN_AMOUNT_TOKENS * 10^18`
+/// ≈ 10^37 raw; 10^38 gives 10× headroom and still fits in `u128`.
+const INITIAL_BALANCE_TOKENS: u128 = 10u128.pow(38);
 
 /// Each burn moves exactly this many wrapped-fungible tokens to a fresh
 /// `Address20`. Constant token amount keeps per-burn EVM gas constant

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -1,29 +1,37 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verifies that multiple `BurnEvent`s in a single Linera block are all
-//! relayed and completed on the EVM side. The user chain submits one
-//! block carrying N `Transfer` operations to N distinct `Address20`
-//! recipients on the bridge chain. The test process drives the inbox
-//! processing on the bridge chain so the resulting `Credit` messages
-//! all land in one chain-A block — a single cert with N `BurnEvent`s.
-//! After the relayer is spawned, exactly one `addBlock` call should
-//! release all N tokens (one `token.transfer` per burn in `_onBlock`)
-//! and the relayer must mark every pending burn complete via the
-//! per-burn `isBurnProcessed(height, eventIndex)` view.
+//! Verifies that when a Linera block's `addBlock(cert)` would exceed the
+//! EVM block gas limit, the relayer falls back to chunked
+//! `processBurns(cert, txIndex, positionsInTx)` calls and every burn
+//! still settles correctly.
+//!
+//! Setup: anvil's block gas limit is dialled down (via
+//! `evm_setBlockGasLimit`) before the bridge is deployed, so `addBlock`
+//! at `NUM_BURNS = 8` does not fit and the relayer must take the
+//! `processBurns` chunk path. Chain B submits one block with N
+//! `Transfer` operations to N distinct recipients on chain A. After the
+//! relayer is spawned, every recipient must hold the correct ERC-20
+//! balance and `linera_bridge_burns_completed` must reach N.
 
 #![recursion_limit = "512"]
 
 use std::time::Duration;
 
-use alloy::{primitives::U256, providers::ProviderBuilder, sol};
-use linera_base::{
-    crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner,
+use std::collections::HashSet;
+
+use alloy::{
+    primitives::{B256, U256},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::Filter,
+    sol,
 };
+use linera_base::{crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner};
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
-    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
-    wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
+    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible,
+    set_anvil_block_gas_limit, start_compose, wait_for_light_client, wait_for_relay_http_ready,
+    wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -40,19 +48,30 @@ sol! {
     }
 }
 
-const NUM_BURNS: usize = 4;
+const NUM_BURNS: usize = 8;
 const BURN_AMOUNT_TOKENS: u128 = 1;
+/// Per-block gas ceiling sized to live between `processBurns(cert, tx, [single])`
+/// (which is dominated by cert verification, ~2–2.5M gas) and `addBlock(cert)`
+/// for `NUM_BURNS` burns (~3.3M gas observed in `burns_per_evm_tx`). The
+/// relayer must therefore route through chunked `processBurns` per tx.
+const ANVIL_BLOCK_GAS_LIMIT: u64 = 3_000_000;
 
 #[tokio::test]
 #[ignore] // Requires pre-built docker images, Wasm, and relay binary.
-async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
+async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_test_writer().try_init().ok();
     linera_bridge_e2e::ensure_rustls_provider();
     let compose_file = compose_file_path();
-    let project_name = "linera-multi-burn-same-block-test";
+    let project_name = "linera-multi-tx-burn-chunking-test";
 
     let compose = start_compose(&compose_file, project_name).await;
     wait_for_light_client(&compose, project_name, &compose_file).await;
+
+    // Provider is held for the post-deploy gas-limit drop and for the
+    // final balance reads. Deploy txs need anvil's default (high) limit;
+    // we tighten it once the bridge is live.
+    let rpc_url = "http://localhost:8545".parse()?;
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     let faucet = Faucet::new("http://localhost:8080".to_string());
     let genesis_config = faucet.genesis_config().await?;
@@ -64,7 +83,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(
         &store_config,
-        "multi-burn-same-block-e2e",
+        "multi-tx-burn-chunking-e2e",
         Some(WasmRuntime::default()),
         StorageCacheConfig {
             blob_cache_size: 1000,
@@ -91,7 +110,6 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     )
     .await?;
 
-    // Chain A hosts the bridge contract.
     let owner_a = AccountOwner::from(signer.generate_new());
     let chain_a_desc = faucet.claim(&owner_a).await?;
     let chain_a = chain_a_desc.id();
@@ -99,7 +117,6 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     let cc_a = ctx.make_chain_client(chain_a).await?;
     cc_a.synchronize_from_validators().await?;
 
-    // Chain B is the user.
     let owner_b = AccountOwner::from(signer.generate_new());
     let chain_b_desc = faucet.claim(&owner_b).await?;
     let chain_b = chain_b_desc.id();
@@ -108,7 +125,6 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     cc_b.synchronize_from_validators().await?;
 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
-
     let fungible_app_id =
         publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
 
@@ -135,23 +151,26 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     )
     .await;
 
-    // NUM_BURNS Address20 recipients in the order they appear in the
-    // block. One address is intentionally repeated to exercise per-burn
-    // accounting independently of the recipient; `_onBlock` must release
-    // tokens for each occurrence even though the dedup key shares no
-    // recipient bits.
+    // Now tighten the block gas limit so `addBlock(cert)` for `NUM_BURNS`
+    // doesn't fit and the relayer is forced through the chunked
+    // `processBurns` path. Deploy + funding txs already landed.
+    set_anvil_block_gas_limit(&provider, ANVIL_BLOCK_GAS_LIMIT).await?;
+
+    // Distinct recipients so each burn produces a distinct ERC-20 balance.
     let recipients: [alloy::primitives::Address; NUM_BURNS] = [
-        "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?,
         "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?,
         "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC".parse()?,
         "0x90F79bf6EB2c4f870365E785982E1f101E93b906".parse()?,
+        "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65".parse()?,
+        "0x9965507D1a55bcC2695C58ba16FB37d819B0A4dc".parse()?,
+        "0x976EA74026E726554dB657fA54763abd0C3a0aa9".parse()?,
+        "0x14dC79964da2C08b23698B3D3cc7Ca32193d9955".parse()?,
+        "0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f".parse()?,
     ];
     let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
 
-    // Bundle every Transfer into a SINGLE chain-B block, then drive
-    // chain A's inbox once. The N Credit messages travel together
-    // and `process_inbox` materialises one chain-A block containing
-    // all N BurnEvents.
+    // Bundle every Transfer into one chain-B block; chain-A's
+    // process_inbox produces a single chain-A block with N BurnEvents.
     let operations = recipients
         .iter()
         .map(|recipient| {
@@ -201,7 +220,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     }
     linera_wallet_json::PersistentWallet::create(&wallet_path, relay_genesis_config)?;
 
-    let relay_port = 3005u16;
+    let relay_port = 3009u16;
     let bridge_addr_str = format!("{bridge_addr}");
     let bridge_app_str = format!("{fungible_app_id}");
     let fungible_app_str = format!("{fungible_app_id}");
@@ -220,7 +239,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
-            linera_storage_runtime::CommonStorageOptions::with_defaults().storage_cache_config(),
+            &linera_storage_runtime::CommonStorageOptions::with_defaults(),
             Duration::from_secs(2),
             0,
             5,
@@ -238,10 +257,6 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     }
 
     let num_burns_i64 = i64::try_from(NUM_BURNS).unwrap();
-    // Gate on the scanner having found every burn; we deliberately do
-    // NOT wait for `pending == 0` because the failure mode we want to
-    // surface is a balance / counter discrepancy, not a timeout —
-    // assertions below catch the actual state.
     if let Err(error) = wait_for_relay_metrics(
         &http,
         &relay_url,
@@ -253,14 +268,14 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         relay_handle.abort();
         return Err(error);
     }
-    // Wait for the relayer to finish: one `addBlock` releases all N
-    // tokens inside `_onBlock`, then `check_burn_completion`'s per-burn
-    // `isBurnProcessed` query flips every entry to completed.
+    // Wait for the chunked-processBurns path to settle every burn.
+    // Allow more wall time than the single-addBlock test because each
+    // chunk is its own EVM tx + receipt round-trip.
     if let Err(error) = wait_for_relay_metrics(
         &http,
         &relay_url,
         |_detected, completed, _pending, _failed| completed >= num_burns_i64,
-        Duration::from_secs(60),
+        Duration::from_secs(180),
     )
     .await
     {
@@ -268,25 +283,12 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         return Err(error);
     }
 
-    let rpc_url = "http://localhost:8545".parse()?;
-    let provider = ProviderBuilder::new().connect_http(rpc_url);
     let token = IERC20::new(erc20_addr, &provider);
-
-    // Each occurrence in `recipients` is one expected transfer. A
-    // recipient listed twice should accumulate two transfers, etc.
-    let mut expected_per_recipient: std::collections::BTreeMap<
-        alloy::primitives::Address,
-        U256,
-    > = std::collections::BTreeMap::new();
     let one_burn = U256::from(BURN_AMOUNT_TOKENS) * U256::from(10u128.pow(18));
+    let mut observed_balances = Vec::with_capacity(recipients.len());
     for recipient in &recipients {
-        *expected_per_recipient.entry(*recipient).or_insert(U256::ZERO) += one_burn;
-    }
-
-    let mut observed_balances = Vec::with_capacity(expected_per_recipient.len());
-    for (recipient, expected) in &expected_per_recipient {
         let balance = token.balanceOf(*recipient).call().await?;
-        observed_balances.push((*recipient, balance, *expected));
+        observed_balances.push((*recipient, balance));
     }
 
     let final_metrics = http
@@ -307,8 +309,6 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         "Final state"
     );
 
-    // Sanity: the scanner must have picked up all NUM_BURNS as separate
-    // PendingBurns even though they share a Linera block.
     assert_eq!(
         burns_detected, num_burns_i64,
         "relayer must have detected all {NUM_BURNS} burns; got {burns_detected}"
@@ -318,15 +318,42 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         "relayer must have completed all {NUM_BURNS} burns; got {burns_completed}"
     );
 
-    // Each unique recipient must hold exactly the sum of their
-    // occurrences in `recipients`. Anything less means a per-burn
-    // release was dropped; anything more means double-spend.
-    for (recipient, balance, expected) in &observed_balances {
+    for (recipient, balance) in &observed_balances {
         assert_eq!(
-            *balance, *expected,
-            "recipient {recipient:?} balance {balance}, expected {expected}"
+            *balance, one_burn,
+            "recipient {recipient:?} balance {balance}, expected {one_burn}"
         );
     }
+
+    // The whole point of this test is the chunked-processBurns path, which
+    // splits the cert across multiple EVM transactions. Each chunk lands in
+    // its own EVM block. Verify by counting distinct block hashes among
+    // ERC-20 `Transfer` events emitted by the bridge contract: if `addBlock`
+    // had fit, all 8 transfers would share one EVM block.
+    //
+    // `Transfer(address,address,uint256)` topic0.
+    let transfer_sig = B256::from(alloy::primitives::keccak256(
+        "Transfer(address,address,uint256)",
+    ));
+    let bridge_topic = B256::left_padding_from(bridge_addr.as_slice());
+    let transfer_logs = provider
+        .get_logs(
+            &Filter::new()
+                .address(erc20_addr)
+                .event_signature(transfer_sig)
+                .topic1(bridge_topic)
+                .from_block(0u64),
+        )
+        .await?;
+    let transfer_blocks: HashSet<B256> =
+        transfer_logs.iter().filter_map(|l| l.block_hash).collect();
+    assert!(
+        transfer_blocks.len() > 1,
+        "expected chunked processBurns path to span multiple EVM blocks; \
+         saw {} distinct block(s) across {} bridge-originated Transfer logs",
+        transfer_blocks.len(),
+        transfer_logs.len(),
+    );
 
     Ok(())
 }

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -118,7 +118,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
 
     let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000).await?;
+        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
 
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");


### PR DESCRIPTION
## Motivation

Backport of #6404 from `testnet_conway` to `main`.

## Proposal

Cherry-pick of commit 6e8fce1f12701e6cfb8f393dafa7fb5ef618c3c6.

The original commit fixes e2e bridge tests by passing raw ERC-20 sub-unit amounts (already scaled by 10^18) to `publish_and_create_wrapped_fungible`, and adds the `multi_tx_burn_chunking` test for the chunked `processBurns` relay path.

Two API differences required adaptation for `main`:
- `U128` type does not exist on `main`; replaced with `Amount::from_attos(initial_balance_tokens)` in `lib.rs` (preserves raw sub-unit value, no double-scaling) and `Amount::from_tokens(BURN_AMOUNT_TOKENS)` in `multi_tx_burn_chunking.rs` (semantically equivalent: 1 token = 10^18 attos).

## Test Plan

CI

## Release Plan

- [ ] This PR requires a protocol upgrade (add the appropriate label).

## Links

- [Reviewer checklist](https://github.com/linera-io/linera-protocol/wiki/Reviewing-a-Pull-Request)