### PR TITLE
Label block-execution metrics by phase

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 #[cfg(with_metrics)]
 use crate::chain::metrics;
 use crate::{
-    chain::EMPTY_BLOCK_SIZE,
+    chain::{BlockExecutionPhase, EMPTY_BLOCK_SIZE},
     data_types::{
         IncomingBundle, MessageAction, OperationResult, PostedMessage, ProposedBlock, Transaction,
     },
@@ -35,6 +35,10 @@ use crate::{
 #[derive(Debug)]
 pub struct BlockExecutionTracker<'resources, 'blobs> {
     chain_id: ChainId,
+    /// The protocol phase this block is executed in (staging a proposal, validating a
+    /// received proposal, or executing a confirmed certificate). Recorded on execution
+    /// spans and used to label execution metrics.
+    phase: BlockExecutionPhase,
     block_height: BlockHeight,
     timestamp: Timestamp,
     authenticated_owner: Option<AccountOwner>,
@@ -78,6 +82,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         local_time: Timestamp,
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         proposal: &ProposedBlock,
+        phase: BlockExecutionPhase,
     ) -> Result<Self, ChainError> {
         resource_controller
             .track_block_size(EMPTY_BLOCK_SIZE)
@@ -85,6 +90,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
 
         Ok(Self {
             chain_id: proposal.chain_id,
+            phase,
             block_height: proposal.height,
             timestamp: proposal.timestamp,
             authenticated_owner: proposal.authenticated_owner,
@@ -114,6 +120,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id,
         block_height = %self.block_height,
+        phase = self.phase.as_str(),
         transaction_index = %self.transaction_index,
         transaction_type = %transaction.as_ref(),
     ))]
@@ -158,7 +165,10 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     .track_block_size_of(&operation)
                     .with_execution_context(chain_execution_context)?;
                 #[cfg(with_metrics)]
-                let _operation_latency = metrics::OPERATION_EXECUTION_LATENCY.measure_latency_us();
+                let operation_latency =
+                    metrics::OPERATION_EXECUTION_LATENCY.with_label_values(&[self.phase.as_str()]);
+                #[cfg(with_metrics)]
+                let _operation_latency = operation_latency.measure_latency_us();
                 let context = OperationContext {
                     chain_id: self.chain_id,
                     height: self.block_height,
@@ -238,7 +248,10 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         C::Extra: ExecutionRuntimeContext,
     {
         #[cfg(with_metrics)]
-        let _message_latency = metrics::MESSAGE_EXECUTION_LATENCY.measure_latency_us();
+        let message_latency =
+            metrics::MESSAGE_EXECUTION_LATENCY.with_label_values(&[self.phase.as_str()]);
+        #[cfg(with_metrics)]
+        let _message_latency = message_latency.measure_latency_us();
         let context = MessageContext {
             chain_id: self.chain_id,
             origin: incoming_bundle.origin,
@@ -519,7 +532,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         assert_eq!(self.blobs.len(), expected_outcomes_count);
 
         #[cfg(with_metrics)]
-        crate::chain::metrics::track_block_metrics(&self.resource_controller.tracker);
+        crate::chain::metrics::track_block_metrics(&self.resource_controller.tracker, self.phase);
 
         let resource_tracker = self.resource_controller.tracker;
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -57,6 +57,36 @@ mod chain_tests;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency;
 
+/// The protocol phase a block is executed in. Recorded as the `phase` label on the
+/// block-execution metrics so the three distinct paths — staging a proposal, validating a
+/// received proposal, and committing a confirmed certificate — are separate time series in
+/// Prometheus.
+///
+/// Every path that executes a block must name its phase explicitly: there is no `Default`,
+/// so a new caller cannot compile without choosing one, and no execution can land in an
+/// unlabeled or silently-mislabeled bucket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockExecutionPhase {
+    /// A block proposer staging (building) its own block (`stage_block_execution`).
+    StageProposal,
+    /// A validator validating a received block proposal (`handle_block_proposal`).
+    HandleProposal,
+    /// A validator executing a confirmed certificate before committing it
+    /// (`process_confirmed_block`).
+    HandleConfirmed,
+}
+
+impl BlockExecutionPhase {
+    /// The Prometheus `phase` label value for this execution phase.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BlockExecutionPhase::StageProposal => "stage_proposal",
+            BlockExecutionPhase::HandleProposal => "handle_proposal",
+            BlockExecutionPhase::HandleConfirmed => "handle_confirmed",
+        }
+    }
+}
+
 #[cfg(with_metrics)]
 pub(crate) mod metrics {
     use std::sync::LazyLock;
@@ -68,14 +98,18 @@ pub(crate) mod metrics {
     use prometheus::{HistogramVec, IntCounterVec};
 
     pub static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec("num_blocks_executed", "Number of blocks executed", &[])
+        register_int_counter_vec(
+            "num_blocks_executed",
+            "Number of blocks executed",
+            &["phase"],
+        )
     });
 
     pub static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
             "block_execution_latency",
             "Block execution latency",
-            &[],
+            &["phase"],
             exponential_bucket_interval(50.0_f64, 10_000_000.0),
         )
     });
@@ -85,7 +119,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "message_execution_latency",
             "Message execution latency",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1_f64, 50_000.0),
         )
     });
@@ -94,7 +128,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "operation_execution_latency",
             "Operation execution latency",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1_f64, 50_000.0),
         )
     });
@@ -103,7 +137,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "wasm_fuel_used_per_block",
             "Wasm fuel used per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
@@ -112,7 +146,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "evm_fuel_used_per_block",
             "EVM fuel used per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
@@ -121,7 +155,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "vm_num_reads_per_block",
             "VM number of reads per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1, 100.0),
         )
     });
@@ -130,7 +164,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "vm_bytes_read_per_block",
             "VM number of bytes read per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1, 10_000_000.0),
         )
     });
@@ -139,7 +173,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "vm_bytes_written_per_block",
             "VM number of bytes written per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1, 10_000_000.0),
         )
     });
@@ -148,7 +182,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "state_hash_computation_latency",
             "Time to recompute the state hash, in microseconds",
-            &[],
+            &["phase"],
             exponential_bucket_interval(1.0, 2_000_000.0),
         )
     });
@@ -171,23 +205,27 @@ pub(crate) mod metrics {
         )
     });
 
-    /// Tracks block execution metrics in Prometheus.
-    pub(crate) fn track_block_metrics(tracker: &ResourceTracker) {
-        NUM_BLOCKS_EXECUTED.with_label_values(&[]).inc();
+    /// Tracks block execution metrics in Prometheus, labeled by the execution `phase`.
+    pub(crate) fn track_block_metrics(
+        tracker: &ResourceTracker,
+        phase: super::BlockExecutionPhase,
+    ) {
+        let phase = &[phase.as_str()];
+        NUM_BLOCKS_EXECUTED.with_label_values(phase).inc();
         WASM_FUEL_USED_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.wasm_fuel as f64);
         EVM_FUEL_USED_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.evm_fuel as f64);
         VM_NUM_READS_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.read_operations as f64);
         VM_BYTES_READ_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.bytes_read as f64);
         VM_BYTES_WRITTEN_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.bytes_written as f64);
     }
 }
@@ -787,6 +825,7 @@ where
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         exec_policy: BundleExecutionPolicy,
+        phase: BlockExecutionPhase,
         checkpoint_origin_cursors: Vec<(ChainId, Cursor)>,
         checkpoint_inbox_cursors: Vec<(ChainId, Cursor)>,
         checkpoint_outbox_block_hashes: Vec<CryptoHash>,
@@ -801,7 +840,10 @@ where
         }
 
         #[cfg(with_metrics)]
-        let _execution_latency = metrics::BLOCK_EXECUTION_LATENCY.measure_latency_us();
+        let block_execution_latency =
+            metrics::BLOCK_EXECUTION_LATENCY.with_label_values(&[phase.as_str()]);
+        #[cfg(with_metrics)]
+        let _execution_latency = block_execution_latency.measure_latency_us();
 
         // Resolve the current epoch's resource policy first: `prepare_checkpoint` needs
         // `maximum_blob_size` to chunk the dump, and `current_committee` is a pure read
@@ -866,6 +908,7 @@ where
             local_time,
             replaying_oracle_responses,
             block,
+            phase,
         )?;
         if let Some(prepared) = prepared_checkpoint {
             block_execution_tracker.set_prepared_checkpoint(prepared);
@@ -1128,7 +1171,10 @@ where
 
         let state_hash = {
             #[cfg(with_metrics)]
-            let _hash_latency = metrics::STATE_HASH_COMPUTATION_LATENCY.measure_latency_us();
+            let state_hash_latency =
+                metrics::STATE_HASH_COMPUTATION_LATENCY.with_label_values(&[phase.as_str()]);
+            #[cfg(with_metrics)]
+            let _hash_latency = state_hash_latency.measure_latency_us();
             chain.crypto_hash_mut().await?
         };
 
@@ -1189,6 +1235,7 @@ where
     /// - After `max_failures` failed bundles, all remaining message bundles are discarded.
     ///
     /// The block may be modified to reflect the actual executed transactions.
+    #[expect(clippy::too_many_arguments)]
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
         block_height = %block.height
@@ -1201,6 +1248,7 @@ where
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         policy: BundleExecutionPolicy,
+        phase: BlockExecutionPhase,
     ) -> Result<
         (
             ProposedBlock,
@@ -1279,6 +1327,7 @@ where
             published_blobs,
             replaying_oracle_responses,
             policy,
+            phase,
             origin_cursors,
             inbox_cursors,
             outbox_block_hashes,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -25,7 +25,7 @@ mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 
-pub use chain::{ChainIdSet, ChainStateView, ChainTipState, StreamCounts};
+pub use chain::{BlockExecutionPhase, ChainIdSet, ChainStateView, ChainTipState, StreamCounts};
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -44,7 +44,7 @@ use crate::{
         PostedMessage, ProposedBlock,
     },
     test::{make_child_block, make_first_block, BlockTestExt, HttpServer},
-    ChainError, ChainExecutionContext, ChainStateView,
+    BlockExecutionPhase, ChainError, ChainExecutionContext, ChainStateView,
 };
 
 impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
@@ -75,6 +75,7 @@ impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
                 published_blobs,
                 None,
                 BundleExecutionPolicy::committed(),
+                BlockExecutionPhase::StageProposal,
             )
             .await?;
         Ok((block, outcome, tracker))

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -33,8 +33,8 @@ use linera_chain::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
         ValidatedBlockCertificate,
     },
-    ChainError, ChainExecutionContext, ChainIdSet, ChainStateView, ChainTipState,
-    ExecutionResultExt as _, StreamCounts,
+    BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
+    ChainTipState, ExecutionResultExt as _, StreamCounts,
 };
 use linera_execution::{
     system::{EpochEventData, EventSubscriptions, EPOCH_STREAM_NAME},
@@ -1300,6 +1300,7 @@ where
                     &published_blobs,
                     oracle_responses,
                     BundleExecutionPolicy::committed(),
+                    BlockExecutionPhase::HandleConfirmed,
                 )
                 .await?;
             // We should always agree on the messages and state hash.
@@ -2302,7 +2303,15 @@ where
             .remove_bundles_from_inboxes(block.timestamp, true, block.incoming_bundles())
             .await?;
         let (executed_block, resource_tracker, never_reject_origins) =
-            Box::pin(self.execute_block(block, local_time, round, published_blobs, policy)).await?;
+            Box::pin(self.execute_block(
+                block,
+                local_time,
+                round,
+                published_blobs,
+                policy,
+                BlockExecutionPhase::StageProposal,
+            ))
+            .await?;
 
         // No need to sign: only used internally.
         let info = ChainInfo::from_chain_view(&mut self.chain).await?;
@@ -2498,6 +2507,7 @@ where
                 round.multi_leader(),
                 &published_blobs,
                 BundleExecutionPolicy::committed(),
+                BlockExecutionPhase::HandleProposal,
             ))
             .await?;
             executed_block
@@ -2654,12 +2664,19 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
         policy: BundleExecutionPolicy,
+        phase: BlockExecutionPhase,
     ) -> Result<(Block, ResourceTracker, HashSet<ChainId>), WorkerError> {
-        let (proposed_block, outcome, resource_tracker, never_reject_origins) = Box::pin(
-            self.chain
-                .execute_block(block, local_time, round, published_blobs, None, policy),
-        )
-        .await?;
+        let (proposed_block, outcome, resource_tracker, never_reject_origins) =
+            Box::pin(self.chain.execute_block(
+                block,
+                local_time,
+                round,
+                published_blobs,
+                None,
+                policy,
+                phase,
+            ))
+            .await?;
         let executed_block = Block::new(proposed_block, outcome);
         let block_hash = executed_block.hash();
         if let Some(cache) = &self.execution_state_cache {


### PR DESCRIPTION
## Motivation

Block execution happens in three protocol-distinct contexts, but they all recorded into the *same* Prometheus time series, so a latency or resource sample gave no way to tell which path produced it:

- **staging a block proposal** — a proposer building its own block,
- **handling a received block proposal** — a validator validating it,
- **handling a confirmed certificate** — a validator committing it.

All three funnel through `ChainStateView::execute_block`, where ten execution metrics are recorded with no discriminating label (`&[]`).

## Proposal

Add a `phase` label to the ten execution metrics, with values `stage_proposal` / `handle_proposal` / `handle_confirmed`:

`block_execution_latency`, `num_blocks_executed`, `wasm_fuel_used_per_block`, `evm_fuel_used_per_block`, `vm_num_reads_per_block`, `vm_bytes_read_per_block`, `vm_bytes_written_per_block`, `message_execution_latency`, `operation_execution_latency`, `state_hash_computation_latency`.

A new `BlockExecutionPhase` enum (no `Default`, exactly three variants) is threaded as a **required** argument through `execute_block` -> `execute_block_inner` -> `BlockExecutionTracker`, plus the worker-level `execute_block` wrapper. Because it is required, a new execution path cannot compile without naming a phase — there is no ambient default that could silently mislabel a sample. The three call sites set it explicitly:

- `stage_block_execution` -> `StageProposal`
- `try_handle_block_proposal` -> `HandleProposal`
- `process_confirmed_block` -> `HandleConfirmed`

The unrelated outbox metrics (`num_outboxes`, `outbox_counters_size`) are untouched. The `phase` field on `BlockExecutionTracker` is compiled out when metrics are disabled.

Existing flat queries keep working (they aggregate over `phase`); new dashboards can split per phase, e.g.:

```
histogram_quantile(0.99, sum by (le, phase) (rate(block_execution_latency_bucket[5m])))
```

## Test Plan

- `cargo clippy -p linera-core -p linera-chain --features "metrics test" --all-targets` — clean, 0 warnings.
- `cargo build -p linera-chain -p linera-core` (default features, i.e. `with_metrics` off) — clean; confirms the cfg-gated `phase` field path compiles.
- `cargo test -p linera-chain --features "metrics test" --lib` — 51 passed (exercises `stage_proposal`).
- `cargo test -p linera-core --features "metrics test" --lib test_handle_block_proposal test_handle_certificate_*` — 13 passed (exercises `handle_proposal` and `handle_confirmed`).

Prometheus panics at runtime on a label-count mismatch, so the suites passing under `--features metrics` is direct evidence the labels are wired consistently across all three paths. Not yet verified by scraping `/metrics` on a running node.

## Release Plan

- Nothing to do / These changes follow the usual release cycle. (Metrics-only change; no protocol or storage format change.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)