### PR TITLE
linera-chain: widen outbox metric ceilings and add outbox_counters_size

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -156,7 +156,16 @@ pub(crate) mod metrics {
             "num_outboxes",
             "Number of outboxes",
             &[],
-            exponential_bucket_interval(1.0, 10_000.0),
+            exponential_bucket_interval(1.0, 1_000_000.0),
+        )
+    });
+
+    pub static OUTBOX_COUNTERS_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "outbox_counters_size",
+            "Number of entries in the outbox_counters map (in-flight message heights)",
+            &[],
+            exponential_bucket_interval(1.0, 1_000_000.0),
         )
     });
 
@@ -432,6 +441,10 @@ where
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
             .observe(self.nonempty_outboxes.get().len() as f64);
+        #[cfg(with_metrics)]
+        metrics::OUTBOX_COUNTERS_SIZE
+            .with_label_values(&[])
+            .observe(self.outbox_counters.get().len() as f64);
         Ok(true)
     }
 
@@ -1427,6 +1440,10 @@ where
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
             .observe(nonempty_outboxes.len() as f64);
+        #[cfg(with_metrics)]
+        metrics::OUTBOX_COUNTERS_SIZE
+            .with_label_values(&[])
+            .observe(outbox_counters.len() as f64);
         Ok(targets)
     }
 

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -31,7 +31,7 @@ pub(crate) mod metrics {
             "outbox_size",
             "Outbox size",
             &[],
-            exponential_bucket_interval(1.0, 10_000.0),
+            exponential_bucket_interval(1.0, 1_000_000.0),
         )
     });
 }


### PR DESCRIPTION
## Motivation

On heavily fan-out workloads (PM engine chains), the per-chain outbox bookkeeping in `ChainStateView` grows very large, and the cost of `save` (which re-serializes the whole `outbox_counters` / `nonempty_outboxes` registers) scales with it. The existing metrics are **right-censored**, so we cannot see how large these actually get:

- `num_outboxes` ceiling is `10_000`; pm-infra-worker-2 p99 has been **pinned at the top bucket (10_000)** for days — true value unknown.
- `outbox_size` ceiling is also `10_000`; observed p99 ~9k — about to censor.
- `outbox_counters.len()` — the value that actually drives `save` cost — has **no metric at all**.

## Proposal

- Raise the `num_outboxes` and `outbox_size` histogram ceilings `10_000` → `1_000_000`.
- Add an `outbox_counters_size` histogram observed at the two sites where `num_outboxes` is already observed.

A **histogram** (not a gauge) is used deliberately: these are per-chain quantities observed on workers that handle thousands of chains, so a no-label gauge would be last-write-wins and meaningless. The histogram captures the distribution across the worker's chains, matching the existing `num_outboxes` pattern.

## Test Plan

`cargo clippy -p linera-chain --features metrics --no-default-features` is clean; `cargo fmt` produces no changes. The new metric mirrors the established `NUM_OUTBOXES` registration/observation exactly. Post-deploy verification: `histogram_quantile(0.99, ...)` on `linera_outbox_counters_size_bucket` and the widened `linera_num_outboxes_bucket` should no longer pin at the old ceiling.

## Release Plan
- These changes should be backported to the latest `testnet` branch (testnet_conway) — the metrics are observability-only (no protocol/storage format change), and the deployed PM workers run testnet_conway. A backport PR follows.

## Links
- Context: worker-2-rpc slow cold-start investigation (outbox registers re-serialized in full on every block during catch-up).