### PR TITLE
Bridge admin retry endpoint

### DIFF
--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -99,6 +99,10 @@ struct ServeOptions {
     #[arg(long, default_value = "3001")]
     port: u16,
 
+    /// Port for the localhost-only admin HTTP server (retry endpoints).
+    #[arg(long, default_value = "3002")]
+    admin_port: u16,
+
     #[command(flatten)]
     common_storage_options: linera_storage_runtime::CommonStorageOptions,
 
@@ -156,6 +160,7 @@ impl ServeOptions {
             &self.evm_private_key,
             self.evm_light_client_address.as_deref(),
             self.port,
+            self.admin_port,
             &self.common_storage_options,
             std::time::Duration::from_secs(self.monitor_scan_interval),
             self.monitor_start_block,

--- a/linera-bridge/src/monitor/db.rs
+++ b/linera-bridge/src/monitor/db.rs
@@ -285,6 +285,135 @@ impl BridgeDb {
         Ok(())
     }
 
+    /// Moves every `failed` burn at `height` from `finished_burns` back to
+    /// `pending_burns` and returns the moved rows. Rows whose status is not
+    /// `"failed"` (e.g. `"completed"`) are left untouched. Inverse of the
+    /// failure half of `update_burn_status`.
+    pub async fn requeue_failed_burns(&self, height: BlockHeight) -> Result<Vec<PendingBurn>> {
+        let mut tx = self.pool.begin().await?;
+        let rows = sqlx::query(
+            "SELECT linera_height, block_hash, tx_index, event_pos_in_tx, event_index, evm_recipient, amount
+             FROM finished_burns
+             WHERE linera_height = ? AND status = 'failed'",
+        )
+        .bind(height.0 as i64)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let h: i64 = row.get(0);
+            let block_hash: String = row.get(1);
+            let tx_index: i64 = row.get(2);
+            let event_pos_in_tx: i64 = row.get(3);
+            let event_index: i64 = row.get(4);
+            let evm_recipient: String = row.get(5);
+            let amount: String = row.get(6);
+            out.push(PendingBurn {
+                height: BlockHeight(h as u64),
+                block_hash: block_hash
+                    .parse()
+                    .context("invalid block_hash in finished_burns row")?,
+                tx_index: tx_index as u32,
+                event_pos_in_tx: event_pos_in_tx as u32,
+                event_index: event_index as u32,
+                evm_recipient: evm_recipient
+                    .parse()
+                    .context("invalid evm_recipient in finished_burns row")?,
+                amount: amount
+                    .parse()
+                    .context("invalid amount in finished_burns row")?,
+            });
+        }
+
+        sqlx::query(
+            "INSERT OR IGNORE INTO pending_burns
+                (linera_height, block_hash, tx_index, event_pos_in_tx, event_index, evm_recipient, amount, raw_cert, created_at)
+             SELECT linera_height, block_hash, tx_index, event_pos_in_tx, event_index, evm_recipient, amount, raw_cert, created_at
+             FROM finished_burns
+             WHERE linera_height = ? AND status = 'failed'",
+        )
+        .bind(height.0 as i64)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM finished_burns WHERE linera_height = ? AND status = 'failed'")
+            .bind(height.0 as i64)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(out)
+    }
+
+    /// Moves every `failed` deposit for `(source_chain_id, tx_hash)` from
+    /// `finished_deposits` back to `pending_deposits` and returns the moved
+    /// rows. Rows whose status is not `"failed"` are left untouched.
+    pub async fn requeue_failed_deposits(
+        &self,
+        source_chain_id: u64,
+        tx_hash: B256,
+    ) -> Result<Vec<PendingDeposit>> {
+        let mut tx = self.pool.begin().await?;
+        let rows = sqlx::query(
+            "SELECT source_chain_id, block_hash, tx_index, log_index, tx_hash, depositor, amount, nonce
+             FROM finished_deposits
+             WHERE source_chain_id = ? AND tx_hash = ? AND status = 'failed'",
+        )
+        .bind(source_chain_id as i64)
+        .bind(tx_hash.as_slice())
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            let source_chain_id: i64 = row.get(0);
+            let block_hash: Vec<u8> = row.get(1);
+            let tx_index: i64 = row.get(2);
+            let log_index: i64 = row.get(3);
+            let tx_hash: Vec<u8> = row.get(4);
+            let depositor: Vec<u8> = row.get(5);
+            let amount: String = row.get(6);
+            let nonce: String = row.get(7);
+            out.push(PendingDeposit {
+                key: DepositKey {
+                    source_chain_id: source_chain_id as u64,
+                    block_hash: B256::try_from(block_hash.as_slice())
+                        .context("invalid block_hash in finished_deposits row")?,
+                    tx_index: tx_index as u64,
+                    log_index: log_index as u64,
+                },
+                tx_hash: B256::try_from(tx_hash.as_slice())
+                    .context("invalid tx_hash in finished_deposits row")?,
+                depositor: Address::try_from(depositor.as_slice())
+                    .context("invalid depositor in finished_deposits row")?,
+                amount: U256::from_str_radix(&amount, 10)
+                    .context("invalid amount in finished_deposits row")?,
+                nonce: U256::from_str_radix(&nonce, 10)
+                    .context("invalid nonce in finished_deposits row")?,
+            });
+        }
+
+        sqlx::query(
+            "INSERT OR IGNORE INTO pending_deposits
+                (source_chain_id, block_hash, tx_index, log_index, tx_hash, depositor, amount, nonce, raw_operation, created_at)
+             SELECT source_chain_id, block_hash, tx_index, log_index, tx_hash, depositor, amount, nonce, raw_operation, created_at
+             FROM finished_deposits
+             WHERE source_chain_id = ? AND tx_hash = ? AND status = 'failed'",
+        )
+        .bind(source_chain_id as i64)
+        .bind(tx_hash.as_slice())
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "DELETE FROM finished_deposits WHERE source_chain_id = ? AND tx_hash = ? AND status = 'failed'",
+        )
+        .bind(source_chain_id as i64)
+        .bind(tx_hash.as_slice())
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(out)
+    }
+
     /// Loads every pending deposit, used at relay startup to repopulate the
     /// in-memory `MonitorState` so that work in flight at the time of the
     /// previous shutdown is not lost.
@@ -449,6 +578,75 @@ mod tests {
                 .unwrap(),
             amount: U128(500_000),
         }
+    }
+
+    #[tokio::test]
+    async fn requeue_failed_burns_moves_failed_rows_back_to_pending() {
+        let db = BridgeDb::open_in_memory().await.unwrap();
+        let failed = test_burn(); // height 100, event_index 0
+        db.insert_burn(&failed).await.unwrap();
+        db.update_burn_status(failed.height, failed.event_index, "failed")
+            .await
+            .unwrap();
+
+        // A completed burn at the same height must NOT be touched.
+        let completed = PendingBurn {
+            event_index: 1,
+            ..test_burn()
+        };
+        db.insert_burn(&completed).await.unwrap();
+        db.update_burn_status(completed.height, completed.event_index, "completed")
+            .await
+            .unwrap();
+
+        let moved = db.requeue_failed_burns(BlockHeight(100)).await.unwrap();
+        assert_eq!(moved.len(), 1);
+        assert_eq!(moved[0].event_index, 0);
+
+        // The failed burn is back in pending; the completed one stays finished.
+        let pending = db.load_pending_burns().await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].event_index, 0);
+
+        let (failed_left,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM finished_burns WHERE status = 'failed'")
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(failed_left, 0);
+        let (completed_left,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM finished_burns WHERE status = 'completed'")
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(completed_left, 1);
+    }
+
+    #[tokio::test]
+    async fn requeue_failed_deposits_moves_failed_rows_for_tx() {
+        let db = BridgeDb::open_in_memory().await.unwrap();
+        let deposit = test_deposit();
+        db.insert_deposit(&deposit).await.unwrap();
+        db.update_deposit_status(&deposit.key, "failed")
+            .await
+            .unwrap();
+
+        let moved = db
+            .requeue_failed_deposits(deposit.key.source_chain_id, deposit.tx_hash)
+            .await
+            .unwrap();
+        assert_eq!(moved.len(), 1);
+        assert_eq!(moved[0].key.log_index, deposit.key.log_index);
+
+        let pending = db.load_pending_deposits().await.unwrap();
+        assert_eq!(pending.len(), 1);
+
+        let (failed_left,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM finished_deposits WHERE status = 'failed'")
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+        assert_eq!(failed_left, 0);
     }
 
     #[test_case(false; "in_memory")]

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -521,6 +521,89 @@ impl MonitorState {
         }
     }
 
+    /// Re-queues every `failed` burn at `height` so the normal retry
+    /// machinery picks them up without a relayer restart. Resets the
+    /// in-memory `Tracked` entry in place, or rebuilds it from the DB row if
+    /// it is gone (e.g. the burn failed before a restart and was not reloaded
+    /// into memory). Moves the DB row back to `pending_burns`. Returns the
+    /// `event_index` values that were reset (empty if none were failed).
+    pub async fn retry_failed_burns(&mut self, height: BlockHeight) -> Vec<u32> {
+        let moved = if let Some(db) = &self.db {
+            db.requeue_failed_burns(height)
+                .await
+                .unwrap_or_else(|error| {
+                    tracing::warn!(?height, ?error, "Failed to requeue burns in SQLite");
+                    Vec::new()
+                })
+        } else {
+            tracing::warn!("No persistent DB configured for the relayer");
+            Vec::new()
+        };
+
+        let mut reset = BTreeSet::new();
+        for (key, burn) in self.burns.iter_mut() {
+            if key.0 == height && burn.failed {
+                burn.failed = false;
+                burn.retry_count = 0;
+                burn.last_retry_at = None;
+                reset.insert(key.1);
+            }
+        }
+        for burn in moved {
+            let key = (burn.height, burn.event_index);
+            if let Entry::Vacant(slot) = self.burns.entry(key) {
+                slot.insert(Tracked::new(burn));
+                reset.insert(key.1);
+            }
+        }
+        reset.into_iter().collect()
+    }
+
+    /// Re-queues every `failed` deposit for `(source_chain_id, tx_hash)` so
+    /// the normal retry machinery picks them up. Resets the in-memory entry
+    /// in place, or rebuilds it from the DB row if it is gone. Moves the DB
+    /// row back to `pending_deposits`. Returns the `log_index` values that
+    /// were reset (empty if none were failed).
+    pub async fn retry_failed_deposits(&mut self, source_chain_id: u64, tx_hash: B256) -> Vec<u64> {
+        let moved = if let Some(db) = &self.db {
+            db.requeue_failed_deposits(source_chain_id, tx_hash)
+                .await
+                .unwrap_or_else(|error| {
+                    tracing::warn!(
+                        source_chain_id,
+                        ?error,
+                        "Failed to requeue deposits in SQLite"
+                    );
+                    Vec::new()
+                })
+        } else {
+            tracing::warn!("No persistent DB configured for the relayer");
+            Vec::new()
+        };
+
+        let mut reset = BTreeSet::new();
+        for (key, deposit) in self.deposits.iter_mut() {
+            if key.source_chain_id == source_chain_id
+                && deposit.value.tx_hash == tx_hash
+                && deposit.failed
+            {
+                deposit.failed = false;
+                deposit.retry_count = 0;
+                deposit.last_retry_at = None;
+                reset.insert(key.log_index);
+            }
+        }
+        for deposit in moved {
+            let key = deposit.key.clone();
+            let log_index = key.log_index;
+            if let Entry::Vacant(slot) = self.deposits.entry(key) {
+                slot.insert(Tracked::new(deposit));
+                reset.insert(log_index);
+            }
+        }
+        reset.into_iter().collect()
+    }
+
     pub fn status_summary(&self) -> StatusSummary {
         StatusSummary {
             deposits_pending: self.deposits.values().filter(|d| !d.forwarded).count(),
@@ -1036,5 +1119,104 @@ mod tests {
         assert_eq!(state.event_index_for_pos(BlockHeight(5), 2, 0), None);
         assert_eq!(state.event_index_for_pos(BlockHeight(5), 0, 1), None);
         assert_eq!(state.event_index_for_pos(BlockHeight(6), 2, 1), None);
+    }
+
+    #[tokio::test]
+    async fn retry_failed_burns_resets_in_memory_entry() {
+        let mut state = MonitorState::new(0);
+        state
+            .track_burn(PendingBurn {
+                height: BlockHeight(5),
+                block_hash: CryptoHash::from([0u8; 32]),
+                tx_index: 0,
+                event_pos_in_tx: 0,
+                event_index: 10,
+                evm_recipient: Address::ZERO,
+                amount: U128(0),
+            })
+            .await;
+        state.mark_burn_failed(BlockHeight(5), 10).await;
+        assert!(state.pending_burns_by_height_and_tx(10).is_empty());
+
+        let reset = state.retry_failed_burns(BlockHeight(5)).await;
+        assert_eq!(reset, vec![10u32]);
+        assert_eq!(state.pending_burns_by_height_and_tx(10).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_failed_burns_rebuilds_entry_from_db_after_restart() {
+        let mut state = MonitorState::new(0);
+        state.set_db(db::BridgeDb::open_in_memory().await.unwrap());
+        state
+            .track_burn(PendingBurn {
+                height: BlockHeight(5),
+                block_hash: CryptoHash::from([0u8; 32]),
+                tx_index: 0,
+                event_pos_in_tx: 0,
+                event_index: 10,
+                evm_recipient: Address::ZERO,
+                amount: U128(0),
+            })
+            .await;
+        state.mark_burn_failed(BlockHeight(5), 10).await;
+        // Simulate a restart: the in-memory entry is gone (only the DB
+        // `finished_burns` row remains).
+        state.burns.remove(&(BlockHeight(5), 10));
+
+        let reset = state.retry_failed_burns(BlockHeight(5)).await;
+        assert_eq!(reset, vec![10u32]);
+        assert_eq!(state.pending_burns_by_height_and_tx(10).len(), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_failed_burns_no_failed_items_returns_empty() {
+        let mut state = MonitorState::new(0);
+        state
+            .track_burn(PendingBurn {
+                height: BlockHeight(5),
+                block_hash: CryptoHash::from([0u8; 32]),
+                tx_index: 0,
+                event_pos_in_tx: 0,
+                event_index: 10,
+                evm_recipient: Address::ZERO,
+                amount: U128(0),
+            })
+            .await;
+        let reset = state.retry_failed_burns(BlockHeight(5)).await;
+        assert!(reset.is_empty());
+    }
+
+    #[tokio::test]
+    async fn retry_failed_deposits_resets_in_memory_entry() {
+        let mut state = MonitorState::new(0);
+        let tx_hash = B256::from([7u8; 32]);
+        let key = DepositKey {
+            source_chain_id: 8453,
+            block_hash: B256::from([1u8; 32]),
+            tx_index: 2,
+            log_index: 0,
+        };
+        state
+            .track_deposit(PendingDeposit {
+                key: key.clone(),
+                tx_hash,
+                depositor: Address::ZERO,
+                amount: U256::from(0),
+                nonce: U256::from(0),
+            })
+            .await;
+        state.mark_deposit_failed(&key).await;
+
+        let reset = state.retry_failed_deposits(8453, tx_hash).await;
+        assert_eq!(reset, vec![0u64]);
+        assert!(state.next_deposit_for_retry(10).is_some());
+    }
+
+    #[tokio::test]
+    async fn retry_failed_deposits_no_failed_items_returns_empty() {
+        let mut state = MonitorState::new(0);
+        let tx_hash = B256::from([7u8; 32]);
+        let reset = state.retry_failed_deposits(8453, tx_hash).await;
+        assert!(reset.is_empty());
     }
 }

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -452,9 +452,12 @@ impl MonitorState {
         }
     }
 
+    /// Marks a deposit `failed`: removes it from the in-memory map (a failed
+    /// deposit is no longer pending work) and moves the DB row to
+    /// `finished_deposits`. The DB row is the durable record; recovery is via
+    /// `retry_failed_deposits`.
     pub async fn mark_deposit_failed(&mut self, key: &DepositKey) {
-        if let Some(d) = self.deposits.get_mut(key) {
-            d.failed = true;
+        if self.deposits.remove(key).is_some() {
             crate::relay::metrics::deposit_failed();
             if let Some(db) = &self.db {
                 if let Err(error) = db.update_deposit_status(key, "failed").await {
@@ -504,9 +507,12 @@ impl MonitorState {
         }
     }
 
+    /// Marks a burn `failed`: removes it from the in-memory map (a failed
+    /// burn is no longer pending work) and moves the DB row to
+    /// `finished_burns`. The DB row is the durable record; recovery is via
+    /// `retry_failed_burns`.
     pub async fn mark_burn_failed(&mut self, height: BlockHeight, event_index: u32) {
-        if let Some(b) = self.burns.get_mut(&(height, event_index)) {
-            b.failed = true;
+        if self.burns.remove(&(height, event_index)).is_some() {
             crate::relay::metrics::burn_failed();
             if let Some(db) = &self.db {
                 if let Err(error) = db.update_burn_status(height, event_index, "failed").await {
@@ -522,11 +528,11 @@ impl MonitorState {
     }
 
     /// Re-queues every `failed` burn at `height` so the normal retry
-    /// machinery picks them up without a relayer restart. Resets the
-    /// in-memory `Tracked` entry in place, or rebuilds it from the DB row if
-    /// it is gone (e.g. the burn failed before a restart and was not reloaded
-    /// into memory). Moves the DB row back to `pending_burns`. Returns the
-    /// `event_index` values that were reset (empty if none were failed).
+    /// machinery picks them up without a relayer restart. A failed burn lives
+    /// only in the `finished_burns` table — it is removed from the in-memory
+    /// map when it fails — so this moves the DB row back to `pending_burns`
+    /// and rebuilds the in-memory `Tracked` entry. Returns the `event_index`
+    /// values re-queued (empty if none were failed or no DB is configured).
     pub async fn retry_failed_burns(&mut self, height: BlockHeight) -> Vec<u32> {
         let moved = if let Some(db) = &self.db {
             db.requeue_failed_burns(height)
@@ -541,14 +547,6 @@ impl MonitorState {
         };
 
         let mut reset = BTreeSet::new();
-        for (key, burn) in self.burns.iter_mut() {
-            if key.0 == height && burn.failed {
-                burn.failed = false;
-                burn.retry_count = 0;
-                burn.last_retry_at = None;
-                reset.insert(key.1);
-            }
-        }
         for burn in moved {
             let key = (burn.height, burn.event_index);
             if let Entry::Vacant(slot) = self.burns.entry(key) {
@@ -560,10 +558,11 @@ impl MonitorState {
     }
 
     /// Re-queues every `failed` deposit for `(source_chain_id, tx_hash)` so
-    /// the normal retry machinery picks them up. Resets the in-memory entry
-    /// in place, or rebuilds it from the DB row if it is gone. Moves the DB
-    /// row back to `pending_deposits`. Returns the `log_index` values that
-    /// were reset (empty if none were failed).
+    /// the normal retry machinery picks them up. A failed deposit lives only
+    /// in the `finished_deposits` table — it is removed from the in-memory
+    /// map when it fails — so this moves the DB row back to `pending_deposits`
+    /// and rebuilds the in-memory `Tracked` entry. Returns the `log_index`
+    /// values re-queued (empty if none were failed or no DB is configured).
     pub async fn retry_failed_deposits(&mut self, source_chain_id: u64, tx_hash: B256) -> Vec<u64> {
         let moved = if let Some(db) = &self.db {
             db.requeue_failed_deposits(source_chain_id, tx_hash)
@@ -582,17 +581,6 @@ impl MonitorState {
         };
 
         let mut reset = BTreeSet::new();
-        for (key, deposit) in self.deposits.iter_mut() {
-            if key.source_chain_id == source_chain_id
-                && deposit.value.tx_hash == tx_hash
-                && deposit.failed
-            {
-                deposit.failed = false;
-                deposit.retry_count = 0;
-                deposit.last_retry_at = None;
-                reset.insert(key.log_index);
-            }
-        }
         for deposit in moved {
             let key = deposit.key.clone();
             let log_index = key.log_index;
@@ -1122,7 +1110,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retry_failed_burns_resets_in_memory_entry() {
+    async fn mark_burn_failed_removes_from_memory() {
         let mut state = MonitorState::new(0);
         state
             .track_burn(PendingBurn {
@@ -1136,15 +1124,11 @@ mod tests {
             })
             .await;
         state.mark_burn_failed(BlockHeight(5), 10).await;
-        assert!(state.pending_burns_by_height_and_tx(10).is_empty());
-
-        let reset = state.retry_failed_burns(BlockHeight(5)).await;
-        assert_eq!(reset, vec![10u32]);
-        assert_eq!(state.pending_burns_by_height_and_tx(10).len(), 1);
+        assert!(!state.burns.contains_key(&(BlockHeight(5), 10)));
     }
 
     #[tokio::test]
-    async fn retry_failed_burns_rebuilds_entry_from_db_after_restart() {
+    async fn retry_failed_burns_rebuilds_from_db() {
         let mut state = MonitorState::new(0);
         state.set_db(db::BridgeDb::open_in_memory().await.unwrap());
         state
@@ -1159,9 +1143,9 @@ mod tests {
             })
             .await;
         state.mark_burn_failed(BlockHeight(5), 10).await;
-        // Simulate a restart: the in-memory entry is gone (only the DB
-        // `finished_burns` row remains).
-        state.burns.remove(&(BlockHeight(5), 10));
+        // Failing removed it from memory and moved it to `finished_burns`.
+        assert!(!state.burns.contains_key(&(BlockHeight(5), 10)));
+        assert!(state.pending_burns_by_height_and_tx(10).is_empty());
 
         let reset = state.retry_failed_burns(BlockHeight(5)).await;
         assert_eq!(reset, vec![10u32]);
@@ -1171,6 +1155,7 @@ mod tests {
     #[tokio::test]
     async fn retry_failed_burns_no_failed_items_returns_empty() {
         let mut state = MonitorState::new(0);
+        state.set_db(db::BridgeDb::open_in_memory().await.unwrap());
         state
             .track_burn(PendingBurn {
                 height: BlockHeight(5),
@@ -1182,13 +1167,39 @@ mod tests {
                 amount: U128(0),
             })
             .await;
+        // Nothing failed at this height; the pending burn is left untouched.
         let reset = state.retry_failed_burns(BlockHeight(5)).await;
         assert!(reset.is_empty());
+        assert_eq!(state.pending_burns_by_height_and_tx(10).len(), 1);
     }
 
     #[tokio::test]
-    async fn retry_failed_deposits_resets_in_memory_entry() {
+    async fn mark_deposit_failed_removes_from_memory() {
         let mut state = MonitorState::new(0);
+        let key = DepositKey {
+            source_chain_id: 8453,
+            block_hash: B256::from([1u8; 32]),
+            tx_index: 2,
+            log_index: 0,
+        };
+        state
+            .track_deposit(PendingDeposit {
+                key: key.clone(),
+                tx_hash: B256::from([7u8; 32]),
+                depositor: Address::ZERO,
+                amount: U256::from(0),
+                nonce: U256::from(0),
+            })
+            .await;
+        state.mark_deposit_failed(&key).await;
+        assert!(!state.deposits.contains_key(&key));
+        assert!(state.next_deposit_for_retry(10).is_none());
+    }
+
+    #[tokio::test]
+    async fn retry_failed_deposits_rebuilds_from_db() {
+        let mut state = MonitorState::new(0);
+        state.set_db(db::BridgeDb::open_in_memory().await.unwrap());
         let tx_hash = B256::from([7u8; 32]);
         let key = DepositKey {
             source_chain_id: 8453,
@@ -1206,6 +1217,7 @@ mod tests {
             })
             .await;
         state.mark_deposit_failed(&key).await;
+        assert!(!state.deposits.contains_key(&key));
 
         let reset = state.retry_failed_deposits(8453, tx_hash).await;
         assert_eq!(reset, vec![0u64]);
@@ -1215,8 +1227,10 @@ mod tests {
     #[tokio::test]
     async fn retry_failed_deposits_no_failed_items_returns_empty() {
         let mut state = MonitorState::new(0);
-        let tx_hash = B256::from([7u8; 32]);
-        let reset = state.retry_failed_deposits(8453, tx_hash).await;
+        state.set_db(db::BridgeDb::open_in_memory().await.unwrap());
+        let reset = state
+            .retry_failed_deposits(8453, B256::from([7u8; 32]))
+            .await;
         assert!(reset.is_empty());
     }
 }

--- a/linera-bridge/src/relay/admin.rs
+++ b/linera-bridge/src/relay/admin.rs
@@ -1,0 +1,205 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Localhost-only admin HTTP endpoints for operator recovery actions.
+//!
+//! Re-queues `failed` burns/deposits back to pending so the normal retry
+//! machinery picks them up without a relayer restart. Bound to 127.0.0.1
+//! only — the localhost bind is the access control, since these routes
+//! re-trigger fund-moving submissions (idempotent on-chain, operator-only).
+
+use std::sync::Arc;
+
+use alloy::primitives::B256;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::post,
+    Json, Router,
+};
+use linera_base::data_types::BlockHeight;
+use tokio::sync::{Notify, RwLock};
+
+use crate::monitor::MonitorState;
+
+#[derive(Clone)]
+pub(crate) struct AdminState {
+    pub monitor: Arc<RwLock<MonitorState>>,
+    pub deposit_notify: Arc<Notify>,
+    pub burn_notify: Arc<Notify>,
+}
+
+pub(crate) fn build_admin_router(state: AdminState) -> Router {
+    Router::new()
+        .route("/admin/retry/burns/{height}", post(retry_burns))
+        .route(
+            "/admin/retry/deposits/{source_chain_id}/{tx_hash}",
+            post(retry_deposits),
+        )
+        .with_state(state)
+}
+
+async fn retry_burns(
+    State(state): State<AdminState>,
+    Path(height): Path<u64>,
+) -> impl IntoResponse {
+    let reset = state
+        .monitor
+        .write()
+        .await
+        .retry_failed_burns(BlockHeight(height))
+        .await;
+    if reset.is_empty() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "status": "no_failed_items" })),
+        )
+            .into_response();
+    }
+    state.burn_notify.notify_one();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "status": "requeued", "count": reset.len(), "items": reset })),
+    )
+        .into_response()
+}
+
+async fn retry_deposits(
+    State(state): State<AdminState>,
+    Path((source_chain_id, tx_hash)): Path<(u64, String)>,
+) -> impl IntoResponse {
+    let tx_hash: B256 = match tx_hash.parse() {
+        Ok(hash) => hash,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "status": "invalid_tx_hash" })),
+            )
+                .into_response();
+        }
+    };
+    let reset = state
+        .monitor
+        .write()
+        .await
+        .retry_failed_deposits(source_chain_id, tx_hash)
+        .await;
+    if reset.is_empty() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "status": "no_failed_items" })),
+        )
+            .into_response();
+    }
+    state.deposit_notify.notify_one();
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "status": "requeued", "count": reset.len(), "items": reset })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::Address;
+    use axum::{body::Body, http::Request};
+    use linera_base::{crypto::CryptoHash, data_types::U128};
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::monitor::PendingBurn;
+
+    async fn state_with_failed_burn() -> AdminState {
+        let mut ms = MonitorState::new(0);
+        ms.track_burn(PendingBurn {
+            height: BlockHeight(5),
+            block_hash: CryptoHash::from([0u8; 32]),
+            tx_index: 0,
+            event_pos_in_tx: 0,
+            event_index: 10,
+            evm_recipient: Address::ZERO,
+            amount: U128(0),
+        })
+        .await;
+        ms.mark_burn_failed(BlockHeight(5), 10).await;
+        AdminState {
+            monitor: Arc::new(RwLock::new(ms)),
+            deposit_notify: Arc::new(Notify::new()),
+            burn_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_burns_requeues_and_returns_200() {
+        let state = state_with_failed_burn().await;
+        let monitor = Arc::clone(&state.monitor);
+        let response = build_admin_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/retry/burns/5")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            monitor
+                .write()
+                .await
+                .pending_burns_by_height_and_tx(10)
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_burns_unknown_height_returns_404() {
+        let state = state_with_failed_burn().await;
+        let response = build_admin_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/retry/burns/999")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn retry_burns_non_numeric_height_returns_400() {
+        let state = state_with_failed_burn().await;
+        let response = build_admin_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/retry/burns/notanumber")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn retry_deposits_bad_tx_hash_returns_400() {
+        let state = state_with_failed_burn().await;
+        let response = build_admin_router(state)
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/retry/deposits/8453/notahash")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/linera-bridge/src/relay/admin.rs
+++ b/linera-bridge/src/relay/admin.rs
@@ -112,6 +112,13 @@ mod tests {
 
     async fn state_with_failed_burn() -> AdminState {
         let mut ms = MonitorState::new(0);
+        // A failed burn is removed from memory and lives in `finished_burns`,
+        // so the retry path needs a DB to rebuild it from.
+        ms.set_db(
+            crate::monitor::db::BridgeDb::open_in_memory()
+                .await
+                .unwrap(),
+        );
         ms.track_burn(PendingBurn {
             height: BlockHeight(5),
             block_hash: CryptoHash::from([0u8; 32]),

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -13,6 +13,7 @@
 
 use linera_base::crypto::Signer as _;
 
+mod admin;
 mod committee;
 pub mod evm;
 pub mod linera;
@@ -90,6 +91,7 @@ pub async fn run(
     evm_private_key: &str,
     evm_light_client_address: Option<&str>,
     port: u16,
+    admin_port: u16,
     common_storage_options: &CommonStorageOptions,
     monitor_scan_interval: Duration,
     monitor_start_block: u64,
@@ -210,6 +212,7 @@ pub async fn run(
         evm_private_key,
         evm_light_client_address,
         port,
+        admin_port,
         monitor_scan_interval,
         monitor_start_block,
         max_retries,
@@ -231,6 +234,7 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
     evm_private_key: &str,
     evm_light_client_address: Option<&str>,
     port: u16,
+    admin_port: u16,
     monitor_scan_interval: Duration,
     monitor_start_block: u64,
     max_retries: u32,
@@ -378,8 +382,8 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
             proof_client,
             evm_client,
             linera_client,
-            deposit_notify,
-            burn_notify,
+            Arc::clone(&deposit_notify),
+            Arc::clone(&burn_notify),
             monitor_scan_interval,
             max_retries,
         ))
@@ -396,6 +400,20 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
             .await
             .context("HTTP server error")
     });
+
+    let admin_app = admin::build_admin_router(admin::AdminState {
+        monitor: Arc::clone(&monitor),
+        deposit_notify: Arc::clone(&deposit_notify),
+        burn_notify: Arc::clone(&burn_notify),
+    });
+    let admin_bind_addr = format!("127.0.0.1:{admin_port}");
+    let admin_listener = tokio::net::TcpListener::bind(&admin_bind_addr).await?;
+    let mut admin_server_handle = tokio::spawn(async move {
+        axum::serve(admin_listener, admin_app)
+            .await
+            .context("Admin HTTP server error")
+    });
+    tracing::info!(?admin_bind_addr, "Admin HTTP server listening");
 
     update_balance_metrics(&evm_client, &linera_client).await;
 
@@ -424,6 +442,9 @@ async fn serve_loop<E: linera_core::environment::Environment + 'static>(
             }
             result = &mut http_server_handle => {
                 anyhow::bail!("HTTP server exited unexpectedly: {result:?}");
+            }
+            result = &mut admin_server_handle => {
+                anyhow::bail!("Admin HTTP server exited unexpectedly: {result:?}");
             }
             notification = notifications.next() => {
                 let notification = match notification {

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -321,6 +321,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
+            0, // admin port (unused in e2e)
             &linera_storage_runtime::CommonStorageOptions::with_defaults(),
             std::time::Duration::from_secs(5), // monitor_scan_interval
             0,                                 // monitor_start_block

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -230,6 +230,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
+            0, // admin port (unused in e2e)
             &linera_storage_runtime::CommonStorageOptions::with_defaults(),
             Duration::from_secs(2),
             0,

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -184,6 +184,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             ANVIL_PRIVATE_KEY,
             Some(&light_client.to_string()),
             relay_port,
+            0, // admin port (unused in e2e)
             &linera_storage_runtime::CommonStorageOptions::with_defaults(),
             std::time::Duration::from_secs(5), // monitor_scan_interval
             0,                                 // monitor_start_block

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -258,6 +258,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
+            0, // admin port (unused in e2e)
             &linera_storage_runtime::CommonStorageOptions::with_defaults(),
             Duration::from_secs(2),
             0,

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -232,6 +232,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
+            0, // admin port (unused in e2e)
             &linera_storage_runtime::CommonStorageOptions::with_defaults(),
             Duration::from_secs(2),
             0,

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -220,6 +220,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
             ANVIL_PRIVATE_KEY,
             None,
             relay_port,
+            0, // admin port (unused in e2e)
             &linera_storage_runtime::CommonStorageOptions::with_defaults(),
             Duration::from_secs(2),
             0,


### PR DESCRIPTION
## Motivation

When a Linera→EVM burn (or EVM→Linera deposit) exhausts its retries — or hits an unrecoverable gas-estimate error in the chunked `processBurns` fallback — the relayer marks it `failed`. A failed item is excluded from the retry loop and, today, is only recoverable by restarting the relayer (which re-scans the chain from height 0). There is no operator-facing way to re-queue a single stuck item.

Separately, marking an item `failed` set `failed = true` in the in-memory monitor state but left the entry in the map, so failed items accumulated indefinitely and were miscounted as pending by `status_summary`.

## Proposal

- **Admin retry endpoint.** Add a localhost-only `axum` server (`127.0.0.1:{admin_port}`, new `--admin-port` flag, default `3002`), separate from the public metrics server, with two routes:
  - `POST /admin/retry/burns/{height}` — re-queues every failed burn in that Linera block.
  - `POST /admin/retry/deposits/{source_chain_id}/{tx_hash}` — re-queues every failed deposit from that EVM transaction.

  Each call moves the matching `finished_*` SQLite rows (only `status = 'failed'`) back to `pending_*`, rebuilds the in-memory `Tracked` entry, and wakes the retry loop via its `Notify`. Responses: `200 {count,
items}`, `404 no_failed_items`, `400` on a malformed path. The localhost bind is the access control — these routes re-trigger fund-moving submissions, which are idempotent on-chain (the EVM `processedBurns` /
deposit dedup prevents double-release), so the worst case of a stray retry is wasted relayer gas. New DB methods `requeue_failed_burns` / `requeue_failed_deposits` are the inverse of the failure half of
`update_*_status`.

- **Drop failed items from in-memory state.** `mark_burn_failed` / `mark_deposit_failed` now remove the entry from the in-memory map instead of flipping `failed = true`. A failed item lives only in the
`finished_*` tables (the durable record); `retry_failed_*` rebuilds the in-memory entry from there. This bounds the in-memory maps to actually-pending work and fixes the `status_summary` miscount.

## Test Plan

- CI:
- - regression tests
- - New unit tests: DB `requeue_failed_*` (move only `failed` rows, leave `completed` untouched), `MonitorState::retry_failed_*` (rebuild-from-DB and no-failed-items paths), `mark_*_failed_removes_from_memory`, and
admin-router tests (`200` requeue, `404` unknown, `400` bad height / bad tx hash).


## Release Plan

- These changes should be backported to `main`.

## Links

- Stacked on #6444 (`symmetric-bridge-driven-burn`); this PR targets that branch.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)