### PR TITLE
linera-storage: cache immutable block-hash, event, and network-description reads (testnet_conway)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -295,6 +295,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--event-cache-size <EVENT_CACHE_SIZE>` — The maximal number of entries in the event cache
 
   Default value: `1000`
+* `--block-hash-by-height-cache-size <BLOCK_HASH_BY_HEIGHT_CACHE_SIZE>` — The maximal number of entries in the block-hash-by-height cache
+
+  Default value: `1000`
 * `--block-cache-size <BLOCK_CACHE_SIZE>` — The number of entries in the block cache
 
   Default value: `5000`

--- a/linera-bridge/tests/e2e/src/lib.rs
+++ b/linera-bridge/tests/e2e/src/lib.rs
@@ -549,9 +549,11 @@ where
     E: linera_core::environment::Environment,
 {
     use linera_execution::Operation;
-    let bytes = bcs::to_bytes(&wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
-        app_id: bridge_app_id,
-    })?;
+    let bytes = bcs::to_bytes(
+        &wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
+            app_id: bridge_app_id,
+        },
+    )?;
     chain_client
         .execute_operations(
             vec![Operation::User {
@@ -685,4 +687,17 @@ where
     let info = chain_client.chain_info().await?;
     let hash = info.block_hash.context("chain has no blocks yet")?;
     Ok(chain_client.read_certificate(hash).await?)
+}
+
+/// Storage cache configuration used by the e2e tests.
+pub fn test_storage_cache_config() -> linera_storage::StorageCacheConfig {
+    linera_storage::StorageCacheConfig {
+        blob_cache_size: 1000,
+        confirmed_block_cache_size: 1000,
+        certificate_cache_size: 1000,
+        certificate_raw_cache_size: 1000,
+        event_cache_size: 1000,
+        block_hash_by_height_cache_size: 1000,
+        cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
+    }
 }

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -42,7 +42,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use wrapped_fungible::{InitialState, WrappedParameters};
 
@@ -91,15 +91,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
         &config,
         "auto-scan-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
 
@@ -221,9 +213,11 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
 
     // ── Phase 6: Register app IDs on both sides ──
     tracing::info!("Registering bridge app in wrapped-fungible...");
-    let register_bytes = bcs::to_bytes(&wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
-        app_id: bridge_app_id,
-    })?;
+    let register_bytes = bcs::to_bytes(
+        &wrapped_fungible::WrappedFungibleOperation::RegisterAuthorizedCaller {
+            app_id: bridge_app_id,
+        },
+    )?;
     let register_operation = Operation::User {
         application_id: fungible_app_id,
         bytes: register_bytes,

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -97,6 +97,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -85,6 +85,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -29,14 +29,14 @@ use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_evm_bridge,
-    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
-    wait_for_light_client, wait_for_relay_http_ready, ANVIL_PRIVATE_KEY,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose, wait_for_light_client,
+    wait_for_relay_http_ready, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -79,15 +79,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
         &store_config,
         "burn-false-positive-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;
@@ -140,7 +132,8 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     )
     .await?;
 
-    let bridge_app_id = publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
 
     // Register the wrapped-fungible app with the evm-bridge so it can drive
     // the escrow transfer + burn.

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -23,7 +23,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use test_case::test_case;
 
@@ -95,15 +95,7 @@ async fn burns_per_evm_tx(
         &store_config,
         &format!("burns-per-tx-{name}-e2e"),
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;
@@ -187,28 +179,14 @@ async fn burns_per_evm_tx(
     .await;
 
     let mut hi: u32 = 8;
-    let mut hi_gas = build_and_estimate(
-        hi,
-        &cc_a,
-        &cc_b,
-        bridge_app_id,
-        bridge_addr,
-        &provider,
-    )
-    .await?;
+    let mut hi_gas =
+        build_and_estimate(hi, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider).await?;
     tracing::info!(n = hi, gas = hi_gas, "search: initial `Burn` ops count");
 
     while hi_gas <= block_gas_limit && hi < MAX_SEARCH_N {
         let next_hi = hi.saturating_mul(2).min(MAX_SEARCH_N);
-        let gas = build_and_estimate(
-            next_hi,
-            &cc_a,
-            &cc_b,
-            bridge_app_id,
-            bridge_addr,
-            &provider,
-        )
-        .await?;
+        let gas = build_and_estimate(next_hi, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider)
+            .await?;
         hi = next_hi;
         hi_gas = gas;
         if hi_gas > block_gas_limit {
@@ -229,15 +207,7 @@ async fn burns_per_evm_tx(
     let mut lo_gas = if hi == 1 {
         hi_gas
     } else {
-        build_and_estimate(
-            lo,
-            &cc_a,
-            &cc_b,
-            bridge_app_id,
-            bridge_addr,
-            &provider,
-        )
-        .await?
+        build_and_estimate(lo, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider).await?
     };
     anyhow::ensure!(
         lo_gas <= block_gas_limit,
@@ -271,15 +241,8 @@ async fn burns_per_evm_tx(
 
     while lo + 1 < hi {
         let mid = lo + (hi - lo) / 2;
-        let g = build_and_estimate(
-            mid,
-            &cc_a,
-            &cc_b,
-            bridge_app_id,
-            bridge_addr,
-            &provider,
-        )
-        .await?;
+        let g =
+            build_and_estimate(mid, &cc_a, &cc_b, bridge_app_id, bridge_addr, &provider).await?;
         tracing::info!(n = mid, gas = g, "search: bisect");
         if g <= block_gas_limit {
             lo = mid;

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -101,6 +101,7 @@ async fn burns_per_evm_tx(
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -80,6 +80,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -23,7 +23,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::WasmRuntime;
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -74,15 +74,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
         &config,
         "committee-rotation-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -88,6 +88,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -33,7 +33,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, Query, QueryResponse, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use serde::Serialize;
 use wrapped_fungible::{InitialState, WrappedParameters};
@@ -82,15 +82,7 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
         &config,
         "e2l-bridge-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -32,7 +32,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::{environment::wallet::Memory, worker::Reason};
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 use wrapped_fungible::{
     Account, InitialState, WrappedFungibleOperation, WrappedFungibleTokenAbi, WrappedParameters,
@@ -76,15 +76,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
         &config,
         "bridge-e2e-test",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
 

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -82,6 +82,7 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -97,6 +97,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -42,7 +42,7 @@ use linera_client::{chain_listener::ClientContext as _, client_context::ClientCo
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -91,15 +91,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
         &store_config,
         "multi-tx-burn-chunking-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;
@@ -144,7 +136,8 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
     )
     .await?;
 
-    let bridge_app_id = publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
+    let bridge_app_id =
+        publish_and_create_evm_bridge(&cc_a, erc20_addr, chain_a, fungible_app_id).await?;
 
     // Register the wrapped-fungible app with the evm-bridge so it can drive
     // the escrow transfer + burn.

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -73,6 +73,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -24,14 +24,14 @@ use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_evm_bridge,
-    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
-    wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose, wait_for_light_client,
+    wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -67,15 +67,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
         &store_config,
         "multi-burn-same-block-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -32,14 +32,14 @@ use linera_bridge::abi::BridgeOperation;
 use linera_bridge_e2e::{
     compose_file_path, deploy_fungible_bridge, deploy_linera_token, fund_bridge_erc20,
     light_client_address, parse_metric_value, publish_and_create_evm_bridge,
-    publish_and_create_wrapped_fungible, register_bridge_app, start_compose,
-    wait_for_light_client, wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
+    publish_and_create_wrapped_fungible, register_bridge_app, start_compose, wait_for_light_client,
+    wait_for_relay_http_ready, wait_for_relay_metrics, ANVIL_PRIVATE_KEY,
 };
 use linera_client::{chain_listener::ClientContext as _, client_context::ClientContext};
 use linera_core::environment::wallet::Memory;
 use linera_execution::{Operation, WasmRuntime};
 use linera_faucet_client::Faucet;
-use linera_storage::{DbStorage, StorageCacheConfig};
+use linera_storage::DbStorage;
 use linera_views::backends::memory::{MemoryDatabase, MemoryStoreConfig};
 
 sol! {
@@ -75,15 +75,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
         &store_config,
         "multi-burn-same-recipient-e2e",
         Some(WasmRuntime::default()),
-        StorageCacheConfig {
-            blob_cache_size: 1000,
-            confirmed_block_cache_size: 1000,
-            certificate_cache_size: 1000,
-            certificate_raw_cache_size: 1000,
-            event_cache_size: 1000,
-            block_hash_by_height_cache_size: 1000,
-            cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
-        },
+        linera_bridge_e2e::test_storage_cache_config(),
     )
     .await?;
     genesis_config.initialize_storage(&mut storage).await?;

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -81,6 +81,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -88,6 +88,10 @@ pub struct RocksDbConfig {
     /// The maximal number of entries in the event cache.
     #[arg(long, default_value = "1000")]
     pub event_cache_size: usize,
+
+    /// The maximal number of entries in the block-hash-by-height cache.
+    #[arg(long, default_value = "1000")]
+    pub block_hash_by_height_cache_size: usize,
 }
 
 pub type RocksDbRunner = Runner<RocksDbDatabase, RocksDbConfig>;
@@ -133,6 +137,7 @@ impl RocksDbRunner {
                     certificate_cache_size: config.client.certificate_cache_size,
                     certificate_raw_cache_size: config.client.certificate_raw_cache_size,
                     event_cache_size: config.client.event_cache_size,
+                    block_hash_by_height_cache_size: config.client.block_hash_by_height_cache_size,
                     cache_cleanup_interval_secs:
                         linera_service::storage::DEFAULT_CLEANUP_INTERVAL_SECS,
                 },

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -83,6 +83,10 @@ pub struct ScyllaDbConfig {
     #[arg(long, default_value = "1000")]
     pub event_cache_size: usize,
 
+    /// The maximal number of entries in the block-hash-by-height cache.
+    #[arg(long, default_value = "1000")]
+    pub block_hash_by_height_cache_size: usize,
+
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1")]
     pub replication_factor: u32,
@@ -127,6 +131,7 @@ impl ScyllaDbRunner {
                     certificate_cache_size: config.client.certificate_cache_size,
                     certificate_raw_cache_size: config.client.certificate_raw_cache_size,
                     event_cache_size: config.client.event_cache_size,
+                    block_hash_by_height_cache_size: config.client.block_hash_by_height_cache_size,
                     cache_cleanup_interval_secs:
                         linera_service::storage::DEFAULT_CLEANUP_INTERVAL_SECS,
                 },

--- a/linera-storage-runtime/src/lib.rs
+++ b/linera-storage-runtime/src/lib.rs
@@ -108,6 +108,10 @@ pub struct CommonStorageOptions {
     #[arg(long, default_value = "1000", global = true)]
     pub event_cache_size: usize,
 
+    /// The maximal number of entries in the block-hash-by-height cache.
+    #[arg(long, default_value = "1000", global = true)]
+    pub block_hash_by_height_cache_size: usize,
+
     /// The number of entries in the block cache.
     #[arg(long, default_value = "5000", global = true)]
     pub block_cache_size: usize,
@@ -130,6 +134,7 @@ impl CommonStorageOptions {
             certificate_cache_size: self.certificate_cache_size,
             certificate_raw_cache_size: self.certificate_raw_cache_size,
             event_cache_size: self.event_cache_size,
+            block_hash_by_height_cache_size: self.block_hash_by_height_cache_size,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         }
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{Arc, OnceLock},
+};
 
 use async_trait::async_trait;
 #[cfg(with_metrics)]
@@ -213,6 +217,17 @@ pub mod metrics {
         )
     });
 
+    /// The metric counting how often a block hash is read by height from storage.
+    #[doc(hidden)]
+    pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: LazyLock<IntCounterVec> =
+        LazyLock::new(|| {
+            register_int_counter_vec(
+                "read_block_hash_by_height",
+                "The metric counting how often a block hash is read by height from storage",
+                &[SOURCE_LABEL],
+            )
+        });
+
     /// The metric counting how often the network description is read from storage.
     #[doc(hidden)]
     pub(super) static READ_NETWORK_DESCRIPTION: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -364,6 +379,8 @@ pub struct StorageCacheConfig {
     pub certificate_raw_cache_size: usize,
     /// The maximum number of events held in the event cache.
     pub event_cache_size: usize,
+    /// The maximum number of block hashes to cache, keyed by `(chain, height)`.
+    pub block_hash_by_height_cache_size: usize,
     /// The interval, in seconds, between cache cleanup passes.
     pub cache_cleanup_interval_secs: u64,
 }
@@ -376,6 +393,7 @@ pub const DEFAULT_STORAGE_CACHE_CONFIG: StorageCacheConfig = StorageCacheConfig 
     certificate_cache_size: 1000,
     certificate_raw_cache_size: 1000,
     event_cache_size: 1000,
+    block_hash_by_height_cache_size: 1000,
     cache_cleanup_interval_secs: linera_cache::DEFAULT_CLEANUP_INTERVAL_SECS,
 };
 
@@ -394,6 +412,8 @@ pub struct StorageCaches {
     pub(crate) certificate: Arc<ValueCache<CryptoHash, ConfirmedBlockCertificate>>,
     pub(crate) certificate_raw: Arc<ValueCache<CryptoHash, RawCertificate>>,
     pub(crate) event: Arc<ValueCache<EventId, Vec<u8>>>,
+    pub(crate) block_hash_by_height: Arc<ValueCache<(ChainId, BlockHeight), CryptoHash>>,
+    pub(crate) network_description: Arc<OnceLock<NetworkDescription>>,
 }
 
 impl StorageCaches {
@@ -406,6 +426,11 @@ impl StorageCaches {
             certificate: Arc::new(ValueCache::new(sizes.certificate_cache_size, interval)),
             certificate_raw: Arc::new(ValueCache::new(sizes.certificate_raw_cache_size, interval)),
             event: Arc::new(ValueCache::new(sizes.event_cache_size, interval)),
+            block_hash_by_height: Arc::new(ValueCache::new(
+                sizes.block_hash_by_height_cache_size,
+                interval,
+            )),
+            network_description: Arc::new(OnceLock::new()),
         }
     }
 }
@@ -1522,7 +1547,16 @@ where
             batch.add_blob(blob);
         }
         batch.add_certificate(certificate)?;
-        self.write_batch(batch).await
+        self.write_batch(batch).await?;
+        // Populate the block-hash-by-height cache so subsequent reads are served from memory.
+        let block = certificate.value().block();
+        let chain_id = block.header.chain_id;
+        let height = block.header.height;
+        let hash = certificate.hash();
+        self.caches
+            .block_hash_by_height
+            .insert(&(chain_id, height), hash);
+        Ok(())
     }
 
     fn cache_certificate(
@@ -1680,19 +1714,49 @@ where
             return Ok(Vec::new());
         }
 
-        let index_root_key = RootKey::BlockByHeight(chain_id).bytes();
-        let store = self.database.open_shared(&index_root_key)?;
-        let height_keys: Vec<Vec<u8>> = heights.iter().map(|h| to_height_key(*h)).collect();
-        let hash_bytes = store.read_multi_values_bytes(&height_keys).await?;
-        let hash_options: Vec<Option<CryptoHash>> = hash_bytes
-            .into_iter()
-            .map(|opt| {
-                opt.map(|bytes| bcs::from_bytes::<CryptoHash>(&bytes))
-                    .transpose()
-            })
-            .collect::<Result<_, _>>()?;
+        let mut results = vec![None; heights.len()];
+        let mut misses = Vec::new();
+        for (i, &height) in heights.iter().enumerate() {
+            if let Some(hash) = self.caches.block_hash_by_height.get(&(chain_id, height)) {
+                results[i] = Some(*hash);
+            } else {
+                misses.push(i);
+            }
+        }
+        #[cfg(with_metrics)]
+        {
+            let cache_hits = (heights.len() - misses.len()) as u64;
+            if cache_hits > 0 {
+                metrics::READ_BLOCK_HASH_BY_HEIGHT_COUNTER
+                    .with_label_values(&[metrics::CACHE])
+                    .inc_by(cache_hits);
+            }
+        }
+        if !misses.is_empty() {
+            let miss_keys: Vec<Vec<u8>> =
+                misses.iter().map(|&i| to_height_key(heights[i])).collect();
+            let index_root_key = RootKey::BlockByHeight(chain_id).bytes();
+            let store = self.database.open_shared(&index_root_key)?;
+            let hash_bytes = store.read_multi_values_bytes(&miss_keys).await?;
+            #[cfg(with_metrics)]
+            {
+                let db_reads = misses.len() as u64;
+                metrics::READ_BLOCK_HASH_BY_HEIGHT_COUNTER
+                    .with_label_values(&[metrics::DB])
+                    .inc_by(db_reads);
+            }
+            for (miss_idx, opt_bytes) in misses.iter().zip(hash_bytes) {
+                if let Some(bytes) = opt_bytes {
+                    let hash = bcs::from_bytes::<CryptoHash>(&bytes)?;
+                    self.caches
+                        .block_hash_by_height
+                        .insert(&(chain_id, heights[*miss_idx]), hash);
+                    results[*miss_idx] = Some(hash);
+                }
+            }
+        }
 
-        Ok(hash_options)
+        Ok(results)
     }
 
     #[instrument(skip_all)]
@@ -1832,24 +1896,48 @@ where
     ) -> Result<Vec<IndexAndEvent>, ViewError> {
         let root_key = RootKey::Event(*chain_id).bytes();
         let store = self.database.open_shared(&root_key)?;
-        let mut keys = Vec::new();
-        let mut indices = Vec::new();
+        let mut db_keys = Vec::new();
+        let mut db_indices = Vec::new();
+        let mut returned_values = Vec::new();
         let prefix = bcs::to_bytes(stream_id).unwrap();
         for short_key in store.find_keys_by_prefix(&prefix).await? {
             let index = bcs::from_bytes::<u32>(&short_key)?;
             if index >= start_index {
-                let mut key = prefix.clone();
-                key.extend(short_key);
-                keys.push(key);
-                indices.push(index);
+                let event_id = EventId {
+                    chain_id: *chain_id,
+                    stream_id: stream_id.clone(),
+                    index,
+                };
+                if let Some(cached) = self.caches.event.get(&event_id) {
+                    returned_values.push(IndexAndEvent {
+                        index,
+                        event: (*cached).clone(),
+                    });
+                } else {
+                    let mut key = prefix.clone();
+                    key.extend(short_key);
+                    db_keys.push(key);
+                    db_indices.push(index);
+                }
             }
         }
-        let values = store.read_multi_values_bytes(&keys).await?;
-        let mut returned_values = Vec::new();
-        for (index, value) in indices.into_iter().zip(values) {
-            let event = value.unwrap();
-            returned_values.push(IndexAndEvent { index, event });
+        if !db_keys.is_empty() {
+            let values = store.read_multi_values_bytes(&db_keys).await?;
+            for (index, value) in db_indices.into_iter().zip(values) {
+                let event_bytes = value.unwrap();
+                let event_id = EventId {
+                    chain_id: *chain_id,
+                    stream_id: stream_id.clone(),
+                    index,
+                };
+                self.caches.event.insert(&event_id, event_bytes.clone());
+                returned_values.push(IndexAndEvent {
+                    index,
+                    event: event_bytes,
+                });
+            }
         }
+        returned_values.sort_unstable_by_key(|ie| ie.index);
         Ok(returned_values)
     }
 
@@ -1867,13 +1955,25 @@ where
 
     #[instrument(skip_all)]
     async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError> {
+        if let Some(desc) = self.caches.network_description.get() {
+            #[cfg(with_metrics)]
+            metrics::READ_NETWORK_DESCRIPTION
+                .with_label_values(&[metrics::CACHE])
+                .inc();
+            return Ok(Some(desc.clone()));
+        }
         let root_key = RootKey::NetworkDescription.bytes();
         let store = self.database.open_shared(&root_key)?;
-        let maybe_value = store.read_value(NETWORK_DESCRIPTION_KEY).await?;
+        let maybe_value: Option<NetworkDescription> =
+            store.read_value(NETWORK_DESCRIPTION_KEY).await?;
         #[cfg(with_metrics)]
         metrics::READ_NETWORK_DESCRIPTION
             .with_label_values(&[metrics::DB])
             .inc();
+        if let Some(ref desc) = maybe_value {
+            // Ignore the error: another thread may have populated the cache concurrently.
+            drop(self.caches.network_description.set(desc.clone()));
+        }
         Ok(maybe_value)
     }
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -35,7 +35,7 @@ use linera_views::{
     ViewError,
 };
 use serde::{Deserialize, Serialize};
-use tracing::instrument;
+use tracing::{debug, instrument};
 #[cfg(with_testing)]
 use {
     futures::channel::oneshot::{self, Receiver},
@@ -1896,9 +1896,10 @@ where
     ) -> Result<Vec<IndexAndEvent>, ViewError> {
         let root_key = RootKey::Event(*chain_id).bytes();
         let store = self.database.open_shared(&root_key)?;
+        // Pair each index with its cached value, or `None` for a cache miss to be
+        // read from the database, so results keep the key-scan order.
+        let mut entries = Vec::new();
         let mut db_keys = Vec::new();
-        let mut db_indices = Vec::new();
-        let mut returned_values = Vec::new();
         let prefix = bcs::to_bytes(stream_id).unwrap();
         for short_key in store.find_keys_by_prefix(&prefix).await? {
             let index = bcs::from_bytes::<u32>(&short_key)?;
@@ -1908,36 +1909,41 @@ where
                     stream_id: stream_id.clone(),
                     index,
                 };
-                if let Some(cached) = self.caches.event.get(&event_id) {
-                    returned_values.push(IndexAndEvent {
-                        index,
-                        event: (*cached).clone(),
-                    });
-                } else {
+                let cached = self.caches.event.get(&event_id).map(|arc| (*arc).clone());
+                if cached.is_none() {
                     let mut key = prefix.clone();
                     key.extend(short_key);
                     db_keys.push(key);
-                    db_indices.push(index);
                 }
+                entries.push((index, cached));
             }
         }
-        if !db_keys.is_empty() {
-            let values = store.read_multi_values_bytes(&db_keys).await?;
-            for (index, value) in db_indices.into_iter().zip(values) {
-                let event_bytes = value.unwrap();
-                let event_id = EventId {
-                    chain_id: *chain_id,
-                    stream_id: stream_id.clone(),
-                    index,
-                };
-                self.caches.event.insert(&event_id, event_bytes.clone());
-                returned_values.push(IndexAndEvent {
-                    index,
-                    event: event_bytes,
-                });
-            }
+        let mut db_values = if db_keys.is_empty() {
+            Vec::new()
+        } else {
+            store.read_multi_values_bytes(&db_keys).await?
         }
-        returned_values.sort_unstable_by_key(|ie| ie.index);
+        .into_iter();
+        let mut returned_values = Vec::with_capacity(entries.len());
+        for (index, cached) in entries {
+            let event = match cached {
+                Some(event) => event,
+                None => {
+                    let event_bytes = db_values
+                        .next()
+                        .expect("one database value per cache miss")
+                        .unwrap();
+                    let event_id = EventId {
+                        chain_id: *chain_id,
+                        stream_id: stream_id.clone(),
+                        index,
+                    };
+                    self.caches.event.insert(&event_id, event_bytes.clone());
+                    event_bytes
+                }
+            };
+            returned_values.push(IndexAndEvent { index, event });
+        }
         Ok(returned_values)
     }
 
@@ -1971,8 +1977,9 @@ where
             .with_label_values(&[metrics::DB])
             .inc();
         if let Some(ref desc) = maybe_value {
-            // Ignore the error: another thread may have populated the cache concurrently.
-            drop(self.caches.network_description.set(desc.clone()));
+            if self.caches.network_description.set(desc.clone()).is_err() {
+                debug!("network description cache was already populated concurrently");
+            }
         }
         Ok(maybe_value)
     }

--- a/linera-storage/src/migration.rs
+++ b/linera-storage/src/migration.rs
@@ -582,6 +582,7 @@ mod tests {
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: crate::DEFAULT_CLEANUP_INTERVAL_SECS,
         };
         let storage = DbStorage::<D, WallClock>::new(database, None, cache_sizes, WallClock);

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -23,6 +23,7 @@ pub async fn get_storage(namespace: &str) -> Result<Storage, linera_views::ViewE
             certificate_cache_size: 1000,
             certificate_raw_cache_size: 1000,
             event_cache_size: 1000,
+            block_hash_by_height_cache_size: 1000,
             cache_cleanup_interval_secs: linera_storage::DEFAULT_CLEANUP_INTERVAL_SECS,
         },
     )


### PR DESCRIPTION
## Motivation

`DbStorage` pays a full Scylla/RocksDB round-trip on every call to several read
methods that return permanently immutable data. On the OVH `testnet_conway`
validators this is a live source of read pressure (sustained multi-second p99
read spikes).

This is the `testnet_conway` backport of #6389, restricted to the three caches
that need **no new storage index** — so it ships now without waiting on the
`EventBlockHeight` index + RPC backport (#5710), which the fourth cache depends on.

## Proposal

Add three caches to `StorageCaches`, mirroring the existing five:

- `block_hash_by_height: Arc<ValueCache<(ChainId, BlockHeight), CryptoHash>>` —
  backs `read_certificate_hashes_by_heights` (uses the existing `BlockByHeight` index)
- `network_description: Arc<OnceLock<NetworkDescription>>` — single-value, zero
  overhead after first read
- `read_events_from_index` now checks the existing `event` cache before bulk-reading values

Read path: check-then-populate (same pattern as `read_certificates_raw`). Write
path: `block_hash_by_height` is populated in `write_blobs_and_certificate` at write time.

One new CLI flag with a conservative default (1 000), overridden via lineractl/linera-infra:
- `--block-hash-by-height-cache-size`

New Prometheus counter `read_block_hash_by_height` (labeled `[cache]`/`[db]`);
`read_network_description` gains the same split on its existing counter.

Deferred to a follow-up (needs the #5710 index + RPC backport first): the
`event_block_height` cache (the 4th cache in #6389).

## Test Plan

- `cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web`
  clean (matches CI's host-clippy invocation; `linera-web` is wasm-only and built
  by CI's dedicated wasm job)
- Covered by existing integration tests exercising `read_certificate_hashes_by_heights`
  and `read_events_from_index`

## Release Plan

- Backport to be released in a validator hotfix.

## Links

- Main version: #6389
- Deferred index/RPC backport (blocks the 4th cache): #5710
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)