### PR TITLE
Backport #6372 to main: Introduce U128(u128) type for contracts

### DIFF
--- a/examples/bridge-demo/index.html
+++ b/examples/bridge-demo/index.html
@@ -455,6 +455,7 @@
       let lineraOwner = null;
       let wrappedApp = null;  // wrapped-fungible application
       let bridgeApp = null;   // evm-bridge application
+      let tokenDecimals = null;  // decimals declared by the wrapped-fungible service
 
       // ── EVM balance ──
       async function updateEvmBalance() {
@@ -471,14 +472,15 @@
 
       // ── Linera balance ──
       async function updateLineraBalance(blockHash) {
-        if (!wrappedApp || !lineraOwner) return;
+        if (!wrappedApp || !lineraOwner || tokenDecimals === null) return;
         try {
           const resp = JSON.parse(await wrappedApp.query(
             gql(`query { accounts { entry(key: "${lineraOwner}") { value } } }`),
             blockHash ? { blockHash } : {},
           ));
-          const val = resp.data?.accounts?.entry?.value || '0';
-          $('#linera-balance').textContent = (+val).toFixed(2);
+          const rawSubUnits = resp.data?.accounts?.entry?.value || '0';
+          const whole = ethers.formatUnits(rawSubUnits, tokenDecimals);
+          $('#linera-balance').textContent = (+whole).toFixed(2);
         } catch (e) {
           console.error('Failed to fetch Linera balance:', e);
         }
@@ -533,8 +535,7 @@
         if (!evmSigner) { addError('Connect MetaMask first'); return; }
 
         try {
-          const decimals = 18;
-          const amountWei = ethers.parseUnits(amount, decimals);
+          const amountWei = ethers.parseUnits(amount, tokenDecimals);
           const token = new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, evmSigner);
           const bridge = new ethers.Contract(BRIDGE_ADDRESS, BRIDGE_ABI, evmSigner);
 
@@ -593,17 +594,18 @@
           const targetOwner = `0x${evmAddrHex}`;
           const targetAccount = { owner: targetOwner, chainId: BRIDGE_CHAIN_ID };
 
-          // Step 1: Transfer wrapped tokens to bridge chain with Address20 owner
+          // Step 1: Transfer wrapped tokens to bridge chain with Address20 owner.
           setStatus('Step 1/3: Burning wrapped tokens (transfer to bridge chain)...');
+          const amountSubUnits = ethers.parseUnits(amount, tokenDecimals).toString();
           const mutation = gql(`mutation(
             $donor: AccountOwner!,
-            $amount: Amount!,
+            $amount: U128!,
             $recipient: FungibleAccount!
           ) {
             transfer(owner: $donor, amount: $amount, targetAccount: $recipient)
           }`, {
             donor: lineraOwner,
-            amount: amount,
+            amount: amountSubUnits,
             recipient: targetAccount,
           });
           const resp = JSON.parse(await wrappedApp.query(mutation));
@@ -669,7 +671,12 @@
         await client.start();
         const chain = await client.chain(lineraChain, { owner: lineraOwner });
         wrappedApp = await chain.application(APP_ID);
-        console.log('[bridge-demo] Linera initialized', { lineraChain, lineraOwner, APP_ID, BRIDGE_APP_ID });
+        const decimalsResp = JSON.parse(await wrappedApp.query(gql(`query { decimals }`)));
+        tokenDecimals = decimalsResp.data?.decimals;
+        if (typeof tokenDecimals !== 'number') {
+          throw new Error(`wrapped-fungible decimals query returned ${JSON.stringify(decimalsResp)}`);
+        }
+        console.log('[bridge-demo] Linera initialized', { lineraChain, lineraOwner, APP_ID, BRIDGE_APP_ID, tokenDecimals });
 
         $('#linera-account').textContent = lineraOwner;
         $('#linera-chain').textContent = lineraChain;

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -31,6 +31,7 @@ FAUCET_URL=""
 RELAY_URL=""
 RELAY_OWNER=""
 TICKER_SYMBOL="wTT"
+TOKEN_DECIMALS=18
 FUND_AMOUNT="500000000000000000000"
 SHARED_DIR=""
 WALLET_DIR="/tmp/wallet"
@@ -70,6 +71,9 @@ Options:
   --faucet-url URL          Linera faucet URL (default: http://localhost:8080)
   --relay-url URL           Relay service URL (default: http://localhost:3001)
   --ticker-symbol SYM       Wrapped token ticker (default: wTT)
+  --token-decimals N        Decimal places for the deployed ERC-20 and the
+                            matching wrapped-fungible app (default: 18). Both
+                            sides MUST agree or the relayer will refuse to start.
   --fund-amount WEI         Fund bridge with this many tokens; 0 to skip
                             (default: 500000000000000000000)
   --shared-dir PATH         Directory for shared state files (bridge-address,
@@ -89,6 +93,7 @@ while [[ $# -gt 0 ]]; do
         --faucet-url)        FAUCET_URL="$2"; shift 2 ;;
         --relay-url)         RELAY_URL="$2"; shift 2 ;;
         --ticker-symbol)     TICKER_SYMBOL="$2"; shift 2 ;;
+        --token-decimals)    TOKEN_DECIMALS="$2"; shift 2 ;;
         --fund-amount)       FUND_AMOUNT="$2"; shift 2 ;;
         --shared-dir)        SHARED_DIR="$2"; shift 2 ;;
         --help)              usage ;;
@@ -189,6 +194,7 @@ EVM_CHAIN_ID_DECIMAL=$(dc_exec foundry-tools cast chain-id --rpc-url "$EVM_RPC_U
 dc_exec foundry-tools env \
     TOKEN_NAME="TestToken" \
     TOKEN_SYMBOL="TT" \
+    TOKEN_DECIMALS="$TOKEN_DECIMALS" \
     TOKEN_SUPPLY="1000000000000000000000" \
     forge script /contracts/script/DeployLineraToken.s.sol \
     --root /contracts \
@@ -273,6 +279,7 @@ linera_exec process-inbox 2>&1
 echo "Publishing and creating wrapped-fungible app..."
 WRAPPED_PARAMS=$(
     TICKER="$TICKER_SYMBOL" \
+    DECIMALS="$TOKEN_DECIMALS" \
     MINTER="$RELAY_OWNER" \
     TOKEN_HEX="$TOKEN_ADDR_HEX" \
     CHAIN_ID="$EVM_CHAIN_ID" \
@@ -284,6 +291,7 @@ def hex_to_array(h):
     return [int(h[i:i+2], 16) for i in range(0, len(h), 2)]
 params = {
     'ticker_symbol': os.environ['TICKER'],
+    'decimals': int(os.environ['DECIMALS']),
     'minter': os.environ['MINTER'],
     'mint_chain_id': os.environ['BRIDGE_CHAIN'],
     'evm_token_address': hex_to_array(os.environ['TOKEN_HEX']),

--- a/examples/wrapped-fungible/src/contract.rs
+++ b/examples/wrapped-fungible/src/contract.rs
@@ -3,19 +3,22 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
-use fungible::{state::FungibleTokenState, FungibleResponse, InitialState};
+mod state;
+
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, StreamName, WithContractAbi},
+    linera_base_types::{AccountOwner, StreamName, WithContractAbi, U128},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
 use wrapped_fungible::{
-    Account, BurnEvent, Message, WrappedFungibleOperation, WrappedFungibleTokenAbi,
-    WrappedParameters,
+    Account, BurnEvent, FungibleResponse, InitialState, Message, WrappedFungibleOperation,
+    WrappedFungibleTokenAbi, WrappedParameters,
 };
 
+use crate::state::WrappedFungibleTokenState;
+
 pub struct WrappedFungibleTokenContract {
-    state: FungibleTokenState,
+    state: WrappedFungibleTokenState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -32,7 +35,7 @@ impl Contract for WrappedFungibleTokenContract {
     type EventValue = BurnEvent;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
-        let state = FungibleTokenState::load(runtime.root_view_storage_context())
+        let state = WrappedFungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         WrappedFungibleTokenContract { state, runtime }
@@ -41,7 +44,7 @@ impl Contract for WrappedFungibleTokenContract {
     async fn instantiate(&mut self, state: Self::InstantiationArgument) {
         self.runtime.application_parameters();
         for (k, v) in state.accounts {
-            if v != Amount::ZERO {
+            if v.0 != 0 {
                 self.state.credit(k, v).await;
             }
         }
@@ -114,10 +117,10 @@ impl Contract for WrappedFungibleTokenContract {
                 FungibleResponse::Ok
             }
 
-            WrappedFungibleOperation::MintAndTransfer {
+            WrappedFungibleOperation::Mint {
                 target_account,
                 amount,
-            } => self.execute_mint_and_transfer(target_account, amount).await,
+            } => self.execute_mint(target_account, amount).await,
 
             WrappedFungibleOperation::Burn { .. } => {
                 panic!("Operation::Burn is not supported; burning happens automatically on cross-chain transfer to an Address20 on the bridge chain");
@@ -205,12 +208,7 @@ impl WrappedFungibleTokenContract {
         }
     }
 
-    /// Mints tokens to a target account (local or remote).
-    async fn execute_mint_and_transfer(
-        &mut self,
-        target_account: Account,
-        amount: Amount,
-    ) -> FungibleResponse {
+    async fn execute_mint(&mut self, target_account: Account, amount: U128) -> FungibleResponse {
         self.require_mint_authorized();
         if target_account.chain_id == self.runtime.chain_id() {
             self.state.credit(target_account.owner, amount).await;
@@ -232,7 +230,7 @@ impl WrappedFungibleTokenContract {
         FungibleResponse::Ok
     }
 
-    async fn claim(&mut self, source_account: Account, amount: Amount, target_account: Account) {
+    async fn claim(&mut self, source_account: Account, amount: U128, target_account: Account) {
         if source_account.chain_id == self.runtime.chain_id() {
             self.state.debit(source_account.owner, amount).await;
             self.finish_transfer_to_account(amount, target_account, source_account.owner)
@@ -252,7 +250,7 @@ impl WrappedFungibleTokenContract {
 
     async fn finish_transfer_to_account(
         &mut self,
-        amount: Amount,
+        amount: U128,
         target_account: Account,
         source: AccountOwner,
     ) {

--- a/examples/wrapped-fungible/src/lib.rs
+++ b/examples/wrapped-fungible/src/lib.rs
@@ -3,7 +3,6 @@
 
 //! ABI and types for a wrapped (bridged) fungible token with Mint/Burn support.
 
-pub use fungible::Message;
 pub use linera_sdk::abis::wrapped_fungible::*;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/examples/wrapped-fungible/src/service.rs
+++ b/examples/wrapped-fungible/src/service.rs
@@ -3,21 +3,25 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
+mod state;
+
 use std::sync::Arc;
 
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
-use fungible::state::FungibleTokenState;
+use fungible::OwnerSpender;
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, Amount, OwnerSpender, WithServiceAbi},
+    linera_base_types::{AccountOwner, WithServiceAbi, U128},
     views::{MapView, View},
     Service, ServiceRuntime,
 };
 use wrapped_fungible::{WrappedFungibleOperation, WrappedFungibleTokenAbi, WrappedParameters};
 
+use crate::state::WrappedFungibleTokenState;
+
 #[derive(Clone)]
 pub struct WrappedFungibleTokenService {
-    state: Arc<FungibleTokenState>,
+    state: Arc<WrappedFungibleTokenState>,
     runtime: Arc<ServiceRuntime<Self>>,
 }
 
@@ -31,7 +35,7 @@ impl Service for WrappedFungibleTokenService {
     type Parameters = WrappedParameters;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
-        let state = FungibleTokenState::load(runtime.root_view_storage_context())
+        let state = WrappedFungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
         WrappedFungibleTokenService {
@@ -53,17 +57,23 @@ impl Service for WrappedFungibleTokenService {
 
 #[Object]
 impl WrappedFungibleTokenService {
-    async fn accounts(&self) -> &MapView<AccountOwner, Amount> {
+    async fn accounts(&self) -> &MapView<AccountOwner, U128> {
         &self.state.accounts
     }
 
-    async fn allowances(&self) -> &MapView<OwnerSpender, Amount> {
+    async fn allowances(&self) -> &MapView<OwnerSpender, U128> {
         &self.state.allowances
     }
 
     async fn ticker_symbol(&self) -> Result<String, async_graphql::Error> {
         let params: WrappedParameters = self.runtime.application_parameters();
         Ok(params.ticker_symbol)
+    }
+
+    /// The number of decimal places used by the source ERC-20.
+    async fn decimals(&self) -> u8 {
+        let params: WrappedParameters = self.runtime.application_parameters();
+        params.decimals
     }
 
     /// The ERC-20 token address on the source EVM chain (hex-encoded).

--- a/examples/wrapped-fungible/src/state.rs
+++ b/examples/wrapped-fungible/src/state.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use fungible::OwnerSpender;
+use linera_sdk::{
+    linera_base_types::{AccountOwner, U128},
+    views::{linera_views, MapView, RootView, ViewStorageContext},
+};
+use wrapped_fungible::InitialState;
+
+/// Wrapped fungible token state, with balances stored as [`U128`]
+/// (raw `u128` in the source ERC-20's decimal scale).
+#[derive(RootView)]
+#[view(context = ViewStorageContext)]
+pub struct WrappedFungibleTokenState {
+    pub accounts: MapView<AccountOwner, U128>,
+    pub allowances: MapView<OwnerSpender, U128>,
+}
+
+#[allow(dead_code)]
+impl WrappedFungibleTokenState {
+    pub async fn initialize_accounts(&mut self, state: InitialState) {
+        for (k, v) in state.accounts {
+            if v.0 != 0 {
+                self.accounts
+                    .insert(&k, v)
+                    .expect("Error in insert statement");
+            }
+        }
+    }
+
+    pub async fn balance(&self, account: &AccountOwner) -> Option<U128> {
+        self.accounts
+            .get(account)
+            .await
+            .expect("Failure in the retrieval")
+    }
+
+    pub async fn balance_or_default(&self, account: &AccountOwner) -> U128 {
+        self.balance(account).await.unwrap_or_default()
+    }
+
+    pub async fn approve(&mut self, owner: AccountOwner, spender: AccountOwner, allowance: U128) {
+        let owner_spender = OwnerSpender::new(owner, spender);
+        if allowance.0 == 0 {
+            self.allowances
+                .remove(&owner_spender)
+                .expect("Failed to remove allowance");
+            return;
+        }
+        let total = self
+            .allowances
+            .get_mut_or_default(&owner_spender)
+            .await
+            .expect("Failed allowance access");
+        *total = allowance;
+    }
+
+    pub async fn debit_for_transfer_from(
+        &mut self,
+        owner: AccountOwner,
+        spender: AccountOwner,
+        amount: U128,
+    ) {
+        if amount.0 == 0 {
+            return;
+        }
+        let balance = self
+            .accounts
+            .get(&owner)
+            .await
+            .expect("Failed balance access")
+            .unwrap_or_default();
+        let new_balance = balance.0.checked_sub(amount.0).unwrap_or_else(|| {
+            panic!("Source owner {owner} does not have sufficient balance for transfer_from")
+        });
+        if new_balance == 0 {
+            self.accounts
+                .remove(&owner)
+                .expect("Failed to remove an empty account");
+        } else {
+            self.accounts
+                .insert(&owner, U128(new_balance))
+                .expect("Failed insertion operation");
+        }
+        let owner_spender = OwnerSpender::new(owner, spender);
+        let allowance = self
+            .allowances
+            .get(&owner_spender)
+            .await
+            .expect("Failed allowance access")
+            .unwrap_or_default();
+        let new_allowance = allowance.0.checked_sub(amount.0).unwrap_or_else(|| {
+            panic!(
+                "Spender {spender} does not have sufficient allowance from owner {owner}; \
+                 allowance={allowance} amount={amount}"
+            )
+        });
+        if new_allowance == 0 {
+            self.allowances
+                .remove(&owner_spender)
+                .expect("Failed to remove an empty allowance");
+        } else {
+            self.allowances
+                .insert(&owner_spender, U128(new_allowance))
+                .expect("Failed insertion operation");
+        }
+    }
+
+    pub async fn credit(&mut self, account: AccountOwner, amount: U128) {
+        if amount.0 == 0 {
+            return;
+        }
+        let balance = self.balance_or_default(&account).await;
+        let new_balance = U128(balance.0.saturating_add(amount.0));
+        self.accounts
+            .insert(&account, new_balance)
+            .expect("Failed insert statement");
+    }
+
+    pub async fn debit(&mut self, account: AccountOwner, amount: U128) {
+        if amount.0 == 0 {
+            return;
+        }
+        let balance = self.balance_or_default(&account).await;
+        let new_balance = balance.0.checked_sub(amount.0).unwrap_or_else(|| {
+            panic!("Source account {account} does not have sufficient balance for transfer")
+        });
+        if new_balance == 0 {
+            self.accounts
+                .remove(&account)
+                .expect("Failed to remove an empty account");
+        } else {
+            self.accounts
+                .insert(&account, U128(new_balance))
+                .expect("Failed insertion operation");
+        }
+    }
+}

--- a/examples/wrapped-fungible/tests/mint_burn.rs
+++ b/examples/wrapped-fungible/tests/mint_burn.rs
@@ -5,21 +5,21 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use fungible::{InitialState, InitialStateBuilder};
 use linera_sdk::{
-    linera_base_types::{
-        Account, AccountOwner, Amount, ApplicationId, ChainId, CryptoHash, TestString,
-    },
+    linera_base_types::{AccountOwner, ApplicationId, ChainId, CryptoHash, TestString, U128},
     test::TestValidator,
 };
-use wrapped_fungible::{WrappedFungibleOperation, WrappedFungibleTokenAbi, WrappedParameters};
+use wrapped_fungible::{
+    Account, InitialState, InitialStateBuilder, WrappedFungibleOperation, WrappedFungibleTokenAbi,
+    WrappedParameters,
+};
 
 /// Helper to query an account balance via GraphQL.
 async fn query_account(
     application_id: linera_sdk::linera_base_types::ApplicationId<WrappedFungibleTokenAbi>,
     chain: &linera_sdk::test::ActiveChain,
     account_owner: AccountOwner,
-) -> Option<Amount> {
+) -> Option<U128> {
     use async_graphql::InputType;
     use linera_sdk::test::QueryOutcome;
 
@@ -48,6 +48,7 @@ fn test_params(
 ) -> WrappedParameters {
     WrappedParameters {
         ticker_symbol: "wUSDC".to_string(),
+        decimals: 18,
         minter: Some(minter),
         mint_chain_id: Some(mint_chain_id),
         evm_token_address: [0xA0; 20],
@@ -80,12 +81,12 @@ async fn test_mint_from_unauthorized_signer() {
         .try_add_block(|block| {
             block.with_operation(
                 application_id,
-                WrappedFungibleOperation::MintAndTransfer {
+                WrappedFungibleOperation::Mint {
                     target_account: Account {
                         chain_id: chain.id(),
                         owner: chain_owner,
                     },
-                    amount: Amount::from_tokens(100),
+                    amount: U128(100u128 * 10u128.pow(18)),
                 },
             );
         })
@@ -107,7 +108,7 @@ async fn test_wrapped_fungible_standard_transfer() {
 
     let params = test_params(owner, chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
-        .with_account(owner, Amount::from_tokens(1000))
+        .with_account(owner, U128(1000u128 * 10u128.pow(18)))
         .build();
     let application_id = chain
         .create_application(module_id, params, initial_state, vec![])
@@ -119,7 +120,7 @@ async fn test_wrapped_fungible_standard_transfer() {
                 application_id,
                 WrappedFungibleOperation::Transfer {
                     owner,
-                    amount: Amount::from_tokens(300),
+                    amount: U128(300u128 * 10u128.pow(18)),
                     target_account: Account {
                         chain_id: chain.id(),
                         owner: recipient,
@@ -131,11 +132,11 @@ async fn test_wrapped_fungible_standard_transfer() {
 
     assert_eq!(
         query_account(application_id, &chain, owner).await,
-        Some(Amount::from_tokens(700)),
+        Some(U128(700u128 * 10u128.pow(18))),
     );
     assert_eq!(
         query_account(application_id, &chain, recipient).await,
-        Some(Amount::from_tokens(300)),
+        Some(U128(300u128 * 10u128.pow(18))),
     );
 }
 
@@ -153,7 +154,7 @@ async fn test_credit_to_address20_on_non_bridge_chain_does_not_burn() {
     let evm_address = AccountOwner::Address20([0xAA; 20]);
 
     // Bridge chain is minter_chain; other_chain is NOT the bridge chain.
-    let mint_amount = Amount::from_tokens(500);
+    let mint_amount = U128(500u128 * 10u128.pow(18));
     let params = test_params(minter_account, minter_chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
         .with_account(minter_account, mint_amount)
@@ -212,7 +213,7 @@ async fn test_credit_to_address20_on_bridge_chain_auto_burns() {
     let minter = AccountOwner::from(bridge_chain.public_key());
     let params = test_params(minter, bridge_chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
-        .with_account(sender_account, Amount::from_tokens(500))
+        .with_account(sender_account, U128(500u128 * 10u128.pow(18)))
         .build();
     let application_id = sender_chain
         .create_application(module_id, params, initial_state, vec![])
@@ -225,7 +226,7 @@ async fn test_credit_to_address20_on_bridge_chain_auto_burns() {
                 application_id,
                 WrappedFungibleOperation::Transfer {
                     owner: sender_account,
-                    amount: Amount::from_tokens(500),
+                    amount: U128(500u128 * 10u128.pow(18)),
                     target_account: Account {
                         chain_id: bridge_chain.id(),
                         owner: evm_address,
@@ -273,7 +274,7 @@ async fn test_credit_to_non_address20_on_bridge_chain_credits_normally() {
     let minter = AccountOwner::from(bridge_chain.public_key());
     let params = test_params(minter, bridge_chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
-        .with_account(sender_account, Amount::from_tokens(500))
+        .with_account(sender_account, U128(500u128 * 10u128.pow(18)))
         .build();
     let application_id = sender_chain
         .create_application(module_id, params, initial_state, vec![])
@@ -286,7 +287,7 @@ async fn test_credit_to_non_address20_on_bridge_chain_credits_normally() {
                 application_id,
                 WrappedFungibleOperation::Transfer {
                     owner: sender_account,
-                    amount: Amount::from_tokens(500),
+                    amount: U128(500u128 * 10u128.pow(18)),
                     target_account: Account {
                         chain_id: bridge_chain.id(),
                         owner: recipient,
@@ -307,7 +308,7 @@ async fn test_credit_to_non_address20_on_bridge_chain_credits_normally() {
     let balance = query_account(application_id, &bridge_chain, recipient).await;
     assert_eq!(
         balance,
-        Some(Amount::from_tokens(500)),
+        Some(U128(500u128 * 10u128.pow(18))),
         "Credit to non-Address20 on bridge chain should credit normally, not burn"
     );
 }
@@ -336,12 +337,12 @@ async fn test_mint_on_wrong_chain() {
         .try_add_block(|block| {
             block.with_operation(
                 application_id,
-                WrappedFungibleOperation::MintAndTransfer {
+                WrappedFungibleOperation::Mint {
                     target_account: Account {
                         chain_id: minter_chain.id(),
                         owner: minter_account,
                     },
-                    amount: Amount::from_tokens(100),
+                    amount: U128(100u128 * 10u128.pow(18)),
                 },
             );
         })
@@ -371,12 +372,12 @@ async fn test_direct_mint_without_bridge_is_rejected() {
         .try_add_block(|block| {
             block.with_operation(
                 application_id,
-                WrappedFungibleOperation::MintAndTransfer {
+                WrappedFungibleOperation::Mint {
                     target_account: Account {
                         chain_id: minter_chain.id(),
                         owner: minter_account,
                     },
-                    amount: Amount::from_tokens(1000),
+                    amount: U128(1000u128 * 10u128.pow(18)),
                 },
             );
         })

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -42,7 +42,14 @@ bcs.workspace = true
 cfg-if.workspace = true
 chrono.workspace = true
 custom_debug_derive.workspace = true
-derive_more = { workspace = true, features = ["display", "from_str"] }
+derive_more = { workspace = true, features = [
+    "deref",
+    "deref_mut",
+    "display",
+    "from",
+    "from_str",
+    "into",
+] }
 ed25519-dalek.workspace = true
 futures.workspace = true
 getrandom = { workspace = true, optional = true }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -359,6 +359,54 @@ impl TryFrom<U256> for Amount {
     }
 }
 
+/// A `u128` newtype that serializes as a decimal string in human-readable
+/// formats (JSON / GraphQL) and as a bare `u128` in binary (BCS).
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Hash,
+    derive_more::Display,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::Deref,
+    derive_more::DerefMut,
+    derive_more::FromStr,
+)]
+pub struct U128(pub u128);
+
+impl Serialize for U128 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.0.to_string())
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for U128 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            let s = String::deserialize(deserializer)?;
+            s.parse().map(U128).map_err(serde::de::Error::custom)
+        } else {
+            u128::deserialize(deserializer).map(U128)
+        }
+    }
+}
+
 /// A block height to identify blocks in a chain.
 #[derive(
     Eq,
@@ -1950,6 +1998,7 @@ impl MessagePolicy {
 
 doc_scalar!(Bytecode, "A module bytecode (WebAssembly or EVM)");
 doc_scalar!(Amount, "A non-negative amount of tokens.");
+doc_scalar!(U128, "A 128-bit unsigned integer.");
 doc_scalar!(
     Epoch,
     "A number identifying the configuration of the chain (aka the committee)"

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -10,11 +10,11 @@ use evm_bridge::{
 use linera_bridge::proof;
 use linera_sdk::{
     ethereum::{ContractEthereumClient, EthereumQueries},
-    linera_base_types::{Account, Amount, ApplicationId, WithContractAbi},
+    linera_base_types::{ApplicationId, U128, WithContractAbi},
     views::{linera_views, RegisterView, RootView, SetView, View, ViewStorageContext},
     Contract, ContractRuntime,
 };
-use wrapped_fungible::{WrappedFungibleOperation, WrappedFungibleTokenAbi};
+use wrapped_fungible::{Account, WrappedFungibleOperation, WrappedFungibleTokenAbi};
 
 /// On-chain state: tracks processed deposits, verified block hashes,
 /// the registered wrapped-fungible application, and the registered EVM
@@ -262,10 +262,15 @@ impl EvmBridgeContract {
                 .expect("failed to cache verified block hash");
         }
 
-        // 6. Convert deposit fields to Linera types and call MintAndTransfer
-        let amount = Amount::try_from(deposit.amount).expect("deposit amount exceeds u128");
+        // 6. Convert deposit fields to Linera types and call Mint
+        let amount = U128(
+            deposit
+                .amount
+                .try_into()
+                .expect("deposit amount exceeds u128"),
+        );
 
-        let mint_op = WrappedFungibleOperation::MintAndTransfer {
+        let mint_op = WrappedFungibleOperation::Mint {
             target_account: Account {
                 chain_id: deposit.target_chain_id,
                 owner: deposit.target_account_owner,

--- a/linera-bridge/contracts/evm-bridge/tests/process_deposit.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/process_deposit.rs
@@ -85,6 +85,7 @@ impl TestBridge {
             .await;
         let wrapped_params = WrappedParameters {
             ticker_symbol: "wUSDC".to_string(),
+            decimals: 6,
             minter: Some(chain_owner),
             mint_chain_id: Some(chain.id()),
             evm_token_address: token_address,
@@ -222,6 +223,7 @@ impl TestBridge {
             .await;
         let wrapped_params = WrappedParameters {
             ticker_symbol: "wUSDC".to_string(),
+            decimals: 6,
             minter: Some(chain_owner),
             mint_chain_id: Some(chain.id()),
             evm_token_address: token_address,
@@ -757,6 +759,7 @@ async fn setup_bridge_with_anvil(
         .await;
     let wrapped_params = WrappedParameters {
         ticker_symbol: "wUSDC".to_string(),
+        decimals: 6,
         minter: Some(chain_owner),
         mint_chain_id: Some(chain.id()),
         evm_token_address: token_address,

--- a/linera-bridge/src/fungible_bridge.rs
+++ b/linera-bridge/src/fungible_bridge.rs
@@ -8,7 +8,7 @@ mod tests {
     use alloy_sol_types::SolEvent;
     use linera_base::{
         crypto::{CryptoHash, TestString, ValidatorSecretKey},
-        data_types::{Amount, BlockHeight},
+        data_types::{BlockHeight, U128},
     };
     use revm::{
         database::{CacheDB, EmptyDB},
@@ -124,7 +124,7 @@ mod tests {
         fn submit_burn(
             &mut self,
             target: [u8; 20],
-            amount: Amount,
+            amount: U128,
         ) -> (Vec<revm::primitives::Log>, u64) {
             let evt = burn_event(self.app_id, target, amount, 0);
             self.submit_block_with_events(vec![vec![evt]])
@@ -185,7 +185,7 @@ mod tests {
 
         let transfer_amount = 100_000_000_000_000_000_000u128;
 
-        t.submit_burn(TEST_TARGET, Amount::from_attos(transfer_amount));
+        t.submit_burn(TEST_TARGET, U128(transfer_amount));
 
         assert_eq!(
             t.query_token_balance(test_target_evm_address()),
@@ -200,7 +200,7 @@ mod tests {
 
         let transfer_amount = 100_000_000_000_000_000_000u128;
 
-        t.submit_burn(TEST_TARGET, Amount::from_attos(transfer_amount));
+        t.submit_burn(TEST_TARGET, U128(transfer_amount));
         assert_eq!(
             t.query_token_balance(test_target_evm_address()),
             alloy_primitives::U256::from(transfer_amount),
@@ -209,7 +209,7 @@ mod tests {
 
         let second_transfer = 50_000_000_000_000_000_000u128;
 
-        t.submit_burn(TEST_TARGET, Amount::from_attos(second_transfer));
+        t.submit_burn(TEST_TARGET, U128(second_transfer));
         assert_eq!(
             t.query_token_balance(test_target_evm_address()),
             alloy_primitives::U256::from(transfer_amount + second_transfer),
@@ -229,7 +229,7 @@ mod tests {
         let mut t = TestBridge::new();
         let other_app_id = CryptoHash::new(&TestString::new("other_app"));
 
-        let evt = burn_event(other_app_id, TEST_TARGET, Amount::from_tokens(50), 0);
+        let evt = burn_event(other_app_id, TEST_TARGET, U128(50u128 * 10u128.pow(18)), 0);
         t.submit_block_with_events(vec![vec![evt]]);
 
         assert_eq!(
@@ -243,7 +243,7 @@ mod tests {
     fn test_fungible_bridge_gas_measurement() {
         let mut t = TestBridge::new();
 
-        let (_, gas_used) = t.submit_burn(TEST_TARGET, Amount::from_tokens(100));
+        let (_, gas_used) = t.submit_burn(TEST_TARGET, U128(100u128 * 10u128.pow(18)));
 
         println!("Gas used for fungible bridge addBlock with BurnEvent: {gas_used}");
     }

--- a/linera-bridge/src/monitor/db.rs
+++ b/linera-bridge/src/monitor/db.rs
@@ -391,7 +391,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     use alloy::primitives::{Address, B256, U256};
-    use linera_base::data_types::Amount;
+    use linera_base::{crypto::CryptoHash, data_types::U128};
     use test_case::test_case;
 
     use super::*;
@@ -435,7 +435,7 @@ mod tests {
             evm_recipient: "0xabcdef1234567890abcdef1234567890abcdef12"
                 .parse()
                 .unwrap(),
-            amount: Amount::from_attos(500_000),
+            amount: U128(500_000),
         }
     }
 

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -19,8 +19,9 @@ use std::{
 };
 
 use alloy::primitives::{Address, B256, U256};
+use anyhow::Context as _;
 use linera_base::{
-    data_types::{Amount, BlockHeight},
+    data_types::{BlockHeight, U128},
     identifiers::ApplicationId,
 };
 use linera_execution::{Query, QueryResponse};
@@ -46,6 +47,29 @@ pub async fn query_deposit_processed<E: linera_core::environment::Environment>(
     Ok(response["data"]["isDepositProcessed"].as_bool() == Some(true))
 }
 
+/// Queries the wrapped-fungible app for its declared source-ERC-20 decimals.
+pub async fn query_wrapped_fungible_decimals<E: linera_core::environment::Environment>(
+    chain_client: &linera_core::client::ChainClient<E>,
+    fungible_app_id: ApplicationId,
+) -> anyhow::Result<u8> {
+    let query = Query::user_without_abi(
+        fungible_app_id,
+        &GqlRequest {
+            query: "{ decimals }".to_string(),
+        },
+    )?;
+    let (outcome, _) = chain_client.query_application(query, None).await?;
+    let response_bytes = match outcome.response {
+        QueryResponse::User(bytes) => bytes,
+        other => anyhow::bail!("unexpected query response: {other:?}"),
+    };
+    let response: serde_json::Value = serde_json::from_slice(&response_bytes)?;
+    let decimals = response["data"]["decimals"]
+        .as_u64()
+        .context("missing or invalid `decimals` field in service response")?;
+    u8::try_from(decimals).context("`decimals` field does not fit in u8")
+}
+
 /// A pending deposit detected by the EVM scanner, sent to the retry loop.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PendingDeposit {
@@ -67,7 +91,7 @@ pub struct PendingBurn {
     pub height: BlockHeight,
     pub event_index: u32,
     pub evm_recipient: Address,
-    pub amount: Amount,
+    pub amount: U128,
 }
 
 /// Wraps a pending bridging request with tracking metadata.
@@ -412,7 +436,7 @@ fn retry_eligible(retry_count: u32, last_retry_at: Option<Instant>, max_retries:
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, B256, U256};
-    use linera_base::data_types::{Amount, BlockHeight};
+    use linera_base::data_types::BlockHeight;
 
     use super::*;
 
@@ -484,7 +508,7 @@ mod tests {
                 height: BlockHeight(10),
                 event_index: 0,
                 evm_recipient: Address::from([0xab; 20]),
-                amount: Amount::from_attos(500),
+                amount: U128(500),
             })
             .await;
 
@@ -521,7 +545,7 @@ mod tests {
                 height: BlockHeight(5),
                 event_index: 0,
                 evm_recipient: Address::from([0x12; 20]),
-                amount: Amount::from_attos(100),
+                amount: U128(100),
             })
             .await;
 
@@ -673,7 +697,7 @@ mod tests {
             height: BlockHeight(99),
             event_index: 2,
             evm_recipient: Address::from([0xDD; 20]),
-            amount: Amount::from_attos(7),
+            amount: U128(7),
         })
         .await
         .unwrap();
@@ -699,7 +723,7 @@ mod tests {
                 height,
                 event_index: 0,
                 evm_recipient: Address::from([0xab; 20]),
-                amount: Amount::from_attos(500),
+                amount: U128(500),
             })
             .await;
 

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -20,7 +20,13 @@ sol! {
     interface IFungibleBridge {
         function addBlock(bytes calldata data) external;
         function lightClient() external view returns (address);
+        function token() external view returns (address);
         function isBurnProcessed(uint64 height, uint32 eventIndex) external view returns (bool);
+    }
+
+    #[sol(rpc)]
+    interface IERC20Decimals {
+        function decimals() external view returns (uint8);
     }
 }
 
@@ -77,6 +83,23 @@ impl<P: Provider> EvmClient<P> {
     /// Returns the relayer's ETH balance in wei.
     pub async fn get_relayer_balance(&self) -> Result<U256> {
         Ok(self.provider.get_balance(self.relayer_addr).await?)
+    }
+
+    /// Returns the decimals of the ERC-20 bridged by the configured `FungibleBridge`.
+    pub async fn token_decimals(&self) -> Result<u8> {
+        let bridge = IFungibleBridge::new(self.bridge_addr, &self.provider);
+        let token_addr = bridge
+            .token()
+            .call()
+            .await
+            .context("failed to query FungibleBridge.token()")?;
+        let token = IERC20Decimals::new(token_addr, &self.provider);
+        let decimals = token
+            .decimals()
+            .call()
+            .await
+            .context("failed to query ERC-20 decimals()")?;
+        Ok(decimals)
     }
 
     /// Queries `DepositInitiated` events in chunked ranges.

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -303,6 +303,25 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
         .parse()
         .context("invalid --linera-fungible-address")?;
 
+    // ── Verify the configured Linera and EVM contracts agree on token decimals ──
+    let linera_decimals = monitor::query_wrapped_fungible_decimals(&chain_client, fungible_app_id)
+        .await
+        .context("failed to query wrapped-fungible decimals from Linera")?;
+    let evm_decimals = evm_client
+        .token_decimals()
+        .await
+        .context("failed to query ERC-20 decimals from EVM")?;
+    anyhow::ensure!(
+        linera_decimals == evm_decimals,
+        "token decimals mismatch between Linera wrapped-fungible ({linera_decimals}) and \
+         EVM ERC-20 ({evm_decimals}); the bridge would silently misinterpret amounts. \
+         Reconfigure both sides with matching `decimals` before starting the relayer."
+    );
+    tracing::info!(
+        decimals = linera_decimals,
+        "Verified Linera ↔ EVM token decimals match"
+    );
+
     let (op_tx, mut op_rx) = mpsc::channel::<linera::ChainOperation>(16);
     let linera_client = Arc::new(linera::LineraClient::new(
         chain_client.clone(),

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -119,11 +119,83 @@ contract FungibleBridge is Microchain {
                 WrappedFungibleTypes.BurnEvent memory burnEvt =
                     WrappedFungibleTypes.bcs_deserialize_BurnEvent(evt.value);
                 address target = address(burnEvt.target);
-                require(token.transfer(target, burnEvt.amount.value), "token transfer failed");
+                require(token.transfer(target, burnEvt.amount), "token transfer failed");
                 processedBurns[key] = true;
             }
         }
     }
+
+    /// Processes burns at the requested `eventPositionsInTx` positions
+    /// within transaction `txIndex` of `cert`. Verifies the cert once
+    /// and uses direct array access (`body.events[txIndex][pos]`) for
+    /// every burn — no nested-loop scan. The off-chain relayer uses
+    /// this when `addBlock(cert)` would not fit in a single EVM tx,
+    /// chunking burns per-tx-then-by-gas.
+    ///
+    /// Idempotent like `_onBlock`: positions already in `processedBurns` are
+    /// skipped silently rather than reverted. Lets the relayer recover from
+    /// overlap with a prior `addBlock` (or a racing/retrying `processBurns`)
+    /// instead of losing the whole chunk to a single duplicate.
+    ///
+    /// Reverts (atomically — no `processedBurns` flag is set if the call
+    /// reverts) on:
+    /// - empty `eventPositionsInTx` (`"empty positions"`)
+    /// - `txIndex` out of range (`"txIndex out of range"`)
+    /// - any position out of range (`"eventPos out of range"`)
+    /// - any position whose event is not a matching burn for this app
+    ///   (`"not a matching burn"`)
+    /// - any failed `token.transfer` (`"token transfer failed"`)
+    function processBurns(bytes calldata data, uint32 txIndex, uint32[] calldata eventPositionsInTx) external {
+        require(eventPositionsInTx.length > 0, "empty positions");
+        (BridgeTypes.Block memory blockValue,) = lightClient.verifyBlock(data);
+        require(blockValue.header.chain_id.value.value == chainId, "chain id mismatch");
+        require(txIndex < blockValue.body.events.length, "txIndex out of range");
+
+        uint64 height = blockValue.header.height.value;
+        bytes32 burnsHash = keccak256("burns");
+        BridgeTypes.Event[] memory txEvents = blockValue.body.events[txIndex];
+
+        for (uint256 k = 0; k < eventPositionsInTx.length; k++) {
+            uint32 pos = eventPositionsInTx[k];
+            require(pos < txEvents.length, "eventPos out of range");
+            BridgeTypes.Event memory evt = txEvents[pos];
+            require(_isMatchingBurn(evt, burnsHash), "not a matching burn");
+
+            bytes32 key = _burnKey(height, evt.index);
+            if (processedBurns[key]) continue;
+
+            _releaseBurn(evt, key);
+        }
+    }
+
+    /// Dedup key for a burn at `(height, eventIndex)`. `eventIndex` is the
+    /// underlying Linera `Event.index`.
+    function _burnKey(uint64 height, uint32 eventIndex) private pure returns (bytes32) {
+        return keccak256(abi.encode(height, eventIndex));
+    }
+
+    /// Returns true if `evt` belongs to the configured wrapped-fungible
+    /// application's "burns" stream.
+    function _isMatchingBurn(BridgeTypes.Event memory evt, bytes32 burnsHash) private view returns (bool) {
+        // choice == 1 is User application
+        if (evt.stream_id.application_id.choice != 1) return false;
+        if (evt.stream_id.application_id.user.application_description_hash.value != fungibleApplicationId) {
+            return false;
+        }
+        if (keccak256(evt.stream_id.stream_name.value) != burnsHash) return false;
+        return true;
+    }
+
+    /// Releases the ERC-20 tokens for the burn described by `evt`. Sets
+    /// the dedup flag BEFORE the external `token.transfer` call
+    /// (checks-effects-interactions) so a malicious token that re-enters
+    /// `addBlock` / `processBurns` cannot trigger a second release.
+    function _releaseBurn(BridgeTypes.Event memory evt, bytes32 key) private {
+        WrappedFungibleTypes.BurnEvent memory burnEvt = WrappedFungibleTypes.bcs_deserialize_BurnEvent(evt.value);
+        processedBurns[key] = true;
+        require(token.transfer(address(burnEvt.target), burnEvt.amount), "token transfer failed");
+    }
+
 
     /// @dev Calls transferFrom and handles tokens that don't return a boolean.
     function _safeTransferFrom(address from, address to, uint256 amount_) internal {

--- a/linera-bridge/src/solidity/LineraToken.sol
+++ b/linera-bridge/src/solidity/LineraToken.sol
@@ -4,7 +4,16 @@ pragma solidity ^0.8.20;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract LineraToken is ERC20 {
-    constructor(string memory name_, string memory symbol_, uint256 initialSupply) ERC20(name_, symbol_) {
+    uint8 private immutable _customDecimals;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_, uint256 initialSupply)
+        ERC20(name_, symbol_)
+    {
+        _customDecimals = decimals_;
         _mint(msg.sender, initialSupply);
+    }
+
+    function decimals() public view virtual override returns (uint8) {
+        return _customDecimals;
     }
 }

--- a/linera-bridge/src/solidity/WrappedFungibleTypes.sol
+++ b/linera-bridge/src/solidity/WrappedFungibleTypes.sol
@@ -45,12 +45,12 @@ library WrappedFungibleTypes {
 
     struct BurnEvent {
         bytes20 target;
-        BridgeTypes.Amount amount;
+        uint128 amount;
     }
 
     function bcs_serialize_BurnEvent(BurnEvent memory input) internal pure returns (bytes memory) {
         bytes memory result = bcs_serialize_bytes20(input.target);
-        return abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        return abi.encodePacked(result, bcs_serialize_uint128(input.amount));
     }
 
     function bcs_deserialize_offset_BurnEvent(uint256 pos, bytes memory input)
@@ -61,8 +61,8 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         bytes20 target;
         (new_pos, target) = bcs_deserialize_offset_bytes20(pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         return (new_pos, BurnEvent(target, amount));
     }
 
@@ -134,13 +134,13 @@ library WrappedFungibleTypes {
 
     struct Message_Credit {
         BridgeTypes.AccountOwner target;
-        BridgeTypes.Amount amount;
+        uint128 amount;
         BridgeTypes.AccountOwner source;
     }
 
     function bcs_serialize_Message_Credit(Message_Credit memory input) internal pure returns (bytes memory) {
         bytes memory result = BridgeTypes.bcs_serialize_AccountOwner(input.target);
-        result = abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        result = abi.encodePacked(result, bcs_serialize_uint128(input.amount));
         return abi.encodePacked(result, BridgeTypes.bcs_serialize_AccountOwner(input.source));
     }
 
@@ -152,8 +152,8 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         BridgeTypes.AccountOwner memory target;
         (new_pos, target) = BridgeTypes.bcs_deserialize_offset_AccountOwner(pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         BridgeTypes.AccountOwner memory source;
         (new_pos, source) = BridgeTypes.bcs_deserialize_offset_AccountOwner(new_pos, input);
         return (new_pos, Message_Credit(target, amount, source));
@@ -169,13 +169,13 @@ library WrappedFungibleTypes {
 
     struct Message_Withdraw {
         BridgeTypes.AccountOwner owner;
-        BridgeTypes.Amount amount;
+        uint128 amount;
         BridgeTypes.Account target_account;
     }
 
     function bcs_serialize_Message_Withdraw(Message_Withdraw memory input) internal pure returns (bytes memory) {
         bytes memory result = BridgeTypes.bcs_serialize_AccountOwner(input.owner);
-        result = abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        result = abi.encodePacked(result, bcs_serialize_uint128(input.amount));
         return abi.encodePacked(result, BridgeTypes.bcs_serialize_Account(input.target_account));
     }
 
@@ -187,8 +187,8 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         BridgeTypes.AccountOwner memory owner;
         (new_pos, owner) = BridgeTypes.bcs_deserialize_offset_AccountOwner(pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         BridgeTypes.Account memory target_account;
         (new_pos, target_account) = BridgeTypes.bcs_deserialize_offset_Account(new_pos, input);
         return (new_pos, Message_Withdraw(owner, amount, target_account));
@@ -450,7 +450,7 @@ library WrappedFungibleTypes {
     struct WrappedFungibleOperation_Approve {
         BridgeTypes.AccountOwner owner;
         BridgeTypes.AccountOwner spender;
-        BridgeTypes.Amount allowance;
+        uint128 allowance;
     }
 
     function bcs_serialize_WrappedFungibleOperation_Approve(WrappedFungibleOperation_Approve memory input)
@@ -460,7 +460,7 @@ library WrappedFungibleTypes {
     {
         bytes memory result = BridgeTypes.bcs_serialize_AccountOwner(input.owner);
         result = abi.encodePacked(result, BridgeTypes.bcs_serialize_AccountOwner(input.spender));
-        return abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.allowance));
+        return abi.encodePacked(result, bcs_serialize_uint128(input.allowance));
     }
 
     function bcs_deserialize_offset_WrappedFungibleOperation_Approve(uint256 pos, bytes memory input)
@@ -473,8 +473,8 @@ library WrappedFungibleTypes {
         (new_pos, owner) = BridgeTypes.bcs_deserialize_offset_AccountOwner(pos, input);
         BridgeTypes.AccountOwner memory spender;
         (new_pos, spender) = BridgeTypes.bcs_deserialize_offset_AccountOwner(new_pos, input);
-        BridgeTypes.Amount memory allowance;
-        (new_pos, allowance) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 allowance;
+        (new_pos, allowance) = bcs_deserialize_offset_uint128(new_pos, input);
         return (new_pos, WrappedFungibleOperation_Approve(owner, spender, allowance));
     }
 
@@ -527,7 +527,7 @@ library WrappedFungibleTypes {
 
     struct WrappedFungibleOperation_Burn {
         BridgeTypes.AccountOwner owner;
-        BridgeTypes.Amount amount;
+        uint128 amount;
     }
 
     function bcs_serialize_WrappedFungibleOperation_Burn(WrappedFungibleOperation_Burn memory input)
@@ -536,7 +536,7 @@ library WrappedFungibleTypes {
         returns (bytes memory)
     {
         bytes memory result = BridgeTypes.bcs_serialize_AccountOwner(input.owner);
-        return abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        return abi.encodePacked(result, bcs_serialize_uint128(input.amount));
     }
 
     function bcs_deserialize_offset_WrappedFungibleOperation_Burn(uint256 pos, bytes memory input)
@@ -547,8 +547,8 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         BridgeTypes.AccountOwner memory owner;
         (new_pos, owner) = BridgeTypes.bcs_deserialize_offset_AccountOwner(pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         return (new_pos, WrappedFungibleOperation_Burn(owner, amount));
     }
 
@@ -566,7 +566,7 @@ library WrappedFungibleTypes {
 
     struct WrappedFungibleOperation_Claim {
         BridgeTypes.Account source_account;
-        BridgeTypes.Amount amount;
+        uint128 amount;
         BridgeTypes.Account target_account;
     }
 
@@ -576,7 +576,7 @@ library WrappedFungibleTypes {
         returns (bytes memory)
     {
         bytes memory result = BridgeTypes.bcs_serialize_Account(input.source_account);
-        result = abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        result = abi.encodePacked(result, bcs_serialize_uint128(input.amount));
         return abi.encodePacked(result, BridgeTypes.bcs_serialize_Account(input.target_account));
     }
 
@@ -588,8 +588,8 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         BridgeTypes.Account memory source_account;
         (new_pos, source_account) = BridgeTypes.bcs_deserialize_offset_Account(pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         BridgeTypes.Account memory target_account;
         (new_pos, target_account) = BridgeTypes.bcs_deserialize_offset_Account(new_pos, input);
         return (new_pos, WrappedFungibleOperation_Claim(source_account, amount, target_account));
@@ -609,7 +609,7 @@ library WrappedFungibleTypes {
 
     struct WrappedFungibleOperation_MintAndTransfer {
         BridgeTypes.Account target_account;
-        BridgeTypes.Amount amount;
+        uint128 amount;
     }
 
     function bcs_serialize_WrappedFungibleOperation_MintAndTransfer(WrappedFungibleOperation_MintAndTransfer memory input)
@@ -618,7 +618,7 @@ library WrappedFungibleTypes {
         returns (bytes memory)
     {
         bytes memory result = BridgeTypes.bcs_serialize_Account(input.target_account);
-        return abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        return abi.encodePacked(result, bcs_serialize_uint128(input.amount));
     }
 
     function bcs_deserialize_offset_WrappedFungibleOperation_MintAndTransfer(uint256 pos, bytes memory input)
@@ -629,8 +629,8 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         BridgeTypes.Account memory target_account;
         (new_pos, target_account) = BridgeTypes.bcs_deserialize_offset_Account(pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         return (new_pos, WrappedFungibleOperation_MintAndTransfer(target_account, amount));
     }
 
@@ -648,7 +648,7 @@ library WrappedFungibleTypes {
 
     struct WrappedFungibleOperation_Transfer {
         BridgeTypes.AccountOwner owner;
-        BridgeTypes.Amount amount;
+        uint128 amount;
         BridgeTypes.Account target_account;
     }
 
@@ -658,7 +658,7 @@ library WrappedFungibleTypes {
         returns (bytes memory)
     {
         bytes memory result = BridgeTypes.bcs_serialize_AccountOwner(input.owner);
-        result = abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        result = abi.encodePacked(result, bcs_serialize_uint128(input.amount));
         return abi.encodePacked(result, BridgeTypes.bcs_serialize_Account(input.target_account));
     }
 
@@ -670,8 +670,8 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         BridgeTypes.AccountOwner memory owner;
         (new_pos, owner) = BridgeTypes.bcs_deserialize_offset_AccountOwner(pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         BridgeTypes.Account memory target_account;
         (new_pos, target_account) = BridgeTypes.bcs_deserialize_offset_Account(new_pos, input);
         return (new_pos, WrappedFungibleOperation_Transfer(owner, amount, target_account));
@@ -692,7 +692,7 @@ library WrappedFungibleTypes {
     struct WrappedFungibleOperation_TransferFrom {
         BridgeTypes.AccountOwner owner;
         BridgeTypes.AccountOwner spender;
-        BridgeTypes.Amount amount;
+        uint128 amount;
         BridgeTypes.Account target_account;
     }
 
@@ -703,7 +703,7 @@ library WrappedFungibleTypes {
     {
         bytes memory result = BridgeTypes.bcs_serialize_AccountOwner(input.owner);
         result = abi.encodePacked(result, BridgeTypes.bcs_serialize_AccountOwner(input.spender));
-        result = abi.encodePacked(result, BridgeTypes.bcs_serialize_Amount(input.amount));
+        result = abi.encodePacked(result, bcs_serialize_uint128(input.amount));
         return abi.encodePacked(result, BridgeTypes.bcs_serialize_Account(input.target_account));
     }
 
@@ -717,8 +717,8 @@ library WrappedFungibleTypes {
         (new_pos, owner) = BridgeTypes.bcs_deserialize_offset_AccountOwner(pos, input);
         BridgeTypes.AccountOwner memory spender;
         (new_pos, spender) = BridgeTypes.bcs_deserialize_offset_AccountOwner(new_pos, input);
-        BridgeTypes.Amount memory amount;
-        (new_pos, amount) = BridgeTypes.bcs_deserialize_offset_Amount(new_pos, input);
+        uint128 amount;
+        (new_pos, amount) = bcs_deserialize_offset_uint128(new_pos, input);
         BridgeTypes.Account memory target_account;
         (new_pos, target_account) = BridgeTypes.bcs_deserialize_offset_Account(new_pos, input);
         return (new_pos, WrappedFungibleOperation_TransferFrom(owner, spender, amount, target_account));
@@ -746,5 +746,50 @@ library WrappedFungibleTypes {
             dest := mload(add(add(input, 0x20), pos))
         }
         return (pos + 20, dest);
+    }
+
+    function bcs_serialize_uint128(uint128 input) internal pure returns (bytes memory) {
+        bytes memory result = new bytes(16);
+        uint128 value = input;
+        result[0] = bytes1(uint8(value));
+        for (uint256 i = 1; i < 16; i++) {
+            value = value >> 8;
+            result[i] = bytes1(uint8(value));
+        }
+        return result;
+    }
+
+    function bcs_deserialize_offset_uint128(uint256 pos, bytes memory input) internal pure returns (uint256, uint128) {
+        uint128 value = uint8(input[pos + 15]);
+        for (uint256 i = 0; i < 15; i++) {
+            value = value << 8;
+            value += uint8(input[pos + 14 - i]);
+        }
+        return (pos + 16, value);
+    }
+
+    function bcs_deserialize_uint128(bytes memory input) internal pure returns (uint128) {
+        uint256 new_pos;
+        uint128 value;
+        (new_pos, value) = bcs_deserialize_offset_uint128(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    function bcs_serialize_uint8(uint8 input) internal pure returns (bytes memory) {
+        return abi.encodePacked(input);
+    }
+
+    function bcs_deserialize_offset_uint8(uint256 pos, bytes memory input) internal pure returns (uint256, uint8) {
+        uint8 value = uint8(input[pos]);
+        return (pos + 1, value);
+    }
+
+    function bcs_deserialize_uint8(bytes memory input) internal pure returns (uint8) {
+        uint256 new_pos;
+        uint8 value;
+        (new_pos, value) = bcs_deserialize_offset_uint8(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
     }
 } // end of library WrappedFungibleTypes

--- a/linera-bridge/src/solidity/script/DeployLineraToken.s.sol
+++ b/linera-bridge/src/solidity/script/DeployLineraToken.s.sol
@@ -9,8 +9,9 @@ contract DeployLineraToken is Script {
         string memory name = vm.envOr("TOKEN_NAME", string("LineraToken"));
         string memory symbol = vm.envOr("TOKEN_SYMBOL", string("LIN"));
         uint256 supply = vm.envOr("TOKEN_SUPPLY", uint256(1_000_000_000_000_000_000_000));
+        uint8 decimals_ = uint8(vm.envOr("TOKEN_DECIMALS", uint256(18)));
 
         vm.broadcast();
-        token = new LineraToken(name, symbol, supply);
+        token = new LineraToken(name, symbol, decimals_, supply);
     }
 }

--- a/linera-bridge/src/solidity/test/LineraToken.t.sol
+++ b/linera-bridge/src/solidity/test/LineraToken.t.sol
@@ -6,7 +6,7 @@ import {LineraToken} from "../LineraToken.sol";
 
 contract LineraTokenTest is Test {
     function test_constructor_mints_supply_to_deployer() public {
-        LineraToken t = new LineraToken("Foo", "FOO", 100);
+        LineraToken t = new LineraToken("Foo", "FOO", 18, 100);
         assertEq(t.name(), "Foo");
         assertEq(t.symbol(), "FOO");
         assertEq(t.decimals(), 18);

--- a/linera-bridge/src/test_helpers.rs
+++ b/linera-bridge/src/test_helpers.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use alloy_sol_types::{SolCall, SolValue};
 use linera_base::{
     crypto::{AccountPublicKey, CryptoHash, TestString, ValidatorPublicKey, ValidatorSecretKey},
-    data_types::{Amount, BlobContent, BlockHeight, Epoch, Round, Timestamp},
+    data_types::{Amount, BlobContent, BlockHeight, Epoch, Round, Timestamp, U128},
     identifiers::{ApplicationId, ChainId},
 };
 use linera_chain::{
@@ -157,16 +157,30 @@ pub fn deploy_fungible_bridge(
 
 const LINERA_TOKEN_SOL: &str = include_str!("solidity/LineraToken.sol");
 
+alloy_sol_types::sol! {
+    #[allow(missing_docs)]
+    struct LineraTokenConstructorArgs {
+        string name;
+        string symbol;
+        uint8 decimals_;
+        uint256 initialSupply;
+    }
+}
+
 pub fn deploy_linera_token(
     db: &mut CacheDB<EmptyDB>,
     deployer: Address,
     initial_supply: alloy_primitives::U256,
 ) -> Address {
     let bytecode = compile_contract(LINERA_TOKEN_SOL, "LineraToken.sol", "LineraToken");
-    let constructor_args =
-        ("TestToken".to_string(), "TT".to_string(), initial_supply).abi_encode_params();
+    let args = LineraTokenConstructorArgs {
+        name: "TestToken".to_string(),
+        symbol: "TT".to_string(),
+        decimals_: 18,
+        initialSupply: initial_supply,
+    };
     let mut deploy_data = bytecode;
-    deploy_data.extend_from_slice(&constructor_args);
+    deploy_data.extend_from_slice(&args.abi_encode_params());
     deploy_contract(db, deployer, deploy_data)
 }
 
@@ -202,7 +216,7 @@ pub fn fungible_message_transaction(
 pub fn burn_event(
     application_id: CryptoHash,
     target: [u8; 20],
-    amount: Amount,
+    amount: U128,
     index: u32,
 ) -> linera_base::data_types::Event {
     use linera_base::identifiers::{GenericApplicationId, StreamId, StreamName};

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -230,6 +230,39 @@ pub async fn deploy_linera_token_with_supply(
     parse_broadcast_address(compose, project_name, compose_file, "DeployLineraToken.s.sol").await
 }
 
+/// Deploys LineraToken with a custom `decimals()` value and initial supply.
+/// `supply_raw` is the raw token amount (i.e. `tokens * 10u128.pow(decimals)`).
+pub async fn deploy_linera_token_with_decimals(
+    compose: &DockerCompose,
+    project_name: &str,
+    compose_file: &std::path::Path,
+    decimals: u8,
+    supply_raw: u128,
+) -> anyhow::Result<Address> {
+    exec_ok(
+        compose,
+        "foundry-tools",
+        &format!(
+            "env TOKEN_DECIMALS={decimals} TOKEN_SUPPLY={supply_raw} \
+             forge script /contracts/script/DeployLineraToken.s.sol \
+             --root /contracts \
+             --rpc-url http://anvil:8545 \
+             --private-key {ANVIL_PRIVATE_KEY} \
+             --broadcast"
+        ),
+        project_name,
+        compose_file,
+    )
+    .await;
+    parse_broadcast_address(
+        compose,
+        project_name,
+        compose_file,
+        "DeployLineraToken.s.sol",
+    )
+    .await
+}
+
 /// Deploys FungibleBridge via the `DeployFungibleBridge.s.sol` forge
 /// script and returns the deployed contract address.
 pub async fn deploy_fungible_bridge(
@@ -402,7 +435,10 @@ where
     E: linera_core::environment::Environment,
 {
     use anyhow::Context as _;
-    use linera_base::{data_types::Bytecode, vm::VmRuntime};
+    use linera_base::{
+        data_types::{Bytecode, U128},
+        vm::VmRuntime,
+    };
 
     let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
@@ -421,12 +457,13 @@ where
     chain_client.synchronize_from_validators().await?;
     chain_client.process_inbox().await?;
 
-    let initial_balance = linera_base::data_types::Amount::from_tokens(initial_balance_tokens);
+    let initial_balance = U128(initial_balance_tokens * 10u128.pow(18));
     let (fungible_app_id, _) = chain_client
         .create_application_untyped(
             wf_module_id,
             serde_json::to_vec(&wrapped_fungible::WrappedParameters {
                 ticker_symbol: "wTEST".to_string(),
+                decimals: 18,
                 minter: None,
                 mint_chain_id: Some(mint_chain_id),
                 evm_token_address: erc20_addr.0 .0,

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -29,7 +29,7 @@ use alloy::{
 use anyhow::Context as _;
 use linera_base::{
     crypto::InMemorySigner,
-    data_types::{Amount, Bytecode},
+    data_types::{Bytecode, U128},
     identifiers::AccountOwner,
     vm::VmRuntime,
 };
@@ -203,6 +203,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             wf_module_id,
             serde_json::to_vec(&WrappedParameters {
                 ticker_symbol: "wTEST".to_string(),
+                decimals: 18,
                 minter: Some(owner_a),
                 mint_chain_id: Some(chain_a),
                 evm_token_address: erc20_addr.0 .0,
@@ -446,7 +447,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     // ══════════════════════════════════════════════════════════════════
     let evm_recipient = "70997970C51812dc3A010C7d01b50e0d17dc79C8";
     let receiver: AccountOwner = format!("0x{evm_recipient}").parse()?;
-    let withdraw_amount = Amount::from_tokens(25);
+    let withdraw_amount = U128(25u128 * 10u128.pow(18));
 
     tracing::info!("Sending cross-chain withdrawal from chain B to Address20 on chain A...");
     cc_b.synchronize_from_validators().await?;

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -24,9 +24,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
     sol,
 };
-use linera_base::{
-    crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner,
-};
+use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
@@ -228,7 +226,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     // the "burns" stream, which the relayer's Linera scanner will pick up.
     let evm_recipient_hex = "70997970C51812dc3A010C7d01b50e0d17dc79C8";
     let receiver: AccountOwner = format!("0x{evm_recipient_hex}").parse()?;
-    let burn_amount = Amount::from_tokens(25);
+    let burn_amount = U128(25u128 * 10u128.pow(18));
 
     cc_b.synchronize_from_validators().await?;
     let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -11,7 +11,7 @@
 #![recursion_limit = "512"]
 
 use alloy::{providers::ProviderBuilder, sol};
-use linera_base::{crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner};
+use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token_with_supply, fetch_latest_cert,
     fund_bridge_erc20, light_client_address, publish_and_create_wrapped_fungible,
@@ -314,7 +314,7 @@ where
 {
     use anyhow::Context as _;
 
-    let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
+    let burn_amount = U128(BURN_AMOUNT_TOKENS * 10u128.pow(18));
     let operations = (1..=n)
         .map(|i| {
             // Deterministic distinct recipients; high bytes spell out the

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -19,7 +19,7 @@ use alloy::{
 use anyhow::Context as _;
 use linera_base::{
     crypto::InMemorySigner,
-    data_types::{Amount, Bytecode},
+    data_types::{Bytecode, U128},
     identifiers::AccountOwner,
     vm::VmRuntime,
 };
@@ -188,6 +188,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     tracing::info!("Creating wrapped-fungible application...");
     let wrapped_params = WrappedParameters {
         ticker_symbol: "wTEST".to_string(),
+        decimals: 18,
         minter: Some(owner),
         mint_chain_id: Some(chain_id),
         evm_token_address: erc20_addr.0 .0,
@@ -371,10 +372,10 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     let balance_str = response["data"]["accounts"]["entry"]["value"]
         .as_str()
         .context("no balance in GraphQL response")?;
-    let balance: Amount = balance_str.parse()?;
+    let balance: U128 = balance_str.parse()?;
     assert_eq!(
         balance,
-        Amount::from_tokens(100),
+        U128(100u128 * 10u128.pow(18)),
         "wrapped-fungible balance should match the 100-token deposit"
     );
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -19,7 +19,7 @@ use anyhow::Context as _;
 use futures::StreamExt as _;
 use linera_base::{
     crypto::InMemorySigner,
-    data_types::{Amount, Bytecode},
+    data_types::{Bytecode, U128},
     identifiers::AccountOwner,
     vm::VmRuntime,
 };
@@ -146,6 +146,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     tracing::info!("Creating wrapped-fungible application...");
     let params = WrappedParameters {
         ticker_symbol: "TEST".to_string(),
+        decimals: 18,
         minter: Some(owner_a),
         mint_chain_id: Some(chain_a),
         evm_token_address: [0u8; 20],
@@ -155,7 +156,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         bridge_app_id: None,
     };
     let init_state = InitialState {
-        accounts: BTreeMap::from([(owner_a, Amount::from_tokens(1000))]),
+        accounts: BTreeMap::from([(owner_a, U128(1000u128 * 10u128.pow(18)))]),
     };
     let (app_id, create_cert): (
         linera_base::identifiers::ApplicationId<WrappedFungibleTokenAbi>,
@@ -233,7 +234,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     tracing::info!("Sending wrapped-fungible transfer to owner_b on chain B...");
     let transfer_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
         owner: owner_a,
-        amount: Amount::from_tokens(100),
+        amount: U128(100u128 * 10u128.pow(18)),
         target_account: Account {
             chain_id: chain_b,
             owner: owner_b,
@@ -282,7 +283,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     tracing::info!("Withdrawing tokens from chain B to evm_recipient on chain A...");
     let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
         owner: owner_b,
-        amount: Amount::from_tokens(100),
+        amount: U128(100u128 * 10u128.pow(18)),
         target_account: Account {
             chain_id: chain_a,
             owner: receiver,

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -17,9 +17,7 @@
 use std::time::Duration;
 
 use alloy::{primitives::U256, providers::ProviderBuilder, sol};
-use linera_base::{
-    crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner,
-};
+use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
@@ -146,7 +144,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC".parse()?,
         "0x90F79bf6EB2c4f870365E785982E1f101E93b906".parse()?,
     ];
-    let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
+    let burn_amount = U128(BURN_AMOUNT_TOKENS * 10u128.pow(18));
 
     // Bundle every Transfer into a SINGLE chain-B block, then drive
     // chain A's inbox once. The N Credit messages travel together

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -25,9 +25,7 @@
 use std::time::Duration;
 
 use alloy::{primitives::U256, providers::ProviderBuilder, sol};
-use linera_base::{
-    crypto::InMemorySigner, data_types::Amount, identifiers::AccountOwner,
-};
+use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
@@ -146,7 +144,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     let evm_recipient: alloy::primitives::Address =
         "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?;
     let receiver = AccountOwner::Address20(evm_recipient.0 .0);
-    let burn_amount = Amount::from_tokens(BURN_AMOUNT_TOKENS);
+    let burn_amount = U128(BURN_AMOUNT_TOKENS * 10u128.pow(18));
 
     for _ in 0..NUM_BURNS {
         cc_b.synchronize_from_validators().await?;

--- a/linera-bridge/tests/snapshots/format_wrapped_fungible__format_wrapped_fungible.yaml.snap
+++ b/linera-bridge/tests/snapshots/format_wrapped_fungible__format_wrapped_fungible.yaml.snap
@@ -23,16 +23,13 @@ AccountOwner:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 20
-Amount:
-  NEWTYPESTRUCT: U128
 BurnEvent:
   STRUCT:
     - target:
         TUPLEARRAY:
           CONTENT: U8
           SIZE: 20
-    - amount:
-        TYPENAME: Amount
+    - amount: U128
 ChainId:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
@@ -48,8 +45,7 @@ Message:
         STRUCT:
           - target:
               TYPENAME: AccountOwner
-          - amount:
-              TYPENAME: Amount
+          - amount: U128
           - source:
               TYPENAME: AccountOwner
     1:
@@ -57,8 +53,7 @@ Message:
         STRUCT:
           - owner:
               TYPENAME: AccountOwner
-          - amount:
-              TYPENAME: Amount
+          - amount: U128
           - target_account:
               TYPENAME: Account
 WrappedFungibleOperation:
@@ -70,8 +65,7 @@ WrappedFungibleOperation:
         STRUCT:
           - owner:
               TYPENAME: AccountOwner
-          - amount:
-              TYPENAME: Amount
+          - amount: U128
           - target_account:
               TYPENAME: Account
     158617459:
@@ -81,22 +75,19 @@ WrappedFungibleOperation:
               TYPENAME: AccountOwner
           - spender:
               TYPENAME: AccountOwner
-          - allowance:
-              TYPENAME: Amount
-    198295567:
-      MintAndTransfer:
+          - allowance: U128
+    189683137:
+      Mint:
         STRUCT:
           - target_account:
               TYPENAME: Account
-          - amount:
-              TYPENAME: Amount
+          - amount: U128
     204322437:
       Claim:
         STRUCT:
           - source_account:
               TYPENAME: Account
-          - amount:
-              TYPENAME: Amount
+          - amount: U128
           - target_account:
               TYPENAME: Account
     206964944:
@@ -111,8 +102,7 @@ WrappedFungibleOperation:
               TYPENAME: AccountOwner
           - spender:
               TYPENAME: AccountOwner
-          - amount:
-              TYPENAME: Amount
+          - amount: U128
           - target_account:
               TYPENAME: Account
     239329758:
@@ -120,5 +110,4 @@ WrappedFungibleOperation:
         STRUCT:
           - owner:
               TYPENAME: AccountOwner
-          - amount:
-              TYPENAME: Amount
+          - amount: U128

--- a/linera-sdk/src/abis/wrapped_fungible.rs
+++ b/linera-sdk/src/abis/wrapped_fungible.rs
@@ -71,7 +71,7 @@ impl InitialStateBuilder {
 }
 
 /// Response variants returned by the wrapped fungible token application.
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Default, StableEnumInCrate)]
 pub enum FungibleResponse {
     #[default]
     Ok,

--- a/linera-sdk/src/abis/wrapped_fungible.rs
+++ b/linera-sdk/src/abis/wrapped_fungible.rs
@@ -3,23 +3,25 @@
 
 //! An ABI for applications that implement a wrapped (bridged) fungible token with Mint/Burn.
 
+use std::collections::BTreeMap;
+
 use async_graphql::{Request, Response};
 pub use linera_base::identifiers::Account;
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
-    data_types::Amount,
+    data_types::U128,
     identifiers::{AccountOwner, ApplicationId, ChainId},
 };
 use linera_sdk_derive::{GraphQLMutationRootInCrate, StableEnumInCrate};
 use serde::{Deserialize, Serialize};
-
-pub use super::fungible::{FungibleResponse, InitialState, InitialStateBuilder};
 
 /// Parameters for a wrapped fungible token backed by an EVM bridge.
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct WrappedParameters {
     /// Ticker symbol (e.g. "USDC")
     pub ticker_symbol: String,
+    /// Number of decimal places used by the source ERC-20 (e.g. 6 for USDC).
+    pub decimals: u8,
     /// If set, only this account owner can sign mint operations
     pub minter: Option<AccountOwner>,
     /// If set, minting and auto-burning are restricted to this chain
@@ -39,75 +41,103 @@ pub struct WrappedParameters {
 pub struct BurnEvent {
     /// The Ethereum address to receive the unlocked ERC-20 tokens
     pub target: [u8; 20],
-    /// Amount of tokens burned
-    pub amount: Amount,
+    /// Amount of tokens burned, in raw sub-units of the source ERC-20.
+    pub amount: U128,
+}
+
+/// Initial accounts and balances for the wrapped fungible token application.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct InitialState {
+    pub accounts: BTreeMap<AccountOwner, U128>,
+}
+
+/// Builder for [`InitialState`].
+#[derive(Debug, Default)]
+pub struct InitialStateBuilder {
+    account_balances: BTreeMap<AccountOwner, U128>,
+}
+
+impl InitialStateBuilder {
+    pub fn with_account(mut self, account: AccountOwner, balance: U128) -> Self {
+        self.account_balances.insert(account, balance);
+        self
+    }
+
+    pub fn build(&self) -> InitialState {
+        InitialState {
+            accounts: self.account_balances.clone(),
+        }
+    }
+}
+
+/// Response variants returned by the wrapped fungible token application.
+#[derive(Debug, Deserialize, Serialize, Default)]
+pub enum FungibleResponse {
+    #[default]
+    Ok,
+    Balance(U128),
+    TickerSymbol(String),
 }
 
 /// Operations for the wrapped fungible token application.
 #[derive(Debug, StableEnumInCrate, GraphQLMutationRootInCrate)]
 pub enum WrappedFungibleOperation {
     /// Requests an account balance.
-    Balance {
-        /// Owner to query the balance for
-        owner: AccountOwner,
-    },
+    Balance { owner: AccountOwner },
     /// Requests this fungible token's ticker symbol.
     TickerSymbol,
-    /// Approve the transfer of tokens
+    /// Approve the transfer of tokens.
     Approve {
-        /// Owner to transfer from
         owner: AccountOwner,
-        /// The spender account
         spender: AccountOwner,
-        /// Maximum amount to be transferred
-        allowance: Amount,
+        allowance: U128,
     },
     /// Transfers tokens from a (locally owned) account to a (possibly remote) account.
     Transfer {
-        /// Owner to transfer from
         owner: AccountOwner,
-        /// Amount to be transferred
-        amount: Amount,
-        /// Target account to transfer the amount to
+        amount: U128,
         target_account: Account,
     },
-    /// Transfers tokens from a (locally owned) account to a (possibly remote) account by using the allowance.
+    /// Transfers tokens from a (locally owned) account using a previously approved allowance.
     TransferFrom {
-        /// Owner to transfer from
         owner: AccountOwner,
-        /// The spender of the amount.
         spender: AccountOwner,
-        /// Amount to be transferred
-        amount: Amount,
-        /// Target account to transfer the amount to
+        amount: U128,
         target_account: Account,
     },
-    /// Same as `Transfer` but the source account may be remote. Depending on its
-    /// configuration, the target chain may take time or refuse to process
-    /// the message.
+    /// Same as `Transfer` but the source account may be remote.
     Claim {
-        /// Source account to claim amount from
         source_account: Account,
-        /// Amount to be claimed
-        amount: Amount,
-        /// Target account to claim the amount into
+        amount: U128,
         target_account: Account,
     },
-    /// Mints new tokens and transfers them to a target account. Only the authorized
-    /// minter can call this.
-    MintAndTransfer {
-        /// Account to receive the minted tokens
+    /// Mints new tokens to a target account. Only the authorized minter can call this.
+    Mint {
         target_account: Account,
-        /// Amount of tokens to mint
-        amount: Amount,
+        amount: U128,
     },
     /// Burns tokens from an account. Rejected by the contract — burning happens
     /// automatically when tokens are transferred to an Address20 on the bridge chain.
-    Burn {
-        /// Account owner whose tokens to burn
+    Burn { owner: AccountOwner, amount: U128 },
+}
+
+/// Cross-chain message used by the wrapped fungible token application.
+/// Amounts are [`U128`] in the source ERC-20's decimal scale.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Message {
+    /// Credits the given `target` account, unless the message is bouncing, in which case
+    /// `source` is credited instead.
+    Credit {
+        target: AccountOwner,
+        amount: U128,
+        source: AccountOwner,
+    },
+
+    /// Withdraws from the given account and starts a transfer to the target account.
+    Withdraw {
         owner: AccountOwner,
-        /// Amount of tokens to burn
-        amount: Amount,
+        amount: U128,
+        target_account: Account,
     },
 }
 


### PR DESCRIPTION
## Motivation

Backport of #6372 from `testnet_conway` to `main`.

## Proposal

Cherry-pick of commit eb2e5765c7f323ffa08026380c0f6d4b3cb0413a with manual conflict resolution.

Key conflicts resolved:
- `MintAndTransfer` → `Mint` rename in `WrappedFungibleOperation` and call sites
- `Amount` → `U128` in all wrapped-fungible and bridge types
- New tests in `monitor/mod.rs` that referenced APIs not present on `main` (`pending_burns_by_height_and_tx`, `PendingBurnsAtHeight`) were dropped — those APIs belong to a separate PR
- Two modify/delete conflicts (`FungibleBridge.t.sol`, `multi_tx_burn_chunking.rs`) resolved by keeping `main`'s deletion
- Snapshot updated with correct stable-enum Keccak discriminants for renamed `Mint` variant (tag 189683137)
- Added `StableEnumInCrate` to `FungibleResponse` (required by `lib.rs` format registration; the inline definition in `wrapped_fungible.rs` was missing the derive)

## Test Plan

CI

## Release Plan

- [ ] This PR requires a protocol upgrade (add the appropriate label).

## Links

- [Reviewer checklist](https://github.com/linera-io/linera-protocol/wiki/Reviewing-a-Pull-Request)