### PR TITLE
Linera->EVM burns go through `EvmBridge` contract.

### DIFF
--- a/examples/bridge-demo/README.md
+++ b/examples/bridge-demo/README.md
@@ -181,10 +181,11 @@ For a production testnet deployment runbook see
 
 ## How a withdrawal works
 
-1. User calls `wrapped-fungible.transfer` targeting the relay's chain with an
-   `Address20` owner (their EVM address)
-2. On the relay chain, the `Credit` message triggers an auto-burn and emits a
-   `BurnEvent` on the `"burns"` stream
+1. User submits a `Burn` operation to the `evm-bridge` app with their EVM
+   address as the target
+2. The bridge moves the tokens into its escrow account on the relay (bridge)
+   chain and burns them, emitting a `BurnEvent` on the bridge app's `"burns"`
+   stream
 3. Relay detects the `BurnEvent` and forwards the Linera block to
    `FungibleBridge.addBlock()`
 4. `FungibleBridge` verifies the block via `LightClient`, deserializes the
@@ -200,9 +201,9 @@ requests and automatically retries them:
   processed. Unprocessed deposits are retried by regenerating the MPT proof
   and resubmitting.
 - **Linera→EVM burns**: the relay scans Linera blocks for `BurnEvent` events
-  on the `"burns"` stream and checks EVM for matching ERC-20 `Transfer` events.
-  Unforwarded burns are retried by re-reading the block containing the
-  auto-burn from chain storage and re-calling `addBlock`.
+  on the bridge app's `"burns"` stream and checks EVM for matching ERC-20
+  `Transfer` events. Unforwarded burns are retried by re-reading the block
+  containing the burn from chain storage and re-calling `addBlock`.
 
 This means the relay self-heals after crashes or transient RPC failures
 without operator intervention. On-chain replay protection (`processed_deposits`

--- a/examples/bridge-demo/index.html
+++ b/examples/bridge-demo/index.html
@@ -586,33 +586,26 @@
       async function withdraw(amount) {
         clearErrors();
         if (!evmSigner) { addError('Connect MetaMask first'); return; }
+        if (!bridgeApp) { addError('Bridge app not initialized'); return; }
 
         try {
-          // Strip 0x and lowercase the EVM address, pad to 40 hex chars
-          const evmAddrHex = evmAddress.replace(/^0x/, '').toLowerCase();
-          // Address20 format: 0x followed by 40 hex chars
-          const targetOwner = `0x${evmAddrHex}`;
-          const targetAccount = { owner: targetOwner, chainId: BRIDGE_CHAIN_ID };
-
-          // Step 1: Transfer wrapped tokens to bridge chain with Address20 owner.
-          setStatus('Step 1/3: Burning wrapped tokens (transfer to bridge chain)...');
+          // Step 1: Submit a Burn to the evm-bridge app. The bridge moves the
+          // wrapped tokens into the signer's own escrow on the bridge chain,
+          // burns them, and emits a BurnEvent the relayer forwards to EVM —
+          // releasing the ERC-20 to the connected address.
+          setStatus('Step 1/3: Submitting burn to the bridge...');
           const amountSubUnits = ethers.parseUnits(amount, tokenDecimals).toString();
-          const mutation = gql(`mutation(
-            $donor: AccountOwner!,
-            $amount: U128!,
-            $recipient: FungibleAccount!
-          ) {
-            transfer(owner: $donor, amount: $amount, targetAccount: $recipient)
+          const mutation = gql(`mutation($amount: U128!, $target: String!) {
+            burn(amount: $amount, evmTarget: $target)
           }`, {
-            donor: lineraOwner,
             amount: amountSubUnits,
-            recipient: targetAccount,
+            target: evmAddress,
           });
-          const resp = JSON.parse(await wrappedApp.query(mutation));
+          const resp = JSON.parse(await bridgeApp.query(mutation));
           if (resp.errors?.length) throw new Error(resp.errors[0].message);
 
-          // Step 2: Wait for relay to forward block
-          setStatus('Step 2/3: Waiting for relay to forward block to EVM...');
+          // Step 2: Wait for relay to forward the burn to EVM
+          setStatus('Step 2/3: Waiting for relay to forward the burn to EVM...');
 
           // Step 3: Poll EVM balance
           const initialBalance = await new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, evmProvider)
@@ -671,6 +664,7 @@
         await client.start();
         const chain = await client.chain(lineraChain, { owner: lineraOwner });
         wrappedApp = await chain.application(APP_ID);
+        bridgeApp = await chain.application(BRIDGE_APP_ID);
         const decimalsResp = JSON.parse(await wrappedApp.query(gql(`query { decimals }`)));
         tokenDecimals = decimalsResp.data?.decimals;
         if (typeof tokenDecimals !== 'number') {

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -212,7 +212,7 @@ echo "  LineraToken: $TOKEN_ADDRESS"
 validate_eth_address "Token address" "$TOKEN_ADDRESS"
 TOKEN_ADDR_HEX=$(echo "$TOKEN_ADDRESS" | sed 's/^0x//')
 
-# ── 3b. Read relay owner (minter for wrapped-fungible) ──
+# ── 3b. Read relay owner (owns the bridge chain; performs the registrations) ──
 echo "Reading relay owner..."
 for i in $(seq 1 30); do
     RELAY_OWNER=$(dc_exec foundry-tools cat /shared/relay-owner 2>/dev/null | tr -d '[:space:]')
@@ -223,56 +223,14 @@ for i in $(seq 1 30); do
     sleep 2
 done
 [[ -z "$RELAY_OWNER" ]] && die "Relay owner not found within timeout"
-echo "  Relay owner (minter): $RELAY_OWNER"
+echo "  Relay owner: $RELAY_OWNER"
 
 # FungibleBridge is deployed below (step 7), after the wrapped-fungible app
 # is created so the canonical applicationId can be baked into its constructor.
 CHAIN_BYTES32="0x${BRIDGE_CHAIN_ID}"
 
-# ── 5. Publish and create evm-bridge app ──
-echo "Syncing chain state..."
-linera_exec sync 2>&1
-linera_exec process-inbox 2>&1
-echo "Publishing and creating evm-bridge app..."
-BRIDGE_PARAMS=$(
-    CHAIN_ID="$EVM_CHAIN_ID" \
-    TOKEN_HEX="$TOKEN_ADDR_HEX" \
-    python3 -c "
-import json, os
-def hex_to_array(h):
-    return [int(h[i:i+2], 16) for i in range(0, len(h), 2)]
-params = {
-    'source_chain_id': int(os.environ['CHAIN_ID']),
-    'token_address': hex_to_array(os.environ['TOKEN_HEX']),
-}
-print(json.dumps(params))
-")
-
-BRIDGE_ARGUMENT=$(EVM_RPC_URL="$EVM_RPC_URL" python3 -c "
-import json, os
-print(json.dumps({'rpc_endpoint': os.environ.get('EVM_RPC_URL', '')}))
-")
-
-for attempt in 1 2 3; do
-    BRIDGE_APP_OUTPUT=$(linera_exec publish-and-create \
-        "$EVM_BRIDGE_WASM_DIR/evm_bridge_contract.wasm" \
-        "$EVM_BRIDGE_WASM_DIR/evm_bridge_service.wasm" \
-        --json-parameters "$BRIDGE_PARAMS" \
-        --json-argument "$BRIDGE_ARGUMENT" 2>&1) && break
-    echo "  Attempt $attempt failed:" >&2
-    echo "$BRIDGE_APP_OUTPUT" >&2
-    sleep 2
-done
-[[ -z "$BRIDGE_APP_OUTPUT" ]] && { echo "ERROR: publish-and-create evm-bridge failed after retries" >&2; exit 1; }
-BRIDGE_APP_ID=$(echo "$BRIDGE_APP_OUTPUT" | grep -oE '^[a-f0-9]{64}$' | tail -1)
-validate_hex64 "Linera bridge app ID" "$BRIDGE_APP_ID"
-echo "  Linera bridge app: $BRIDGE_APP_ID"
-
-# Write bridge app ID to shared dir for relay.
-dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_APP_ID' > /shared/bridge-app-id"
-echo "$BRIDGE_APP_ID" > "$SHARED_DIR/bridge-app-id"
-
-# ── 6. Publish and create wrapped-fungible app ──
+# ── 5. Publish and create wrapped-fungible app (first; the evm-bridge app takes
+#       its app ID as a creation parameter) ──
 echo "Syncing chain state..."
 linera_exec sync 2>&1
 linera_exec process-inbox 2>&1
@@ -280,11 +238,9 @@ echo "Publishing and creating wrapped-fungible app..."
 WRAPPED_PARAMS=$(
     TICKER="$TICKER_SYMBOL" \
     DECIMALS="$TOKEN_DECIMALS" \
-    MINTER="$RELAY_OWNER" \
     TOKEN_HEX="$TOKEN_ADDR_HEX" \
     CHAIN_ID="$EVM_CHAIN_ID" \
     BRIDGE_CHAIN="$BRIDGE_CHAIN_ID" \
-    BRIDGE_APP="$BRIDGE_APP_ID" \
     python3 -c "
 import json, os
 def hex_to_array(h):
@@ -292,11 +248,9 @@ def hex_to_array(h):
 params = {
     'ticker_symbol': os.environ['TICKER'],
     'decimals': int(os.environ['DECIMALS']),
-    'minter': os.environ['MINTER'],
     'mint_chain_id': os.environ['BRIDGE_CHAIN'],
     'evm_token_address': hex_to_array(os.environ['TOKEN_HEX']),
     'evm_source_chain_id': int(os.environ['CHAIN_ID']),
-    'bridge_app_id': os.environ['BRIDGE_APP'],
 }
 print(json.dumps(params))
 ")
@@ -319,7 +273,62 @@ echo "  Wrapped-fungible app: $WRAPPED_APP_ID"
 dc_exec --user root foundry-tools sh -c "echo '$WRAPPED_APP_ID' > /shared/wrapped-app-id"
 echo "$WRAPPED_APP_ID" > "$SHARED_DIR/wrapped-app-id"
 
-APP_ID_BYTES32="0x${WRAPPED_APP_ID:0:64}"
+APP_ID_BYTES32="0x${WRAPPED_APP_ID}"
+
+# ── 6. Publish and create evm-bridge app (points at the wrapped app) ──
+echo "Syncing chain state..."
+linera_exec sync 2>&1
+linera_exec process-inbox 2>&1
+echo "Publishing and creating evm-bridge app..."
+BRIDGE_PARAMS=$(
+    CHAIN_ID="$EVM_CHAIN_ID" \
+    TOKEN_HEX="$TOKEN_ADDR_HEX" \
+    BRIDGE_CHAIN="$BRIDGE_CHAIN_ID" \
+    FUNGIBLE_APP="$WRAPPED_APP_ID" \
+    python3 -c "
+import json, os
+def hex_to_array(h):
+    return [int(h[i:i+2], 16) for i in range(0, len(h), 2)]
+params = {
+    'source_chain_id': int(os.environ['CHAIN_ID']),
+    'token_address': hex_to_array(os.environ['TOKEN_HEX']),
+    'bridge_chain_id': os.environ['BRIDGE_CHAIN'],
+    'fungible_app_id': os.environ['FUNGIBLE_APP'],
+}
+print(json.dumps(params))
+")
+
+BRIDGE_ARGUMENT=$(EVM_RPC_URL="$EVM_RPC_URL" python3 -c "
+import json, os
+print(json.dumps({'rpc_endpoint': os.environ.get('EVM_RPC_URL', '')}))
+")
+
+for attempt in 1 2 3; do
+    # The bridge calls the wrapped-fungible app (escrow transfer + burn), so it is
+    # declared as a required application dependency. This makes the wrapped module
+    # load eagerly with the bridge — required on the web client, which cannot load
+    # modules dynamically mid-execution (#2927). Removed in a follow-up commit that
+    # adds generalized module preloading.
+    BRIDGE_APP_OUTPUT=$(linera_exec publish-and-create \
+        "$EVM_BRIDGE_WASM_DIR/evm_bridge_contract.wasm" \
+        "$EVM_BRIDGE_WASM_DIR/evm_bridge_service.wasm" \
+        --json-parameters "$BRIDGE_PARAMS" \
+        --json-argument "$BRIDGE_ARGUMENT" \
+        --required-application-ids "$WRAPPED_APP_ID" 2>&1) && break
+    echo "  Attempt $attempt failed:" >&2
+    echo "$BRIDGE_APP_OUTPUT" >&2
+    sleep 2
+done
+[[ -z "$BRIDGE_APP_OUTPUT" ]] && { echo "ERROR: publish-and-create evm-bridge failed after retries" >&2; exit 1; }
+BRIDGE_APP_ID=$(echo "$BRIDGE_APP_OUTPUT" | grep -oE '^[a-f0-9]{64}$' | tail -1)
+validate_hex64 "Linera bridge app ID" "$BRIDGE_APP_ID"
+echo "  Linera bridge app: $BRIDGE_APP_ID"
+
+# Write bridge app ID to shared dir for relay.
+dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_APP_ID' > /shared/bridge-app-id"
+echo "$BRIDGE_APP_ID" > "$SHARED_DIR/bridge-app-id"
+
+BRIDGE_APP_ID_BYTES32="0x${BRIDGE_APP_ID}"
 
 # ── 7. Deploy FungibleBridge with the wrapped-fungible applicationId baked in ──
 echo "Deploying FungibleBridge via forge script..."
@@ -328,6 +337,7 @@ dc_exec foundry-tools env \
     BRIDGE_CHAIN_ID="$CHAIN_BYTES32" \
     TOKEN_ADDRESS="$TOKEN_ADDRESS" \
     FUNGIBLE_APP_ID="$APP_ID_BYTES32" \
+    BRIDGE_APP_ID="$BRIDGE_APP_ID_BYTES32" \
     forge script /contracts/script/DeployFungibleBridge.s.sol \
     --root /contracts \
     --rpc-url "$EVM_RPC_URL" \
@@ -348,23 +358,24 @@ echo "  FungibleBridge: $BRIDGE_ADDRESS"
 dc_exec --user root foundry-tools sh -c "echo '$BRIDGE_ADDRESS' > /shared/bridge-address"
 echo "$BRIDGE_ADDRESS" > "$SHARED_DIR/bridge-address"
 
-# ── 8. Register app IDs on both sides ──
-echo "Registering fungible app in evm-bridge..."
-# BCS encoding: variant index 0 (RegisterFungibleApp) + 32-byte app ID hash.
-# Must use the relay wallet since it owns the bridge chain.
-REGISTER_HEX="00${WRAPPED_APP_ID}"
+# ── 8. Register the bridge ↔ wrapped relationship on both sides ──
+echo "Registering the bridge as the wrapped-fungible authorized caller..."
+# BCS: WrappedFungibleOperation::RegisterAuthorizedCaller (variant 8) + 32-byte
+# bridge app ID. Submitted on the WRAPPED app, on the mint (bridge) chain — the
+# relay wallet owns that chain.
+REGISTER_CALLER_HEX="08${BRIDGE_APP_ID}"
 dc_exec linera-network env \
     LINERA_WALLET=/shared/relay-wallet/wallet.json \
     LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
     LINERA_STORAGE=rocksdb:/shared/relay-wallet/client.db \
     ./linera execute-operation \
-    --application-id "$BRIDGE_APP_ID" \
-    --operation "$REGISTER_HEX" \
+    --application-id "$WRAPPED_APP_ID" \
+    --operation "$REGISTER_CALLER_HEX" \
     --chain-id "$BRIDGE_CHAIN_ID" 2>&1
 
 echo "Registering FungibleBridge address in evm-bridge..."
-# BCS encoding: variant index 3 (RegisterFungibleBridge) + 20-byte EVM address.
-REGISTER_BRIDGE_HEX="03${BRIDGE_ADDR_HEX}"
+# BCS: BridgeOperation::RegisterFungibleBridge (variant 2) + 20-byte EVM address.
+REGISTER_BRIDGE_HEX="02${BRIDGE_ADDR_HEX}"
 dc_exec linera-network env \
     LINERA_WALLET=/shared/relay-wallet/wallet.json \
     LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
@@ -373,7 +384,7 @@ dc_exec linera-network env \
     --application-id "$BRIDGE_APP_ID" \
     --operation "$REGISTER_BRIDGE_HEX" \
     --chain-id "$BRIDGE_CHAIN_ID" 2>&1
-echo "  App IDs registered on both sides"
+echo "  Registered: bridge as wrapped's authorized caller; FungibleBridge address in evm-bridge"
 
 # ── 8. Fund FungibleBridge with ERC20 tokens ──
 if [[ "$FUND_AMOUNT" != "0" ]]; then

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -304,17 +304,11 @@ print(json.dumps({'rpc_endpoint': os.environ.get('EVM_RPC_URL', '')}))
 ")
 
 for attempt in 1 2 3; do
-    # The bridge calls the wrapped-fungible app (escrow transfer + burn), so it is
-    # declared as a required application dependency. This makes the wrapped module
-    # load eagerly with the bridge — required on the web client, which cannot load
-    # modules dynamically mid-execution (#2927). Removed in a follow-up commit that
-    # adds generalized module preloading.
     BRIDGE_APP_OUTPUT=$(linera_exec publish-and-create \
         "$EVM_BRIDGE_WASM_DIR/evm_bridge_contract.wasm" \
         "$EVM_BRIDGE_WASM_DIR/evm_bridge_service.wasm" \
         --json-parameters "$BRIDGE_PARAMS" \
-        --json-argument "$BRIDGE_ARGUMENT" \
-        --required-application-ids "$WRAPPED_APP_ID" 2>&1) && break
+        --json-argument "$BRIDGE_ARGUMENT" 2>&1) && break
     echo "  Attempt $attempt failed:" >&2
     echo "$BRIDGE_APP_OUTPUT" >&2
     sleep 2

--- a/examples/counter/metamask/package.json
+++ b/examples/counter/metamask/package.json
@@ -16,6 +16,6 @@
     "@linera/metamask": "workspace:*"
   },
   "devDependencies": {
-    "vite": "^5.4.11"
+    "vite": "7.1.7"
   }
 }

--- a/examples/native-fungible/metamask/package.json
+++ b/examples/native-fungible/metamask/package.json
@@ -16,6 +16,6 @@
     "@linera/metamask": "workspace:*"
   },
   "devDependencies": {
-    "vite": "^5.4.11"
+    "vite": "7.1.7"
   }
 }

--- a/examples/pnpm-lock.yaml
+++ b/examples/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 22.7.5
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(playwright@1.54.0)(vite@5.4.20(@types/node@22.7.5))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.54.0)(vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1))(vitest@3.2.4)
       playwright:
         specifier: 1.54.0
         version: 1.54.0
@@ -41,7 +41,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)(yaml@2.8.1)
 
   ../web/@linera/metamask:
     dependencies:
@@ -70,7 +70,7 @@ importers:
     devDependencies:
       vite:
         specifier: 7.1.7
-        version: 7.1.7(@types/node@25.0.10)(yaml@2.8.1)
+        version: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
 
   counter:
     dependencies:
@@ -83,7 +83,7 @@ importers:
     devDependencies:
       vite:
         specifier: 7.1.7
-        version: 7.1.7(@types/node@25.0.10)(yaml@2.8.1)
+        version: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
 
   counter/metamask:
     dependencies:
@@ -95,8 +95,8 @@ importers:
         version: link:../../../web/@linera/metamask
     devDependencies:
       vite:
-        specifier: ^5.4.11
-        version: 5.4.20(@types/node@25.0.10)
+        specifier: 7.1.7
+        version: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
 
   native-fungible:
     dependencies:
@@ -109,7 +109,7 @@ importers:
     devDependencies:
       vite:
         specifier: 7.1.7
-        version: 7.1.7(@types/node@25.0.10)(yaml@2.8.1)
+        version: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
 
   native-fungible/metamask:
     dependencies:
@@ -121,8 +121,8 @@ importers:
         version: link:../../../web/@linera/metamask
     devDependencies:
       vite:
-        specifier: ^5.4.11
-        version: 5.4.20(@types/node@25.0.10)
+        specifier: 7.1.7
+        version: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
 
 packages:
 
@@ -141,34 +141,16 @@ packages:
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.25.10':
     resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.10':
     resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.10':
@@ -177,34 +159,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.10':
     resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.10':
     resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.10':
@@ -213,22 +177,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.10':
     resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.10':
@@ -237,22 +189,10 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.10':
     resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.10':
@@ -261,22 +201,10 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.10':
     resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.10':
@@ -285,22 +213,10 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.10':
     resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.10':
@@ -309,34 +225,16 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.10':
     resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.10':
     resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.10':
@@ -351,12 +249,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.10':
     resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
     engines: {node: '>=18'}
@@ -367,12 +259,6 @@ packages:
     resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.10':
@@ -387,23 +273,11 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.10':
     resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.10':
     resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
@@ -411,22 +285,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.10':
     resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.10':
@@ -554,56 +416,67 @@ packages:
     resolution: {integrity: sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.2':
     resolution: {integrity: sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.2':
     resolution: {integrity: sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.2':
     resolution: {integrity: sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.2':
     resolution: {integrity: sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.2':
     resolution: {integrity: sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.2':
     resolution: {integrity: sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.2':
     resolution: {integrity: sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.2':
     resolution: {integrity: sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.2':
     resolution: {integrity: sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.2':
     resolution: {integrity: sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.2':
     resolution: {integrity: sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==}
@@ -693,9 +566,6 @@ packages:
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
-
-  '@types/node@25.0.10':
-    resolution: {integrity: sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -848,11 +718,6 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
-
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
-    hasBin: true
 
   esbuild@0.25.10:
     resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
@@ -1215,51 +1080,18 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
-
-  vite@5.4.20:
-    resolution: {integrity: sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
 
   vite@7.1.7:
     resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
@@ -1383,103 +1215,52 @@ snapshots:
 
   '@babel/runtime@7.28.4': {}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.10':
-    optional: true
-
-  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.10':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
-    optional: true
-
   '@esbuild/android-arm@0.25.10':
-    optional: true
-
-  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.10':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.10':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.10':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.10':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.10':
-    optional: true
-
-  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.10':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.10':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.10':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.10':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.10':
-    optional: true
-
-  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.10':
@@ -1488,16 +1269,10 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.10':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.10':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.10':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.10':
@@ -1506,25 +1281,13 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.10':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.10':
-    optional: true
-
-  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.10':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.10':
-    optional: true
-
-  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.10':
@@ -1795,23 +1558,18 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@25.0.10':
-    dependencies:
-      undici-types: 7.16.0
-    optional: true
-
   '@types/unist@3.0.3': {}
 
-  '@vitest/browser@3.2.4(playwright@1.54.0)(vite@5.4.20(@types/node@22.7.5))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.54.0)(vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@22.7.5))
+      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)(yaml@2.8.1)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.54.0
@@ -1829,13 +1587,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@5.4.20(@types/node@22.7.5))':
+  '@vitest/mocker@3.2.4(vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.20(@types/node@22.7.5)
+      vite: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -1945,32 +1703,6 @@ snapshots:
   entities@4.5.0: {}
 
   es-module-lexer@1.7.0: {}
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -2331,22 +2063,20 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  undici-types@7.16.0:
-    optional: true
-
   util-deprecate@1.0.2: {}
 
   uuid@9.0.1: {}
 
-  vite-node@3.2.4(@types/node@22.7.5):
+  vite-node@3.2.4(@types/node@22.7.5)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.20(@types/node@22.7.5)
+      vite: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -2355,26 +2085,10 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
-  vite@5.4.20(@types/node@22.7.5):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.52.2
-    optionalDependencies:
-      '@types/node': 22.7.5
-      fsevents: 2.3.3
-
-  vite@5.4.20(@types/node@25.0.10):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.6
-      rollup: 4.52.2
-    optionalDependencies:
-      '@types/node': 25.0.10
-      fsevents: 2.3.3
-
-  vite@7.1.7(@types/node@25.0.10)(yaml@2.8.1):
+  vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2383,15 +2097,15 @@ snapshots:
       rollup: 4.52.2
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.0.10
+      '@types/node': 22.7.5
       fsevents: 2.3.3
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.7.5)(@vitest/browser@3.2.4)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@5.4.20(@types/node@22.7.5))
+      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2409,14 +2123,15 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 5.4.20(@types/node@22.7.5)
-      vite-node: 3.2.4(@types/node@22.7.5)
+      vite: 7.1.7(@types/node@22.7.5)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@22.7.5)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.7.5
-      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@5.4.20(@types/node@22.7.5))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.54.0)(vite@7.1.7(@types/node@22.7.5)(yaml@2.8.1))(vitest@3.2.4)
     transitivePeerDependencies:
+      - jiti
       - less
       - lightningcss
       - msw
@@ -2426,6 +2141,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
   webextension-polyfill@0.12.0: {}
 

--- a/examples/pnpm-workspace.yaml
+++ b/examples/pnpm-workspace.yaml
@@ -1,8 +1,10 @@
 packages:
-- ../web/@linera/client
-- ../web/@linera/metamask
-- bridge-demo
-- counter
-- counter/metamask
-- native-fungible
-- native-fungible/metamask
+  - ../web/@linera/client
+  - ../web/@linera/metamask
+  - bridge-demo
+  - counter
+  - counter/metamask
+  - native-fungible
+  - native-fungible/metamask
+allowBuilds:
+  esbuild: true

--- a/examples/wrapped-fungible/README.md
+++ b/examples/wrapped-fungible/README.md
@@ -1,42 +1,36 @@
 # Wrapped Fungible Token Example Application
 
-This example application implements a wrapped (bridged) fungible token for the EVM<>Linera bridge. It extends the base fungible token with minting, burning, and bridge-specific authorization.
-
-Tokens are minted when a deposit proof from EVM is verified by the `evm-bridge` application, and burned automatically when transferred cross-chain to an Ethereum address (`Address20`) on the bridge chain.
+This example application implements a wrapped (bridged) fungible token, used by the EVM↔Linera bridge. It extends the base `fungible` token with `Mint` and `Burn` operations whose authority is restricted to a single registered application — the *authorized caller* — on a designated mint chain. In the bridge, that authorized caller is the `evm-bridge` application.
 
 ## How It Works
 
-The wrapped fungible token shares the same account model as the `fungible` example: individual chains have accounts with owners and balances. It adds three bridge-specific features:
+The wrapped fungible token shares the same account model as the `fungible` example: individual chains have accounts with owners and balances. It adds supply control (`Mint`/`Burn`) gated to a registered authorized caller.
 
-### Minting
+### Authorization
 
-Minting creates new wrapped tokens backed by locked ERC-20 tokens on EVM. Authorization is configurable via `WrappedParameters`:
+`Mint` and `Burn` are driven only by the registered authorized caller, and only on the designated mint chain. Two checks, both mandatory:
 
-- `bridge_app_id` (optional): if set, minting is only allowed via cross-application call from the bridge app
-- `minter` (optional): if set, the block signer must match this account
-- `mint_chain_id` (optional): if set, minting is restricted to this chain
+- The cross-application caller must equal the application registered via `RegisterAuthorizedCaller`.
+- The operation must run on `mint_chain_id` (a `WrappedParameters` field).
 
-Each check is enforced only when the corresponding parameter is `Some`. A fully unconfigured token allows unrestricted minting.
+`RegisterAuthorizedCaller` is itself restricted to the mint chain — the only chain where the authorized caller is consulted — and requires an authenticated signer. The caller is registered after creation rather than passed as a parameter, so an authorized caller that takes this token's id as a creation parameter can be created first (see Deployment).
 
-### Auto-Burning
-
-When tokens are transferred cross-chain to an `Address20` target (Ethereum address) on the designated bridge chain, they are automatically burned instead of credited. The contract emits a `BurnEvent` on the `"burns"` stream, which the off-chain relayer detects and forwards to the EVM bridge contract to release the corresponding ERC-20 tokens.
-
-This replaces the previous flow where the relayer had to propose a separate `Burn` operation.
+There is no signer check on `Mint`/`Burn`: the authorized caller is trusted to validate its own input, so whoever relays the request is irrelevant. This keeps relaying permissionless.
 
 ### Operations
 
 All standard fungible operations are supported (`Transfer`, `TransferFrom`, `Approve`, `Claim`, `Balance`, `TickerSymbol`), plus:
 
-- `Mint { target_account, amount }` - Creates new tokens (subject to authorization checks)
-- `Burn { owner, amount }` - Rejected at the contract level. Burning happens automatically via cross-chain transfer to an Address20 on the bridge chain.
+- `Mint { target_account, amount }` — creates new tokens; authorized caller only, on the mint chain.
+- `Burn { owner, amount }` — burns tokens from an account; authorized caller only, on the mint chain.
+- `RegisterAuthorizedCaller { app_id }` — registers the application allowed to `Mint`/`Burn`; mint chain only, requires an authenticated signer.
 
 ## Deployment
 
-The wrapped fungible token is deployed as part of the EVM<>Linera bridge. The deployment order is:
+The wrapped fungible token is deployed as part of the EVM↔Linera bridge. Because the `evm-bridge` application takes this token's id as a creation parameter, the token is created first:
 
-1. Deploy the `evm-bridge` Linera application
-2. Deploy `wrapped-fungible` with `bridge_app_id` pointing to the bridge app
-3. Register the wrapped-fungible app ID in the bridge via `RegisterFungibleApp`
+1. Deploy `wrapped-fungible`.
+2. Deploy the `evm-bridge` application, pointing it at the wrapped-fungible app id.
+3. On the mint chain, register the bridge as the authorized caller via `RegisterAuthorizedCaller`.
 
 See `examples/bridge-demo/setup.sh` for the complete deployment script.

--- a/examples/wrapped-fungible/src/contract.rs
+++ b/examples/wrapped-fungible/src/contract.rs
@@ -6,12 +6,12 @@
 mod state;
 
 use linera_sdk::{
-    linera_base_types::{AccountOwner, StreamName, WithContractAbi, U128},
+    linera_base_types::{AccountOwner, WithContractAbi, U128},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
 use wrapped_fungible::{
-    Account, BurnEvent, FungibleResponse, InitialState, Message, WrappedFungibleOperation,
+    Account, FungibleResponse, InitialState, Message, WrappedFungibleOperation,
     WrappedFungibleTokenAbi, WrappedParameters,
 };
 
@@ -32,7 +32,7 @@ impl Contract for WrappedFungibleTokenContract {
     type Message = Message;
     type Parameters = WrappedParameters;
     type InstantiationArgument = InitialState;
-    type EventValue = BurnEvent;
+    type EventValue = ();
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = WrappedFungibleTokenState::load(runtime.root_view_storage_context())
@@ -120,10 +120,32 @@ impl Contract for WrappedFungibleTokenContract {
             WrappedFungibleOperation::Mint {
                 target_account,
                 amount,
-            } => self.execute_mint(target_account, amount).await,
+            } => {
+                self.require_authorized_chain();
+                self.execute_mint(target_account, amount).await;
+                FungibleResponse::Ok
+            }
 
-            WrappedFungibleOperation::Burn { .. } => {
-                panic!("Operation::Burn is not supported; burning happens automatically on cross-chain transfer to an Address20 on the bridge chain");
+            WrappedFungibleOperation::Burn { owner, amount } => {
+                self.require_authorized_chain();
+                self.state.debit(owner, amount).await;
+                FungibleResponse::Ok
+            }
+
+            WrappedFungibleOperation::RegisterAuthorizedCaller { app_id } => {
+                self.runtime
+                    .authenticated_signer()
+                    .expect("RegisterAuthorizedCaller requires an authenticated signer");
+                // The authorized caller is only consulted by `Mint`/`Burn`, which
+                // runs only on the mint chain. Restrict registration to that chain
+                // so it cannot be set (even inertly) on user-owned chains.
+                let mint_chain_id = self.runtime.application_parameters().mint_chain_id;
+                assert!(
+                    self.runtime.chain_id() == mint_chain_id,
+                    "the authorized caller may only be registered on the mint chain"
+                );
+                self.state.authorized_caller_id.set(Some(app_id));
+                FungibleResponse::Ok
             }
         }
     }
@@ -139,21 +161,11 @@ impl Contract for WrappedFungibleTokenContract {
                     .runtime
                     .message_is_bouncing()
                     .expect("Delivery status is available when executing a message");
-                let on_mint_chain = self
-                    .runtime
-                    .application_parameters()
-                    .mint_chain_id
-                    .is_some_and(|id| self.runtime.chain_id() == id);
+                // A bouncing Credit returns funds to the original `source`
+                // (e.g. when a driven burn is rejected and the funding transfer
+                // bounces back). Otherwise credit the `target`.
                 if is_bouncing {
                     self.state.credit(source, amount).await;
-                } else if let (true, AccountOwner::Address20(addr)) = (on_mint_chain, target) {
-                    self.runtime.emit(
-                        StreamName::from("burns"),
-                        &BurnEvent {
-                            target: addr,
-                            amount,
-                        },
-                    );
                 } else {
                     self.state.credit(target, amount).await;
                 }
@@ -182,37 +194,35 @@ impl Contract for WrappedFungibleTokenContract {
 }
 
 impl WrappedFungibleTokenContract {
-    /// Checks the configured minting restrictions. Each check is only
-    /// enforced when the corresponding parameter is `Some`.
-    fn require_mint_authorized(&mut self) {
-        let params: WrappedParameters = self.runtime.application_parameters();
-        if let Some(bridge_app_id) = params.bridge_app_id {
-            let caller = self.runtime.authenticated_caller_id();
-            assert!(
-                caller == Some(bridge_app_id),
-                "minting is only allowed via the bridge application"
-            );
-        }
-        if let Some(minter) = params.minter {
-            let signer = self
-                .runtime
-                .authenticated_signer()
-                .expect("minter is configured but no authenticated signer");
-            assert!(
-                signer == minter,
-                "only the minter can perform this operation"
-            );
-        }
-        if let Some(mint_chain_id) = params.mint_chain_id {
-            assert!(
-                self.runtime.chain_id() == mint_chain_id,
-                "minting is only allowed on the designated mint chain"
-            );
-        }
+    /// Enforces the authorization shared by `Mint` and `Burn`: the
+    /// cross-application caller must be the registered authorized caller (set via
+    /// `RegisterAuthorizedCaller`), and the operation must run on the designated
+    /// `mint_chain_id`. Both are **mandatory**: `Mint` and `Burn` may be driven
+    /// only by the authorized caller, so a wrapped token with no caller registered
+    /// — or no mint chain configured — must never change supply. Requiring
+    /// registration also removes any setup window in which an impostor application
+    /// could mint or burn.
+    ///
+    /// There is intentionally no signer check: the authorized caller is the sole
+    /// caller and is trusted to act only on its own validated input, so the
+    /// authenticated signer — whoever relayed the request — is irrelevant to
+    /// safety. Omitting it makes relaying permissionless.
+    fn require_authorized_chain(&mut self) {
+        let authorized_caller_id = (*self.state.authorized_caller_id.get())
+            .expect("authorized caller not registered — call RegisterAuthorizedCaller first");
+        let caller = self.runtime.authenticated_caller_id();
+        assert!(
+            caller == Some(authorized_caller_id),
+            "only the authorized caller may mint or burn"
+        );
+        let mint_chain_id = self.runtime.application_parameters().mint_chain_id;
+        assert!(
+            self.runtime.chain_id() == mint_chain_id,
+            "minting and burning are only allowed on the designated mint chain"
+        );
     }
 
-    async fn execute_mint(&mut self, target_account: Account, amount: U128) -> FungibleResponse {
-        self.require_mint_authorized();
+    async fn execute_mint(&mut self, target_account: Account, amount: U128) {
         if target_account.chain_id == self.runtime.chain_id() {
             self.state.credit(target_account.owner, amount).await;
         } else {
@@ -230,7 +240,6 @@ impl WrappedFungibleTokenContract {
                 .with_tracking()
                 .send_to(target_account.chain_id);
         }
-        FungibleResponse::Ok
     }
 
     async fn claim(&mut self, source_account: Account, amount: U128, target_account: Account) {

--- a/examples/wrapped-fungible/src/state.rs
+++ b/examples/wrapped-fungible/src/state.rs
@@ -3,8 +3,8 @@
 
 use fungible::OwnerSpender;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, U128},
-    views::{linera_views, MapView, RootView, ViewStorageContext},
+    linera_base_types::{AccountOwner, ApplicationId, U128},
+    views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 use wrapped_fungible::InitialState;
 
@@ -15,6 +15,9 @@ use wrapped_fungible::InitialState;
 pub struct WrappedFungibleTokenState {
     pub accounts: MapView<AccountOwner, U128>,
     pub allowances: MapView<OwnerSpender, U128>,
+    /// The application authorized to drive `Mint`/`Burn`, set via
+    /// `RegisterAuthorizedCaller`. `None` until registered.
+    pub authorized_caller_id: RegisterView<Option<ApplicationId>>,
 }
 
 #[allow(dead_code)]

--- a/examples/wrapped-fungible/tests/mint_burn.rs
+++ b/examples/wrapped-fungible/tests/mint_burn.rs
@@ -37,61 +37,18 @@ async fn query_account(
     )
 }
 
-fn dummy_bridge_app_id() -> ApplicationId {
+fn dummy_caller_id() -> ApplicationId {
     ApplicationId::new(CryptoHash::new(&TestString::new("dummy_bridge")))
 }
 
-fn test_params(
-    minter: AccountOwner,
-    mint_chain_id: ChainId,
-    bridge_app_id: ApplicationId,
-) -> WrappedParameters {
+fn wrapped_params(mint_chain_id: ChainId) -> WrappedParameters {
     WrappedParameters {
         ticker_symbol: "wUSDC".to_string(),
         decimals: 18,
-        minter: Some(minter),
-        mint_chain_id: Some(mint_chain_id),
+        mint_chain_id,
         evm_token_address: [0xA0; 20],
         evm_source_chain_id: 8453,
-        bridge_app_id: Some(bridge_app_id),
     }
-}
-
-#[tokio::test]
-async fn test_mint_from_unauthorized_signer() {
-    let (validator, module_id) = TestValidator::with_current_module::<
-        WrappedFungibleTokenAbi,
-        WrappedParameters,
-        InitialState,
-    >()
-    .await;
-    let mut chain = validator.new_chain().await;
-    let chain_owner = AccountOwner::from(chain.public_key());
-
-    // Minter is a different account
-    let other_minter = AccountOwner::Address20([0xBB; 20]);
-    let params = test_params(other_minter, chain.id(), dummy_bridge_app_id());
-    let initial_state = InitialStateBuilder::default().build();
-    let application_id = chain
-        .create_application(module_id, params, initial_state, vec![])
-        .await;
-
-    // Chain owner tries to mint, but they're not the minter — should fail
-    let result = chain
-        .try_add_block(|block| {
-            block.with_operation(
-                application_id,
-                WrappedFungibleOperation::Mint {
-                    target_account: Account {
-                        chain_id: chain.id(),
-                        owner: chain_owner,
-                    },
-                    amount: U128(100u128 * 10u128.pow(18)),
-                },
-            );
-        })
-        .await;
-    assert!(result.is_err(), "mint from unauthorized signer should fail");
 }
 
 #[tokio::test]
@@ -106,12 +63,11 @@ async fn test_wrapped_fungible_standard_transfer() {
     let owner = AccountOwner::from(chain.public_key());
     let recipient = AccountOwner::Address20([0xCC; 20]);
 
-    let params = test_params(owner, chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
         .with_account(owner, U128(1000u128 * 10u128.pow(18)))
         .build();
     let application_id = chain
-        .create_application(module_id, params, initial_state, vec![])
+        .create_application(module_id, wrapped_params(chain.id()), initial_state, vec![])
         .await;
 
     chain
@@ -155,12 +111,16 @@ async fn test_credit_to_address20_on_non_bridge_chain_does_not_burn() {
 
     // Bridge chain is minter_chain; other_chain is NOT the bridge chain.
     let mint_amount = U128(500u128 * 10u128.pow(18));
-    let params = test_params(minter_account, minter_chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
         .with_account(minter_account, mint_amount)
         .build();
     let application_id = minter_chain
-        .create_application(module_id, params, initial_state, vec![])
+        .create_application(
+            module_id,
+            wrapped_params(minter_chain.id()),
+            initial_state,
+            vec![],
+        )
         .await;
 
     // Transfer cross-chain to an Address20 on other_chain (NOT the bridge chain).
@@ -197,7 +157,7 @@ async fn test_credit_to_address20_on_non_bridge_chain_does_not_burn() {
 }
 
 #[tokio::test]
-async fn test_credit_to_address20_on_bridge_chain_auto_burns() {
+async fn test_credit_to_address20_on_bridge_chain_credits_normally() {
     let (validator, module_id) = TestValidator::with_current_module::<
         WrappedFungibleTokenAbi,
         WrappedParameters,
@@ -210,13 +170,16 @@ async fn test_credit_to_address20_on_bridge_chain_auto_burns() {
     let evm_address = AccountOwner::Address20([0xAA; 20]);
 
     // Bridge chain is bridge_chain (the mint chain).
-    let minter = AccountOwner::from(bridge_chain.public_key());
-    let params = test_params(minter, bridge_chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
         .with_account(sender_account, U128(500u128 * 10u128.pow(18)))
         .build();
     let application_id = sender_chain
-        .create_application(module_id, params, initial_state, vec![])
+        .create_application(
+            module_id,
+            wrapped_params(bridge_chain.id()),
+            initial_state,
+            vec![],
+        )
         .await;
 
     // Transfer cross-chain to an Address20 on bridge_chain.
@@ -243,18 +206,21 @@ async fn test_credit_to_address20_on_bridge_chain_auto_burns() {
         })
         .await;
 
-    // Verify sender was debited (tokens removed from circulation).
+    // Verify sender was debited on the source chain.
     let sender_balance = query_account(application_id, &sender_chain, sender_account).await;
     assert_eq!(
         sender_balance, None,
         "Sender's tokens should have been debited on the source chain"
     );
 
-    // Credit to Address20 on the bridge chain should auto-burn: balance must be 0.
+    // The Credit-to-Address20-on-bridge-chain auto-burn special case has been
+    // removed: burning is now driven explicitly by the bridge app. A plain
+    // Credit to an Address20 on the bridge chain must credit the account.
     let balance = query_account(application_id, &bridge_chain, evm_address).await;
     assert_eq!(
-        balance, None,
-        "Credit to Address20 on the bridge chain should auto-burn, not credit the account"
+        balance,
+        Some(U128(500u128 * 10u128.pow(18))),
+        "Credit to Address20 on the bridge chain should credit normally, not burn"
     );
 }
 
@@ -271,13 +237,16 @@ async fn test_credit_to_non_address20_on_bridge_chain_credits_normally() {
     let sender_account = AccountOwner::from(sender_chain.public_key());
     let recipient = AccountOwner::from(bridge_chain.public_key());
 
-    let minter = AccountOwner::from(bridge_chain.public_key());
-    let params = test_params(minter, bridge_chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default()
         .with_account(sender_account, U128(500u128 * 10u128.pow(18)))
         .build();
     let application_id = sender_chain
-        .create_application(module_id, params, initial_state, vec![])
+        .create_application(
+            module_id,
+            wrapped_params(bridge_chain.id()),
+            initial_state,
+            vec![],
+        )
         .await;
 
     // Transfer cross-chain to a non-Address20 on the bridge chain.
@@ -325,14 +294,20 @@ async fn test_mint_on_wrong_chain() {
     let other_chain = validator.new_chain().await;
     let minter_account = AccountOwner::from(minter_chain.public_key());
 
-    // Designate other_chain as the mint chain, but deploy on minter_chain
-    let params = test_params(minter_account, other_chain.id(), dummy_bridge_app_id());
+    // Designate other_chain as the mint chain, but deploy on minter_chain. A
+    // bridge cannot be registered here (registration is restricted to the mint
+    // chain), so the Mint is rejected by the mandatory-registration check.
     let initial_state = InitialStateBuilder::default().build();
     let application_id = minter_chain
-        .create_application(module_id, params, initial_state, vec![])
+        .create_application(
+            module_id,
+            wrapped_params(other_chain.id()),
+            initial_state,
+            vec![],
+        )
         .await;
 
-    // Minter is authorized but on the wrong chain — should fail
+    // A direct Mint on a chain that is not the mint chain fails.
     let result = minter_chain
         .try_add_block(|block| {
             block.with_operation(
@@ -361,13 +336,18 @@ async fn test_direct_mint_without_bridge_is_rejected() {
     let mut minter_chain = validator.new_chain().await;
     let minter_account = AccountOwner::from(minter_chain.public_key());
 
-    let params = test_params(minter_account, minter_chain.id(), dummy_bridge_app_id());
     let initial_state = InitialStateBuilder::default().build();
     let application_id = minter_chain
-        .create_application(module_id, params, initial_state, vec![])
+        .create_application(
+            module_id,
+            wrapped_params(minter_chain.id()),
+            initial_state,
+            vec![],
+        )
         .await;
 
-    // Minter directly calls Mint (not via FungibleBridge) — should be rejected
+    // No bridge is registered, so the mandatory bridge-registration check
+    // rejects the Mint outright.
     let result = minter_chain
         .try_add_block(|block| {
             block.with_operation(
@@ -384,6 +364,45 @@ async fn test_direct_mint_without_bridge_is_rejected() {
         .await;
     assert!(
         result.is_err(),
-        "direct mint without going through FungibleBridge should be rejected"
+        "direct mint without a registered bridge should be rejected"
+    );
+}
+
+#[tokio::test]
+async fn test_register_bridge_app_rejected_off_mint_chain() {
+    let (validator, module_id) = TestValidator::with_current_module::<
+        WrappedFungibleTokenAbi,
+        WrappedParameters,
+        InitialState,
+    >()
+    .await;
+    let mut deploy_chain = validator.new_chain().await;
+    let mint_chain = validator.new_chain().await;
+
+    // The mint chain is `mint_chain`, but we deploy and attempt to register the
+    // bridge on `deploy_chain`. Registration is restricted to the mint chain, so
+    // it must be rejected here.
+    let application_id = deploy_chain
+        .create_application(
+            module_id,
+            wrapped_params(mint_chain.id()),
+            InitialStateBuilder::default().build(),
+            vec![],
+        )
+        .await;
+
+    let result = deploy_chain
+        .try_add_block(|block| {
+            block.with_operation(
+                application_id,
+                WrappedFungibleOperation::RegisterAuthorizedCaller {
+                    app_id: dummy_caller_id(),
+                },
+            );
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "RegisterAuthorizedCaller off the mint chain should be rejected"
     );
 }

--- a/linera-bridge/README.md
+++ b/linera-bridge/README.md
@@ -113,11 +113,11 @@ Blocks can be submitted in any order; sequential height enforcement is not requi
 
 ### FungibleBridge (concrete Microchain)
 
-A `Microchain` subcontract that bridges ERC-20 tokens from Linera to Ethereum. When the wrapped-fungible application emits a `BurnEvent` (tokens auto-burned on the bridge chain), the contract releases the corresponding ERC-20 tokens to the target Ethereum address.
+A `Microchain` subcontract that bridges ERC-20 tokens from Linera to Ethereum. When the bridge application emits a `BurnEvent` on its `"burns"` stream (after burning wrapped tokens on the bridge chain), the contract releases the corresponding ERC-20 tokens to the target Ethereum address.
 
-#### `constructor(address _lightClient, bytes32 _chainId, address _token)`
+#### `constructor(address _lightClient, bytes32 _chainId, address _token, bytes32 _fungibleApplicationId, bytes32 _bridgeApplicationId)`
 
-Binds to a specific `LightClient`, chain, and ERC-20 token contract.
+Binds to a specific `LightClient`, chain, and ERC-20 token contract. `_fungibleApplicationId` is the wrapped-fungible application (the deposit/mint target); `_bridgeApplicationId` is the bridge application whose `"burns"` stream releases are matched against.
 
 #### `registerFungibleApplicationId(bytes32 _fungibleApplicationId)`
 
@@ -125,7 +125,7 @@ Registers the wrapped-fungible application ID. Can only be called once. Only eve
 
 #### `_onBlock(BridgeTypes.Block)`
 
-Scans the block's `events` for entries on the `"burns"` stream matching `fungibleApplicationId`. For each match, the event value is deserialized as a `WrappedFungibleTypes.BurnEvent`. The `target` (Ethereum address) receives an ERC-20 `transfer` from the bridge's balance.
+Scans the block's `events` for entries on the `"burns"` stream matching `bridgeApplicationId`. For each match, the event value is deserialized as a `WrappedFungibleTypes.BurnEvent`. The `target` (Ethereum address) receives an ERC-20 `transfer` from the bridge's balance.
 
 ## Rust API
 

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -307,12 +307,28 @@ impl EvmBridge {
     /// signer to the bridge chain, so `execute_burn` there burns the very escrow
     /// account this signer funded.
     fn initiate_burn(&mut self, amount: U128, evm_target: [u8; 20]) {
+        assert!(amount.0 > 0, "Burn amount must be non-zero");
         let signer = self
             .runtime
             .authenticated_signer()
             .expect("Burn requires an authenticated signer");
         let params = self.runtime.application_parameters();
         let bridge_chain_id = params.bridge_chain_id;
+
+        // A burn must originate from a *user* chain distinct from the bridge
+        // chain. The atomic funding-then-burn bundle relies on a tracked
+        // cross-chain `Credit` that bounces — refunding the signer — if the
+        // burn is rejected. On the bridge chain itself the funding `Transfer`
+        // is a local credit with no Credit message to bounce, so a rejected
+        // self-delivered burn would strand the escrow in the signer's account.
+        // Refuse to run that unsafe path: a same-chain burn is a no-op.
+        if self.runtime.chain_id() == bridge_chain_id {
+            log::warn!(
+                "ignoring Burn submitted on the bridge chain; \
+                 burns must originate from a separate user chain"
+            );
+            return;
+        }
         let fungible_app_id = params.fungible_app_id.with_abi::<WrappedFungibleTokenAbi>();
 
         // Move the signer's tokens into the signer's own escrow account on the

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -5,27 +5,28 @@
 
 use alloy_primitives::Bytes;
 use evm_bridge::{
-    BridgeInstantiationArgument, BridgeOperation, BridgeParameters, DepositKey, EvmBridgeAbi,
+    BridgeInstantiationArgument, BridgeMessage, BridgeOperation, BridgeParameters, DepositKey,
+    EvmBridgeAbi,
 };
 use fungible::Account;
 use linera_bridge::proof;
 use linera_sdk::{
     ethereum::{ContractEthereumClient, EthereumQueries},
-    linera_base_types::{ApplicationId, U128, WithContractAbi},
+    linera_base_types::{StreamName, WithContractAbi, U128},
     views::{linera_views, RegisterView, RootView, SetView, View, ViewStorageContext},
     Contract, ContractRuntime,
 };
-use wrapped_fungible::{WrappedFungibleOperation, WrappedFungibleTokenAbi};
+use wrapped_fungible::{BurnEvent, WrappedFungibleOperation, WrappedFungibleTokenAbi};
 
-/// On-chain state: tracks processed deposits, verified block hashes,
-/// the registered wrapped-fungible application, and the registered EVM
-/// FungibleBridge contract address.
+/// On-chain state: tracks processed deposits, verified block hashes, and the
+/// registered EVM FungibleBridge contract address. The wrapped-fungible
+/// application is a creation parameter (`BridgeParameters::fungible_app_id`),
+/// not state.
 #[derive(RootView)]
 #[view(context = ViewStorageContext)]
 pub struct BridgeState {
     pub processed_deposits: SetView<[u8; 32]>,
     pub verified_block_hashes: SetView<[u8; 32]>,
-    pub fungible_app_id: RegisterView<Option<ApplicationId>>,
     pub bridge_contract_address: RegisterView<Option<[u8; 20]>>,
     pub rpc_endpoint: RegisterView<String>,
 }
@@ -42,10 +43,10 @@ impl WithContractAbi for EvmBridgeContract {
 }
 
 impl Contract for EvmBridgeContract {
-    type Message = ();
+    type Message = BridgeMessage;
     type Parameters = BridgeParameters;
     type InstantiationArgument = BridgeInstantiationArgument;
-    type EventValue = ();
+    type EventValue = BurnEvent;
 
     async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = BridgeState::load(runtime.root_view_storage_context())
@@ -73,16 +74,6 @@ impl Contract for EvmBridgeContract {
 
     async fn execute_operation(&mut self, operation: BridgeOperation) {
         match operation {
-            BridgeOperation::RegisterFungibleApp { app_id } => {
-                self.runtime
-                    .authenticated_signer()
-                    .expect("RegisterFungibleApp requires an authenticated signer");
-                assert!(
-                    self.state.fungible_app_id.get().is_none(),
-                    "fungible app is already registered and cannot be changed"
-                );
-                self.state.fungible_app_id.set(Some(app_id));
-            }
             BridgeOperation::ProcessDeposit {
                 block_header_rlp,
                 receipt_rlp,
@@ -127,10 +118,28 @@ impl Contract for EvmBridgeContract {
                     .expect("SetRpcEndpoint requires an authenticated signer");
                 self.state.rpc_endpoint.set(rpc_endpoint);
             }
+            BridgeOperation::Burn { amount, evm_target } => {
+                self.initiate_burn(amount, evm_target);
+            }
         }
     }
 
-    async fn execute_message(&mut self, _message: ()) {}
+    async fn execute_message(&mut self, message: BridgeMessage) {
+        match message {
+            BridgeMessage::Burn { amount, evm_target } => {
+                // A bouncing delivery is a no-op: the funding transfer is part
+                // of the same outgoing bundle and bounces on its own, refunding
+                // the user on their chain via wrapped-fungible's Credit handler.
+                let is_bouncing = self
+                    .runtime
+                    .message_is_bouncing()
+                    .expect("Delivery status is available when executing a message");
+                if !is_bouncing {
+                    self.execute_burn(amount, evm_target);
+                }
+            }
+        }
+    }
 
     async fn store(self) {
         self.state
@@ -283,13 +292,79 @@ impl EvmBridgeContract {
         };
 
         // Forward authenticated signer (chain owner = minter) to the fungible app.
-        let fungible_app_id = self
-            .state
-            .fungible_app_id
-            .get()
-            .expect("fungible app not registered — call RegisterFungibleApp first")
-            .with_abi::<WrappedFungibleTokenAbi>();
+        let fungible_app_id = params.fungible_app_id.with_abi::<WrappedFungibleTokenAbi>();
         self.runtime
             .call_application(true, fungible_app_id, &mint_op);
+    }
+
+    /// Drives a user-initiated burn. Runs on the *user's* chain: moves `amount`
+    /// of the authenticated signer's wrapped tokens into the signer's own escrow
+    /// account on the bridge chain (a tracked transfer via the bridge's
+    /// `fungible_app_id` parameter) and, in the same outgoing bundle, sends a
+    /// tracked [`BridgeMessage::Burn`] to the bridge chain. Both messages share
+    /// one bundle, so if the burn is rejected the funding transfer bounces back
+    /// and the signer is refunded. `.with_authentication()` propagates the
+    /// signer to the bridge chain, so `execute_burn` there burns the very escrow
+    /// account this signer funded.
+    fn initiate_burn(&mut self, amount: U128, evm_target: [u8; 20]) {
+        let signer = self
+            .runtime
+            .authenticated_signer()
+            .expect("Burn requires an authenticated signer");
+        let params = self.runtime.application_parameters();
+        let bridge_chain_id = params.bridge_chain_id;
+        let fungible_app_id = params.fungible_app_id.with_abi::<WrappedFungibleTokenAbi>();
+
+        // Move the signer's tokens into the signer's own escrow account on the
+        // bridge chain. Forwarding the signer's authentication lets the
+        // wrapped-fungible app authorize the debit.
+        let transfer_op = WrappedFungibleOperation::Transfer {
+            owner: signer,
+            amount,
+            target_account: Account {
+                chain_id: bridge_chain_id,
+                owner: signer,
+            },
+        };
+        self.runtime
+            .call_application(true, fungible_app_id, &transfer_op);
+
+        // Ask the bridge chain to burn the escrowed tokens and emit the event.
+        self.runtime
+            .prepare_message(BridgeMessage::Burn { amount, evm_target })
+            .with_authentication()
+            .with_tracking()
+            .send_to(bridge_chain_id);
+    }
+
+    /// Burns the escrowed tokens on the bridge chain and emits the [`BurnEvent`]
+    /// the relayer forwards to EVM. Runs when a non-bouncing
+    /// [`BridgeMessage::Burn`] is delivered to the bridge chain. The escrow is
+    /// held under the originating signer (propagated via the authenticated
+    /// message), so a message can only ever burn the escrow its own signer
+    /// funded.
+    fn execute_burn(&mut self, amount: U128, evm_target: [u8; 20]) {
+        let signer = self
+            .runtime
+            .authenticated_signer()
+            .expect("burn message carries the originating authenticated signer");
+        let fungible_app_id = self
+            .runtime
+            .application_parameters()
+            .fungible_app_id
+            .with_abi::<WrappedFungibleTokenAbi>();
+        let burn_op = WrappedFungibleOperation::Burn {
+            owner: signer,
+            amount,
+        };
+        self.runtime
+            .call_application(true, fungible_app_id, &burn_op);
+        self.runtime.emit(
+            StreamName::from("burns"),
+            &BurnEvent {
+                target: evm_target,
+                amount,
+            },
+        );
     }
 }

--- a/linera-bridge/contracts/evm-bridge/src/contract.rs
+++ b/linera-bridge/contracts/evm-bridge/src/contract.rs
@@ -31,18 +31,18 @@ pub struct BridgeState {
     pub rpc_endpoint: RegisterView<String>,
 }
 
-pub struct EvmBridgeContract {
+pub struct EvmBridge {
     state: BridgeState,
     runtime: ContractRuntime<Self>,
 }
 
-linera_sdk::contract!(EvmBridgeContract);
+linera_sdk::contract!(EvmBridge);
 
-impl WithContractAbi for EvmBridgeContract {
+impl WithContractAbi for EvmBridge {
     type Abi = EvmBridgeAbi;
 }
 
-impl Contract for EvmBridgeContract {
+impl Contract for EvmBridge {
     type Message = BridgeMessage;
     type Parameters = BridgeParameters;
     type InstantiationArgument = BridgeInstantiationArgument;
@@ -52,7 +52,7 @@ impl Contract for EvmBridgeContract {
         let state = BridgeState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
-        EvmBridgeContract { state, runtime }
+        EvmBridge { state, runtime }
     }
 
     async fn instantiate(&mut self, argument: BridgeInstantiationArgument) {
@@ -149,7 +149,7 @@ impl Contract for EvmBridgeContract {
     }
 }
 
-impl EvmBridgeContract {
+impl EvmBridge {
     async fn verify_block_hash(&mut self, block_hash: [u8; 32]) {
         let rpc_endpoint = self.state.rpc_endpoint.get();
         assert!(

--- a/linera-bridge/contracts/evm-bridge/src/lib.rs
+++ b/linera-bridge/contracts/evm-bridge/src/lib.rs
@@ -8,7 +8,7 @@
 
 use async_graphql::{Request, Response};
 pub use linera_bridge::{
-    abi::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters},
+    abi::{BridgeInstantiationArgument, BridgeMessage, BridgeOperation, BridgeParameters},
     proof::DepositKey,
 };
 use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};

--- a/linera-bridge/contracts/evm-bridge/src/service.rs
+++ b/linera-bridge/contracts/evm-bridge/src/service.rs
@@ -6,11 +6,11 @@
 use std::sync::Arc;
 
 use alloy_primitives::B256;
-use async_graphql::{EmptyMutation, EmptySubscription, Object, Request, Response, Schema};
-use evm_bridge::{BridgeParameters, EvmBridgeAbi};
+use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use evm_bridge::{BridgeOperation, BridgeParameters, EvmBridgeAbi};
 use linera_sdk::{
     ethereum::{EthereumQueries, ServiceEthereumClient},
-    linera_base_types::{ApplicationId, WithServiceAbi},
+    linera_base_types::{WithServiceAbi, U128},
     views::{linera_views, RegisterView, RootView, SetView, View, ViewStorageContext},
     Service, ServiceRuntime,
 };
@@ -23,7 +23,6 @@ use linera_sdk::{
 pub struct BridgeState {
     pub processed_deposits: SetView<[u8; 32]>,
     pub verified_block_hashes: SetView<[u8; 32]>,
-    pub fungible_app_id: RegisterView<Option<ApplicationId>>,
     pub bridge_contract_address: RegisterView<Option<[u8; 20]>>,
     pub rpc_endpoint: RegisterView<String>,
 }
@@ -55,8 +54,106 @@ impl Service for EvmBridgeService {
     }
 
     async fn handle_query(&self, request: Request) -> Response {
-        let schema = Schema::build(self.clone(), EmptyMutation, EmptySubscription).finish();
+        let schema = Schema::build(
+            self.clone(),
+            MutationRoot {
+                runtime: self.runtime.clone(),
+            },
+            EmptySubscription,
+        )
+        .finish();
         schema.execute(request).await
+    }
+}
+
+/// Decodes a hex string (optional `0x` prefix) into bytes.
+fn decode_hex(label: &str, s: &str) -> async_graphql::Result<Vec<u8>> {
+    hex::decode(s.strip_prefix("0x").unwrap_or(s))
+        .map_err(|e| async_graphql::Error::new(format!("invalid {label} hex: {e}")))
+}
+
+/// Decodes a hex string into a fixed-size byte array.
+fn decode_hex_array<const N: usize>(label: &str, s: &str) -> async_graphql::Result<[u8; N]> {
+    decode_hex(label, s)?.as_slice().try_into().map_err(|_| {
+        async_graphql::Error::new(format!(
+            "{label} must be exactly {N} bytes ({} hex chars)",
+            N * 2
+        ))
+    })
+}
+
+/// GraphQL mutation root: schedules bridge operations submitted by a client (the
+/// demo UI, an admin tool, or a custom relayer). The application bytecode — and
+/// thus this interface — cannot change after deployment, so every
+/// [`BridgeOperation`] is exposed; on-chain authorization still gates each.
+/// Byte-array arguments are hex-encoded strings (with or without `0x`).
+pub struct MutationRoot {
+    runtime: Arc<ServiceRuntime<EvmBridgeService>>,
+}
+
+#[Object]
+impl MutationRoot {
+    /// Burns `amount` wrapped tokens from the operation's authenticated signer
+    /// and releases the corresponding ERC-20 to `evm_target` (20-byte EVM
+    /// address) on the source chain.
+    async fn burn(&self, amount: U128, evm_target: String) -> async_graphql::Result<[u8; 0]> {
+        let evm_target = decode_hex_array::<20>("evm_target", &evm_target)?;
+        self.runtime
+            .schedule_operation(&BridgeOperation::Burn { amount, evm_target });
+        Ok([])
+    }
+
+    /// Verifies a deposit proof from the source chain and mints wrapped tokens.
+    /// `block_header_rlp`, `receipt_rlp`, and each `proof_nodes` entry are
+    /// hex-encoded; `tx_index`/`log_index` select the log within the block.
+    async fn process_deposit(
+        &self,
+        block_header_rlp: String,
+        receipt_rlp: String,
+        proof_nodes: Vec<String>,
+        tx_index: u64,
+        log_index: u64,
+    ) -> async_graphql::Result<[u8; 0]> {
+        let block_header_rlp = decode_hex("block_header_rlp", &block_header_rlp)?;
+        let receipt_rlp = decode_hex("receipt_rlp", &receipt_rlp)?;
+        let proof_nodes = proof_nodes
+            .iter()
+            .map(|n| decode_hex("proof_nodes", n))
+            .collect::<async_graphql::Result<Vec<_>>>()?;
+        self.runtime
+            .schedule_operation(&BridgeOperation::ProcessDeposit {
+                block_header_rlp,
+                receipt_rlp,
+                proof_nodes,
+                tx_index,
+                log_index,
+            });
+        Ok([])
+    }
+
+    /// Verifies that an EVM block hash (32 bytes) is authentic and finalized.
+    async fn verify_block_hash(&self, block_hash: String) -> async_graphql::Result<[u8; 0]> {
+        let block_hash = decode_hex_array::<32>("block_hash", &block_hash)?;
+        self.runtime
+            .schedule_operation(&BridgeOperation::VerifyBlockHash { block_hash });
+        Ok([])
+    }
+
+    /// Registers the EVM `FungibleBridge` contract address (20 bytes). One-shot,
+    /// chain-owner-only.
+    async fn register_fungible_bridge(&self, address: String) -> async_graphql::Result<[u8; 0]> {
+        let address = decode_hex_array::<20>("address", &address)?;
+        self.runtime
+            .schedule_operation(&BridgeOperation::RegisterFungibleBridge { address });
+        Ok([])
+    }
+
+    /// Sets the EVM JSON-RPC endpoint used for finality verification (empty
+    /// string disables it). Chain-owner-only.
+    async fn set_rpc_endpoint(&self, rpc_endpoint: String) -> async_graphql::Result<[u8; 0]> {
+        self.runtime
+            .schedule_operation(&BridgeOperation::SetRpcEndpoint { rpc_endpoint });
+        Ok([])
     }
 }
 

--- a/linera-bridge/contracts/evm-bridge/tests/burn.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/burn.rs
@@ -11,13 +11,341 @@
 
 use evm_bridge::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters, EvmBridgeAbi};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, ApplicationId, U128},
-    test::{ActiveChain, TestValidator},
+    linera_base_types::{AccountOwner, ApplicationId, GenericApplicationId, StreamName, U128},
+    test::{ActiveChain, MessageAction, TestValidator},
 };
 use wrapped_fungible::{
-    InitialState, InitialStateBuilder, WrappedFungibleOperation, WrappedFungibleTokenAbi,
-    WrappedParameters,
+    Account, BurnEvent, InitialState, InitialStateBuilder, WrappedFungibleOperation,
+    WrappedFungibleTokenAbi, WrappedParameters,
 };
+
+/// Happy path of the bridge-driven burn, end to end across two chains.
+///
+/// A user on their own chain submits `Burn`, which debits them locally and sends a
+/// (`Credit` + `BridgeMessage::Burn`) bundle to the bridge chain. The bridge chain accepts
+/// it: the funding `Credit` lands in the user's *own* escrow account, then the burn consumes
+/// that escrow and emits the `BurnEvent` the relayer forwards to EVM. Asserts the user is
+/// debited on their chain, the escrow is funded-then-burned to nothing, the bridge never
+/// holds tokens under its own application id, and a `BurnEvent` is emitted.
+#[tokio::test]
+async fn test_burn_via_bridge_debits_owner_and_burns_escrow() {
+    let initial_supply = U128(1_000_000);
+    let BridgeDeployment {
+        validator,
+        bridge_chain,
+        chain_owner: bridge_owner,
+        fungible_app_id,
+        bridge_app_id,
+    } = deploy(initial_supply, true).await;
+
+    // Give a user a wrapped balance on their own chain (distinct from the bridge chain),
+    // by transferring from the bridge chain's owner. The user drives the burn from there.
+    let user_chain = validator.new_chain().await;
+    let user = AccountOwner::from(user_chain.public_key());
+    let user_balance = U128(600_000);
+
+    bridge_chain
+        .add_block(|block| {
+            block.with_operation(
+                fungible_app_id,
+                WrappedFungibleOperation::Transfer {
+                    owner: bridge_owner,
+                    amount: user_balance,
+                    target_account: Account {
+                        chain_id: user_chain.id(),
+                        owner: user,
+                    },
+                },
+            );
+        })
+        .await;
+    user_chain.handle_received_messages().await;
+    assert_eq!(
+        query_balance(fungible_app_id, &user_chain, user).await,
+        Some(user_balance),
+        "user must hold the transferred wrapped balance on their own chain",
+    );
+
+    // The user burns part of their balance toward an EVM address. This debits the user on
+    // their chain and sends the (Credit + BridgeMessage::Burn) bundle to the bridge chain.
+    let burn_amount = U128(250_000);
+    let evm_target = [0xE7; 20];
+    let (burn_cert, _) = user_chain
+        .add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::Burn {
+                    amount: burn_amount,
+                    evm_target,
+                },
+            );
+        })
+        .await;
+
+    // The user is debited on their own chain while the burn is in flight.
+    assert_eq!(
+        query_balance(fungible_app_id, &user_chain, user).await,
+        Some(U128(user_balance.0 - burn_amount.0)),
+        "user must be debited by the burn amount on their own chain",
+    );
+
+    // The escrow is the user's own account on the bridge chain — the bridge must never hold
+    // the escrow under its own application id.
+    let bridge_as_owner = AccountOwner::from(bridge_app_id.forget_abi());
+    assert_eq!(
+        query_balance(fungible_app_id, &bridge_chain, bridge_as_owner).await,
+        None,
+        "bridge must never escrow tokens under its own application id",
+    );
+
+    // The bridge chain accepts the bundle: the funding Credit lands in the user's escrow
+    // account, then BridgeMessage::Burn burns that escrow and emits the BurnEvent.
+    let (burn_msg_cert, _) = bridge_chain
+        .add_block(|block| {
+            block.with_messages_from(&burn_cert);
+        })
+        .await;
+
+    // The escrow on the bridge chain was funded and then fully burned — net zero.
+    assert_eq!(
+        query_balance(fungible_app_id, &bridge_chain, user).await,
+        None,
+        "the user's escrow on the bridge chain must be burned, not left behind",
+    );
+    assert_eq!(
+        query_balance(fungible_app_id, &bridge_chain, bridge_as_owner).await,
+        None,
+        "bridge must never escrow tokens under its own application id",
+    );
+
+    // The bridge emitted exactly one BurnEvent, on its "burns" stream, carrying the user's
+    // EVM target and burn amount — this is what the relayer forwards to EVM.
+    let events: Vec<_> = burn_msg_cert
+        .inner()
+        .block()
+        .body
+        .events
+        .iter()
+        .flatten()
+        .collect();
+    assert_eq!(
+        events.len(),
+        1,
+        "the burn-processing block must emit exactly one event",
+    );
+    let event = events[0];
+    assert_eq!(
+        event.stream_id.application_id,
+        GenericApplicationId::User(bridge_app_id.forget_abi()),
+        "the event must be emitted by the bridge application — the relayer keys burns on it",
+    );
+    assert_eq!(
+        event.stream_id.stream_name,
+        StreamName::from("burns"),
+        "the event must be on the bridge's \"burns\" stream",
+    );
+    let burn_event: BurnEvent = linera_sdk::bcs::from_bytes(&event.value)
+        .expect("the event value must decode as a BurnEvent");
+    assert_eq!(
+        burn_event,
+        BurnEvent {
+            target: evm_target,
+            amount: burn_amount,
+        },
+        "the BurnEvent must carry the user's EVM target and burn amount",
+    );
+}
+
+/// Refund-on-reject: the load-bearing safety property of the bridge-driven burn.
+///
+/// A user on their own chain submits `Burn`, which in one bundle escrows their wrapped
+/// tokens onto the bridge chain (a tracked `Credit`) and sends a tracked
+/// `BridgeMessage::Burn`. If the bridge chain rejects that bundle, the funding `Credit`
+/// must bounce and refund the user on *their* chain — never leaving the escrow stranded on
+/// the bridge chain. This test forces the rejection and asserts the user is made whole.
+#[tokio::test]
+async fn test_rejected_burn_refunds_user_and_strands_no_escrow() {
+    let initial_supply = U128(1_000_000);
+    let BridgeDeployment {
+        validator,
+        bridge_chain,
+        chain_owner: bridge_owner,
+        fungible_app_id,
+        bridge_app_id,
+    } = deploy(initial_supply, true).await;
+
+    // Give a user on their own chain a wrapped balance, by transferring from the bridge
+    // chain's owner. The user — not the bridge chain owner — will drive the burn.
+    let user_chain = validator.new_chain().await;
+    let user = AccountOwner::from(user_chain.public_key());
+    let user_balance = U128(400_000);
+
+    bridge_chain
+        .add_block(|block| {
+            block.with_operation(
+                fungible_app_id,
+                WrappedFungibleOperation::Transfer {
+                    owner: bridge_owner,
+                    amount: user_balance,
+                    target_account: Account {
+                        chain_id: user_chain.id(),
+                        owner: user,
+                    },
+                },
+            );
+        })
+        .await;
+    user_chain.handle_received_messages().await;
+    assert_eq!(
+        query_balance(fungible_app_id, &user_chain, user).await,
+        Some(user_balance),
+        "user must hold the transferred wrapped balance on their own chain",
+    );
+
+    // The user burns part of their balance toward an EVM address. This debits the user on
+    // their chain and sends the (Credit + BridgeMessage::Burn) bundle to the bridge chain.
+    let burn_amount = U128(250_000);
+    let evm_target = [0xE7; 20];
+    let (burn_cert, _) = user_chain
+        .add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::Burn {
+                    amount: burn_amount,
+                    evm_target,
+                },
+            );
+        })
+        .await;
+    assert_eq!(
+        query_balance(fungible_app_id, &user_chain, user).await,
+        Some(U128(user_balance.0 - burn_amount.0)),
+        "user is debited on their chain while the burn is in flight",
+    );
+
+    // The bridge chain rejects the burn bundle (e.g. the burn handler failed). Both tracked
+    // messages bounce back to the user's chain.
+    let (reject_cert, _) = bridge_chain
+        .add_block(|block| {
+            block.with_messages_from_by_action(&burn_cert, MessageAction::Reject);
+        })
+        .await;
+
+    // No burn was performed: no escrow held on the bridge chain, and no BurnEvent emitted.
+    assert_eq!(
+        query_balance(fungible_app_id, &bridge_chain, user).await,
+        None,
+        "a rejected burn must leave no escrow stranded on the bridge chain",
+    );
+    let reject_event_count: usize = reject_cert
+        .inner()
+        .block()
+        .body
+        .events
+        .iter()
+        .map(|tx_events| tx_events.len())
+        .sum();
+    assert_eq!(
+        reject_event_count, 0,
+        "a rejected burn must not emit a BurnEvent",
+    );
+
+    // The funding Credit bounces back and the user is made whole on their own chain.
+    user_chain.handle_received_messages().await;
+    assert_eq!(
+        query_balance(fungible_app_id, &user_chain, user).await,
+        Some(user_balance),
+        "a rejected burn must refund the user in full on their own chain",
+    );
+}
+
+/// A wrapped-fungible + evm-bridge deployment, both apps on one chain that is both the
+/// bridge chain and the wrapped-fungible mint chain. Each test adds its own separate user
+/// chain on top of this.
+struct BridgeDeployment {
+    validator: TestValidator,
+    bridge_chain: ActiveChain,
+    chain_owner: AccountOwner,
+    fungible_app_id: ApplicationId<WrappedFungibleTokenAbi>,
+    bridge_app_id: ApplicationId<EvmBridgeAbi>,
+}
+
+/// Deploys wrapped-fungible (seeded with `initial_supply` for the chain owner) and the
+/// evm-bridge that points at it, on a single chain that is both the bridge chain and the
+/// wrapped-fungible mint chain. When `register_caller` is set, the bridge is registered as
+/// the wrapped-fungible authorized caller (required for `Mint`/`Burn` to succeed).
+async fn deploy(initial_supply: U128, register_caller: bool) -> BridgeDeployment {
+    let (validator, bridge_module_id) = TestValidator::with_current_module::<
+        EvmBridgeAbi,
+        BridgeParameters,
+        BridgeInstantiationArgument,
+    >()
+    .await;
+    let mut bridge_chain = validator.new_chain().await;
+    let chain_owner = AccountOwner::from(bridge_chain.public_key());
+
+    let token_address = [0xA0; 20];
+    let source_chain_id = 8453u64;
+
+    let fungible_module_id = bridge_chain
+        .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
+            "../../../examples/wrapped-fungible",
+        )
+        .await;
+    let wrapped_params = WrappedParameters {
+        ticker_symbol: "wUSDC".to_string(),
+        decimals: 6,
+        mint_chain_id: bridge_chain.id(),
+        evm_token_address: token_address,
+        evm_source_chain_id: source_chain_id,
+    };
+    let fungible_app_id = bridge_chain
+        .create_application(
+            fungible_module_id,
+            wrapped_params,
+            InitialStateBuilder::default()
+                .with_account(chain_owner, initial_supply)
+                .build(),
+            vec![],
+        )
+        .await;
+
+    let bridge_params = BridgeParameters {
+        source_chain_id,
+        token_address,
+        bridge_chain_id: bridge_chain.id(),
+        fungible_app_id: fungible_app_id.forget_abi(),
+    };
+    let bridge_app_id = bridge_chain
+        .create_application(
+            bridge_module_id,
+            bridge_params,
+            BridgeInstantiationArgument::default(),
+            vec![],
+        )
+        .await;
+
+    if register_caller {
+        bridge_chain
+            .add_block(|block| {
+                block.with_operation(
+                    fungible_app_id,
+                    WrappedFungibleOperation::RegisterAuthorizedCaller {
+                        app_id: bridge_app_id.forget_abi(),
+                    },
+                );
+            })
+            .await;
+    }
+
+    BridgeDeployment {
+        validator,
+        bridge_chain,
+        chain_owner,
+        fungible_app_id,
+        bridge_app_id,
+    }
+}
 
 /// Queries an account balance on the wrapped-fungible app.
 async fn query_balance(
@@ -37,137 +365,4 @@ async fn query_balance(
     Some(U128(
         balance.parse().expect("balance cannot be parsed as u128"),
     ))
-}
-
-#[tokio::test]
-async fn test_burn_via_bridge_debits_owner_and_burns_escrow() {
-    let (validator, bridge_module_id) = TestValidator::with_current_module::<
-        EvmBridgeAbi,
-        BridgeParameters,
-        BridgeInstantiationArgument,
-    >()
-    .await;
-    let mut chain = validator.new_chain().await;
-    let chain_owner = AccountOwner::from(chain.public_key());
-
-    let token_address = [0xA0; 20];
-    let source_chain_id = 8453u64;
-    let initial_supply = U128(1_000_000);
-
-    // 1. Deploy wrapped-fungible first (the bridge takes its app id as a
-    //    creation parameter), seeding the user with a balance.
-    let fungible_module_id = chain
-        .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
-            "../../../examples/wrapped-fungible",
-        )
-        .await;
-    let wrapped_params = WrappedParameters {
-        ticker_symbol: "wUSDC".to_string(),
-        decimals: 6,
-        mint_chain_id: chain.id(),
-        evm_token_address: token_address,
-        evm_source_chain_id: source_chain_id,
-    };
-    let fungible_app_id = chain
-        .create_application(
-            fungible_module_id,
-            wrapped_params,
-            InitialStateBuilder::default()
-                .with_account(chain_owner, initial_supply)
-                .build(),
-            vec![],
-        )
-        .await;
-
-    // 2. Deploy the bridge (the bridge chain is this chain), pointing it at the
-    //    wrapped-fungible app.
-    let bridge_params = BridgeParameters {
-        source_chain_id,
-        token_address,
-        bridge_chain_id: chain.id(),
-        fungible_app_id: fungible_app_id.forget_abi(),
-    };
-    let bridge_app_id = chain
-        .create_application(
-            bridge_module_id,
-            bridge_params,
-            BridgeInstantiationArgument::default(),
-            vec![],
-        )
-        .await;
-
-    // 3. Register the bridge with the wrapped-fungible app so it may mint/burn.
-    chain
-        .add_block(|block| {
-            block.with_operation(
-                fungible_app_id,
-                WrappedFungibleOperation::RegisterAuthorizedCaller {
-                    app_id: bridge_app_id.forget_abi(),
-                },
-            );
-        })
-        .await;
-
-    let transfer_amount = U128(600_000);
-
-    // 4. User burns part of the balance toward an EVM address.
-    let evm_target = [0xE7; 20];
-    let (burn_cert, _) = chain
-        .add_block(|block| {
-            block.with_operation(
-                bridge_app_id,
-                BridgeOperation::Burn {
-                    amount: transfer_amount,
-                    evm_target,
-                },
-            );
-        })
-        .await;
-
-    // Between the Burn operation and the burn message, the bridge must NOT hold
-    // the escrow under its own application id: the user is the escrow holder.
-    let bridge_as_owner = AccountOwner::from(bridge_app_id.forget_abi());
-    assert_eq!(
-        query_balance(fungible_app_id, &chain, bridge_as_owner).await,
-        None,
-        "bridge must never escrow tokens under its own application id",
-    );
-
-    // 5. Process the BridgeMessage::Burn that the operation sent to the bridge
-    //    chain (here, the same chain).
-    let (burn_msg_cert, _) = chain
-        .add_block(|block| {
-            block.with_messages_from(&burn_cert);
-        })
-        .await;
-
-    let expected_amount = U128(initial_supply.0 - transfer_amount.0);
-
-    // The signer was debited by the burned amount.
-    assert_eq!(
-        query_balance(fungible_app_id, &chain, chain_owner).await,
-        Some(expected_amount),
-        "signer must be debited by the burn amount"
-    );
-
-    // The bridge still holds nothing under its own application id after the burn.
-    assert_eq!(
-        query_balance(fungible_app_id, &chain, bridge_as_owner).await,
-        None,
-        "bridge must never escrow tokens under its own application id"
-    );
-
-    // The bridge emitted a BurnEvent in the burn-processing block.
-    let event_count: usize = burn_msg_cert
-        .inner()
-        .block()
-        .body
-        .events
-        .iter()
-        .map(|tx_events| tx_events.len())
-        .sum();
-    assert!(
-        event_count >= 1,
-        "bridge must emit a BurnEvent for the relayer"
-    );
 }

--- a/linera-bridge/contracts/evm-bridge/tests/burn.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/burn.rs
@@ -1,0 +1,173 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration test for the EVM bridge app's `Burn` operation. A user submits
+//! `BridgeOperation::Burn` on their own chain; the bridge moves the tokens into
+//! the signer's *own* escrow account on the bridge chain, burns them, and emits
+//! a `BurnEvent` that the relayer forwards to EVM. The bridge never holds the
+//! escrow under its own application id.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use evm_bridge::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters, EvmBridgeAbi};
+use linera_sdk::{
+    linera_base_types::{AccountOwner, ApplicationId, U128},
+    test::{ActiveChain, TestValidator},
+};
+use wrapped_fungible::{
+    InitialState, InitialStateBuilder, WrappedFungibleOperation, WrappedFungibleTokenAbi,
+    WrappedParameters,
+};
+
+/// Queries an account balance on the wrapped-fungible app.
+async fn query_balance(
+    app_id: ApplicationId<WrappedFungibleTokenAbi>,
+    chain: &ActiveChain,
+    owner: AccountOwner,
+) -> Option<U128> {
+    use async_graphql::InputType;
+    use linera_sdk::test::QueryOutcome;
+
+    let query = format!(
+        "query {{ accounts {{ entry(key: {}) {{ value }} }} }}",
+        owner.to_value()
+    );
+    let QueryOutcome { response, .. } = chain.graphql_query(app_id, query).await;
+    let balance = response["accounts"]["entry"]["value"].as_str()?;
+    Some(U128(
+        balance.parse().expect("balance cannot be parsed as u128"),
+    ))
+}
+
+#[tokio::test]
+async fn test_burn_via_bridge_debits_owner_and_burns_escrow() {
+    let (validator, bridge_module_id) = TestValidator::with_current_module::<
+        EvmBridgeAbi,
+        BridgeParameters,
+        BridgeInstantiationArgument,
+    >()
+    .await;
+    let mut chain = validator.new_chain().await;
+    let chain_owner = AccountOwner::from(chain.public_key());
+
+    let token_address = [0xA0; 20];
+    let source_chain_id = 8453u64;
+    let initial_supply = U128(1_000_000);
+
+    // 1. Deploy wrapped-fungible first (the bridge takes its app id as a
+    //    creation parameter), seeding the user with a balance.
+    let fungible_module_id = chain
+        .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
+            "../../../examples/wrapped-fungible",
+        )
+        .await;
+    let wrapped_params = WrappedParameters {
+        ticker_symbol: "wUSDC".to_string(),
+        decimals: 6,
+        mint_chain_id: chain.id(),
+        evm_token_address: token_address,
+        evm_source_chain_id: source_chain_id,
+    };
+    let fungible_app_id = chain
+        .create_application(
+            fungible_module_id,
+            wrapped_params,
+            InitialStateBuilder::default()
+                .with_account(chain_owner, initial_supply)
+                .build(),
+            vec![],
+        )
+        .await;
+
+    // 2. Deploy the bridge (the bridge chain is this chain), pointing it at the
+    //    wrapped-fungible app.
+    let bridge_params = BridgeParameters {
+        source_chain_id,
+        token_address,
+        bridge_chain_id: chain.id(),
+        fungible_app_id: fungible_app_id.forget_abi(),
+    };
+    let bridge_app_id = chain
+        .create_application(
+            bridge_module_id,
+            bridge_params,
+            BridgeInstantiationArgument::default(),
+            vec![],
+        )
+        .await;
+
+    // 3. Register the bridge with the wrapped-fungible app so it may mint/burn.
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                fungible_app_id,
+                WrappedFungibleOperation::RegisterAuthorizedCaller {
+                    app_id: bridge_app_id.forget_abi(),
+                },
+            );
+        })
+        .await;
+
+    let transfer_amount = U128(600_000);
+
+    // 4. User burns part of the balance toward an EVM address.
+    let evm_target = [0xE7; 20];
+    let (burn_cert, _) = chain
+        .add_block(|block| {
+            block.with_operation(
+                bridge_app_id,
+                BridgeOperation::Burn {
+                    amount: transfer_amount,
+                    evm_target,
+                },
+            );
+        })
+        .await;
+
+    // Between the Burn operation and the burn message, the bridge must NOT hold
+    // the escrow under its own application id: the user is the escrow holder.
+    let bridge_as_owner = AccountOwner::from(bridge_app_id.forget_abi());
+    assert_eq!(
+        query_balance(fungible_app_id, &chain, bridge_as_owner).await,
+        None,
+        "bridge must never escrow tokens under its own application id",
+    );
+
+    // 5. Process the BridgeMessage::Burn that the operation sent to the bridge
+    //    chain (here, the same chain).
+    let (burn_msg_cert, _) = chain
+        .add_block(|block| {
+            block.with_messages_from(&burn_cert);
+        })
+        .await;
+
+    let expected_amount = U128(initial_supply.0 - transfer_amount.0);
+
+    // The signer was debited by the burned amount.
+    assert_eq!(
+        query_balance(fungible_app_id, &chain, chain_owner).await,
+        Some(expected_amount),
+        "signer must be debited by the burn amount"
+    );
+
+    // The bridge still holds nothing under its own application id after the burn.
+    assert_eq!(
+        query_balance(fungible_app_id, &chain, bridge_as_owner).await,
+        None,
+        "bridge must never escrow tokens under its own application id"
+    );
+
+    // The bridge emitted a BurnEvent in the burn-processing block.
+    let event_count: usize = burn_msg_cert
+        .inner()
+        .block()
+        .body
+        .events
+        .iter()
+        .map(|tx_events| tx_events.len())
+        .sum();
+    assert!(
+        event_count >= 1,
+        "bridge must emit a BurnEvent for the relayer"
+    );
+}

--- a/linera-bridge/contracts/evm-bridge/tests/process_deposit.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/process_deposit.rs
@@ -16,11 +16,11 @@ use linera_bridge::proof::{
     ReceiptLog,
 };
 use linera_sdk::{
-    linera_base_types::{AccountOwner, ApplicationId, U128},
+    linera_base_types::{AccountOwner, ApplicationId, CryptoHash, TestString, U128},
     test::{ActiveChain, TestValidator},
 };
 use serde::Deserialize;
-use wrapped_fungible::{WrappedFungibleTokenAbi, WrappedParameters};
+use wrapped_fungible::{WrappedFungibleOperation, WrappedFungibleTokenAbi, WrappedParameters};
 
 /// Helper to query an account balance on the wrapped-fungible app.
 async fn query_balance(
@@ -38,10 +38,13 @@ async fn query_balance(
     let QueryOutcome { response, .. } = chain.graphql_query(app_id, query).await;
     let balance = response["accounts"]["entry"]["value"].as_str()?;
     Some(U128(
-        balance
-            .parse()
-            .expect("balance cannot be parsed as u128"),
+        balance.parse().expect("balance cannot be parsed as u128"),
     ))
+}
+
+/// A placeholder wrapped-fungible app id for bridge tests that never mint/burn.
+fn dummy_fungible_app_id() -> ApplicationId {
+    ApplicationId::new(CryptoHash::new(&TestString::new("dummy_fungible")))
 }
 
 /// Common setup for bridge integration tests.
@@ -59,24 +62,20 @@ struct TestBridge {
 
 impl TestBridge {
     async fn setup() -> Self {
-        let (validator, bridge_module_id) =
-            TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
+        let (validator, bridge_module_id) = TestValidator::with_current_module::<
+            EvmBridgeAbi,
+            BridgeParameters,
+            BridgeInstantiationArgument,
+        >()
+        .await;
         let mut chain = validator.new_chain().await;
         let chain_owner = AccountOwner::from(chain.public_key());
 
         let token_address = [0xA0; 20];
         let source_chain_id = 8453u64;
 
-        // 1. Deploy bridge first
-        let bridge_params = BridgeParameters {
-            source_chain_id,
-            token_address,
-        };
-        let bridge_app_id = chain
-            .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument::default(), vec![])
-            .await;
-
-        // 2. Deploy wrapped-fungible with the bridge's app ID
+        // 1. Deploy wrapped-fungible first (the bridge takes its app id as a
+        //    creation parameter).
         let fungible_module_id = chain
             .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
                 "../../../examples/wrapped-fungible",
@@ -85,11 +84,9 @@ impl TestBridge {
         let wrapped_params = WrappedParameters {
             ticker_symbol: "wUSDC".to_string(),
             decimals: 6,
-            minter: Some(chain_owner),
-            mint_chain_id: Some(chain.id()),
+            mint_chain_id: chain.id(),
             evm_token_address: token_address,
             evm_source_chain_id: source_chain_id,
-            bridge_app_id: Some(bridge_app_id.forget_abi()),
         };
         let fungible_app_id = chain
             .create_application(
@@ -100,13 +97,29 @@ impl TestBridge {
             )
             .await;
 
-        // 3. Register the fungible app in the bridge
+        // 2. Deploy the bridge, pointing at the wrapped-fungible app.
+        let bridge_params = BridgeParameters {
+            source_chain_id,
+            token_address,
+            bridge_chain_id: chain.id(),
+            fungible_app_id: fungible_app_id.forget_abi(),
+        };
+        let bridge_app_id = chain
+            .create_application(
+                bridge_module_id,
+                bridge_params,
+                BridgeInstantiationArgument::default(),
+                vec![],
+            )
+            .await;
+
+        // 3. Register the bridge with the wrapped-fungible app so it may mint.
         chain
             .add_block(|block| {
                 block.with_operation(
-                    bridge_app_id,
-                    BridgeOperation::RegisterFungibleApp {
-                        app_id: fungible_app_id.forget_abi(),
+                    fungible_app_id,
+                    WrappedFungibleOperation::RegisterAuthorizedCaller {
+                        app_id: bridge_app_id.forget_abi(),
                     },
                 );
             })
@@ -198,21 +211,17 @@ impl TestBridge {
     /// Like `setup`, but skips the FungibleBridge address registration so callers
     /// can verify that `ProcessDeposit` panics when the address has not been set.
     async fn setup_without_bridge_address() -> Self {
-        let (validator, bridge_module_id) =
-            TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
+        let (validator, bridge_module_id) = TestValidator::with_current_module::<
+            EvmBridgeAbi,
+            BridgeParameters,
+            BridgeInstantiationArgument,
+        >()
+        .await;
         let mut chain = validator.new_chain().await;
         let chain_owner = AccountOwner::from(chain.public_key());
 
         let token_address = [0xA0; 20];
         let source_chain_id = 8453u64;
-
-        let bridge_params = BridgeParameters {
-            source_chain_id,
-            token_address,
-        };
-        let bridge_app_id = chain
-            .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument::default(), vec![])
-            .await;
 
         let fungible_module_id = chain
             .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
@@ -222,11 +231,9 @@ impl TestBridge {
         let wrapped_params = WrappedParameters {
             ticker_symbol: "wUSDC".to_string(),
             decimals: 6,
-            minter: Some(chain_owner),
-            mint_chain_id: Some(chain.id()),
+            mint_chain_id: chain.id(),
             evm_token_address: token_address,
             evm_source_chain_id: source_chain_id,
-            bridge_app_id: Some(bridge_app_id.forget_abi()),
         };
         let fungible_app_id = chain
             .create_application(
@@ -237,12 +244,27 @@ impl TestBridge {
             )
             .await;
 
+        let bridge_params = BridgeParameters {
+            source_chain_id,
+            token_address,
+            bridge_chain_id: chain.id(),
+            fungible_app_id: fungible_app_id.forget_abi(),
+        };
+        let bridge_app_id = chain
+            .create_application(
+                bridge_module_id,
+                bridge_params,
+                BridgeInstantiationArgument::default(),
+                vec![],
+            )
+            .await;
+
         chain
             .add_block(|block| {
                 block.with_operation(
-                    bridge_app_id,
-                    BridgeOperation::RegisterFungibleApp {
-                        app_id: fungible_app_id.forget_abi(),
+                    fungible_app_id,
+                    WrappedFungibleOperation::RegisterAuthorizedCaller {
+                        app_id: bridge_app_id.forget_abi(),
                     },
                 );
             })
@@ -667,8 +689,12 @@ async fn test_replay_different_log_index_succeeds() {
 /// instantiation should fail because the chain ID check cannot succeed.
 #[tokio::test]
 async fn test_instantiation_fails_with_unreachable_endpoint() {
-    let (validator, bridge_module_id) =
-        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
+    let (validator, bridge_module_id) = TestValidator::with_current_module::<
+        EvmBridgeAbi,
+        BridgeParameters,
+        BridgeInstantiationArgument,
+    >()
+    .await;
     let mut chain = validator.new_chain().await;
 
     let token_address = [0xA0; 20];
@@ -678,9 +704,18 @@ async fn test_instantiation_fails_with_unreachable_endpoint() {
     let bridge_params = BridgeParameters {
         source_chain_id,
         token_address,
+        bridge_chain_id: chain.id(),
+        fungible_app_id: dummy_fungible_app_id(),
     };
     let result = chain
-        .try_create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument { rpc_endpoint: "http://localhost:8545".to_string() }, vec![])
+        .try_create_application(
+            bridge_module_id,
+            bridge_params,
+            BridgeInstantiationArgument {
+                rpc_endpoint: "http://localhost:8545".to_string(),
+            },
+            vec![],
+        )
         .await;
 
     assert!(
@@ -719,8 +754,12 @@ async fn setup_bridge_with_anvil(
     ApplicationId<EvmBridgeAbi>,
     ApplicationId<WrappedFungibleTokenAbi>,
 ) {
-    let (mut validator, bridge_module_id) =
-        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
+    let (mut validator, bridge_module_id) = TestValidator::with_current_module::<
+        EvmBridgeAbi,
+        BridgeParameters,
+        BridgeInstantiationArgument,
+    >()
+    .await;
 
     // Allow the contract to make HTTP requests to the Anvil host.
     validator
@@ -738,16 +777,8 @@ async fn setup_bridge_with_anvil(
     // Anvil's default chain ID is 31337.
     let source_chain_id = 31337u64;
 
-    // 1. Deploy bridge first
-    let bridge_params = BridgeParameters {
-        source_chain_id,
-        token_address,
-    };
-    let bridge_app_id = chain
-        .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument { rpc_endpoint: anvil_endpoint.to_string() }, vec![])
-        .await;
-
-    // 2. Deploy wrapped-fungible with bridge's app ID
+    // 1. Deploy wrapped-fungible first (the bridge takes its app id as a
+    //    creation parameter).
     let fungible_module_id = chain
         .publish_bytecode_files_in::<WrappedFungibleTokenAbi, WrappedParameters, InitialState>(
             "../../../examples/wrapped-fungible",
@@ -756,11 +787,9 @@ async fn setup_bridge_with_anvil(
     let wrapped_params = WrappedParameters {
         ticker_symbol: "wUSDC".to_string(),
         decimals: 6,
-        minter: Some(chain_owner),
-        mint_chain_id: Some(chain.id()),
+        mint_chain_id: chain.id(),
         evm_token_address: token_address,
         evm_source_chain_id: source_chain_id,
-        bridge_app_id: Some(bridge_app_id.forget_abi()),
     };
     let fungible_app_id = chain
         .create_application(
@@ -771,13 +800,31 @@ async fn setup_bridge_with_anvil(
         )
         .await;
 
-    // 3. Register fungible app in bridge
+    // 2. Deploy the bridge (Anvil endpoint), pointing at the wrapped app.
+    let bridge_params = BridgeParameters {
+        source_chain_id,
+        token_address,
+        bridge_chain_id: chain.id(),
+        fungible_app_id: fungible_app_id.forget_abi(),
+    };
+    let bridge_app_id = chain
+        .create_application(
+            bridge_module_id,
+            bridge_params,
+            BridgeInstantiationArgument {
+                rpc_endpoint: anvil_endpoint.to_string(),
+            },
+            vec![],
+        )
+        .await;
+
+    // 3. Register the bridge with the wrapped-fungible app.
     chain
         .add_block(|block| {
             block.with_operation(
-                bridge_app_id,
-                BridgeOperation::RegisterFungibleApp {
-                    app_id: fungible_app_id.forget_abi(),
+                fungible_app_id,
+                WrappedFungibleOperation::RegisterAuthorizedCaller {
+                    app_id: bridge_app_id.forget_abi(),
                 },
             );
         })
@@ -855,32 +902,6 @@ async fn test_verify_block_hash_not_found() {
 }
 
 #[tokio::test]
-async fn test_register_fungible_app_cannot_be_called_twice() {
-    let tb = TestBridge::setup().await;
-
-    // The bridge already has a registered fungible app from setup.
-    // Attempting to register again should fail.
-    let dummy_app_id = ApplicationId::new(linera_sdk::linera_base_types::CryptoHash::new(
-        &linera_sdk::linera_base_types::TestString::new("other_app"),
-    ));
-    let result = tb
-        .chain
-        .try_add_block(|block| {
-            block.with_operation(
-                tb.bridge_app_id,
-                BridgeOperation::RegisterFungibleApp {
-                    app_id: dummy_app_id,
-                },
-            );
-        })
-        .await;
-    assert!(
-        result.is_err(),
-        "registering fungible app a second time should be rejected"
-    );
-}
-
-#[tokio::test]
 async fn test_process_deposit_rejects_when_bridge_address_unregistered() {
     let tb = TestBridge::setup_without_bridge_address().await;
     let (block_header, receipt, proof_nodes, tx_index, log_index) = tb.build_valid_deposit();
@@ -909,16 +930,27 @@ async fn test_process_deposit_rejects_when_bridge_address_unregistered() {
 
 #[tokio::test]
 async fn test_register_fungible_bridge_is_one_shot() {
-    let (validator, bridge_module_id) =
-        TestValidator::with_current_module::<EvmBridgeAbi, BridgeParameters, BridgeInstantiationArgument>().await;
+    let (validator, bridge_module_id) = TestValidator::with_current_module::<
+        EvmBridgeAbi,
+        BridgeParameters,
+        BridgeInstantiationArgument,
+    >()
+    .await;
     let mut chain = validator.new_chain().await;
 
     let bridge_params = BridgeParameters {
         source_chain_id: 8453u64,
         token_address: [0xA0; 20],
+        bridge_chain_id: chain.id(),
+        fungible_app_id: dummy_fungible_app_id(),
     };
     let bridge_app_id = chain
-        .create_application(bridge_module_id, bridge_params, BridgeInstantiationArgument::default(), vec![])
+        .create_application(
+            bridge_module_id,
+            bridge_params,
+            BridgeInstantiationArgument::default(),
+            vec![],
+        )
         .await;
 
     chain

--- a/linera-bridge/contracts/evm-bridge/tests/set_rpc_endpoint.rs
+++ b/linera-bridge/contracts/evm-bridge/tests/set_rpc_endpoint.rs
@@ -7,7 +7,7 @@
 
 use evm_bridge::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters, EvmBridgeAbi};
 use linera_sdk::{
-    linera_base_types::ApplicationId,
+    linera_base_types::{ApplicationId, CryptoHash, TestString},
     test::{ActiveChain, QueryOutcome, TestValidator},
 };
 
@@ -25,6 +25,9 @@ async fn setup_bridge() -> (ActiveChain, ApplicationId<EvmBridgeAbi>) {
     let bridge_params = BridgeParameters {
         source_chain_id: 8453u64,
         token_address: [0xA0; 20],
+        bridge_chain_id: chain.id(),
+        // This suite never mints/burns; a placeholder fungible app id suffices.
+        fungible_app_id: ApplicationId::new(CryptoHash::new(&TestString::new("dummy_fungible"))),
     };
     let bridge_app_id = chain
         .create_application(

--- a/linera-bridge/src/abi.rs
+++ b/linera-bridge/src/abi.rs
@@ -8,7 +8,10 @@
 //! - the off-chain relay,
 //! - and end-to-end tests.
 
-use linera_base::identifiers::ApplicationId;
+use linera_base::{
+    data_types::U128,
+    identifiers::{ApplicationId, ChainId},
+};
 use serde::{Deserialize, Serialize};
 
 /// Parameters for a deployed bridge instance.
@@ -18,14 +21,21 @@ pub struct BridgeParameters {
     pub source_chain_id: u64,
     /// ERC-20 token address on the source EVM chain.
     pub token_address: [u8; 20],
+    /// Linera chain ID of the bridge chain (the wrapped-fungible mint chain),
+    /// where burns are driven and the `BurnEvent` is emitted. A user's local
+    /// `Burn` operation routes the funding transfer and burn request here.
+    pub bridge_chain_id: ChainId,
+    /// The wrapped-fungible application this bridge mints and burns. The bridge
+    /// calls `Mint`/`Burn` on it. Set at creation — the wrapped app must exist
+    /// first (it learns its bridge afterwards via `RegisterAuthorizedCaller`). Being a
+    /// parameter, it is available on every chain, so a user's local `Burn`
+    /// operation never has to supply it.
+    pub fungible_app_id: ApplicationId,
 }
 
 /// Operations accepted by the bridge contract.
 #[derive(Debug, Deserialize, Serialize)]
 pub enum BridgeOperation {
-    /// Register the wrapped-fungible token application.
-    /// Can only be called once, by the chain owner.
-    RegisterFungibleApp { app_id: ApplicationId },
     /// Verify a deposit proof and mint wrapped tokens.
     ProcessDeposit {
         block_header_rlp: Vec<u8>,
@@ -43,6 +53,42 @@ pub enum BridgeOperation {
     /// Replace the bridge's RPC endpoint. Chain-owner-only.
     /// Empty string disables finality verification.
     SetRpcEndpoint { rpc_endpoint: String },
+    /// Burn wrapped tokens and signal an EVM release. Submitted by a user to
+    /// the bridge instance on their *own* chain. The tokens are burned from the
+    /// operation's authenticated signer; the wrapped-fungible application is
+    /// taken from the bridge's own `fungible_app_id` parameter, never from the
+    /// operation. Atomically (one outgoing bundle) the bridge moves `amount`
+    /// from the signer into the signer's own escrow account on the bridge chain
+    /// — a tracked transfer through that wrapped-fungible app — and sends a
+    /// tracked [`BridgeMessage::Burn`] to the bridge chain. The signer is
+    /// propagated to the bridge chain via the authenticated message, so the burn
+    /// there can only ever drain the escrow that same signer funded. If the burn
+    /// cannot complete, the whole bundle is rejected and the funding transfer
+    /// bounces back to the signer.
+    Burn {
+        /// Amount to burn, in the source ERC-20's decimal scale.
+        amount: U128,
+        /// EVM address that will receive the released ERC-20 tokens.
+        evm_target: [u8; 20],
+    },
+}
+
+/// Cross-chain messages sent between bridge application instances.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum BridgeMessage {
+    /// Sent from the user's chain to the bridge chain to drive a burn. Paired,
+    /// in the same outgoing bundle, with the funding wrapped-fungible transfer
+    /// into the signer's escrow account on the bridge chain. The message is
+    /// authenticated, so the bridge chain recovers the originating signer and
+    /// burns that signer's escrowed `amount`, then emits the `BurnEvent`
+    /// carrying `evm_target`. A bouncing delivery is a no-op (the funding
+    /// transfer's own bounce refunds the user).
+    Burn {
+        /// Amount to burn, matching the funding transfer.
+        amount: U128,
+        /// EVM address that will receive the released ERC-20 tokens.
+        evm_target: [u8; 20],
+    },
 }
 
 /// Initial state passed at `create_application`.

--- a/linera-bridge/src/fungible_bridge.rs
+++ b/linera-bridge/src/fungible_bridge.rs
@@ -93,8 +93,15 @@ mod tests {
 
             let chain_id = CryptoHash::new(&TestString::new("test_chain"));
             let app_id = CryptoHash::new(&TestString::new("fungible_app"));
-            let bridge =
-                deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, token, app_id);
+            let bridge = deploy_fungible_bridge(
+                &mut db,
+                deployer,
+                light_client,
+                chain_id,
+                token,
+                app_id,
+                app_id,
+            );
 
             // Fund the bridge with the full token supply
             call_contract(
@@ -285,8 +292,15 @@ mod tests {
 
         let chain_id = CryptoHash::new(&TestString::new("test_chain"));
         let app_id = CryptoHash::new(&TestString::new("fungible_app"));
-        let bridge =
-            deploy_fungible_bridge(&mut db, deployer, light_client, chain_id, token, app_id);
+        let bridge = deploy_fungible_bridge(
+            &mut db,
+            deployer,
+            light_client,
+            chain_id,
+            token,
+            app_id,
+            app_id,
+        );
 
         // Give depositor tokens (instead of funding the bridge)
         call_contract(
@@ -555,14 +569,49 @@ mod tests {
             "FungibleBridge",
         );
         let zero_app_id: [u8; 32] = [0u8; 32];
-        let constructor_args =
-            (light_client, chain_id_bytes, token, zero_app_id).abi_encode_params();
-        let mut deploy_data = bytecode;
-        deploy_data.extend_from_slice(&constructor_args);
+        let valid_app_id: [u8; 32] =
+            (*CryptoHash::new(&TestString::new("valid_app")).as_bytes()).into();
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            deploy_contract(&mut db, deployer, deploy_data)
-        }));
-        assert!(result.is_err(), "deployment with zero app id must revert");
+        // Zero fungible application id must revert.
+        {
+            let mut deploy_data = bytecode.clone();
+            let constructor_args = (
+                light_client,
+                chain_id_bytes,
+                token,
+                zero_app_id,
+                valid_app_id,
+            )
+                .abi_encode_params();
+            deploy_data.extend_from_slice(&constructor_args);
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                deploy_contract(&mut db, deployer, deploy_data)
+            }));
+            assert!(
+                result.is_err(),
+                "deployment with zero fungible app id must revert"
+            );
+        }
+
+        // Zero bridge application id must revert.
+        {
+            let mut deploy_data = bytecode;
+            let constructor_args = (
+                light_client,
+                chain_id_bytes,
+                token,
+                valid_app_id,
+                zero_app_id,
+            )
+                .abi_encode_params();
+            deploy_data.extend_from_slice(&constructor_args);
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                deploy_contract(&mut db, deployer, deploy_data)
+            }));
+            assert!(
+                result.is_err(),
+                "deployment with zero bridge app id must revert"
+            );
+        }
     }
 }

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -121,17 +121,23 @@ pub(crate) async fn process_pending_burns<E: linera_core::environment::Environme
                     relay::update_balance_metrics(evm_client, linera_client).await;
                 }
                 Err(error) => {
-                    // Bumping the retry counter is critical: an `eth_estimateGas`
-                    // revert is typically deterministic (the cert is invalid for
-                    // the configured bridge), and without this the burn would be
-                    // re-polled every scan interval forever. After `max_retries`
-                    // the burns at this height transition to `failed` and stop
-                    // being yielded by `pending_burns_by_height_and_tx`.
-                    tracing::warn!(?height, ?error, "estimate_add_block_gas failed");
-                    let mut state = monitor.write().await;
-                    for ei in &event_indices {
-                        state.mark_burn_retried(height, *ei, max_retries).await;
-                    }
+                    // `eth_estimateGas` on the whole-block `addBlock` reverted.
+                    // This happens when the block is too large to even estimate
+                    // (it would exceed the EVM block gas limit) — common now that
+                    // a bridge-driven burn adds a funding `Credit` plus a
+                    // `BridgeMessage::Burn` to the block — but also for a
+                    // genuinely invalid cert. Either way, fall back to the per-tx
+                    // chunked `processBurns` path: it estimates each chunk
+                    // independently, submits the ones that fit, and marks any
+                    // single burn that still can't fit as `failed` (so an invalid
+                    // cert terminates instead of being re-polled forever).
+                    tracing::warn!(
+                        ?height,
+                        ?error,
+                        "estimate_add_block_gas failed; falling back to chunked processBurns"
+                    );
+                    submit_chunked(monitor, evm_client, &cert, height, &by_tx, max_retries).await;
+                    relay::update_balance_metrics(evm_client, linera_client).await;
                 }
             }
         }

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -232,32 +232,25 @@ async fn split_to_fit<P: Provider>(
     let mut oversized: Vec<u32> = Vec::new();
     let mut errored: Vec<u32> = Vec::new();
     while let Some(slice) = stack.pop() {
-        match estimate_fits(
+        let fits = estimate_fits(
             evm_client
                 .estimate_process_burns_gas(cert, tx_index, &slice)
                 .await,
-        ) {
-            Ok(true) => chunks.push(slice),
-            Ok(false) if slice.len() == 1 => oversized.push(slice[0]),
-            Ok(false) => {
+        );
+        match classify_slice(&fits, slice.len()) {
+            SliceVerdict::Fits => chunks.push(slice),
+            SliceVerdict::Oversized => oversized.push(slice[0]),
+            SliceVerdict::Bisect => {
                 let mid = slice.len() / 2;
                 let (left, right) = slice.split_at(mid);
                 stack.push(right.to_vec());
                 stack.push(left.to_vec());
             }
-            Err(error) => {
-                // The estimate itself failed — a transient transport/RPC error
-                // or a revert — as opposed to a successful estimate reporting an
-                // over-limit burn (`Ok(false)`). Treating this as "doesn't fit"
-                // would permanently fail a burn on a single node hiccup,
-                // stranding escrow already burned on Linera. Hand the whole
-                // slice to the caller for bounded retry: a persistent failure
-                // still terminates via `max_retries`, a transient one is
-                // re-estimated and settles on a later poll.
+            SliceVerdict::Errored => {
                 tracing::warn!(
                     tx_index,
                     ?slice,
-                    ?error,
+                    error = ?fits,
                     "estimate_process_burns_gas failed; scheduling retry instead of failing"
                 );
                 errored.extend_from_slice(&slice);
@@ -265,6 +258,36 @@ async fn split_to_fit<P: Provider>(
         }
     }
     (chunks, oversized, errored)
+}
+
+/// How `split_to_fit` should dispose of one slice, decided purely from the
+/// gas-estimate verdict and the slice length. Factored out so the
+/// transient-error vs. genuinely-oversized distinction — the property that
+/// keeps a single RPC hiccup from permanently failing a relayable burn — is
+/// unit-testable without a live EVM provider.
+#[derive(Debug, PartialEq, Eq)]
+enum SliceVerdict {
+    /// Estimate succeeded and the slice fits — submit it as a chunk.
+    Fits,
+    /// Estimate succeeded and a single burn exceeds the block gas limit —
+    /// genuinely un-relayable, fail it.
+    Oversized,
+    /// Estimate succeeded, the slice doesn't fit but holds more than one burn —
+    /// bisect and re-test the halves.
+    Bisect,
+    /// The estimate itself failed (transient transport/RPC error or a revert)
+    /// rather than returning a verdict — must NOT be read as "doesn't fit";
+    /// route to bounded retry instead.
+    Errored,
+}
+
+fn classify_slice(fits: &anyhow::Result<bool>, slice_len: usize) -> SliceVerdict {
+    match fits {
+        Ok(true) => SliceVerdict::Fits,
+        Ok(false) if slice_len == 1 => SliceVerdict::Oversized,
+        Ok(false) => SliceVerdict::Bisect,
+        Err(_) => SliceVerdict::Errored,
+    }
 }
 
 /// Marks oversized positions `failed` so they drop out of subsequent
@@ -515,4 +538,42 @@ async fn check_burn_completion(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{classify_slice, SliceVerdict};
+
+    #[test]
+    fn fitting_slice_is_a_chunk() {
+        assert_eq!(classify_slice(&Ok(true), 1), SliceVerdict::Fits);
+        assert_eq!(classify_slice(&Ok(true), 8), SliceVerdict::Fits);
+    }
+
+    #[test]
+    fn single_over_limit_burn_is_oversized() {
+        assert_eq!(classify_slice(&Ok(false), 1), SliceVerdict::Oversized);
+    }
+
+    #[test]
+    fn multi_burn_non_fit_bisects() {
+        assert_eq!(classify_slice(&Ok(false), 2), SliceVerdict::Bisect);
+        assert_eq!(classify_slice(&Ok(false), 9), SliceVerdict::Bisect);
+    }
+
+    #[test]
+    fn estimate_error_routes_to_retry_not_failure() {
+        // A failed estimate (transient transport/RPC error, or a revert) must
+        // NOT be classified `Oversized` — not even for a single-position slice.
+        // Otherwise one node hiccup would permanently fail a burn whose escrow
+        // is already gone on Linera. It must route to bounded retry instead.
+        assert_eq!(
+            classify_slice(&Err(anyhow::anyhow!("connection reset")), 1),
+            SliceVerdict::Errored
+        );
+        assert_eq!(
+            classify_slice(&Err(anyhow::anyhow!("execution reverted")), 5),
+            SliceVerdict::Errored
+        );
+    }
 }

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Linera-side monitoring: scans for BurnEvent stream events (auto-burns),
+//! Linera-side monitoring: scans for BurnEvent stream events,
 //! forwards certificates to EVM, checks EVM for completion via ERC-20
 //! Transfer events, and retries unforwarded burns.
 
@@ -341,7 +341,10 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
         return Ok(());
     }
 
-    let fungible_app_id = linera_client.fungible_app_id();
+    // Burns are now driven by the bridge application, which emits the
+    // `BurnEvent` on its own "burns" stream — so scan the bridge app's events,
+    // not the wrapped-fungible app's.
+    let bridge_app_id = linera_client.bridge_app_id();
 
     let mut blocks = Vec::new();
     let mut hash = info.block_hash;
@@ -359,7 +362,7 @@ async fn linera_scan_iteration<E: linera_core::environment::Environment>(
     let mut new_burns = Vec::new();
     for (block_hash, block) in &blocks {
         let height = block.block().header.height;
-        let burn_events = find_burn_events(&block.block().body.events, fungible_app_id);
+        let burn_events = find_burn_events(&block.block().body.events, bridge_app_id);
         for (tx_index, event_pos_in_tx, event_index, burn_event) in burn_events {
             new_burns.push((
                 height,

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -186,8 +186,10 @@ async fn submit_chunked<P: Provider>(
     max_retries: u32,
 ) {
     for (tx_index, positions) in by_tx {
-        let (chunks, oversized) = split_to_fit(evm_client, cert, *tx_index, positions).await;
+        let (chunks, oversized, errored) =
+            split_to_fit(evm_client, cert, *tx_index, positions).await;
         mark_oversized_failed(monitor, height, *tx_index, &oversized).await;
+        mark_estimate_errored_retry(monitor, height, *tx_index, &errored, max_retries).await;
         submit_chunks_with_retry(
             monitor,
             evm_client,
@@ -208,36 +210,61 @@ async fn submit_chunked<P: Provider>(
 /// `&EvmClient` across awaits (which trips an HRTB Send bound under
 /// `tokio::spawn`).
 ///
-/// Returns `(chunks, oversized)`. Chunks are in input order because each
-/// split pushes right then left.
+/// Returns `(chunks, oversized, errored)`:
+/// - `chunks`: slices that fit, in input order (each split pushes right then
+///   left).
+/// - `oversized`: single positions whose gas estimate *succeeded* and reported
+///   the burn cannot fit under the EVM block gas limit — genuinely
+///   un-relayable, hence terminal.
+/// - `errored`: positions whose estimate *failed* (transient transport/RPC
+///   error, or a revert) rather than returning a verdict. These must NOT be
+///   treated as "doesn't fit": a single node hiccup must not permanently fail
+///   a burn that would otherwise settle, so the caller routes them to bounded
+///   retry (`max_retries`) instead of immediate failure.
 async fn split_to_fit<P: Provider>(
     evm_client: &EvmClient<P>,
     cert: &linera_chain::types::ConfirmedBlockCertificate,
     tx_index: u32,
     positions: &[u32],
-) -> (Vec<Vec<u32>>, Vec<u32>) {
+) -> (Vec<Vec<u32>>, Vec<u32>, Vec<u32>) {
     let mut stack: Vec<Vec<u32>> = vec![positions.to_vec()];
     let mut chunks: Vec<Vec<u32>> = Vec::new();
     let mut oversized: Vec<u32> = Vec::new();
+    let mut errored: Vec<u32> = Vec::new();
     while let Some(slice) = stack.pop() {
-        let est = evm_client
-            .estimate_process_burns_gas(cert, tx_index, &slice)
-            .await;
-        let fits = estimate_fits(est).unwrap_or(false);
-        if fits {
-            chunks.push(slice);
-            continue;
+        match estimate_fits(
+            evm_client
+                .estimate_process_burns_gas(cert, tx_index, &slice)
+                .await,
+        ) {
+            Ok(true) => chunks.push(slice),
+            Ok(false) if slice.len() == 1 => oversized.push(slice[0]),
+            Ok(false) => {
+                let mid = slice.len() / 2;
+                let (left, right) = slice.split_at(mid);
+                stack.push(right.to_vec());
+                stack.push(left.to_vec());
+            }
+            Err(error) => {
+                // The estimate itself failed — a transient transport/RPC error
+                // or a revert — as opposed to a successful estimate reporting an
+                // over-limit burn (`Ok(false)`). Treating this as "doesn't fit"
+                // would permanently fail a burn on a single node hiccup,
+                // stranding escrow already burned on Linera. Hand the whole
+                // slice to the caller for bounded retry: a persistent failure
+                // still terminates via `max_retries`, a transient one is
+                // re-estimated and settles on a later poll.
+                tracing::warn!(
+                    tx_index,
+                    ?slice,
+                    ?error,
+                    "estimate_process_burns_gas failed; scheduling retry instead of failing"
+                );
+                errored.extend_from_slice(&slice);
+            }
         }
-        if slice.len() == 1 {
-            oversized.push(slice[0]);
-            continue;
-        }
-        let mid = slice.len() / 2;
-        let (left, right) = slice.split_at(mid);
-        stack.push(right.to_vec());
-        stack.push(left.to_vec());
     }
-    (chunks, oversized)
+    (chunks, oversized, errored)
 }
 
 /// Marks oversized positions `failed` so they drop out of subsequent
@@ -268,6 +295,38 @@ async fn mark_oversized_failed(
             "single burn does not fit under the EVM block gas limit; marking failed"
         );
         state.mark_burn_failed(height, event_index).await;
+    }
+}
+
+/// Bumps the retry budget for positions whose chunk-gas estimate hit a
+/// transient/infra error (a *failed* estimate, not a successful over-limit
+/// verdict). Routing these through `mark_burn_retried` — the same path a failed
+/// `processBurns` submission uses — keeps a single RPC hiccup from permanently
+/// failing a relayable burn: a persistent failure still terminates once
+/// `max_retries` is exhausted, while a transient one is re-estimated and
+/// settles on a later poll.
+async fn mark_estimate_errored_retry(
+    monitor: &RwLock<MonitorState>,
+    height: BlockHeight,
+    tx_index: u32,
+    errored: &[u32],
+    max_retries: u32,
+) {
+    if errored.is_empty() {
+        return;
+    }
+    let to_retry = {
+        let state = monitor.read().await;
+        errored
+            .iter()
+            .filter_map(|&pos| state.event_index_for_pos(height, tx_index, pos))
+            .collect::<Vec<u32>>()
+    };
+    let mut state = monitor.write().await;
+    for event_index in to_retry {
+        state
+            .mark_burn_retried(height, event_index, max_retries)
+            .await;
     }
 }
 

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -84,7 +84,7 @@ pub struct PendingDeposit {
 /// A pending burn detected by the Linera scanner, sent to the retry loop.
 ///
 /// `event_index` is the underlying Linera `Event.index` — the position of
-/// the burn event within its stream ("burns" on the configured fungible
+/// the burn event within its stream ("burns" on the configured bridge
 /// application). Used both as the dedup key off-chain and as the value
 /// the `FungibleBridge.isBurnProcessed(height, eventIndex)` view consumes.
 #[derive(Debug, Clone, serde::Serialize)]
@@ -101,7 +101,7 @@ pub struct PendingBurn {
     /// Used by `processBurns(cert, tx_index, [event_pos_in_tx, ...])`.
     pub event_pos_in_tx: u32,
     /// `Event.index` — sequential position of this burn within its stream
-    /// (the "burns" stream of the configured fungible app on the configured
+    /// (the "burns" stream of the configured bridge app on the configured
     /// Linera chain). Unique for the lifetime of that stream, so unique
     /// across all heights within the relayer's scope. Off-chain and on-chain
     /// dedup key.

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -171,9 +171,11 @@ impl<P: Provider> EvmClient<P> {
         cert: &linera_chain::types::ConfirmedBlockCertificate,
     ) -> alloy::contract::Result<u64> {
         let cert_bytes = bcs::to_bytes(cert).expect("BCS-serialize cert");
-        tracing::trace!(size = cert_bytes.len(), "Estimating gas for addBlock");
+        let cert_size = cert_bytes.len();
         let bridge = IFungibleBridge::new(self.bridge_addr, &self.provider);
-        bridge.addBlock(cert_bytes.into()).estimate_gas().await
+        let estimate = bridge.addBlock(cert_bytes.into()).estimate_gas().await;
+        tracing::debug!(?estimate, cert_size, "addBlock gas estimate");
+        estimate
     }
 
     /// Same as `estimate_add_block_gas` but for
@@ -185,17 +187,21 @@ impl<P: Provider> EvmClient<P> {
         positions_in_tx: &[u32],
     ) -> alloy::contract::Result<u64> {
         let cert_bytes = bcs::to_bytes(cert).expect("BCS-serialize cert");
-        tracing::trace!(
-            tx_index,
-            count = positions_in_tx.len(),
-            size = cert_bytes.len(),
-            "Estimating gas for processBurns"
-        );
+        let cert_size = cert_bytes.len();
+        let count = positions_in_tx.len();
         let bridge = IFungibleBridge::new(self.bridge_addr, &self.provider);
-        bridge
+        let estimate = bridge
             .processBurns(cert_bytes.into(), tx_index, positions_in_tx.to_vec())
             .estimate_gas()
-            .await
+            .await;
+        tracing::debug!(
+            tx_index,
+            count,
+            ?estimate,
+            cert_size,
+            "processBurns gas estimate"
+        );
+        estimate
     }
 
     /// Submits `processBurns(cert, tx_index, positions_in_tx)` and waits

--- a/linera-bridge/src/relay/linera.rs
+++ b/linera-bridge/src/relay/linera.rs
@@ -148,7 +148,8 @@ impl<E: linera_core::environment::Environment> Clone for LineraClient<E> {
     }
 }
 
-/// Finds all `BurnEvent`s in a block's event streams for a given application.
+/// Finds all `BurnEvent`s emitted by the bridge application on its "burns"
+/// stream within a block's event streams.
 ///
 /// Returns `(tx_index, event_pos_in_tx, event_index, BurnEvent)` for each burn:
 /// - `tx_index`: position of the transaction within `body.events` (outer index)
@@ -156,12 +157,12 @@ impl<E: linera_core::environment::Environment> Clone for LineraClient<E> {
 /// - `event_index`: `Event.index` — the stream index, used as the on-chain dedup key
 pub(crate) fn find_burn_events(
     events: &[Vec<Event>],
-    fungible_app_id: ApplicationId,
+    bridge_app_id: ApplicationId,
 ) -> Vec<(u32, u32, u32, wrapped_fungible::BurnEvent)> {
     let mut result = Vec::new();
     for (tx_index, tx_events) in (0u32..).zip(events) {
         for (event_pos, event) in (0u32..).zip(tx_events) {
-            if event.stream_id.application_id != GenericApplicationId::User(fungible_app_id) {
+            if event.stream_id.application_id != GenericApplicationId::User(bridge_app_id) {
                 continue;
             }
             if event.stream_id.stream_name.0 != b"burns" {
@@ -173,4 +174,79 @@ pub(crate) fn find_burn_events(
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::{
+        crypto::{CryptoHash, TestString},
+        data_types::{Event, U128},
+        identifiers::{ApplicationId, GenericApplicationId, StreamId, StreamName},
+    };
+
+    use super::find_burn_events;
+
+    fn app_id(tag: &str) -> ApplicationId {
+        ApplicationId::new(CryptoHash::new(&TestString::new(tag)))
+    }
+
+    fn encoded_burn(target: [u8; 20], amount: u128) -> Vec<u8> {
+        bcs::to_bytes(&wrapped_fungible::BurnEvent {
+            target,
+            amount: U128(amount),
+        })
+        .unwrap()
+    }
+
+    fn event(app: ApplicationId, stream: &str, value: Vec<u8>, index: u32) -> Event {
+        Event {
+            stream_id: StreamId {
+                application_id: GenericApplicationId::User(app),
+                stream_name: StreamName::from(stream),
+            },
+            index,
+            value,
+        }
+    }
+
+    /// The relayer must match burns by the *bridge* application's "burns"
+    /// stream — not by any other application or stream.
+    #[test]
+    fn matches_only_the_given_app_burns_stream() {
+        let bridge_app_id = app_id("bridge");
+        let other = app_id("other");
+        let burn_target = [0xE7; 20];
+        let burn_amount = 123;
+        let value = encoded_burn(burn_target, burn_amount);
+
+        let events = vec![
+            // tx 0: a burn emitted by the bridge app.
+            vec![event(bridge_app_id, "burns", value.clone(), 7)],
+            // tx 1: a burn from a different app, and a non-"burns" stream event
+            // from the bridge app — neither should match when keyed on `bridge_app_id`.
+            vec![
+                event(other, "burns", value.clone(), 0),
+                event(bridge_app_id, "transfers", value.clone(), 1),
+            ],
+        ];
+
+        let found = find_burn_events(&events, bridge_app_id);
+        assert_eq!(
+            found.len(),
+            1,
+            "only the bridge app's burns-stream event must match"
+        );
+        let (tx_index, event_pos, event_index, decoded) = &found[0];
+        assert_eq!((*tx_index, *event_pos, *event_index), (0, 0, 7));
+        assert_eq!(decoded.target, burn_target);
+        assert_eq!(decoded.amount, U128(burn_amount));
+
+        // Keyed on a different application, the bridge app's burn is ignored.
+        let found_other = find_burn_events(&events, other);
+        assert_eq!(found_other.len(), 1);
+        assert_eq!(
+            found_other[0].2, 0,
+            "matches the other app's burn at index 0"
+        );
+    }
 }

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -44,7 +44,8 @@ contract FungibleBridge is Microchain {
     IERC20 public immutable token;
     uint256 public depositNonce;
 
-    /// Per-burn dedup keyed by `keccak256(abi.encode(height, eventIndex))`
+    /// Per-burn dedup keyed by
+    /// `keccak256(abi.encode(bridgeApplicationId, height, eventIndex))`
     /// where `eventIndex` is the underlying Linera `Event.index` — the
     /// position of the burn event within its stream. Set inside
     /// `_onBlock` after the burn's `token.transfer` succeeds.
@@ -107,7 +108,7 @@ contract FungibleBridge is Microchain {
     /// Processes a Linera block and releases ERC-20 tokens for any BurnEvent
     /// events on the "burns" stream from the bridge application.
     /// Idempotent: each burn's release is gated on
-    /// `processedBurns[keccak256(abi.encode(height, evt.index))]`, so
+    /// `processedBurns[keccak256(abi.encode(bridgeApplicationId, height, evt.index))]`, so
     /// re-submitting the same cert is a no-op for burns already released
     /// by a prior call.
     function _onBlock(BridgeTypes.Block memory blockValue) internal override {
@@ -171,9 +172,13 @@ contract FungibleBridge is Microchain {
     }
 
     /// Dedup key for a burn at `(height, eventIndex)`. `eventIndex` is the
-    /// underlying Linera `Event.index`.
-    function _burnKey(uint64 height, uint32 eventIndex) private pure returns (bytes32) {
-        return keccak256(abi.encode(height, eventIndex));
+    /// underlying Linera `Event.index`. `bridgeApplicationId` is folded in so
+    /// the key is self-describing: dedup correctness no longer rests on the
+    /// implicit invariant that this contract only ever consumes the bridge
+    /// app's "burns" stream — if a future change let it match more than one
+    /// stream, keys from different apps could not collide.
+    function _burnKey(uint64 height, uint32 eventIndex) private view returns (bytes32) {
+        return keccak256(abi.encode(bridgeApplicationId, height, eventIndex));
     }
 
     /// Returns true if `evt` belongs to the configured bridge application's

--- a/linera-bridge/src/solidity/FungibleBridge.sol
+++ b/linera-bridge/src/solidity/FungibleBridge.sol
@@ -34,9 +34,12 @@ contract FungibleBridge is Microchain {
     /// the source Linera block (matches the on-chain dedup key).
     event BurnReleased(uint64 indexed height, uint32 indexed eventIndex, address indexed target, uint256 amount);
 
-    // WrappedFungible application ID on Linera,
-    // used to identify Burn events in the block stream.
+    // WrappedFungible application ID on Linera. Required deposit target
+    // (see `deposit`), on whose behalf the released ERC-20 is bridged.
     bytes32 public immutable fungibleApplicationId;
+    // EVM bridge application ID on Linera, whose "burns" stream this contract
+    // matches Burn events against when releasing ERC-20 tokens.
+    bytes32 public immutable bridgeApplicationId;
     // The ERC-20 token being bridged.
     IERC20 public immutable token;
     uint256 public depositNonce;
@@ -47,12 +50,18 @@ contract FungibleBridge is Microchain {
     /// `_onBlock` after the burn's `token.transfer` succeeds.
     mapping(bytes32 => bool) internal processedBurns;
 
-    constructor(address _lightClient, bytes32 _chainId, address _token, bytes32 _fungibleApplicationId)
-        Microchain(_lightClient, _chainId)
-    {
+    constructor(
+        address _lightClient,
+        bytes32 _chainId,
+        address _token,
+        bytes32 _fungibleApplicationId,
+        bytes32 _bridgeApplicationId
+    ) Microchain(_lightClient, _chainId) {
         require(_fungibleApplicationId != bytes32(0), "fungibleApplicationId must be non-zero");
+        require(_bridgeApplicationId != bytes32(0), "bridgeApplicationId must be non-zero");
         token = IERC20(_token);
         fungibleApplicationId = _fungibleApplicationId;
+        bridgeApplicationId = _bridgeApplicationId;
     }
 
     /// Returns whether the burn at `(height, eventIndex)` has already been
@@ -96,7 +105,7 @@ contract FungibleBridge is Microchain {
     }
 
     /// Processes a Linera block and releases ERC-20 tokens for any BurnEvent
-    /// events on the "burns" stream from the wrapped-fungible application.
+    /// events on the "burns" stream from the bridge application.
     /// Idempotent: each burn's release is gated on
     /// `processedBurns[keccak256(abi.encode(height, evt.index))]`, so
     /// re-submitting the same cert is a no-op for burns already released
@@ -167,12 +176,12 @@ contract FungibleBridge is Microchain {
         return keccak256(abi.encode(height, eventIndex));
     }
 
-    /// Returns true if `evt` belongs to the configured wrapped-fungible
-    /// application's "burns" stream.
+    /// Returns true if `evt` belongs to the configured bridge application's
+    /// "burns" stream.
     function _isMatchingBurn(BridgeTypes.Event memory evt, bytes32 burnsHash) private view returns (bool) {
         // choice == 1 is User application
         if (evt.stream_id.application_id.choice != 1) return false;
-        if (evt.stream_id.application_id.user.application_description_hash.value != fungibleApplicationId) {
+        if (evt.stream_id.application_id.user.application_description_hash.value != bridgeApplicationId) {
             return false;
         }
         if (keccak256(evt.stream_id.stream_name.value) != burnsHash) return false;

--- a/linera-bridge/src/solidity/WrappedFungibleTypes.sol
+++ b/linera-bridge/src/solidity/WrappedFungibleTypes.sol
@@ -3,6 +3,33 @@ pragma solidity ^0.8.0;
 import "BridgeTypes.sol";
 
 library WrappedFungibleTypes {
+    struct ApplicationId {
+        BridgeTypes.CryptoHash application_description_hash;
+    }
+
+    function bcs_serialize_ApplicationId(ApplicationId memory input) internal pure returns (bytes memory) {
+        return BridgeTypes.bcs_serialize_CryptoHash(input.application_description_hash);
+    }
+
+    function bcs_deserialize_offset_ApplicationId(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, ApplicationId memory)
+    {
+        uint256 new_pos;
+        BridgeTypes.CryptoHash memory application_description_hash;
+        (new_pos, application_description_hash) = BridgeTypes.bcs_deserialize_offset_CryptoHash(pos, input);
+        return (new_pos, ApplicationId(application_description_hash));
+    }
+
+    function bcs_deserialize_ApplicationId(bytes memory input) internal pure returns (ApplicationId memory) {
+        uint256 new_pos;
+        ApplicationId memory value;
+        (new_pos, value) = bcs_deserialize_offset_ApplicationId(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
     struct BurnEvent {
         bytes20 target;
         uint128 amount;
@@ -177,6 +204,8 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Mint mint;
         // choice=7 corresponds to Burn
         WrappedFungibleOperation_Burn burn;
+        // choice=8 corresponds to RegisterAuthorizedCaller
+        WrappedFungibleOperation_RegisterAuthorizedCaller register_authorized_caller;
     }
 
     function WrappedFungibleOperation_case_balance(WrappedFungibleOperation_Balance memory balance_)
@@ -190,7 +219,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Mint memory mint;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(0), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(0), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function WrappedFungibleOperation_case_ticker_symbol() internal pure returns (WrappedFungibleOperation memory) {
@@ -201,7 +233,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Mint memory mint;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(1), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(1), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function WrappedFungibleOperation_case_approve(WrappedFungibleOperation_Approve memory approve)
@@ -215,7 +250,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Mint memory mint;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(2), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(2), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function WrappedFungibleOperation_case_transfer(WrappedFungibleOperation_Transfer memory transfer_)
@@ -229,7 +267,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Mint memory mint;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(3), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(3), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function WrappedFungibleOperation_case_transfer_from(WrappedFungibleOperation_TransferFrom memory transfer_from)
@@ -243,7 +284,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Mint memory mint;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(4), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(4), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function WrappedFungibleOperation_case_claim(WrappedFungibleOperation_Claim memory claim)
@@ -257,7 +301,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Mint memory mint;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(5), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(5), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function WrappedFungibleOperation_case_mint(WrappedFungibleOperation_Mint memory mint)
@@ -271,7 +318,10 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Burn memory burn;
-        return WrappedFungibleOperation(uint8(6), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(6), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function WrappedFungibleOperation_case_burn(WrappedFungibleOperation_Burn memory burn)
@@ -285,7 +335,27 @@ library WrappedFungibleTypes {
         WrappedFungibleOperation_TransferFrom memory transfer_from;
         WrappedFungibleOperation_Claim memory claim;
         WrappedFungibleOperation_Mint memory mint;
-        return WrappedFungibleOperation(uint8(7), balance_, approve, transfer_, transfer_from, claim, mint, burn);
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        return WrappedFungibleOperation(
+            uint8(7), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
+    }
+
+    function WrappedFungibleOperation_case_register_authorized_caller(WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller)
+        internal
+        pure
+        returns (WrappedFungibleOperation memory)
+    {
+        WrappedFungibleOperation_Balance memory balance_;
+        WrappedFungibleOperation_Approve memory approve;
+        WrappedFungibleOperation_Transfer memory transfer_;
+        WrappedFungibleOperation_TransferFrom memory transfer_from;
+        WrappedFungibleOperation_Claim memory claim;
+        WrappedFungibleOperation_Mint memory mint;
+        WrappedFungibleOperation_Burn memory burn;
+        return WrappedFungibleOperation(
+            uint8(8), balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+        );
     }
 
     function bcs_serialize_WrappedFungibleOperation(WrappedFungibleOperation memory input)
@@ -314,6 +384,12 @@ library WrappedFungibleTypes {
         }
         if (input.choice == 7) {
             return abi.encodePacked(input.choice, bcs_serialize_WrappedFungibleOperation_Burn(input.burn));
+        }
+        if (input.choice == 8) {
+            return abi.encodePacked(
+                input.choice,
+                bcs_serialize_WrappedFungibleOperation_RegisterAuthorizedCaller(input.register_authorized_caller)
+            );
         }
         return abi.encodePacked(input.choice);
     }
@@ -354,9 +430,18 @@ library WrappedFungibleTypes {
         if (choice == 7) {
             (new_pos, burn) = bcs_deserialize_offset_WrappedFungibleOperation_Burn(new_pos, input);
         }
-        require(choice < 8);
-        return
-            (new_pos, WrappedFungibleOperation(choice, balance_, approve, transfer_, transfer_from, claim, mint, burn));
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory register_authorized_caller;
+        if (choice == 8) {
+            (new_pos, register_authorized_caller) =
+                bcs_deserialize_offset_WrappedFungibleOperation_RegisterAuthorizedCaller(new_pos, input);
+        }
+        require(choice < 9);
+        return (
+            new_pos,
+            WrappedFungibleOperation(
+                choice, balance_, approve, transfer_, transfer_from, claim, mint, burn, register_authorized_caller
+            )
+        );
     }
 
     function bcs_deserialize_WrappedFungibleOperation(bytes memory input)
@@ -566,6 +651,41 @@ library WrappedFungibleTypes {
         uint256 new_pos;
         WrappedFungibleOperation_Mint memory value;
         (new_pos, value) = bcs_deserialize_offset_WrappedFungibleOperation_Mint(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
+    struct WrappedFungibleOperation_RegisterAuthorizedCaller {
+        ApplicationId app_id;
+    }
+
+    function bcs_serialize_WrappedFungibleOperation_RegisterAuthorizedCaller(WrappedFungibleOperation_RegisterAuthorizedCaller memory input)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return bcs_serialize_ApplicationId(input.app_id);
+    }
+
+    function bcs_deserialize_offset_WrappedFungibleOperation_RegisterAuthorizedCaller(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, WrappedFungibleOperation_RegisterAuthorizedCaller memory)
+    {
+        uint256 new_pos;
+        ApplicationId memory app_id;
+        (new_pos, app_id) = bcs_deserialize_offset_ApplicationId(pos, input);
+        return (new_pos, WrappedFungibleOperation_RegisterAuthorizedCaller(app_id));
+    }
+
+    function bcs_deserialize_WrappedFungibleOperation_RegisterAuthorizedCaller(bytes memory input)
+        internal
+        pure
+        returns (WrappedFungibleOperation_RegisterAuthorizedCaller memory)
+    {
+        uint256 new_pos;
+        WrappedFungibleOperation_RegisterAuthorizedCaller memory value;
+        (new_pos, value) = bcs_deserialize_offset_WrappedFungibleOperation_RegisterAuthorizedCaller(0, input);
         require(new_pos == input.length, "incomplete deserialization");
         return value;
     }

--- a/linera-bridge/src/solidity/script/DeployFungibleBridge.s.sol
+++ b/linera-bridge/src/solidity/script/DeployFungibleBridge.s.sol
@@ -10,9 +10,10 @@ contract DeployFungibleBridge is Script {
         bytes32 chainId = vm.envBytes32("BRIDGE_CHAIN_ID");
         address token = vm.envAddress("TOKEN_ADDRESS");
         bytes32 fungibleAppId = vm.envBytes32("FUNGIBLE_APP_ID");
+        bytes32 bridgeAppId = vm.envBytes32("BRIDGE_APP_ID");
 
         vm.broadcast();
-        bridge = new FungibleBridge(lightClient, chainId, token, fungibleAppId);
+        bridge = new FungibleBridge(lightClient, chainId, token, fungibleAppId, bridgeAppId);
 
         require(address(bridge.lightClient()) == lightClient, "post-deploy lightClient mismatch");
     }

--- a/linera-bridge/src/solidity/test/DeployFungibleBridge.t.sol
+++ b/linera-bridge/src/solidity/test/DeployFungibleBridge.t.sol
@@ -23,11 +23,13 @@ contract DeployFungibleBridgeTest is Test {
 
         bytes32 chainId = bytes32(uint256(0xdeadbeef));
         bytes32 appId = bytes32(uint256(0xfeedface));
+        bytes32 bridgeAppId = bytes32(uint256(0xb0a4d));
 
         vm.setEnv("LIGHT_CLIENT", vm.toString(address(lc)));
         vm.setEnv("BRIDGE_CHAIN_ID", vm.toString(chainId));
         vm.setEnv("TOKEN_ADDRESS", vm.toString(address(token)));
         vm.setEnv("FUNGIBLE_APP_ID", vm.toString(appId));
+        vm.setEnv("BRIDGE_APP_ID", vm.toString(bridgeAppId));
 
         FungibleBridge bridge = new DeployFungibleBridge().run();
 

--- a/linera-bridge/src/solidity/test/FungibleBridge.t.sol
+++ b/linera-bridge/src/solidity/test/FungibleBridge.t.sol
@@ -18,7 +18,12 @@ uint128 constant AMOUNT = 1_000_000_000_000_000_000; // 1e18
 address constant RECIP_0 = address(0xA0);
 address constant RECIP_1 = address(0xA1);
 address constant RECIP_2 = address(0xA2);
-bytes32 constant APP_ID = bytes32(uint256(0xF00D));
+// The Linera bridge application ID the mock emits its "burns" stream under;
+// the FungibleBridge matches burns against this id.
+bytes32 constant BRIDGE_APP_ID = bytes32(uint256(0xF00D));
+// A distinct wrapped-fungible (deposit/mint target) application ID, used to
+// confirm that burn-matching keys on the bridge id and not on this one.
+bytes32 constant FUNGIBLE_APP_ID = bytes32(uint256(0xBEEF));
 
 // ------------------------------------------------------------------
 // MockLightClientForBurns
@@ -155,7 +160,7 @@ contract FungibleBridgeProcessBurnsTest is Test {
     // `supply` tokens pre-minted to the bridge.
     function _deployBridge(address lc, uint256 supply) internal returns (FungibleBridge bridge, LineraToken tok) {
         tok = new LineraToken("Test", "TST", 18, supply);
-        bridge = new FungibleBridge(lc, CHAIN_ID, address(tok), APP_ID);
+        bridge = new FungibleBridge(lc, CHAIN_ID, address(tok), FUNGIBLE_APP_ID, BRIDGE_APP_ID);
         // Send all tokens to the bridge so transfer() calls succeed.
         tok.transfer(address(bridge), supply);
     }
@@ -165,7 +170,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
     function test_processBurns_single_position_marks_processed() public {
         // 2 burns in tx TX at positions 0 and 1 with stream indices 5 and 6.
         // Settle only position 0; assert (HEIGHT, 5) is flipped, (HEIGHT, 6) stays false.
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 2, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 2, AMOUNT, RECIP_0);
         (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
 
         bridge.processBurns(hex"deadbeef", TX, _u32s_single(0));
@@ -176,7 +182,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
 
     function test_processBurns_multi_position_marks_both_processed() public {
         // 2 burns; settle both positions; both flags true.
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 2, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 2, AMOUNT, RECIP_0);
         (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
 
         bridge.processBurns(hex"deadbeef", TX, _u32s(0, 1));
@@ -190,7 +197,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
         // no-op, not a revert. Keeps the relayer robust to overlap between
         // an addBlock-path settlement and a racing/retrying processBurns
         // call covering the same (height, tx, pos).
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 1, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 1, AMOUNT, RECIP_0);
         (FungibleBridge bridge, LineraToken tok) = _deployBridge(address(lc), AMOUNT * 10);
 
         bridge.processBurns(hex"deadbeef", TX, _u32s_single(0));
@@ -205,7 +213,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
 
     function test_processBurns_tx_index_out_of_range_reverts() public {
         // Block has 1 tx; processBurns with txIndex=99 → revert "txIndex out of range".
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 1, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 1, AMOUNT, RECIP_0);
         (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
 
         vm.expectRevert(bytes("txIndex out of range"));
@@ -214,7 +223,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
 
     function test_processBurns_event_pos_out_of_range_reverts() public {
         // 2 burns at positions 0,1; processBurns with position=99 → revert "eventPos out of range".
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 2, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 2, AMOUNT, RECIP_0);
         (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
 
         vm.expectRevert(bytes("eventPos out of range"));
@@ -224,7 +234,7 @@ contract FungibleBridgeProcessBurnsTest is Test {
     function test_processBurns_non_burn_event_reverts() public {
         // MockLightClient returns a Block whose only event has the wrong
         // stream_name ("deposits") → processBurns(tx=0, [0]) → revert "not a matching burn".
-        MockLightClientForNonBurn lc = new MockLightClientForNonBurn(CHAIN_ID, HEIGHT, APP_ID, AMOUNT, RECIP_0);
+        MockLightClientForNonBurn lc = new MockLightClientForNonBurn(CHAIN_ID, HEIGHT, BRIDGE_APP_ID, AMOUNT, RECIP_0);
         (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
 
         vm.expectRevert(bytes("not a matching burn"));
@@ -234,7 +244,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
     function test_processBurns_empty_positions_reverts() public {
         // An empty positions array would silently pay for cert verification
         // with no work to do. Reject it eagerly so caller bugs surface.
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 1, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 1, AMOUNT, RECIP_0);
         (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
 
         uint32[] memory empty = new uint32[](0);
@@ -246,7 +257,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
         // Settle two burns; each release emits BurnReleased with
         // (height, evt.index, target, amount). Recipients are
         // RECIP_0 and RECIP_0+1; stream indices are 5 and 6.
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 2, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 2, AMOUNT, RECIP_0);
         (FungibleBridge bridge,) = _deployBridge(address(lc), AMOUNT * 10);
 
         address recip1 = address(uint160(RECIP_0) + 1);
@@ -263,7 +275,8 @@ contract FungibleBridgeProcessBurnsTest is Test {
         // 2 burns at positions 0,1. Settle pos 1 first; then call
         // processBurns([0, 1]). Under skip-on-duplicate semantics pos 0 must
         // be released and pos 1 silently skipped — no revert, no double-release.
-        MockLightClientForBurns lc = new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, APP_ID, 2, AMOUNT, RECIP_0);
+        MockLightClientForBurns lc =
+            new MockLightClientForBurns(CHAIN_ID, HEIGHT, TX, BRIDGE_APP_ID, 2, AMOUNT, RECIP_0);
         (FungibleBridge bridge, LineraToken tok) = _deployBridge(address(lc), AMOUNT * 10);
 
         bridge.processBurns(hex"deadbeef", TX, _u32s_single(1));

--- a/linera-bridge/src/test_helpers.rs
+++ b/linera-bridge/src/test_helpers.rs
@@ -141,6 +141,7 @@ pub fn deploy_fungible_bridge(
     chain_id: CryptoHash,
     token: Address,
     application_id: CryptoHash,
+    bridge_application_id: CryptoHash,
 ) -> Address {
     let bytecode = compile_contract(
         evm::FUNGIBLE_BRIDGE_SOURCE,
@@ -152,6 +153,7 @@ pub fn deploy_fungible_bridge(
         *chain_id.as_bytes(),
         token,
         *application_id.as_bytes(),
+        *bridge_application_id.as_bytes(),
     )
         .abi_encode_params();
     let mut deploy_data = bytecode;

--- a/linera-bridge/tests/anvil_deposit_proof.rs
+++ b/linera-bridge/tests/anvil_deposit_proof.rs
@@ -201,6 +201,7 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
     // application ID baked into the constructor (immutable since #6173).
     let target_chain_id = B256::from([0xAA; 32]);
     let target_application_id = B256::from([0xBB; 32]);
+    let bridge_application_id = B256::from([0xDD; 32]);
 
     let bridge_bytecode = compile_contract(
         FUNGIBLE_BRIDGE_SOURCE,
@@ -212,6 +213,7 @@ async fn test_deposit_proof_generation() -> Result<(), Box<dyn std::error::Error
         <[u8; 32]>::from(target_chain_id),       // chainId
         token_address,                           // token
         <[u8; 32]>::from(target_application_id), // fungibleApplicationId
+        <[u8; 32]>::from(bridge_application_id), // bridgeApplicationId
     )
         .abi_encode_params();
 

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -282,6 +282,7 @@ pub async fn deploy_fungible_bridge(
     chain_id_bytes32: &str,
     token: Address,
     fungible_app_id_bytes32: &str,
+    bridge_app_id_bytes32: &str,
 ) -> anyhow::Result<Address> {
     exec_ok(
         compose,
@@ -291,6 +292,7 @@ pub async fn deploy_fungible_bridge(
                  BRIDGE_CHAIN_ID={chain_id_bytes32} \
                  TOKEN_ADDRESS={token} \
                  FUNGIBLE_APP_ID={fungible_app_id_bytes32} \
+                 BRIDGE_APP_ID={bridge_app_id_bytes32} \
              forge script /contracts/script/DeployFungibleBridge.s.sol \
              --root /contracts \
              --rpc-url http://anvil:8545 \
@@ -469,11 +471,9 @@ where
             serde_json::to_vec(&wrapped_fungible::WrappedParameters {
                 ticker_symbol: "wTEST".to_string(),
                 decimals: 18,
-                minter: None,
-                mint_chain_id: Some(mint_chain_id),
+                mint_chain_id: mint_chain_id,
                 evm_token_address: erc20_addr.0 .0,
                 evm_source_chain_id: 31337,
-                bridge_app_id: None,
             })?,
             serde_json::to_vec(&wrapped_fungible::InitialState {
                 accounts: std::collections::BTreeMap::from([(initial_holder, initial_balance)]),
@@ -483,6 +483,88 @@ where
         .await?
         .expect("create wrapped-fungible app committed");
     Ok(fungible_app_id)
+}
+
+/// Publishes the evm-bridge Wasm module on `chain_client` and creates an
+/// application instance for the given source token, with `bridge_chain_id`
+/// set to the chain that drives mints/burns. The Wasm artifacts load from
+/// `linera-bridge/contracts/evm-bridge/target/wasm32-unknown-unknown/release/`
+/// — bridge tests must build the evm-bridge contract before invoking this.
+pub async fn publish_and_create_evm_bridge<E>(
+    chain_client: &linera_core::client::ChainClient<E>,
+    erc20_addr: Address,
+    bridge_chain_id: linera_base::identifiers::ChainId,
+    fungible_app_id: linera_base::identifiers::ApplicationId,
+) -> anyhow::Result<linera_base::identifiers::ApplicationId>
+where
+    E: linera_core::environment::Environment,
+{
+    use anyhow::Context as _;
+    use linera_base::{data_types::Bytecode, vm::VmRuntime};
+
+    let repo_root = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .context("manifest dir has fewer than 3 ancestors")?
+        .to_path_buf();
+    let wasm_dir =
+        repo_root.join("linera-bridge/contracts/evm-bridge/target/wasm32-unknown-unknown/release");
+    let eb_contract = Bytecode::load_from_file(wasm_dir.join("evm_bridge_contract.wasm"))?;
+    let eb_service = Bytecode::load_from_file(wasm_dir.join("evm_bridge_service.wasm"))?;
+    let (eb_module_id, _) = chain_client
+        .publish_module(eb_contract, eb_service, VmRuntime::Wasm)
+        .await?
+        .expect("publish evm-bridge module committed");
+    chain_client.synchronize_from_validators().await?;
+    chain_client.process_inbox().await?;
+
+    let (bridge_app_id, _) = chain_client
+        .create_application_untyped(
+            eb_module_id,
+            serde_json::to_vec(&linera_bridge::abi::BridgeParameters {
+                source_chain_id: 31337,
+                token_address: erc20_addr.0 .0,
+                bridge_chain_id,
+                fungible_app_id,
+            })?,
+            serde_json::to_vec(&linera_bridge::abi::BridgeInstantiationArgument {
+                rpc_endpoint: String::new(),
+            })?,
+            vec![],
+        )
+        .await?
+        .expect("create evm-bridge app committed");
+    Ok(bridge_app_id)
+}
+
+/// Registers the evm-bridge application with the wrapped-fungible app so the
+/// bridge may drive Mint/Burn on it. Submits `RegisterAuthorizedCaller` on the
+/// wrapped-fungible application and processes the inbox.
+pub async fn register_bridge_app<E>(
+    chain_client: &linera_core::client::ChainClient<E>,
+    fungible_app_id: linera_base::identifiers::ApplicationId,
+    bridge_app_id: linera_base::identifiers::ApplicationId,
+) -> anyhow::Result<()>
+where
+    E: linera_core::environment::Environment,
+{
+    use linera_execution::Operation;
+    let bytes = bcs::to_bytes(&wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
+        app_id: bridge_app_id,
+    })?;
+    chain_client
+        .execute_operations(
+            vec![Operation::User {
+                application_id: fungible_app_id,
+                bytes,
+            }],
+            vec![],
+        )
+        .await?
+        .expect("register bridge app committed");
+    chain_client.synchronize_from_validators().await?;
+    chain_client.process_inbox().await?;
+    Ok(())
 }
 
 /// Transfers `amount` ERC-20 attos from the deployer (Anvil account 0)

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -44,7 +44,7 @@ use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use wrapped_fungible::{Account, InitialState, WrappedFungibleOperation, WrappedParameters};
+use wrapped_fungible::{InitialState, WrappedParameters};
 
 sol! {
     #[sol(rpc)]
@@ -168,23 +168,6 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     cc_a.synchronize_from_validators().await?;
     cc_a.process_inbox().await?;
 
-    tracing::info!("Creating evm-bridge application...");
-    let (bridge_app_id, _) = cc_a
-        .create_application_untyped(
-            eb_module_id,
-            serde_json::to_vec(&BridgeParameters {
-                source_chain_id: 31337,
-                token_address: erc20_addr.0 .0,
-            })?,
-            serde_json::to_vec(&BridgeInstantiationArgument {
-                rpc_endpoint: String::new(),
-            })?,
-            vec![],
-        )
-        .await?
-        .expect("create evm-bridge app committed");
-    tracing::info!(%bridge_app_id, "evm-bridge app created");
-
     tracing::info!("Publishing wrapped-fungible module...");
     let wf_contract = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm"))?;
     let wf_service = Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_service.wasm"))?;
@@ -195,6 +178,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     cc_a.synchronize_from_validators().await?;
     cc_a.process_inbox().await?;
 
+    // Create the wrapped-fungible app first; its id is a parameter of the bridge.
     tracing::info!("Creating wrapped-fungible application...");
     let (fungible_app_id, _) = cc_a
         .create_application_untyped(
@@ -202,11 +186,9 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             serde_json::to_vec(&WrappedParameters {
                 ticker_symbol: "wTEST".to_string(),
                 decimals: 18,
-                minter: Some(owner_a),
-                mint_chain_id: Some(chain_a),
+                mint_chain_id: chain_a,
                 evm_token_address: erc20_addr.0 .0,
                 evm_source_chain_id: 31337,
-                bridge_app_id: Some(bridge_app_id),
             })?,
             serde_json::to_vec(&InitialState {
                 accounts: BTreeMap::new(),
@@ -217,21 +199,41 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         .expect("create wrapped-fungible app committed");
     tracing::info!(%fungible_app_id, "wrapped-fungible app created");
 
+    tracing::info!("Creating evm-bridge application...");
+    let (bridge_app_id, _) = cc_a
+        .create_application_untyped(
+            eb_module_id,
+            serde_json::to_vec(&BridgeParameters {
+                source_chain_id: 31337,
+                token_address: erc20_addr.0 .0,
+                bridge_chain_id: chain_a,
+                fungible_app_id,
+            })?,
+            serde_json::to_vec(&BridgeInstantiationArgument {
+                rpc_endpoint: String::new(),
+            })?,
+            vec![],
+        )
+        .await?
+        .expect("create evm-bridge app committed");
+    tracing::info!(%bridge_app_id, "evm-bridge app created");
+
     // ── Phase 6: Register app IDs on both sides ──
-    tracing::info!("Registering fungible app in evm-bridge...");
-    let register_bytes = bcs::to_bytes(&BridgeOperation::RegisterFungibleApp {
-        app_id: fungible_app_id,
+    tracing::info!("Registering bridge app in wrapped-fungible...");
+    let register_bytes = bcs::to_bytes(&wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
+        app_id: bridge_app_id,
     })?;
     let register_operation = Operation::User {
-        application_id: bridge_app_id,
+        application_id: fungible_app_id,
         bytes: register_bytes,
     };
     cc_a.execute_operations(vec![register_operation], vec![])
         .await?
-        .expect("register fungible app committed");
+        .expect("register bridge app committed");
 
     // Deploy FungibleBridge with the wrapped-fungible applicationId baked in.
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     tracing::info!("Deploying FungibleBridge via forge script...");
     let bridge_addr = deploy_fungible_bridge(
         &compose,
@@ -241,6 +243,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         &chain_a_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
     tracing::info!(%bridge_addr, "FungibleBridge deployed");
@@ -446,33 +449,28 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     // Phase 9: Linera→EVM burn via cross-chain transfer
     // ══════════════════════════════════════════════════════════════════
     let evm_recipient = "70997970C51812dc3A010C7d01b50e0d17dc79C8";
-    let receiver: AccountOwner = format!("0x{evm_recipient}").parse()?;
+    let evm_recipient_addr: alloy::primitives::Address = format!("0x{evm_recipient}").parse()?;
     let withdraw_amount = U128(25u128 * 10u128.pow(18));
 
-    tracing::info!("Sending cross-chain withdrawal from chain B to Address20 on chain A...");
+    tracing::info!("Submitting Burn to the evm-bridge app from chain B...");
     cc_b.synchronize_from_validators().await?;
-    let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-        owner: owner_b,
+    let burn_bytes = bcs::to_bytes(&BridgeOperation::Burn {
         amount: withdraw_amount,
-        target_account: Account {
-            chain_id: chain_a,
-            owner: receiver,
-        },
+        evm_target: evm_recipient_addr.0 .0,
     })?;
     cc_b.execute_operations(
         vec![Operation::User {
-            application_id: fungible_app_id,
-            bytes: withdraw_bytes,
+            application_id: bridge_app_id,
+            bytes: burn_bytes,
         }],
         vec![],
     )
     .await?
-    .expect("withdrawal committed");
-    tracing::info!("Cross-chain withdrawal committed on chain B");
+    .expect("burn committed");
+    tracing::info!("Burn submitted on chain B");
 
     // Wait for relay to burn and forward to EVM.
     tracing::info!("Waiting for ERC-20 balance...");
-    let evm_recipient_addr: alloy::primitives::Address = format!("0x{evm_recipient}").parse()?;
     let expected_balance = U256::from(25u128 * 10u128.pow(18));
 
     for attempt in 0..60 {

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -5,14 +5,14 @@
 //! the EVM side has provably released the underlying tokens, not merely
 //! because `addBlock` returned Ok.
 //!
-//! The setup deploys `FungibleBridge` with a `fungibleApplicationId`
-//! that does not match the real wrapped-fungible app the scanner
-//! watches, so `_onBlock`'s app-id check rejects every burn event the
-//! relayer forwards. `addBlock` still succeeds (the cert is valid)
-//! but no `token.transfer` runs. Completion is gated on the per-burn
-//! `isBurnProcessed(height, eventIndex)` query, which stays false, so
-//! `linera_bridge_burns_completed` must remain at 0 for every detected
-//! burn.
+//! The setup deploys `FungibleBridge` with a `bridgeApplicationId`
+//! that does not match the real evm-bridge app whose "burns" stream the
+//! scanner watches, so `_onBlock`'s `_isMatchingBurn` app-id check
+//! rejects every burn event the relayer forwards. `addBlock` still
+//! succeeds (the cert is valid) but no `token.transfer` runs. Completion
+//! is gated on the per-burn `isBurnProcessed(height, eventIndex)` query,
+//! which stays false, so `linera_bridge_burns_completed` must remain at 0
+//! for every detected burn.
 
 #![recursion_limit = "512"]
 
@@ -25,9 +25,11 @@ use alloy::{
     sol,
 };
 use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
+use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
-    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
+    light_client_address, parse_metric_value, publish_and_create_evm_bridge,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
     wait_for_light_client, wait_for_relay_http_ready, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
@@ -36,7 +38,6 @@ use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use wrapped_fungible::{Account, WrappedFungibleOperation};
 
 sol! {
     #[sol(rpc)]
@@ -45,10 +46,12 @@ sol! {
     }
 }
 
-/// `bytes32` value with no relation to any real wrapped-fungible application
-/// description hash. Used as the `_fungibleApplicationId` in the deployed
-/// `FungibleBridge` so that `_onBlock`'s app-id check rejects every burn
-/// event the scanner forwards. Non-zero to satisfy the constructor guard.
+/// `bytes32` value with no relation to any real evm-bridge application
+/// description hash. Used as the `_bridgeApplicationId` in the deployed
+/// `FungibleBridge` so that `_onBlock`'s `_isMatchingBurn` app-id check
+/// rejects every burn event the scanner forwards (the BurnEvents are
+/// emitted on the evm-bridge app's "burns" stream, matched against
+/// `bridgeApplicationId`). Non-zero to satisfy the constructor guard.
 const SYNTHETIC_APP_ID_BYTES32: &str =
     "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
@@ -101,8 +104,9 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     )
     .await?;
 
-    // Chain A hosts the wrapped-fungible app and is the chain the relayer
-    // operates on. Chain B is the user chain initiating the burn.
+    // Chain A is the bridge/mint chain: it hosts the evm-bridge app and is
+    // the chain the relayer operates on. Chain B is the user chain that
+    // holds the wrapped tokens and initiates the burn.
     let owner_a = AccountOwner::from(signer.generate_new());
     let chain_a_desc = faucet.claim(&owner_a).await?;
     let chain_a = chain_a_desc.id();
@@ -119,19 +123,40 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
 
-    // The created app's `application_description_hash` is the *real*
-    // fungible_app_id the scanner will see in burn events. The deployed
-    // `FungibleBridge` is given a *different* id
-    // (`SYNTHETIC_APP_ID_BYTES32`) below so `_onBlock` rejects every
-    // burn event the relayer forwards.
-    let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
-    let real_app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    // The evm-bridge app drives the burn; create it on the bridge/mint chain
+    // (chain A) before the wrapped-fungible app so its id can be baked in.
+    // Its `application_description_hash` is the *real* bridge app id the
+    // scanner will see as the burn event's stream application. The deployed
+    // `FungibleBridge` is given a *different* `bridgeApplicationId`
+    // (`SYNTHETIC_APP_ID_BYTES32`) below so `_onBlock`'s `_isMatchingBurn`
+    // rejects every burn event the relayer forwards.
+    let fungible_app_id = publish_and_create_wrapped_fungible(
+        &cc_b,
+        owner_b,
+        chain_a,
+        erc20_addr,
+        1_000 * 10u128.pow(18),
+    )
+    .await?;
+
+    let bridge_app_id = publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+
+    // Register the wrapped-fungible app with the evm-bridge so it can drive
+    // the escrow transfer + burn.
+    register_bridge_app(&cc_a, fungible_app_id, bridge_app_id).await?;
+
+    let real_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     assert_ne!(
         real_app_id_bytes32, SYNTHETIC_APP_ID_BYTES32,
-        "real app ID collided with the synthetic value used to misconfigure the bridge"
+        "real bridge app ID collided with the synthetic value used to misconfigure the bridge"
     );
 
+    // `fungibleApplicationId` is set to the real wrapped-fungible app (used
+    // only by the deposit path, which never runs here). The match that
+    // `_onBlock` actually uses for burn events is `bridgeApplicationId`,
+    // which we deliberately set to the non-matching synthetic value so every
+    // forwarded burn event is rejected.
+    let fungible_app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");
     let bridge_addr = deploy_fungible_bridge(
         &compose,
@@ -140,6 +165,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
         light_client_address(),
         &chain_a_bytes32,
         erc20_addr,
+        &fungible_app_id_bytes32,
         SYNTHETIC_APP_ID_BYTES32,
     )
     .await?;
@@ -183,10 +209,11 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
 
     let relay_port = 3003u16;
     let bridge_addr_str = format!("{bridge_addr}");
-    // The relayer needs an evm-bridge app ID even though this test never
-    // uses the EVM→Linera direction. Reuse the wrapped-fungible app ID as
-    // a syntactically valid placeholder — no deposit flow runs against it.
-    let bridge_app_str = format!("{fungible_app_id}");
+    // The relayer monitors the evm-bridge app's "burns" stream, so its
+    // bridge app ID must be the real `bridge_app_id`. It is the source of
+    // the BurnEvents the scanner detects and forwards. `fungible_app_id` is
+    // kept for its existing use.
+    let bridge_app_str = format!("{bridge_app_id}");
     let fungible_app_str = format!("{fungible_app_id}");
     let sqlite_path_for_relay = sqlite_path.clone();
     let relay_handle = tokio::spawn(async move {
@@ -220,32 +247,35 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
         return Err(error);
     }
 
-    // Trigger a single burn: chain B transfers wrapped tokens to an
-    // Address20 owner on chain A. The wrapped-fungible app on chain A
-    // detects the Credit-to-Address20 message and emits a `BurnEvent` on
-    // the "burns" stream, which the relayer's Linera scanner will pick up.
+    // Trigger a single burn: chain B submits a `BridgeOperation::Burn` to
+    // the evm-bridge app. The bridge app escrows + burns the wrapped tokens
+    // and routes a tracked `BridgeMessage::Burn` to the bridge chain
+    // (chain A); processing chain A's inbox materialises the `BurnEvent` on
+    // the evm-bridge app's "burns" stream, which the relayer's Linera
+    // scanner will pick up.
     let evm_recipient_hex = "70997970C51812dc3A010C7d01b50e0d17dc79C8";
-    let receiver: AccountOwner = format!("0x{evm_recipient_hex}").parse()?;
+    let recipient: alloy::primitives::Address = format!("0x{evm_recipient_hex}").parse()?;
     let burn_amount = U128(25u128 * 10u128.pow(18));
 
     cc_b.synchronize_from_validators().await?;
-    let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-        owner: owner_b,
+    let burn_bytes = bcs::to_bytes(&BridgeOperation::Burn {
         amount: burn_amount,
-        target_account: Account {
-            chain_id: chain_a,
-            owner: receiver,
-        },
+        evm_target: recipient.0 .0,
     })?;
     cc_b.execute_operations(
         vec![Operation::User {
-            application_id: fungible_app_id,
-            bytes: withdraw_bytes,
+            application_id: bridge_app_id,
+            bytes: burn_bytes,
         }],
         vec![],
     )
     .await?
-    .expect("cross-chain withdrawal committed on chain B");
+    .expect("burn operation committed on chain B");
+
+    // Drive chain A's inbox so the tracked `BridgeMessage::Burn` is
+    // processed and the `BurnEvent` lands on the evm-bridge "burns" stream.
+    cc_a.synchronize_from_validators().await?;
+    cc_a.process_inbox().await?;
 
     // Wait until the relayer has had a chance to detect the burn AND to
     // attempt forwarding it. `bridge_burns_detected` increments when the
@@ -306,9 +336,8 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     let burns_failed = parse_metric_value(&metrics_body, "linera_bridge_burns_failed");
     let burns_pending = parse_metric_value(&metrics_body, "linera_bridge_burns_pending");
 
-    let evm_recipient: alloy::primitives::Address = format!("0x{evm_recipient_hex}").parse()?;
     let token_balance = IERC20::new(erc20_addr, &provider)
-        .balanceOf(evm_recipient)
+        .balanceOf(recipient)
         .call()
         .await?;
 
@@ -330,7 +359,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
         token_balance,
         U256::ZERO,
         "no on-chain Transfer should have happened — \
-         _onBlock skips every event because fungibleApplicationId is mismatched"
+         _onBlock skips every event because bridgeApplicationId is mismatched"
     );
 
     // Bug demonstration: the relayer must not mark a burn as completed

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -12,10 +12,12 @@
 
 use alloy::{providers::ProviderBuilder, sol};
 use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
+use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token_with_supply, fetch_latest_cert,
-    fund_bridge_erc20, light_client_address, publish_and_create_wrapped_fungible,
-    set_anvil_block_gas_limit, start_compose, wait_for_light_client,
+    fund_bridge_erc20, light_client_address, publish_and_create_evm_bridge,
+    publish_and_create_wrapped_fungible, register_bridge_app, set_anvil_block_gas_limit,
+    start_compose, wait_for_light_client,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -24,7 +26,6 @@ use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use test_case::test_case;
-use wrapped_fungible::{Account, WrappedFungibleOperation};
 
 sol! {
     #[sol(rpc)]
@@ -51,8 +52,14 @@ const INITIAL_BALANCE_TOKENS: u128 = 10u128.pow(38);
 /// not by the amount value).
 const BURN_AMOUNT_TOKENS: u128 = 10u128.pow(15);
 
-#[test_case("ethereum",     30_000_000,  Some(50); "ethereum")]
-#[test_case("base",         240_000_000, Some(190); "base")]
+// Floors recalibrated for the bridge-driven burn flow: each burn now carries a
+// funding `Credit` plus a `BridgeMessage::Burn` in the chain-A block, so the
+// `verifyBlock` paid by `addBlock`/`processBurns` sees a heavier block — roughly
+// +22% gas per burn, ~18% fewer burns per EVM tx than the old auto-burn flow
+// (measured: base ~155, ethereum ~41). The floors are a sanity lower bound at
+// the new capacity, not a tight target.
+#[test_case("ethereum",     30_000_000,  Some(40); "ethereum")]
+#[test_case("base",         240_000_000, Some(150); "base")]
 #[tokio::test]
 #[serial_test::serial]
 #[ignore] // Requires pre-built docker images, Wasm, and bridge contracts.
@@ -132,6 +139,7 @@ async fn burns_per_evm_tx(
     let erc20_addr =
         deploy_linera_token_with_supply(&compose, &project_name, &compose_file, token_supply_attos)
             .await?;
+
     let fungible_app_id = publish_and_create_wrapped_fungible(
         &cc_b,
         owner_b,
@@ -141,7 +149,17 @@ async fn burns_per_evm_tx(
     )
     .await?;
 
+    // The evm-bridge app drives the burn; create it on the bridge/mint chain
+    // (chain A) after the wrapped-fungible app so its id can be baked in.
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+
+    // Register the wrapped-fungible app with the evm-bridge so it can drive
+    // the escrow transfer + burn.
+    register_bridge_app(&cc_a, fungible_app_id, bridge_app_id).await?;
+
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");
     let bridge_addr = deploy_fungible_bridge(
         &compose,
@@ -151,6 +169,7 @@ async fn burns_per_evm_tx(
         &chain_a_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
 
@@ -171,9 +190,7 @@ async fn burns_per_evm_tx(
         hi,
         &cc_a,
         &cc_b,
-        owner_b,
-        chain_a,
-        fungible_app_id,
+        bridge_app_id,
         bridge_addr,
         &provider,
     )
@@ -186,9 +203,7 @@ async fn burns_per_evm_tx(
             next_hi,
             &cc_a,
             &cc_b,
-            owner_b,
-            chain_a,
-            fungible_app_id,
+            bridge_app_id,
             bridge_addr,
             &provider,
         )
@@ -217,9 +232,7 @@ async fn burns_per_evm_tx(
             lo,
             &cc_a,
             &cc_b,
-            owner_b,
-            chain_a,
-            fungible_app_id,
+            bridge_app_id,
             bridge_addr,
             &provider,
         )
@@ -261,9 +274,7 @@ async fn burns_per_evm_tx(
             mid,
             &cc_a,
             &cc_b,
-            owner_b,
-            chain_a,
-            fungible_app_id,
+            bridge_app_id,
             bridge_addr,
             &provider,
         )
@@ -293,21 +304,19 @@ async fn burns_per_evm_tx(
     Ok(())
 }
 
-/// Bundles `n` `WrappedFungibleOperation::Transfer` ops into a single
-/// chain-B block, drives `cc_a.process_inbox()` (which produces one
-/// chain-A block with `n` `BurnEvent`s), reads the resulting
+/// Bundles `n` `BridgeOperation::Burn` ops into a single chain-B block;
+/// each routes a funding transfer + tracked `BridgeMessage::Burn` to the
+/// bridge chain (chain A). Drives `cc_a.process_inbox()` (which produces
+/// one chain-A block with `n` `BurnEvent`s), reads the resulting
 /// `ConfirmedBlockCertificate`, BCS-encodes it, and asks anvil to
 /// estimate the gas required by `bridge.addBlock(cert_bytes)`.
 ///
 /// Returns the estimated gas. Reverts surface as `Err`.
-#[allow(clippy::too_many_arguments)]
 async fn build_and_estimate<P, E>(
     n: u32,
     cc_a: &linera_core::client::ChainClient<E>,
     cc_b: &linera_core::client::ChainClient<E>,
-    owner_b: AccountOwner,
-    chain_a: linera_base::identifiers::ChainId,
-    fungible_app_id: linera_base::identifiers::ApplicationId,
+    bridge_app_id: linera_base::identifiers::ApplicationId,
     bridge_addr: alloy::primitives::Address,
     provider: &P,
 ) -> anyhow::Result<u64>
@@ -324,21 +333,16 @@ where
             // iteration counter so log inspection makes the address ↔ burn
             // mapping easy to read. Start from 1 — `Address20(0…0)` is the
             // zero address and ERC-20 rejects transfers to it.
-            let mut bytes = [0u8; 20];
-            bytes[16..].copy_from_slice(&i.to_be_bytes());
-            let owner = AccountOwner::Address20(bytes);
-            let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-                owner: owner_b,
+            let mut evm_target = [0u8; 20];
+            evm_target[16..].copy_from_slice(&i.to_be_bytes());
+            let burn_bytes = bcs::to_bytes(&BridgeOperation::Burn {
                 amount: burn_amount,
-                target_account: Account {
-                    chain_id: chain_a,
-                    owner,
-                },
+                evm_target,
             })
             .expect("BCS serialization");
             Operation::User {
-                application_id: fungible_app_id,
-                bytes: withdraw_bytes,
+                application_id: bridge_app_id,
+                bytes: burn_bytes,
             }
         })
         .collect::<Vec<_>>();

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -16,7 +16,8 @@ use linera_base::{
 use linera_bridge_e2e::{
     compose_file_path, create_extra_wallet, deploy_fungible_bridge, deploy_linera_token,
     dump_compose_logs, exec_ok, extra_wallet_env, light_client_address,
-    publish_and_create_wrapped_fungible, start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
+    publish_and_create_evm_bridge, publish_and_create_wrapped_fungible, register_bridge_app,
+    start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -122,8 +123,19 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
     .await?;
     tracing::info!(%fungible_app_id, "wrapped-fungible app created");
 
+    // The evm-bridge app drives the burn; create it on the bridge/mint chain
+    // (the relay chain) after the wrapped-fungible app so its id can be baked in.
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc, erc20_addr, relay_chain_id, fungible_app_id).await?;
+    tracing::info!(%bridge_app_id, "evm-bridge app created");
+
+    // Register the wrapped-fungible app with the evm-bridge so it can drive
+    // the escrow transfer + burn.
+    register_bridge_app(&cc, fungible_app_id, bridge_app_id).await?;
+
     let chain_id_bytes32 = format!("0x{relay_chain_id}");
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     let light_client = light_client_address();
     let bridge_addr = deploy_fungible_bridge(
         &compose,
@@ -133,6 +145,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
         &chain_id_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
     tracing::info!(%bridge_addr, "FungibleBridge deployed");
@@ -155,9 +168,8 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
     linera_wallet_json::PersistentWallet::create(&wallet_path, relay_genesis_config)?;
 
     let bridge_addr_str = format!("{bridge_addr}");
+    let bridge_app_str = format!("{bridge_app_id}");
     let fungible_app_str = format!("{fungible_app_id}");
-    // evm-bridge app is not needed for committee relay; use a placeholder that parses.
-    let dummy_bridge_app = "0000000000000000000000000000000000000000000000000000000000000000";
     let relay_handle = tokio::spawn(async move {
         Box::pin(linera_bridge::relay::run(
             "http://localhost:8545",
@@ -167,7 +179,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             relay_chain_id,
             relay_owner,
             &bridge_addr_str,
-            dummy_bridge_app,
+            &bridge_app_str,
             &fungible_app_str,
             ANVIL_PRIVATE_KEY,
             Some(&light_client.to_string()),

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -149,7 +149,8 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     cc.synchronize_from_validators().await?;
     cc.process_inbox().await?;
 
-    // 4b. Publish and create evm-bridge app first (so wrapped-fungible can reference it)
+    // 4b. Publish evm-bridge module (created after wrapped-fungible so it can
+    // take the wrapped applicationId as a creation parameter).
     tracing::info!("Publishing evm-bridge module...");
     let eb_contract =
         Bytecode::load_from_file(evm_bridge_wasm_dir.join("evm_bridge_contract.wasm"))?;
@@ -163,34 +164,14 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     cc.synchronize_from_validators().await?;
     cc.process_inbox().await?;
 
-    tracing::info!("Creating evm-bridge application...");
-    let bridge_params = BridgeParameters {
-        source_chain_id: 31337,
-        token_address: erc20_addr.0 .0,
-    };
-    let (bridge_app_id, _) = cc
-        .create_application_untyped(
-            eb_module_id,
-            serde_json::to_vec(&bridge_params)?,
-            serde_json::to_vec(&BridgeInstantiationArgument {
-                rpc_endpoint: String::new(),
-            })?,
-            vec![],
-        )
-        .await?
-        .expect("create evm-bridge app committed");
-    tracing::info!(%bridge_app_id, "evm-bridge app created");
-
-    // 4c. Create wrapped-fungible app with bridge_app_id
+    // 4c. Create wrapped-fungible app first (its id is a parameter of the bridge)
     tracing::info!("Creating wrapped-fungible application...");
     let wrapped_params = WrappedParameters {
         ticker_symbol: "wTEST".to_string(),
         decimals: 18,
-        minter: Some(owner),
-        mint_chain_id: Some(chain_id),
+        mint_chain_id: chain_id,
         evm_token_address: erc20_addr.0 .0,
         evm_source_chain_id: 31337,
-        bridge_app_id: Some(bridge_app_id),
     };
     let wrapped_init = InitialState {
         accounts: BTreeMap::new(),
@@ -206,22 +187,44 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         .expect("create wrapped-fungible app committed");
     tracing::info!(%fungible_app_id, "wrapped-fungible app created");
 
-    // 4d. Register fungible app in the bridge
-    tracing::info!("Registering fungible app in bridge...");
-    let register_op = BridgeOperation::RegisterFungibleApp {
-        app_id: fungible_app_id,
+    // 4d. Create evm-bridge app with the wrapped-fungible app id as a parameter
+    tracing::info!("Creating evm-bridge application...");
+    let bridge_params = BridgeParameters {
+        source_chain_id: 31337,
+        token_address: erc20_addr.0 .0,
+        bridge_chain_id: chain_id,
+        fungible_app_id,
+    };
+    let (bridge_app_id, _) = cc
+        .create_application_untyped(
+            eb_module_id,
+            serde_json::to_vec(&bridge_params)?,
+            serde_json::to_vec(&BridgeInstantiationArgument {
+                rpc_endpoint: String::new(),
+            })?,
+            vec![],
+        )
+        .await?
+        .expect("create evm-bridge app committed");
+    tracing::info!(%bridge_app_id, "evm-bridge app created");
+
+    // 4e. Register the bridge app on the wrapped-fungible app
+    tracing::info!("Registering bridge app in wrapped-fungible...");
+    let register_op = wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
+        app_id: bridge_app_id,
     };
     let register_bytes = bcs::to_bytes(&register_op)?;
     let register_operation = Operation::User {
-        application_id: bridge_app_id,
+        application_id: fungible_app_id,
         bytes: register_bytes,
     };
     cc.execute_operations(vec![register_operation], vec![])
         .await?
-        .expect("register fungible app committed");
+        .expect("register bridge app committed");
 
-    // 4e. Deploy FungibleBridge with the wrapped-fungible applicationId baked in
+    // 4f. Deploy FungibleBridge with the wrapped-fungible applicationId baked in
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     let light_client = light_client_address();
     tracing::info!("Deploying FungibleBridge via forge script...");
     let bridge_addr = deploy_fungible_bridge(
@@ -232,11 +235,12 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &chain_id_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
     tracing::info!(%bridge_addr, "FungibleBridge deployed");
 
-    // 4f. Register the FungibleBridge contract address in the evm-bridge app
+    // 4g. Register the FungibleBridge contract address in the evm-bridge app
     tracing::info!("Registering FungibleBridge address in evm-bridge...");
     let register_bridge_op = BridgeOperation::RegisterFungibleBridge {
         address: bridge_addr.0 .0,

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -23,6 +23,7 @@ use linera_base::{
     identifiers::AccountOwner,
     vm::VmRuntime,
 };
+use linera_bridge::abi::{BridgeInstantiationArgument, BridgeOperation, BridgeParameters};
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, exec_ok, light_client_address,
     start_compose, wait_for_light_client, ANVIL_PRIVATE_KEY,
@@ -116,14 +117,26 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     // Collect all chain A certificate bytes to submit to the bridge in sequential order.
     let mut chain_a_cert_bytes: Vec<Vec<u8>> = Vec::new();
 
-    // ── 3. Publish and create wrapped-fungible app on chain A ──
-    tracing::info!("Publishing wrapped-fungible module...");
+    // ── 2b. Deploy LineraToken on Anvil ──
+    // Done before creating the Linera apps so its address can be baked into both the
+    // evm-bridge `token_address` and the wrapped-fungible `evm_token_address`.
+    tracing::info!("Deploying LineraToken via forge script...");
+    let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
+    tracing::info!(%erc20_addr, "LineraToken deployed");
+
+    // ── 3. Publish and create the wrapped-fungible app, then evm-bridge, on chain A ──
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .ancestors()
         .nth(3)
         .context("manifest dir has fewer than 3 ancestors")?
         .to_path_buf();
+    let evm_bridge_wasm_dir =
+        repo_root.join("linera-bridge/contracts/evm-bridge/target/wasm32-unknown-unknown/release");
     let wasm_dir = repo_root.join("examples/target/wasm32-unknown-unknown/release");
+
+    // 3a. Publish and create the wrapped-fungible app first. The evm-bridge app takes the
+    // wrapped-fungible app id as a creation parameter, so it must exist beforehand.
+    tracing::info!("Publishing wrapped-fungible module...");
     let contract_bytecode =
         Bytecode::load_from_file(wasm_dir.join("wrapped_fungible_contract.wasm"))?;
     let service_bytecode =
@@ -146,13 +159,9 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     let params = WrappedParameters {
         ticker_symbol: "TEST".to_string(),
         decimals: 18,
-        minter: Some(owner_a),
-        mint_chain_id: Some(chain_a),
-        evm_token_address: [0u8; 20],
+        mint_chain_id: chain_a,
+        evm_token_address: erc20_addr.0 .0,
         evm_source_chain_id: 31337,
-        // This test doesn't deploy the evm-bridge Linera app (only the Solidity side),
-        // so bridge_app_id is unused. Mint is never called in this test.
-        bridge_app_id: None,
     };
     let init_state = InitialState {
         accounts: BTreeMap::from([(owner_a, U128(1000u128 * 10u128.pow(18)))]),
@@ -173,6 +182,62 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     tracing::info!(%app_id, "Application created");
     chain_a_cert_bytes.push(bcs::to_bytes(&create_cert)?);
 
+    // 3b. Publish and create the evm-bridge app, pointing it at the wrapped-fungible app
+    // via `fungible_app_id`. It drives the burn: a user submits `BridgeOperation::Burn`
+    // here, and the app emits the `BurnEvent` that FungibleBridge matches against its
+    // `bridgeApplicationId`.
+    tracing::info!("Publishing evm-bridge module...");
+    let eb_contract =
+        Bytecode::load_from_file(evm_bridge_wasm_dir.join("evm_bridge_contract.wasm"))?;
+    let eb_service = Bytecode::load_from_file(evm_bridge_wasm_dir.join("evm_bridge_service.wasm"))?;
+    let (eb_module_id, eb_publish_cert) = cc_a
+        .publish_module(eb_contract, eb_service, VmRuntime::Wasm)
+        .await?
+        .expect("publish evm-bridge module committed");
+    tracing::info!(height=?eb_publish_cert.inner().block().header.height, "evm-bridge module published");
+    chain_a_cert_bytes.push(bcs::to_bytes(&eb_publish_cert)?);
+    cc_a.synchronize_from_validators().await?;
+    let (eb_inbox_certs, _) = cc_a.process_inbox().await?;
+    for c in &eb_inbox_certs {
+        chain_a_cert_bytes.push(bcs::to_bytes(c)?);
+    }
+
+    tracing::info!("Creating evm-bridge application...");
+    let (bridge_app_id, eb_create_cert) = cc_a
+        .create_application_untyped(
+            eb_module_id,
+            serde_json::to_vec(&BridgeParameters {
+                source_chain_id: 31337,
+                token_address: erc20_addr.0 .0,
+                bridge_chain_id: chain_a,
+                fungible_app_id: app_id,
+            })?,
+            serde_json::to_vec(&BridgeInstantiationArgument {
+                rpc_endpoint: String::new(),
+            })?,
+            vec![],
+        )
+        .await?
+        .expect("create evm-bridge app committed");
+    tracing::info!(%bridge_app_id, "evm-bridge app created");
+    chain_a_cert_bytes.push(bcs::to_bytes(&eb_create_cert)?);
+
+    // 3c. Register the evm-bridge app on the wrapped-fungible app so the bridge can
+    // drive the burn. This must happen before any Burn operation is submitted.
+    tracing::info!("Registering evm-bridge app in wrapped-fungible...");
+    let register_bytes = bcs::to_bytes(&WrappedFungibleOperation::RegisterAuthorizedCaller {
+        app_id: bridge_app_id,
+    })?;
+    let register_op = Operation::User {
+        application_id: app_id,
+        bytes: register_bytes,
+    };
+    let register_cert = cc_a
+        .execute_operations(vec![register_op], vec![])
+        .await?
+        .expect("register bridge app committed");
+    chain_a_cert_bytes.push(bcs::to_bytes(&register_cert)?);
+
     // ── 4. Claim chain B (user chain) from faucet and subscribe to notifications ──
     tracing::info!("Claiming chain B from faucet...");
     let owner_b = AccountOwner::from(signer.generate_new());
@@ -186,13 +251,12 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     let (listener, _abort_handle, _) = cc_b.listen().await?;
     tokio::spawn(listener);
 
-    // ── 5. Deploy LineraToken on Anvil ──
-    tracing::info!("Deploying LineraToken via forge script...");
-    let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
-    tracing::info!(%erc20_addr, "LineraToken deployed");
-
     // ── 6. Deploy FungibleBridge on Anvil ──
+    // The wrapped-fungible app id (`app_id_bytes32`) is still required as the deposit
+    // target; the new `bridge_app_id_bytes32` is what the bridge matches BurnEvents
+    // against (burns are now driven and emitted by the evm-bridge app).
     let app_id_bytes32 = format!("0x{}", app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");
 
     tracing::info!("Deploying FungibleBridge via forge script...");
@@ -204,6 +268,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &chain_a_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
     tracing::info!(%bridge_addr, "FungibleBridge deployed");
@@ -278,26 +343,31 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         "process_inbox should produce at least one certificate"
     );
 
-    // ── 10. Withdraw: owner_b transfers tokens from chain B to evm_recipient on chain A ──
-    tracing::info!("Withdrawing tokens from chain B to evm_recipient on chain A...");
-    let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-        owner: owner_b,
-        amount: U128(100u128 * 10u128.pow(18)),
-        target_account: Account {
-            chain_id: chain_a,
-            owner: receiver,
-        },
-    })?;
-    let withdraw_op = Operation::User {
-        application_id: app_id,
-        bytes: withdraw_bytes,
+    // ── 10. Burn: owner_b submits a `BridgeOperation::Burn` to the evm-bridge app on
+    // chain B. The bridge moves the tokens into its escrow on the bridge chain
+    // (chain A) and burns them, emitting the `BurnEvent` there. ──
+    let evm_target: [u8; 20] = match receiver {
+        AccountOwner::Address20(bytes) => bytes,
+        other => anyhow::bail!("expected Address20 receiver, got {other:?}"),
     };
-    cc_b.execute_operations(vec![withdraw_op], vec![])
-        .await?
-        .expect("withdrawal committed");
 
-    // ── 11. Process inbox on chain A to receive the withdrawal ──
-    tracing::info!("Processing inbox on chain A...");
+    tracing::info!("Submitting Burn operation to evm-bridge app on chain B...");
+    let burn_bytes = bcs::to_bytes(&BridgeOperation::Burn {
+        amount: U128(100u128 * 10u128.pow(18)),
+        evm_target,
+    })?;
+    let burn_op = Operation::User {
+        application_id: bridge_app_id,
+        bytes: burn_bytes,
+    };
+    cc_b.execute_operations(vec![burn_op], vec![])
+        .await?
+        .expect("burn operation committed");
+
+    // ── 11. Process inbox on chain A so the Credit+Burn bundle lands and the
+    // evm-bridge app emits the `BurnEvent` in a chain A block. Collect those certs
+    // so the BurnEvent block is submitted to FungibleBridge. ──
+    tracing::info!("Processing inbox on chain A to drive the burn...");
     cc_a.synchronize_from_validators().await?;
     let (inbox_a_certs, _) = cc_a.process_inbox().await?;
     for c in &inbox_a_certs {
@@ -305,8 +375,9 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     }
 
     // ── 12. Submit all chain A blocks to FungibleBridge sequentially ──
-    // The inbox processing in step 11 auto-burned the tokens and emitted a
-    // BurnEvent, so no explicit Burn operation is needed.
+    // Step 11's inbox processing landed the Credit+Burn bundle, so the evm-bridge app
+    // burned the escrowed tokens and emitted a `BurnEvent` in a chain A block (collected
+    // above). FungibleBridge matches that event against its `bridgeApplicationId`.
     tracing::info!(
         count = chain_a_cert_bytes.len(),
         "Submitting all chain A blocks to bridge"

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -10,9 +10,12 @@
 //! `evm_setBlockGasLimit`) before the bridge is deployed, so `addBlock`
 //! at `NUM_BURNS = 8` does not fit and the relayer must take the
 //! `processBurns` chunk path. Chain B submits one block with N
-//! `Transfer` operations to N distinct recipients on chain A. After the
-//! relayer is spawned, every recipient must hold the correct ERC-20
-//! balance and `linera_bridge_burns_completed` must reach N.
+//! `BridgeOperation::Burn` operations toward N distinct EVM recipients;
+//! each routes a funding transfer + tracked `BridgeMessage::Burn` to the
+//! bridge chain (chain A), which processes its inbox in a single block
+//! that carries all N `BurnEvent`s. After the relayer is spawned, every
+//! recipient must hold the correct ERC-20 balance and
+//! `linera_bridge_burns_completed` must reach N.
 
 #![recursion_limit = "512"]
 
@@ -27,11 +30,13 @@ use alloy::{
     sol,
 };
 use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
+use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
-    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible,
-    set_anvil_block_gas_limit, start_compose, wait_for_light_client, wait_for_relay_http_ready,
-    wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
+    light_client_address, parse_metric_value, publish_and_create_evm_bridge,
+    publish_and_create_wrapped_fungible, register_bridge_app, set_anvil_block_gas_limit,
+    start_compose, wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics,
+    ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
@@ -39,7 +44,6 @@ use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use wrapped_fungible::{Account, WrappedFungibleOperation};
 
 sol! {
     #[sol(rpc)]
@@ -51,10 +55,12 @@ sol! {
 const NUM_BURNS: usize = 8;
 const BURN_AMOUNT_TOKENS: u128 = 1;
 /// Per-block gas ceiling sized to live between `processBurns(cert, tx, [single])`
-/// (which is dominated by cert verification, ~2–2.5M gas) and `addBlock(cert)`
-/// for `NUM_BURNS` burns (~3.3M gas observed in `burns_per_evm_tx`). The
-/// relayer must therefore route through chunked `processBurns` per tx.
-const ANVIL_BLOCK_GAS_LIMIT: u64 = 3_000_000;
+/// (~3.8M gas, measured — dominated by `verifyBlock` in the
+/// bridge-driven burn flow where each burn adds a funding `Credit` plus a
+/// `BridgeMessage::Burn` to the chain-A block) and `addBlock(cert)` for all
+/// `NUM_BURNS` burns (~4.21M gas, measured). `addBlock` therefore cannot fit,
+/// so the relayer routes through chunked per-tx `processBurns` instead.
+const ANVIL_BLOCK_GAS_LIMIT: u64 = 4_000_000;
 
 #[tokio::test]
 #[ignore] // Requires pre-built docker images, Wasm, and relay binary.
@@ -125,10 +131,26 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
     cc_b.synchronize_from_validators().await?;
 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
-    let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
+
+    // The evm-bridge app drives the burn; create it on the bridge/mint chain
+    // (chain A) before the wrapped-fungible app so its id can be baked in.
+    let fungible_app_id = publish_and_create_wrapped_fungible(
+        &cc_b,
+        owner_b,
+        chain_a,
+        erc20_addr,
+        1_000 * 10u128.pow(18),
+    )
+    .await?;
+
+    let bridge_app_id = publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+
+    // Register the wrapped-fungible app with the evm-bridge so it can drive
+    // the escrow transfer + burn.
+    register_bridge_app(&cc_a, fungible_app_id, bridge_app_id).await?;
 
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");
     let bridge_addr = deploy_fungible_bridge(
         &compose,
@@ -138,6 +160,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
         &chain_a_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
 
@@ -169,24 +192,20 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
     ];
     let burn_amount = U128(BURN_AMOUNT_TOKENS * 10u128.pow(18));
 
-    // Bundle every Transfer into one chain-B block; chain-A's
-    // process_inbox produces a single chain-A block with N BurnEvents.
+    // Bundle every Burn into one chain-B block; each routes a funding
+    // transfer + tracked BridgeMessage::Burn to chain A, whose process_inbox
+    // then produces a single chain-A block with N BurnEvents.
     let operations = recipients
         .iter()
         .map(|recipient| {
-            let owner = AccountOwner::Address20(recipient.0 .0);
-            let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-                owner: owner_b,
+            let burn_bytes = bcs::to_bytes(&BridgeOperation::Burn {
                 amount: burn_amount,
-                target_account: Account {
-                    chain_id: chain_a,
-                    owner,
-                },
+                evm_target: recipient.0 .0,
             })
             .expect("BCS serialization");
             Operation::User {
-                application_id: fungible_app_id,
-                bytes: withdraw_bytes,
+                application_id: bridge_app_id,
+                bytes: burn_bytes,
             }
         })
         .collect();
@@ -222,7 +241,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
 
     let relay_port = 3009u16;
     let bridge_addr_str = format!("{bridge_addr}");
-    let bridge_app_str = format!("{fungible_app_id}");
+    let bridge_app_str = format!("{bridge_app_id}");
     let fungible_app_str = format!("{fungible_app_id}");
     let sqlite_path_for_relay = sqlite_path.clone();
     let relay_handle = tokio::spawn(async move {

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -3,14 +3,16 @@
 
 //! Verifies that multiple `BurnEvent`s in a single Linera block are all
 //! relayed and completed on the EVM side. The user chain submits one
-//! block carrying N `Transfer` operations to N distinct `Address20`
-//! recipients on the bridge chain. The test process drives the inbox
-//! processing on the bridge chain so the resulting `Credit` messages
-//! all land in one chain-A block — a single cert with N `BurnEvent`s.
-//! After the relayer is spawned, exactly one `addBlock` call should
-//! release all N tokens (one `token.transfer` per burn in `_onBlock`)
-//! and the relayer must mark every pending burn complete via the
-//! per-burn `isBurnProcessed(height, eventIndex)` view.
+//! block carrying N `BridgeOperation::Burn` operations to the evm-bridge
+//! app, each targeting a distinct EVM recipient. The evm-bridge app
+//! escrows + burns the wrapped tokens and routes a tracked
+//! `BridgeMessage::Burn` to the bridge chain (chain A). The test process
+//! drives chain A's inbox once so all N messages land in one chain-A
+//! block — a single cert with N `BurnEvent`s. After the relayer is
+//! spawned, exactly one `addBlock` call should release all N tokens (one
+//! `token.transfer` per burn in `_onBlock`) and the relayer must mark
+//! every pending burn complete via the per-burn
+//! `isBurnProcessed(height, eventIndex)` view.
 
 #![recursion_limit = "512"]
 
@@ -18,9 +20,11 @@ use std::time::Duration;
 
 use alloy::{primitives::U256, providers::ProviderBuilder, sol};
 use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
+use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
-    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
+    light_client_address, parse_metric_value, publish_and_create_evm_bridge,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
     wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
@@ -29,7 +33,6 @@ use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use wrapped_fungible::{Account, WrappedFungibleOperation};
 
 sol! {
     #[sol(rpc)]
@@ -107,10 +110,24 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
 
-    let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
+    let fungible_app_id = publish_and_create_wrapped_fungible(
+        &cc_b,
+        owner_b,
+        chain_a,
+        erc20_addr,
+        1_000 * 10u128.pow(18),
+    )
+    .await?;
+
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+
+    // Register the wrapped-fungible app with the evm-bridge so it can drive
+    // the escrow transfer + burn.
+    register_bridge_app(&cc_a, fungible_app_id, bridge_app_id).await?;
 
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");
     let bridge_addr = deploy_fungible_bridge(
         &compose,
@@ -120,6 +137,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         &chain_a_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
 
@@ -146,26 +164,22 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     ];
     let burn_amount = U128(BURN_AMOUNT_TOKENS * 10u128.pow(18));
 
-    // Bundle every Transfer into a SINGLE chain-B block, then drive
-    // chain A's inbox once. The N Credit messages travel together
-    // and `process_inbox` materialises one chain-A block containing
-    // all N BurnEvents.
+    // Bundle every Burn into a SINGLE chain-B block, then drive chain A's
+    // inbox once. Each Burn routes a funding transfer + tracked
+    // `BridgeMessage::Burn` to chain A; the messages travel together and
+    // `process_inbox` materialises one chain-A block containing all N
+    // BurnEvents.
     let operations = recipients
         .iter()
         .map(|recipient| {
-            let owner = AccountOwner::Address20(recipient.0 .0);
-            let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-                owner: owner_b,
+            let burn_bytes = bcs::to_bytes(&BridgeOperation::Burn {
                 amount: burn_amount,
-                target_account: Account {
-                    chain_id: chain_a,
-                    owner,
-                },
+                evm_target: recipient.0 .0,
             })
             .expect("BCS serialization");
             Operation::User {
-                application_id: fungible_app_id,
-                bytes: withdraw_bytes,
+                application_id: bridge_app_id,
+                bytes: burn_bytes,
             }
         })
         .collect();
@@ -201,7 +215,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
 
     let relay_port = 3005u16;
     let bridge_addr_str = format!("{bridge_addr}");
-    let bridge_app_str = format!("{fungible_app_id}");
+    let bridge_app_str = format!("{bridge_app_id}");
     let fungible_app_str = format!("{fungible_app_id}");
     let sqlite_path_for_relay = sqlite_path.clone();
     let relay_handle = tokio::spawn(async move {

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -8,12 +8,14 @@
 //!
 //! Setup: 5 burns to the same EVM recipient, materialised as 5
 //! separate Linera blocks on the bridge chain BEFORE the relayer is
-//! spawned. The test process drives both the cross-chain `Transfer`
-//! on the user chain and the inbox processing on the bridge chain,
-//! so each `Credit` lands in its own block deterministically (no
-//! race with the relayer's notification loop batching multiple
-//! `Credit`s into one block). When the relayer starts, its first
-//! scan iteration finds all 5 pending burns at once.
+//! spawned. Each iteration submits one `BridgeOperation::Burn` to the
+//! evm-bridge app on the user chain — the app escrows + burns the
+//! wrapped tokens and routes a tracked `BridgeMessage::Burn` to the
+//! bridge chain (chain A) — and the test process then drives chain
+//! A's inbox once, so each `BurnEvent` lands in its own block
+//! deterministically (no race with the relayer's notification loop
+//! batching multiple events into one block). When the relayer
+//! starts, its first scan iteration finds all 5 pending burns at once.
 //!
 //! The relayer must forward every burn via `addBlock` and the
 //! per-burn `isBurnProcessed(height, eventIndex)` query must return
@@ -26,9 +28,11 @@ use std::time::Duration;
 
 use alloy::{primitives::U256, providers::ProviderBuilder, sol};
 use linera_base::{crypto::InMemorySigner, data_types::U128, identifiers::AccountOwner};
+use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
-    light_client_address, parse_metric_value, publish_and_create_wrapped_fungible, start_compose,
+    light_client_address, parse_metric_value, publish_and_create_evm_bridge,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
     wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
@@ -37,7 +41,6 @@ use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
 use linera_storage::{DbStorage, StorageCacheConfig};
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
-use wrapped_fungible::{Account, WrappedFungibleOperation};
 
 sol! {
     #[sol(rpc)]
@@ -115,10 +118,24 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
 
     let erc20_addr = deploy_linera_token(&compose, project_name, &compose_file).await?;
 
-    let fungible_app_id =
-        publish_and_create_wrapped_fungible(&cc_b, owner_b, chain_a, erc20_addr, 1_000 * 10u128.pow(18)).await?;
+    let fungible_app_id = publish_and_create_wrapped_fungible(
+        &cc_b,
+        owner_b,
+        chain_a,
+        erc20_addr,
+        1_000 * 10u128.pow(18),
+    )
+    .await?;
+
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+
+    // Register the wrapped-fungible app with the evm-bridge so it can drive
+    // the escrow transfer + burn.
+    register_bridge_app(&cc_a, fungible_app_id, bridge_app_id).await?;
 
     let app_id_bytes32 = format!("0x{}", fungible_app_id.application_description_hash);
+    let bridge_app_id_bytes32 = format!("0x{}", bridge_app_id.application_description_hash);
     let chain_a_bytes32 = format!("0x{chain_a}");
     let bridge_addr = deploy_fungible_bridge(
         &compose,
@@ -128,6 +145,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
         &chain_a_bytes32,
         erc20_addr,
         &app_id_bytes32,
+        &bridge_app_id_bytes32,
     )
     .await?;
 
@@ -143,28 +161,28 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
 
     let evm_recipient: alloy::primitives::Address =
         "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".parse()?;
-    let receiver = AccountOwner::Address20(evm_recipient.0 .0);
     let burn_amount = U128(BURN_AMOUNT_TOKENS * 10u128.pow(18));
 
+    // One Burn per chain-B block, draining chain A's inbox after each so
+    // every `BurnEvent` to the same EVM recipient lands in its own
+    // chain-A block. Each `BridgeOperation::Burn` routes a funding
+    // transfer + tracked `BridgeMessage::Burn` to chain A; the evm-bridge
+    // app escrows + burns the wrapped tokens before emitting the event.
     for _ in 0..NUM_BURNS {
         cc_b.synchronize_from_validators().await?;
-        let withdraw_bytes = bcs::to_bytes(&WrappedFungibleOperation::Transfer {
-            owner: owner_b,
+        let burn_bytes = bcs::to_bytes(&BridgeOperation::Burn {
             amount: burn_amount,
-            target_account: Account {
-                chain_id: chain_a,
-                owner: receiver,
-            },
+            evm_target: evm_recipient.0 .0,
         })?;
         cc_b.execute_operations(
             vec![Operation::User {
-                application_id: fungible_app_id,
-                bytes: withdraw_bytes,
+                application_id: bridge_app_id,
+                bytes: burn_bytes,
             }],
             vec![],
         )
         .await?
-        .expect("cross-chain withdrawal committed on chain B");
+        .expect("burn committed on chain B");
 
         cc_a.synchronize_from_validators().await?;
         cc_a.process_inbox().await?;
@@ -185,7 +203,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
 
     let relay_port = 3004u16;
     let bridge_addr_str = format!("{bridge_addr}");
-    let bridge_app_str = format!("{fungible_app_id}");
+    let bridge_app_str = format!("{bridge_app_id}");
     let fungible_app_str = format!("{fungible_app_id}");
     let sqlite_path_for_relay = sqlite_path.clone();
     let relay_handle = tokio::spawn(async move {

--- a/linera-bridge/tests/snapshots/format_wrapped_fungible__format_wrapped_fungible.yaml.snap
+++ b/linera-bridge/tests/snapshots/format_wrapped_fungible__format_wrapped_fungible.yaml.snap
@@ -23,6 +23,10 @@ AccountOwner:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 20
+ApplicationId:
+  STRUCT:
+    - application_description_hash:
+        TYPENAME: CryptoHash
 BurnEvent:
   STRUCT:
     - target:
@@ -111,3 +115,8 @@ WrappedFungibleOperation:
           - owner:
               TYPENAME: AccountOwner
           - amount: U128
+    8:
+      RegisterAuthorizedCaller:
+        STRUCT:
+          - app_id:
+              TYPENAME: ApplicationId

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -294,6 +294,12 @@ where
         let thread_pool = self.context().extra().thread_pool().clone();
         let mut actor = ExecutionStateActor::new(self, &mut txn_tracker, &mut resource_controller);
 
+        // On the web, modules cannot be loaded dynamically mid-execution (#2927),
+        // so eagerly preload every installed application's module; natively, only
+        // the target and its declared dependencies (undeclared callees load lazily).
+        #[cfg(web)]
+        let (codes, descriptions) = actor.all_installed_services(application_id).await?;
+        #[cfg(not(web))]
         let (codes, descriptions) = actor.service_and_dependencies(application_id).await?;
 
         let service_runtime_task = thread_pool

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -812,6 +812,8 @@ where
     }
 
     // TODO(#5034): unify with `contract_and_dependencies`
+    // On the web, `all_installed_services` is used instead (see #2927).
+    #[cfg(not(web))]
     pub(crate) async fn service_and_dependencies(
         &mut self,
         application: ApplicationId,
@@ -836,6 +838,8 @@ where
     }
 
     // TODO(#5034): unify with `service_and_dependencies`
+    // On the web, `all_installed_contracts` is used instead (see #2927).
+    #[cfg(not(web))]
     #[instrument(skip_all, fields(application_id = %application))]
     async fn contract_and_dependencies(
         &mut self,
@@ -857,6 +861,68 @@ where
         codes.reverse();
         descriptions.reverse();
 
+        Ok((codes, descriptions))
+    }
+
+    /// Every application installed on this chain — i.e. whose
+    /// `ApplicationDescription` blob the chain has used — including applications
+    /// created earlier in the current block. Used on the web to eagerly preload
+    /// all modules before synchronous execution, since the web build cannot load
+    /// a module dynamically mid-execution (see #2927).
+    #[cfg(web)]
+    async fn installed_application_ids(&self) -> Result<Vec<ApplicationId>, ExecutionError> {
+        let mut ids = std::collections::BTreeSet::new();
+        for blob_id in self.state.system.used_blobs.indices().await? {
+            if blob_id.blob_type == BlobType::ApplicationDescription {
+                ids.insert(ApplicationId::new(blob_id.hash));
+            }
+        }
+        for blob_id in self.txn_tracker.created_blobs().keys() {
+            if blob_id.blob_type == BlobType::ApplicationDescription {
+                ids.insert(ApplicationId::new(blob_id.hash));
+            }
+        }
+        Ok(ids.into_iter().collect())
+    }
+
+    /// Loads `application` plus the contract module of every application installed
+    /// on the chain. Used on the web in place of `contract_and_dependencies`, so a
+    /// cross-application call to any installed application finds its module already
+    /// preloaded even if it was not declared in `required_application_ids` (#2927).
+    #[cfg(web)]
+    async fn all_installed_contracts(
+        &mut self,
+        application: ApplicationId,
+    ) -> Result<(Vec<UserContractCode>, Vec<ApplicationDescription>), ExecutionError> {
+        let mut codes = vec![];
+        let mut descriptions = vec![];
+        let mut seen = std::collections::BTreeSet::new();
+        for id in std::iter::once(application).chain(self.installed_application_ids().await?) {
+            if seen.insert(id) {
+                let (code, description) = self.load_contract(id).await?;
+                codes.push(code);
+                descriptions.push(description);
+            }
+        }
+        Ok((codes, descriptions))
+    }
+
+    /// Service counterpart of [`Self::all_installed_contracts`] (#2927).
+    #[cfg(web)]
+    pub(crate) async fn all_installed_services(
+        &mut self,
+        application: ApplicationId,
+    ) -> Result<(Vec<UserServiceCode>, Vec<ApplicationDescription>), ExecutionError> {
+        let mut codes = vec![];
+        let mut descriptions = vec![];
+        let mut seen = std::collections::BTreeSet::new();
+        for id in std::iter::once(application).chain(self.installed_application_ids().await?) {
+            if seen.insert(id) {
+                let (code, description) = self.load_service(id).await?;
+                codes.push(code);
+                descriptions.push(description);
+            }
+        }
         Ok((codes, descriptions))
     }
 
@@ -892,6 +958,14 @@ where
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
 
+        // On the web, modules cannot be loaded dynamically mid-execution (#2927),
+        // so eagerly preload every installed application's module. Natively, only
+        // the target and its declared dependencies are loaded; undeclared callees
+        // are then fetched lazily during the call.
+        #[cfg(web)]
+        let (codes, descriptions): (Vec<_>, Vec<_>) =
+            self.all_installed_contracts(application_id).await?;
+        #[cfg(not(web))]
         let (codes, descriptions): (Vec<_>, Vec<_>) =
             self.contract_and_dependencies(application_id).await?;
 

--- a/linera-sdk/src/abis/wrapped_fungible.rs
+++ b/linera-sdk/src/abis/wrapped_fungible.rs
@@ -23,21 +23,17 @@ pub struct WrappedParameters {
     pub ticker_symbol: String,
     /// Number of decimal places used by the source ERC-20 (e.g. 6 for USDC).
     pub decimals: u8,
-    /// If set, only this account owner can sign mint operations
-    pub minter: Option<AccountOwner>,
-    /// If set, minting and auto-burning are restricted to this chain
-    pub mint_chain_id: Option<ChainId>,
+    /// The chain on which minting and burning are allowed (the bridge chain).
+    pub mint_chain_id: ChainId,
     /// The ERC-20 token address on the source EVM chain
     pub evm_token_address: [u8; 20],
     /// The EVM chain ID of the source chain (e.g. 8453 for Base)
     pub evm_source_chain_id: u64,
-    /// If set, only this application can call Mint (via cross-app call)
-    pub bridge_app_id: Option<ApplicationId>,
 }
 
-/// Event emitted when tokens are auto-burned on the bridge chain.
-/// The relayer observes these on the "burns" stream and forwards
-/// to EVM to release the corresponding ERC-20 tokens.
+/// Event emitted by the bridge application on its "burns" stream when it burns
+/// wrapped tokens on the bridge chain. The relayer observes these and forwards
+/// them to EVM to release the corresponding ERC-20 tokens.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BurnEvent {
     /// The Ethereum address to receive the unlocked ERC-20 tokens
@@ -112,14 +108,22 @@ pub enum WrappedFungibleOperation {
         amount: U128,
         target_account: Account,
     },
-    /// Mints new tokens to a target account. Only the authorized minter can call this.
+    /// Mints new tokens to a target account. Driven by the registered authorized
+    /// caller (see [`Self::RegisterAuthorizedCaller`]) on the designated mint chain.
     Mint {
         target_account: Account,
         amount: U128,
     },
-    /// Burns tokens from an account. Rejected by the contract — burning happens
-    /// automatically when tokens are transferred to an Address20 on the bridge chain.
+    /// Burns tokens from an account. Authorized only via the registered authorized
+    /// caller (see [`Self::RegisterAuthorizedCaller`]) on the designated mint chain.
     Burn { owner: AccountOwner, amount: U128 },
+    /// Registers the application authorized to drive `Mint`/`Burn`. Must run on
+    /// the designated `mint_chain_id` — the only chain where it is consulted — and
+    /// requires an authenticated signer. Because an authorized caller may take
+    /// this token's id as a creation parameter, the two cannot reference each
+    /// other at creation; this token is created first and registers its caller
+    /// afterwards.
+    RegisterAuthorizedCaller { app_id: ApplicationId },
 }
 
 /// Cross-chain message used by the wrapped fungible token application.


### PR DESCRIPTION
## Motivation

The mint and burn flows are asymmetric.

**Mint (EVM→Linera)** is bridge-driven: a `DepositInitiated` event on `FungibleBridge.sol` is proven on Linera via `BridgeOperation::ProcessDeposit`, and the `evm-bridge` contract calls
`WrappedFungibleOperation::Mint`. The bridge is the active party.

**Burn (Linera→EVM)** was driven by a special case inside wrapped-fungible: a user `Transfer`s wrapped tokens to `Account { chain_id: mint_chain, owner: Address20(evm_addr) }`; the resulting cross-chain
`Message::Credit`, on landing, was intercepted in `execute_message` and turned into a `BurnEvent` on wrapped-fungible's `"burns"` stream. The bridge app never participated. This is surprising (a transfer that
silently burns), couples wrapped-fungible to EVM-address encoding, and keys the relayer off the wrong app.

This PR makes burn symmetric with mint: the user sends an explicit `Burn` operation to the **local** `evm-bridge` instance on their own chain, and the bridge contract drives the burn end-to-end. The
`Message::Credit` special case is removed entirely.

## Proposal

- **Bridge-driven burn.** Users submit `BridgeOperation::Burn { amount, evm_target }` to the local `evm-bridge` app. In one atomic bundle the bridge escrows the signer's wrapped tokens into the signer's *own*
account on the bridge chain and sends a tracked `BridgeMessage::Burn`; the bridge chain burns the escrow and emits a `BurnEvent` on the bridge app's `"burns"` stream. The relayer keys on the **bridge** app id and
releases the ERC-20 on EVM. A rejected burn bounces the funding transfer, refunding the signer — no stranded escrow.

- **Self-funding escrow.** The escrow account is the operation's authenticated signer, propagated to the bridge chain via `.with_authentication()`. A `Bridge::Burn` can only ever drain the escrow its own signer
funded — never another user's balance, and never without its paired Credit (an unfunded burn underflows → bundle rejected → bounced → no release).

- **Break the creation circularity.** Move `fungible_app_id` out of the `Burn` operation into `BridgeParameters` (global, not user-supplied). Move wrapped-fungible's `bridge_app_id` from a creation parameter to
registrable state via the new `RegisterAuthorizedCaller` op (mint-chain only). Creation order is now: wrapped first, then the bridge with `fungible_app_id`, then `RegisterAuthorizedCaller`.

- **Tighten authorization.** Mint/Burn are authorized only by the registered authorized caller on the mandatory `mint_chain_id`; the `minter` parameter and its signer check are dropped.

- **Solidity.** Burn-event matching moves to the bridge app id — `_isMatchingBurn` now trusts `BurnEvents` from the bridge app's "burns" stream, where they originate post-refactor. Deposits are unchanged: `deposit()` still requires `target_application_id == fungibleApplicationId`, pinning each locked ERC-20 to a mint of the correct wrapped token on Linera.

- **Relay robustness.** `process_pending_burns` estimates gas for a whole-block `addBlock` before submitting; that `eth_estimateGas` can revert when the block is too large to estimate (now common, since a
bridge-driven burn adds a funding Credit plus a `BridgeMessage::Burn`) or for a genuinely invalid cert. The error branch previously only bumped the retry counter, re-polling forever until `max_retries`. Now it
falls back to `submit_chunked`: each per-tx chunk is estimated independently, fitting chunks are submitted, and any single burn that still doesn't fit is marked failed (so an invalid cert terminates instead of
looping).

- **Web module preloading (#2927).** A cross-app call to an application whose Wasm module isn't already loaded fails on the web with `UnsupportedDynamicApplicationLoad` (blocked by #2552: synchronous host
functions can't await the `postMessage` to fetch a module). Before running a user action or service query on the web, eagerly preload the module of every application installed on the chain (enumerated from
`used_blobs` plus the current block's created blobs, filtered to `ApplicationDescription`), deduplicated against the target and its declared dependencies. Web-gated (`#[cfg(web)]`); native keeps loading lazily,
so this is zero-cost there and the two platforms now agree. This replaces the `required_application_ids` workaround that declared wrapped-fungible as a bridge dependency only to force eager loading.

- **GraphQL + demo.** Expose every `BridgeOperation` as a GraphQL mutation on the evm-bridge service so the demo UI can submit them. Update the bridge demo (`setup.sh`, frontend), e2e + integration tests;
decouple wrapped-fungible's docs from bridge specifics; fix demo tooling (wasm-split detection, pnpm build approvals, esbuild dedup).

## Test Plan

- CI
- verified manually that the demo UI works

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Web preloading: #2927 (blocked by #2552)
- Design: `2026-06-01-symmetric-bridge-driven-burn-design.md`
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)