### PR TITLE
Filter client outbox indices to tracked chains (forward-port of #6447)

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -299,8 +299,6 @@ where
     /// indices are reconciled (`reconcile_outbox_index`). `None` means
     /// they have never been filtered — a pre-existing database entry (migration), or a validator
     /// that tracks all chains and never filters.
-    ///
-    /// Appended last to keep the storage-key prefixes of the preceding fields stable.
     pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
 }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -749,10 +749,22 @@ where
         &mut self,
         tracked: Option<&Hashed<ChainIdSet>>,
     ) -> Result<bool, ChainError> {
-        let digest = tracked.map(|tracked| tracked.hash());
-        if *self.outbox_index_tracked_hash.get() == digest {
+        if *self.outbox_index_tracked_hash.get() == tracked.map(|tracked| tracked.hash()) {
             return Ok(false);
         }
+        self.rebuild_outbox_index(tracked).await?;
+        Ok(true)
+    }
+
+    /// Rebuilds `nonempty_outboxes` and `outbox_counters` from the retained outbox queues for the
+    /// tracked set (every retained queue on a validator, `tracked == None`), and stamps
+    /// [`Self::outbox_index_tracked_hash`]. Unlike [`Self::reconcile_outbox_index`] this always
+    /// rebuilds, so callers that have just rewritten the queues can refresh the indices regardless
+    /// of the stored stamp.
+    async fn rebuild_outbox_index(
+        &mut self,
+        tracked: Option<&Hashed<ChainIdSet>>,
+    ) -> Result<(), ChainError> {
         self.nonempty_outboxes.get_mut().clear();
         self.outbox_counters.get_mut().clear();
         // In full mode (`None`) there is no tracked subset to iterate, so re-index from the keys of
@@ -776,8 +788,9 @@ where
             }
             self.nonempty_outboxes.get_mut().insert(*target);
         }
-        self.outbox_index_tracked_hash.set(digest);
-        Ok(true)
+        self.outbox_index_tracked_hash
+            .set(tracked.map(|tracked| tracked.hash()));
+        Ok(())
     }
 
     /// Returns whether the outbox index is already reconciled to `tracked` (the stored hash
@@ -1353,7 +1366,10 @@ where
     /// pre-checkpoint messages — the off-chain outbox state isn't part of the
     /// certified checkpoint blob, so without this a bootstrapped node would
     /// silently stop pushing pending messages forward.
-    pub async fn restore_outboxes_from_unfinalized(&mut self) -> Result<(), ChainError> {
+    pub async fn restore_outboxes_from_unfinalized(
+        &mut self,
+        tracked: Option<&Hashed<ChainIdSet>>,
+    ) -> Result<(), ChainError> {
         // A lagging validator hit by a checkpoint push may already have outbox
         // queues from blocks it processed before the gap. Clear them so the
         // rebuild from `unfinalized_message_blocks` doesn't append duplicate
@@ -1365,8 +1381,6 @@ where
             outbox.queue.clear();
             outbox.next_height_to_schedule.set(BlockHeight::ZERO);
         }
-        let mut new_counters = BTreeMap::<BlockHeight, u32>::new();
-        let mut new_nonempty = BTreeSet::new();
         let entries = self
             .execution_state
             .system
@@ -1386,7 +1400,6 @@ where
             let mut outbox = self.outboxes.try_load_entry_mut(&recipient).await?;
             for height in &heights {
                 outbox.queue.push_back(*height);
-                *new_counters.entry(*height).or_default() += 1;
             }
             let max_height = *heights
                 .last()
@@ -1394,10 +1407,9 @@ where
             outbox
                 .next_height_to_schedule
                 .set(max_height.try_add_one()?);
-            new_nonempty.insert(recipient);
         }
-        self.outbox_counters.set(new_counters.into());
-        self.nonempty_outboxes.set(new_nonempty);
+        // The queues are now authoritative; rebuild the tracked-only indices from them.
+        self.rebuild_outbox_index(tracked).await?;
         Ok(())
     }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -14,6 +14,7 @@ use linera_base::{
         Epoch, NonCanonicalBTreeMap, NonCanonicalBTreeSet, OracleResponse, Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, StreamId},
     ownership::ChainOwnership,
     time::{Duration, Instant},
@@ -194,6 +195,24 @@ pub(crate) mod metrics {
 /// The BCS-serialized size of an empty [`Block`].
 pub(crate) const EMPTY_BLOCK_SIZE: usize = 94;
 
+/// A set of fully-tracked chains. Wrapped in [`Hashed`] (as `Hashed<ChainIdSet>`) so the hash that
+/// identifies the set — stored in [`ChainStateView::outbox_index_tracked_hash`] to detect when the
+/// outbox indices must be reconciled — is computed once when the tracked set changes rather than on
+/// every cross-chain operation. The hash is order-independent because `BTreeSet` iterates in sorted
+/// order.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainIdSet(pub BTreeSet<ChainId>);
+
+impl linera_base::crypto::BcsHashable<'_> for ChainIdSet {}
+
+impl std::ops::Deref for ChainIdSet {
+    type Target = BTreeSet<ChainId>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// A view accessing the state of a chain.
 #[cfg_attr(
     with_graphql,
@@ -273,6 +292,16 @@ where
     /// removes the entry. Once the set is empty, the checkpoint restoration can run
     /// end-to-end.
     pub pre_checkpoint_block_trust: SetView<C, CryptoHash>,
+
+    /// The hash of the set of fully-tracked chains that `nonempty_outboxes` and
+    /// `outbox_counters` were last reconciled against. On a client these two indices only hold
+    /// entries for tracked targets; when the tracked set changes this hash stops matching and the
+    /// indices are reconciled (`reconcile_outbox_index`). `None` means
+    /// they have never been filtered — a pre-existing database entry (migration), or a validator
+    /// that tracks all chains and never filters.
+    ///
+    /// Appended last to keep the storage-key prefixes of the preceding fields stable.
+    pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
 }
 
 /// Block-chaining state.
@@ -420,24 +449,33 @@ where
         &mut self,
         target: &ChainId,
         height: BlockHeight,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<bool, ChainError> {
         let mut outbox = self.outboxes.try_load_entry_mut(target).await?;
         let updates = outbox.mark_messages_as_received(height).await?;
         if updates.is_empty() {
             return Ok(false);
         }
-        for update in updates {
-            let counter = self
-                .outbox_counters
-                .get_mut()
-                .get_mut(&update)
-                .ok_or_else(|| {
-                    ChainError::CorruptedChainState("message counter should be present".into())
-                })?;
-            *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
-            if *counter == 0 {
-                // Important for the test in `all_messages_delivered_up_to`.
-                self.outbox_counters.get_mut().remove(&update);
+        // `outbox_counters` is keyed by block height and shared across all recipients of that
+        // block, but only counts targets we index: every chain on a validator (`tracked == None`),
+        // or tracked targets on a client. An untracked target was never counted, so confirming it
+        // must NOT touch the counters at all — a present `counter[height]` belongs to a tracked
+        // sibling recipient of the same block and must be left intact. We only drain the queue
+        // (done above) for such a target.
+        if tracked.is_none_or(|tracked| tracked.contains(target)) {
+            for update in updates {
+                let counter = self
+                    .outbox_counters
+                    .get_mut()
+                    .get_mut(&update)
+                    .ok_or_else(|| {
+                        ChainError::CorruptedChainState("message counter should be present".into())
+                    })?;
+                *counter = counter.checked_sub(1).ok_or(ArithmeticError::Underflow)?;
+                if *counter == 0 {
+                    // Important for the test in `all_messages_delivered_up_to`.
+                    self.outbox_counters.get_mut().remove(&update);
+                }
             }
         }
         if outbox.queue.count() == 0 {
@@ -702,6 +740,52 @@ where
         let vec_of_options = self.outboxes.try_load_entries(targets).await?;
         let optional_vec = vec_of_options.into_iter().collect::<Option<Vec<_>>>();
         optional_vec.ok_or_else(|| ChainError::CorruptedChainState("Missing outboxes".into()))
+    }
+
+    /// Reconciles the `nonempty_outboxes` and `outbox_counters` indices from the retained outbox
+    /// queues, rebuilding only when the tracked set changed since the last call (i.e. the stored
+    /// [`Self::outbox_index_tracked_hash`] no longer matches). The per-target outbox *queues* in
+    /// `outboxes` are always kept; only these indices are filtered. Returns whether a rebuild
+    /// actually happened, so a read-only caller can skip persisting when nothing changed.
+    pub async fn reconcile_outbox_index(
+        &mut self,
+        tracked: Option<&Hashed<ChainIdSet>>,
+    ) -> Result<bool, ChainError> {
+        let digest = tracked.map(|tracked| tracked.hash());
+        if *self.outbox_index_tracked_hash.get() == digest {
+            return Ok(false);
+        }
+        self.nonempty_outboxes.get_mut().clear();
+        self.outbox_counters.get_mut().clear();
+        // In full mode (`None`) there is no tracked subset to iterate, so re-index from the keys of
+        // every retained outbox queue.
+        let targets = match tracked {
+            Some(tracked) => tracked.inner().iter().copied().collect::<Vec<_>>(),
+            None => self.outboxes.indices().await?,
+        };
+        for target in &targets {
+            let heights = {
+                let Some(outbox) = self.outboxes.try_load_entry(target).await? else {
+                    continue;
+                };
+                outbox.queue.elements().await?
+            };
+            if heights.is_empty() {
+                continue;
+            }
+            for height in heights {
+                *self.outbox_counters.get_mut().entry(height).or_default() += 1;
+            }
+            self.nonempty_outboxes.get_mut().insert(*target);
+        }
+        self.outbox_index_tracked_hash.set(digest);
+        Ok(true)
+    }
+
+    /// Returns whether the outbox index is already reconciled to `tracked` (the stored hash
+    /// matches), so the read-only network-actions path can read it without a write-lock rebuild.
+    pub fn outbox_index_is_reconciled(&self, tracked: Option<&Hashed<ChainIdSet>>) -> bool {
+        *self.outbox_index_tracked_hash.get() == tracked.map(|tracked| tracked.hash())
     }
 
     /// Executes a block with a specified policy for handling bundle failures.
@@ -1369,6 +1453,7 @@ where
         &mut self,
         block: &ConfirmedBlock,
         local_time: Timestamp,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
@@ -1376,7 +1461,7 @@ where
             self.block_zero_executed_at.set(local_time);
         }
         let updated_streams = self.process_emitted_events(block).await?;
-        self.process_outgoing_messages(block).await?;
+        self.process_outgoing_messages(block, tracked).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1403,6 +1488,7 @@ where
     pub async fn preprocess_block(
         &mut self,
         block: &ConfirmedBlock,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<BTreeSet<StreamId>, ChainError> {
         let hash = block.inner().hash();
         let block = block.inner().inner();
@@ -1410,7 +1496,7 @@ where
         if height < self.tip_state.get().next_block_height {
             return Ok(BTreeSet::new());
         }
-        self.process_outgoing_messages(block).await?;
+        self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
@@ -1546,6 +1632,7 @@ where
     async fn process_outgoing_messages(
         &mut self,
         block: &Block,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<Vec<ChainId>, ChainError> {
         // Record the messages of the execution. Messages are understood within an
         // application.
@@ -1553,11 +1640,11 @@ where
         let block_height = block.header.height;
         let next_height = self.tip_state.get().next_block_height;
 
-        // Update the outboxes.
-        let outbox_counters = self.outbox_counters.get_mut();
-        let nonempty_outboxes = self.nonempty_outboxes.get_mut();
+        // Update the outboxes. Every recipient's per-target outbox queue is updated, but the
+        // `nonempty_outboxes` and `outbox_counters` indices are only populated for targets we track.
         let targets = recipients.into_iter().collect::<Vec<_>>();
         let outboxes = self.outboxes.try_load_entries_mut(&targets).await?;
+        let mut scheduled_tracked = Vec::new();
         for (mut outbox, target) in outboxes.into_iter().zip(&targets) {
             if block_height > next_height {
                 // There may be a gap in the chain before this block. We can only add it to this
@@ -1613,9 +1700,10 @@ where
                     }
                 }
             }
-            if outbox.schedule_message(block_height)? {
-                *outbox_counters.entry(block_height).or_default() += 1;
-                nonempty_outboxes.insert(*target);
+            if outbox.schedule_message(block_height)?
+                && tracked.is_none_or(|set| set.contains(target))
+            {
+                scheduled_tracked.push(*target);
             }
             #[cfg(with_metrics)]
             crate::outbox::metrics::OUTBOX_SIZE
@@ -1623,14 +1711,29 @@ where
                 .observe(outbox.queue.count() as f64);
         }
 
+        if !scheduled_tracked.is_empty() {
+            // All scheduled messages are at `block_height`.
+            let scheduled_count =
+                u32::try_from(scheduled_tracked.len()).map_err(|_| ArithmeticError::Overflow)?;
+            *self
+                .outbox_counters
+                .get_mut()
+                .entry(block_height)
+                .or_default() += scheduled_count;
+            let nonempty_outboxes = self.nonempty_outboxes.get_mut();
+            for target in &scheduled_tracked {
+                nonempty_outboxes.insert(*target);
+            }
+        }
+
         #[cfg(with_metrics)]
         metrics::NUM_OUTBOXES
             .with_label_values(&[])
-            .observe(nonempty_outboxes.len() as f64);
+            .observe(self.nonempty_outboxes.get().len() as f64);
         #[cfg(with_metrics)]
         metrics::OUTBOX_COUNTERS_SIZE
             .with_label_values(&[])
-            .observe(outbox_counters.len() as f64);
+            .observe(self.outbox_counters.get().len() as f64);
         Ok(targets)
     }
 

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -20,7 +20,7 @@ mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 
-pub use chain::{ChainStateView, ChainTipState};
+pub use chain::{ChainIdSet, ChainStateView, ChainTipState};
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -357,7 +357,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .await?;
 
     let value = ConfirmedBlock::new(outcome.with(valid_block));
-    chain.apply_confirmed_block(&value, time).await?;
+    chain.apply_confirmed_block(&value, time, None).await?;
 
     // In the second block, other operations are still not allowed.
     let invalid_block = make_child_block(&value.clone())
@@ -389,7 +389,7 @@ async fn test_application_permissions() -> anyhow::Result<()> {
         .execute_test_block_simple(valid_block, time, &[])
         .await?;
     let value = ConfirmedBlock::new(outcome.with(valid_block));
-    chain.apply_confirmed_block(&value, time).await?;
+    chain.apply_confirmed_block(&value, time, None).await?;
 
     Ok(())
 }
@@ -486,7 +486,7 @@ async fn test_mandatory_applications_with_messages() -> anyhow::Result<()> {
         .execute_test_block_simple(block_with_accepted, time, &[])
         .await?;
     let value = ConfirmedBlock::new(outcome.with(block_with_accepted));
-    chain.apply_confirmed_block(&value, time).await?;
+    chain.apply_confirmed_block(&value, time, None).await?;
 
     Ok(())
 }
@@ -898,4 +898,296 @@ async fn test_next_height_to_preprocess_register() {
     // Set the register to a height crossing the first byte boundary.
     chain.next_height_to_preprocess.set(BlockHeight(257));
     assert_eq!(*chain.next_height_to_preprocess.get(), BlockHeight(257));
+}
+
+fn test_chain_id(seed: &str) -> ChainId {
+    ChainId(CryptoHash::test_hash(seed))
+}
+
+/// Builds the hashed tracked-chain set passed to `reconcile_outbox_index`.
+fn tracked_set<const N: usize>(
+    ids: [ChainId; N],
+) -> linera_base::hashed::Hashed<crate::ChainIdSet> {
+    linera_base::hashed::Hashed::new(crate::ChainIdSet(ids.into_iter().collect()))
+}
+
+/// Schedules a message to `target`'s outbox at `height` and indexes it in
+/// `nonempty_outboxes`/`outbox_counters`, mirroring `process_outgoing_messages` for a tracked
+/// target.
+async fn schedule_indexed(
+    chain: &mut ChainStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    target: ChainId,
+    height: BlockHeight,
+) -> anyhow::Result<()> {
+    {
+        let mut outbox = chain.outboxes.try_load_entry_mut(&target).await?;
+        assert!(outbox.schedule_message(height)?);
+    }
+    *chain.outbox_counters.get_mut().entry(height).or_default() += 1;
+    chain.nonempty_outboxes.get_mut().insert(target);
+    Ok(())
+}
+
+/// Schedules a message to `target`'s outbox at `height` without indexing it, mirroring an
+/// untracked target: the per-target queue is kept but the indices are not touched.
+async fn schedule_unindexed(
+    chain: &mut ChainStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    target: ChainId,
+    height: BlockHeight,
+) -> anyhow::Result<()> {
+    let mut outbox = chain.outboxes.try_load_entry_mut(&target).await?;
+    assert!(outbox.schedule_message(height)?);
+    Ok(())
+}
+
+async fn outbox_queue_len(
+    chain: &ChainStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    target: &ChainId,
+) -> anyhow::Result<usize> {
+    Ok(chain
+        .outboxes
+        .try_load_entry(target)
+        .await?
+        .map_or(0, |outbox| outbox.queue.count()))
+}
+
+/// On the first reconciliation (`None` stamp, i.e. a database written before filtering), targets
+/// that are no longer tracked are dropped from the indices, but their outbox queues are kept.
+#[tokio::test]
+async fn test_reconcile_outbox_index_migration_drops_untracked() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(5);
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_indexed(&mut chain, b, height).await?;
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+
+    let tracked = tracked_set([a]);
+    let digest = tracked.hash();
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
+
+    assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert_eq!(outbox_queue_len(&chain, &b).await?, 1);
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), Some(digest));
+    Ok(())
+}
+
+/// Shrinking the tracked set drops the removed chains from the indices (queue kept).
+#[tokio::test]
+async fn test_reconcile_outbox_index_shrink_removes_chain() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(1);
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_indexed(&mut chain, b, height).await?;
+    chain
+        .outbox_index_tracked_hash
+        .set(Some(tracked_set([a, b]).hash()));
+
+    let tracked = tracked_set([a]);
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
+
+    assert_eq!(chain.nonempty_outbox_chain_ids(), vec![a]);
+    assert!(!chain.nonempty_outboxes.get().contains(&b));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert_eq!(outbox_queue_len(&chain, &b).await?, 1);
+    Ok(())
+}
+
+/// Growing the tracked set re-indexes a newly tracked chain from its retained outbox queue.
+#[tokio::test]
+async fn test_reconcile_outbox_index_retrack_reindexes_from_queue() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(7);
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_unindexed(&mut chain, b, height).await?;
+    chain
+        .outbox_index_tracked_hash
+        .set(Some(tracked_set([a]).hash()));
+    assert!(!chain.nonempty_outboxes.get().contains(&b));
+
+    let tracked = tracked_set([a, b]);
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
+
+    assert!(chain.nonempty_outboxes.get().contains(&b));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 2);
+    Ok(())
+}
+
+/// A matching stamp short-circuits reconciliation without touching the indices.
+#[tokio::test]
+async fn test_reconcile_outbox_index_noop_when_hash_matches() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(3);
+    schedule_indexed(&mut chain, a, height).await?;
+    let tracked = tracked_set([a]);
+    let digest = tracked.hash();
+    chain.outbox_index_tracked_hash.set(Some(digest));
+
+    // `b` is indexed even though it is untracked; a matching hash means reconcile returns early.
+    schedule_indexed(&mut chain, b, height).await?;
+    chain.reconcile_outbox_index(Some(&tracked)).await?;
+
+    assert!(chain.nonempty_outboxes.get().contains(&b));
+    Ok(())
+}
+
+/// A `ConfirmUpdatedRecipient` arriving for a chain that has just been un-tracked must not error,
+/// even though reconciliation already dropped its outbox counter.
+#[tokio::test]
+async fn test_mark_received_untracked_target_is_tolerated() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let height = BlockHeight(2);
+    schedule_indexed(&mut chain, a, height).await?;
+
+    // Un-track `a`: its counter is dropped and it leaves the index, but the queue is kept.
+    let empty = tracked_set([]);
+    chain.reconcile_outbox_index(Some(&empty)).await?;
+    assert!(!chain.nonempty_outboxes.get().contains(&a));
+    assert!(chain.outbox_counters.get().is_empty());
+    assert_eq!(outbox_queue_len(&chain, &a).await?, 1);
+
+    // The in-flight confirmation arrives; `a` is untracked, so this drains the queue without error.
+    let drained = chain
+        .mark_messages_as_received(&a, height, Some(empty.inner()))
+        .await?;
+    assert!(drained);
+    assert_eq!(outbox_queue_len(&chain, &a).await?, 0);
+    Ok(())
+}
+
+/// A missing counter for a *tracked* target is still reported as corruption.
+#[tokio::test]
+async fn test_mark_received_tracked_missing_counter_errors() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let height = BlockHeight(2);
+    // Queue a message but never count it: corrupt-by-construction for a tracked target.
+    schedule_unindexed(&mut chain, a, height).await?;
+    let tracked = tracked_set([a]);
+    let result = chain
+        .mark_messages_as_received(&a, height, Some(tracked.inner()))
+        .await;
+    assert!(result.is_err());
+    Ok(())
+}
+
+/// Confirming an untracked target must not disturb a tracked sibling's counter: `outbox_counters`
+/// is keyed by block height and shared across all recipients of that block, and only tracked
+/// recipients are counted.
+#[tokio::test]
+async fn test_mark_received_untracked_keeps_tracked_sibling_counter() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(4);
+    // Same block height: A is tracked (counted), B is untracked (not counted).
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_unindexed(&mut chain, b, height).await?;
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+
+    let tracked = tracked_set([a]);
+    // Confirming the untracked B drains its queue but must leave A's counter untouched.
+    assert!(
+        chain
+            .mark_messages_as_received(&b, height, Some(tracked.inner()))
+            .await?
+    );
+    assert_eq!(outbox_queue_len(&chain, &b).await?, 0);
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+
+    // A's own confirmation still succeeds and clears the (intact) counter.
+    assert!(
+        chain
+            .mark_messages_as_received(&a, height, Some(tracked.inner()))
+            .await?
+    );
+    assert!(chain.outbox_counters.get().is_empty());
+    assert!(!chain.nonempty_outboxes.get().contains(&a));
+    Ok(())
+}
+
+/// Reconciliation counts every queued height of a target, not just one.
+#[tokio::test]
+async fn test_reconcile_outbox_index_counts_all_queued_heights() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    // `a` has two pending heights in its outbox queue, neither yet indexed/counted.
+    schedule_unindexed(&mut chain, a, BlockHeight(3)).await?;
+    schedule_unindexed(&mut chain, a, BlockHeight(5)).await?;
+
+    let tracked = tracked_set([a]);
+    assert!(chain.reconcile_outbox_index(Some(&tracked)).await?);
+
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+    assert_eq!(
+        *chain.outbox_counters.get().get(&BlockHeight(3)).unwrap(),
+        1
+    );
+    assert_eq!(
+        *chain.outbox_counters.get().get(&BlockHeight(5)).unwrap(),
+        1
+    );
+    // A second reconciliation against the same set is a no-op.
+    assert!(!chain.reconcile_outbox_index(Some(&tracked)).await?);
+    Ok(())
+}
+
+/// In full mode (`None`), when the indices have never been filtered (stored hash `None`),
+/// reconciliation is a no-op: a steady-state validator keeps its incrementally-maintained indices
+/// untouched and never scans the full set of outbox targets.
+#[tokio::test]
+async fn test_reconcile_outbox_index_full_mode_noop_when_unfiltered() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let height = BlockHeight(4);
+    schedule_indexed(&mut chain, a, height).await?;
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+
+    assert!(!chain.reconcile_outbox_index(None).await?);
+
+    // Indices are untouched and the chain stays in unfiltered (full) mode.
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 1);
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+    Ok(())
+}
+
+/// Switching a previously-filtered chain back to full mode (`None`) re-indexes *every* outbox
+/// target from its retained queue — including targets dropped while filtered — and stamps the
+/// hash back to `None`.
+#[tokio::test]
+async fn test_reconcile_outbox_index_full_mode_reindexes_all() -> anyhow::Result<()> {
+    let mut chain = ChainStateView::new(test_chain_id("self")).await;
+    let a = test_chain_id("a");
+    let b = test_chain_id("b");
+    let height = BlockHeight(6);
+    // `a` is tracked/indexed; `b`'s queue is kept but it was dropped from the index while filtered.
+    schedule_indexed(&mut chain, a, height).await?;
+    schedule_unindexed(&mut chain, b, height).await?;
+    chain
+        .outbox_index_tracked_hash
+        .set(Some(tracked_set([a]).hash()));
+    assert!(!chain.nonempty_outboxes.get().contains(&b));
+
+    assert!(chain.reconcile_outbox_index(None).await?);
+
+    // Both targets are now indexed from their retained queues, and the stamp is back to `None`.
+    assert!(chain.nonempty_outboxes.get().contains(&a));
+    assert!(chain.nonempty_outboxes.get().contains(&b));
+    assert_eq!(*chain.outbox_counters.get().get(&height).unwrap(), 2);
+    assert_eq!(*chain.outbox_index_tracked_hash.get(), None);
+
+    // A second full-mode reconciliation is now a no-op.
+    assert!(!chain.reconcile_outbox_index(None).await?);
+    Ok(())
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -19,6 +19,7 @@ use linera_base::{
         Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, StreamId},
 };
 use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache};
@@ -32,7 +33,8 @@ use linera_chain::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
         ValidatedBlockCertificate,
     },
-    ChainError, ChainExecutionContext, ChainStateView, ChainTipState, ExecutionResultExt as _,
+    ChainError, ChainExecutionContext, ChainIdSet, ChainStateView, ChainTipState,
+    ExecutionResultExt as _,
 };
 use linera_execution::{
     system::{EpochEventData, EventSubscriptions, EPOCH_STREAM_NAME},
@@ -51,7 +53,7 @@ use tracing::{debug, instrument, trace, warn};
 
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
-    client::ListeningMode,
+    client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
@@ -109,7 +111,7 @@ where
     block_values: Arc<ValueCache<CryptoHash, ConfirmedBlock>>,
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
-    chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+    chain_modes: Option<Arc<sync::RwLock<ChainModes>>>,
     delivery_notifier: DeliveryNotifier,
     knows_chain_is_active: bool,
     /// Set to `true` if a database `save` failure has left storage potentially
@@ -172,7 +174,7 @@ where
         execution_state_cache: Option<
             Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>,
         >,
-        chain_modes: Option<Arc<sync::RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+        chain_modes: Option<Arc<sync::RwLock<ChainModes>>>,
         delivery_notifier: DeliveryNotifier,
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
@@ -345,13 +347,41 @@ where
         self.service_runtime_task.take()
     }
 
-    /// Returns the pending cross-chain network actions for this chain, without
-    /// initializing the chain's execution state. Intended for callers that only
-    /// need to re-emit cross-chain requests from the outbox of a sender chain
-    /// whose `ChainDescription` we may never have needed.
+    /// Returns the pending cross-chain network actions if the outbox index is already
+    /// reconciled to the current tracked set, or `None` if it must first be reconciled (which
+    /// needs a write lock).
+    pub(crate) async fn cross_chain_network_actions_if_reconciled(
+        &self,
+    ) -> Result<Option<NetworkActions>, WorkerError> {
+        let tracked = self.tracked_full_chains();
+        if !self.chain.outbox_index_is_reconciled(tracked.as_deref()) {
+            return Ok(None);
+        }
+        Ok(Some(
+            self.build_network_actions(None, tracked.as_deref().map(|h| h.inner()))
+                .await?,
+        ))
+    }
+
+    /// Reconciles the outbox index with the current tracked set, then returns the pending
+    /// cross-chain network actions for this chain, without initializing the chain's execution
+    /// state. Intended for callers that only need to re-emit cross-chain requests from the
+    /// outbox of a sender chain whose `ChainDescription` we may never have needed.
+    ///
+    /// This is the slow path of [`Self::cross_chain_network_actions_if_reconciled`].
     #[instrument(skip_all, fields(chain_id = %self.chain_id()))]
-    pub(crate) async fn cross_chain_network_actions(&self) -> Result<NetworkActions, WorkerError> {
-        self.create_network_actions(None).await
+    pub(crate) async fn reconcile_and_cross_chain_network_actions(
+        &mut self,
+    ) -> Result<NetworkActions, WorkerError> {
+        let tracked = self.tracked_full_chains();
+        self.chain
+            .reconcile_outbox_index(tracked.as_deref())
+            .await?;
+        let actions = self
+            .build_network_actions(None, tracked.as_deref().map(|h| h.inner()))
+            .await?;
+        self.save().await?;
+        Ok(actions)
     }
 
     /// Handles a [`ChainInfoQuery`], potentially voting on the next block.
@@ -501,21 +531,71 @@ where
         })
     }
 
-    /// Loads pending cross-chain requests, and adds `NewRound` notifications where appropriate.
+    /// Returns the set of chains tracked in full mode together with its memoized hash, or `None` if
+    /// every chain is implicitely in full-mode (e.g. on validator).
+    fn tracked_full_chains(&self) -> Option<Arc<Hashed<ChainIdSet>>> {
+        let chain_modes = self.chain_modes.as_ref()?;
+        let full = chain_modes
+            .read()
+            .expect("Panics should not happen while holding a lock to `chain_modes`")
+            .full();
+        Some(full)
+    }
+
+    /// Returns whether the given chain is tracked in full mode (always `true` on a validator),
+    /// i.e. whether its outbox should be indexed.
+    fn is_tracked(&self, chain_id: &ChainId) -> bool {
+        self.chain_modes.as_ref().is_none_or(|chain_modes| {
+            chain_modes
+                .read()
+                .expect("Panics should not happen while holding a lock to `chain_modes`")
+                .get(chain_id)
+                .is_some_and(ListeningMode::is_full)
+        })
+    }
+
+    /// Reconciles the chain's `nonempty_outboxes` and `outbox_counters` indices with the current
+    /// set of fully-tracked chains.
+    async fn reconcile_tracked_outboxes(
+        &mut self,
+    ) -> Result<Option<Arc<Hashed<ChainIdSet>>>, WorkerError> {
+        let full_chains = self.tracked_full_chains();
+        self.chain
+            .reconcile_outbox_index(full_chains.as_deref())
+            .await?;
+        Ok(full_chains)
+    }
+
+    /// Reconciles the outbox index with the current tracked set, then loads pending cross-chain
+    /// requests and adds `NewRound` notifications where appropriate.
     async fn create_network_actions(
+        &mut self,
+        old_round: Option<Round>,
+    ) -> Result<NetworkActions, WorkerError> {
+        // Make the outbox index authoritative for the current tracked set first, so it already
+        // holds only `is_full` targets and needs no read-time filtering.
+        let tracked = self.reconcile_tracked_outboxes().await?;
+        self.build_network_actions(old_round, tracked.as_deref().map(|h| h.inner()))
+            .await
+    }
+
+    /// Builds the pending cross-chain actions from the already-reconciled outbox index.
+    async fn build_network_actions(
         &self,
         old_round: Option<Round>,
+        tracked: Option<&ChainIdSet>,
     ) -> Result<NetworkActions, WorkerError> {
         #[cfg(with_metrics)]
         let _latency = metrics::CREATE_NETWORK_ACTIONS_LATENCY.measure_latency();
         let mut heights_by_recipient = BTreeMap::<_, Vec<_>>::new();
-        let mut targets = self.chain.nonempty_outbox_chain_ids();
-        if let Some(chain_modes) = self.chain_modes.as_ref() {
-            let chain_modes = chain_modes
-                .read()
-                .expect("Panics should not happen while holding a lock to `chain_modes`");
-            // Only process outboxes for full chains (those whose inboxes we update).
-            targets.retain(|target| chain_modes.get(target).is_some_and(ListeningMode::is_full));
+        let targets = self.chain.nonempty_outbox_chain_ids();
+        if let Some(tracked) = tracked {
+            if let Some(target) = targets.iter().find(|target| !tracked.contains(*target)) {
+                return Err(ChainError::CorruptedChainState(format!(
+                    "outbox index contains untracked target {target}"
+                ))
+                .into());
+            }
         }
         let outboxes = self.chain.load_outboxes(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {
@@ -662,38 +742,6 @@ where
             }
         }
         Ok(cross_chain_requests)
-    }
-
-    /// Returns true if there are no more outgoing messages in flight up to the given
-    /// block height for all tracked chains (those whose inboxes we update).
-    #[instrument(skip_all, fields(
-        chain_id = %self.chain_id(),
-        height = %height
-    ))]
-    async fn all_messages_to_tracked_chains_delivered_up_to(
-        &self,
-        height: BlockHeight,
-    ) -> Result<bool, WorkerError> {
-        if self.chain.all_messages_delivered_up_to(height) {
-            return Ok(true);
-        }
-        let Some(chain_modes) = self.chain_modes.as_ref() else {
-            return Ok(false);
-        };
-        let mut targets = self.chain.nonempty_outbox_chain_ids();
-        {
-            let chain_modes = chain_modes.read().unwrap();
-            // Only consider full chains (those whose inboxes we update).
-            targets.retain(|target| chain_modes.get(target).is_some_and(ListeningMode::is_full));
-        }
-        let outboxes = self.chain.load_outboxes(&targets).await?;
-        for outbox in outboxes {
-            let front = outbox.queue.front().await?;
-            if front.is_some_and(|key| key <= height) {
-                return Ok(false);
-            }
-        }
-        Ok(true)
     }
 
     /// Processes a leader timeout issued for this multi-owner chain.
@@ -995,7 +1043,11 @@ where
         let chain_id = block.header.chain_id;
         let height = block.header.height;
 
-        let updated_event_streams = self.chain.preprocess_block(certificate.value()).await?;
+        let tracked = self.reconcile_tracked_outboxes().await?;
+        let updated_event_streams = self
+            .chain
+            .preprocess_block(certificate.value(), tracked.as_deref().map(|h| h.inner()))
+            .await?;
         self.save().await?;
         let mut actions = self.create_network_actions(None).await?;
         if !updated_event_streams.is_empty() {
@@ -1185,6 +1237,7 @@ where
                 "Confirmed block has a timestamp in the future beyond the block time grace period"
             );
         }
+        let tracked = self.reconcile_tracked_outboxes().await?;
         let chain = &mut self.chain;
         chain
             .remove_bundles_from_inboxes(
@@ -1233,7 +1286,11 @@ where
         };
 
         let updated_streams = chain
-            .apply_confirmed_block(&confirmed_block, local_time)
+            .apply_confirmed_block(
+                &confirmed_block,
+                local_time,
+                tracked.as_deref().map(|h| h.inner()),
+            )
             .await?;
         let mut actions = self.create_network_actions(None).await?;
         trace!("Processed confirmed block {height}");
@@ -1394,13 +1451,20 @@ where
         recipient: ChainId,
         latest_height: BlockHeight,
     ) -> Result<bool, WorkerError> {
+        // Reconcile the outbox indices with the *current* tracked set before draining the counter
+        // and checking delivery.
+        let tracked = self.reconcile_tracked_outboxes().await?;
+        // The indices are now reconciled to the tracked set, so `all_messages_delivered_up_to`
+        // (the `outbox_counters` fast path) is already the complete answer for tracked chains.
         Ok(self
             .chain
-            .mark_messages_as_received(&recipient, latest_height)
+            .mark_messages_as_received(
+                &recipient,
+                latest_height,
+                tracked.as_deref().map(|h| h.inner()),
+            )
             .await?
-            && self
-                .all_messages_to_tracked_chains_delivered_up_to(latest_height)
-                .await?)
+            && self.chain.all_messages_delivered_up_to(latest_height))
     }
 
     /// Notifies delivery waiters that all messages up to `height` have been delivered.
@@ -1525,6 +1589,7 @@ where
         recipient: ChainId,
         retransmit_from: BlockHeight,
     ) -> Result<NetworkActions, WorkerError> {
+        self.reconcile_tracked_outboxes().await?;
         // 1. Walk backward through previous_message_blocks to collect all heights
         //    that sent messages to this recipient, from the latest down to retransmit_from.
         let Some(latest_height) = self
@@ -1590,12 +1655,15 @@ where
             return Ok(NetworkActions::default());
         }
 
-        // 3. Update outbox_counters (+1 per new height for this one recipient).
+        // 3. Update the indices only for tracked recipients (mirroring `process_outgoing_messages`):
+        //    an untracked recipient keeps its re-added outbox queue but is not counted or indexed.
         let new_heights_len = new_heights.len();
-        for h in new_heights {
-            *self.chain.outbox_counters.get_mut().entry(h).or_default() += 1;
+        if self.is_tracked(&recipient) {
+            for h in new_heights {
+                *self.chain.outbox_counters.get_mut().entry(h).or_default() += 1;
+            }
+            self.chain.nonempty_outboxes.get_mut().insert(recipient);
         }
-        self.chain.nonempty_outboxes.get_mut().insert(recipient);
 
         // 4. Create cross-chain requests for this recipient.
         let actions = self

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1166,7 +1166,10 @@ where
         // isn't part of the certified checkpoint blob, so without this a
         // bootstrapped validator would silently stop delivering pending
         // messages.
-        self.chain.restore_outboxes_from_unfinalized().await?;
+        let tracked = self.tracked_full_chains();
+        self.chain
+            .restore_outboxes_from_unfinalized(tracked.as_deref())
+            .await?;
         for (origin, cursor) in inbox_cursors {
             let mut inbox = self.chain.inboxes.try_load_entry_mut(&origin).await?;
             inbox.restore_from_checkpoint(cursor).await?;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -22,6 +22,7 @@ use linera_base::{
         ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, Round, TimeDelta, Timestamp,
     },
     ensure,
+    hashed::Hashed,
     identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
     time::Duration,
 };
@@ -37,7 +38,7 @@ use linera_chain::{
         Block, CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, GenericCertificate,
         LiteCertificate, ValidatedBlock, ValidatedBlockCertificate,
     },
-    ChainError,
+    ChainError, ChainIdSet,
 };
 use linera_execution::{committee::Committee, ExecutionError};
 use linera_storage::{Arc as CacheArc, Clock as _, ResultReadCertificates, Storage as _};
@@ -246,6 +247,72 @@ impl ListeningMode {
     }
 }
 
+/// The per-chain [`ListeningMode`]s tracked by a local node, together with a memoized
+/// [`Hashed`] of the fully-tracked subset.
+///
+/// The hash is the version of the outbox index (see
+/// [`ChainStateView::outbox_index_tracked_hash`]). Caching it here — recomputed only when a chain
+/// newly becomes `FullChain`, which is rare and client-side — lets every cross-chain operation
+/// compare and reconcile the index in `O(1)` instead of rehashing the tracked set each time.
+///
+/// [`ChainStateView::outbox_index_tracked_hash`]: linera_chain::ChainStateView
+#[derive(Debug)]
+pub struct ChainModes {
+    modes: BTreeMap<ChainId, ListeningMode>,
+    full: Arc<Hashed<ChainIdSet>>,
+}
+
+impl Default for ChainModes {
+    fn default() -> Self {
+        Self::new(BTreeMap::new())
+    }
+}
+
+impl ChainModes {
+    /// Builds the listening modes from `modes`, computing the tracked-set hash once.
+    pub fn new(modes: BTreeMap<ChainId, ListeningMode>) -> Self {
+        let full = Self::compute_full(&modes);
+        Self { modes, full }
+    }
+
+    fn compute_full(modes: &BTreeMap<ChainId, ListeningMode>) -> Arc<Hashed<ChainIdSet>> {
+        Arc::new(Hashed::new(ChainIdSet(
+            modes
+                .iter()
+                .filter(|(_, mode)| mode.is_full())
+                .map(|(id, _)| *id)
+                .collect(),
+        )))
+    }
+
+    /// The fully-tracked chains together with their memoized hash (`O(1)` clone).
+    pub fn full(&self) -> Arc<Hashed<ChainIdSet>> {
+        self.full.clone()
+    }
+
+    /// Returns the listening mode for `chain_id`, if it is tracked.
+    pub fn get(&self, chain_id: &ChainId) -> Option<&ListeningMode> {
+        self.modes.get(chain_id)
+    }
+
+    /// Merges `mode` into the entry for `chain_id` — monotonic in the listening-mode order, so it
+    /// never weakens an existing entry — and returns the resulting mode. The tracked-set hash is
+    /// recomputed only if the chain newly became `FullChain`.
+    pub fn extend_mode(&mut self, chain_id: ChainId, mode: ListeningMode) -> ListeningMode {
+        let entry = self
+            .modes
+            .entry(chain_id)
+            .or_insert_with(|| ListeningMode::EventsOnly(BTreeSet::new()));
+        let was_full = entry.is_full();
+        entry.extend(Some(mode));
+        let result = entry.clone();
+        if !was_full && result.is_full() {
+            self.full = Self::compute_full(&self.modes);
+        }
+        result
+    }
+}
+
 /// A builder that creates [`ChainClient`]s which share the cache and notifiers.
 pub struct Client<Env: Environment> {
     environment: Env,
@@ -258,7 +325,7 @@ pub struct Client<Env: Environment> {
     admin_chain_id: ChainId,
     /// Chains that should be tracked by the client, along with their listening mode.
     /// The presence of a chain in this map means it is tracked by the local node.
-    chain_modes: Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>,
+    chain_modes: Arc<RwLock<ChainModes>>,
     /// References to clients waiting for chain notifications.
     notifier: Arc<ChannelNotifier<Notification>>,
     /// Chain state for the managed chains.
@@ -285,15 +352,15 @@ impl<Env: Environment> Client<Env> {
         execution_state_cache_size: usize,
         requests_scheduler_config: &requests_scheduler::RequestsSchedulerConfig,
     ) -> Self {
-        let mut chain_modes = chain_modes.into_iter().collect::<BTreeMap<_, _>>();
+        let mut modes = chain_modes.into_iter().collect::<BTreeMap<_, _>>();
         // The client needs the admin chain fully synced for epoch tracking, so
         // promote it (or insert) into `FullChain`. `extend` is monotonic in the
         // listening mode order, so this never weakens an existing entry.
-        chain_modes
+        modes
             .entry(admin_chain_id)
             .or_insert(ListeningMode::FullChain)
             .extend(Some(ListeningMode::FullChain));
-        let chain_modes = Arc::new(RwLock::new(chain_modes));
+        let chain_modes = Arc::new(RwLock::new(ChainModes::new(modes)));
         let config = ChainWorkerConfig {
             nickname: name.into(),
             long_lived_services,
@@ -412,13 +479,10 @@ impl<Env: Environment> Client<Env> {
     /// Returns the resulting mode.
     #[instrument(level = "trace", skip(self))]
     pub fn extend_chain_mode(&self, chain_id: ChainId, mode: ListeningMode) -> ListeningMode {
-        let mut chain_modes = self
-            .chain_modes
+        self.chain_modes
             .write()
-            .expect("Panics should not happen while holding a lock to `chain_modes`");
-        let entry = chain_modes.entry(chain_id).or_insert_with(|| mode.clone());
-        entry.extend(Some(mode));
-        entry.clone()
+            .expect("Panics should not happen while holding a lock to `chain_modes`")
+            .extend_mode(chain_id, mode)
     }
 
     /// Returns the listening mode for a chain, if it is tracked.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4442,6 +4442,24 @@ where
             *outbox_chain.next_height_to_schedule.get(),
             BlockHeight::from(1)
         );
+        // The follower only follows `chain_id`; it does not track the recipient, so the
+        // tracked-only outbox indices stay empty even though the queue above was restored.
+        assert!(!chain_state
+            .nonempty_outboxes
+            .get()
+            .contains(&recipient.chain_id()));
+        assert!(chain_state.outbox_counters.get().is_empty());
+    }
+
+    // The restored queue is what lets delivery resume once the recipient is tracked: reconciling
+    // against a tracked set that includes it rebuilds the indices from that queue.
+    {
+        let tracked = linera_base::hashed::Hashed::new(linera_chain::ChainIdSet(
+            [recipient.chain_id()].into_iter().collect(),
+        ));
+        let storage = follower.storage_client();
+        let mut chain_state = storage.load_chain(chain_id).await?;
+        chain_state.reconcile_outbox_index(Some(&tracked)).await?;
         assert!(chain_state
             .nonempty_outboxes
             .get()

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5152,3 +5152,247 @@ where
 
     Ok(())
 }
+
+/// Worker-level regression test for the outbox-index filtering: a client worker that does not
+/// track the recipient must tolerate a `ConfirmUpdatedRecipient` for it. The recipient's outbox
+/// entry is scheduled but never counted, so before the fix this hit `CorruptedChainState` via the
+/// "message counter should be present" assertion.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_confirm_updated_recipient_untracked_target_is_tolerated<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(&mut storage_builder, true, false).await?;
+    // Run the worker as a client; share the tracked-set map so later inserts are visible to the
+    // chain worker (which holds a clone of the `Arc`).
+    let chain_modes = Arc::new(std::sync::RwLock::new(crate::client::ChainModes::default()));
+    env.worker.chain_modes = Some(chain_modes.clone());
+
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    // Track only the sender; the recipient `chain_2` stays untracked.
+    chain_modes
+        .write()
+        .unwrap()
+        .extend_mode(chain_1, crate::client::ListeningMode::FullChain);
+
+    // chain_1 transfers to the untracked chain_2: the outbox queue is scheduled but not indexed.
+    let certificate = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            None,
+        )
+        .await;
+    env.worker()
+        .process_confirmed_block(certificate, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        assert!(!chain.nonempty_outboxes.get().contains(&chain_2));
+        assert!(chain.outbox_counters.get().is_empty());
+        assert_eq!(
+            chain
+                .outboxes
+                .try_load_entry(&chain_2)
+                .await?
+                .expect("outbox queue is kept for untracked targets")
+                .queue
+                .count(),
+            1
+        );
+    }
+
+    // The confirmation for the untracked recipient must drain the outbox without erroring.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::ZERO,
+        })
+        .await?;
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        let outbox = chain.outboxes.try_load_entry(&chain_2).await?;
+        assert!(outbox.is_none() || outbox.unwrap().queue.count() == 0);
+    }
+    Ok(())
+}
+
+/// Confirming a chain that became tracked *after* its message was scheduled must reconcile the
+/// indices first: otherwise its counter is missing (a spurious `CorruptedChainState`) and the
+/// delivery check cannot see it. Here chain_3 is tracked late and must end up indexed.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_confirm_reconciles_newly_tracked_chain<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(&mut storage_builder, true, false).await?;
+    let chain_modes = Arc::new(std::sync::RwLock::new(crate::client::ChainModes::default()));
+    env.worker.chain_modes = Some(chain_modes.clone());
+
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    let chain_3 = dummy_chain_description(3).id();
+    chain_modes
+        .write()
+        .unwrap()
+        .extend_mode(chain_1, crate::client::ListeningMode::FullChain);
+
+    // chain_1 sends to chain_2 (height 0) and chain_3 (height 1) while both are untracked.
+    let cert_0 = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            None,
+        )
+        .await;
+    let cert_1 = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_3,
+            Amount::from_tokens(5),
+            Vec::new(),
+            Some(&cert_0),
+        )
+        .await;
+    env.worker()
+        .process_confirmed_block(cert_0, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_1, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+
+    // Track both recipients; the indices are now stale until the next reconciliation.
+    {
+        let mut modes = chain_modes.write().unwrap();
+        modes.extend_mode(chain_2, crate::client::ListeningMode::FullChain);
+        modes.extend_mode(chain_3, crate::client::ListeningMode::FullChain);
+    }
+
+    // Confirming chain_2 reconciles first, so it re-counts chain_2 (no `CorruptedChainState`),
+    // drains it, and indexes the newly tracked chain_3 with its still-undelivered message.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::from(1),
+        })
+        .await?;
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        assert!(!chain.nonempty_outboxes.get().contains(&chain_2));
+        assert!(chain.nonempty_outboxes.get().contains(&chain_3));
+    }
+    Ok(())
+}
+
+/// `RevertConfirm` for an untracked recipient must re-add its outbox queue but leave it out of the
+/// `nonempty_outboxes`/`outbox_counters` indices (the untracked branch of the tracking guard).
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_revert_confirm_untracked_recipient_not_indexed<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(&mut storage_builder, true, false).await?;
+    let chain_modes = Arc::new(std::sync::RwLock::new(crate::client::ChainModes::default()));
+    env.worker.chain_modes = Some(chain_modes.clone());
+
+    let chain_1_desc = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(100))
+        .await;
+    let chain_1 = chain_1_desc.id();
+    let chain_2 = dummy_chain_description(2).id();
+    // Track only the sender; the recipient chain_2 stays untracked.
+    chain_modes
+        .write()
+        .unwrap()
+        .extend_mode(chain_1, crate::client::ListeningMode::FullChain);
+
+    // chain_1 sends to the untracked chain_2 at heights 0 and 1.
+    let cert_0 = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(5),
+            Vec::new(),
+            None,
+        )
+        .await;
+    let cert_1 = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(3),
+            Vec::new(),
+            Some(&cert_0),
+        )
+        .await;
+    env.worker()
+        .process_confirmed_block(cert_0, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_1, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+
+    // Drain chain_1's outbox for chain_2 so the revert below has heights to re-add.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::from(1),
+        })
+        .await?;
+
+    // RevertConfirm re-adds chain_2's heights; since chain_2 is untracked it must not be indexed.
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::RevertConfirm {
+            sender: chain_1,
+            recipient: chain_2,
+            retransmit_from: BlockHeight::ZERO,
+        })
+        .await?;
+
+    let chain = env.worker().chain_state_view(chain_1).await?;
+    assert_eq!(
+        chain
+            .outboxes
+            .try_load_entry(&chain_2)
+            .await?
+            .expect("the revert re-creates chain_2's outbox")
+            .queue
+            .count(),
+        2,
+        "the revert should re-add both heights to chain_2's outbox queue",
+    );
+    assert!(!chain.nonempty_outboxes.get().contains(&chain_2));
+    assert!(chain.outbox_counters.get().is_empty());
+    Ok(())
+}

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -69,7 +69,7 @@ use crate::{
         BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult, DeliveryNotifier,
         ProcessConfirmedBlockMode,
     },
-    client::ListeningMode,
+    client::{ChainModes, ListeningMode},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     notifier::Notifier,
 };
@@ -689,7 +689,7 @@ pub struct WorkerState<StorageClient: Storage> {
     execution_state_cache:
         Option<Arc<UniqueValueCache<CryptoHash, ExecutionStateView<InactiveContext>>>>,
     /// Chains tracked by a worker, along with their listening modes.
-    chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+    pub(crate) chain_modes: Option<Arc<RwLock<ChainModes>>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
@@ -860,7 +860,7 @@ where
     pub fn new(
         storage: StorageClient,
         chain_worker_config: ChainWorkerConfig,
-        chain_modes: Option<Arc<RwLock<BTreeMap<ChainId, ListeningMode>>>>,
+        chain_modes: Option<Arc<RwLock<ChainModes>>>,
     ) -> Self {
         let chain_workers = Arc::new(papaya::HashMap::new());
         start_sweep(&chain_workers, &chain_worker_config);
@@ -1968,8 +1968,21 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<NetworkActions, WorkerError> {
-        self.chain_read(chain_id, |guard| async move {
-            guard.cross_chain_network_actions().await
+        // Fast path: when the outbox index is already reconciled to the current tracked set,
+        // the network actions are built from a read-only view, so a shared lock with no save
+        // suffices — avoiding the write lock, task spawn and `save()` of the slow path.
+        if let Some(actions) = self
+            .chain_read(chain_id, |guard| async move {
+                guard.cross_chain_network_actions_if_reconciled().await
+            })
+            .await?
+        {
+            return Ok(actions);
+        }
+        // Slow path (first load after migration, or the tracked set changed): reconcile and
+        // persist the index under an exclusive lock before building.
+        self.chain_write(chain_id, |mut guard| async move {
+            guard.reconcile_and_cross_chain_network_actions().await
         })
         .await
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -424,8 +424,6 @@ type ChainStateExtendedView {
 	indices are reconciled (`reconcile_outbox_index`). `None` means
 	they have never been filtered — a pre-existing database entry (migration), or a validator
 	that tracks all chains and never filters.
-	
-	Appended last to keep the storage-key prefixes of the preceding fields stable.
 	"""
 	outboxIndexTrackedHash: CryptoHash
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -417,6 +417,17 @@ type ChainStateExtendedView {
 	end-to-end.
 	"""
 	preCheckpointBlockTrust: SetView_CryptoHash_87fbb60c!
+	"""
+	The hash of the set of fully-tracked chains that `nonempty_outboxes` and
+	`outbox_counters` were last reconciled against. On a client these two indices only hold
+	entries for tracked targets; when the tracked set changes this hash stops matching and the
+	indices are reconciled (`reconcile_outbox_index`). `None` means
+	they have never been filtered — a pre-existing database entry (migration), or a validator
+	that tracks all chains and never filters.
+	
+	Appended last to keep the storage-key prefixes of the preceding fields stable.
+	"""
+	outboxIndexTrackedHash: CryptoHash
 }
 
 """

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -59,7 +59,11 @@ const MAX_VALUE_SIZE: usize = 3 * 1024 * 1024 * 1024 - 400;
 // For offset reasons we decrease by 400
 const MAX_KEY_SIZE: usize = 8 * 1024 * 1024 - 400;
 
-const WRITE_BUFFER_SIZE: usize = 256 * 1024 * 1024; // 256 MiB
+// A small write buffer keeps the memtable flushing even on low-write workloads. A large buffer
+// (e.g. 256 MiB) lets a slowly-filling memtable grow huge and accumulate range tombstones, so every
+// point read has to scan it — which severely amplifies reads during e.g. a long chain
+// synchronization, where blocks are re-executed with little net data written.
+const WRITE_BUFFER_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 const MAX_WRITE_BUFFER_NUMBER: i32 = 6;
 
 fn get_available_memory(sys: &System) -> usize {


### PR DESCRIPTION
## Motivation

A client's `nonempty_outboxes` and `outbox_counters` are `RegisterView`s (each re-serialized whole on every block). They only drop an entry when the local node *delivers* to that target, and a client only delivers to chains its wallet tracks (`is_full`). High-fan-out chains send to many untracked targets, whose entries are inserted but never removed, so the two blobs grow without bound and every block re-serializes a large value to local storage — stalling block production. Validators (which track all chains) keep these indices near-empty.

This is the forward-port of #6447 (which targets `testnet_conway`) to `main`.

## Proposal

Keep the two indices filtered to tracked targets on clients (validators, `chain_modes == None`, are unchanged):

- `process_outgoing_messages` still schedules every target's outbox *queue*, but only indexes/counts targets the wallet tracks (new `tracked: Option<&ChainIdSet>` parameter).
- New `ChainStateView::outbox_index_tracked_hash: RegisterView<Option<CryptoHash>>` (appended **last** to keep storage-key prefixes stable) stamps the hash of the tracked set; `reconcile_outbox_index` rebuilds the indices **additively** from the tracked chains' retained outbox queues when the hash changes — `O(|tracked|)`, no scan of the full fan-out, correct for migration / restart / shrink / growth.
- `mark_messages_as_received` only enforces the "counter must be present" invariant for validators and tracked targets, tolerating untracked ones (fixes a `CorruptedChainState` reachable when a target is un-tracked between sending an update and receiving its confirmation).
- The chain worker derives the tracked set from `chain_modes` and threads it through block application and `confirm_updated_recipient`.
- `confirm_updated_recipient` no longer needs a separate `all_messages_to_tracked_chains_delivered_up_to` helper: once the indices are tracked-only, the `outbox_counters` fast path (`all_messages_delivered_up_to`) is the complete answer, so it is inlined (this folds in the cleanup from the review of #6447).

Outboxes are local node state (not in the consensus `state_hash`), so validators and clients legitimately differ here; the change is consensus-safe.

### Notes on the forward-port

`main` already has the substrate (`nonempty_outboxes`, `outbox_counters`, `all_messages_delivered_up_to`, `ListeningMode`). Differences from the `testnet_conway` PR, due to divergence on `main`:

- `outbox_index_tracked_hash` is appended after `pre_checkpoint_block_trust` (main's current last `ChainStateView` field) to preserve the storage-prefix-stability intent.
- `apply_confirmed_block` keeps main's structure (no `previous_message_blocks`/`execution_state_hash` handling, which were removed on main); only the `tracked` parameter is threaded through.
- The conway-only `initialize_next_expected_events` migration helper is not part of this change and is omitted; only the `tracked` threading is applied to the `preprocess_block` path.
- `service_schema.graphql` was regenerated on `main`.

## Test Plan

- `linera-chain` lib unit tests (51), including the 10 new reconcile / mark-received tests (migration / shrink / re-track / no-op; un-track race tolerated; corruption still caught for tracked targets).
- `linera-core` worker-level tests, including the 3 new `confirm`/`revert` tests for untracked recipients (regresses the `CorruptedChainState`), plus the `cross_chain` delivery suite (9).
- `linera-service-graphql-client` schema-check test passes against the regenerated schema.
- `cargo clippy --all-targets --all-features` clean on `linera-chain` and `linera-core`.

## Release Plan

- These changes add a trailing field to `ChainStateView` (storage-format change) and so require a new deployment.

## Links

- Original PR (testnet_conway): #6447
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
