### PR TITLE
[main] Cache the Wasmer memory export instead of resolving it by name on every host call

### DIFF
--- a/linera-witty/src/runtime/borrowed_instance.rs
+++ b/linera-witty/src/runtime/borrowed_instance.rs
@@ -79,6 +79,10 @@ where
     ) -> Result<Option<<Self::Runtime as Runtime>::Memory>, RuntimeError> {
         I::memory_from_export(&**self, export)
     }
+
+    fn load_memory(&mut self) -> Result<<Self::Runtime as Runtime>::Memory, RuntimeError> {
+        I::load_memory(*self)
+    }
 }
 
 impl<M, I> RuntimeMemory<&mut I> for M

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -110,14 +110,20 @@ pub trait InstanceWithMemory: CabiReallocAlias + CabiFreeAlias {
 
     /// Returns the memory export from the current Wasm module instance.
     fn memory(&mut self) -> Result<Memory<'_, Self>, RuntimeError> {
+        let memory = self.load_memory()?;
+        Ok(Memory::new(self, memory))
+    }
+
+    /// Resolves the guest module's memory export.
+    ///
+    /// Runtimes may override this to cache the resolved handle and skip the export lookup
+    /// on every host call.
+    fn load_memory(&mut self) -> Result<<Self::Runtime as Runtime>::Memory, RuntimeError> {
         let export = self
             .load_export("memory")
             .ok_or(RuntimeError::MissingMemory)?;
 
-        let memory = self
-            .memory_from_export(export)?
-            .ok_or(RuntimeError::NotMemory)?;
-
-        Ok(Memory::new(self, memory))
+        self.memory_from_export(export)?
+            .ok_or(RuntimeError::NotMemory)
     }
 }

--- a/linera-witty/src/runtime/wasmer/memory.rs
+++ b/linera-witty/src/runtime/wasmer/memory.rs
@@ -7,7 +7,9 @@ use std::borrow::Cow;
 
 use wasmer::{Extern, Memory};
 
-use super::{super::traits::InstanceWithMemory, EntrypointInstance, ReentrantInstance};
+use super::{
+    super::traits::InstanceWithMemory, EntrypointInstance, ReentrantInstance, WithEnvironment,
+};
 use crate::{GuestPointer, RuntimeError, RuntimeMemory};
 
 macro_rules! impl_memory_traits {
@@ -18,6 +20,10 @@ macro_rules! impl_memory_traits {
                     Extern::Memory(memory) => Some(memory),
                     _ => None,
                 })
+            }
+
+            fn load_memory(&mut self) -> Result<Memory, RuntimeError> {
+                WithEnvironment::environment(self).memory()
             }
         }
 

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -189,6 +189,7 @@ impl<UserData: 'static> Instance for ReentrantInstance<'_, UserData> {
 /// A slot to store a [`wasmer::Instance`] in a way that can be shared with reentrant calls.
 pub struct Environment<UserData> {
     exports: Arc<OnceLock<wasmer::Exports>>,
+    memory: Arc<OnceLock<Memory>>,
     user_data: Arc<Mutex<UserData>>,
 }
 
@@ -197,6 +198,7 @@ impl<UserData> Environment<UserData> {
     fn new(user_data: UserData) -> Self {
         Environment {
             exports: Arc::new(OnceLock::new()),
+            memory: Arc::new(OnceLock::new()),
             user_data: Arc::new(Mutex::new(user_data)),
         }
     }
@@ -214,6 +216,24 @@ impl<UserData> Environment<UserData> {
             .cloned()
     }
 
+    /// Returns the guest module's memory export, resolving it by name only on the first call
+    /// and reusing the cached handle afterwards.
+    fn memory(&self) -> Result<Memory, crate::RuntimeError> {
+        if let Some(memory) = self.memory.get() {
+            return Ok(memory.clone());
+        }
+
+        let export = self
+            .load_export("memory")
+            .ok_or(crate::RuntimeError::MissingMemory)?;
+        let Extern::Memory(memory) = export else {
+            return Err(crate::RuntimeError::NotMemory);
+        };
+
+        // Cache for subsequent calls; a concurrent reentrant call may win the race, harmlessly.
+        Ok(self.memory.get_or_init(|| memory).clone())
+    }
+
     /// Returns a reference to the `UserData` stored in this [`Environment`].
     fn user_data(&self) -> MutexGuard<'_, UserData> {
         self.user_data
@@ -226,7 +246,25 @@ impl<UserData> Clone for Environment<UserData> {
     fn clone(&self) -> Self {
         Environment {
             exports: self.exports.clone(),
+            memory: self.memory.clone(),
             user_data: self.user_data.clone(),
         }
+    }
+}
+
+/// Provides access to the shared [`Environment`] backing a Wasmer instance.
+trait WithEnvironment<UserData> {
+    fn environment(&self) -> &Environment<UserData>;
+}
+
+impl<UserData> WithEnvironment<UserData> for EntrypointInstance<UserData> {
+    fn environment(&self) -> &Environment<UserData> {
+        &self.instance_slot
+    }
+}
+
+impl<UserData: 'static> WithEnvironment<UserData> for ReentrantInstance<'_, UserData> {
+    fn environment(&self) -> &Environment<UserData> {
+        self.data()
     }
 }

--- a/linera-witty/src/runtime/wasmtime/memory.rs
+++ b/linera-witty/src/runtime/wasmtime/memory.rs
@@ -51,5 +51,8 @@ macro_rules! impl_memory_traits {
     };
 }
 
+// TODO(#6463): cache the resolved `"memory"` export like the Wasmer runtime does, so it is not
+// re-resolved by name on every host call. The reentrant `Caller` is recreated per host call and
+// the store's `UserData` is owned by the caller, so this needs a different mechanism than Wasmer.
 impl_memory_traits!(EntrypointInstance<UserData>);
 impl_memory_traits!(ReentrantInstance<'_, UserData>);


### PR DESCRIPTION
## Motivation

Profiling `linera sync` on a linera.market user chain (#6461) showed the single WASM-execution thread — which carries ~65% of all client CPU — spends **~25% of its time re-resolving the WASM `"memory"` export by name on every host call**:

```
linera_witty::runtime::traits::InstanceWithMemory::memory
  └─ wasmer::Exports::get_extern("memory")
       └─ IndexMap::get → SipHasher::write
```

99.5% of all hashmap lookups on that thread came from this one path. Closes #6462.

## Proposal

`InstanceWithMemory::memory()` called `load_export("memory")` on every host function that touches guest memory (nearly all of them), doing a SipHash-keyed `IndexMap<String, Extern>` lookup each time; the resolved handle was never cached.

- Split `InstanceWithMemory::memory()` so the export resolution lives in a new, overridable `load_memory()`. The default keeps the resolve-by-name behavior, so the Wasmtime and test runtimes are unchanged.
- For Wasmer, cache the resolved `wasmer::Memory` in the shared `Environment` (next to the existing `exports: Arc<OnceLock<…>>`) and override `load_memory()` to reuse it. The cache is shared between the entrypoint instance and reentrant host calls (`FunctionEnvMut`) via the same `Arc<OnceLock>`, and is per-instantiation, so there is no cross-instance leakage and the cheap `Memory` handle is resolved at most once per instance.

The same optimization for Wasmtime is **not** a drop-in change — its reentrant `Caller` is recreated per host call and the store's `UserData` is owned by `linera-execution`, so it needs a different mechanism. That is tracked in #6463, with a `TODO` left in `wasmtime/memory.rs`.

## Test Plan

- `cargo test -p linera-witty --features wasmer,wasmtime` — all 37 reentrancy tests pass on both runtimes, including the getters/setters/operations cases that perform repeated guest-memory reads/writes through the cached handle.
- `cargo clippy -p linera-witty --features wasmer,wasmtime` clean; `cargo fmt` clean.
- Expected impact (from the #6461 profile): removes ~25% of the bottleneck thread, ≈16% of total client CPU during sync.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Parent performance investigation: #6461
- Wasmtime follow-up: #6463
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
