### PR TITLE
[testnet] Log the fallback-sync failure at ERROR on a rejected proposal

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2002,7 +2002,7 @@ impl<Env: Environment> ChainClient<Env> {
                 }
                 did_fallback_sync = true;
                 if let Err(error) = self.synchronize_chain_state(self.chain_id).await {
-                    tracing::debug!(%error, "fallback sync failed after rejected proposal");
+                    tracing::error!(%error, "fallback sync failed after rejected proposal");
                     return Err(err);
                 }
                 let Ok(after_sync) = self.consensus_state_snapshot().await else {


### PR DESCRIPTION
## Motivation

Follow-up to #6454, addressing [this review comment](https://github.com/linera-io/linera-protocol/pull/6454#discussion_r3367085219): when the explicit fallback chain-state sync fails and we propagate the original rejected-proposal error, the sync failure was only logged at `debug`. That makes a genuinely stuck proposal hard to diagnose in production.

## Proposal

Log the fallback-sync failure at `ERROR` instead of `debug` before returning the propagated error.

## Test Plan

CI. The change only raises the level of an existing log statement.

## Links

- Follows up #6454
- Synced into the forward-port #6457
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)