### PR TITLE
[testnet] Fall back to an explicit chain-state sync when a rejected proposal did not absorb a locking block

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2001,7 +2001,8 @@ impl<Env: Environment> ChainClient<Env> {
                     return Err(err);
                 }
                 did_fallback_sync = true;
-                if self.synchronize_chain_state(self.chain_id).await.is_err() {
+                if let Err(sync_err) = self.synchronize_chain_state(self.chain_id).await {
+                    tracing::debug!(%sync_err, "fallback sync failed after rejected proposal");
                     return Err(err);
                 }
                 let Ok(after_sync) = self.consensus_state_snapshot().await else {

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1964,6 +1964,8 @@ impl<Env: Environment> ChainClient<Env> {
         &self,
         proposal_guard: &mut Option<PendingProposal>,
     ) -> Result<ClientOutcome<Option<ConfirmedBlockCertificate>>, Error> {
+        // The fallback sync below is done at most once, so a genuinely stuck proposal can't loop.
+        let mut did_fallback_sync = false;
         loop {
             // `process_pending_block_inner` records the baseline snapshot itself, after
             // the initial timeout request, so that absorbing a timeout certificate isn't
@@ -1984,7 +1986,38 @@ impl<Env: Environment> ChainClient<Env> {
                 return Err(err);
             };
             if current == snapshot {
-                return Err(err);
+                // The lazy per-validator pull on rejection (`Updater::send_block_proposal`) can be
+                // raced out: `communicate_with_quorum` breaks as soon as a quorum is impossible and
+                // drops the still-in-flight `synchronize_chain_state_from` calls, so a locking block
+                // held only by the slower-to-respond validators is never absorbed. Fall back once to
+                // an explicit quorum sync — guaranteed to reach a lock-holder — and retry if it
+                // absorbed anything; otherwise the rejection was genuine, so propagate it.
+                //
+                // TODO(#6453): this fallback path has no deterministic regression test yet — forcing
+                // the lazy pull to miss needs a clock-driven per-validator response delay in the test
+                // harness (building on #6448); until then it is only covered indirectly by the (now
+                // non-flaky) `test_lazy_pull_absorbs_locking_block_on_proposal_rejection`.
+                if did_fallback_sync {
+                    return Err(err);
+                }
+                did_fallback_sync = true;
+                if self.synchronize_chain_state(self.chain_id).await.is_err() {
+                    return Err(err);
+                }
+                let Ok(after_sync) = self.consensus_state_snapshot().await else {
+                    return Err(err);
+                };
+                if after_sync == snapshot {
+                    return Err(err);
+                }
+                tracing::debug!(
+                    chain_id = %self.chain_id,
+                    ?snapshot,
+                    ?after_sync,
+                    %err,
+                    "fallback sync absorbed new consensus state after rejected proposal; retrying"
+                );
+                continue;
             }
             tracing::debug!(
                 chain_id = %self.chain_id,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2001,8 +2001,8 @@ impl<Env: Environment> ChainClient<Env> {
                     return Err(err);
                 }
                 did_fallback_sync = true;
-                if let Err(sync_err) = self.synchronize_chain_state(self.chain_id).await {
-                    tracing::debug!(%sync_err, "fallback sync failed after rejected proposal");
+                if let Err(error) = self.synchronize_chain_state(self.chain_id).await {
+                    tracing::debug!(%error, "fallback sync failed after rejected proposal");
                     return Err(err);
                 }
                 let Ok(after_sync) = self.consensus_state_snapshot().await else {


### PR DESCRIPTION
## Motivation

`test_lazy_pull_absorbs_locking_block_on_proposal_rejection` is flaky (surfaces on the slower storage backends / under CI contention, not on fast in-memory single runs).

Root cause: on proposal rejection, the per-validator "lazy pull" in `Updater::send_block_proposal` calls `synchronize_chain_state_from` **inside each validator future** to absorb the locking block that justified the rejection. But `communicate_with_quorum` breaks as soon as a quorum is provably impossible (after `f+1` rejections) and drops the still-in-flight futures (it's a `FuturesUnordered`). If the only validators holding the locking block are the slower-to-respond ones, their pulls get cancelled before committing, so `consensus_state_snapshot()` doesn't advance, `process_pending_block_without_prepare` returns the error instead of retrying, and the chain doesn't finalize the locked block. Whether this happens is a timing race on validator-response order, hence the flakiness.

## Proposal

Keep the lazy pull as the fast common-case path, but make absorption reliable: in `process_pending_block_without_prepare`, when a rejected proposal did **not** advance the local consensus snapshot, fall back **once** to an explicit `synchronize_chain_state` (a quorum sync, which is guaranteed to reach a lock-holder), and retry if it absorbed anything. If it absorbed nothing, the rejection was genuine and the original error propagates. The fallback runs at most once, so a genuinely stuck proposal can't loop.

This is effectively a *scoped* version of the proactive sync that #6408 reverted — it only pays the extra sync on the rare no-absorb path, leaving the common case untouched.

## Test Plan

- `test_lazy_pull_absorbs_locking_block_on_proposal_rejection` (memory + rocksdb) passes repeatedly.
- Proof the fallback is what does the work: with the inline lazy pull temporarily disabled, the test still passes — absorption happens via the fallback sync alone.
- Full `linera-core` lib suite green (144/144); `cargo clippy` and `fmt` clean.

A deterministic regression test for the fallback path specifically isn't possible with the current harness (the lazy-pull miss is a timing race that can't be forced via fault injection). Tracked in #6453; it needs a clock-driven per-validator response delay in the test harness, building on the client clock seam from #6448.

## Release Plan

- These changes follow the usual release cycle. (Bug fix on `testnet_conway`; consider forward-porting the same fix to `main`.)

## Links

- Follow-up (deterministic test): #6453
- Foundation for that test: #6448
- Introduced the lazy-pull path: #6432
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)