### PR TITLE
Backport #6385 to main: Add WebCryptoEd25519 signer + Address32 owner bridge dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6228,6 +6228,7 @@ version = "0.16.0"
 dependencies = [
  "console_error_panic_hook",
  "futures",
+ "hex",
  "js-sys",
  "linera-base",
  "linera-client",

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -1464,4 +1464,45 @@ mod tests {
         let address2 = account_owner.to_evm_address().unwrap();
         assert_eq!(address1, address2);
     }
+
+    #[test]
+    fn ed25519_public_key_to_account_owner_known_vector() {
+        use crate::crypto::Ed25519PublicKey;
+        // Pins the entire derivation pipeline against silent drift, not just BCS.
+        // The chain executed:
+        //
+        //   [u8; 32]
+        //     -> Ed25519PublicKey                       (newtype wrap)
+        //     -> AccountOwner::from(public_key)         (impl From, this file)
+        //          -> CryptoHash::new(&public_key)
+        //               -> Hashable::write into a Keccak256 hasher
+        //                    -> BcsHashable blanket impl writes:
+        //                         * type-name discriminator prefix
+        //                         * BCS body (32 raw bytes for [u8; 32])
+        //               -> Keccak256 finalize -> 32-byte hash
+        //     -> AccountOwner::Address32(hash)
+        //     -> Display: "0x" + lowercase hex
+        //
+        // Any change in any link breaks this test: BCS format, the
+        // `BcsHashable` type-name discriminator, the hash function, the
+        // `From<Ed25519PublicKey>` impl, the `Address32` carrier, or the
+        // `Display` formatting.
+        //
+        // Fixed 32-byte public key (0x01..0x20).
+        let pubkey_bytes: [u8; 32] = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+            0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c,
+            0x1d, 0x1e, 0x1f, 0x20,
+        ];
+        let pubkey = Ed25519PublicKey(pubkey_bytes);
+        let owner = AccountOwner::from(pubkey);
+        // The expected hex is the pinned output of `Keccak256(BCS(Ed25519PublicKey))`.
+        // Do not update it without understanding why the derivation changed — the JS
+        // test in `@linera/client` cross-checks this exact value.
+        assert_eq!(
+            owner.to_string(),
+            "0xeacee5344cbec9569e836f95029d476c700f4f5bc007c71c0752c73fba149043",
+            "Ed25519 owner derivation drifted; verify intentional before updating"
+        );
+    }
 }

--- a/web/@linera/client/Cargo.toml
+++ b/web/@linera/client/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 console_error_panic_hook.workspace = true
 futures.workspace = true
+hex.workspace = true
 js-sys.workspace = true
 num-traits.workspace = true
 serde.workspace = true

--- a/web/@linera/client/README.md
+++ b/web/@linera/client/README.md
@@ -13,6 +13,40 @@ policies, including in-memory keys and signing using an existing MetaMask wallet
 
 <!-- cargo-rdme end -->
 
+## Building
+
+Make sure your `cargo` invokes a nightly `rustc`. Then, you can build
+the package with `pnpm build` and publish it with `pnpm publish`.
+
+## Signers
+
+This package ships two reference `Signer` implementations.
+
+### `PrivateKey` (testing / development only)
+
+`PrivateKey` keeps an in-memory secp256k1 key (EIP-191 signing). Intended for tests and local
+development — do not use in production where the key must persist or where the page is
+exposed to untrusted code.
+
+### `WebCryptoEd25519` (browser, production-ready for session keys)
+
+`WebCryptoEd25519` holds the private half of an Ed25519 keypair as a non-extractable
+`CryptoKey` from the Web Crypto API. The raw **private** bytes never enter JavaScript:
+the key is generated with `extractable: false` and the `CryptoKey` handle is persisted
+in IndexedDB so it survives reloads. An in-page attacker can request signatures while
+the tab is open, but cannot exfiltrate the key.
+
+```typescript
+import * as linera from "@linera/client";
+
+await linera.initialize();
+const signer = await linera.signer.WebCryptoEd25519.loadOrCreate("my-app-key");
+const owner = signer.address(); // "0x" + 64 hex chars (AccountOwner::Address32)
+```
+
+Browser support: Chrome 137+, Firefox 129+, Safari 17+ — Web Crypto Ed25519 is
+available in all current stable browsers.
+
 ## Contributing
 
 See the [CONTRIBUTING](../../../CONTRIBUTING.md) file for how to help out.

--- a/web/@linera/client/src/crypto.rs
+++ b/web/@linera/client/src/crypto.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cryptographic helpers exposed to JavaScript.
+
+use linera_base::{crypto::Ed25519PublicKey, identifiers::AccountOwner};
+use wasm_bindgen::prelude::*;
+
+/// Derives the `Address32` `AccountOwner` from a raw 32-byte Ed25519 public key.
+///
+/// Returns the canonical `0x`-prefixed lowercase hex string for the owner address,
+/// matching `AccountOwner::Display`.
+#[wasm_bindgen(js_name = "accountOwnerFromEd25519PublicKey")]
+pub fn account_owner_from_ed25519_public_key(public_key: &[u8]) -> Result<String, JsError> {
+    let pubkey =
+        Ed25519PublicKey::from_slice(public_key).map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(AccountOwner::from(pubkey).to_string())
+}

--- a/web/@linera/client/src/lib.rs
+++ b/web/@linera/client/src/lib.rs
@@ -36,6 +36,9 @@ pub use listener::Listener;
 pub mod faucet;
 pub mod lock;
 
+pub mod crypto;
+pub use crypto::account_owner_from_ed25519_public_key;
+
 pub mod signer;
 pub use signer::Signer;
 pub mod storage;

--- a/web/@linera/client/src/signer/Composite.ts
+++ b/web/@linera/client/src/signer/Composite.ts
@@ -18,6 +18,14 @@ export default class Composite implements Signer {
     throw new Error(`no signer found for owner ${owner}`);
   }
 
+  async getPublicKey(owner: string): Promise<string> {
+    for (const signer of this.signers)
+      if (await signer.containsKey(owner))
+        return await signer.getPublicKey(owner);
+
+    throw new Error(`no signer found for owner ${owner}`);
+  }
+
   async containsKey(owner: string): Promise<boolean> {
     for (const signer of this.signers)
       if (await signer.containsKey(owner))

--- a/web/@linera/client/src/signer/Signer.ts
+++ b/web/@linera/client/src/signer/Signer.ts
@@ -1,22 +1,40 @@
 /**
- * Interface for signing and key management compatible with Ethereum (EVM) addresses.
+ * Interface for signing and key management for Linera account owners.
+ *
+ * Implementations may back any subset of supported owner schemes:
+ *   - `Address20` (EVM secp256k1, EIP-191 signatures)
+ *   - `Address32` (Ed25519 over the 32-byte `CryptoHash` prehash)
  */
 export interface Signer {
   /**
-   * Signs a given value using the private key associated with the specified EVM address.
-   * The signing process must follow the EIP-191 standard.
+   * Signs `value` using the private key associated with `owner`.
    *
-   * @param owner - The EVM address whose private key will be used to sign the value.
-   * @param value - The data to be signed, as a `Uint8Array`.
-   * @returns A promise that resolves to the EIP-191-compatible signature in hexadecimal string format.
+   * For `Address20` owners, the returned signature must follow EIP-191 (hex, `0x`-prefixed,
+   * 65-byte r||s||v form). For `Address32` owners, the returned signature must be the raw
+   * 64-byte Ed25519 signature (`r||s`) as a `0x`-prefixed hex string.
+   *
+   * @param owner - The account owner whose key signs.
+   * @param value - The data to be signed.
    */
   sign(owner: string, value: Uint8Array): Promise<string>;
 
   /**
-   * Checks whether the instance holds a key whose associated address matches the given EVM address.
+   * Returns the public key associated with `owner`, as a `0x`-prefixed hex string.
    *
-   * @param owner - The EVM address to check for.
-   * @returns A promise that resolves to `true` if the key exists and matches the given address, otherwise `false`.
+   * For `Address20` owners, this is the uncompressed secp256k1 public key (65 bytes).
+   * For `Address32` owners, this is the raw 32-byte Ed25519 public key.
+   *
+   * Required for `Address32` owners so the wasm bridge can construct
+   * `AccountSignature::Ed25519 { signature, public_key }`.
+   *
+   * @param owner - The account owner to look up.
+   */
+  getPublicKey(owner: string): Promise<string>;
+
+  /**
+   * Checks whether the signer holds a key for `owner`.
+   *
+   * @param owner - The account owner to check.
    */
   containsKey(owner: string): Promise<boolean>;
 }

--- a/web/@linera/client/src/signer/WebCryptoEd25519.ts
+++ b/web/@linera/client/src/signer/WebCryptoEd25519.ts
@@ -1,0 +1,234 @@
+import type { Signer } from "./Signer.d.ts";
+import { accountOwnerFromEd25519PublicKey } from "../wasm/index.js";
+
+type StoredRecord = {
+  // Canonical owner address: "0x" + 64 lowercase hex chars. Lowercase is invariant —
+  // produced by Rust's `Display for AccountOwner` which uses `hex::encode`. Callers
+  // comparing against it must `.toLowerCase()` their side only.
+  owner: string;
+  publicKey: Uint8Array;
+  privateKey: CryptoKey;
+};
+
+/**
+ * A {@link Signer} backed by a non-extractable Ed25519 key from the Web Crypto API.
+ *
+ * The private key never leaves the browser's crypto subsystem: it is generated with
+ * `extractable: false` and persisted as a `CryptoKey` handle in IndexedDB. An in-page
+ * attacker (XSS, malicious dependency) can request signatures while the tab is open but
+ * cannot copy the key off the device.
+ *
+ * Owner addresses are `AccountOwner::Address32(Keccak256(BCS(public_key)))`, derived in
+ * Rust via {@link accountOwnerFromEd25519PublicKey}.
+ *
+ * **Requires** `linera.initialize()` to have been called before `generate()` or
+ * `loadOrCreate()` — both call the wasm owner-derivation helper. `load()` and
+ * `delete()` are wasm-free and may be invoked before initialization.
+ */
+export default class WebCryptoEd25519 implements Signer {
+  private constructor(private readonly record: StoredRecord) {
+    // Shallow freeze guards against accidental mutation of the cached owner / key
+    // references by the rest of the codebase. The nested `publicKey` Uint8Array's
+    // bytes remain mutable per JS semantics; treat them as read-only.
+    Object.freeze(this.record);
+  }
+
+  /**
+   * Generates a fresh non-extractable Ed25519 keypair in memory.
+   *
+   * The returned signer is NOT yet persisted to IndexedDB; call {@link persist} to
+   * commit it. Use this when the caller needs to take an extra step (e.g. registering
+   * the autosigner address on-chain) before the keypair becomes durable.
+   */
+  static async generate(): Promise<WebCryptoEd25519> {
+    const pair = await crypto.subtle.generateKey(
+      { name: "Ed25519" },
+      false,
+      ["sign", "verify"],
+    );
+    if (!("privateKey" in pair)) {
+      throw new Error(
+        "crypto.subtle.generateKey did not return a CryptoKeyPair for Ed25519",
+      );
+    }
+    const publicKey = new Uint8Array(
+      await crypto.subtle.exportKey("raw", pair.publicKey),
+    );
+    const owner = accountOwnerFromEd25519PublicKey(publicKey);
+    return new WebCryptoEd25519({
+      owner,
+      publicKey,
+      privateKey: pair.privateKey,
+    });
+  }
+
+  /**
+   * Commits this signer's keypair to IndexedDB under `recordKey`. Subsequent calls to
+   * {@link load} with the same `recordKey` will return a signer pointing at the same
+   * key material. Overwrites any existing record.
+   */
+  async persist(recordKey: string): Promise<void> {
+    const db = await openDb();
+    try {
+      await txWrite(db, (store) => store.put(this.record, recordKey));
+    } finally {
+      db.close();
+    }
+  }
+
+  /**
+   * Loads an existing keypair stored under `recordKey`. Returns `null` if no record exists.
+   */
+  static async load(recordKey: string): Promise<WebCryptoEd25519 | null> {
+    const db = await openDb();
+    try {
+      const stored = await txRead<StoredRecord | undefined>(db, (store) =>
+        store.get(recordKey) as IDBRequest<StoredRecord | undefined>,
+      );
+      if (!stored) return null;
+      return new WebCryptoEd25519(stored);
+    } finally {
+      db.close();
+    }
+  }
+
+  /** Convenience: load existing, or generate + persist a fresh keypair. */
+  static async loadOrCreate(recordKey: string): Promise<WebCryptoEd25519> {
+    const existing = await WebCryptoEd25519.load(recordKey);
+    if (existing) return existing;
+    const signer = await WebCryptoEd25519.generate();
+    await signer.persist(recordKey);
+    return signer;
+  }
+
+  /**
+   * Removes the keypair record stored under `recordKey`. No-op if no record exists.
+   * Use to revoke a session locally (e.g. after `forgoDelegation` succeeds on-chain
+   * or during a migration to a different key shape).
+   */
+  static async delete(recordKey: string): Promise<void> {
+    const db = await openDb();
+    try {
+      await txWrite(db, (store) => store.delete(recordKey));
+    } finally {
+      db.close();
+    }
+  }
+
+  /** The `Address32` account owner address, as `0x` + 64 hex chars (lowercase). */
+  address(): string {
+    return this.record.owner;
+  }
+
+  async sign(owner: string, value: Uint8Array): Promise<string> {
+    this.assertOwner(owner);
+    console.debug(
+      "[Linera Signer] WebCryptoEd25519.sign via Web Crypto API",
+      { owner, valueBytes: value.length },
+    );
+    // Runtime defense: `crypto.subtle.sign` rejects SharedArrayBuffer-backed views in
+    // some browsers. Copy into a fresh ArrayBuffer so the call works regardless of how
+    // the caller obtained `value`.
+    const buf = new Uint8Array(value).buffer as ArrayBuffer;
+    const sig = await crypto.subtle.sign("Ed25519", this.record.privateKey, buf);
+    return "0x" + bytesToHex(new Uint8Array(sig));
+  }
+
+  async getPublicKey(owner: string): Promise<string> {
+    this.assertOwner(owner);
+    return "0x" + bytesToHex(this.record.publicKey);
+  }
+
+  async containsKey(owner: string): Promise<boolean> {
+    // record.owner is canonical lowercase; only normalize the caller side.
+    return owner.toLowerCase() === this.record.owner;
+  }
+
+  private assertOwner(owner: string): void {
+    // record.owner is canonical lowercase; only normalize the caller side.
+    if (owner.toLowerCase() !== this.record.owner) {
+      throw new Error("Invalid owner address");
+    }
+  }
+}
+
+const DB_NAME = "linera-signer";
+const STORE_NAME = "keys";
+const DB_VERSION = 1;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME);
+      }
+    };
+    // Fires when another open connection on a lower version blocks this upgrade.
+    // Surface as an error rather than hanging indefinitely.
+    req.onblocked = () =>
+      reject(
+        new Error(
+          `IndexedDB upgrade blocked: another open connection is holding ` +
+            `"${DB_NAME}" at an older version. Close other tabs of this site and retry.`,
+        ),
+      );
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => {
+      const db = req.result;
+      // If another tab triggers a version upgrade, close this connection so the
+      // upgrade can proceed rather than blocking it indefinitely.
+      db.onversionchange = () => db.close();
+      resolve(db);
+    };
+  });
+}
+
+// Resolves on `req.onsuccess`. Reads have no durability barrier — the value is
+// already in memory by the time `onsuccess` fires, so waiting for
+// `transaction.oncomplete` would only add latency. Contrast with `txWrite` below,
+// which must wait for the commit.
+function txRead<T>(
+  db: IDBDatabase,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const req = fn(store);
+    req.onerror = () => reject(req.error);
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error("IndexedDB read transaction aborted"));
+    req.onsuccess = () => resolve(req.result);
+  });
+}
+
+// Resolves on `transaction.oncomplete` (not `req.onsuccess`) so the caller knows the
+// write has reached the IndexedDB log, not just the request's buffer. Without this,
+// `persist()` could return before the keypair is durable, and a tab close in the
+// intervening window would silently lose the autosigner association.
+function txWrite<T>(
+  db: IDBDatabase,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    const req = fn(store);
+    let result: T;
+    req.onerror = () => reject(req.error);
+    req.onsuccess = () => {
+      result = req.result;
+    };
+    transaction.onerror = () => reject(transaction.error);
+    transaction.onabort = () =>
+      reject(transaction.error ?? new Error("IndexedDB write transaction aborted"));
+    transaction.oncomplete = () => resolve(result);
+  });
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/web/@linera/client/src/signer/index.ts
+++ b/web/@linera/client/src/signer/index.ts
@@ -1,3 +1,4 @@
 export type { Signer } from './Signer.js';
 export { default as Composite } from './Composite.js';
 export { default as PrivateKey } from './PrivateKey.js';
+export { default as WebCryptoEd25519 } from './WebCryptoEd25519.js';

--- a/web/@linera/client/src/signer/mod.rs
+++ b/web/@linera/client/src/signer/mod.rs
@@ -36,10 +36,7 @@ impl Display for Error {
                 write!(f, "Unexpected signature format received from JS")
             }
             Error::InvalidAccountOwnerType => {
-                write!(
-                    f,
-                    "Invalid account owner type provided. Expected AccountOwner::Address20"
-                )
+                write!(f, "Invalid account owner type provided")
             }
             Error::Unknown => write!(f, "An unknown error occurred"),
         }
@@ -79,6 +76,12 @@ extern "C" {
 
     #[wasm_bindgen(catch, method, js_name = "containsKey")]
     async fn contains_key(this: &Signer, owner: AccountOwner) -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(catch, method, js_name = "getPublicKey")]
+    async fn get_public_key(
+        this: &Signer,
+        owner: AccountOwner,
+    ) -> Result<js_sys::JsString, JsValue>;
 }
 
 impl linera_base::crypto::Signer for Signer {
@@ -93,21 +96,48 @@ impl linera_base::crypto::Signer for Signer {
         owner: &AccountOwner,
         value: &CryptoHash,
     ) -> Result<AccountSignature, Self::Error> {
-        Ok(AccountSignature::EvmSecp256k1 {
-            signature: String::from(
-                self
-                    // Pass CryptoHash without serializing as that adds bytes
-                    // to the serialized value which we don't want for signing.
-                    .sign(*owner, value.as_bytes().0.to_vec())
-                    .await?,
-            )
-            .parse()
-            .map_err(|_| Error::UnexpectedSignatureFormat)?,
-            address: if let AccountOwner::Address20(address) = owner {
-                *address
-            } else {
-                return Err(Error::InvalidAccountOwnerType);
-            },
-        })
+        // We pass `CryptoHash` bytes (not BCS-serialized) to the JS layer because the JS
+        // signers sign the raw prehash directly.
+        let prehash_bytes = value.as_bytes().0.to_vec();
+        let sig_str: String = self.sign(*owner, prehash_bytes).await?.into();
+
+        match owner {
+            AccountOwner::Address20(address) => {
+                let signature = sig_str
+                    .parse()
+                    .map_err(|_| Error::UnexpectedSignatureFormat)?;
+                Ok(AccountSignature::EvmSecp256k1 {
+                    signature,
+                    address: *address,
+                })
+            }
+            AccountOwner::Address32(_) => {
+                let pub_str: String = self.get_public_key(*owner).await?.into();
+                let public_key = parse_ed25519_public_key(&pub_str).ok_or(Error::PublicKeyParse)?;
+                let signature =
+                    parse_ed25519_signature(&sig_str).ok_or(Error::UnexpectedSignatureFormat)?;
+                // Error early if signer returns a valid signature with the wrong public key.
+                if AccountOwner::from(public_key) != *owner {
+                    return Err(Error::InvalidAccountOwnerType);
+                }
+                Ok(AccountSignature::Ed25519 {
+                    signature,
+                    public_key,
+                })
+            }
+            AccountOwner::Reserved(_) => Err(Error::InvalidAccountOwnerType),
+        }
     }
+}
+
+fn parse_ed25519_public_key(hex_str: &str) -> Option<linera_base::crypto::Ed25519PublicKey> {
+    let trimmed = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = hex::decode(trimmed).ok()?;
+    linera_base::crypto::Ed25519PublicKey::from_slice(&bytes).ok()
+}
+
+fn parse_ed25519_signature(hex_str: &str) -> Option<linera_base::crypto::Ed25519Signature> {
+    let trimmed = hex_str.strip_prefix("0x").unwrap_or(hex_str);
+    let bytes = hex::decode(trimmed).ok()?;
+    linera_base::crypto::Ed25519Signature::from_slice(&bytes).ok()
 }

--- a/web/@linera/client/tests/WebCryptoEd25519.test.ts
+++ b/web/@linera/client/tests/WebCryptoEd25519.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, expect, test } from "vitest";
+import * as linera from "../dist";
+
+const RECORD_KEY = "test-record";
+const DB_NAME = "linera-signer";
+
+// Pinned by `linera-base/src/identifiers.rs::ed25519_public_key_to_account_owner_known_vector`.
+// Bytes are 0x01..0x20; the expected hex is the captured output of that Rust test.
+const KNOWN_PUBKEY = new Uint8Array([
+  0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+  0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+  0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+  0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+]);
+const OWNER_EXPECTED =
+  "0xeacee5344cbec9569e836f95029d476c700f4f5bc007c71c0752c73fba149043";
+
+beforeEach(async () => {
+  await linera.initialize();
+  await wipeDb();
+});
+
+afterEach(async () => {
+  await wipeDb();
+});
+
+test("accountOwnerFromEd25519PublicKey matches Rust known vector", () => {
+  const owner = linera.accountOwnerFromEd25519PublicKey(KNOWN_PUBKEY);
+  expect(owner).toBe(OWNER_EXPECTED);
+});
+
+test("loadOrCreate() (no prior record) yields a signer whose address matches the derived owner", async () => {
+  const signer = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  const address = signer.address();
+  expect(address).toMatch(/^0x[0-9a-f]{64}$/);
+  expect(await signer.containsKey(address)).toBe(true);
+});
+
+test("load() returns null when no record exists", async () => {
+  const loaded = await linera.signer.WebCryptoEd25519.load(RECORD_KEY);
+  expect(loaded).toBeNull();
+});
+
+test("loadOrCreate() then load() returns a signer with the same address", async () => {
+  const first = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  const second = await linera.signer.WebCryptoEd25519.load(RECORD_KEY);
+  expect(second).not.toBeNull();
+  expect(second!.address()).toBe(first.address());
+});
+
+test("loaded signer can still sign — IndexedDB CryptoKey roundtrip preserves usability", async () => {
+  const first = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  const owner = first.address();
+  const loaded = await linera.signer.WebCryptoEd25519.load(RECORD_KEY);
+  expect(loaded).not.toBeNull();
+
+  const message = new Uint8Array(32).fill(0x37);
+  const sigHex = await loaded!.sign(owner, message);
+  const pubHex = await loaded!.getPublicKey(owner);
+
+  const verifyKey = await crypto.subtle.importKey(
+    "raw",
+    hexToBytes(pubHex),
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+  const ok = await crypto.subtle.verify(
+    "Ed25519",
+    verifyKey,
+    hexToBytes(sigHex),
+    message,
+  );
+  expect(ok).toBe(true);
+});
+
+test("loadOrCreate() is idempotent for the same recordKey", async () => {
+  const first = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  const second = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  expect(second.address()).toBe(first.address());
+});
+
+test("sign() returns a 64-byte hex string that verifies against the public key", async () => {
+  const signer = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  const owner = signer.address();
+  const message = new Uint8Array(32).fill(0x42);
+  const sigHex = await signer.sign(owner, message);
+  expect(sigHex).toMatch(/^0x[0-9a-f]{128}$/);
+
+  const pubHex = await signer.getPublicKey(owner);
+  expect(pubHex).toMatch(/^0x[0-9a-f]{64}$/);
+
+  const pubBytes = hexToBytes(pubHex);
+  const sigBytes = hexToBytes(sigHex);
+  const verifyKey = await crypto.subtle.importKey(
+    "raw",
+    pubBytes,
+    { name: "Ed25519" },
+    false,
+    ["verify"],
+  );
+  const ok = await crypto.subtle.verify(
+    "Ed25519",
+    verifyKey,
+    sigBytes,
+    message,
+  );
+  expect(ok).toBe(true);
+});
+
+test("sign() rejects requests for a mismatched owner", async () => {
+  const signer = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  const wrongOwner = "0x" + "0".repeat(64);
+  await expect(signer.sign(wrongOwner, new Uint8Array(32))).rejects.toThrow(
+    /Invalid owner address/,
+  );
+});
+
+test("getPublicKey() rejects requests for a mismatched owner", async () => {
+  const signer = await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  const wrongOwner = "0x" + "0".repeat(64);
+  await expect(signer.getPublicKey(wrongOwner)).rejects.toThrow(
+    /Invalid owner address/,
+  );
+});
+
+test("generate() alone does not persist — load() still returns null", async () => {
+  const signer = await linera.signer.WebCryptoEd25519.generate();
+  expect(signer.address()).toMatch(/^0x[0-9a-f]{64}$/);
+  const loaded = await linera.signer.WebCryptoEd25519.load(RECORD_KEY);
+  expect(loaded).toBeNull();
+});
+
+test("generate() then persist() makes the keypair loadable", async () => {
+  const generated = await linera.signer.WebCryptoEd25519.generate();
+  await generated.persist(RECORD_KEY);
+  const loaded = await linera.signer.WebCryptoEd25519.load(RECORD_KEY);
+  expect(loaded).not.toBeNull();
+  expect(loaded!.address()).toBe(generated.address());
+});
+
+test("delete() removes the record so load() returns null again", async () => {
+  await linera.signer.WebCryptoEd25519.loadOrCreate(RECORD_KEY);
+  expect(await linera.signer.WebCryptoEd25519.load(RECORD_KEY)).not.toBeNull();
+
+  await linera.signer.WebCryptoEd25519.delete(RECORD_KEY);
+  expect(await linera.signer.WebCryptoEd25519.load(RECORD_KEY)).toBeNull();
+});
+
+test("delete() is a no-op on a missing record", async () => {
+  await expect(
+    linera.signer.WebCryptoEd25519.delete(RECORD_KEY),
+  ).resolves.toBeUndefined();
+});
+
+async function wipeDb(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const req = indexedDB.deleteDatabase(DB_NAME);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => resolve();
+  });
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const trimmed = hex.startsWith("0x") ? hex.slice(2) : hex;
+  const out = new Uint8Array(trimmed.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(trimmed.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}

--- a/web/@linera/metamask/src/signer.ts
+++ b/web/@linera/metamask/src/signer.ts
@@ -79,6 +79,16 @@ export default class Signer implements SignerInterface {
     }
   }
 
+  async getPublicKey(_owner: string): Promise<string> {
+    // MetaMask signs only for `Address20` (EVM secp256k1) owners. The wasm bridge
+    // never calls `getPublicKey` on the Address20 path — EVM signatures carry the
+    // signer's address inline in `AccountSignature::EvmSecp256k1`. If we get here,
+    // a caller is reaching past the bridge contract.
+    throw new Error(
+      "MetaMask signer does not expose a public key; EVM signatures carry the address",
+    );
+  }
+
   async containsKey(owner: string): Promise<boolean> {
     const accounts = await this.provider.send("eth_requestAccounts", []);
     return accounts.some(


### PR DESCRIPTION
## Motivation

Backport of #6385 from `testnet_conway` to `main`.

## Proposal

Cherry-pick of commit ee67025c5db1969114563d54da2d6f382251c095.

Conflicts resolved:
- `linera-base/src/identifiers.rs`: kept both the existing `#[cfg(with_revm)]` EVM address test and the new Ed25519 known-vector test from the cherry-pick.
- `web/@linera/client/README.md`: kept the new Building/Signers documentation section from the cherry-pick (HEAD had no content in that slot).

## Test Plan

CI

## Release Plan

- These changes should follow regular release cycle.

## Links

- [Reviewer checklist](https://github.com/linera-io/linera-protocol/wiki/Reviewing-a-Pull-Request)