### PR TITLE
Use uncompressed encoding for secp256k1 validator public keys

### DIFF
--- a/linera-base/src/crypto/secp256k1/mod.rs
+++ b/linera-base/src/crypto/secp256k1/mod.rs
@@ -31,8 +31,8 @@ use crate::doc_scalar;
 /// Name of the secp256k1 scheme.
 const SECP256K1_SCHEME_LABEL: &str = "secp256k1";
 
-/// Length of secp256k1 compressed public key.
-const SECP256K1_PUBLIC_KEY_SIZE: usize = 33;
+/// Length of secp256k1 uncompressed public key.
+const SECP256K1_PUBLIC_KEY_SIZE: usize = 65;
 
 /// Length of secp256k1 signature.
 const SECP256K1_SIGNATURE_SIZE: usize = 64;
@@ -53,7 +53,7 @@ impl Allocative for Secp256k1PublicKey {
 
 impl Hash for Secp256k1PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.to_encoded_point(true).as_bytes().hash(state);
+        self.as_bytes().hash(state);
     }
 }
 
@@ -86,14 +86,18 @@ impl Secp256k1PublicKey {
         Self(sk.public_key().into())
     }
 
-    /// Returns the bytes of the public key in compressed representation.
+    /// Returns the bytes of the public key in uncompressed representation.
     pub fn as_bytes(&self) -> [u8; SECP256K1_PUBLIC_KEY_SIZE] {
         // UNWRAP: We already have valid key so conversion should not fail.
-        self.0.to_encoded_point(true).as_bytes().try_into().unwrap()
+        self.0
+            .to_encoded_point(false)
+            .as_bytes()
+            .try_into()
+            .unwrap()
     }
 
     /// Decodes the bytes into the public key.
-    /// Expects the bytes to be of compressed representation.
+    /// Expects the bytes to be of uncompressed representation.
     ///
     /// Panics if the encoding can't be done in a constant time.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, CryptoError> {
@@ -153,7 +157,7 @@ impl Serialize for Secp256k1PublicKey {
         if serializer.is_human_readable() {
             serializer.serialize_str(&hex::encode(self.as_bytes()))
         } else {
-            let compact_pk = serde_utils::CompressedPublicKey(self.as_bytes());
+            let compact_pk = serde_utils::UncompressedPublicKey(self.as_bytes());
             serializer.serialize_newtype_struct("Secp256k1PublicKey", &compact_pk)
         }
     }
@@ -171,7 +175,7 @@ impl<'de> Deserialize<'de> for Secp256k1PublicKey {
         } else {
             #[derive(Deserialize)]
             #[serde(rename = "Secp256k1PublicKey")]
-            struct PublicKey(serde_utils::CompressedPublicKey);
+            struct PublicKey(serde_utils::UncompressedPublicKey);
             let compact = PublicKey::deserialize(deserializer)?;
             Ok(Secp256k1PublicKey::from_bytes(&compact.0 .0).map_err(serde::de::Error::custom)?)
         }
@@ -210,8 +214,8 @@ impl fmt::Debug for Secp256k1PublicKey {
 impl BcsHashable<'_> for Secp256k1PublicKey {}
 
 impl WitType for Secp256k1PublicKey {
-    const SIZE: u32 = <(u64, u64, u64, u64, u8) as WitType>::SIZE;
-    type Layout = <(u64, u64, u64, u64, u8) as WitType>::Layout;
+    const SIZE: u32 = <(u64, u64, u64, u64, u64, u64, u64, u64, u8) as WitType>::SIZE;
+    type Layout = <(u64, u64, u64, u64, u64, u64, u64, u64, u8) as WitType>::Layout;
     type Dependencies = HList![];
 
     fn wit_type_name() -> Cow<'static, str> {
@@ -225,7 +229,11 @@ impl WitType for Secp256k1PublicKey {
             "        part2: u64,\n",
             "        part3: u64,\n",
             "        part4: u64,\n",
-            "        part5: u8\n",
+            "        part5: u64,\n",
+            "        part6: u64,\n",
+            "        part7: u64,\n",
+            "        part8: u64,\n",
+            "        part9: u8\n",
             "    }\n",
         )
         .into()
@@ -241,8 +249,8 @@ impl WitLoad for Secp256k1PublicKey {
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let (part1, part2, part3, part4, part5) = WitLoad::load(memory, location)?;
-        Ok(Self::from((part1, part2, part3, part4, part5)))
+        let parts = WitLoad::load(memory, location)?;
+        Ok(Self::from_parts(parts))
     }
 
     fn lift_from<Instance>(
@@ -253,8 +261,8 @@ impl WitLoad for Secp256k1PublicKey {
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let (part1, part2, part3, part4, part5) = WitLoad::lift_from(flat_layout, memory)?;
-        Ok(Self::from((part1, part2, part3, part4, part5)))
+        let parts = WitLoad::lift_from(flat_layout, memory)?;
+        Ok(Self::from_parts(parts))
     }
 }
 
@@ -268,8 +276,7 @@ impl WitStore for Secp256k1PublicKey {
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let (part1, part2, part3, part4, part5) = (*self).into();
-        (part1, part2, part3, part4, part5).store(memory, location)
+        self.into_parts().store(memory, location)
     }
 
     fn lower<Instance>(
@@ -280,32 +287,43 @@ impl WitStore for Secp256k1PublicKey {
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
-        let (part1, part2, part3, part4, part5) = (*self).into();
-        (part1, part2, part3, part4, part5).lower(memory)
+        self.into_parts().lower(memory)
     }
 }
 
-impl From<(u64, u64, u64, u64, u8)> for Secp256k1PublicKey {
-    fn from((part1, part2, part3, part4, part5): (u64, u64, u64, u64, u8)) -> Self {
+/// The tuple of integers making up a public key's bytes in its WIT representation.
+type PublicKeyParts = (u64, u64, u64, u64, u64, u64, u64, u64, u8);
+
+impl Secp256k1PublicKey {
+    fn from_parts(parts: PublicKeyParts) -> Self {
+        let (part1, part2, part3, part4, part5, part6, part7, part8, part9) = parts;
         let mut bytes = [0u8; SECP256K1_PUBLIC_KEY_SIZE];
         bytes[0..8].copy_from_slice(&part1.to_be_bytes());
         bytes[8..16].copy_from_slice(&part2.to_be_bytes());
         bytes[16..24].copy_from_slice(&part3.to_be_bytes());
         bytes[24..32].copy_from_slice(&part4.to_be_bytes());
-        bytes[32] = part5;
+        bytes[32..40].copy_from_slice(&part5.to_be_bytes());
+        bytes[40..48].copy_from_slice(&part6.to_be_bytes());
+        bytes[48..56].copy_from_slice(&part7.to_be_bytes());
+        bytes[56..64].copy_from_slice(&part8.to_be_bytes());
+        bytes[64] = part9;
         Self::from_bytes(&bytes).unwrap()
     }
-}
 
-impl From<Secp256k1PublicKey> for (u64, u64, u64, u64, u8) {
-    fn from(key: Secp256k1PublicKey) -> Self {
-        let bytes = key.as_bytes();
+    fn into_parts(self) -> PublicKeyParts {
+        let bytes = self.as_bytes();
         let part1 = u64::from_be_bytes(bytes[0..8].try_into().unwrap());
         let part2 = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
         let part3 = u64::from_be_bytes(bytes[16..24].try_into().unwrap());
         let part4 = u64::from_be_bytes(bytes[24..32].try_into().unwrap());
-        let part5 = bytes[32];
-        (part1, part2, part3, part4, part5)
+        let part5 = u64::from_be_bytes(bytes[32..40].try_into().unwrap());
+        let part6 = u64::from_be_bytes(bytes[40..48].try_into().unwrap());
+        let part7 = u64::from_be_bytes(bytes[48..56].try_into().unwrap());
+        let part8 = u64::from_be_bytes(bytes[56..64].try_into().unwrap());
+        let part9 = bytes[64];
+        (
+            part1, part2, part3, part4, part5, part6, part7, part8, part9,
+        )
     }
 }
 
@@ -503,7 +521,9 @@ mod serde_utils {
     #[serde_as]
     #[derive(Serialize, Deserialize)]
     #[serde(transparent)]
-    pub struct CompressedPublicKey(#[serde_as(as = "[_; 33]")] pub [u8; SECP256K1_PUBLIC_KEY_SIZE]);
+    pub struct UncompressedPublicKey(
+        #[serde_as(as = "[_; 65]")] pub [u8; SECP256K1_PUBLIC_KEY_SIZE],
+    );
 }
 
 #[cfg(with_testing)]
@@ -593,7 +613,7 @@ mod tests {
         let bytes = key_in.as_bytes();
         assert!(
             bytes.len() == SECP256K1_PUBLIC_KEY_SIZE,
-            "::to_bytes() should return compressed representation"
+            "::to_bytes() should return uncompressed representation"
         );
         let key_out = Secp256k1PublicKey::from_bytes(&bytes).unwrap();
         assert_eq!(key_in, key_out);

--- a/linera-bridge/README.md
+++ b/linera-bridge/README.md
@@ -72,7 +72,7 @@ All snapshots are checked in and tested via `insta`. This means the generated So
 
 ### Why `ecrecover` works
 
-Linera validators use secp256k1 keys (the same curve as Ethereum). The contract stores committee members as Ethereum addresses, derived off-chain as `keccak256(uncompressed_pubkey[1:])[12:]`. This lets us use Solidity's native `ecrecover` precompile rather than implementing signature verification from scratch.
+Linera validators use secp256k1 keys (the same curve as Ethereum). The contract stores committee members as Ethereum addresses, derived as `keccak256(uncompressed_pubkey[1:])[12:]`. This lets us use Solidity's native `ecrecover` precompile rather than implementing signature verification from scratch.
 
 ## Contract API
 
@@ -82,7 +82,7 @@ Linera validators use secp256k1 keys (the same curve as Ethereum). The contract 
 
 Verifies a BCS-encoded `ConfirmedBlockCertificate` against the committee for the block's declared epoch and returns the deserialized `Block` and the `signedHash` (for duplicate detection). This is a `view` function — it does not modify state. Other contracts (like `Microchain`) call this to get verified block data.
 
-#### `addCommittee(bytes calldata data, bytes calldata committeeBlob, bytes[] calldata validators)`
+#### `addCommittee(bytes calldata data, bytes calldata committeeBlob)`
 
 Advances the committee to the next epoch. This is the only state-modifying operation (besides construction).
 
@@ -90,10 +90,10 @@ Advances the committee to the next epoch. This is the only state-modifying opera
 2. Require the block is from the admin chain and the current epoch.
 3. Scan the block's transactions for an `AdminOperation::CreateCommittee { epoch, blob_hash }`.
 4. Verify that `keccak256("BlobContent::" || BCS(BlobContent { Committee, committeeBlob }))` matches `blob_hash`. This proves the caller's `committeeBlob` is the one referenced by the certified block.
-5. Parse the committee blob on-chain. For each validator, verify the caller's uncompressed public key matches the blob's compressed key at the same index (x-coordinate, y-parity, and secp256k1 curve membership), then derive the Ethereum address via `keccak256(uncompressed_key)`. The caller must supply `validators` in the same order as the blob's compressed keys (BCS canonical map order, i.e. sorted by serialized key bytes); the production helper `extract_validator_keys` does this automatically.
+5. Parse the committee blob on-chain. For each validator, derive the Ethereum address directly from the blob's 65-byte uncompressed key via `keccak256(x || y)[12:]`.
 6. Store derived addresses and blob-extracted weights as the committee for the new epoch.
 
-The `committeeBlob` is the BCS-serialized `Committee` from Linera. The `validators` parameter is an array of 64-byte uncompressed secp256k1 public keys (without the `0x04` prefix). The caller must provide these separately because the blob only contains compressed keys (33 bytes: x-coordinate + y-parity prefix), and Ethereum addresses are derived from the uncompressed form (`keccak256(x || y)[12:]`). Decompressing a key on-chain would require computing a modular square root on the secp256k1 field — expensive in the EVM. Instead, the caller provides the uncompressed keys and the contract verifies them against the blob's compressed keys: it checks that the x-coordinate matches, the y-parity matches, and the point satisfies y² ≡ x³ + 7 (mod p). This curve membership check uses Solidity's `mulmod`/`addmod` builtins and is cheap. Addresses and weights are extracted from the blob rather than caller-provided, preventing substitution attacks. The authenticity chain is: validator signatures → certified block → `CreateCommittee` operation → `blob_hash` → `committeeBlob` → parsed validators/weights.
+The `committeeBlob` is the BCS-serialized `Committee` from Linera. Validator keys are stored in the blob in the 65-byte uncompressed SEC1 encoding (`0x04 || x || y`), so the contract derives each Ethereum address directly from the blob bytes — no caller-supplied key material is needed and no on-chain decompression (modular square root) is required. Addresses and weights are extracted from the blob rather than caller-provided, preventing substitution attacks. The authenticity chain is: validator signatures → certified block → `CreateCommittee` operation → `blob_hash` → `committeeBlob` → parsed validators/weights.
 
 The constructor takes `(address[], uint64[], bytes32, uint32)` — the genesis committee's validator addresses, weights, the admin chain ID, and the initial epoch. The deployer is trusted at genesis (no blob exists).
 
@@ -134,11 +134,10 @@ The crate exposes typed bindings for each contract, plus the generated Solidity 
 ```rust
 use linera_bridge::evm::{light_client, microchain, BRIDGE_TYPES_SOURCE};
 
-// Encode a contract call (validators are 64-byte uncompressed public keys)
+// Encode a contract call
 let call = light_client::addCommitteeCall {
     data: bcs_bytes.into(),
     committeeBlob: committee_bytes.into(),
-    validators: vec![uncompressed_key.into()],
 };
 let calldata: Vec<u8> = call.abi_encode();
 
@@ -173,7 +172,7 @@ The constructor takes `(address[], uint64[], bytes32, uint32)` — the genesis c
 
 - **Generated BCS code via serde-generate**: Rather than hand-writing Solidity deserializers, we auto-generate them from the same Rust type definitions that produce the data. This eliminates an entire class of serialization bugs.
 
-- **Partial committee blob parsing on-chain**: The contract parses just enough of the BCS-serialized committee blob to extract compressed public keys and voting weights. It skips fields it doesn't need (network addresses, account public keys, resource control policy). The caller provides uncompressed public keys, which the contract verifies against the blob's compressed keys (x-coordinate match, y-parity match, and secp256k1 curve membership via y² ≡ x³ + 7). This eliminates the need to trust caller-provided addresses and weights, while avoiding the cost of on-chain modular square root for full decompression.
+- **Partial committee blob parsing on-chain**: The contract parses just enough of the BCS-serialized committee blob to extract the uncompressed public keys and voting weights. It skips fields it doesn't need (network addresses, account public keys, resource control policy). Since the blob carries 65-byte uncompressed keys, Ethereum addresses are derived directly from the hash-committed blob bytes — there is no caller-provided key material to validate and no on-chain decompression cost.
 
 - **Separation of concerns between LightClient and Microchain**: The `LightClient` is a singleton that only manages committees and certificate verification. It has no knowledge of individual chains or their blocks. Each `Microchain` instance tracks a single chain's block sequence and delegates verification to the `LightClient`. This means one `LightClient` deployment can serve any number of `Microchain` contracts, each following a different Linera microchain.
 

--- a/linera-bridge/src/evm/client.rs
+++ b/linera-bridge/src/evm/client.rs
@@ -18,7 +18,6 @@ use alloy::{
 };
 use alloy_sol_types::SolCall;
 use linera_base::crypto::ValidatorPublicKey;
-use linera_execution::committee::Committee;
 use url::Url;
 
 use super::light_client::addCommitteeCall;
@@ -63,9 +62,6 @@ impl EvmLightClient {
 
     /// Calls `LightClient.addCommittee()` on the EVM chain.
     ///
-    /// Extracts uncompressed validator keys from the committee blob internally,
-    /// then submits the transaction to the LightClient contract.
-    ///
     /// - `certificate_bytes`: BCS-serialized `ConfirmedBlockCertificate`
     /// - `committee_blob`: raw committee blob bytes (BCS-serialized `Committee`)
     pub async fn add_committee(
@@ -73,12 +69,9 @@ impl EvmLightClient {
         certificate_bytes: &[u8],
         committee_blob: &[u8],
     ) -> anyhow::Result<TxHash> {
-        let validator_keys = extract_validator_keys(committee_blob)?;
-
         let call = addCommitteeCall {
             data: Bytes::copy_from_slice(certificate_bytes),
             committeeBlob: Bytes::copy_from_slice(committee_blob),
-            validators: validator_keys.into_iter().map(Bytes::from).collect(),
         };
 
         let tx = TransactionRequest::default()
@@ -96,29 +89,8 @@ impl EvmLightClient {
     }
 }
 
-/// Extracts uncompressed validator public keys from a BCS-serialized committee blob.
-///
-/// Returns 64-byte uncompressed keys (without the 0x04 prefix) for each validator,
-/// sorted by their compressed byte representation to match BCS canonical map ordering.
-///
-/// BCS serializes map entries sorted by serialized key bytes, which may differ from
-/// Rust's `BTreeMap` iteration order (based on `Ord` for `VerifyingKey`).
-pub fn extract_validator_keys(committee_blob: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
-    let committee: Committee = bcs::from_bytes(committee_blob)?;
-    let mut keys: Vec<ValidatorPublicKey> = committee.validators().keys().copied().collect();
-    keys.sort_by_key(|a| a.as_bytes());
-    Ok(keys.iter().map(validator_uncompressed_key).collect())
-}
-
 /// Derives the Ethereum address from a secp256k1 validator public key.
 pub fn validator_evm_address(public: &ValidatorPublicKey) -> Address {
-    let uncompressed = public.0.to_encoded_point(false);
-    let hash = keccak256(&uncompressed.as_bytes()[1..]); // skip 0x04 prefix
+    let hash = keccak256(&public.as_bytes()[1..]); // skip 0x04 prefix
     Address::from_slice(&hash[12..])
-}
-
-/// Returns the 64-byte uncompressed public key (without the 0x04 prefix).
-pub fn validator_uncompressed_key(public: &ValidatorPublicKey) -> Vec<u8> {
-    let uncompressed = public.0.to_encoded_point(false);
-    uncompressed.as_bytes()[1..].to_vec()
 }

--- a/linera-bridge/src/evm/light_client.rs
+++ b/linera-bridge/src/evm/light_client.rs
@@ -9,8 +9,7 @@ pub const SOURCE: &str = include_str!("../solidity/LightClient.sol");
 sol! {
     function addCommittee(
         bytes calldata data,
-        bytes calldata committeeBlob,
-        bytes[] calldata validators
+        bytes calldata committeeBlob
     ) external;
 
     function verifyBlock(bytes calldata data) external view;
@@ -179,24 +178,33 @@ mod tests {
     }
 
     #[test]
-    fn test_light_client_add_committee_rejects_off_curve_key() {
+    fn test_light_client_add_committee_rejects_invalid_key_prefix() {
+        use linera_base::data_types::BlobContent;
+
         let mut light_client: TestLightClient = TestLightClient::new();
         let new_secret = ValidatorSecretKey::generate();
         let new_public = new_secret.public();
 
-        let mut call = light_client.add_committee_call(
-            &new_public,
-            Epoch(1),
+        // Corrupt the blob: change the first validator key's SEC1 prefix from
+        // 0x04 (uncompressed) to 0x02. The blob hash commitment is recomputed
+        // over the corrupted bytes, so the failure comes from key parsing.
+        let (mut committee_bytes, _) = create_committee_blob(&new_public);
+        assert_eq!(committee_bytes[1], 0x04);
+        committee_bytes[1] = 0x02;
+        let blob_hash = CryptoHash::new(&BlobContent::new_committee(committee_bytes.clone()));
+
+        let transactions = create_committee_transaction(Epoch(1), blob_hash);
+        let block = create_test_block(
+            test_admin_chain_id(),
             Epoch::ZERO,
             BlockHeight(1),
-            test_admin_chain_id(),
+            transactions,
         );
-
-        // Construct a fake uncompressed key: correct x and y-parity, but y is
-        // not the actual square root — the point is not on secp256k1.
-        let mut fake_key = validator_uncompressed_key(&new_public);
-        fake_key[32] ^= 0xFF; // corrupt y-coordinate while preserving parity
-        call.validators = vec![fake_key.into()];
+        let bcs_bytes = sign_and_serialize(&light_client.secret, &light_client.public, block);
+        let call = addCommitteeCall {
+            data: bcs_bytes.into(),
+            committeeBlob: committee_bytes.into(),
+        };
 
         assert!(
             try_call_contract(
@@ -206,7 +214,7 @@ mod tests {
                 &call
             )
             .is_err(),
-            "should reject uncompressed key that is not on the secp256k1 curve"
+            "should reject validator key without the uncompressed SEC1 prefix"
         );
     }
 
@@ -253,38 +261,6 @@ mod tests {
             )
             .is_err(),
             "should reject committee transition from wrong epoch block"
-        );
-    }
-
-    #[test]
-    fn test_light_client_add_committee_rejects_substituted_keys() {
-        let mut light_client: TestLightClient = TestLightClient::new();
-
-        let real_secret = ValidatorSecretKey::generate();
-        let real_public = real_secret.public();
-
-        let attacker_secret = ValidatorSecretKey::generate();
-        let attacker_public = attacker_secret.public();
-
-        let mut call = light_client.add_committee_call(
-            &real_public,
-            Epoch(1),
-            Epoch::ZERO,
-            BlockHeight(1),
-            test_admin_chain_id(),
-        );
-        // Substitute the attacker's uncompressed key
-        call.validators = vec![validator_uncompressed_key(&attacker_public).into()];
-
-        assert!(
-            try_call_contract(
-                &mut light_client.db,
-                light_client.deployer,
-                light_client.contract,
-                &call
-            )
-            .is_err(),
-            "should reject substituted keys that don't match the blob"
         );
     }
 
@@ -735,11 +711,9 @@ mod tests {
         let transactions = create_committee_transaction(new_epoch, blob_hash);
         let block = create_test_block(chain_id, block_epoch, height, transactions);
         let bcs_bytes = sign_and_serialize(signer_secret, signer_public, block);
-        let new_uncompressed = validator_uncompressed_key(new_public);
         addCommitteeCall {
             data: bcs_bytes.into(),
             committeeBlob: committee_bytes.into(),
-            validators: vec![new_uncompressed.into()],
         }
     }
 
@@ -823,18 +797,9 @@ mod tests {
         );
         let bcs_bytes = sign_and_serialize(&light_client.secret, &light_client.public, block);
 
-        // Extract uncompressed keys in BCS blob order (sorted by compressed bytes).
-        // The contract requires `validators` to align positionally with the blob.
-        let uncompressed_keys = crate::evm::client::extract_validator_keys(&committee_bytes)
-            .expect("validator key extraction failed")
-            .into_iter()
-            .map(alloy_primitives::Bytes::from)
-            .collect::<Vec<_>>();
-
         let call = addCommitteeCall {
             data: bcs_bytes.into(),
             committeeBlob: committee_bytes.into(),
-            validators: uncompressed_keys,
         };
         call_contract(
             &mut light_client.db,
@@ -894,18 +859,9 @@ mod tests {
         let block = create_test_block(chain_id, block_epoch, height, transactions);
         let bcs_bytes = sign_and_serialize(signer_secret, signer_public, block);
 
-        // Extract uncompressed keys in BCS blob order (sorted by compressed bytes).
-        // The contract requires `validators` to align positionally with the blob.
-        let uncompressed_keys = crate::evm::client::extract_validator_keys(&committee_bytes)
-            .expect("validator key extraction failed")
-            .into_iter()
-            .map(alloy_primitives::Bytes::from)
-            .collect::<Vec<_>>();
-
         addCommitteeCall {
             data: bcs_bytes.into(),
             committeeBlob: committee_bytes.into(),
-            validators: uncompressed_keys,
         }
     }
 

--- a/linera-bridge/src/gas.rs
+++ b/linera-bridge/src/gas.rs
@@ -39,7 +39,6 @@ mod tests {
             transactions,
         );
         let bcs_bytes = sign_and_serialize(&secret, &public, block);
-        let new_uncompressed = validator_uncompressed_key(&new_public);
 
         let (_, _, gas_used) = call_contract(
             &mut db,
@@ -48,7 +47,6 @@ mod tests {
             &addCommitteeCall {
                 data: bcs_bytes.into(),
                 committeeBlob: committee_bytes.into(),
-                validators: vec![new_uncompressed.into()],
             },
         );
 

--- a/linera-bridge/src/relay/committee.rs
+++ b/linera-bridge/src/relay/committee.rs
@@ -18,7 +18,6 @@ use linera_storage::Storage;
 use tokio::time::sleep;
 
 use super::evm::EvmClient;
-use crate::evm::client::extract_validator_keys;
 
 /// Base delay between committee-relay attempts; scaled by the attempt number
 /// (capped) so worst-case inline blocking stays bounded regardless of the
@@ -214,11 +213,10 @@ async fn relay_committee<P: Provider>(
     cert: &ConfirmedBlockCertificate,
     committee_blob_bytes: &[u8],
 ) -> Result<()> {
-    let validator_keys = extract_validator_keys(committee_blob_bytes)?;
     let cert_bytes = bcs::to_bytes(cert).context("failed to BCS-serialize certificate")?;
 
     let tx_hash = evm_client
-        .add_committee(&cert_bytes, committee_blob_bytes, validator_keys)
+        .add_committee(&cert_bytes, committee_blob_bytes)
         .await?;
 
     tracing::info!(%tx_hash, "Relayed committee to LightClient");

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -283,13 +283,11 @@ impl<P: Provider> EvmClient<P> {
         &self,
         certificate_bytes: &[u8],
         committee_blob: &[u8],
-        validator_keys: Vec<Vec<u8>>,
     ) -> Result<alloy::primitives::TxHash> {
         let lc_addr = self.get_light_client_address().await?;
         let call = addCommitteeCall {
             data: Bytes::copy_from_slice(certificate_bytes),
             committeeBlob: Bytes::copy_from_slice(committee_blob),
-            validators: validator_keys.into_iter().map(Bytes::from).collect(),
         };
         let tx = alloy::rpc::types::TransactionRequest::default()
             .to(lc_addr)

--- a/linera-bridge/src/solidity/BridgeTypes.sol
+++ b/linera-bridge/src/solidity/BridgeTypes.sol
@@ -2103,11 +2103,11 @@ library BridgeTypes {
     }
 
     struct Secp256k1PublicKey {
-        tuplearray33_uint8 value;
+        tuplearray65_uint8 value;
     }
 
     function bcs_serialize_Secp256k1PublicKey(Secp256k1PublicKey memory input) internal pure returns (bytes memory) {
-        return bcs_serialize_tuplearray33_uint8(input.value);
+        return bcs_serialize_tuplearray65_uint8(input.value);
     }
 
     function bcs_deserialize_offset_Secp256k1PublicKey(uint256 pos, bytes memory input)
@@ -2116,8 +2116,8 @@ library BridgeTypes {
         returns (uint256, Secp256k1PublicKey memory)
     {
         uint256 new_pos;
-        tuplearray33_uint8 memory value;
-        (new_pos, value) = bcs_deserialize_offset_tuplearray33_uint8(pos, input);
+        tuplearray65_uint8 memory value;
+        (new_pos, value) = bcs_deserialize_offset_tuplearray65_uint8(pos, input);
         return (new_pos, Secp256k1PublicKey(value));
     }
 

--- a/linera-bridge/src/solidity/LightClient.sol
+++ b/linera-bridge/src/solidity/LightClient.sol
@@ -32,7 +32,7 @@ contract LightClient {
         adminChainId = _adminChainId;
     }
 
-    function addCommittee(bytes calldata data, bytes calldata committeeBlob, bytes[] calldata validators) external {
+    function addCommittee(bytes calldata data, bytes calldata committeeBlob) external {
         (BridgeTypes.Block memory blockValue,) = verifyCertificate(data);
 
         // The block must be from the admin chain and the current epoch
@@ -74,8 +74,8 @@ contract LightClient {
             keccak256(abi.encodePacked("BlobContent::", BridgeTypes.bcs_serialize_BlobContent(blobContent)));
         require(computedHash == expectedBlobHash, "committee blob hash mismatch");
 
-        // Parse blob to extract addresses and weights, verified against caller's keys
-        (address[] memory addrs, uint64[] memory weights) = _parseCommitteeBlob(committeeBlob, validators);
+        // Parse blob to extract addresses and weights
+        (address[] memory addrs, uint64[] memory weights) = _parseCommitteeBlob(committeeBlob);
 
         // Store the new committee, recording the admin-chain height of the
         // block that created it so the relayer can resume scanning from here.
@@ -229,33 +229,32 @@ contract LightClient {
         currentEpoch = epoch;
     }
 
-    /// Parses a BCS-serialized CommitteeMinimal blob and derives Ethereum addresses.
-    /// The caller must provide `uncompressedKeys` in the same order as the blob's
-    /// compressed keys (BCS canonical map order, i.e. sorted by serialized key bytes).
+    // secp256k1 curve order
+    uint256 private constant SECP256K1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
+
+    /// Parses a BCS-serialized committee blob and derives Ethereum addresses
+    /// directly from the uncompressed validator keys it contains.
     /// Returns (addresses, weights) extracted from the blob.
-    function _parseCommitteeBlob(bytes memory blob, bytes[] calldata uncompressedKeys)
-        internal
-        pure
-        returns (address[] memory, uint64[] memory)
-    {
+    function _parseCommitteeBlob(bytes memory blob) internal pure returns (address[] memory, uint64[] memory) {
         uint256 pos;
         uint256 count;
         (pos, count) = BridgeTypes.bcs_deserialize_offset_uleb128(0, blob);
-        require(count == uncompressedKeys.length, "validator count mismatch");
 
         address[] memory addrs = new address[](count);
         uint64[] memory weights = new uint64[](count);
 
         for (uint256 i = 0; i < count; i++) {
-            // _verifyKeyCompression checks the x-coordinate against blob[pos+1..pos+33],
-            // so a wrong-order or wrong-key entry reverts there.
-            require(uncompressedKeys[i].length == 64, "uncompressed key must be 64 bytes");
-            _verifyKeyCompression(uncompressedKeys[i], blob, pos);
+            // Validator key: 65-byte uncompressed SEC1 encoding (0x04 ++ x ++ y)
+            require(pos + 65 <= blob.length, "truncated validator key");
+            require(uint8(blob[pos]) == 0x04, "invalid uncompressed key prefix");
 
-            // Derive Ethereum address from the verified uncompressed key
-            addrs[i] = address(uint160(uint256(keccak256(uncompressedKeys[i]))));
-
-            pos += 33; // skip compressed key
+            // Derive the Ethereum address: keccak256 of the 64-byte x ++ y
+            bytes32 keyHash;
+            assembly ("memory-safe") {
+                keyHash := keccak256(add(add(blob, 33), pos), 64)
+            }
+            addrs[i] = address(uint160(uint256(keyHash)));
+            pos += 65;
 
             // Skip network_address (ULEB128 length-prefixed string)
             uint256 strLen;
@@ -271,46 +270,14 @@ contract LightClient {
             pos += 1;
             if (tag == 0) {
                 pos += 32; // Ed25519: 32 bytes
+            } else if (tag == 1) {
+                pos += 65; // Secp256k1: 65 bytes (uncompressed)
             } else {
-                pos += 33; // Secp256k1 or EvmSecp256k1: 33 bytes
+                pos += 33; // EvmSecp256k1: 33 bytes (compressed)
             }
         }
 
         return (addrs, weights);
-    }
-
-    /// Verifies that a caller-provided 64-byte uncompressed key matches
-    /// the 33-byte compressed key in the blob at the given position.
-    // secp256k1 field prime
-    uint256 private constant SECP256K1_P = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;
-    // secp256k1 curve order
-    uint256 private constant SECP256K1_N = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
-
-    function _verifyKeyCompression(bytes calldata uncompressed, bytes memory blob, uint256 keyPos) internal pure {
-        // Compressed key format: prefix (0x02 if y is even, 0x03 if odd) + 32-byte x
-        // Uncompressed key: 32-byte x + 32-byte y (no 0x04 prefix)
-
-        // Check x-coordinate matches (bytes 1..33 of compressed == bytes 0..32 of uncompressed)
-        for (uint256 i = 0; i < 32; i++) {
-            require(blob[keyPos + 1 + i] == uncompressed[i], "key x-coordinate mismatch");
-        }
-
-        // Check y-parity: last byte of y determines even/odd
-        uint8 yLastByte = uint8(uncompressed[63]);
-        uint8 expectedPrefix = (yLastByte % 2 == 0) ? 0x02 : 0x03;
-        require(uint8(blob[keyPos]) == expectedPrefix, "key y-parity mismatch");
-
-        // Verify (x, y) is on secp256k1: y^2 = x^3 + 7 (mod p)
-        uint256 x;
-        uint256 y;
-        assembly {
-            x := calldataload(uncompressed.offset)
-            y := calldataload(add(uncompressed.offset, 32))
-        }
-        uint256 lhs = mulmod(y, y, SECP256K1_P);
-        uint256 x2 = mulmod(x, x, SECP256K1_P);
-        uint256 rhs = addmod(mulmod(x2, x, SECP256K1_P), 7, SECP256K1_P);
-        require(lhs == rhs, "key not on secp256k1 curve");
     }
 
     /// Reads 8 bytes from data at pos as a little-endian uint64.

--- a/linera-bridge/src/test_helpers.rs
+++ b/linera-bridge/src/test_helpers.rs
@@ -29,7 +29,7 @@ use revm::{
 use revm_context::result::{ExecutionResult, Output};
 
 use crate::evm;
-pub use crate::evm::client::{validator_evm_address, validator_uncompressed_key};
+pub use crate::evm::client::validator_evm_address;
 
 pub const GAS_LIMIT: u64 = 500_000_000;
 

--- a/linera-bridge/tests/snapshots/format__format.yaml.snap
+++ b/linera-bridge/tests/snapshots/format__format.yaml.snap
@@ -431,7 +431,7 @@ Secp256k1PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
-      SIZE: 33
+      SIZE: 65
 Secp256k1Signature:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1214,7 +1214,7 @@ Secp256k1PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:
       CONTENT: U8
-      SIZE: 33
+      SIZE: 65
 Secp256k1Signature:
   NEWTYPESTRUCT:
     TUPLEARRAY:


### PR DESCRIPTION
## Motivation

Flamegraphs of validator nodes showed significant time spent in `Secp256k1PublicKey::from_bytes`. Parsing a 33-byte compressed SEC1 key requires recovering the `y` coordinate via a modular square root — a full field exponentiation — and this cost is paid for every validator key in every deserialized certificate, vote, and committee blob.

The compressed encoding also complicated the Ethereum bridge: `LightClient.addCommittee` needed callers to supply uncompressed keys out-of-band (Ethereum addresses are derived from the uncompressed form), and then had to verify on-chain that each supplied key matched the compressed key in the committee blob (x-coordinate match, y-parity check, on-curve verification).

## Proposal

Store secp256k1 validator public keys in the 65-byte uncompressed SEC1 encoding (`0x04 || x || y`) instead of the 33-byte compressed one.

- **`linera-base`**: `as_bytes()`, BCS serialization, and the WIT layout of `Secp256k1PublicKey` now use the uncompressed encoding. Parsing an uncompressed key only validates the curve equation instead of computing a square root: measured **6.11 µs → 68 ns per key (~90x)** in release mode. Hex/JSON parsing remains tag-based and still accepts compressed keys, so existing human-readable configs stay readable. EVM account keys (`EvmPublicKey`) are unaffected and stay compressed.
- **`linera-bridge` (LightClient)**: `addCommittee(data, committeeBlob)` drops the caller-supplied `bytes[] validators` parameter. `_parseCommitteeBlob` derives each validator's Ethereum address directly via `keccak256` of the key's `x || y`
bytes from the hash-committed blob, so `_verifyKeyCompression` (and the field-prime constant) is removed entirely — there is no untrusted key material left to cross-check. The relay and `EvmLightClient` callers drop the now-unneeded key-extraction plumbing.

⚠️ This is a **breaking protocol change**: the key's serialized bytes feed `CryptoHash`, so derived account owners and committee blob hashes change. Existing networks cannot read old certificates; a new deployment is required.

## Test Plan

- CI
- Performance was measured with a release-mode microbenchmark calling `from_bytes` 10,000 times on the same key in each encoding (6.11 µs/iter compressed vs 68 ns/iter uncompressed).
- A multi-agent security review of the three commits (Solidity/EVM, Rust crypto, and cross-layer consistency lenses with adversarial false-positive filtering) found no newly introduced vulnerabilities.

## Release Plan

- Backporting is not possible but we may want to deploy a new `testnet` and release a new SDK.

## Links
- Closes https://github.com/linera-io/linera-protocol/issues/5702
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)