### PR TITLE
Backport #6401 to main: Wrap papaya hashmaps with an Arc – avoid cloning

### DIFF
--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -74,7 +74,7 @@ pub struct GrpcClient {
     /// Shared across all `GrpcClient` instances created by the same `GrpcNodeProvider`.
     /// Tracks when each validator address last had a subscription failure, so that
     /// other chains don't independently retry the same dead validator.
-    subscription_cooldowns: papaya::HashMap<String, Instant>,
+    subscription_cooldowns: Arc<papaya::HashMap<String, Instant>>,
 }
 
 impl GrpcClient {
@@ -84,7 +84,7 @@ impl GrpcClient {
         retry_delay: Duration,
         max_retries: u32,
         max_backoff: Duration,
-        subscription_cooldowns: papaya::HashMap<String, Instant>,
+        subscription_cooldowns: Arc<papaya::HashMap<String, Instant>>,
     ) -> Self {
         let client = ValidatorNodeClient::new(channel)
             .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)

--- a/linera-rpc/src/grpc/node_provider.rs
+++ b/linera-rpc/src/grpc/node_provider.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr as _;
+use std::{str::FromStr as _, sync::Arc};
 
 use linera_base::time::{Duration, Instant};
 use linera_core::node::{NodeError, ValidatorNodeProvider};
@@ -22,7 +22,7 @@ pub struct GrpcNodeProvider {
     /// Shared across all `GrpcClient` instances. When a subscription to a validator
     /// fails, the failure time is recorded here so that other chains (which share the
     /// same provider) skip retrying the same dead validator.
-    subscription_cooldowns: papaya::HashMap<String, Instant>,
+    subscription_cooldowns: Arc<papaya::HashMap<String, Instant>>,
 }
 
 impl GrpcNodeProvider {
@@ -37,7 +37,7 @@ impl GrpcNodeProvider {
             retry_delay,
             max_retries,
             max_backoff,
-            subscription_cooldowns: papaya::HashMap::new(),
+            subscription_cooldowns: Arc::new(papaya::HashMap::new()),
         }
     }
 }

--- a/linera-rpc/src/grpc/pool.rs
+++ b/linera-rpc/src/grpc/pool.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use linera_base::time::Duration;
 
 use super::{transport, GrpcError};
@@ -9,14 +11,14 @@ use super::{transport, GrpcError};
 #[derive(Clone, Default)]
 pub struct GrpcConnectionPool {
     options: transport::Options,
-    channels: papaya::HashMap<String, transport::Channel>,
+    channels: Arc<papaya::HashMap<String, transport::Channel>>,
 }
 
 impl GrpcConnectionPool {
     pub fn new(options: transport::Options) -> Self {
         Self {
             options,
-            channels: papaya::HashMap::default(),
+            channels: Arc::new(papaya::HashMap::default()),
         }
     }
 

--- a/linera-rpc/tests/transport.rs
+++ b/linera-rpc/tests/transport.rs
@@ -30,7 +30,7 @@ async fn client() {
         retry_delay,
         max_retries,
         linera_rpc::node_provider::DEFAULT_MAX_BACKOFF,
-        papaya::HashMap::new(),
+        std::sync::Arc::new(papaya::HashMap::new()),
     )
     .get_version_info()
     .await


### PR DESCRIPTION
## Motivation

Backport of #6401 from `testnet_conway` to `main`.

## Proposal

Cherry-pick of commit 943c1f85ddee578d31db2bdff8f19d84c13d840d.

## Test Plan

CI

## Release Plan

- These changes should follow regular release cycle.

## Links

- [Reviewer checklist](https://github.com/linera-io/linera-protocol/wiki/Reviewing-a-Pull-Request)