### PR TITLE
Backport #6407 to main: Fix anvil_deposit_proof after introduction of decimals

### DIFF
--- a/linera-bridge/tests/anvil_deposit_proof.rs
+++ b/linera-bridge/tests/anvil_deposit_proof.rs
@@ -45,6 +45,13 @@ alloy_sol_types::sol! {
         bytes32 target_account_owner,
         uint256 amount
     ) external;
+
+    struct LineraTokenConstructorArgs {
+        string name;
+        string symbol;
+        uint8 decimals_;
+        uint256 initialSupply;
+    }
 }
 
 /// Compiles a Solidity contract via `solc`, returning deployment bytecode.
@@ -97,7 +104,13 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
     let initial_supply = U256::from(1_000_000_000u64);
     let mut erc20_deploy = erc20_bytecode;
     erc20_deploy.extend_from_slice(
-        &("TestToken".to_string(), "TT".to_string(), initial_supply).abi_encode_params(),
+        &LineraTokenConstructorArgs {
+            name: "TestToken".to_string(),
+            symbol: "TT".to_string(),
+            decimals_: 18,
+            initialSupply: initial_supply,
+        }
+        .abi_encode_params(),
     );
 
     let tx = TransactionRequest::default()


### PR DESCRIPTION
## Motivation

Backport of #6407 from `testnet_conway` to `main`.

## Proposal

Cherry-pick of commit d8519c77b721b57b21bdf3517c7378f710d0cb30.

## Test Plan

CI

## Release Plan

- [ ] This PR requires a protocol upgrade (add the appropriate label).

## Links

- [Reviewer checklist](https://github.com/linera-io/linera-protocol/wiki/Reviewing-a-Pull-Request)