### PR TITLE
docker: make linera-tests image runnable on main (forward-port #6362 + #6393)

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -88,6 +88,13 @@ jobs:
             local BUILD_NAME=$5
             local TARGET=$6
             local LOG_FILE="/tmp/${BUILD_NAME}.log"
+            # Only pass --build-arg build_features when a 7th arg is given (even
+            # if empty), so callers can override the Dockerfile default of
+            # scylladb,metrics,jemalloc with a smaller feature set.
+            local features_arg=()
+            if [[ $# -ge 7 ]]; then
+                features_arg=(--build-arg "build_features=${7}")
+            fi
 
             {
               echo "========================================"
@@ -104,6 +111,7 @@ jobs:
                 --build-arg "build_date=${BUILD_DATE}" \
                 --build-arg "build_flag=--release" \
                 --build-arg "build_folder=release" \
+                "${features_arg[@]+"${features_arg[@]}"}" \
                 .
 
               echo "Pushing ${BUILD_NAME} images..."
@@ -124,8 +132,12 @@ jobs:
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
           # the remote-net integration test binary on top of the runtime.
+          # Build with no extra features: the linera binary here is a client-side
+          # tool used by the test harness and does not need a DB backend,
+          # metrics, or a custom allocator. Without `metrics`, `linera service`
+          # does not require --metrics-port, which the test harness does not pass.
           build_and_push "docker/Dockerfile" \
-            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" &
+            "${LINERA_TESTS_IMAGE_BRANCH}" "${LINERA_TESTS_IMAGE_SHORT}" "${LINERA_TESTS_IMAGE_LONG}" "LineraTests" "tests" "" &
           PID_LINERA_TESTS=$!
 
           build_and_push "docker/Dockerfile.indexer" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --bin linera-proxy \
     --bin linera-server \
     --bin linera \
-    --features $build_features
+    ${build_features:+--features $build_features}
 
 # Copy full source and build (only changed crates recompile).
 COPY . .
@@ -132,7 +132,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         --bin linera-proxy \
         --bin linera-server \
         --bin linera \
-        --features $build_features \
+        ${build_features:+--features $build_features} \
     && cp \
         target/"$build_folder"/linera \
         target/"$build_folder"/linera-proxy \
@@ -173,17 +173,21 @@ COPY --from=binaries \
     ./
 
 # ── Stage 4: tests-builder — compile the remote-net integration test ──
-# Builds /linera_net_tests by parsing cargo's JSON output for the executable
-# path; the underlying binary lives in /app/target/release/deps/ which is a
-# cache mount and won't persist past this RUN, hence the explicit cp.
+# Builds /linera_net_tests and /linera-benchmark; also pre-compiles all
+# example Wasm contracts so the test binary can publish them without needing
+# cargo or source code at runtime.  The test binary lives in
+# /app/target/release/deps/ (a cache mount) so it must be copied out in the
+# same RUN.
 
 FROM builder_src AS tests-builder
 ARG build_flag
+ARG build_folder
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
-    cargo test --no-run ${build_flag:+"$build_flag"} \
+    cargo build ${build_flag:+"$build_flag"} --bin linera-benchmark \
+    && cargo test --no-run ${build_flag:+"$build_flag"} \
         -p linera-service \
         --features remote-net \
         --test linera_net_tests \
@@ -191,7 +195,26 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     && jq -r 'select(.executable != null) | .executable' /tmp/cargo-tests.json \
         | grep '/linera_net_tests-' \
         | head -1 \
-        | xargs -I{} cp {} /linera_net_tests
+        | xargs -I{} cp {} /linera_net_tests \
+    && cp target/"${build_folder}"/linera-benchmark /linera-benchmark
+
+# Build every example contract exactly the way CI does (.github/workflows/
+# scylladb.yml: `cd examples && cargo build --locked --release --target
+# wasm32-unknown-unknown`). Building the whole examples workspace guarantees
+# every `<name>_contract.wasm` / `<name>_service.wasm` the tests publish is
+# produced — an explicit `-p` list silently misses contracts.
+#
+# No cache mount on examples/target: the wasm must persist into this image
+# layer for the `tests` stage to copy, and building into a real dir (as CI
+# does) avoids any cache-mount visibility ambiguity.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    cd examples \
+    && cargo build --locked --release --target wasm32-unknown-unknown \
+    && mkdir -p /wasm-examples \
+    && find target/wasm32-unknown-unknown/release \
+        -maxdepth 1 -name "*.wasm" \
+        -exec cp {} /wasm-examples/ \;
 
 # ── Stage 5: tests runtime — runtime image + remote-net test binary ──
 # Used by linera-infra's network-health-check CronJob; production image
@@ -201,3 +224,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 FROM runtime AS tests
 RUN ln -s /linera /usr/local/bin/linera
 COPY --from=tests-builder /linera_net_tests /usr/local/bin/linera-net-tests
+COPY --from=tests-builder /linera-benchmark /usr/local/bin/linera-benchmark
+# Stub cargo so build_application() succeeds without a Rust toolchain: it calls
+# `cargo build`, the stub exits 0, then reads the pre-built .wasm files below.
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/cargo && chmod +x /usr/local/bin/cargo
+# The remote-net tests run from `/` and treat `/examples` as a linera-protocol
+# checkout: they read contract sources and snapshot fixtures (e.g.
+# examples/counter/tests/snapshots/format__format.snap), resolve each contract
+# via `…/examples/<name>/../target/…/release/<name>_contract.wasm` (needs the
+# real `/examples/<name>` dir to exist for the `..` to collapse), and
+# linera-benchmark canonicalize()s `/examples/fungible`. Ship the examples
+# source tree (.dockerignore strips target/) and overlay the pre-built wasm.
+COPY examples /examples
+COPY --from=tests-builder /wasm-examples/ /examples/target/wasm32-unknown-unknown/release/


### PR DESCRIPTION
## Motivation

The `linera-tests` Docker image (consumed by linera-infra's `network-health-check`
CronJob) is broken on `main` in the same two ways it was on `testnet_conway`,
which were fixed there by #6362 and #6393 but never forward-ported:

1. **Built with `metrics`** — `main`'s `docker_image.yml` builds the
   `LineraTests` image with the Dockerfile's default features, which include
   `metrics`. That makes `linera service` require `--metrics-port`, a flag the
   test harness never passes.
2. **Missing the test runtime environment** — the `tests` stage shipped only the
   `linera_net_tests` binary. The binary expects a linera-protocol checkout at
   runtime: it `cargo build`s example contracts (no toolchain/sources in the
   image), reads example source fixtures, and resolves `linera-benchmark` (never
   copied in).

`main` builds `linera-tests` on every `devnet_*` / `testnet_*` / `bridge-main`
push, so without this a devnet health-check — or the next release branch cut
from `main` — rebuilds a fully broken image and reintroduces the bug.

## Proposal

Forward-port both fixes onto `main`'s (diverged) files; no Rust code is touched.

**`.github/workflows/docker_image.yml`** (#6362): add a `features_arg`
mechanism to `build_and_push` so a 7th arg (even empty) overrides the
Dockerfile's `build_features` default, and pass `""` for the `LineraTests`
build so it ships without `metrics`. `main`'s `linera-bridge` image and WIF auth
are preserved.

**`docker/Dockerfile`** (#6393):
- `tests-builder`: also build `linera-benchmark`, and build the whole examples
  workspace to wasm (as CI's `scylladb.yml` does), staging the `.wasm` under
  `/wasm-examples/`.
- `tests`: copy in `linera-benchmark`, stub `cargo` (so `build_application()`'s
  `cargo build` no-ops and falls through to the pre-built wasm), `COPY examples
  /examples` (source tree; `.dockerignore` strips `target/`), and overlay the
  wasm at `/examples/target/wasm32-unknown-unknown/release/`.
- The `${build_features:+--features …}` conditional is applied so an empty
  feature set builds with Cargo defaults. **`main`'s `build_features` default
  (`scylladb,metrics,jemalloc`, no `opentelemetry`) is kept as-is.**

The resulting `docker/Dockerfile` is identical to the merged `testnet_conway`
version except for that intentional `build_features` default; `docker_image.yml`
is identical except for `main`'s bridge/WIF/`bridge-main` additions.

## Test Plan

- The same change on `testnet_conway` (#6362 + #6393) is verified end-to-end
  against the live network: triggering the `network-health-check` e2e job on the
  resulting image gives `28 passed; 0 failed; 1 ignored`, Slack ✅.
- This PR is a mechanical forward-port: diffing the result against
  `testnet_conway` shows only the intended `main`-specific divergences
  (build_features default, `linera-bridge`, WIF auth). `bash -n` on the rendered
  build script is clean.
- CI on this PR exercises the image build itself.

## Release Plan

- Nothing to do / These changes follow the usual release cycle. (The fix is
  already live on `testnet_conway`; this prevents regression on branches cut
  from `main`.)

## Links

- #6362 (build linera-tests without metrics) — merged to `testnet_conway`
- #6393 (bundle wasm + examples source + linera-benchmark) — merged to `testnet_conway`
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
