### PR TITLE
Reapply "Sync chain state after rejected proposal; revert proactive sync"

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -145,6 +145,16 @@ struct CircuitBreakerState {
     probe_interval: Duration,
 }
 
+/// A fingerprint of the chain manager's observable consensus state, used to detect
+/// whether a per-validator updater absorbed new info during a proposal attempt.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ConsensusStateSnapshot {
+    next_block_height: BlockHeight,
+    current_round: Round,
+    lock_round: Option<Round>,
+    timeout_round: Option<Round>,
+}
+
 #[cfg(with_testing)]
 impl Options {
     pub fn test_default() -> Self {
@@ -542,6 +552,30 @@ impl<Env: Environment> ChainClient<Env> {
             .handle_chain_info_query(query)
             .await?;
         Ok(response.info)
+    }
+
+    /// Returns a fingerprint of the chain manager's observable state: height,
+    /// current round, locking block round, and timeout certificate round.
+    ///
+    /// [`Self::process_pending_block_without_prepare`] takes one snapshot just before
+    /// each network call (re-taking it after our own local proposal handling) and
+    /// compares against the post-call state. A change means a per-validator updater
+    /// absorbed something we didn't have. The local node verifies signatures on
+    /// anything it stores, so a single dishonest validator can't fake this.
+    async fn consensus_state_snapshot(&self) -> Result<ConsensusStateSnapshot, Error> {
+        let info = self.chain_info_with_manager_values().await?;
+        let lock_round = info
+            .manager
+            .requested_locking
+            .as_deref()
+            .map(LockingBlock::round);
+        let timeout_round = info.manager.timeout.as_deref().map(|cert| cert.round);
+        Ok(ConsensusStateSnapshot {
+            next_block_height: info.next_block_height,
+            current_round: info.manager.current_round,
+            lock_round,
+            timeout_round,
+        })
     }
 
     /// Returns the chain's description. Fetches it from the validators if necessary.
@@ -1959,14 +1993,66 @@ impl<Env: Environment> ChainClient<Env> {
     ///
     /// The caller must hold the proposal mutex via `proposal_guard`. The pending proposal
     /// is read from and cleared through the guard, ensuring synchronization.
+    ///
+    /// On error, compares the chain manager's snapshot just before the failing network
+    /// call against the current state. If a per-validator updater absorbed new info
+    /// (e.g. a locking block we didn't have) while we were calling, retries with the
+    /// refreshed state. The snapshot is updated after our own local proposal handling
+    /// so that doesn't count as "new info from a validator".
+    ///
+    /// Retrying terminates without an explicit bound: each retry corresponds to local
+    /// consensus state that actually advanced (verified by the local node, which checks
+    /// signatures and quorums), and that state is monotone.
     #[instrument(level = "debug", skip(self, proposal_guard), fields(chain_id = %self.chain_id))]
     async fn process_pending_block_without_prepare(
         &self,
         proposal_guard: &mut Option<PendingProposal>,
     ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, Error> {
+        loop {
+            // `process_pending_block_inner` records the baseline snapshot itself, after
+            // the initial timeout request, so that absorbing a timeout certificate isn't
+            // counted as new info. It stays `None` only if the call fails before that
+            // point, in which case there is no baseline to retry against.
+            let mut snapshot = None;
+            let err = match self
+                .process_pending_block_inner(proposal_guard, &mut snapshot)
+                .await
+            {
+                Ok(outcome) => return Ok(outcome),
+                Err(err) => err,
+            };
+            let Some(snapshot) = snapshot else {
+                return Err(err);
+            };
+            let Ok(current) = self.consensus_state_snapshot().await else {
+                return Err(err);
+            };
+            if current == snapshot {
+                return Err(err);
+            }
+            tracing::debug!(
+                chain_id = %self.chain_id,
+                ?snapshot,
+                ?current,
+                %err,
+                "local consensus state advanced during process_pending_block; retrying"
+            );
+        }
+    }
+
+    async fn process_pending_block_inner(
+        &self,
+        proposal_guard: &mut Option<PendingProposal>,
+        snapshot: &mut Option<ConsensusStateSnapshot>,
+    ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, Error> {
         let process_start = linera_base::time::Instant::now();
         tracing::debug!("process_pending_block_without_prepare started");
         let info = self.request_leader_timeout_if_needed().await?;
+        // After the timeout request (which may itself absorb a timeout cert from
+        // validators), bake the resulting state into the snapshot. The rest of this
+        // iteration will propose in the round the timeout produced, so a state diff
+        // from just that absorption isn't a retry signal.
+        *snapshot = Some(self.consensus_state_snapshot().await?);
 
         // Clear stale pending proposals whose height has already been committed.
         if let Some(pending) = &*proposal_guard {
@@ -2125,6 +2211,11 @@ impl<Env: Environment> ChainClient<Env> {
                 }
             }
         }
+        // The local handle of our own proposal can set a Fast lock, advance
+        // `proposed`/`signed_proposal`, and thereby bump `current_round`. None of that
+        // is "new info from a validator", so fold it into the snapshot before the
+        // network calls below.
+        *snapshot = Some(self.consensus_state_snapshot().await?);
         let committee = self.local_committee().await?;
         let block = Block::new(proposed_block, outcome);
         // Send the query to validators.
@@ -3047,11 +3138,8 @@ impl<Env: Environment> ChainClient<Env> {
             }
             Reason::NewRound { height, round } => {
                 let chain_id = notification.chain_id;
-                // The validator may hold a locking block whose round is below both its
-                // current round and ours, so we only short-circuit when strictly past its
-                // height.
                 if let Some(info) = self.maybe_local_chain_info(chain_id, &local_node).await? {
-                    if info.next_block_height > height {
+                    if (info.next_block_height, info.manager.current_round) >= (height, round) {
                         debug!(
                             chain_id = %self.chain_id,
                             "Accepting redundant notification for new round"

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2336,20 +2336,34 @@ where
     Ok(())
 }
 
+/// Exercises the lazy locking-block fetch on proposal rejection.
+///
+/// Sets up a state where validators 2 and 3 hold a `Regular` locking block at
+/// `MultiLeader(0)` but validators 0 and 1 do not. `client_a` — which has no
+/// local knowledge of the lock — proposes a new (different) block. All four
+/// validators reject the proposal with `ChainError` (each has
+/// `validated_vote @ ML(0)` from `client_b`'s earlier attempt, so a fresh
+/// proposal at the same round fails the strict-round check). The per-validator
+/// updater's `NodeError::ChainError` arm pulls manager state from each
+/// rejecter, absorbing the locking block from validators 2 and 3 into
+/// `client_a`'s local node. `process_pending_block_without_prepare` detects the
+/// snapshot advance and retries; the retry finalizes the absorbed locking block
+/// (`client_b`'s transfer) and the chain advances. The outcome is `Conflict`
+/// because the committed block is `client_b`'s transfer, not `client_a`'s
+/// intended burn.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
-async fn test_new_round_notification_pulls_lower_round_locking_block<B>(
+async fn test_lazy_pull_absorbs_locking_block_on_proposal_rejection<B>(
     storage_builder: B,
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
-    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let client_a = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
     let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
@@ -2358,10 +2372,8 @@ where
     let owner_a = client_a.identity().await?;
     let owner_b: AccountOwner = builder.signer.generate_new().into();
 
-    // Single multi-leader round, so ML(0) has a non-`None` round duration and times out
-    // into SL(0).
     let owners = [(owner_a, 100), (owner_b, 100)];
-    let ownership = ChainOwnership::multiple(owners, 1, TimeoutConfig::default());
+    let ownership = ChainOwnership::multiple(owners, 4, TimeoutConfig::default());
     client_a.change_ownership(ownership).await?;
 
     let info = client_a.chain_info().await?;
@@ -2370,11 +2382,13 @@ where
         .await?;
     client_b.set_preferred_owner(owner_b);
 
-    // client_b proposes at MultiLeader(0). All four validators vote validate, but
-    // validators 0 and 1 refuse to absorb the resulting certificate and validator 3
-    // refuses to confirm: validators 2 and 3 end up holding a `LockingBlock::Regular @
-    // MultiLeader(0)` and a `confirmed_vote` for it, while the block never reaches a
-    // confirmation quorum and stays uncommitted.
+    // Setup: `client_b` proposes a transfer at `MultiLeader(0)`. All four validators
+    // vote to validate, but validators 0 and 1 refuse to absorb the resulting
+    // validated certificate and validator 3 refuses to send its confirm vote. So
+    // validators 2 and 3 end up holding a `LockingBlock::Regular @ MultiLeader(0)`
+    // and a `confirmed_vote` for it; validators 0 and 1 hold only a
+    // `validated_vote @ MultiLeader(0)`. The block never reaches a confirmation
+    // quorum, so `client_b`'s transfer fails.
     builder.set_fault_type([0, 1], FaultType::DontProcessValidated);
     builder.set_fault_type([3], FaultType::DontSendConfirmVote);
     client_b.synchronize_from_validators().await?;
@@ -2387,35 +2401,9 @@ where
         .await;
     assert!(b_result.is_err());
 
-    let manager_v2 = builder
-        .node(2)
-        .chain_info_with_manager_values(chain_id)
-        .await?
-        .manager;
-    let v2_locking = *manager_v2
-        .requested_locking
-        .expect("validator 2 should hold a locking block");
-    let LockingBlock::Regular(v2_validated) = v2_locking else {
-        panic!("expected a Regular locking block on validator 2");
-    };
-    assert_eq!(v2_validated.round, Round::MultiLeader(0));
-
-    // Restore honest behavior and drive timeout certificates until client_a is the leader
-    // of the current round. request_leader_timeout only fetches the timeout cert, not
-    // manager values, so client_a advances rounds without absorbing the locking block.
+    // Restore honest behavior. `client_a`'s local node has not been touched since
+    // `change_ownership` — it has no proposed block and no locking block.
     builder.set_fault_type([0, 1, 2, 3], FaultType::Honest);
-    let target_round = loop {
-        let manager = client_a.chain_info().await?.manager;
-        if manager.leader == Some(owner_a) {
-            break manager.current_round;
-        }
-        clock.set(
-            manager
-                .round_timeout
-                .expect("round_timeout should be set outside the early multi-leader rounds"),
-        );
-        client_a.request_leader_timeout().await?;
-    };
     assert!(
         client_a
             .chain_info_with_manager_values()
@@ -2426,173 +2414,20 @@ where
         "client_a must not yet hold a locking block"
     );
 
-    // Validator 2 delivers a NewRound notification reporting that it is in the current
-    // round. The resulting `synchronize_chain_state_from` pulls validator 2's locking
-    // block into client_a.
-    let pk_v2 = builder.node(2).name();
-    let validator_2 = builder
-        .initial_committee
-        .validator_addresses()
-        .find(|(pk, _)| *pk == pk_v2)
-        .expect("validator 2 should be in the committee");
-    let notification = Notification {
-        chain_id,
-        reason: Reason::NewRound {
-            height: BlockHeight::from(1),
-            round: target_round,
-        },
-    };
-    client_a
-        .process_notification_from(notification, validator_2)
-        .await;
-
-    // Now client_a can drive the chain forward. The locking block (owner_b's transfer)
-    // is finalized — classified as a Conflict because the authenticated signer doesn't
-    // match owner_a's intended burn — and the chain advances to height 2.
+    // `client_a` burns. The proposal goes out at `MultiLeader(0)`; every validator
+    // rejects it (each has `validated_vote @ ML(0)` from `client_b`'s transfer
+    // attempt, so a fresh proposal at the same round fails the strict-round check).
+    // The per-validator `NodeError::ChainError` arm pulls manager state, and
+    // `client_a`'s local node absorbs the locking block from validators 2/3. The
+    // retry then finalizes the locked block via `finalize_locking_block` and the
+    // chain advances to height 2 with `client_b`'s transfer committed — classified
+    // as `Conflict` because the committed block is not `client_a`'s intended burn.
     let burn_result = client_a.burn(AccountOwner::CHAIN, Amount::ONE).await?;
     assert_matches!(burn_result, ClientOutcome::Conflict(_));
     assert_eq!(
         client_a.chain_info().await?.next_block_height,
         BlockHeight::from(2)
     );
-
-    Ok(())
-}
-
-#[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
-#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
-#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
-#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
-#[test_log::test(tokio::test)]
-async fn test_sync_consensus_round_pushes_locking_below_current_round<B>(
-    storage_builder: B,
-) -> anyhow::Result<()>
-where
-    B: StorageBuilder,
-{
-    let signer = InMemorySigner::new(None);
-    let clock = storage_builder.clock().clone();
-    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let client_a = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
-    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
-    let chain_id = client_a.chain_id();
-    let recipient_id = recipient.chain_id();
-    let owner_a = client_a.identity().await?;
-    let owner_b: AccountOwner = builder.signer.generate_new().into();
-
-    let owners = [(owner_a, 100), (owner_b, 100)];
-    let ownership = ChainOwnership::multiple(owners, 1, TimeoutConfig::default());
-    client_a.change_ownership(ownership).await?;
-
-    let info = client_a.chain_info().await?;
-    let mut client_b = builder
-        .make_client(chain_id, info.block_hash, info.next_block_height)
-        .await?;
-    client_b.set_preferred_owner(owner_b);
-
-    // client_b proposes at MultiLeader(0). All four validators vote validate, but only
-    // validator 2 absorbs the resulting certificate: validators 0, 1, 3 refuse to process
-    // it. So validator 2 ends up holding a `LockingBlock::Regular @ MultiLeader(0)` and
-    // `confirmed_vote @ MultiLeader(0)`; the other three hold neither.
-    builder.set_fault_type([0, 1, 3], FaultType::DontProcessValidated);
-    client_b.synchronize_from_validators().await?;
-    let b_result = client_b
-        .transfer(
-            AccountOwner::CHAIN,
-            Amount::ONE,
-            Account::chain(recipient_id),
-        )
-        .await;
-    assert!(b_result.is_err());
-    assert!(
-        builder
-            .node(2)
-            .chain_info_with_manager_values(chain_id)
-            .await?
-            .manager
-            .requested_locking
-            .is_some(),
-        "validator 2 should hold the locking block",
-    );
-
-    // Take validator 1 offline and let the other three timeout out of MultiLeader(0) into
-    // SingleLeader(0). Validator 1 stays at MultiLeader(0) without any locking block.
-    builder.set_fault_type([0, 2, 3], FaultType::Honest);
-    builder.set_fault_type([1], FaultType::OfflineWithInfo);
-    let manager_a = client_a.chain_info().await?.manager;
-    clock.set(manager_a.round_timeout.expect("round_timeout"));
-    client_a.request_leader_timeout().await?;
-    assert_eq!(
-        client_a.chain_info().await?.manager.current_round,
-        Round::SingleLeader(0)
-    );
-
-    builder.set_fault_type([1], FaultType::Honest);
-    let manager_v1 = builder
-        .node(1)
-        .chain_info_with_manager_values(chain_id)
-        .await?
-        .manager;
-    assert_eq!(manager_v1.current_round, Round::MultiLeader(0));
-    assert!(manager_v1.requested_locking.is_none());
-
-    // Pull validator 2's locking block into client_a via a NewRound notification (the
-    // mechanism added by the same branch).
-    let pk_v2 = builder.node(2).name();
-    let validator_2 = builder
-        .initial_committee
-        .validator_addresses()
-        .find(|(pk, _)| *pk == pk_v2)
-        .expect("validator 2 should be in the committee");
-    let notification = Notification {
-        chain_id,
-        reason: Reason::NewRound {
-            height: BlockHeight::from(1),
-            round: Round::SingleLeader(0),
-        },
-    };
-    client_a
-        .process_notification_from(notification, validator_2)
-        .await;
-    let info_a = client_a.chain_info_with_manager_values().await?;
-    let locking = *info_a
-        .manager
-        .requested_locking
-        .expect("client_a should hold the locking block");
-    let LockingBlock::Regular(client_locking_cert) = locking else {
-        panic!("expected Regular locking block on client_a");
-    };
-
-    // Advance the clock past the SingleLeader(0) round_timeout and call
-    // `request_leader_timeout` again. The per-validator request for validator 1 hits the
-    // `WrongRound(MultiLeader(0))` path, which routes through `send_chain_information` →
-    // `sync_consensus_round`. Branch 2 of that function now pushes the locking
-    // certificate because its round (`MultiLeader(0)`) is at least the remote validator's
-    // current round (`MultiLeader(0)`).
-    clock.set(
-        client_a
-            .chain_info()
-            .await?
-            .manager
-            .round_timeout
-            .expect("round_timeout for SingleLeader(0)"),
-    );
-    client_a.request_leader_timeout().await?;
-
-    let manager_v1_after = builder
-        .node(1)
-        .chain_info_with_manager_values(chain_id)
-        .await?
-        .manager;
-    let v1_locking = *manager_v1_after
-        .requested_locking
-        .expect("validator 1 should have absorbed the pushed locking block");
-    let LockingBlock::Regular(v1_validated) = v1_locking else {
-        panic!("expected Regular locking block on validator 1");
-    };
-    assert_eq!(v1_validated.round, Round::MultiLeader(0));
-    assert_eq!(v1_validated.hash(), client_locking_cert.hash());
 
     Ok(())
 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -606,6 +606,31 @@ where
                     )
                     .await?;
                 }
+                Err(error @ NodeError::ChainError { .. }) => {
+                    // The validator rejected the proposal because of its local chain
+                    // manager state — most commonly an incompatible confirmed vote tied
+                    // to a locking block we don't yet have. Pull manager values from
+                    // this validator so the local node absorbs whatever justified the
+                    // rejection (signatures are checked locally, so the source can't
+                    // fool us), then surface the error. If our local state actually
+                    // advanced, `execute_operations` will rebuild and re-propose; if
+                    // not, the error propagates as usual.
+                    self.warn_if_unexpected(&error);
+                    tracing::debug!(
+                        remote_node = self.remote_node.address(),
+                        %chain_id,
+                        %error,
+                        "validator rejected proposal; pulling manager state",
+                    );
+                    if let Err(sync_err) = self
+                        .client
+                        .synchronize_chain_state_from(&self.remote_node, chain_id)
+                        .await
+                    {
+                        tracing::debug!(%sync_err, "failed to pull manager state from validator");
+                    }
+                    return Err(error.into());
+                }
                 Err(NodeError::BlobsNotFound(_) | NodeError::InactiveChain(_))
                     if !blob_ids.is_empty() =>
                 {
@@ -891,14 +916,12 @@ where
     ) -> Result<(), chain_client::Error> {
         let target_round = manager.current_round;
 
-        // First, push the locking certificate. A remote with an older lock rotates to this
-        // one (and one already locked at this round becomes able to accept a proposal
-        // carrying the cert). Pushing it does not necessarily advance the remote's current
-        // round — e.g. if the remote already holds this exact cert as its lock,
-        // `process_validated_block` returns `Skip` — so only early-return when the
-        // response shows the remote has actually reached our current round.
+        // First, push the locking certificate if it justifies our current round. A
+        // locking block from an earlier round is not enough on its own to advance the
+        // remote: the remote may still be ahead via a timeout or signed proposal, and
+        // pushing a stale lock would not move them. Push only the current-round lock.
         if let Some(LockingBlock::Regular(validated)) = manager.requested_locking.as_deref() {
-            if validated.round >= remote_round {
+            if validated.round == target_round {
                 match self
                     .remote_node
                     .handle_optimized_validated_certificate(


### PR DESCRIPTION
## Motivation

Re-lands #6408, which was reverted by #6430 during the 2026-05-29 PM market incident on the (incorrect) hypothesis that it caused the liveness wedge. The actual root cause was a separate, pre-existing bug in `multi_leader_jitter_target` — fixed in #6431 — not #6408. Reverting #6408 did not unwedge the chains.

#6408 replaced the proactive locking-block sync from #6343 (which #6408 identified as a performance regression that "causes redundant requests") with a reactive sync on proposal rejection. The revert (#6430) restored that chattier proactive behavior, which is what is running in production now.

This matters for restart latency: while the jitter bug had several workers wedged, the liveness probe restarted each stuck worker every ~10 min, and every restart triggered a cold re-sync burst against the validators’ Scylla. The proactive-sync behavior sends more redundant `handle_chain_info_query` requests on each of those re-syncs, amplifying the read-latency spikes. Re-landing #6408 reduces that redundant request volume.

## Proposal

`git revert` of the #6430 revert commit — restores #6408 verbatim (chain_client, updater, and the tests it changed). No behavioral additions.

Should land **after** #6431 (the jitter fix): #6408’s reactive sync relies on the worker actually proposing when it should, which the jitter fix restores. With that in place, #6408 preserves liveness while cutting redundant requests.

## Test Plan

- `cargo clippy -p linera-core` clean.
- Restores #6408’s own diff, including the regression tests it added.

## Follow-up

A separate change will look at hardening the reactive approach so a worker that is wedged *not proposing* (for any future reason) can still recover the chain state it needs — i.e. add back a bounded proactive safety net without reintroducing the request-volume regression. Tracked as a follow-up; not in scope here.

## Links

- Reverts the revert: #6430
- Original: #6408 (and the proactive sync it replaced, #6343)
- Incident root-cause fix: #6431