### PR TITLE
ci: raise timeouts on bridge-e2e and long-faucet-chain-test

### DIFF
--- a/.github/workflows/bridge-check.yml
+++ b/.github/workflows/bridge-check.yml
@@ -27,7 +27,35 @@ permissions:
   contents: read
 
 jobs:
+  # paths-ignore within a pull_request doesn't work well with merge_group, so we need to use a custom filter.
+  changed-files:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.files-changed.outputs.paths }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Filter paths
+        uses: dorny/paths-filter@v4.0.1
+        id: files-changed
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            paths:
+              - '!docker/**'
+              - '!configuration/**'
+              - '!docs/**'
+              - '!mdbook/**'
+              - '!CONTRIBUTING.md'
+              - '!INSTALL.md'
+              - '!README.md'
+              # Workflow-only PRs don't need heavy code tests; merge to main
+              # validates the workflow itself by running it for real.
+              - '!.github/workflows/**'
   bridge-check:
+    needs: changed-files
+    if: needs.changed-files.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -38,6 +38,12 @@ jobs:
           submodules: recursive
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-workspaces: |
+            . -> target
+            linera-bridge/contracts/evm-bridge -> target
+            linera-bridge/tests/e2e -> target
+            examples -> target
 
       - name: Install Protoc
         uses: ./.github/actions/install-protoc

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -29,7 +29,7 @@ jobs:
   bridge-e2e:
     if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v6.0.2

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -35,6 +35,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6.0.2
     - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        cache-workspaces: |
+          -> target
     - name: Clear up some space
       run: |
         sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -30,7 +30,7 @@ jobs:
   long-faucet-chain-test:
     if: ${{ github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 40
+    timeout-minutes: 55
 
     steps:
     - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Motivation

CI is failing for those two in the merge group.

## Proposal

Recent merge-group history shows there's no headroom left:

- `long-faucet-chain-test` (40m cap): recent passing runs at 39m36s, 38m41s, 36m59s, 35m37s. #6438 hit 41m13s → cancelled.
- `bridge-e2e` (60m cap): runtime swings from ~21m to 57m26s across recent runs. #6438 hit 1h1m → cancelled.

We also include the following, related changes:
- cache cargo workspaces in bridge-e2e and long-faucet jobs
- don't run bridge-check on text-only files (filter similar to all other CI jobs – detect if code has changed and only then run the check; don't run the job if we changed READMEs, instructions or CI workflow file)
 

## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
