### PR TITLE
[testnet_conway] linera-chain: widen outbox metric ceilings and add outbox_counters_size (backport of #6440)

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -159,7 +159,16 @@ pub(crate) mod metrics {
             "num_outboxes",
             "Number of outboxes",
             &[],
-            exponential_bucket_interval(1.0, 10_000.0),
+            exponential_bucket_interval(1.0, 1_000_000.0),
+        )
+    });
+
+    pub static OUTBOX_COUNTERS_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "outbox_counters_size",
+            "Number of entries in the outbox_counters map (in-flight message heights)",
+            &[],
+            exponential_bucket_interval(1.0, 1_000_000.0),
         )
     });
 
@@ -460,6 +469,10 @@ where
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
             .observe(self.nonempty_outboxes.get().len() as f64);
+        #[cfg(with_metrics)]
+        metrics::OUTBOX_COUNTERS_SIZE
+            .with_label_values(&[])
+            .observe(self.outbox_counters.get().len() as f64);
         Ok(true)
     }
 
@@ -1400,6 +1413,10 @@ where
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
             .observe(nonempty_outboxes.len() as f64);
+        #[cfg(with_metrics)]
+        metrics::OUTBOX_COUNTERS_SIZE
+            .with_label_values(&[])
+            .observe(outbox_counters.len() as f64);
         Ok(targets)
     }
 }

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -31,7 +31,7 @@ pub(crate) mod metrics {
             "outbox_size",
             "Outbox size",
             &[],
-            exponential_bucket_interval(1.0, 10_000.0),
+            exponential_bucket_interval(1.0, 1_000_000.0),
         )
     });
 }


### PR DESCRIPTION
## Motivation

Backport of #6440 to `testnet_conway`. The deployed PM workers run `testnet_conway`, and their outbox metrics are right-censored: `num_outboxes` p99 has been pinned at the `10_000` top bucket for days, `outbox_size` is approaching its `10_000` ceiling, and `outbox_counters.len()` (the value driving `save` cost) has no metric. This is observability-only — no protocol or storage-format change.

## Proposal

Same as #6440: raise `num_outboxes` and `outbox_size` ceilings `10_000` → `1_000_000`, and add an `outbox_counters_size` histogram at the two existing `num_outboxes` observation sites. Re-applied by hand (line offsets differ from `main`); identical resulting metric definitions and observations.

## Test Plan

`cargo clippy -p linera-chain --features metrics --no-default-features` is clean. Post-deploy: `histogram_quantile(0.99, linera_num_outboxes_bucket)` / `linera_outbox_counters_size_bucket` on pm-infra-worker-* should no longer pin at the old ceiling, giving the true backlog size.

## Release Plan
- This is the `testnet_conway` backport. Observability-only; ships in the normal worker image cycle.

## Links
- Backport of #6440