### PR TITLE
Check `linera-explorer-new/server-rust` in CI.

### DIFF
--- a/.github/workflows/explorer-rust-check.yml
+++ b/.github/workflows/explorer-rust-check.yml
@@ -1,0 +1,41 @@
+name: Explorer Rust check
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: warn
+
+permissions:
+  contents: read
+
+jobs:
+  explorer-rust-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: cargo check linera-explorer-server
+        working-directory: linera-explorer-new/server-rust
+        run: cargo check --locked --all-targets

--- a/linera-explorer-new/server-rust/Cargo.lock
+++ b/linera-explorer-new/server-rust/Cargo.lock
@@ -1226,15 +1226,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
- "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -2346,9 +2345,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"


### PR DESCRIPTION
## Motivation

`linera-explorer-new/server-rust` isn't compiled by routine CI. Only the Docker image build (`docker/Dockerfile.explorer`, `FROM rust:1.85-alpine`) touches it, and that workflow only runs on `devnet_*`/`testnet_*` branch pushes or via `workflow_dispatch`. Routine PRs can silently break the explorer server until a testnet cut bites.

A recent registry update bumped `serde_json` to `1.0.149`, which pulls in `zmij` as a transitive perf dep. `zmij` calls `std::hint::select_unpredictable`, stabilized in Rust 1.88 — so `cargo check` fails on the repo's stable (1.86) and on the Docker base (1.85). No CI noticed.

## Proposal

1. Add `.github/workflows/explorer-rust-check.yml` — mirrors `bridge-check.yml`, runs `cargo check --locked --all-targets` in `linera-explorer-new/server-rust` on every PR + merge_group.
2. Pin `serde_json = 1.0.140` in the explorer workspace's `Cargo.lock` via `cargo update -p serde_json --precise 1.0.140`. Drops `zmij` from the dep graph; compiles clean on 1.86 / 1.85.

The first commit alone fails CI; the second commit makes it pass — PR history demonstrates the regression and the fix.

## Test Plan

- `cd linera-explorer-new/server-rust && cargo check --locked --all-targets` — passes locally on stable 1.86 after the pin.
- New `Explorer Rust check` CI job will run on this PR.

## Release Plan

- These changes should be backported to the `testnet_conway` branch.
- Follow-up: bump root toolchain to 1.88 (matches `linera-bridge/tests/e2e`) and revert the `serde_json` pin. Out of scope for this PR.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)