### PR TITLE
[testnet] Retry block proposal when the chain advances mid-execution (#5664)

### DIFF
--- a/linera-base/src/crypto/signer.rs
+++ b/linera-base/src/crypto/signer.rs
@@ -124,6 +124,13 @@ mod in_mem {
             let inner = self.0.read().unwrap();
             inner.keys()
         }
+
+        /// Removes the key for `owner`, returning whether one was present. Useful to
+        /// simulate a key becoming unavailable (e.g. an autosigner key that is rotated or
+        /// withdrawn after a block was already staged by it).
+        pub fn forget_key(&self, owner: &AccountOwner) -> bool {
+            self.0.write().unwrap().keys.remove(owner).is_some()
+        }
     }
 
     /// In-memory signer.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1468,37 +1468,54 @@ impl<Env: Environment> ChainClient<Env> {
             ClientOutcome::Committed(None) => {}
         }
 
-        // Collect pending messages and epoch changes after acquiring the lock to avoid
-        // race conditions where messages valid for one block height are proposed at a
-        // different height.
-        let transactions = self.prepend_epochs_messages_and_events(operations).await?;
+        loop {
+            // Collect pending messages and epoch changes after acquiring the lock to avoid
+            // race conditions where messages valid for one block height are proposed at a
+            // different height. This is recomputed on every retry because the set of
+            // receivable messages and epoch changes can differ at a new height.
+            let transactions = self
+                .prepend_epochs_messages_and_events(operations.clone())
+                .await?;
 
-        if transactions.is_empty() {
-            return Err(Error::LocalNodeError(LocalNodeError::WorkerError(
-                WorkerError::ChainError(Box::new(ChainError::EmptyBlock)),
-            )));
-        }
+            if transactions.is_empty() {
+                return Err(Error::LocalNodeError(LocalNodeError::WorkerError(
+                    WorkerError::ChainError(Box::new(ChainError::EmptyBlock)),
+                )));
+            }
 
-        let block = self
-            .new_pending_block(transactions, blobs, &mut proposal_guard)
-            .await?;
+            let block = self
+                .new_pending_block(transactions, blobs.clone(), &mut proposal_guard)
+                .await?;
 
-        match self
-            .process_pending_block_without_prepare(&mut proposal_guard)
-            .await?
-        {
-            ClientOutcome::Committed(Some(certificate)) if certificate.block() == &block => {
-                Ok(ClientOutcome::Committed(certificate))
+            match self
+                .process_pending_block_without_prepare(&mut proposal_guard)
+                .await?
+            {
+                ClientOutcome::Committed(Some(certificate)) if certificate.block() == &block => {
+                    return Ok(ClientOutcome::Committed(certificate));
+                }
+                ClientOutcome::Committed(Some(certificate)) => {
+                    return Ok(ClientOutcome::Conflict(Box::new(certificate)));
+                }
+                // The chain advanced past the height we staged at while we were proposing
+                // (e.g. a notification or background sync committed another block at our
+                // height), so `process_pending_block_inner` cleared the pending proposal
+                // without committing ours. Our operations were not applied; re-stage at
+                // the new height and retry. See #5664.
+                ClientOutcome::Committed(None) => {
+                    tracing::debug!(
+                        chain_id = %self.chain_id,
+                        "chain advanced during proposal; re-staging block at new height"
+                    );
+                    continue;
+                }
+                ClientOutcome::WaitForTimeout(timeout) => {
+                    return Ok(ClientOutcome::WaitForTimeout(timeout));
+                }
+                ClientOutcome::Conflict(certificate) => {
+                    return Ok(ClientOutcome::Conflict(certificate));
+                }
             }
-            ClientOutcome::Committed(Some(certificate)) => {
-                Ok(ClientOutcome::Conflict(Box::new(certificate)))
-            }
-            // Unreachable: We just set the pending proposal in the guard.
-            ClientOutcome::Committed(None) => {
-                Err(Error::BlockProposalError("Unexpected block proposal error"))
-            }
-            ClientOutcome::WaitForTimeout(timeout) => Ok(ClientOutcome::WaitForTimeout(timeout)),
-            ClientOutcome::Conflict(certificate) => Ok(ClientOutcome::Conflict(certificate)),
         }
     }
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1497,15 +1497,23 @@ impl<Env: Environment> ChainClient<Env> {
                 ClientOutcome::Committed(Some(certificate)) => {
                     return Ok(ClientOutcome::Conflict(Box::new(certificate)));
                 }
-                // The chain advanced past the height we staged at while we were proposing
-                // (e.g. a notification or background sync committed another block at our
-                // height), so `process_pending_block_inner` cleared the pending proposal
-                // without committing ours. Our operations were not applied; re-stage at
-                // the new height and retry. See #5664.
+                // `process_pending_block_without_prepare` cleared the pending proposal
+                // without committing ours, so our operations were not applied. This happens
+                // in two ways:
+                //   * the chain advanced past the height we staged at while we were
+                //     proposing (e.g. a notification or background sync committed another
+                //     block at our height) — the common #5664 case; or
+                //   * the staged proposal's authenticated signer's key is no longer held
+                //     (the preferred owner changed since we staged), so the stale proposal
+                //     was discarded.
+                // Either way, re-stage and retry: `new_pending_block` recomputes the block
+                // at the current height and signs as the current identity, so the first
+                // case advances to the new height (genuine external progress) and the
+                // second adopts a signer we hold, so the retry converges. See #5664.
                 ClientOutcome::Committed(None) => {
                     tracing::debug!(
                         chain_id = %self.chain_id,
-                        "chain advanced during proposal; re-staging block at new height"
+                        "pending proposal cleared without committing ours; re-staging and retrying"
                     );
                     continue;
                 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4054,3 +4054,69 @@ where
 
     Ok(())
 }
+
+/// Regression test for the no-signer-key branch in `process_pending_block_without_prepare`:
+/// when a pending proposal is authenticated by an owner whose key the signer no longer holds
+/// (e.g. an autosigner key that staged the block is later withdrawn), the client must discard
+/// the stale proposal and report `Committed(None)` rather than erroring or wedging. This is the
+/// second of the two ways `execute_block`'s retry loop can observe `Committed(None)` — the
+/// other being the chain advancing past the staged height
+/// (`test_execute_block_retries_when_chain_advances`).
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_pending_block_discarded_when_signer_key_missing<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let owner_a = client.identity().await?;
+
+    // Co-own the chain with a second owner `b` and no super-owner, so it runs in multi-leader
+    // (non-fast) rounds — the branch that discards rather than erroring.
+    let owner_b: AccountOwner = builder.signer.generate_new().into();
+    let ownership =
+        ChainOwnership::multiple([(owner_a, 50), (owner_b, 50)], 10, TimeoutConfig::default());
+    client.change_ownership(ownership).await?;
+
+    // Stage a block as owner `a` that can't reach a quorum, so it stays pending, authenticated
+    // by `a` (signing it here requires `a`'s key, which the signer still holds at this point).
+    builder.set_fault_type([0, 1], FaultType::Offline);
+    assert_matches!(
+        client.burn(AccountOwner::CHAIN, Amount::ONE).await,
+        Err(_),
+        "the burn should fail to commit with only two of four validators online"
+    );
+    assert_eq!(
+        client
+            .pending_proposal()
+            .await
+            .expect("a pending proposal authored by `a` should remain")
+            .block
+            .authenticated_signer,
+        Some(owner_a),
+    );
+
+    // Bring the validators back, then withdraw owner `a`'s key from the signer and act as `b`.
+    builder.set_fault_type([0, 1], FaultType::Honest);
+    client.synchronize_from_validators().await?;
+    assert!(
+        builder.signer.forget_key(&owner_a),
+        "owner `a`'s key should have been present before we forget it"
+    );
+    client.set_preferred_owner(owner_b);
+
+    // Processing the pending block must discard the stale proposal (we can no longer sign as `a`)
+    // and report `Committed(None)`, rather than raising an error or looping.
+    assert_matches!(
+        client.process_pending_block().await?,
+        ClientOutcome::Committed(None)
+    );
+    assert!(client.pending_proposal().await.is_none());
+
+    Ok(())
+}

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -3970,3 +3970,87 @@ where
 
     Ok(())
 }
+
+/// Regression test for #5664: when the chain advances (e.g. a notification or background
+/// sync commits another owner's block at our height) while a client is in the middle of
+/// `execute_block`, the staged pending proposal is cleared without committing ours. This
+/// used to surface as a hard `BlockProposalError("Unexpected block proposal error")`.
+/// The client must instead re-stage at the new height and never raise that error.
+///
+/// Two owners hammer the same multi-owner chain concurrently while each client runs a
+/// notification listener that advances its local node underneath the proposer task,
+/// reproducing the race. Requires the multi-threaded runtime: on a single thread the
+/// listener cannot advance the local node between staging and re-processing.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 4))]
+async fn test_execute_block_retries_when_chain_advances<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    const ROUNDS: usize = 50;
+
+    let mut signer = InMemorySigner::new(None);
+    let owner1 = signer.generate_new().into();
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let chain_id = client0.chain_id();
+    let owner0 = client0.identity().await?;
+
+    // Make the chain a two-owner chain so both clients can propose at the same height.
+    let ownership = ChainOwnership {
+        super_owners: BTreeSet::new(),
+        owners: BTreeMap::from_iter([(owner0, 100), (owner1, 100)]),
+        multi_leader_rounds: 10,
+        open_multi_leader_rounds: false,
+        timeout_config: TimeoutConfig::default(),
+    };
+    client0.change_ownership(ownership).await.unwrap();
+
+    let mut client1 = builder
+        .make_client(
+            chain_id,
+            client0.chain_info().await?.block_hash,
+            BlockHeight::from(1),
+        )
+        .await?;
+    client1.set_preferred_owner(owner1);
+    client1.synchronize_from_validators().await.unwrap();
+
+    // Run a notification listener on each client so its local node is advanced by the other
+    // owner's commits in the background — the same way the node service's background sync
+    // advances the chain while `execute_block` is running.
+    let (listener0, _abort0, _notifs0) = client0.listen().await?;
+    let (listener1, _abort1, _notifs1) = client1.listen().await?;
+    tokio::spawn(listener0);
+    tokio::spawn(listener1);
+
+    // Both owners publish a stream of data blobs to the same chain concurrently. They
+    // collide at the same height repeatedly; whichever loses a race may observe the chain
+    // advancing mid-proposal. None of these calls may fail with the "unexpected block
+    // proposal error".
+    async fn race(client: &ChainClient<impl Environment>, tag: u8) {
+        for i in 0..ROUNDS {
+            let data = vec![tag, i as u8];
+            match client.publish_data_blob(data).await {
+                // Committed / Conflict / WaitForTimeout are all acceptable outcomes of a
+                // concurrent proposal.
+                Ok(_) => {}
+                Err(err) => {
+                    let message = err.to_string();
+                    assert!(
+                        !message.contains("Unexpected block proposal error"),
+                        "execute_block raised the #5664 error instead of retrying: {message}",
+                    );
+                    // Other transient errors (communication, conflicts surfaced as errors)
+                    // are not what this test guards; resynchronize and continue.
+                    client.synchronize_from_validators().await.ok();
+                }
+            }
+        }
+    }
+
+    futures::join!(race(&client0, 0), race(&client1, 1));
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Backport of #6458 to `testnet_conway`.

`execute_block` holds the proposal mutex for its whole duration, but that mutex only
serializes proposers — it does not stop the background `LocalNode` worker (notification
handler / background sync) from absorbing certificates and advancing the chain. If another
owner's block is committed at our height in the window between staging our pending block and
re-processing it, `process_pending_block_inner` clears the now-stale pending proposal and
returns `Committed(None)`. `execute_block` treated that as unreachable and surfaced a hard
`BlockProposalError("Unexpected block proposal error")`, even though our operations simply
weren't applied yet.

This is issue #5664, and it shows up as intermittent failures in the remote-net e2e suite
(e.g. `test_wasm_end_to_end_allowances_fungible::remote_net_grpc`), where the node service's
background sync advances the chain while a GraphQL mutation is proposing. It also surfaces in
production as recurring `"Unexpected block proposal error"` reports.

## Proposal

Treat the post-staging `Committed(None)` as a retry signal rather than an error: wrap the
stage-and-propose section of `execute_block` in a loop and re-stage at the new height when
the chain advances underneath us. Re-staging starts from `prepend_epochs_messages_and_events`
because the set of receivable messages and epoch changes can differ at the new height.

The loop only iterates when the local chain height strictly advanced (i.e. another party
committed a block), so each iteration corresponds to real external progress and does genuine
network work — it cannot busy-spin. This mirrors the existing unbounded `UnexpectedBlockHeight`
retry in `execute_operations`.

Note vs. #6458: `testnet_conway` predates `main`'s `classify_committed` refactor, so this
backport keeps the branch's existing commit-vs-conflict classification
(`certificate.block() == &block`) rather than importing `classify_committed`. The retry logic
is otherwise identical. The regression test ports unchanged except for dropping the
`first_leader` field, which does not exist in `ChainOwnership` on this branch.

## Test Plan

- New regression test `test_execute_block_retries_when_chain_advances`: two owners hammer the
  same multi-owner chain concurrently, each running a notification listener that advances its
  local node underneath the proposer task. On a multi-threaded runtime this reproduces the
  race. It requires the multi-threaded runtime — on a single thread the listener cannot
  advance the chain between staging and re-processing.
- `cargo test -p linera-core --lib test_execute_block_retries_when_chain_advances` passes
  (memory backend, 4.4s).
- `cargo clippy -p linera-core --tests` is clean (0 warnings) and `cargo +nightly-2025-04-03 fmt -- --check` is clean.

## Release Plan

- These changes are the `testnet`-branch backport of #6458 and should
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Backport of #6458
- Fixes #5664
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
