### PR TITLE
CI: add bridge-check workflow to gate PRs on cargo check of bridge crates

### DIFF
--- a/.github/workflows/bridge-check.yml
+++ b/.github/workflows/bridge-check.yml
@@ -1,0 +1,62 @@
+name: Bridge check
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: warn
+
+permissions:
+  contents: read
+
+jobs:
+  bridge-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          submodules: recursive
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+
+      - name: Install Protoc
+        uses: ./.github/actions/install-protoc
+
+      - name: cargo check linera-bridge (default)
+        run: cargo check --locked -p linera-bridge --all-targets
+
+      - name: cargo check linera-bridge (relay)
+        run: cargo check --locked -p linera-bridge --features relay --all-targets
+
+      - name: cargo check evm-bridge contract (wasm32)
+        working-directory: linera-bridge/contracts/evm-bridge
+        run: cargo check --locked --target wasm32-unknown-unknown --all-targets
+
+      - name: cargo check wrapped-fungible (wasm32)
+        working-directory: examples
+        run: cargo check --locked --target wasm32-unknown-unknown -p wrapped-fungible --all-targets
+
+      - name: cargo check bridge e2e (separate workspace)
+        working-directory: linera-bridge/tests/e2e
+        run: cargo check --locked --all-targets


### PR DESCRIPTION
## Motivation

We often hit a compile-break against the bridge crates that wasn't caught by PR CI — `bridge-e2e` only runs on `merge_group` and pushes to `testnet_*`/`main`, so the failure only surfaced when the PR entered the merge queue. That wastes reviewer time and merge-queue runner minutes for a problem a fast `cargo check` would have flagged on the first PR push.

## Proposal

Add a lightweight `.github/workflows/bridge-check.yml` that runs on every `pull_request` push. It runs `cargo check` (no build, no test, no docker images) on every crate the `bridge-e2e` workflow later builds and tests:

- `linera-bridge` (default features and `relay`)
- `linera-bridge/contracts/evm-bridge` (wasm32 target)
- `wrapped-fungible` in the `examples/` workspace (wasm32 target)
- `linera-bridge/tests/e2e` (separate workspace)

`-D warnings` is kept so warnings still gate the PR.

## Test Plan

- CI on this PR runs the new workflow and shows it passing on a no-op change.
- Verified locally that each `cargo check` invocation succeeds against current `main`.

## Release Plan

- Backport to `testnet_conway`

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)