### PR TITLE
Export ValueCache occupancy and capacity gauges

### DIFF
--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -34,6 +34,9 @@ pub const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 30;
 /// A background task periodically sweeps dead `Weak` entries from the index
 /// to prevent unbounded memory growth.
 pub struct ValueCache<K, V> {
+    /// Stable instance name distinguishing this cache in metrics; several
+    /// caches may share the same key/value types within one process.
+    name: &'static str,
     cache: Arc<Cache<K, crate::Arc<V>>>,
     weak_index: Arc<papaya::HashMap<K, Weak<V>>>,
 }
@@ -43,38 +46,51 @@ where
     K: Hash + Eq + Clone + Send + Sync + 'static,
     V: Send + Sync + 'static,
 {
-    /// Creates a new `ValueCache` with the given bounded-cache capacity
-    /// and cleanup interval for the weak-reference index.
+    /// Creates a new `ValueCache` with the given instance name (used as the
+    /// `cache` metric label), bounded-cache capacity, and cleanup interval
+    /// for the weak-reference index.
     #[cfg(not(web))]
-    pub fn new(size: usize, cleanup_interval_secs: u64) -> Self {
+    pub fn new(name: &'static str, size: usize, cleanup_interval_secs: u64) -> Self {
         let cache = Arc::new(Cache::new(size));
         let weak_index = Arc::new(papaya::HashMap::new());
+        // Report quick_cache's actual capacity, which may round the requested
+        // size up, so that occupancy (entries / capacity) cannot exceed 1.
         #[cfg(with_metrics)]
         metrics::CACHE_CAPACITY
-            .with_label_values(&[type_name::<K>(), type_name::<V>()])
-            .set(i64::try_from(size).unwrap_or(i64::MAX));
+            .with_label_values(&[name, type_name::<K>(), type_name::<V>()])
+            .set(i64::try_from(cache.capacity()).unwrap_or(i64::MAX));
         Self::spawn_cleanup_task(
             Arc::clone(&weak_index),
             #[cfg(with_metrics)]
-            Arc::clone(&cache),
+            (name, Arc::clone(&cache)),
             std::time::Duration::from_secs(cleanup_interval_secs),
         );
-        ValueCache { cache, weak_index }
+        ValueCache {
+            name,
+            cache,
+            weak_index,
+        }
     }
 
     /// Creates a new `ValueCache` (web variant, no background cleanup task).
     #[cfg(web)]
-    pub fn new(size: usize, _cleanup_interval_secs: u64) -> Self {
+    pub fn new(name: &'static str, size: usize, _cleanup_interval_secs: u64) -> Self {
         ValueCache {
+            name,
             cache: Arc::new(Cache::new(size)),
             weak_index: Arc::new(papaya::HashMap::new()),
         }
     }
 
+    /// Returns the instance name of this cache.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
     /// Returns the number of entries currently held in the bounded cache.
     ///
     /// This is the live occupancy (excludes the weak dedup index), and is
-    /// exported as the `value_cache_entries` gauge for the
+    /// periodically sampled as the `value_cache_entries` gauge for the
     /// occupancy-vs-capacity diagnosis.
     pub fn len(&self) -> usize {
         self.cache.len()
@@ -82,7 +98,7 @@ where
 
     /// Returns `true` if the bounded cache currently holds no entries.
     pub fn is_empty(&self) -> bool {
-        self.cache.len() == 0
+        self.cache.is_empty()
     }
 
     /// Inserts a value into the cache, returning the canonical [`crate::Arc`].
@@ -105,7 +121,7 @@ where
         if value.is_some() {
             self.cache.remove(key);
         }
-        Self::track_cache_usage(value)
+        self.track_cache_usage(value)
     }
 
     /// Returns an [`crate::Arc`] to the value, checking both the bounded
@@ -113,7 +129,7 @@ where
     pub fn get(&self, key: &K) -> Option<crate::Arc<V>> {
         // Tier 1: bounded cache (hot path)
         if let Some(arc) = self.cache.get(key) {
-            return Self::track_cache_usage(Some(arc));
+            return self.track_cache_usage(Some(arc));
         }
 
         // Tier 2: weak index (catches evicted-but-still-held entries)
@@ -123,11 +139,11 @@ where
                 let arc = crate::Arc(arc);
                 // Re-insert into bounded cache for future fast lookups
                 self.cache.insert(key.clone(), arc.clone());
-                return Self::track_cache_usage(Some(arc));
+                return self.track_cache_usage(Some(arc));
             }
         }
 
-        Self::track_cache_usage(None)
+        self.track_cache_usage(None)
     }
 
     /// Returns `true` if the value exists in either the bounded cache or
@@ -156,7 +172,7 @@ where
     #[cfg(not(web))]
     fn spawn_cleanup_task(
         weak_index: Arc<papaya::HashMap<K, Weak<V>>>,
-        #[cfg(with_metrics)] cache: Arc<Cache<K, crate::Arc<V>>>,
+        #[cfg(with_metrics)] metrics_handle: (&'static str, Arc<Cache<K, crate::Arc<V>>>),
         cleanup_interval: std::time::Duration,
     ) {
         if tokio::runtime::Handle::try_current().is_err() {
@@ -166,14 +182,19 @@ where
             let mut interval = tokio::time::interval(cleanup_interval);
             loop {
                 interval.tick().await;
-                let guard = weak_index.guard();
-                weak_index.retain(|_, weak| weak.strong_count() > 0, &guard);
-                // Refresh the occupancy gauge on the same cadence as the sweep;
-                // keeps it off the cache hot path.
+                {
+                    let guard = weak_index.guard();
+                    weak_index.retain(|_, weak| weak.strong_count() > 0, &guard);
+                }
+                // Refresh the occupancy gauge on the same cadence as the sweep
+                // (after the guard is dropped); keeps it off the cache hot path.
                 #[cfg(with_metrics)]
-                metrics::CACHE_ENTRIES
-                    .with_label_values(&[type_name::<K>(), type_name::<V>()])
-                    .set(i64::try_from(cache.len()).unwrap_or(i64::MAX));
+                {
+                    let (name, cache) = &metrics_handle;
+                    metrics::CACHE_ENTRIES
+                        .with_label_values(&[name, type_name::<K>(), type_name::<V>()])
+                        .set(i64::try_from(cache.len()).unwrap_or(i64::MAX));
+                }
             }
         });
     }
@@ -207,7 +228,7 @@ where
         canonical_arc
     }
 
-    fn track_cache_usage(maybe_value: Option<crate::Arc<V>>) -> Option<crate::Arc<V>> {
+    fn track_cache_usage(&self, maybe_value: Option<crate::Arc<V>>) -> Option<crate::Arc<V>> {
         #[cfg(with_metrics)]
         {
             let metric = if maybe_value.is_some() {
@@ -217,7 +238,7 @@ where
             };
 
             metric
-                .with_label_values(&[type_name::<K>(), type_name::<V>()])
+                .with_label_values(&[self.name, type_name::<K>(), type_name::<V>()])
                 .inc();
         }
         maybe_value
@@ -273,35 +294,33 @@ mod metrics {
     use linera_base::prometheus_util::{register_int_counter_vec, register_int_gauge_vec};
     use prometheus::{IntCounterVec, IntGaugeVec};
 
+    /// Shared label set: `cache` is the per-instance name passed to
+    /// [`super::ValueCache::new`], required because several caches may share
+    /// the same key/value types within one process.
+    const LABELS: &[&str] = &["cache", "key_type", "value_type"];
+
     pub static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "value_cache_hit",
-            "Cache hits in `ValueCache`",
-            &["key_type", "value_type"],
-        )
+        register_int_counter_vec("value_cache_hit", "Cache hits in `ValueCache`", LABELS)
     });
 
     pub static CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "value_cache_miss",
-            "Cache misses in `ValueCache`",
-            &["key_type", "value_type"],
-        )
+        register_int_counter_vec("value_cache_miss", "Cache misses in `ValueCache`", LABELS)
     });
 
     pub static CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
         register_int_gauge_vec(
             "value_cache_entries",
-            "Current number of entries held in the bounded `ValueCache`",
-            &["key_type", "value_type"],
+            "Number of entries held in the bounded `ValueCache`, sampled at \
+             each cleanup sweep",
+            LABELS,
         )
     });
 
     pub static CACHE_CAPACITY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
         register_int_gauge_vec(
             "value_cache_capacity",
-            "Configured maximum number of entries of the bounded `ValueCache`",
-            &["key_type", "value_type"],
+            "Maximum number of entries of the bounded `ValueCache`",
+            LABELS,
         )
     });
 }
@@ -340,11 +359,11 @@ mod tests {
     }
 
     fn new_hashed_cache(size: usize) -> ValueCache<CryptoHash, TestValue> {
-        ValueCache::new(size, DEFAULT_CLEANUP_INTERVAL_SECS)
+        ValueCache::new("test_hashed", size, DEFAULT_CLEANUP_INTERVAL_SECS)
     }
 
     fn new_string_cache(size: usize) -> ValueCache<u64, String> {
-        ValueCache::new(size, DEFAULT_CLEANUP_INTERVAL_SECS)
+        ValueCache::new("test_string", size, DEFAULT_CLEANUP_INTERVAL_SECS)
     }
 
     #[test]
@@ -438,12 +457,13 @@ mod tests {
         assert_eq!(cache.len(), 2);
 
         // Filling well beyond capacity caps the bounded-cache occupancy, which
-        // is exactly what the `value_cache_entries` gauge reports.
+        // is exactly what the `value_cache_entries` gauge reports. Note that
+        // `len()` counts only the bounded cache, not the weak dedup index.
         for i in 3..(TEST_CACHE_SIZE as u64 * 3) {
             cache.insert(&i, format!("v{i}"));
         }
         assert!(
-            cache.len() <= TEST_CACHE_SIZE + 1,
+            cache.len() <= TEST_CACHE_SIZE,
             "bounded-cache occupancy {} must not exceed capacity {TEST_CACHE_SIZE}",
             cache.len(),
         );

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -34,7 +34,7 @@ pub const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 30;
 /// A background task periodically sweeps dead `Weak` entries from the index
 /// to prevent unbounded memory growth.
 pub struct ValueCache<K, V> {
-    cache: Cache<K, crate::Arc<V>>,
+    cache: Arc<Cache<K, crate::Arc<V>>>,
     weak_index: Arc<papaya::HashMap<K, Weak<V>>>,
 }
 
@@ -47,24 +47,42 @@ where
     /// and cleanup interval for the weak-reference index.
     #[cfg(not(web))]
     pub fn new(size: usize, cleanup_interval_secs: u64) -> Self {
+        let cache = Arc::new(Cache::new(size));
         let weak_index = Arc::new(papaya::HashMap::new());
+        #[cfg(with_metrics)]
+        metrics::CACHE_CAPACITY
+            .with_label_values(&[type_name::<K>(), type_name::<V>()])
+            .set(i64::try_from(size).unwrap_or(i64::MAX));
         Self::spawn_cleanup_task(
             Arc::clone(&weak_index),
+            #[cfg(with_metrics)]
+            Arc::clone(&cache),
             std::time::Duration::from_secs(cleanup_interval_secs),
         );
-        ValueCache {
-            cache: Cache::new(size),
-            weak_index,
-        }
+        ValueCache { cache, weak_index }
     }
 
     /// Creates a new `ValueCache` (web variant, no background cleanup task).
     #[cfg(web)]
     pub fn new(size: usize, _cleanup_interval_secs: u64) -> Self {
         ValueCache {
-            cache: Cache::new(size),
+            cache: Arc::new(Cache::new(size)),
             weak_index: Arc::new(papaya::HashMap::new()),
         }
+    }
+
+    /// Returns the number of entries currently held in the bounded cache.
+    ///
+    /// This is the live occupancy (excludes the weak dedup index), and is
+    /// exported as the `value_cache_entries` gauge for the
+    /// occupancy-vs-capacity diagnosis.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Returns `true` if the bounded cache currently holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.cache.len() == 0
     }
 
     /// Inserts a value into the cache, returning the canonical [`crate::Arc`].
@@ -138,6 +156,7 @@ where
     #[cfg(not(web))]
     fn spawn_cleanup_task(
         weak_index: Arc<papaya::HashMap<K, Weak<V>>>,
+        #[cfg(with_metrics)] cache: Arc<Cache<K, crate::Arc<V>>>,
         cleanup_interval: std::time::Duration,
     ) {
         if tokio::runtime::Handle::try_current().is_err() {
@@ -149,6 +168,12 @@ where
                 interval.tick().await;
                 let guard = weak_index.guard();
                 weak_index.retain(|_, weak| weak.strong_count() > 0, &guard);
+                // Refresh the occupancy gauge on the same cadence as the sweep;
+                // keeps it off the cache hot path.
+                #[cfg(with_metrics)]
+                metrics::CACHE_ENTRIES
+                    .with_label_values(&[type_name::<K>(), type_name::<V>()])
+                    .set(i64::try_from(cache.len()).unwrap_or(i64::MAX));
             }
         });
     }
@@ -245,8 +270,8 @@ impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
 mod metrics {
     use std::sync::LazyLock;
 
-    use linera_base::prometheus_util::register_int_counter_vec;
-    use prometheus::IntCounterVec;
+    use linera_base::prometheus_util::{register_int_counter_vec, register_int_gauge_vec};
+    use prometheus::{IntCounterVec, IntGaugeVec};
 
     pub static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
@@ -260,6 +285,22 @@ mod metrics {
         register_int_counter_vec(
             "value_cache_miss",
             "Cache misses in `ValueCache`",
+            &["key_type", "value_type"],
+        )
+    });
+
+    pub static CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "value_cache_entries",
+            "Current number of entries held in the bounded `ValueCache`",
+            &["key_type", "value_type"],
+        )
+    });
+
+    pub static CACHE_CAPACITY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "value_cache_capacity",
+            "Configured maximum number of entries of the bounded `ValueCache`",
             &["key_type", "value_type"],
         )
     });
@@ -383,6 +424,29 @@ mod tests {
              but has {present_count} entries for capacity {TEST_CACHE_SIZE}"
         );
         assert!(present_count > 0, "cache should still hold some entries");
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let cache = new_string_cache(TEST_CACHE_SIZE);
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+
+        cache.insert(&1, "a".to_string());
+        cache.insert(&2, "b".to_string());
+        assert!(!cache.is_empty());
+        assert_eq!(cache.len(), 2);
+
+        // Filling well beyond capacity caps the bounded-cache occupancy, which
+        // is exactly what the `value_cache_entries` gauge reports.
+        for i in 3..(TEST_CACHE_SIZE as u64 * 3) {
+            cache.insert(&i, format!("v{i}"));
+        }
+        assert!(
+            cache.len() <= TEST_CACHE_SIZE + 1,
+            "bounded-cache occupancy {} must not exceed capacity {TEST_CACHE_SIZE}",
+            cache.len(),
+        );
     }
 
     #[test]

--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -36,6 +36,13 @@ pub const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 30;
 pub struct ValueCache<K, V> {
     /// Stable instance name distinguishing this cache in metrics; several
     /// caches may share the same key/value types within one process.
+    ///
+    /// Must be unique among the `ValueCache` instances of a process:
+    /// instances sharing a name and key/value types report into the same
+    /// metric series, so their gauges would overwrite each other. The name
+    /// is used verbatim as the `cache` Prometheus label value; any UTF-8
+    /// string is valid, but prefer a short, stable `snake_case` identifier
+    /// since dashboards and alerts query it.
     name: &'static str,
     cache: Arc<Cache<K, crate::Arc<V>>>,
     weak_index: Arc<papaya::HashMap<K, Weak<V>>>,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -870,6 +870,7 @@ where
             storage,
             chain_worker_config,
             block_cache: Arc::new(ValueCache::new(
+                "worker_block",
                 block_cache_size,
                 DEFAULT_CLEANUP_INTERVAL_SECS,
             )),

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -460,11 +460,31 @@ impl StorageCaches {
     pub fn new(sizes: StorageCacheConfig) -> Self {
         let interval = sizes.cache_cleanup_interval_secs;
         Self {
-            blob: Arc::new(ValueCache::new(sizes.blob_cache_size, interval)),
-            confirmed_block: Arc::new(ValueCache::new(sizes.confirmed_block_cache_size, interval)),
-            certificate: Arc::new(ValueCache::new(sizes.certificate_cache_size, interval)),
-            certificate_raw: Arc::new(ValueCache::new(sizes.certificate_raw_cache_size, interval)),
-            event: Arc::new(ValueCache::new(sizes.event_cache_size, interval)),
+            blob: Arc::new(ValueCache::new(
+                "storage_blob",
+                sizes.blob_cache_size,
+                interval,
+            )),
+            confirmed_block: Arc::new(ValueCache::new(
+                "storage_confirmed_block",
+                sizes.confirmed_block_cache_size,
+                interval,
+            )),
+            certificate: Arc::new(ValueCache::new(
+                "storage_certificate",
+                sizes.certificate_cache_size,
+                interval,
+            )),
+            certificate_raw: Arc::new(ValueCache::new(
+                "storage_certificate_raw",
+                sizes.certificate_raw_cache_size,
+                interval,
+            )),
+            event: Arc::new(ValueCache::new(
+                "storage_event",
+                sizes.event_cache_size,
+                interval,
+            )),
         }
     }
 }


### PR DESCRIPTION
## Motivation

The `ValueCache` instances (certificate, raw-certificate, blob, confirmed-block, event, worker block cache) only export `value_cache_hit` / `value_cache_miss` counters. A low hit rate alone is ambiguous: it can mean the cache is **saturated and evicting** entries that would be re-requested (so a size bump would help), or that the working set is **cold / low-reuse** (so a bigger cache changes nothing). With no occupancy signal we can only infer which, which has made cache-sizing decisions guesswork.

Additionally, the existing counters are labelled only by `[key_type, value_type]`, which is not unique per instance: `DbStorage::confirmed_block` and `WorkerState::block_cache` are both `ValueCache<CryptoHash, ConfirmedBlock>` and live in the same server process, so their hit/miss counts were conflated.

## Proposal

Export two gauges per cache, alongside the existing counters:

- `value_cache_entries` — number of entries in the bounded cache, sampled at each cleanup sweep (`quick_cache::len()`).
- `value_cache_capacity` — the cache's maximum entry count, reported from `quick_cache::capacity()` (the real, post-rounding value, so occupancy = entries/capacity cannot exceed 1).

All four metrics (hit, miss, entries, capacity) now carry a `cache` label: a stable per-instance name passed to `ValueCache::new` (`storage_blob`, `storage_confirmed_block`, `storage_certificate`, `storage_certificate_raw`, `storage_event`, `worker_block`). This disambiguates instances sharing the same key/value types — without it the two `ConfirmedBlock` caches would clobber each other's gauge series (`.set()` is last-writer-wins), and it also fixes the pre-existing hit/miss conflation.

A cache that is at capacity yet still high-miss is churning (size-bound); one well below capacity and high-miss is cold / low-reuse (size bumps won't help).

The entries gauge is refreshed inside the existing 30s weak-index cleanup task (after the sweep's guard is dropped), so there is no cost on the cache hot path. The bounded cache is wrapped in `Arc` so the task can read its length. The metrics handle is `#[cfg(with_metrics)]`-gated, so there is no unused parameter when metrics are disabled. Also adds public `name()` / `len()` / `is_empty()`.

## Test Plan

`cargo clippy --all-targets -- -D warnings` passes for `linera-cache` (both with `--features metrics` and `--no-default-features`), `linera-storage`, and `linera-core`. `cargo test -p linera-cache --features metrics` passes (18 tests), including `test_len_and_is_empty` asserting occupancy tracks inserts and never exceeds capacity under overflow (verified empirically that `quick_cache::len()` is exactly the requested size at small capacities and rounds up at larger ones — hence capacity is reported from `capacity()`, not the requested size).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.