### PR TITLE
Add pending-proposal, round, and ownership APIs to `@linera/client` (forward-port of #6383)

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -903,6 +903,23 @@ impl ChainManagerInfo {
             .map(|vote| Box::new(vote.value.clone()));
     }
 
+    /// Returns whether `owner` may propose a block in the current round, based on the
+    /// already-computed [`leader`](Self::leader) for that round.
+    ///
+    /// [`leader`](Self::leader) is `None` in the fast and multi-leader rounds, where any
+    /// eligible owner may propose; in the single-leader and validator rounds it names the
+    /// only owner allowed to propose. Unlike [`should_propose`](Self::should_propose),
+    /// this needs no seed or committee, since the leader is taken as given.
+    pub fn can_propose(&self, owner: &AccountOwner) -> bool {
+        match &self.leader {
+            Some(leader) => leader == owner,
+            None => match self.current_round {
+                Round::Fast => self.ownership.super_owners.contains(owner),
+                _ => self.ownership.can_propose_in_multi_leader_round(owner),
+            },
+        }
+    }
+
     /// Returns whether the `identity` is allowed to propose a block in `round`.
     ///
     /// **Exception:** In single-leader rounds, a **super owner** should only propose

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2297,8 +2297,12 @@ impl<Env: Environment> ChainClient<Env> {
         (propose_at > now).then_some(propose_at)
     }
 
-    /// Clears the information on any operation that previously failed.
-    #[cfg(with_testing)]
+    /// Discards the pending block proposal, if any, so that a fresh block can be
+    /// proposed instead of retrying the queued one.
+    ///
+    /// Note that this does not update the copy persisted in the wallet (callers that
+    /// persist pending proposals should refresh it afterwards). Also, this should never
+    /// be used on a proposal already submitted in the fast round.
     #[instrument(level = "trace")]
     pub async fn clear_pending_proposal(&self) {
         *self.proposal_mutex().lock().await = None;

--- a/web/@linera/client/src/chain/mod.rs
+++ b/web/@linera/client/src/chain/mod.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use futures::stream::StreamExt;
-use linera_base::identifiers::AccountOwner;
+use linera_base::{data_types::Round, identifiers::AccountOwner};
 use linera_client::chain_listener::ClientContext as _;
 use linera_core::{
     client::ChainClient,
@@ -39,6 +39,23 @@ pub struct TransferParams {
 pub struct AddOwnerOptions {
     #[serde(default)]
     pub weight: u64,
+}
+
+/// Information about the round in which a block would currently be proposed on a chain.
+#[derive(serde::Serialize, tsify::Tsify)]
+#[tsify(into_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct RoundInfo {
+    /// The category of the round: `"fast"`, `"multiLeader"`, `"singleLeader"` or
+    /// `"validator"`.
+    pub kind: String,
+    /// The index of the round within its category (always `0` for the fast round).
+    pub number: u32,
+    /// The owner currently allowed to propose, or `undefined` if any eligible owner
+    /// may propose (the fast and multi-leader rounds).
+    pub leader: Option<AccountOwner>,
+    /// Whether this client's current identity may propose a block in this round.
+    pub can_propose: bool,
 }
 
 #[wasm_bindgen]
@@ -130,6 +147,153 @@ impl Chain {
             .await
             .apply_client_command(&self.chain_client, |_chain_client| {
                 self.chain_client.share_ownership(owner, weight)
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Synchronizes this chain with the validators, downloading any blocks and state that
+    /// the local node is missing.
+    ///
+    /// Reads such as [`balance`](Self::balance), [`nextRoundInfo`](Self::next_round_info),
+    /// [`isOwner`](Self::is_owner) and [`ownerWeight`](Self::owner_weight) operate on the
+    /// local node, so call this after first connecting to a chain (for example one just
+    /// claimed from the faucet) to make sure they observe the chain's current state.
+    ///
+    /// # Errors
+    /// If synchronization fails, e.g. because validators are unreachable.
+    #[wasm_bindgen]
+    pub async fn synchronize(&self) -> JsResult<()> {
+        self.chain_client.synchronize_from_validators().await?;
+        self.client
+            .context
+            .lock()
+            .await
+            .update_wallet(&self.chain_client)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns whether `owner` is currently an owner of this chain, either as a regular
+    /// owner or a super owner.
+    ///
+    /// Useful before calling [`addOwner`](Self::add_owner), which silently overwrites the
+    /// weight of an existing owner rather than failing.
+    ///
+    /// # Errors
+    /// If the chain ownership cannot be retrieved.
+    #[wasm_bindgen(js_name = isOwner)]
+    pub async fn is_owner(&self, owner: AccountOwner) -> JsResult<bool> {
+        let ownership = self.chain_client.query_chain_ownership().await?;
+        Ok(ownership.is_owner(&owner))
+    }
+
+    /// Returns the weight of a regular owner of this chain, or `undefined` if `owner` is
+    /// not a regular owner (it may be a super owner, which has no weight, or not an owner
+    /// at all).
+    ///
+    /// The weight determines how often the owner is selected as the leader in
+    /// single-leader and validator rounds.
+    ///
+    /// # Errors
+    /// If the chain ownership cannot be retrieved.
+    #[wasm_bindgen(js_name = ownerWeight)]
+    pub async fn owner_weight(&self, owner: AccountOwner) -> JsResult<Option<f64>> {
+        let ownership = self.chain_client.query_chain_ownership().await?;
+        let weight = ownership.owners.get(&owner).copied();
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "owner weights are small relative values"
+        )]
+        let weight = weight.map(|weight| weight as f64);
+        Ok(weight)
+    }
+
+    /// Discards any pending block proposal on this chain.
+    ///
+    /// When a proposal fails to reach a quorum (for example because the client went
+    /// offline mid-round) it stays queued and is retried before any new block. Call this
+    /// to drop it so a fresh block can be proposed instead.
+    ///
+    /// Importantly, this must never be used to clear a proposal already submitted in the
+    /// fast round: fast-round proposals are final, so clearing one is rejected with an
+    /// error.
+    ///
+    /// # Errors
+    /// If the chain is currently in the fast round, or the wallet fails to persist the
+    /// cleared state.
+    #[wasm_bindgen(js_name = clearPendingProposal)]
+    pub async fn clear_pending_proposal(&self) -> JsResult<()> {
+        let info = self.chain_client.chain_info().await?;
+        if info.manager.current_round == Round::Fast {
+            return Err(JsError::new(
+                "cannot clear a pending proposal in the fast round",
+            ));
+        }
+        self.chain_client.clear_pending_proposal().await;
+        // Of all proposals, only fast-round ones are persisted in the wallet across
+        // sessions. The guard above forbids clearing one while the chain is still in the
+        // fast round, but a stuck fast-round proposal can outlive the fast round itself;
+        // refresh the persisted copy so that clearing it here is not undone on reload.
+        self.client
+            .context
+            .lock()
+            .await
+            .update_wallet(&self.chain_client)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns information about the round in which a block would currently be proposed on
+    /// this chain: its category, its index, the current leader (if the round restricts
+    /// proposals to a single owner) and whether this client's identity may propose.
+    ///
+    /// `leader` is `undefined` in the fast and multi-leader rounds, where any eligible
+    /// owner may propose; in the single-leader and validator rounds it is the owner
+    /// currently allowed to propose.
+    ///
+    /// # Errors
+    /// If the chain information cannot be retrieved.
+    #[wasm_bindgen(js_name = nextRoundInfo)]
+    pub async fn next_round_info(&self) -> JsResult<RoundInfo> {
+        let info = self.chain_client.chain_info().await?;
+        let manager = &info.manager;
+        let identity = self.chain_client.identity().await?;
+        let can_propose = manager.can_propose(&identity);
+        let (kind, number) = match manager.current_round {
+            Round::Fast => ("fast", 0),
+            Round::MultiLeader(number) => ("multiLeader", number),
+            Round::SingleLeader(number) => ("singleLeader", number),
+            Round::Validator(number) => ("validator", number),
+        };
+        Ok(RoundInfo {
+            kind: kind.to_owned(),
+            number,
+            leader: manager.leader,
+            can_propose,
+        })
+    }
+
+    /// Sets the number of multi-leader rounds for this chain, leaving the rest of the
+    /// ownership configuration (owners, super owners, timeouts) unchanged.
+    ///
+    /// In multi-leader rounds every eligible owner may propose a block concurrently;
+    /// afterwards the chain falls back to single-leader rounds. A larger number favors
+    /// liveness under contention, while `0` makes the chain reach single-leader rounds
+    /// immediately.
+    ///
+    /// # Errors
+    /// If the chain is inactive, or the ownership change fails to commit.
+    #[wasm_bindgen(js_name = setMultiLeaderRounds)]
+    pub async fn set_multi_leader_rounds(&self, rounds: u32) -> JsResult<()> {
+        self.client
+            .context
+            .lock()
+            .await
+            .apply_client_command(&self.chain_client, |_chain_client| async {
+                let mut ownership = self.chain_client.query_chain_ownership().await?;
+                ownership.multi_leader_rounds = rounds;
+                self.chain_client.change_ownership(ownership).await
             })
             .await?;
         Ok(())

--- a/web/@linera/client/tests/Chain.test.ts
+++ b/web/@linera/client/tests/Chain.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "vitest";
+import * as linera from "../dist";
+
+const VALID_ROUND_KINDS = ["fast", "multiLeader", "singleLeader", "validator"];
+
+// Claims a fresh chain from the faucet and returns a connected `Chain` handle
+// together with the owner that controls it. The faucet hands out chains with a
+// single regular owner and several multi-leader rounds (`ChainOwnership::single`),
+// so a fresh chain starts in the multi-leader round.
+async function freshChain() {
+  await linera.initialize();
+  const faucet = await new linera.Faucet(import.meta.env.LINERA_FAUCET_URL);
+  const signer = linera.signer.PrivateKey.createRandom();
+  const owner = signer.address();
+  const wallet = await faucet.createWallet();
+  const chainId = await faucet.claimChain(wallet, owner);
+  const client = await new linera.Client(wallet, signer);
+  const chain = await client.chain(chainId, { owner });
+  // The chain was just claimed, so pull its state into the local node before the tests
+  // read from it (balance, ownership, round are all local reads).
+  await chain.synchronize();
+  return { chain, owner };
+}
+
+test("nextRoundInfo reports a well-formed multi-leader round for a fresh chain", async () => {
+  const { chain } = await freshChain();
+  const round = await chain.nextRoundInfo();
+
+  expect(VALID_ROUND_KINDS).toContain(round.kind);
+  expect(round.number).toBeGreaterThanOrEqual(0);
+  // A fresh faucet chain has a single regular owner and starts in a multi-leader
+  // round, where any eligible owner may propose (no single designated leader).
+  expect(round.kind).toBe("multiLeader");
+  expect(round.leader == null).toBe(true);
+  // The chain's sole owner is the connected identity, so it may propose.
+  expect(round.canPropose).toBe(true);
+}, 150000);
+
+test("isOwner reflects chain membership", async () => {
+  const { chain, owner } = await freshChain();
+  // The chain's sole owner is recognized; a random address is not.
+  expect(await chain.isOwner(owner)).toBe(true);
+  const stranger = linera.signer.PrivateKey.createRandom().address();
+  expect(await chain.isOwner(stranger)).toBe(false);
+
+  // After adding it, the stranger is recognized as an owner.
+  await chain.addOwner(stranger, { weight: 100 });
+  expect(await chain.isOwner(stranger)).toBe(true);
+}, 150000);
+
+test("ownerWeight reads owner weights", async () => {
+  const { chain } = await freshChain();
+  const owner = linera.signer.PrivateKey.createRandom().address();
+
+  // An address that is not a regular owner has no weight.
+  expect(await chain.ownerWeight(owner)).toBeUndefined();
+
+  await chain.addOwner(owner, { weight: 100 });
+  expect(await chain.ownerWeight(owner)).toBe(100);
+
+  // Re-adding an existing owner overwrites its weight.
+  await chain.addOwner(owner, { weight: 250 });
+  expect(await chain.ownerWeight(owner)).toBe(250);
+}, 150000);
+
+test("clearPendingProposal is a no-op when nothing is pending", async () => {
+  const { chain } = await freshChain();
+  // No proposal has failed, so there is nothing to clear; this should resolve.
+  await chain.clearPendingProposal();
+  // The round structure is unchanged.
+  expect((await chain.nextRoundInfo()).kind).toBe("multiLeader");
+}, 150000);
+
+test("setMultiLeaderRounds changes the round structure", async () => {
+  const { chain, owner } = await freshChain();
+  expect((await chain.nextRoundInfo()).kind).toBe("multiLeader");
+
+  // With zero multi-leader rounds, an owner-based chain starts directly in a
+  // single-leader round, where the sole owner is the designated leader.
+  await chain.setMultiLeaderRounds(0);
+  const single = await chain.nextRoundInfo();
+  expect(single.kind).toBe("singleLeader");
+  // The serialized leader is lowercase, while `owner` is an EIP-55 checksummed
+  // address; they denote the same account, so compare case-insensitively.
+  expect(single.leader?.toLowerCase()).toBe(owner.toLowerCase());
+  expect(single.canPropose).toBe(true);
+
+  // Restoring multi-leader rounds brings back the multi-leader round.
+  await chain.setMultiLeaderRounds(3);
+  expect((await chain.nextRoundInfo()).kind).toBe("multiLeader");
+}, 150000);


### PR DESCRIPTION
## Motivation

Forward-port of #6383 (merged to `testnet_conway`) to `main`.

The web client (`@linera/client`) exposes only a small slice of chain operations. Frontends
that build wallet / chain-management UIs need to inspect and manage a chain's consensus
state — clear a stuck pending proposal, tell which round a block would be proposed in, and
query or adjust chain ownership — none of which were reachable from JavaScript.

## Proposal

Add five methods to the `Chain` class, and un-gate the one `ChainClient` method they rely on
(`clear_pending_proposal`, previously `#[cfg(with_testing)]`):

- **`clearPendingProposal()`** — discards the queued block proposal and refreshes the copy
  persisted in the wallet (fast-round proposals are persisted across sessions, so the
  in-memory clear alone would let them resurrect on reload).
- **`nextRound()`** — returns `{ kind, number, leader, canPropose }` describing the round a
  block would currently be proposed in (`"fast"` / `"multiLeader"` / `"singleLeader"` /
  `"validator"`). `leader` is `undefined` when any eligible owner may propose (fast and
  multi-leader rounds), and `canPropose` reflects the connected identity.
- **`setMultiLeaderRounds(n)`** — changes only `multi_leader_rounds`, committing a
  `ChangeOwnership` while preserving the rest of the ownership configuration.
- **`isOwner(owner)`** — whether an address is a (super or regular) owner. Useful before
  `addOwner`, which silently overwrites an existing owner's weight rather than failing.
- **`ownerWeight(owner)`** — the weight of a regular owner, or `undefined` for super owners
  (which have no weight) and non-owners.

Weights cross the wasm boundary as `number`, consistent with the existing `addOwner({ weight })`.

### Differences from #6383

The net change is identical to the merged testnet PR (same 4 files), with two adaptations
required by `main`'s divergence from `testnet_conway`:

- The cherry-pick conflicted only in `linera-core/src/client/chain_client/mod.rs`, contextually:
  `main` has an extra `multi_leader_jitter_target` helper just above `clear_pending_proposal`.
  Resolved by keeping `main`'s helper and applying the PR's change (new doc comment, dropping
  the `#[cfg(with_testing)]` gate).
- `ChainOwnership::verify_owner` (on `testnet_conway`) is named `is_owner` on `main`, so
  `Chain::isOwner` now calls `ownership.is_owner(&owner)`.

## Test Plan

- Added browser integration tests in `web/@linera/client/tests/Chain.test.ts` covering each
  method, using the same faucet harness as `Client.test.ts`. These run via `pnpm test` against
  a faucet (`LINERA_FAUCET_URL`).
- Verified `cargo check -p linera-chain -p linera-core` and
  `cargo clippy -p linera-web --target wasm32-unknown-unknown` (with `--cfg=web_sys_unstable_apis`,
  as `build.bash` uses) are clean, and that `cargo fmt --check` passes.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

(Already present on `testnet_conway` via #6383; this PR lands the same change on `main`.)

## Links

- Forward-port of #6383
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
