### PR TITLE
[testnet] Filter client outbox indices to tracked chains

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -745,13 +745,16 @@ where
     /// written before filtering, a restart after a tracked-set change, a shrink, or a growth; in
     /// particular it never scans the (unbounded) full set of outbox targets. A subtractive
     /// `O(|delta|)` fast path can be added on top once the worker supplies the added/removed sets.
+    ///
+    /// Returns whether the indices were actually rebuilt (`false` if they were already current), so
+    /// a read-only caller can skip persisting when nothing changed.
     pub async fn reconcile_outbox_index(
         &mut self,
         full_chains: &BTreeSet<ChainId>,
-    ) -> Result<(), ChainError> {
+    ) -> Result<bool, ChainError> {
         let digest = tracked_chains_hash(full_chains);
         if *self.outbox_index_tracked_hash.get() == Some(digest) {
-            return Ok(());
+            return Ok(false);
         }
         self.nonempty_outboxes.get_mut().clear();
         self.outbox_counters.get_mut().clear();
@@ -771,7 +774,7 @@ where
             self.nonempty_outboxes.get_mut().insert(*target);
         }
         self.outbox_index_tracked_hash.set(Some(digest));
-        Ok(())
+        Ok(true)
     }
 
     /// Executes a block with a specified policy for handling bundle failures.
@@ -1485,10 +1488,14 @@ where
         }
 
         if !scheduled_tracked.is_empty() {
-            let outbox_counters = self.outbox_counters.get_mut();
+            // All scheduled messages are at `block_height`, so bump its shared counter once.
+            *self
+                .outbox_counters
+                .get_mut()
+                .entry(block_height)
+                .or_default() += scheduled_tracked.len() as u32;
             let nonempty_outboxes = self.nonempty_outboxes.get_mut();
             for target in &scheduled_tracked {
-                *outbox_counters.entry(block_height).or_default() += 1;
                 nonempty_outboxes.insert(*target);
             }
         }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -8,7 +8,7 @@ use std::{
 
 use allocative::Allocative;
 use linera_base::{
-    crypto::{CryptoHash, ValidatorPublicKey},
+    crypto::{CryptoHash, CryptoHashVec, ValidatorPublicKey},
     data_types::{
         ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Epoch,
         NonCanonicalBTreeMap, NonCanonicalBTreeSet, OracleResponse, Timestamp,
@@ -220,6 +220,13 @@ pub struct BundleInInbox {
 // of 100 seems reasonable for the storing of the data.
 const TIMESTAMPBUNDLE_BUCKET_SIZE: usize = 100;
 
+/// Computes the hash identifying a set of fully-tracked chains, stored in
+/// [`ChainStateView::outbox_index_tracked_hash`] to detect when the outbox indices must be
+/// reconciled. The input is order-independent because `BTreeSet` iterates in sorted order.
+pub fn tracked_chains_hash(full_chains: &BTreeSet<ChainId>) -> CryptoHash {
+    CryptoHash::new(&CryptoHashVec(full_chains.iter().map(|id| id.0).collect()))
+}
+
 /// A view accessing the state of a chain.
 #[cfg_attr(
     with_graphql,
@@ -291,6 +298,18 @@ where
     /// reset-on-incorrect-outcome from looping: if not enough time has elapsed since
     /// the last reset, the error is returned instead.
     pub block_zero_executed_at: RegisterView<C, Timestamp>,
+
+    /// The hash of the set of fully-tracked chains that `nonempty_outboxes` and
+    /// `outbox_counters` were last reconciled against (see [`tracked_chains_hash`]). On a client
+    /// these two indices only hold entries for tracked targets; when the tracked set changes this
+    /// hash stops matching and the indices are reconciled (`reconcile_outbox_index`). `None` means
+    /// they have never been filtered — a pre-existing database entry (migration), or a validator
+    /// that tracks all chains and never filters.
+    ///
+    /// MUST stay last in this struct: `View` derives each sub-view's storage-key prefix from field
+    /// order, so inserting a field earlier would shift every following view's keys and corrupt
+    /// existing databases.
+    pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
 }
 
 /// Block-chaining state.
@@ -706,6 +725,99 @@ where
         let vec_of_options = self.outboxes.try_load_entries(targets).await?;
         let optional_vec = vec_of_options.into_iter().collect::<Option<Vec<_>>>();
         optional_vec.ok_or_else(|| ChainError::CorruptedChainState("Missing outboxes".into()))
+    }
+
+    /// Reconciles the `nonempty_outboxes` and `outbox_counters` indices with the given set of
+    /// fully-tracked chains, if the tracked set has changed since the last reconciliation.
+    ///
+    /// On a client these indices only hold entries for tracked targets, so that they stay small
+    /// (the per-target outbox *queues* in `outboxes` are still kept for every target, so a chain
+    /// that becomes tracked can be re-indexed). `digest` must be [`tracked_chains_hash`] of
+    /// `full_chains`.
+    ///
+    /// Cost: the removal pass is `O(index)`. The addition pass only runs when chains may have been
+    /// *added* to the tracked set. On initialization (`None` stamp = migration of a database
+    /// written before filtering) the old index already lists every target, so only removals are
+    /// needed. On a pure shrink (new set ⊆ old set) there are no additions either. The expensive
+    /// `outboxes` rescan is therefore reserved for the genuine growth case.
+    pub async fn reconcile_outbox_index(
+        &mut self,
+        full_chains: &BTreeSet<ChainId>,
+        digest: CryptoHash,
+    ) -> Result<(), ChainError> {
+        if *self.outbox_index_tracked_hash.get() == Some(digest) {
+            return Ok(());
+        }
+        let initializing = self.outbox_index_tracked_hash.get().is_none();
+
+        // 1. Removal pass: drop index/counter entries for targets that are no longer tracked.
+        //    The per-target outbox queue is left untouched so it can be re-indexed later.
+        let indexed = self.nonempty_outboxes.get().clone();
+        for target in indexed.iter() {
+            if full_chains.contains(target) {
+                continue;
+            }
+            self.unindex_outbox(target).await?;
+        }
+
+        // 2. Addition pass: index tracked targets that have a pending queue but are not indexed.
+        //    Skipped on initialization (migration: the old index already covered every target, so
+        //    step 1 alone leaves it tracked-only) and on a pure shrink. See the note above; the
+        //    `may_have_additions` decision is made by the caller, which knows the tracked-set delta
+        //    (defaults to a correct full rescan when the delta is unknown).
+        if !initializing {
+            for target in self.outboxes.indices().await? {
+                if !full_chains.contains(&target) || self.nonempty_outboxes.get().contains(&target) {
+                    continue;
+                }
+                self.reindex_outbox(&target).await?;
+            }
+        }
+
+        self.outbox_index_tracked_hash.set(Some(digest));
+        Ok(())
+    }
+
+    /// Removes `target` from `nonempty_outboxes` and subtracts its queued heights from
+    /// `outbox_counters`, leaving the per-target outbox queue intact.
+    async fn unindex_outbox(&mut self, target: &ChainId) -> Result<(), ChainError> {
+        let heights = {
+            let outbox = self.outboxes.try_load_entry(target).await?;
+            match outbox {
+                Some(outbox) => outbox.queue.elements().await?,
+                None => Vec::new(),
+            }
+        };
+        for height in heights {
+            if let Some(counter) = self.outbox_counters.get_mut().get_mut(&height) {
+                *counter = counter.saturating_sub(1);
+                if *counter == 0 {
+                    self.outbox_counters.get_mut().remove(&height);
+                }
+            }
+        }
+        self.nonempty_outboxes.get_mut().remove(target);
+        Ok(())
+    }
+
+    /// Adds `target` to `nonempty_outboxes` and its queued heights to `outbox_counters`. Inverse
+    /// of [`Self::unindex_outbox`]; used when a previously untracked chain becomes tracked.
+    async fn reindex_outbox(&mut self, target: &ChainId) -> Result<(), ChainError> {
+        let heights = {
+            let outbox = self.outboxes.try_load_entry(target).await?;
+            match outbox {
+                Some(outbox) => outbox.queue.elements().await?,
+                None => Vec::new(),
+            }
+        };
+        if heights.is_empty() {
+            return Ok(());
+        }
+        for height in heights {
+            *self.outbox_counters.get_mut().entry(height).or_default() += 1;
+        }
+        self.nonempty_outboxes.get_mut().insert(*target);
+        Ok(())
     }
 
     /// Executes a block with a specified policy for handling bundle failures.
@@ -1155,6 +1267,7 @@ where
         &mut self,
         block: &ConfirmedBlock,
         local_time: Timestamp,
+        tracked: Option<&BTreeSet<ChainId>>,
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
@@ -1162,7 +1275,7 @@ where
             self.block_zero_executed_at.set(local_time);
         }
         self.execution_state_hash.set(Some(block.header.state_hash));
-        let recipients = self.process_outgoing_messages(block).await?;
+        let recipients = self.process_outgoing_messages(block, tracked).await?;
 
         for recipient in recipients {
             self.previous_message_blocks
@@ -1196,6 +1309,7 @@ where
     pub async fn preprocess_block(
         &mut self,
         block: &ConfirmedBlock,
+        tracked: Option<&BTreeSet<ChainId>>,
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
@@ -1203,7 +1317,7 @@ where
         if height < self.tip_state.get().next_block_height {
             return Ok(BTreeSet::new());
         }
-        self.process_outgoing_messages(block).await?;
+        self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
         self.preprocessed_blocks.insert(&height, hash)?;
         Ok(updated_streams)
@@ -1323,6 +1437,7 @@ where
     async fn process_outgoing_messages(
         &mut self,
         block: &Block,
+        tracked: Option<&BTreeSet<ChainId>>,
     ) -> Result<Vec<ChainId>, ChainError> {
         // Record the messages of the execution. Messages are understood within an
         // application.
@@ -1330,11 +1445,16 @@ where
         let block_height = block.header.height;
         let next_height = self.tip_state.get().next_block_height;
 
-        // Update the outboxes.
-        let outbox_counters = self.outbox_counters.get_mut();
-        let nonempty_outboxes = self.nonempty_outboxes.get_mut();
+        // Update the outboxes. Every recipient's per-target outbox queue is updated, but the
+        // `nonempty_outboxes`/`outbox_counters` indices are only populated for targets we track
+        // (`tracked == None` means a validator that tracks all chains). Untracked targets are
+        // delivered by the validators, never by this local node, so indexing them would grow the
+        // two `RegisterView` indices — which are re-serialized whole on every block — without
+        // bound. Targets are collected and the indices updated once, after the loop, so a block
+        // that schedules nothing tracked does not mark the registers dirty.
         let targets = recipients.into_iter().collect::<Vec<_>>();
         let outboxes = self.outboxes.try_load_entries_mut(&targets).await?;
+        let mut scheduled_tracked = Vec::new();
         for (mut outbox, target) in outboxes.into_iter().zip(&targets) {
             if block_height > next_height {
                 // There may be a gap in the chain before this block. We can only add it to this
@@ -1399,9 +1519,10 @@ where
                     }
                 }
             }
-            if outbox.schedule_message(block_height)? {
-                *outbox_counters.entry(block_height).or_default() += 1;
-                nonempty_outboxes.insert(*target);
+            if outbox.schedule_message(block_height)?
+                && tracked.is_none_or(|set| set.contains(target))
+            {
+                scheduled_tracked.push(*target);
             }
             #[cfg(with_metrics)]
             crate::outbox::metrics::OUTBOX_SIZE
@@ -1409,14 +1530,23 @@ where
                 .observe(outbox.queue.count() as f64);
         }
 
+        if !scheduled_tracked.is_empty() {
+            let outbox_counters = self.outbox_counters.get_mut();
+            let nonempty_outboxes = self.nonempty_outboxes.get_mut();
+            for target in &scheduled_tracked {
+                *outbox_counters.entry(block_height).or_default() += 1;
+                nonempty_outboxes.insert(*target);
+            }
+        }
+
         #[cfg(with_metrics)]
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
-            .observe(nonempty_outboxes.len() as f64);
+            .observe(self.nonempty_outboxes.get().len() as f64);
         #[cfg(with_metrics)]
         metrics::OUTBOX_COUNTERS_SIZE
             .with_label_values(&[])
-            .observe(outbox_counters.len() as f64);
+            .observe(self.outbox_counters.get().len() as f64);
         Ok(targets)
     }
 }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -300,9 +300,9 @@ where
     pub block_zero_executed_at: RegisterView<C, Timestamp>,
 
     /// The hash of the set of fully-tracked chains that `nonempty_outboxes` and
-    /// `outbox_counters` were last reconciled against (see [`tracked_chains_hash`]). On a client
-    /// these two indices only hold entries for tracked targets; when the tracked set changes this
-    /// hash stops matching and the indices are reconciled (`reconcile_outbox_index`). `None` means
+    /// `outbox_counters` were last reconciled against. On a client these two indices only hold
+    /// entries for tracked targets; when the tracked set changes this hash stops matching and the
+    /// indices are reconciled (`reconcile_outbox_index`). `None` means
     /// they have never been filtered — a pre-existing database entry (migration), or a validator
     /// that tracks all chains and never filters.
     pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -464,25 +464,26 @@ where
         if updates.is_empty() {
             return Ok(false);
         }
-        // `outbox_counters` only counts targets we index: every chain on a validator
-        // (`tracked == None`), or tracked targets on a client. A missing counter for such a target
-        // is genuine corruption; for an untracked target it is expected (its messages were never
-        // counted — e.g. it was untracked when scheduled, or untracked between sending an update
-        // and receiving its confirmation), so there is nothing to decrement.
-        let expect_counter = tracked.is_none_or(|tracked| tracked.contains(target));
-        for update in updates {
-            let Some(counter) = self.outbox_counters.get_mut().get_mut(&update) else {
-                if expect_counter {
-                    return Err(ChainError::CorruptedChainState(
-                        "message counter should be present".into(),
-                    ));
+        // `outbox_counters` is keyed by block height and shared across all recipients of that
+        // block, but only counts targets we index: every chain on a validator (`tracked == None`),
+        // or tracked targets on a client. An untracked target was never counted, so confirming it
+        // must NOT touch the counters at all — a present `counter[height]` belongs to a tracked
+        // sibling recipient of the same block and must be left intact. We only drain the queue
+        // (done above) for such a target.
+        if tracked.is_none_or(|tracked| tracked.contains(target)) {
+            for update in updates {
+                let counter = self
+                    .outbox_counters
+                    .get_mut()
+                    .get_mut(&update)
+                    .ok_or_else(|| {
+                        ChainError::CorruptedChainState("message counter should be present".into())
+                    })?;
+                *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
+                if *counter == 0 {
+                    // Important for the test in `all_messages_delivered_up_to`.
+                    self.outbox_counters.get_mut().remove(&update);
                 }
-                continue;
-            };
-            *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
-            if *counter == 0 {
-                // Important for the test in `all_messages_delivered_up_to`.
-                self.outbox_counters.get_mut().remove(&update);
             }
         }
         if outbox.queue.count() == 0 {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -223,7 +223,7 @@ const TIMESTAMPBUNDLE_BUCKET_SIZE: usize = 100;
 /// Computes the hash identifying a set of fully-tracked chains, stored in
 /// [`ChainStateView::outbox_index_tracked_hash`] to detect when the outbox indices must be
 /// reconciled. The input is order-independent because `BTreeSet` iterates in sorted order.
-pub fn tracked_chains_hash(full_chains: &BTreeSet<ChainId>) -> CryptoHash {
+pub(crate) fn tracked_chains_hash(full_chains: &BTreeSet<ChainId>) -> CryptoHash {
     CryptoHash::new(&CryptoHashVec(full_chains.iter().map(|id| id.0).collect()))
 }
 
@@ -737,11 +737,11 @@ where
     }
 
     /// Reconciles the `nonempty_outboxes` and `outbox_counters` indices with the given set of
-    /// fully-tracked chains, if the tracked set has changed since the last reconciliation.
+    /// fully-tracked chains, if the tracked set has changed since the last reconciliation
+    /// (i.e. the stored [`Self::outbox_index_tracked_hash`] no longer matches).
     ///
     /// On a client these indices only hold entries for tracked targets, so that they stay small
-    /// (the per-target outbox *queues* in `outboxes` are kept for every target). `digest` must be
-    /// [`tracked_chains_hash`] of `full_chains`.
+    /// (the per-target outbox *queues* in `outboxes` are kept for every target).
     ///
     /// This rebuilds the indices additively from the tracked chains' retained outbox queues, which
     /// is `O(|full_chains|)` — bounded by the wallet's tracked set — and needs no knowledge of the
@@ -752,8 +752,8 @@ where
     pub async fn reconcile_outbox_index(
         &mut self,
         full_chains: &BTreeSet<ChainId>,
-        digest: CryptoHash,
     ) -> Result<(), ChainError> {
+        let digest = tracked_chains_hash(full_chains);
         if *self.outbox_index_tracked_hash.get() == Some(digest) {
             return Ok(());
         }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -305,10 +305,6 @@ where
     /// hash stops matching and the indices are reconciled (`reconcile_outbox_index`). `None` means
     /// they have never been filtered — a pre-existing database entry (migration), or a validator
     /// that tracks all chains and never filters.
-    ///
-    /// MUST stay last in this struct: `View` derives each sub-view's storage-key prefix from field
-    /// order, so inserting a field earlier would shift every following view's keys and corrupt
-    /// existing databases.
     pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
 }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -777,6 +777,13 @@ where
         Ok(true)
     }
 
+    /// Returns whether the outbox index is already reconciled to `full_chains` — i.e. the
+    /// stored version hash matches — so the index can be read without rebuilding it. Lets the
+    /// read-only network-actions fast path decide whether a write-lock reconcile is needed.
+    pub fn outbox_index_is_reconciled(&self, full_chains: &BTreeSet<ChainId>) -> bool {
+        *self.outbox_index_tracked_hash.get() == Some(tracked_chains_hash(full_chains))
+    }
+
     /// Executes a block with a specified policy for handling bundle failures.
     #[instrument(skip_all, fields(
         chain_id = %block.chain_id,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -8,12 +8,13 @@ use std::{
 
 use allocative::Allocative;
 use linera_base::{
-    crypto::{CryptoHash, CryptoHashVec, ValidatorPublicKey},
+    crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
         ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Epoch,
         NonCanonicalBTreeMap, NonCanonicalBTreeSet, OracleResponse, Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, StreamId},
     ownership::ChainOwnership,
     time::{Duration, Instant},
@@ -220,11 +221,22 @@ pub struct BundleInInbox {
 // of 100 seems reasonable for the storing of the data.
 const TIMESTAMPBUNDLE_BUCKET_SIZE: usize = 100;
 
-/// Computes the hash identifying a set of fully-tracked chains, stored in
-/// [`ChainStateView::outbox_index_tracked_hash`] to detect when the outbox indices must be
-/// reconciled. The input is order-independent because `BTreeSet` iterates in sorted order.
-pub(crate) fn tracked_chains_hash(full_chains: &BTreeSet<ChainId>) -> CryptoHash {
-    CryptoHash::new(&CryptoHashVec(full_chains.iter().map(|id| id.0).collect()))
+/// A set of fully-tracked chains. Wrapped in [`Hashed`] (as `Hashed<ChainIdSet>`) so the hash that
+/// identifies the set — stored in [`ChainStateView::outbox_index_tracked_hash`] to detect when the
+/// outbox indices must be reconciled — is computed once when the tracked set changes rather than on
+/// every cross-chain operation. The hash is order-independent because `BTreeSet` iterates in sorted
+/// order.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainIdSet(pub BTreeSet<ChainId>);
+
+impl linera_base::crypto::BcsHashable<'_> for ChainIdSet {}
+
+impl std::ops::Deref for ChainIdSet {
+    type Target = BTreeSet<ChainId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 /// A view accessing the state of a chain.
@@ -453,7 +465,7 @@ where
         &mut self,
         target: &ChainId,
         height: BlockHeight,
-        tracked: Option<&BTreeSet<ChainId>>,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<bool, ChainError> {
         let mut outbox = self.outboxes.try_load_entry_mut(target).await?;
         let updates = outbox.mark_messages_as_received(height).await?;
@@ -750,15 +762,15 @@ where
     /// a read-only caller can skip persisting when nothing changed.
     pub async fn reconcile_outbox_index(
         &mut self,
-        full_chains: &BTreeSet<ChainId>,
+        tracked: &Hashed<ChainIdSet>,
     ) -> Result<bool, ChainError> {
-        let digest = tracked_chains_hash(full_chains);
+        let digest = tracked.hash();
         if *self.outbox_index_tracked_hash.get() == Some(digest) {
             return Ok(false);
         }
         self.nonempty_outboxes.get_mut().clear();
         self.outbox_counters.get_mut().clear();
-        for target in full_chains {
+        for target in tracked.inner().iter() {
             let heights = {
                 let Some(outbox) = self.outboxes.try_load_entry(target).await? else {
                     continue;
@@ -780,8 +792,8 @@ where
     /// Returns whether the outbox index is already reconciled to `full_chains` — i.e. the
     /// stored version hash matches — so the index can be read without rebuilding it. Lets the
     /// read-only network-actions fast path decide whether a write-lock reconcile is needed.
-    pub fn outbox_index_is_reconciled(&self, full_chains: &BTreeSet<ChainId>) -> bool {
-        *self.outbox_index_tracked_hash.get() == Some(tracked_chains_hash(full_chains))
+    pub fn outbox_index_is_reconciled(&self, tracked: &Hashed<ChainIdSet>) -> bool {
+        *self.outbox_index_tracked_hash.get() == Some(tracked.hash())
     }
 
     /// Executes a block with a specified policy for handling bundle failures.
@@ -1231,7 +1243,7 @@ where
         &mut self,
         block: &ConfirmedBlock,
         local_time: Timestamp,
-        tracked: Option<&BTreeSet<ChainId>>,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
@@ -1273,7 +1285,7 @@ where
     pub async fn preprocess_block(
         &mut self,
         block: &ConfirmedBlock,
-        tracked: Option<&BTreeSet<ChainId>>,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
@@ -1401,7 +1413,7 @@ where
     async fn process_outgoing_messages(
         &mut self,
         block: &Block,
-        tracked: Option<&BTreeSet<ChainId>>,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<Vec<ChainId>, ChainError> {
         // Record the messages of the execution. Messages are understood within an
         // application.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -745,32 +745,44 @@ where
     }
 
     /// Reconciles the `nonempty_outboxes` and `outbox_counters` indices with the given set of
-    /// fully-tracked chains, if the tracked set has changed since the last reconciliation
-    /// (i.e. the stored [`Self::outbox_index_tracked_hash`] no longer matches).
+    /// tracked chains, if it has changed since the last reconciliation (i.e. the stored
+    /// [`Self::outbox_index_tracked_hash`] no longer matches).
     ///
-    /// On a client these indices only hold entries for tracked targets, so that they stay small
-    /// (the per-target outbox *queues* in `outboxes` are kept for every target).
+    /// `tracked` is `Some` on a client, whose indices only hold entries for tracked targets so that
+    /// they stay small (the per-target outbox *queues* in `outboxes` are kept for every target).
+    /// `tracked` is `None` in full mode (a validator), where every target is indexed; the stored
+    /// hash is then `None` and, in steady state, this is an `O(1)` no-op because full-mode indices
+    /// are maintained incrementally as blocks are applied.
     ///
-    /// This rebuilds the indices additively from the tracked chains' retained outbox queues, which
-    /// is `O(|full_chains|)` — bounded by the wallet's tracked set — and needs no knowledge of the
-    /// previous set. It is therefore correct and cheap for every case: migration of a database
-    /// written before filtering, a restart after a tracked-set change, a shrink, or a growth; in
-    /// particular it never scans the (unbounded) full set of outbox targets. A subtractive
-    /// `O(|delta|)` fast path can be added on top once the worker supplies the added/removed sets.
+    /// In the `Some` case the indices are rebuilt additively from the tracked chains' retained
+    /// outbox queues, which is `O(|tracked|)` — bounded by the wallet's tracked set — and never
+    /// scans the (unbounded) full set of outbox targets. The `None` case does real work only on a
+    /// mode transition (a previously-filtered chain switching back to full mode, so the stored hash
+    /// is still `Some`): it then re-indexes from *all* outbox queues, an `O(|outboxes|)` rebuild,
+    /// and stamps the hash back to `None`. Either case is correct for every scenario: migration of a
+    /// database written before filtering, a restart after a tracked-set change, a shrink, or a
+    /// growth. A subtractive `O(|delta|)` fast path can be added on top once the worker supplies the
+    /// added/removed sets.
     ///
     /// Returns whether the indices were actually rebuilt (`false` if they were already current), so
     /// a read-only caller can skip persisting when nothing changed.
     pub async fn reconcile_outbox_index(
         &mut self,
-        tracked: &Hashed<ChainIdSet>,
+        tracked: Option<&Hashed<ChainIdSet>>,
     ) -> Result<bool, ChainError> {
-        let digest = tracked.hash();
-        if *self.outbox_index_tracked_hash.get() == Some(digest) {
+        let digest = tracked.map(|tracked| tracked.hash());
+        if *self.outbox_index_tracked_hash.get() == digest {
             return Ok(false);
         }
         self.nonempty_outboxes.get_mut().clear();
         self.outbox_counters.get_mut().clear();
-        for target in tracked.inner().iter() {
+        // In full mode (`None`) there is no tracked subset to iterate, so re-index from the keys of
+        // every retained outbox queue.
+        let targets = match tracked {
+            Some(tracked) => tracked.inner().iter().copied().collect::<Vec<_>>(),
+            None => self.outboxes.indices().await?,
+        };
+        for target in &targets {
             let heights = {
                 let Some(outbox) = self.outboxes.try_load_entry(target).await? else {
                     continue;
@@ -785,15 +797,16 @@ where
             }
             self.nonempty_outboxes.get_mut().insert(*target);
         }
-        self.outbox_index_tracked_hash.set(Some(digest));
+        self.outbox_index_tracked_hash.set(digest);
         Ok(true)
     }
 
-    /// Returns whether the outbox index is already reconciled to `full_chains` — i.e. the
-    /// stored version hash matches — so the index can be read without rebuilding it. Lets the
-    /// read-only network-actions fast path decide whether a write-lock reconcile is needed.
-    pub fn outbox_index_is_reconciled(&self, tracked: &Hashed<ChainIdSet>) -> bool {
-        *self.outbox_index_tracked_hash.get() == Some(tracked.hash())
+    /// Returns whether the outbox index is already reconciled to `tracked` — i.e. the stored
+    /// version hash matches (in full mode, `tracked` is `None` and the stored hash must be `None`)
+    /// — so the index can be read without rebuilding it. Lets the read-only network-actions fast
+    /// path decide whether a write-lock reconcile is needed.
+    pub fn outbox_index_is_reconciled(&self, tracked: Option<&Hashed<ChainIdSet>>) -> bool {
+        *self.outbox_index_tracked_hash.get() == tracked.map(|tracked| tracked.hash())
     }
 
     /// Executes a block with a specified policy for handling bundle failures.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -457,20 +457,28 @@ where
         &mut self,
         target: &ChainId,
         height: BlockHeight,
+        tracked: Option<&BTreeSet<ChainId>>,
     ) -> Result<bool, ChainError> {
         let mut outbox = self.outboxes.try_load_entry_mut(target).await?;
         let updates = outbox.mark_messages_as_received(height).await?;
         if updates.is_empty() {
             return Ok(false);
         }
+        // `outbox_counters` only counts targets we index: every chain on a validator
+        // (`tracked == None`), or tracked targets on a client. A missing counter for such a target
+        // is genuine corruption; for an untracked target it is expected (its messages were never
+        // counted — e.g. it was untracked when scheduled, or untracked between sending an update
+        // and receiving its confirmation), so there is nothing to decrement.
+        let expect_counter = tracked.is_none_or(|tracked| tracked.contains(target));
         for update in updates {
-            let counter = self
-                .outbox_counters
-                .get_mut()
-                .get_mut(&update)
-                .ok_or_else(|| {
-                    ChainError::CorruptedChainState("message counter should be present".into())
-                })?;
+            let Some(counter) = self.outbox_counters.get_mut().get_mut(&update) else {
+                if expect_counter {
+                    return Err(ChainError::CorruptedChainState(
+                        "message counter should be present".into(),
+                    ));
+                }
+                continue;
+            };
             *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
             if *counter == 0 {
                 // Important for the test in `all_messages_delivered_up_to`.
@@ -731,15 +739,15 @@ where
     /// fully-tracked chains, if the tracked set has changed since the last reconciliation.
     ///
     /// On a client these indices only hold entries for tracked targets, so that they stay small
-    /// (the per-target outbox *queues* in `outboxes` are still kept for every target, so a chain
-    /// that becomes tracked can be re-indexed). `digest` must be [`tracked_chains_hash`] of
-    /// `full_chains`.
+    /// (the per-target outbox *queues* in `outboxes` are kept for every target). `digest` must be
+    /// [`tracked_chains_hash`] of `full_chains`.
     ///
-    /// Cost: the removal pass is `O(index)`. The addition pass only runs when chains may have been
-    /// *added* to the tracked set. On initialization (`None` stamp = migration of a database
-    /// written before filtering) the old index already lists every target, so only removals are
-    /// needed. On a pure shrink (new set ⊆ old set) there are no additions either. The expensive
-    /// `outboxes` rescan is therefore reserved for the genuine growth case.
+    /// This rebuilds the indices additively from the tracked chains' retained outbox queues, which
+    /// is `O(|full_chains|)` — bounded by the wallet's tracked set — and needs no knowledge of the
+    /// previous set. It is therefore correct and cheap for every case: migration of a database
+    /// written before filtering, a restart after a tracked-set change, a shrink, or a growth; in
+    /// particular it never scans the (unbounded) full set of outbox targets. A subtractive
+    /// `O(|delta|)` fast path can be added on top once the worker supplies the added/removed sets.
     pub async fn reconcile_outbox_index(
         &mut self,
         full_chains: &BTreeSet<ChainId>,
@@ -748,75 +756,24 @@ where
         if *self.outbox_index_tracked_hash.get() == Some(digest) {
             return Ok(());
         }
-        let initializing = self.outbox_index_tracked_hash.get().is_none();
-
-        // 1. Removal pass: drop index/counter entries for targets that are no longer tracked.
-        //    The per-target outbox queue is left untouched so it can be re-indexed later.
-        let indexed = self.nonempty_outboxes.get().clone();
-        for target in indexed.iter() {
-            if full_chains.contains(target) {
+        self.nonempty_outboxes.get_mut().clear();
+        self.outbox_counters.get_mut().clear();
+        for target in full_chains {
+            let heights = {
+                let Some(outbox) = self.outboxes.try_load_entry(target).await? else {
+                    continue;
+                };
+                outbox.queue.elements().await?
+            };
+            if heights.is_empty() {
                 continue;
             }
-            self.unindex_outbox(target).await?;
-        }
-
-        // 2. Addition pass: index tracked targets that have a pending queue but are not indexed.
-        //    Skipped on initialization (migration: the old index already covered every target, so
-        //    step 1 alone leaves it tracked-only) and on a pure shrink. See the note above; the
-        //    `may_have_additions` decision is made by the caller, which knows the tracked-set delta
-        //    (defaults to a correct full rescan when the delta is unknown).
-        if !initializing {
-            for target in self.outboxes.indices().await? {
-                if !full_chains.contains(&target) || self.nonempty_outboxes.get().contains(&target) {
-                    continue;
-                }
-                self.reindex_outbox(&target).await?;
+            for height in heights {
+                *self.outbox_counters.get_mut().entry(height).or_default() += 1;
             }
+            self.nonempty_outboxes.get_mut().insert(*target);
         }
-
         self.outbox_index_tracked_hash.set(Some(digest));
-        Ok(())
-    }
-
-    /// Removes `target` from `nonempty_outboxes` and subtracts its queued heights from
-    /// `outbox_counters`, leaving the per-target outbox queue intact.
-    async fn unindex_outbox(&mut self, target: &ChainId) -> Result<(), ChainError> {
-        let heights = {
-            let outbox = self.outboxes.try_load_entry(target).await?;
-            match outbox {
-                Some(outbox) => outbox.queue.elements().await?,
-                None => Vec::new(),
-            }
-        };
-        for height in heights {
-            if let Some(counter) = self.outbox_counters.get_mut().get_mut(&height) {
-                *counter = counter.saturating_sub(1);
-                if *counter == 0 {
-                    self.outbox_counters.get_mut().remove(&height);
-                }
-            }
-        }
-        self.nonempty_outboxes.get_mut().remove(target);
-        Ok(())
-    }
-
-    /// Adds `target` to `nonempty_outboxes` and its queued heights to `outbox_counters`. Inverse
-    /// of [`Self::unindex_outbox`]; used when a previously untracked chain becomes tracked.
-    async fn reindex_outbox(&mut self, target: &ChainId) -> Result<(), ChainError> {
-        let heights = {
-            let outbox = self.outboxes.try_load_entry(target).await?;
-            match outbox {
-                Some(outbox) => outbox.queue.elements().await?,
-                None => Vec::new(),
-            }
-        };
-        if heights.is_empty() {
-            return Ok(());
-        }
-        for height in heights {
-            *self.outbox_counters.get_mut().entry(height).or_default() += 1;
-        }
-        self.nonempty_outboxes.get_mut().insert(*target);
         Ok(())
     }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -749,14 +749,6 @@ where
     /// [`Self::outbox_index_tracked_hash`] no longer matches). The per-target outbox *queues* in
     /// `outboxes` are always kept; only these indices are filtered. Returns whether a rebuild
     /// actually happened, so a read-only caller can skip persisting when nothing changed.
-    ///
-    /// `tracked` is `Some` on a client, whose indices only hold its tracked targets: an
-    /// `O(|tracked|)` rebuild that never scans the (unbounded) full set of targets. `tracked` is
-    /// `None` in full mode (a validator), where every target is indexed; this is an `O(1)` no-op in
-    /// steady state (the stored hash is already `None`), doing the `O(|outboxes|)` full rebuild only
-    /// when switching back from a filtered set. Correct for every case — migration of a pre-filter
-    /// database, restart, shrink, or growth; a subtractive `O(|delta|)` fast path could be added
-    /// later once the worker supplies the added/removed sets.
     pub async fn reconcile_outbox_index(
         &mut self,
         tracked: Option<&Hashed<ChainIdSet>>,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -744,28 +744,19 @@ where
         optional_vec.ok_or_else(|| ChainError::CorruptedChainState("Missing outboxes".into()))
     }
 
-    /// Reconciles the `nonempty_outboxes` and `outbox_counters` indices with the given set of
-    /// tracked chains, if it has changed since the last reconciliation (i.e. the stored
-    /// [`Self::outbox_index_tracked_hash`] no longer matches).
+    /// Reconciles the `nonempty_outboxes` and `outbox_counters` indices from the retained outbox
+    /// queues, rebuilding only when the tracked set changed since the last call (i.e. the stored
+    /// [`Self::outbox_index_tracked_hash`] no longer matches). The per-target outbox *queues* in
+    /// `outboxes` are always kept; only these indices are filtered. Returns whether a rebuild
+    /// actually happened, so a read-only caller can skip persisting when nothing changed.
     ///
-    /// `tracked` is `Some` on a client, whose indices only hold entries for tracked targets so that
-    /// they stay small (the per-target outbox *queues* in `outboxes` are kept for every target).
-    /// `tracked` is `None` in full mode (a validator), where every target is indexed; the stored
-    /// hash is then `None` and, in steady state, this is an `O(1)` no-op because full-mode indices
-    /// are maintained incrementally as blocks are applied.
-    ///
-    /// In the `Some` case the indices are rebuilt additively from the tracked chains' retained
-    /// outbox queues, which is `O(|tracked|)` — bounded by the wallet's tracked set — and never
-    /// scans the (unbounded) full set of outbox targets. The `None` case does real work only on a
-    /// mode transition (a previously-filtered chain switching back to full mode, so the stored hash
-    /// is still `Some`): it then re-indexes from *all* outbox queues, an `O(|outboxes|)` rebuild,
-    /// and stamps the hash back to `None`. Either case is correct for every scenario: migration of a
-    /// database written before filtering, a restart after a tracked-set change, a shrink, or a
-    /// growth. A subtractive `O(|delta|)` fast path can be added on top once the worker supplies the
-    /// added/removed sets.
-    ///
-    /// Returns whether the indices were actually rebuilt (`false` if they were already current), so
-    /// a read-only caller can skip persisting when nothing changed.
+    /// `tracked` is `Some` on a client, whose indices only hold its tracked targets: an
+    /// `O(|tracked|)` rebuild that never scans the (unbounded) full set of targets. `tracked` is
+    /// `None` in full mode (a validator), where every target is indexed; this is an `O(1)` no-op in
+    /// steady state (the stored hash is already `None`), doing the `O(|outboxes|)` full rebuild only
+    /// when switching back from a filtered set. Correct for every case — migration of a pre-filter
+    /// database, restart, shrink, or growth; a subtractive `O(|delta|)` fast path could be added
+    /// later once the worker supplies the added/removed sets.
     pub async fn reconcile_outbox_index(
         &mut self,
         tracked: Option<&Hashed<ChainIdSet>>,
@@ -801,10 +792,8 @@ where
         Ok(true)
     }
 
-    /// Returns whether the outbox index is already reconciled to `tracked` — i.e. the stored
-    /// version hash matches (in full mode, `tracked` is `None` and the stored hash must be `None`)
-    /// — so the index can be read without rebuilding it. Lets the read-only network-actions fast
-    /// path decide whether a write-lock reconcile is needed.
+    /// Returns whether the outbox index is already reconciled to `tracked` (the stored hash
+    /// matches), so the read-only network-actions path can read it without a write-lock rebuild.
     pub fn outbox_index_is_reconciled(&self, tracked: Option<&Hashed<ChainIdSet>>) -> bool {
         *self.outbox_index_tracked_hash.get() == tracked.map(|tracked| tracked.hash())
     }
@@ -1435,12 +1424,7 @@ where
         let next_height = self.tip_state.get().next_block_height;
 
         // Update the outboxes. Every recipient's per-target outbox queue is updated, but the
-        // `nonempty_outboxes`/`outbox_counters` indices are only populated for targets we track
-        // (`tracked == None` means a validator that tracks all chains). Untracked targets are
-        // delivered by the validators, never by this local node, so indexing them would grow the
-        // two `RegisterView` indices — which are re-serialized whole on every block — without
-        // bound. Targets are collected and the indices updated once, after the loop, so a block
-        // that schedules nothing tracked does not mark the registers dirty.
+        // `nonempty_outboxes` and `outbox_counters` indices are only populated for targets we track.
         let targets = recipients.into_iter().collect::<Vec<_>>();
         let outboxes = self.outboxes.try_load_entries_mut(&targets).await?;
         let mut scheduled_tracked = Vec::new();
@@ -1520,7 +1504,7 @@ where
         }
 
         if !scheduled_tracked.is_empty() {
-            // All scheduled messages are at `block_height`, so bump its shared counter once.
+            // All scheduled messages are at `block_height`.
             *self
                 .outbox_counters
                 .get_mut()

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -20,7 +20,7 @@ mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 
-pub use chain::{tracked_chains_hash, ChainStateView, ChainTipState};
+pub use chain::{ChainStateView, ChainTipState};
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -20,7 +20,7 @@ mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 
-pub use chain::{ChainStateView, ChainTipState};
+pub use chain::{tracked_chains_hash, ChainStateView, ChainTipState};
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -20,7 +20,7 @@ mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 
-pub use chain::{ChainStateView, ChainTipState};
+pub use chain::{ChainIdSet, ChainStateView, ChainTipState};
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1022,3 +1022,139 @@ async fn test_backward_compatible_view_field_append() {
         assert_eq!(new_view.field_c.count().await.unwrap(), 0);
     }
 }
+
+fn test_chain_id(seed: &str) -> ChainId {
+    ChainId(CryptoHash::test_hash(seed))
+}
+
+/// Schedules a message to `target`'s outbox at `height` and indexes it in
+/// `nonempty_outboxes`/`outbox_counters`, mirroring `process_outgoing_messages` for a tracked
+/// target.
+async fn schedule_indexed(
+    chain: &mut ChainStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    target: ChainId,
+    height: BlockHeight,
+) -> anyhow::Result<()> {
+    {
+        let mut outbox = chain.outboxes.try_load_entry_mut(&target).await?;
+        assert!(outbox.schedule_message(height)?);
+    }
+    *chain.outbox_counters.get_mut().entry(height).or_default() += 1;
+    chain.nonempty_outboxes.get_mut().insert(target);
+    Ok(())
+}
+
+/// Schedules a message to `target`'s outbox at `height` without indexing it, mirroring an
+/// untracked target: the per-target queue is kept but the indices are not touched.
+async fn schedule_unindexed(
+    chain: &mut ChainStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    target: ChainId,
+    height: BlockHeight,
+) -> anyhow::Result<()> {
+    let mut outbox = chain.outboxes.try_load_entry_mut(&target).await?;
+    assert!(outbox.schedule_message(height)?);
+    Ok(())
+}
+
+async fn outbox_queue_len(
+    chain: &ChainStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    target: &ChainId,
+) -> anyhow::Result<usize> {
+    Ok(chain
+        .outboxes
+        .try_load_entry(target)
+        .await?
+        .map_or(0, |outbox| outbox.queue.count()))
+}
+
+/// On the first reconciliation (`None` stamp, i.e. a database written before filtering), targets
+/// that are no longer tracked are dropped from the indices, but their outbox queues are kept.
+#[tokio::test]
+async fn test_reconcile_outbox_index_migration_drops_untracked() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(5);
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_indexed(&mut chain, b, height).await?;
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+
+    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let digest = crate::chain::tracked_chains_hash(&tracked);
+    chain.reconcile_outbox_index(&tracked, digest).await?;
+
+    assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert_eq!(outbox_queue_len(&chain, &b).await?, 1);
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), Some(digest));
+    Ok(())
+}
+
+/// Shrinking the tracked set drops the removed chains from the indices (queue kept).
+#[tokio::test]
+async fn test_reconcile_outbox_index_shrink_removes_chain() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(1);
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_indexed(&mut chain, b, height).await?;
+    let both: BTreeSet<ChainId> = [a, b].into_iter().collect();
+    chain
+        .outbox_index_tracked_hash
+        .set(Some(crate::chain::tracked_chains_hash(&both)));
+
+    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let digest = crate::chain::tracked_chains_hash(&tracked);
+    chain.reconcile_outbox_index(&tracked, digest).await?;
+
+    assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
+    assert!(!chain.nonempty_outboxes.get().contains(&b));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert_eq!(outbox_queue_len(&chain, &b).await?, 1);
+    Ok(())
+}
+
+/// Growing the tracked set re-indexes a newly tracked chain from its retained outbox queue.
+#[tokio::test]
+async fn test_reconcile_outbox_index_retrack_reindexes_from_queue() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(7);
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_unindexed(&mut chain, b, height).await?;
+    let only_a: BTreeSet<ChainId> = [a].into_iter().collect();
+    chain
+        .outbox_index_tracked_hash
+        .set(Some(crate::chain::tracked_chains_hash(&only_a)));
+    assert!(!chain.nonempty_outboxes.get().contains(&b));
+
+    let tracked: BTreeSet<ChainId> = [a, b].into_iter().collect();
+    let digest = crate::chain::tracked_chains_hash(&tracked);
+    chain.reconcile_outbox_index(&tracked, digest).await?;
+
+    assert!(chain.nonempty_outboxes.get().contains(&b));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 2);
+    Ok(())
+}
+
+/// A matching stamp short-circuits reconciliation without touching the indices.
+#[tokio::test]
+async fn test_reconcile_outbox_index_noop_when_hash_matches() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(3);
+    schedule_indexed(&mut chain, a, height).await?;
+    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let digest = crate::chain::tracked_chains_hash(&tracked);
+    chain.outbox_index_tracked_hash.set(Some(digest));
+
+    // `b` is indexed even though it is untracked; a matching hash means reconcile returns early.
+    schedule_indexed(&mut chain, b, height).await?;
+    chain.reconcile_outbox_index(&tracked, digest).await?;
+
+    assert!(chain.nonempty_outboxes.get().contains(&b));
+    Ok(())
+}

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1027,6 +1027,13 @@ fn test_chain_id(seed: &str) -> ChainId {
     ChainId(CryptoHash::test_hash(seed))
 }
 
+/// Builds the hashed tracked-chain set passed to `reconcile_outbox_index`.
+fn tracked_set<const N: usize>(
+    ids: [ChainId; N],
+) -> linera_base::hashed::Hashed<crate::ChainIdSet> {
+    linera_base::hashed::Hashed::new(crate::ChainIdSet(ids.into_iter().collect()))
+}
+
 /// Schedules a message to `target`'s outbox at `height` and indexes it in
 /// `nonempty_outboxes`/`outbox_counters`, mirroring `process_outgoing_messages` for a tracked
 /// target.
@@ -1079,8 +1086,8 @@ async fn test_reconcile_outbox_index_migration_drops_untracked() -> anyhow::Resu
     schedule_indexed(&mut chain, b, height).await?;
     assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
 
-    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
-    let digest = crate::chain::tracked_chains_hash(&tracked);
+    let tracked = tracked_set([a]);
+    let digest = tracked.hash();
     chain.reconcile_outbox_index(&tracked).await?;
 
     assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
@@ -1099,12 +1106,11 @@ async fn test_reconcile_outbox_index_shrink_removes_chain() -> anyhow::Result<()
     let height = BlockHeight(1);
     schedule_indexed(&mut chain, a, height).await?;
     schedule_indexed(&mut chain, b, height).await?;
-    let both: BTreeSet<ChainId> = [a, b].into_iter().collect();
     chain
         .outbox_index_tracked_hash
-        .set(Some(crate::chain::tracked_chains_hash(&both)));
+        .set(Some(tracked_set([a, b]).hash()));
 
-    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let tracked = tracked_set([a]);
     chain.reconcile_outbox_index(&tracked).await?;
 
     assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
@@ -1123,13 +1129,12 @@ async fn test_reconcile_outbox_index_retrack_reindexes_from_queue() -> anyhow::R
     let height = BlockHeight(7);
     schedule_indexed(&mut chain, a, height).await?;
     schedule_unindexed(&mut chain, b, height).await?;
-    let only_a: BTreeSet<ChainId> = [a].into_iter().collect();
     chain
         .outbox_index_tracked_hash
-        .set(Some(crate::chain::tracked_chains_hash(&only_a)));
+        .set(Some(tracked_set([a]).hash()));
     assert!(!chain.nonempty_outboxes.get().contains(&b));
 
-    let tracked: BTreeSet<ChainId> = [a, b].into_iter().collect();
+    let tracked = tracked_set([a, b]);
     chain.reconcile_outbox_index(&tracked).await?;
 
     assert!(chain.nonempty_outboxes.get().contains(&b));
@@ -1145,8 +1150,8 @@ async fn test_reconcile_outbox_index_noop_when_hash_matches() -> anyhow::Result<
     let b = test_chain_id("b");
     let height = BlockHeight(3);
     schedule_indexed(&mut chain, a, height).await?;
-    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
-    let digest = crate::chain::tracked_chains_hash(&tracked);
+    let tracked = tracked_set([a]);
+    let digest = tracked.hash();
     chain.outbox_index_tracked_hash.set(Some(digest));
 
     // `b` is indexed even though it is untracked; a matching hash means reconcile returns early.
@@ -1167,7 +1172,7 @@ async fn test_mark_received_untracked_target_is_tolerated() -> anyhow::Result<()
     schedule_indexed(&mut chain, a, height).await?;
 
     // Un-track `a`: its counter is dropped and it leaves the index, but the queue is kept.
-    let empty: BTreeSet<ChainId> = BTreeSet::new();
+    let empty = tracked_set([]);
     chain.reconcile_outbox_index(&empty).await?;
     assert!(!chain.nonempty_outboxes.get().contains(&a));
     assert!(chain.outbox_counters.get().is_empty());
@@ -1175,7 +1180,7 @@ async fn test_mark_received_untracked_target_is_tolerated() -> anyhow::Result<()
 
     // The in-flight confirmation arrives; `a` is untracked, so this drains the queue without error.
     let drained = chain
-        .mark_messages_as_received(&a, height, Some(&empty))
+        .mark_messages_as_received(&a, height, Some(empty.inner()))
         .await?;
     assert!(drained);
     assert_eq!(outbox_queue_len(&chain, &a).await?, 0);
@@ -1190,9 +1195,9 @@ async fn test_mark_received_tracked_missing_counter_errors() -> anyhow::Result<(
     let height = BlockHeight(2);
     // Queue a message but never count it: corrupt-by-construction for a tracked target.
     schedule_unindexed(&mut chain, a, height).await?;
-    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let tracked = tracked_set([a]);
     let result = chain
-        .mark_messages_as_received(&a, height, Some(&tracked))
+        .mark_messages_as_received(&a, height, Some(tracked.inner()))
         .await;
     assert!(result.is_err());
     Ok(())
@@ -1212,11 +1217,11 @@ async fn test_mark_received_untracked_keeps_tracked_sibling_counter() -> anyhow:
     schedule_unindexed(&mut chain, b, height).await?;
     assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
 
-    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let tracked = tracked_set([a]);
     // Confirming the untracked B drains its queue but must leave A's counter untouched.
     assert!(
         chain
-            .mark_messages_as_received(&b, height, Some(&tracked))
+            .mark_messages_as_received(&b, height, Some(tracked.inner()))
             .await?
     );
     assert_eq!(outbox_queue_len(&chain, &b).await?, 0);
@@ -1226,7 +1231,7 @@ async fn test_mark_received_untracked_keeps_tracked_sibling_counter() -> anyhow:
     // A's own confirmation still succeeds and clears the (intact) counter.
     assert!(
         chain
-            .mark_messages_as_received(&a, height, Some(&tracked))
+            .mark_messages_as_received(&a, height, Some(tracked.inner()))
             .await?
     );
     assert!(chain.outbox_counters.get().is_empty());
@@ -1243,7 +1248,7 @@ async fn test_reconcile_outbox_index_counts_all_queued_heights() -> anyhow::Resu
     schedule_unindexed(&mut chain, a, BlockHeight(3)).await?;
     schedule_unindexed(&mut chain, a, BlockHeight(5)).await?;
 
-    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let tracked = tracked_set([a]);
     assert!(chain.reconcile_outbox_index(&tracked).await?);
 
     assert!(chain.nonempty_outboxes.get().contains(&a));

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1201,3 +1201,31 @@ async fn test_mark_received_tracked_missing_counter_errors() -> anyhow::Result<(
     assert!(result.is_err());
     Ok(())
 }
+
+/// Confirming an untracked target must not disturb a tracked sibling's counter: `outbox_counters`
+/// is keyed by block height and shared across all recipients of that block, and only tracked
+/// recipients are counted.
+#[tokio::test]
+async fn test_mark_received_untracked_keeps_tracked_sibling_counter() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(4);
+    // Same block height: A is tracked (counted), B is untracked (not counted).
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_unindexed(&mut chain, b, height).await?;
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+
+    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    // Confirming the untracked B drains its queue but must leave A's counter untouched.
+    assert!(chain.mark_messages_as_received(&b, height, Some(&tracked)).await?);
+    assert_eq!(outbox_queue_len(&chain, &b).await?, 0);
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+
+    // A's own confirmation still succeeds and clears the (intact) counter.
+    assert!(chain.mark_messages_as_received(&a, height, Some(&tracked)).await?);
+    assert!(chain.outbox_counters.get().is_empty());
+    assert!(!chain.nonempty_outboxes.get().contains(&a));
+    Ok(())
+}

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1158,3 +1158,46 @@ async fn test_reconcile_outbox_index_noop_when_hash_matches() -> anyhow::Result<
     assert!(chain.nonempty_outboxes.get().contains(&b));
     Ok(())
 }
+
+/// A `ConfirmUpdatedRecipient` arriving for a chain that has just been un-tracked must not error,
+/// even though reconciliation already dropped its outbox counter.
+#[tokio::test]
+async fn test_mark_received_untracked_target_is_tolerated() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let height = BlockHeight(2);
+    schedule_indexed(&mut chain, a, height).await?;
+
+    // Un-track `a`: its counter is dropped and it leaves the index, but the queue is kept.
+    let empty: BTreeSet<ChainId> = BTreeSet::new();
+    chain
+        .reconcile_outbox_index(&empty, crate::chain::tracked_chains_hash(&empty))
+        .await?;
+    assert!(!chain.nonempty_outboxes.get().contains(&a));
+    assert!(chain.outbox_counters.get().is_empty());
+    assert_eq!(outbox_queue_len(&chain, &a).await?, 1);
+
+    // The in-flight confirmation arrives; `a` is untracked, so this drains the queue without error.
+    let drained = chain
+        .mark_messages_as_received(&a, height, Some(&empty))
+        .await?;
+    assert!(drained);
+    assert_eq!(outbox_queue_len(&chain, &a).await?, 0);
+    Ok(())
+}
+
+/// A missing counter for a *tracked* target is still reported as corruption.
+#[tokio::test]
+async fn test_mark_received_tracked_missing_counter_errors() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let height = BlockHeight(2);
+    // Queue a message but never count it: corrupt-by-construction for a tracked target.
+    schedule_unindexed(&mut chain, a, height).await?;
+    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    let result = chain
+        .mark_messages_as_received(&a, height, Some(&tracked))
+        .await;
+    assert!(result.is_err());
+    Ok(())
+}

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1088,7 +1088,7 @@ async fn test_reconcile_outbox_index_migration_drops_untracked() -> anyhow::Resu
 
     let tracked = tracked_set([a]);
     let digest = tracked.hash();
-    chain.reconcile_outbox_index(&tracked).await?;
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
 
     assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
     assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
@@ -1111,7 +1111,7 @@ async fn test_reconcile_outbox_index_shrink_removes_chain() -> anyhow::Result<()
         .set(Some(tracked_set([a, b]).hash()));
 
     let tracked = tracked_set([a]);
-    chain.reconcile_outbox_index(&tracked).await?;
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
 
     assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
     assert!(!chain.nonempty_outboxes.get().contains(&b));
@@ -1135,7 +1135,7 @@ async fn test_reconcile_outbox_index_retrack_reindexes_from_queue() -> anyhow::R
     assert!(!chain.nonempty_outboxes.get().contains(&b));
 
     let tracked = tracked_set([a, b]);
-    chain.reconcile_outbox_index(&tracked).await?;
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
 
     assert!(chain.nonempty_outboxes.get().contains(&b));
     assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 2);
@@ -1156,7 +1156,7 @@ async fn test_reconcile_outbox_index_noop_when_hash_matches() -> anyhow::Result<
 
     // `b` is indexed even though it is untracked; a matching hash means reconcile returns early.
     schedule_indexed(&mut chain, b, height).await?;
-    chain.reconcile_outbox_index(&tracked).await?;
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
 
     assert!(chain.nonempty_outboxes.get().contains(&b));
     Ok(())
@@ -1173,7 +1173,7 @@ async fn test_mark_received_untracked_target_is_tolerated() -> anyhow::Result<()
 
     // Un-track `a`: its counter is dropped and it leaves the index, but the queue is kept.
     let empty = tracked_set([]);
-    chain.reconcile_outbox_index(&empty).await?;
+    chain.reconcile_outbox_index(Some(&empty)).await?;
     assert!(!chain.nonempty_outboxes.get().contains(&a));
     assert!(chain.outbox_counters.get().is_empty());
     assert_eq!(outbox_queue_len(&chain, &a).await?, 1);
@@ -1249,7 +1249,7 @@ async fn test_reconcile_outbox_index_counts_all_queued_heights() -> anyhow::Resu
     schedule_unindexed(&mut chain, a, BlockHeight(5)).await?;
 
     let tracked = tracked_set([a]);
-    assert!(chain.reconcile_outbox_index(&tracked).await?);
+    assert!(chain.reconcile_outbox_index(Some(&tracked)).await?);
 
     assert!(chain.nonempty_outboxes.get().contains(&a));
     assert_eq!(
@@ -1261,6 +1261,56 @@ async fn test_reconcile_outbox_index_counts_all_queued_heights() -> anyhow::Resu
         1
     );
     // A second reconciliation against the same set is a no-op.
-    assert!(!chain.reconcile_outbox_index(&tracked).await?);
+    assert!(!chain.reconcile_outbox_index(Some(&tracked)).await?);
+    Ok(())
+}
+
+/// In full mode (`None`), when the indices have never been filtered (stored hash `None`),
+/// reconciliation is a no-op: a steady-state validator keeps its incrementally-maintained indices
+/// untouched and never scans the full set of outbox targets.
+#[tokio::test]
+async fn test_reconcile_outbox_index_full_mode_noop_when_unfiltered() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let height = BlockHeight(4);
+    schedule_indexed(&mut chain, a, height).await?;
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+
+    assert!(!chain.reconcile_outbox_index(None).await?);
+
+    // Indices are untouched and the chain stays in unfiltered (full) mode.
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+    Ok(())
+}
+
+/// Switching a previously-filtered chain back to full mode (`None`) re-indexes *every* outbox
+/// target from its retained queue — including targets dropped while filtered — and stamps the
+/// hash back to `None`.
+#[tokio::test]
+async fn test_reconcile_outbox_index_full_mode_reindexes_all() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(6);
+    // `a` is tracked/indexed; `b`'s queue is kept but it was dropped from the index while filtered.
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_unindexed(&mut chain, b, height).await?;
+    chain
+        .outbox_index_tracked_hash
+        .set(Some(tracked_set([a]).hash()));
+    assert!(!chain.nonempty_outboxes.get().contains(&b));
+
+    assert!(chain.reconcile_outbox_index(None).await?);
+
+    // Both targets are now indexed from their retained queues, and the stamp is back to `None`.
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+    assert!(chain.nonempty_outboxes.get().contains(&b));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 2);
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+
+    // A second full-mode reconciliation is now a no-op.
+    assert!(!chain.reconcile_outbox_index(None).await?);
     Ok(())
 }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1081,7 +1081,7 @@ async fn test_reconcile_outbox_index_migration_drops_untracked() -> anyhow::Resu
 
     let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
     let digest = crate::chain::tracked_chains_hash(&tracked);
-    chain.reconcile_outbox_index(&tracked, digest).await?;
+    chain.reconcile_outbox_index(&tracked).await?;
 
     assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
     assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
@@ -1105,8 +1105,7 @@ async fn test_reconcile_outbox_index_shrink_removes_chain() -> anyhow::Result<()
         .set(Some(crate::chain::tracked_chains_hash(&both)));
 
     let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
-    let digest = crate::chain::tracked_chains_hash(&tracked);
-    chain.reconcile_outbox_index(&tracked, digest).await?;
+    chain.reconcile_outbox_index(&tracked).await?;
 
     assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
     assert!(!chain.nonempty_outboxes.get().contains(&b));
@@ -1131,8 +1130,7 @@ async fn test_reconcile_outbox_index_retrack_reindexes_from_queue() -> anyhow::R
     assert!(!chain.nonempty_outboxes.get().contains(&b));
 
     let tracked: BTreeSet<ChainId> = [a, b].into_iter().collect();
-    let digest = crate::chain::tracked_chains_hash(&tracked);
-    chain.reconcile_outbox_index(&tracked, digest).await?;
+    chain.reconcile_outbox_index(&tracked).await?;
 
     assert!(chain.nonempty_outboxes.get().contains(&b));
     assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 2);
@@ -1153,7 +1151,7 @@ async fn test_reconcile_outbox_index_noop_when_hash_matches() -> anyhow::Result<
 
     // `b` is indexed even though it is untracked; a matching hash means reconcile returns early.
     schedule_indexed(&mut chain, b, height).await?;
-    chain.reconcile_outbox_index(&tracked, digest).await?;
+    chain.reconcile_outbox_index(&tracked).await?;
 
     assert!(chain.nonempty_outboxes.get().contains(&b));
     Ok(())
@@ -1170,9 +1168,7 @@ async fn test_mark_received_untracked_target_is_tolerated() -> anyhow::Result<()
 
     // Un-track `a`: its counter is dropped and it leaves the index, but the queue is kept.
     let empty: BTreeSet<ChainId> = BTreeSet::new();
-    chain
-        .reconcile_outbox_index(&empty, crate::chain::tracked_chains_hash(&empty))
-        .await?;
+    chain.reconcile_outbox_index(&empty).await?;
     assert!(!chain.nonempty_outboxes.get().contains(&a));
     assert!(chain.outbox_counters.get().is_empty());
     assert_eq!(outbox_queue_len(&chain, &a).await?, 1);
@@ -1218,13 +1214,21 @@ async fn test_mark_received_untracked_keeps_tracked_sibling_counter() -> anyhow:
 
     let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
     // Confirming the untracked B drains its queue but must leave A's counter untouched.
-    assert!(chain.mark_messages_as_received(&b, height, Some(&tracked)).await?);
+    assert!(
+        chain
+            .mark_messages_as_received(&b, height, Some(&tracked))
+            .await?
+    );
     assert_eq!(outbox_queue_len(&chain, &b).await?, 0);
     assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
     assert!(chain.nonempty_outboxes.get().contains(&a));
 
     // A's own confirmation still succeeds and clears the (intact) counter.
-    assert!(chain.mark_messages_as_received(&a, height, Some(&tracked)).await?);
+    assert!(
+        chain
+            .mark_messages_as_received(&a, height, Some(&tracked))
+            .await?
+    );
     assert!(chain.outbox_counters.get().is_empty());
     assert!(!chain.nonempty_outboxes.get().contains(&a));
     Ok(())

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -358,7 +358,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .await?;
 
     let value = ConfirmedBlock::new(outcome.with(valid_block));
-    chain.apply_confirmed_block(&value, time).await?;
+    chain.apply_confirmed_block(&value, time, None).await?;
 
     // In the second block, other operations are still not allowed.
     let invalid_block = make_child_block(&value.clone())
@@ -390,7 +390,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .execute_test_block_simple(valid_block, time, &[])
         .await?;
     let value = ConfirmedBlock::new(outcome.with(valid_block));
-    chain.apply_confirmed_block(&value, time).await?;
+    chain.apply_confirmed_block(&value, time, None).await?;
 
     Ok(())
 }
@@ -474,7 +474,7 @@ async fn test_mandatory_applications_with_messages() -> anyhow::Result<()> {
         .execute_test_block_simple(block_with_rejected, time, &[])
         .await?;
     let value = ConfirmedBlock::new(outcome.with(block_with_rejected));
-    chain.apply_confirmed_block(&value, time).await?;
+    chain.apply_confirmed_block(&value, time, None).await?;
 
     // Now test with the migration flag enabled.
     // We create a new chain with its own TestExecutionRuntimeContext (separate blob storage).
@@ -544,7 +544,7 @@ async fn test_mandatory_applications_with_messages() -> anyhow::Result<()> {
         .execute_test_block_simple(block_with_accepted, time, &[])
         .await?;
     let value = ConfirmedBlock::new(outcome.with(block_with_accepted));
-    chain2.apply_confirmed_block(&value, time).await?;
+    chain2.apply_confirmed_block(&value, time, None).await?;
 
     Ok(())
 }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1233,3 +1233,29 @@ async fn test_mark_received_untracked_keeps_tracked_sibling_counter() -> anyhow:
     assert!(!chain.nonempty_outboxes.get().contains(&a));
     Ok(())
 }
+
+/// Reconciliation counts every queued height of a target, not just one.
+#[tokio::test]
+async fn test_reconcile_outbox_index_counts_all_queued_heights() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    // `a` has two pending heights in its outbox queue, neither yet indexed/counted.
+    schedule_unindexed(&mut chain, a, BlockHeight(3)).await?;
+    schedule_unindexed(&mut chain, a, BlockHeight(5)).await?;
+
+    let tracked: BTreeSet<ChainId> = [a].into_iter().collect();
+    assert!(chain.reconcile_outbox_index(&tracked).await?);
+
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+    assert_eq!(
+        *chain.outbox_counters.get().get(&BlockHeight(3)).unwrap(),
+        1
+    );
+    assert_eq!(
+        *chain.outbox_counters.get().get(&BlockHeight(5)).unwrap(),
+        1
+    );
+    // A second reconciliation against the same set is a no-op.
+    assert!(!chain.reconcile_outbox_index(&tracked).await?);
+    Ok(())
+}

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -400,6 +400,37 @@ where
         })
     }
 
+    /// Returns the set of chains tracked in full mode, or `None` on a validator (which tracks all
+    /// chains and never filters its outbox indices).
+    fn tracked_full_chains(&self) -> Option<BTreeSet<ChainId>> {
+        let chain_modes = self.chain_modes.as_ref()?;
+        let chain_modes = chain_modes
+            .read()
+            .expect("Panics should not happen while holding a lock to `chain_modes`");
+        Some(
+            chain_modes
+                .iter()
+                .filter(|(_, mode)| mode.is_full())
+                .map(|(id, _)| *id)
+                .collect(),
+        )
+    }
+
+    /// Reconciles the chain's `nonempty_outboxes`/`outbox_counters` indices with the current set
+    /// of fully-tracked chains, and returns that set to be passed to block application so that
+    /// newly scheduled messages are only indexed for tracked targets. Returns `None` on a
+    /// validator (no filtering).
+    async fn reconcile_tracked_outboxes(&mut self) -> Result<Option<BTreeSet<ChainId>>, WorkerError> {
+        let Some(full_chains) = self.tracked_full_chains() else {
+            return Ok(None);
+        };
+        let digest = linera_chain::tracked_chains_hash(&full_chains);
+        self.chain
+            .reconcile_outbox_index(&full_chains, digest)
+            .await?;
+        Ok(Some(full_chains))
+    }
+
     /// Loads pending cross-chain requests, and adds `NewRound` notifications where appropriate.
     async fn create_network_actions(
         &self,
@@ -783,10 +814,13 @@ where
         let index_values = self.chain.preprocessed_blocks.index_values().await?;
         let hashes = index_values.iter().map(|(_, hash)| *hash).collect();
         let blocks = self.read_confirmed_blocks(hashes).await?;
+        let tracked = self.reconcile_tracked_outboxes().await?;
         for ((height, _), maybe_block) in index_values.into_iter().zip(blocks) {
             let block =
                 maybe_block.ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
-            self.chain.preprocess_block(&block).await?;
+            self.chain
+                .preprocess_block(&block, tracked.as_ref())
+                .await?;
         }
         Ok(())
     }
@@ -913,7 +947,11 @@ where
         if block.body.events.iter().any(|events| !events.is_empty()) {
             self.initialize_next_expected_events().await?;
         }
-        let updated_event_streams = self.chain.preprocess_block(certificate.value()).await?;
+        let tracked = self.reconcile_tracked_outboxes().await?;
+        let updated_event_streams = self
+            .chain
+            .preprocess_block(certificate.value(), tracked.as_ref())
+            .await?;
         self.save().await?;
         let mut actions = self.create_network_actions(None).await?;
         if !updated_event_streams.is_empty() {
@@ -981,6 +1019,7 @@ where
                 "Confirmed block has a timestamp in the future beyond the block time grace period"
             );
         }
+        let tracked = self.reconcile_tracked_outboxes().await?;
         let chain = &mut self.chain;
         chain
             .remove_bundles_from_inboxes(
@@ -1029,7 +1068,7 @@ where
         };
 
         let event_streams = chain
-            .apply_confirmed_block(&confirmed_block, local_time)
+            .apply_confirmed_block(&confirmed_block, local_time, tracked.as_ref())
             .await?;
         let mut actions = self.create_network_actions(None).await?;
         trace!("Processed confirmed block {height}");

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -420,7 +420,9 @@ where
     /// of fully-tracked chains, and returns that set to be passed to block application so that
     /// newly scheduled messages are only indexed for tracked targets. Returns `None` on a
     /// validator (no filtering).
-    async fn reconcile_tracked_outboxes(&mut self) -> Result<Option<BTreeSet<ChainId>>, WorkerError> {
+    async fn reconcile_tracked_outboxes(
+        &mut self,
+    ) -> Result<Option<BTreeSet<ChainId>>, WorkerError> {
         let Some(full_chains) = self.tracked_full_chains() else {
             return Ok(None);
         };

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -236,20 +236,41 @@ where
         self.service_runtime_task.take()
     }
 
-    /// Returns the pending cross-chain network actions for this chain, without
-    /// initializing the chain's execution state. Intended for callers that only
-    /// need to re-emit cross-chain requests from the outbox of a sender chain
-    /// whose `ChainDescription` we may never have needed.
+    /// Returns the pending cross-chain network actions if the outbox index is already
+    /// reconciled to the current tracked set, or `None` if it must first be reconciled (which
+    /// needs a write lock). Read-only: it never reconciles or saves, so on the common path the
+    /// worker can serve it under a shared lock, avoiding the write lock, task spawn and `save()`
+    /// of [`Self::reconcile_and_cross_chain_network_actions`].
+    pub(crate) async fn cross_chain_network_actions_if_reconciled(
+        &self,
+    ) -> Result<Option<NetworkActions>, WorkerError> {
+        let tracked = self.tracked_full_chains();
+        if let Some(full_chains) = &tracked {
+            if !self.chain.outbox_index_is_reconciled(full_chains) {
+                return Ok(None);
+            }
+        }
+        Ok(Some(
+            self.build_network_actions(None, tracked.as_ref()).await?,
+        ))
+    }
+
+    /// Reconciles the outbox index with the current tracked set, then returns the pending
+    /// cross-chain network actions for this chain, without initializing the chain's execution
+    /// state. Intended for callers that only need to re-emit cross-chain requests from the
+    /// outbox of a sender chain whose `ChainDescription` we may never have needed.
     ///
-    /// Takes `&mut self` because it reconciles the outbox indices with the current tracked set
-    /// (this only touches the outbox indices, not the execution state).
+    /// This is the slow path of [`Self::cross_chain_network_actions_if_reconciled`], used only
+    /// when the index is stale (first load after migration, or the tracked set changed). It
+    /// takes `&mut self` to rebuild the outbox indices (this only touches the outbox indices,
+    /// not the execution state).
     ///
     /// It always `save()`s, even though reconciliation is usually a no-op: this runs under a write
     /// lock, so dropping the `RollbackGuard` *without* saving would call `rollback()` and discard
     /// any uncommitted in-memory chain state — e.g. a pending block proposal the client set
     /// mid-operation. `save()` is a no-op write when the resulting batch is empty.
     #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
-    pub(crate) async fn cross_chain_network_actions(
+    pub(crate) async fn reconcile_and_cross_chain_network_actions(
         &mut self,
     ) -> Result<NetworkActions, WorkerError> {
         let tracked = self.tracked_full_chains();

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -242,14 +242,22 @@ where
     /// whose `ChainDescription` we may never have needed.
     ///
     /// Takes `&mut self` because it reconciles the outbox indices with the current tracked set
-    /// (this only touches the outbox indices, not the execution state) and persists the result.
-    /// The save is a no-op write when nothing changed.
+    /// (this only touches the outbox indices, not the execution state). It only persists — and only
+    /// pays the write cost — when reconciliation actually rebuilt the indices, i.e. when the tracked
+    /// set changed since the last reconciliation; the common case is a lock-only read.
     #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
     pub(crate) async fn cross_chain_network_actions(
         &mut self,
     ) -> Result<NetworkActions, WorkerError> {
-        let actions = self.create_network_actions(None).await?;
-        self.save().await?;
+        let tracked = self.tracked_full_chains();
+        let rebuilt = match &tracked {
+            Some(full_chains) => self.chain.reconcile_outbox_index(full_chains).await?,
+            None => false,
+        };
+        let actions = self.build_network_actions(None, tracked.as_ref()).await?;
+        if rebuilt {
+            self.save().await?;
+        }
         Ok(actions)
     }
 
@@ -424,6 +432,19 @@ where
         )
     }
 
+    /// Returns whether the given chain is tracked in full mode (always `true` on a validator),
+    /// i.e. whether its outbox should be indexed. Avoids materializing the whole tracked set for a
+    /// single membership test.
+    fn is_tracked(&self, chain_id: &ChainId) -> bool {
+        self.chain_modes.as_ref().is_none_or(|chain_modes| {
+            chain_modes
+                .read()
+                .expect("Panics should not happen while holding a lock to `chain_modes`")
+                .get(chain_id)
+                .is_some_and(ListeningMode::is_full)
+        })
+    }
+
     /// Reconciles the chain's `nonempty_outboxes`/`outbox_counters` indices with the current set
     /// of fully-tracked chains, and returns that set to be passed to block application so that
     /// newly scheduled messages are only indexed for tracked targets. Returns `None` on a
@@ -438,19 +459,32 @@ where
         Ok(Some(full_chains))
     }
 
-    /// Loads pending cross-chain requests, and adds `NewRound` notifications where appropriate.
+    /// Reconciles the outbox index with the current tracked set, then loads pending cross-chain
+    /// requests and adds `NewRound` notifications where appropriate.
     async fn create_network_actions(
         &mut self,
         old_round: Option<Round>,
     ) -> Result<NetworkActions, WorkerError> {
-        #[cfg(with_metrics)]
-        let _latency = metrics::CREATE_NETWORK_ACTIONS_LATENCY.measure_latency();
         // Make the outbox index authoritative for the current tracked set first, so it already
         // holds only `is_full` targets and needs no read-time filtering.
         let tracked = self.reconcile_tracked_outboxes().await?;
+        self.build_network_actions(old_round, tracked.as_ref())
+            .await
+    }
+
+    /// Builds the pending cross-chain actions from the already-reconciled outbox index. The caller
+    /// must have reconciled `self` against `tracked` (the current set of fully-tracked chains, or
+    /// `None` on a validator), so that the index holds only tracked targets.
+    async fn build_network_actions(
+        &self,
+        old_round: Option<Round>,
+        tracked: Option<&BTreeSet<ChainId>>,
+    ) -> Result<NetworkActions, WorkerError> {
+        #[cfg(with_metrics)]
+        let _latency = metrics::CREATE_NETWORK_ACTIONS_LATENCY.measure_latency();
         let mut heights_by_recipient = BTreeMap::<_, Vec<_>>::new();
         let targets = self.chain.nonempty_outbox_chain_ids();
-        if let Some(tracked) = tracked.as_ref() {
+        if let Some(tracked) = tracked {
             // Invariant (reconciliation + guarded writers): the index only holds tracked targets.
             // Surface a violation as corruption rather than silently delivering to a wrong chain.
             if let Some(target) = targets.iter().find(|target| !tracked.contains(*target)) {
@@ -1381,6 +1415,9 @@ where
         recipient: ChainId,
         retransmit_from: BlockHeight,
     ) -> Result<NetworkActions, WorkerError> {
+        // Reconcile the outbox index with the current tracked set before mutating it below, so the
+        // persisted index stays consistent with its tracked-set hash.
+        self.reconcile_tracked_outboxes().await?;
         // 1. Walk backward through previous_message_blocks to collect all heights
         //    that sent messages to this recipient, from the latest down to retransmit_from.
         let Some(latest_height) = self.chain.previous_message_blocks.get(&recipient).await? else {
@@ -1439,10 +1476,7 @@ where
         // 3. Update the indices only for tracked recipients (mirroring `process_outgoing_messages`):
         //    an untracked recipient keeps its re-added outbox queue but is not counted or indexed.
         let new_heights_len = new_heights.len();
-        if self
-            .tracked_full_chains()
-            .is_none_or(|tracked| tracked.contains(&recipient))
-        {
+        if self.is_tracked(&recipient) {
             for h in new_heights {
                 *self.chain.outbox_counters.get_mut().entry(h).or_default() += 1;
             }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1236,7 +1236,11 @@ where
         recipient: ChainId,
         latest_height: BlockHeight,
     ) -> Result<bool, WorkerError> {
-        let tracked = self.tracked_full_chains();
+        // Reconcile the outbox indices with the *current* tracked set before draining the counter
+        // and checking delivery. A chain tracked since the last reconciliation would otherwise be
+        // missing from the indices: its counter would be absent (a spurious `CorruptedChainState`)
+        // and the delivery check below would wrongly report it as fully delivered.
+        let tracked = self.reconcile_tracked_outboxes().await?;
         Ok(self
             .chain
             .mark_messages_as_received(&recipient, latest_height, tracked.as_ref())

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -247,10 +247,8 @@ where
         &self,
     ) -> Result<Option<NetworkActions>, WorkerError> {
         let tracked = self.tracked_full_chains();
-        if let Some(full_chains) = &tracked {
-            if !self.chain.outbox_index_is_reconciled(full_chains) {
-                return Ok(None);
-            }
+        if !self.chain.outbox_index_is_reconciled(tracked.as_deref()) {
+            return Ok(None);
         }
         Ok(Some(
             self.build_network_actions(None, tracked.as_deref().map(|h| h.inner()))
@@ -277,9 +275,9 @@ where
         &mut self,
     ) -> Result<NetworkActions, WorkerError> {
         let tracked = self.tracked_full_chains();
-        if let Some(full_chains) = &tracked {
-            self.chain.reconcile_outbox_index(full_chains).await?;
-        }
+        self.chain
+            .reconcile_outbox_index(tracked.as_deref())
+            .await?;
         let actions = self
             .build_network_actions(None, tracked.as_deref().map(|h| h.inner()))
             .await?;
@@ -468,17 +466,19 @@ where
     }
 
     /// Reconciles the chain's `nonempty_outboxes`/`outbox_counters` indices with the current set
-    /// of fully-tracked chains, and returns that set to be passed to block application so that
-    /// newly scheduled messages are only indexed for tracked targets. Returns `None` on a
-    /// validator (no filtering).
+    /// of fully-tracked chains (or, in full mode, with all targets), and returns that set to be
+    /// passed to block application so that newly scheduled messages are only indexed for tracked
+    /// targets. Returns `None` on a validator, which is passed through as "no filtering"; the
+    /// reconciliation itself still runs (a no-op in full mode unless the chain is switching back
+    /// from a filtered tracked set).
     async fn reconcile_tracked_outboxes(
         &mut self,
     ) -> Result<Option<Arc<Hashed<ChainIdSet>>>, WorkerError> {
-        let Some(full_chains) = self.tracked_full_chains() else {
-            return Ok(None);
-        };
-        self.chain.reconcile_outbox_index(&full_chains).await?;
-        Ok(Some(full_chains))
+        let full_chains = self.tracked_full_chains();
+        self.chain
+            .reconcile_outbox_index(full_chains.as_deref())
+            .await?;
+        Ok(full_chains)
     }
 
     /// Reconciles the outbox index with the current tracked set, then loads pending cross-chain

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -641,34 +641,6 @@ where
         Ok(cross_chain_requests)
     }
 
-    /// Returns true if there are no more outgoing messages in flight up to the given
-    /// block height for all tracked chains (those whose inboxes we update).
-    #[instrument(skip_all, fields(
-        chain_id = %self.chain_id(),
-        height = %height
-    ))]
-    async fn all_messages_to_tracked_chains_delivered_up_to(
-        &self,
-        height: BlockHeight,
-    ) -> Result<bool, WorkerError> {
-        if self.chain.all_messages_delivered_up_to(height) {
-            return Ok(true);
-        }
-        if self.chain_modes.is_none() {
-            // Validators track every chain, so the counter fast path above is the complete answer.
-            return Ok(false);
-        }
-        let targets = self.chain.nonempty_outbox_chain_ids();
-        let outboxes = self.chain.load_outboxes(&targets).await?;
-        for outbox in outboxes {
-            let front = outbox.queue.front();
-            if front.is_some_and(|key| *key <= height) {
-                return Ok(false);
-            }
-        }
-        Ok(true)
-    }
-
     /// Processes a leader timeout issued for this multi-owner chain.
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
@@ -1286,6 +1258,8 @@ where
         // Reconcile the outbox indices with the *current* tracked set before draining the counter
         // and checking delivery.
         let tracked = self.reconcile_tracked_outboxes().await?;
+        // The indices are now reconciled to the tracked set, so `all_messages_delivered_up_to`
+        // (the `outbox_counters` fast path) is already the complete answer for tracked chains.
         Ok(self
             .chain
             .mark_messages_as_received(
@@ -1294,9 +1268,7 @@ where
                 tracked.as_deref().map(|h| h.inner()),
             )
             .await?
-            && self
-                .all_messages_to_tracked_chains_delivered_up_to(latest_height)
-                .await?)
+            && self.chain.all_messages_delivered_up_to(latest_height))
     }
 
     /// Notifies delivery waiters that all messages up to `height` have been delivered.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -240,9 +240,17 @@ where
     /// initializing the chain's execution state. Intended for callers that only
     /// need to re-emit cross-chain requests from the outbox of a sender chain
     /// whose `ChainDescription` we may never have needed.
+    ///
+    /// Takes `&mut self` because it reconciles the outbox indices with the current tracked set
+    /// (this only touches the outbox indices, not the execution state) and persists the result.
+    /// The save is a no-op write when nothing changed.
     #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
-    pub(crate) async fn cross_chain_network_actions(&self) -> Result<NetworkActions, WorkerError> {
-        self.create_network_actions(None).await
+    pub(crate) async fn cross_chain_network_actions(
+        &mut self,
+    ) -> Result<NetworkActions, WorkerError> {
+        let actions = self.create_network_actions(None).await?;
+        self.save().await?;
+        Ok(actions)
     }
 
     /// Handles a [`ChainInfoQuery`], potentially voting on the next block.
@@ -435,19 +443,25 @@ where
 
     /// Loads pending cross-chain requests, and adds `NewRound` notifications where appropriate.
     async fn create_network_actions(
-        &self,
+        &mut self,
         old_round: Option<Round>,
     ) -> Result<NetworkActions, WorkerError> {
         #[cfg(with_metrics)]
         let _latency = metrics::CREATE_NETWORK_ACTIONS_LATENCY.measure_latency();
+        // Make the outbox index authoritative for the current tracked set first, so it already
+        // holds only `is_full` targets and needs no read-time filtering.
+        let tracked = self.reconcile_tracked_outboxes().await?;
         let mut heights_by_recipient = BTreeMap::<_, Vec<_>>::new();
-        let mut targets = self.chain.nonempty_outbox_chain_ids();
-        if let Some(chain_modes) = self.chain_modes.as_ref() {
-            let chain_modes = chain_modes
-                .read()
-                .expect("Panics should not happen while holding a lock to `chain_modes`");
-            // Only process outboxes for full chains (those whose inboxes we update).
-            targets.retain(|target| chain_modes.get(target).is_some_and(ListeningMode::is_full));
+        let targets = self.chain.nonempty_outbox_chain_ids();
+        if let Some(tracked) = tracked.as_ref() {
+            // Invariant (reconciliation + guarded writers): the index only holds tracked targets.
+            // Surface a violation as corruption rather than silently delivering to a wrong chain.
+            if let Some(target) = targets.iter().find(|target| !tracked.contains(*target)) {
+                return Err(ChainError::CorruptedChainState(format!(
+                    "outbox index contains untracked target {target}"
+                ))
+                .into());
+            }
         }
         let outboxes = self.chain.load_outboxes(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {
@@ -607,15 +621,13 @@ where
         if self.chain.all_messages_delivered_up_to(height) {
             return Ok(true);
         }
-        let Some(chain_modes) = self.chain_modes.as_ref() else {
+        if self.chain_modes.is_none() {
+            // Validators track every chain, so the counter fast path above is the complete answer.
             return Ok(false);
-        };
-        let mut targets = self.chain.nonempty_outbox_chain_ids();
-        {
-            let chain_modes = chain_modes.read().unwrap();
-            // Only consider full chains (those whose inboxes we update).
-            targets.retain(|target| chain_modes.get(target).is_some_and(ListeningMode::is_full));
         }
+        // On a client the caller (`confirm_updated_recipient`) has reconciled the outbox indices
+        // with the current tracked set, so every indexed target is tracked — no filtering needed.
+        let targets = self.chain.nonempty_outbox_chain_ids();
         let outboxes = self.chain.load_outboxes(&targets).await?;
         for outbox in outboxes {
             let front = outbox.queue.front();
@@ -1427,12 +1439,18 @@ where
             return Ok(NetworkActions::default());
         }
 
-        // 3. Update outbox_counters (+1 per new height for this one recipient).
+        // 3. Update the indices only for tracked recipients (mirroring `process_outgoing_messages`):
+        //    an untracked recipient keeps its re-added outbox queue but is not counted or indexed.
         let new_heights_len = new_heights.len();
-        for h in new_heights {
-            *self.chain.outbox_counters.get_mut().entry(h).or_default() += 1;
+        if self
+            .tracked_full_chains()
+            .is_none_or(|tracked| tracked.contains(&recipient))
+        {
+            for h in new_heights {
+                *self.chain.outbox_counters.get_mut().entry(h).or_default() += 1;
+            }
+            self.chain.nonempty_outboxes.get_mut().insert(recipient);
         }
-        self.chain.nonempty_outboxes.get_mut().insert(recipient);
 
         // 4. Create cross-chain requests for this recipient.
         let actions = self

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1234,9 +1234,10 @@ where
         recipient: ChainId,
         latest_height: BlockHeight,
     ) -> Result<bool, WorkerError> {
+        let tracked = self.tracked_full_chains();
         Ok(self
             .chain
-            .mark_messages_as_received(&recipient, latest_height)
+            .mark_messages_as_received(&recipient, latest_height, tracked.as_ref())
             .await?
             && self
                 .all_messages_to_tracked_chains_delivered_up_to(latest_height)

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -242,22 +242,22 @@ where
     /// whose `ChainDescription` we may never have needed.
     ///
     /// Takes `&mut self` because it reconciles the outbox indices with the current tracked set
-    /// (this only touches the outbox indices, not the execution state). It only persists — and only
-    /// pays the write cost — when reconciliation actually rebuilt the indices, i.e. when the tracked
-    /// set changed since the last reconciliation; the common case is a lock-only read.
+    /// (this only touches the outbox indices, not the execution state).
+    ///
+    /// It always `save()`s, even though reconciliation is usually a no-op: this runs under a write
+    /// lock, so dropping the `RollbackGuard` *without* saving would call `rollback()` and discard
+    /// any uncommitted in-memory chain state — e.g. a pending block proposal the client set
+    /// mid-operation. `save()` is a no-op write when the resulting batch is empty.
     #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
     pub(crate) async fn cross_chain_network_actions(
         &mut self,
     ) -> Result<NetworkActions, WorkerError> {
         let tracked = self.tracked_full_chains();
-        let rebuilt = match &tracked {
-            Some(full_chains) => self.chain.reconcile_outbox_index(full_chains).await?,
-            None => false,
-        };
-        let actions = self.build_network_actions(None, tracked.as_ref()).await?;
-        if rebuilt {
-            self.save().await?;
+        if let Some(full_chains) = &tracked {
+            self.chain.reconcile_outbox_index(full_chains).await?;
         }
+        let actions = self.build_network_actions(None, tracked.as_ref()).await?;
+        self.save().await?;
         Ok(actions)
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -434,10 +434,7 @@ where
         let Some(full_chains) = self.tracked_full_chains() else {
             return Ok(None);
         };
-        let digest = linera_chain::tracked_chains_hash(&full_chains);
-        self.chain
-            .reconcile_outbox_index(&full_chains, digest)
-            .await?;
+        self.chain.reconcile_outbox_index(&full_chains).await?;
         Ok(Some(full_chains))
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -240,9 +240,7 @@ where
 
     /// Returns the pending cross-chain network actions if the outbox index is already
     /// reconciled to the current tracked set, or `None` if it must first be reconciled (which
-    /// needs a write lock). Read-only: it never reconciles or saves, so on the common path the
-    /// worker can serve it under a shared lock, avoiding the write lock, task spawn and `save()`
-    /// of [`Self::reconcile_and_cross_chain_network_actions`].
+    /// needs a write lock).
     pub(crate) async fn cross_chain_network_actions_if_reconciled(
         &self,
     ) -> Result<Option<NetworkActions>, WorkerError> {
@@ -261,15 +259,7 @@ where
     /// state. Intended for callers that only need to re-emit cross-chain requests from the
     /// outbox of a sender chain whose `ChainDescription` we may never have needed.
     ///
-    /// This is the slow path of [`Self::cross_chain_network_actions_if_reconciled`], used only
-    /// when the index is stale (first load after migration, or the tracked set changed). It
-    /// takes `&mut self` to rebuild the outbox indices (this only touches the outbox indices,
-    /// not the execution state).
-    ///
-    /// It always `save()`s, even though reconciliation is usually a no-op: this runs under a write
-    /// lock, so dropping the `RollbackGuard` *without* saving would call `rollback()` and discard
-    /// any uncommitted in-memory chain state — e.g. a pending block proposal the client set
-    /// mid-operation. `save()` is a no-op write when the resulting batch is empty.
+    /// This is the slow path of [`Self::cross_chain_network_actions_if_reconciled`].
     #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
     pub(crate) async fn reconcile_and_cross_chain_network_actions(
         &mut self,
@@ -440,9 +430,8 @@ where
         })
     }
 
-    /// Returns the set of chains tracked in full mode together with its memoized hash, or `None` on
-    /// a validator (which tracks all chains and never filters its outbox indices). The hash is
-    /// cached in [`ChainModes`], so this is an `O(1)` clone rather than a rehash of the set.
+    /// Returns the set of chains tracked in full mode together with its memoized hash, or `None` if
+    /// every chain is implicitely in full-mode (e.g. on validator).
     fn tracked_full_chains(&self) -> Option<Arc<Hashed<ChainIdSet>>> {
         let chain_modes = self.chain_modes.as_ref()?;
         let full = chain_modes
@@ -453,8 +442,7 @@ where
     }
 
     /// Returns whether the given chain is tracked in full mode (always `true` on a validator),
-    /// i.e. whether its outbox should be indexed. Avoids materializing the whole tracked set for a
-    /// single membership test.
+    /// i.e. whether its outbox should be indexed.
     fn is_tracked(&self, chain_id: &ChainId) -> bool {
         self.chain_modes.as_ref().is_none_or(|chain_modes| {
             chain_modes
@@ -465,12 +453,8 @@ where
         })
     }
 
-    /// Reconciles the chain's `nonempty_outboxes`/`outbox_counters` indices with the current set
-    /// of fully-tracked chains (or, in full mode, with all targets), and returns that set to be
-    /// passed to block application so that newly scheduled messages are only indexed for tracked
-    /// targets. Returns `None` on a validator, which is passed through as "no filtering"; the
-    /// reconciliation itself still runs (a no-op in full mode unless the chain is switching back
-    /// from a filtered tracked set).
+    /// Reconciles the chain's `nonempty_outboxes` and `outbox_counters` indices with the current
+    /// set of fully-tracked chains.
     async fn reconcile_tracked_outboxes(
         &mut self,
     ) -> Result<Option<Arc<Hashed<ChainIdSet>>>, WorkerError> {
@@ -494,9 +478,7 @@ where
             .await
     }
 
-    /// Builds the pending cross-chain actions from the already-reconciled outbox index. The caller
-    /// must have reconciled `self` against `tracked` (the current set of fully-tracked chains, or
-    /// `None` on a validator), so that the index holds only tracked targets.
+    /// Builds the pending cross-chain actions from the already-reconciled outbox index.
     async fn build_network_actions(
         &self,
         old_round: Option<Round>,
@@ -507,8 +489,6 @@ where
         let mut heights_by_recipient = BTreeMap::<_, Vec<_>>::new();
         let targets = self.chain.nonempty_outbox_chain_ids();
         if let Some(tracked) = tracked {
-            // Invariant (reconciliation + guarded writers): the index only holds tracked targets.
-            // Surface a violation as corruption rather than silently delivering to a wrong chain.
             if let Some(target) = targets.iter().find(|target| !tracked.contains(*target)) {
                 return Err(ChainError::CorruptedChainState(format!(
                     "outbox index contains untracked target {target}"
@@ -678,8 +658,6 @@ where
             // Validators track every chain, so the counter fast path above is the complete answer.
             return Ok(false);
         }
-        // On a client the caller (`confirm_updated_recipient`) has reconciled the outbox indices
-        // with the current tracked set, so every indexed target is tracked — no filtering needed.
         let targets = self.chain.nonempty_outbox_chain_ids();
         let outboxes = self.chain.load_outboxes(&targets).await?;
         for outbox in outboxes {
@@ -1306,9 +1284,7 @@ where
         latest_height: BlockHeight,
     ) -> Result<bool, WorkerError> {
         // Reconcile the outbox indices with the *current* tracked set before draining the counter
-        // and checking delivery. A chain tracked since the last reconciliation would otherwise be
-        // missing from the indices: its counter would be absent (a spurious `CorruptedChainState`)
-        // and the delivery check below would wrongly report it as fully delivered.
+        // and checking delivery.
         let tracked = self.reconcile_tracked_outboxes().await?;
         Ok(self
             .chain
@@ -1445,8 +1421,6 @@ where
         recipient: ChainId,
         retransmit_from: BlockHeight,
     ) -> Result<NetworkActions, WorkerError> {
-        // Reconcile the outbox index with the current tracked set before mutating it below, so the
-        // persisted index stays consistent with its tracked-set hash.
         self.reconcile_tracked_outboxes().await?;
         // 1. Walk backward through previous_message_blocks to collect all heights
         //    that sent messages to this recipient, from the latest down to retransmit_from.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -18,6 +18,7 @@ use linera_base::{
         ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round, Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, StreamId},
 };
 use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache};
@@ -31,7 +32,8 @@ use linera_chain::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
         ValidatedBlockCertificate,
     },
-    ChainError, ChainExecutionContext, ChainStateView, ChainTipState, ExecutionResultExt as _,
+    ChainError, ChainExecutionContext, ChainIdSet, ChainStateView, ChainTipState,
+    ExecutionResultExt as _,
 };
 use linera_execution::{
     system::EventSubscriptions, ExecutionRuntimeContext as _, ExecutionStateView, Query,
@@ -47,7 +49,7 @@ use tracing::{debug, instrument, trace, warn};
 
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
-    client::ListeningMode,
+    client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
@@ -105,7 +107,7 @@ where
     block_values: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
-    chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+    chain_modes: Option<Arc<sync::RwLock<ChainModes>>>,
     delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
     /// Set to `true` if a database `save` failure has left storage potentially
@@ -168,7 +170,7 @@ where
         execution_state_cache: Option<
             Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>,
         >,
-        chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+        chain_modes: Option<Arc<sync::RwLock<ChainModes>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
@@ -251,7 +253,8 @@ where
             }
         }
         Ok(Some(
-            self.build_network_actions(None, tracked.as_ref()).await?,
+            self.build_network_actions(None, tracked.as_deref().map(|h| h.inner()))
+                .await?,
         ))
     }
 
@@ -277,7 +280,9 @@ where
         if let Some(full_chains) = &tracked {
             self.chain.reconcile_outbox_index(full_chains).await?;
         }
-        let actions = self.build_network_actions(None, tracked.as_ref()).await?;
+        let actions = self
+            .build_network_actions(None, tracked.as_deref().map(|h| h.inner()))
+            .await?;
         self.save().await?;
         Ok(actions)
     }
@@ -437,20 +442,16 @@ where
         })
     }
 
-    /// Returns the set of chains tracked in full mode, or `None` on a validator (which tracks all
-    /// chains and never filters its outbox indices).
-    fn tracked_full_chains(&self) -> Option<BTreeSet<ChainId>> {
+    /// Returns the set of chains tracked in full mode together with its memoized hash, or `None` on
+    /// a validator (which tracks all chains and never filters its outbox indices). The hash is
+    /// cached in [`ChainModes`], so this is an `O(1)` clone rather than a rehash of the set.
+    fn tracked_full_chains(&self) -> Option<Arc<Hashed<ChainIdSet>>> {
         let chain_modes = self.chain_modes.as_ref()?;
-        let chain_modes = chain_modes
+        let full = chain_modes
             .read()
-            .expect("Panics should not happen while holding a lock to `chain_modes`");
-        Some(
-            chain_modes
-                .iter()
-                .filter(|(_, mode)| mode.is_full())
-                .map(|(id, _)| *id)
-                .collect(),
-        )
+            .expect("Panics should not happen while holding a lock to `chain_modes`")
+            .full();
+        Some(full)
     }
 
     /// Returns whether the given chain is tracked in full mode (always `true` on a validator),
@@ -472,7 +473,7 @@ where
     /// validator (no filtering).
     async fn reconcile_tracked_outboxes(
         &mut self,
-    ) -> Result<Option<BTreeSet<ChainId>>, WorkerError> {
+    ) -> Result<Option<Arc<Hashed<ChainIdSet>>>, WorkerError> {
         let Some(full_chains) = self.tracked_full_chains() else {
             return Ok(None);
         };
@@ -489,7 +490,7 @@ where
         // Make the outbox index authoritative for the current tracked set first, so it already
         // holds only `is_full` targets and needs no read-time filtering.
         let tracked = self.reconcile_tracked_outboxes().await?;
-        self.build_network_actions(old_round, tracked.as_ref())
+        self.build_network_actions(old_round, tracked.as_deref().map(|h| h.inner()))
             .await
     }
 
@@ -499,7 +500,7 @@ where
     async fn build_network_actions(
         &self,
         old_round: Option<Round>,
-        tracked: Option<&BTreeSet<ChainId>>,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<NetworkActions, WorkerError> {
         #[cfg(with_metrics)]
         let _latency = metrics::CREATE_NETWORK_ACTIONS_LATENCY.measure_latency();
@@ -885,7 +886,7 @@ where
             let block =
                 maybe_block.ok_or_else(|| WorkerError::LocalBlockNotFound { height, chain_id })?;
             self.chain
-                .preprocess_block(&block, tracked.as_ref())
+                .preprocess_block(&block, tracked.as_deref().map(|h| h.inner()))
                 .await?;
         }
         Ok(())
@@ -1016,7 +1017,7 @@ where
         let tracked = self.reconcile_tracked_outboxes().await?;
         let updated_event_streams = self
             .chain
-            .preprocess_block(certificate.value(), tracked.as_ref())
+            .preprocess_block(certificate.value(), tracked.as_deref().map(|h| h.inner()))
             .await?;
         self.save().await?;
         let mut actions = self.create_network_actions(None).await?;
@@ -1134,7 +1135,11 @@ where
         };
 
         let event_streams = chain
-            .apply_confirmed_block(&confirmed_block, local_time, tracked.as_ref())
+            .apply_confirmed_block(
+                &confirmed_block,
+                local_time,
+                tracked.as_deref().map(|h| h.inner()),
+            )
             .await?;
         let mut actions = self.create_network_actions(None).await?;
         trace!("Processed confirmed block {height}");
@@ -1307,7 +1312,11 @@ where
         let tracked = self.reconcile_tracked_outboxes().await?;
         Ok(self
             .chain
-            .mark_messages_as_received(&recipient, latest_height, tracked.as_ref())
+            .mark_messages_as_received(
+                &recipient,
+                latest_height,
+                tracked.as_deref().map(|h| h.inner()),
+            )
             .await?
             && self
                 .all_messages_to_tracked_chains_delivered_up_to(latest_height)

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -22,6 +22,7 @@ use linera_base::{
         ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, Round, TimeDelta, Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
     time::Duration,
 };
@@ -34,7 +35,7 @@ use linera_chain::{
         Block, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
-    ChainError,
+    ChainError, ChainIdSet,
 };
 use linera_execution::committee::Committee;
 use linera_storage::{Arc as CacheArc, Clock as _, ResultReadCertificates, Storage as _};
@@ -246,6 +247,72 @@ impl ListeningMode {
     }
 }
 
+/// The per-chain [`ListeningMode`]s tracked by a local node, together with a memoized
+/// [`Hashed`] of the fully-tracked subset.
+///
+/// The hash is the version of the outbox index (see
+/// [`ChainStateView::outbox_index_tracked_hash`]). Caching it here — recomputed only when a chain
+/// newly becomes `FullChain`, which is rare and client-side — lets every cross-chain operation
+/// compare and reconcile the index in `O(1)` instead of rehashing the tracked set each time.
+///
+/// [`ChainStateView::outbox_index_tracked_hash`]: linera_chain::ChainStateView
+#[derive(Debug)]
+pub struct ChainModes {
+    modes: BTreeMap<ChainId, ListeningMode>,
+    full: Arc<Hashed<ChainIdSet>>,
+}
+
+impl Default for ChainModes {
+    fn default() -> Self {
+        Self::new(BTreeMap::new())
+    }
+}
+
+impl ChainModes {
+    /// Builds the listening modes from `modes`, computing the tracked-set hash once.
+    pub fn new(modes: BTreeMap<ChainId, ListeningMode>) -> Self {
+        let full = Self::compute_full(&modes);
+        Self { modes, full }
+    }
+
+    fn compute_full(modes: &BTreeMap<ChainId, ListeningMode>) -> Arc<Hashed<ChainIdSet>> {
+        Arc::new(Hashed::new(ChainIdSet(
+            modes
+                .iter()
+                .filter(|(_, mode)| mode.is_full())
+                .map(|(id, _)| *id)
+                .collect(),
+        )))
+    }
+
+    /// The fully-tracked chains together with their memoized hash (`O(1)` clone).
+    pub fn full(&self) -> Arc<Hashed<ChainIdSet>> {
+        self.full.clone()
+    }
+
+    /// Returns the listening mode for `chain_id`, if it is tracked.
+    pub fn get(&self, chain_id: &ChainId) -> Option<&ListeningMode> {
+        self.modes.get(chain_id)
+    }
+
+    /// Merges `mode` into the entry for `chain_id` — monotonic in the listening-mode order, so it
+    /// never weakens an existing entry — and returns the resulting mode. The tracked-set hash is
+    /// recomputed only if the chain newly became `FullChain`.
+    pub fn extend_mode(&mut self, chain_id: ChainId, mode: ListeningMode) -> ListeningMode {
+        let was_full = self
+            .modes
+            .get(&chain_id)
+            .is_some_and(ListeningMode::is_full);
+        let entry = self.modes.entry(chain_id).or_insert_with(|| mode.clone());
+        entry.extend(Some(mode));
+        let result = entry.clone();
+        if !was_full && result.is_full() {
+            self.full = Self::compute_full(&self.modes);
+        }
+        result
+    }
+}
+
 /// A builder that creates [`ChainClient`]s which share the cache and notifiers.
 pub struct Client<Env: Environment> {
     environment: Env,
@@ -258,7 +325,7 @@ pub struct Client<Env: Environment> {
     admin_chain_id: ChainId,
     /// Chains that should be tracked by the client, along with their listening mode.
     /// The presence of a chain in this map means it is tracked by the local node.
-    chain_modes: Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>,
+    chain_modes: Arc<RwLock<ChainModes>>,
     /// References to clients waiting for chain notifications.
     notifier: Arc<ChannelNotifier<Notification>>,
     /// Chain state for the managed chains.
@@ -285,15 +352,15 @@ impl<Env: Environment> Client<Env> {
         block_cache_size: usize,
         execution_state_cache_size: usize,
     ) -> Self {
-        let mut chain_modes = chain_modes.into_iter().collect::<BTreeMap<_, _>>();
+        let mut modes = chain_modes.into_iter().collect::<BTreeMap<_, _>>();
         // The client needs the admin chain fully synced for epoch tracking, so
         // promote it (or insert) into `FullChain`. `extend` is monotonic in the
         // listening mode order, so this never weakens an existing entry.
-        chain_modes
+        modes
             .entry(admin_chain_id)
             .or_insert(ListeningMode::FullChain)
             .extend(Some(ListeningMode::FullChain));
-        let chain_modes = Arc::new(RwLock::new(chain_modes));
+        let chain_modes = Arc::new(RwLock::new(ChainModes::new(modes)));
         let config = ChainWorkerConfig {
             nickname: name.into(),
             long_lived_services,
@@ -425,13 +492,10 @@ impl<Env: Environment> Client<Env> {
     /// Returns the resulting mode.
     #[instrument(level = "trace", skip(self))]
     pub fn extend_chain_mode(&self, chain_id: ChainId, mode: ListeningMode) -> ListeningMode {
-        let mut chain_modes = self
-            .chain_modes
+        self.chain_modes
             .write()
-            .expect("Panics should not happen while holding a lock to `chain_modes`");
-        let entry = chain_modes.entry(chain_id).or_insert_with(|| mode.clone());
-        entry.extend(Some(mode));
-        entry.clone()
+            .expect("Panics should not happen while holding a lock to `chain_modes`")
+            .extend_mode(chain_id, mode)
     }
 
     /// Returns the listening mode for a chain, if it is tracked.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -299,11 +299,11 @@ impl ChainModes {
     /// never weakens an existing entry — and returns the resulting mode. The tracked-set hash is
     /// recomputed only if the chain newly became `FullChain`.
     pub fn extend_mode(&mut self, chain_id: ChainId, mode: ListeningMode) -> ListeningMode {
-        let was_full = self
+        let entry = self
             .modes
-            .get(&chain_id)
-            .is_some_and(ListeningMode::is_full);
-        let entry = self.modes.entry(chain_id).or_insert_with(|| mode.clone());
+            .entry(chain_id)
+            .or_insert_with(|| ListeningMode::EventsOnly(BTreeSet::new()));
+        let was_full = entry.is_full();
         entry.extend(Some(mode));
         let result = entry.clone();
         if !was_full && result.is_full() {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5093,3 +5093,80 @@ where
 
     Ok(())
 }
+
+/// Worker-level regression test for the outbox-index filtering: a client worker that does not
+/// track the recipient must tolerate a `ConfirmUpdatedRecipient` for it. The recipient's outbox
+/// entry is scheduled but never counted, so before the fix this hit `CorruptedChainState` via the
+/// "message counter should be present" assertion.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_confirm_updated_recipient_untracked_target_is_tolerated<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(storage_builder.build().await?, true, false).await;
+    // Run the worker as a client; share the tracked-set map so later inserts are visible to the
+    // chain worker (which holds a clone of the `Arc`).
+    let chain_modes = Arc::new(std::sync::RwLock::new(BTreeMap::new()));
+    env.worker.chain_modes = Some(chain_modes.clone());
+
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    // Track only the sender; the recipient `chain_2` stays untracked.
+    chain_modes
+        .write()
+        .unwrap()
+        .insert(chain_1, crate::client::ListeningMode::FullChain);
+
+    // chain_1 transfers to the untracked chain_2: the outbox queue is scheduled but not indexed.
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::from_tokens(95),
+            vec![],
+        )
+        .await;
+    env.worker()
+        .process_confirmed_block(certificate, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        assert!(!chain.nonempty_outboxes.get().contains(&chain_2));
+        assert!(chain.outbox_counters.get().is_empty());
+        assert_eq!(
+            chain
+                .outboxes
+                .try_load_entry(&chain_2)
+                .await?
+                .expect("outbox queue is kept for untracked targets")
+                .queue
+                .count(),
+            1
+        );
+    }
+
+    // The confirmation for the untracked recipient must drain the outbox without erroring.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::ZERO,
+        })
+        .await?;
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        let outbox = chain.outboxes.try_load_entry(&chain_2).await?;
+        assert!(outbox.is_none() || outbox.unwrap().queue.count() == 0);
+    }
+    Ok(())
+}

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5251,3 +5251,94 @@ where
     }
     Ok(())
 }
+
+/// `RevertConfirm` for an untracked recipient must re-add its outbox queue but leave it out of the
+/// `nonempty_outboxes`/`outbox_counters` indices (the untracked branch of the tracking guard).
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_revert_confirm_untracked_recipient_not_indexed<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(storage_builder.build().await?, true, false).await;
+    let chain_modes = Arc::new(std::sync::RwLock::new(BTreeMap::new()));
+    env.worker.chain_modes = Some(chain_modes.clone());
+
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    // Track only the sender; the recipient chain_2 stays untracked.
+    chain_modes
+        .write()
+        .unwrap()
+        .insert(chain_1, crate::client::ListeningMode::FullChain);
+
+    // chain_1 sends to the untracked chain_2 at heights 0 and 1.
+    let cert_0 = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::from_tokens(95),
+            vec![],
+        )
+        .await;
+    let cert_1 = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(3),
+            Vec::new(),
+            Amount::from_tokens(92),
+            vec![&cert_0],
+        )
+        .await;
+    env.worker()
+        .process_confirmed_block(cert_0, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_1, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+
+    // Drain chain_1's outbox for chain_2 so the revert below has heights to re-add.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::from(1),
+        })
+        .await?;
+
+    // RevertConfirm re-adds chain_2's heights; since chain_2 is untracked it must not be indexed.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::RevertConfirm {
+            sender: chain_1,
+            recipient: chain_2,
+            retransmit_from: BlockHeight::ZERO,
+        })
+        .await?;
+
+    let chain = env.worker().chain_state_view(chain_1).await?;
+    assert_eq!(
+        chain
+            .outboxes
+            .try_load_entry(&chain_2)
+            .await?
+            .expect("the revert re-creates chain_2's outbox")
+            .queue
+            .count(),
+        2,
+        "the revert should re-add both heights to chain_2's outbox queue",
+    );
+    assert!(!chain.nonempty_outboxes.get().contains(&chain_2));
+    assert!(chain.outbox_counters.get().is_empty());
+    Ok(())
+}

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5170,3 +5170,84 @@ where
     }
     Ok(())
 }
+
+/// Confirming a chain that became tracked *after* its message was scheduled must reconcile the
+/// indices first: otherwise its counter is missing (a spurious `CorruptedChainState`) and the
+/// delivery check cannot see it. Here chain_3 is tracked late and must end up indexed.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_confirm_reconciles_newly_tracked_chain<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(storage_builder.build().await?, true, false).await;
+    let chain_modes = Arc::new(std::sync::RwLock::new(BTreeMap::new()));
+    env.worker.chain_modes = Some(chain_modes.clone());
+
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    let chain_3 = dummy_chain_description(3).id();
+    chain_modes
+        .write()
+        .unwrap()
+        .insert(chain_1, crate::client::ListeningMode::FullChain);
+
+    // chain_1 sends to chain_2 (height 0) and chain_3 (height 1) while both are untracked.
+    let cert_0 = env
+        .make_simple_transfer_certificate(
+            chain_1_desc.clone(),
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::from_tokens(95),
+            vec![],
+        )
+        .await;
+    let cert_1 = env
+        .make_simple_transfer_certificate(
+            chain_1_desc,
+            sender_key_pair.public(),
+            chain_3,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Amount::from_tokens(90),
+            vec![&cert_0],
+        )
+        .await;
+    env.worker()
+        .process_confirmed_block(cert_0, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_1, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+
+    // Track both recipients; the indices are now stale until the next reconciliation.
+    {
+        let mut modes = chain_modes.write().unwrap();
+        modes.insert(chain_2, crate::client::ListeningMode::FullChain);
+        modes.insert(chain_3, crate::client::ListeningMode::FullChain);
+    }
+
+    // Confirming chain_2 reconciles first, so it re-counts chain_2 (no `CorruptedChainState`),
+    // drains it, and indexes the newly tracked chain_3 with its still-undelivered message.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::from(1),
+        })
+        .await?;
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        assert!(!chain.nonempty_outboxes.get().contains(&chain_2));
+        assert!(chain.nonempty_outboxes.get().contains(&chain_3));
+    }
+    Ok(())
+}

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5110,7 +5110,7 @@ where
     let mut env = TestEnvironment::new(storage_builder.build().await?, true, false).await;
     // Run the worker as a client; share the tracked-set map so later inserts are visible to the
     // chain worker (which holds a clone of the `Arc`).
-    let chain_modes = Arc::new(std::sync::RwLock::new(BTreeMap::new()));
+    let chain_modes = Arc::new(std::sync::RwLock::new(crate::client::ChainModes::default()));
     env.worker.chain_modes = Some(chain_modes.clone());
 
     let chain_1_desc = env
@@ -5122,7 +5122,7 @@ where
     chain_modes
         .write()
         .unwrap()
-        .insert(chain_1, crate::client::ListeningMode::FullChain);
+        .extend_mode(chain_1, crate::client::ListeningMode::FullChain);
 
     // chain_1 transfers to the untracked chain_2: the outbox queue is scheduled but not indexed.
     let certificate = env
@@ -5184,7 +5184,7 @@ where
 {
     let sender_key_pair = AccountSecretKey::generate();
     let mut env = TestEnvironment::new(storage_builder.build().await?, true, false).await;
-    let chain_modes = Arc::new(std::sync::RwLock::new(BTreeMap::new()));
+    let chain_modes = Arc::new(std::sync::RwLock::new(crate::client::ChainModes::default()));
     env.worker.chain_modes = Some(chain_modes.clone());
 
     let chain_1_desc = env
@@ -5196,7 +5196,7 @@ where
     chain_modes
         .write()
         .unwrap()
-        .insert(chain_1, crate::client::ListeningMode::FullChain);
+        .extend_mode(chain_1, crate::client::ListeningMode::FullChain);
 
     // chain_1 sends to chain_2 (height 0) and chain_3 (height 1) while both are untracked.
     let cert_0 = env
@@ -5231,8 +5231,8 @@ where
     // Track both recipients; the indices are now stale until the next reconciliation.
     {
         let mut modes = chain_modes.write().unwrap();
-        modes.insert(chain_2, crate::client::ListeningMode::FullChain);
-        modes.insert(chain_3, crate::client::ListeningMode::FullChain);
+        modes.extend_mode(chain_2, crate::client::ListeningMode::FullChain);
+        modes.extend_mode(chain_3, crate::client::ListeningMode::FullChain);
     }
 
     // Confirming chain_2 reconciles first, so it re-counts chain_2 (no `CorruptedChainState`),
@@ -5264,7 +5264,7 @@ where
 {
     let sender_key_pair = AccountSecretKey::generate();
     let mut env = TestEnvironment::new(storage_builder.build().await?, true, false).await;
-    let chain_modes = Arc::new(std::sync::RwLock::new(BTreeMap::new()));
+    let chain_modes = Arc::new(std::sync::RwLock::new(crate::client::ChainModes::default()));
     env.worker.chain_modes = Some(chain_modes.clone());
 
     let chain_1_desc = env
@@ -5276,7 +5276,7 @@ where
     chain_modes
         .write()
         .unwrap()
-        .insert(chain_1, crate::client::ListeningMode::FullChain);
+        .extend_mode(chain_1, crate::client::ListeningMode::FullChain);
 
     // chain_1 sends to the untracked chain_2 at heights 0 and 1.
     let cert_0 = env

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1911,7 +1911,7 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<NetworkActions, WorkerError> {
-        self.chain_read(chain_id, |guard| async move {
+        self.chain_write(chain_id, |mut guard| async move {
             guard.cross_chain_network_actions().await
         })
         .await

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -69,7 +69,7 @@ use crate::{
         BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult, DeliveryNotifier,
         ProcessConfirmedBlockMode,
     },
-    client::ListeningMode,
+    client::{ChainModes, ListeningMode},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     notifier::Notifier,
 };
@@ -697,7 +697,7 @@ pub struct WorkerState<StorageClient: Storage> {
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
     /// Chains tracked by a worker, along with their listening modes.
-    pub(crate) chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+    pub(crate) chain_modes: Option<Arc<RwLock<ChainModes>>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
@@ -853,7 +853,7 @@ where
     pub fn new(
         storage: StorageClient,
         chain_worker_config: ChainWorkerConfig,
-        chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+        chain_modes: Option<Arc<RwLock<ChainModes>>>,
     ) -> Self {
         let chain_workers = Arc::new(papaya::HashMap::new());
         start_sweep(&chain_workers, &chain_worker_config);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -697,7 +697,7 @@ pub struct WorkerState<StorageClient: Storage> {
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
     /// Chains tracked by a worker, along with their listening modes.
-    chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+    pub(crate) chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1911,8 +1911,21 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<NetworkActions, WorkerError> {
+        // Fast path: when the outbox index is already reconciled to the current tracked set,
+        // the network actions are built from a read-only view, so a shared lock with no save
+        // suffices — avoiding the write lock, task spawn and `save()` of the slow path.
+        if let Some(actions) = self
+            .chain_read(chain_id, |guard| async move {
+                guard.cross_chain_network_actions_if_reconciled().await
+            })
+            .await?
+        {
+            return Ok(actions);
+        }
+        // Slow path (first load after migration, or the tracked set changed): reconcile and
+        // persist the index under an exclusive lock before building.
         self.chain_write(chain_id, |mut guard| async move {
-            guard.cross_chain_network_actions().await
+            guard.reconcile_and_cross_chain_network_actions().await
         })
         .await
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -421,9 +421,9 @@ type ChainStateExtendedView {
 	blockZeroExecutedAt: Timestamp!
 	"""
 	The hash of the set of fully-tracked chains that `nonempty_outboxes` and
-	`outbox_counters` were last reconciled against (see [`tracked_chains_hash`]). On a client
-	these two indices only hold entries for tracked targets; when the tracked set changes this
-	hash stops matching and the indices are reconciled (`reconcile_outbox_index`). `None` means
+	`outbox_counters` were last reconciled against. On a client these two indices only hold
+	entries for tracked targets; when the tracked set changes this hash stops matching and the
+	indices are reconciled (`reconcile_outbox_index`). `None` means
 	they have never been filtered — a pre-existing database entry (migration), or a validator
 	that tracks all chains and never filters.
 	"""

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -419,6 +419,19 @@ type ChainStateExtendedView {
 	the last reset, the error is returned instead.
 	"""
 	blockZeroExecutedAt: Timestamp!
+	"""
+	The hash of the set of fully-tracked chains that `nonempty_outboxes` and
+	`outbox_counters` were last reconciled against (see [`tracked_chains_hash`]). On a client
+	these two indices only hold entries for tracked targets; when the tracked set changes this
+	hash stops matching and the indices are reconciled (`reconcile_outbox_index`). `None` means
+	they have never been filtered — a pre-existing database entry (migration), or a validator
+	that tracks all chains and never filters.
+	
+	MUST stay last in this struct: `View` derives each sub-view's storage-key prefix from field
+	order, so inserting a field earlier would shift every following view's keys and corrupt
+	existing databases.
+	"""
+	outboxIndexTrackedHash: CryptoHash
 }
 
 """

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -426,10 +426,6 @@ type ChainStateExtendedView {
 	hash stops matching and the indices are reconciled (`reconcile_outbox_index`). `None` means
 	they have never been filtered — a pre-existing database entry (migration), or a validator
 	that tracks all chains and never filters.
-	
-	MUST stay last in this struct: `View` derives each sub-view's storage-key prefix from field
-	order, so inserting a field earlier would shift every following view's keys and corrupt
-	existing databases.
 	"""
 	outboxIndexTrackedHash: CryptoHash
 }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -51,7 +51,11 @@ const MAX_VALUE_SIZE: usize = 3 * 1024 * 1024 * 1024 - 400;
 // For offset reasons we decrease by 400
 const MAX_KEY_SIZE: usize = 8 * 1024 * 1024 - 400;
 
-const WRITE_BUFFER_SIZE: usize = 256 * 1024 * 1024; // 256 MiB
+// A small write buffer keeps the memtable flushing even on low-write workloads. A large buffer
+// (e.g. 256 MiB) lets a slowly-filling memtable grow huge and accumulate range tombstones, so every
+// point read has to scan it — which severely amplifies reads during e.g. a long chain
+// synchronization, where blocks are re-executed with little net data written.
+const WRITE_BUFFER_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 const MAX_WRITE_BUFFER_NUMBER: i32 = 6;
 
 fn get_available_memory(sys: &System) -> usize {


### PR DESCRIPTION
## Motivation

A client's `nonempty_outboxes` and `outbox_counters` are `RegisterView`s (each re-serialized whole on every block). They only drop an entry when the local node *delivers* to that target, and a client only delivers to chains its wallet tracks (`is_full`). High-fan-out chains send to many untracked targets, whose entries are inserted but never removed, so the two blobs grow without bound and every block re-serializes a large value to local storage — stalling block production. Validators (which track all chains) keep these indices near-empty.

## Proposal

Keep the two indices filtered to tracked targets on clients (validators, `chain_modes == None`, are unchanged):

- `process_outgoing_messages` still schedules every target's outbox *queue*, but only indexes/counts targets the wallet tracks (new `tracked: Option<&BTreeSet<ChainId>>` parameter).
- New `ChainStateView::outbox_index_tracked_hash: RegisterView<Option<CryptoHash>>` (appended **last** to keep storage-key prefixes stable) stamps the hash of the tracked set; `reconcile_outbox_index` rebuilds the indices **additively** from the tracked chains' retained outbox queues when the hash changes — `O(|tracked|)`, no scan of the full fan-out, correct for migration / restart / shrink / growth.
- `mark_messages_as_received` only enforces the "counter must be present" invariant for validators and tracked targets, tolerating untracked ones (fixes a `CorruptedChainState` reachable when a target is un-tracked between sending an update and receiving its confirmation).
- The chain worker derives the tracked set from `chain_modes` and threads it through block application and `confirm_updated_recipient`.

Outboxes are local node state (not in the consensus `state_hash`), so validators and clients legitimately differ here; the change is consensus-safe.

A subtractive `O(|delta|)` fast path can be layered on later once the worker supplies the added/removed sets; until then the additive `O(|tracked|)` rebuild is used.

## Test Plan

- `linera-chain` unit tests: reconcile migration / shrink / re-track / no-op; un-track race tolerated; corruption still caught for tracked targets.
- `linera-core` worker-level test: full `confirm_updated_recipient` → `mark_messages_as_received` path for an untracked recipient (regresses the `CorruptedChainState`).
- `cargo clippy --all-targets --all-features` clean on `linera-chain` and `linera-core`; full `linera-chain` suite green.

## Release Plan

- These changes add a trailing field to `ChainStateView` (storage-format change) and so require a new deployment. Targeting `testnet_conway`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
