### PR TITLE
Sync the admin chain and retry when receiving a certificate from an unknown epoch

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -317,6 +317,9 @@ pub enum Error {
         target_next_block_height: BlockHeight,
     },
 
+    #[error("No validator provided a usable certificate registering blob {0}")]
+    BlobRecoveryFailed(BlobId),
+
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -318,7 +318,7 @@ pub enum Error {
     },
 
     #[error("No validator provided a usable certificate registering blob {0}")]
-    BlobRecoveryFailed(BlobId),
+    CannotDownloadBlob(BlobId),
 
     #[error(transparent)]
     BcsError(#[from] bcs::Error),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1398,7 +1398,41 @@ impl<Env: Environment> Client<Env> {
     ) -> Result<(), chain_client::Error> {
         // Verify the certificate before doing any expensive networking.
         if let ReceiveCertificateMode::NeedsCheck = mode {
-            self.check_certificate(&certificate).await?.into_result()?;
+            let mut check_result = self.check_certificate(&certificate).await?;
+            if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                // The certificate is from an epoch our local view of the admin chain
+                // hasn't caught up to yet. Catch up and check again instead of failing.
+                // Prefer the nodes that gave us the certificate: they evidently know
+                // the newer epoch even if our own committee view is stale or its
+                // members are unreachable. A sync only counts if it actually made the
+                // epoch known; otherwise fall back to the known committee.
+                let admin_chain_id = self.admin_chain_id;
+                let epoch = certificate.block().header.epoch;
+                info!(
+                    %epoch,
+                    "certificate is from an unknown epoch; synchronizing the admin chain"
+                );
+                for node in nodes.iter().flatten() {
+                    match Box::pin(self.synchronize_chain_state_from(node, admin_chain_id)).await {
+                        Ok(()) => {
+                            check_result = self.check_certificate(&certificate).await?;
+                            if !matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                                break;
+                            }
+                        }
+                        Err(error) => warn!(
+                            %error,
+                            validator = %node.public_key,
+                            "failed to synchronize the admin chain from validator",
+                        ),
+                    }
+                }
+                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                    Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
+                    check_result = self.check_certificate(&certificate).await?;
+                }
+            }
+            check_result.into_result()?;
         }
         // Recover history from the network.
         let nodes = if let Some(nodes) = nodes {
@@ -2200,7 +2234,7 @@ impl<Env: Environment> Client<Env> {
                         "failed to download certificate-for-blob from validator",
                     );
                 }
-                chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id]))
+                blob_recovery_error(errors, blob_id)
             })
         }))
         .buffer_unordered(self.options.max_joined_tasks)
@@ -2406,6 +2440,26 @@ impl CheckCertificateResult {
     }
 }
 
+/// Chooses the error to surface when every validator failed to provide the certificate
+/// introducing a blob. A committee-epoch failure is local and node-independent: if any
+/// node ran into it, it is the real cause — surface it rather than fabricating a
+/// `BlobsNotFound` for a blob the network may well have.
+fn blob_recovery_error(
+    mut errors: Vec<(ValidatorPublicKey, chain_client::Error)>,
+    blob_id: BlobId,
+) -> chain_client::Error {
+    if let Some(position) = errors.iter().position(|(_, error)| {
+        matches!(
+            error,
+            chain_client::Error::CommitteeSynchronizationError
+                | chain_client::Error::CommitteeDeprecationError
+        )
+    }) {
+        return errors.swap_remove(position).1;
+    }
+    chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id]))
+}
+
 /// Creates a compressed Contract, Service and bytecode, plus an optional
 /// `ApplicationFormats` blob built from the JSON-encoded `Formats` description
 /// bytes.
@@ -2450,4 +2504,65 @@ pub async fn create_bytecode_blobs(
         blobs.push(blob);
     }
     (blobs, module_id)
+}
+
+#[cfg(test)]
+mod blob_recovery_error_tests {
+    use linera_base::crypto::ValidatorKeypair;
+
+    use super::*;
+
+    fn test_blob_id(name: &str) -> BlobId {
+        BlobId::new(CryptoHash::test_hash(name), BlobType::Data)
+    }
+
+    fn validator() -> ValidatorPublicKey {
+        ValidatorKeypair::generate().public_key
+    }
+
+    #[test]
+    fn surfaces_committee_synchronization_failure() {
+        let blob_id = test_blob_id("blob");
+        let errors = vec![
+            (
+                validator(),
+                chain_client::Error::from(NodeError::BlobsNotFound(vec![test_blob_id("other")])),
+            ),
+            (
+                validator(),
+                chain_client::Error::CommitteeSynchronizationError,
+            ),
+        ];
+        assert_matches::assert_matches!(
+            blob_recovery_error(errors, blob_id),
+            chain_client::Error::CommitteeSynchronizationError
+        );
+    }
+
+    #[test]
+    fn surfaces_committee_deprecation_failure() {
+        let blob_id = test_blob_id("blob");
+        let errors = vec![(validator(), chain_client::Error::CommitteeDeprecationError)];
+        assert_matches::assert_matches!(
+            blob_recovery_error(errors, blob_id),
+            chain_client::Error::CommitteeDeprecationError
+        );
+    }
+
+    #[test]
+    fn falls_back_to_blobs_not_found() {
+        let blob_id = test_blob_id("blob");
+        let errors = vec![(
+            validator(),
+            chain_client::Error::from(NodeError::BlobsNotFound(vec![test_blob_id("other")])),
+        )];
+        assert_matches::assert_matches!(
+            blob_recovery_error(errors, blob_id),
+            chain_client::Error::RemoteNodeError(NodeError::BlobsNotFound(ids)) if ids == vec![blob_id]
+        );
+        assert_matches::assert_matches!(
+            blob_recovery_error(Vec::new(), blob_id),
+            chain_client::Error::RemoteNodeError(NodeError::BlobsNotFound(ids)) if ids == vec![blob_id]
+        );
+    }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2234,7 +2234,7 @@ impl<Env: Environment> Client<Env> {
                         "failed to download certificate-for-blob from validator",
                     );
                 }
-                blob_recovery_error(errors, blob_id)
+                chain_client::Error::BlobRecoveryFailed(blob_id)
             })
         }))
         .buffer_unordered(self.options.max_joined_tasks)
@@ -2440,26 +2440,6 @@ impl CheckCertificateResult {
     }
 }
 
-/// Chooses the error to surface when every validator failed to provide the certificate
-/// introducing a blob. A committee-epoch failure is local and node-independent: if any
-/// node ran into it, it is the real cause — surface it rather than fabricating a
-/// `BlobsNotFound` for a blob the network may well have.
-fn blob_recovery_error(
-    mut errors: Vec<(ValidatorPublicKey, chain_client::Error)>,
-    blob_id: BlobId,
-) -> chain_client::Error {
-    if let Some(position) = errors.iter().position(|(_, error)| {
-        matches!(
-            error,
-            chain_client::Error::CommitteeSynchronizationError
-                | chain_client::Error::CommitteeDeprecationError
-        )
-    }) {
-        return errors.swap_remove(position).1;
-    }
-    chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id]))
-}
-
 /// Creates a compressed Contract, Service and bytecode, plus an optional
 /// `ApplicationFormats` blob built from the JSON-encoded `Formats` description
 /// bytes.
@@ -2504,65 +2484,4 @@ pub async fn create_bytecode_blobs(
         blobs.push(blob);
     }
     (blobs, module_id)
-}
-
-#[cfg(test)]
-mod blob_recovery_error_tests {
-    use linera_base::crypto::ValidatorKeypair;
-
-    use super::*;
-
-    fn test_blob_id(name: &str) -> BlobId {
-        BlobId::new(CryptoHash::test_hash(name), BlobType::Data)
-    }
-
-    fn validator() -> ValidatorPublicKey {
-        ValidatorKeypair::generate().public_key
-    }
-
-    #[test]
-    fn surfaces_committee_synchronization_failure() {
-        let blob_id = test_blob_id("blob");
-        let errors = vec![
-            (
-                validator(),
-                chain_client::Error::from(NodeError::BlobsNotFound(vec![test_blob_id("other")])),
-            ),
-            (
-                validator(),
-                chain_client::Error::CommitteeSynchronizationError,
-            ),
-        ];
-        assert_matches::assert_matches!(
-            blob_recovery_error(errors, blob_id),
-            chain_client::Error::CommitteeSynchronizationError
-        );
-    }
-
-    #[test]
-    fn surfaces_committee_deprecation_failure() {
-        let blob_id = test_blob_id("blob");
-        let errors = vec![(validator(), chain_client::Error::CommitteeDeprecationError)];
-        assert_matches::assert_matches!(
-            blob_recovery_error(errors, blob_id),
-            chain_client::Error::CommitteeDeprecationError
-        );
-    }
-
-    #[test]
-    fn falls_back_to_blobs_not_found() {
-        let blob_id = test_blob_id("blob");
-        let errors = vec![(
-            validator(),
-            chain_client::Error::from(NodeError::BlobsNotFound(vec![test_blob_id("other")])),
-        )];
-        assert_matches::assert_matches!(
-            blob_recovery_error(errors, blob_id),
-            chain_client::Error::RemoteNodeError(NodeError::BlobsNotFound(ids)) if ids == vec![blob_id]
-        );
-        assert_matches::assert_matches!(
-            blob_recovery_error(Vec::new(), blob_id),
-            chain_client::Error::RemoteNodeError(NodeError::BlobsNotFound(ids)) if ids == vec![blob_id]
-        );
-    }
 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1404,29 +1404,34 @@ impl<Env: Environment> Client<Env> {
                 // hasn't caught up to yet. Catch up and check again instead of failing.
                 // Prefer the nodes that gave us the certificate: they evidently know
                 // the newer epoch even if our own committee view is stale or its
-                // members are unreachable. A sync only counts if it actually made the
-                // epoch known; otherwise fall back to the known committee.
+                // members are unreachable. Race them concurrently rather than blocking
+                // on a slow one, then fall back to the known committee. A sync only
+                // counts if it actually made the epoch known.
                 let admin_chain_id = self.admin_chain_id;
                 let epoch = certificate.block().header.epoch;
                 info!(
                     %epoch,
                     "certificate is from an unknown epoch; synchronizing the admin chain"
                 );
-                for node in nodes.iter().flatten() {
-                    match Box::pin(self.synchronize_chain_state_from(node, admin_chain_id)).await {
-                        Ok(()) => {
-                            check_result = self.check_certificate(&certificate).await?;
-                            if !matches!(check_result, CheckCertificateResult::FutureEpoch) {
-                                break;
+                if let Some(nodes) = &nodes {
+                    let certificate = &certificate;
+                    let _ = communicate_concurrently(
+                        nodes,
+                        async move |node| {
+                            Box::pin(self.synchronize_chain_state_from(&node, admin_chain_id))
+                                .await?;
+                            match self.check_certificate(certificate).await? {
+                                CheckCertificateResult::FutureEpoch => {
+                                    Err(chain_client::Error::CommitteeSynchronizationError)
+                                }
+                                _ => Result::<(), chain_client::Error>::Ok(()),
                             }
-                        }
-                        Err(error) => warn!(
-                            %error,
-                            validator = %node.public_key,
-                            "failed to synchronize the admin chain from validator",
-                        ),
-                    }
+                        },
+                        self.options.blob_download_timeout,
+                    )
+                    .await;
                 }
+                check_result = self.check_certificate(&certificate).await?;
                 if matches!(check_result, CheckCertificateResult::FutureEpoch) {
                     Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
                     check_result = self.check_certificate(&certificate).await?;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1404,34 +1404,29 @@ impl<Env: Environment> Client<Env> {
                 // hasn't caught up to yet. Catch up and check again instead of failing.
                 // Prefer the nodes that gave us the certificate: they evidently know
                 // the newer epoch even if our own committee view is stale or its
-                // members are unreachable. Race them concurrently rather than blocking
-                // on a slow one, then fall back to the known committee. A sync only
-                // counts if it actually made the epoch known.
+                // members are unreachable. A sync only counts if it actually made the
+                // epoch known; otherwise fall back to the known committee.
                 let admin_chain_id = self.admin_chain_id;
                 let epoch = certificate.block().header.epoch;
                 info!(
                     %epoch,
                     "certificate is from an unknown epoch; synchronizing the admin chain"
                 );
-                if let Some(nodes) = &nodes {
-                    let certificate = &certificate;
-                    let _ = communicate_concurrently(
-                        nodes,
-                        async move |node| {
-                            Box::pin(self.synchronize_chain_state_from(&node, admin_chain_id))
-                                .await?;
-                            match self.check_certificate(certificate).await? {
-                                CheckCertificateResult::FutureEpoch => {
-                                    Err(chain_client::Error::CommitteeSynchronizationError)
-                                }
-                                _ => Result::<(), chain_client::Error>::Ok(()),
+                for node in nodes.iter().flatten() {
+                    match Box::pin(self.synchronize_chain_state_from(node, admin_chain_id)).await {
+                        Ok(()) => {
+                            check_result = self.check_certificate(&certificate).await?;
+                            if !matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                                break;
                             }
-                        },
-                        self.options.blob_download_timeout,
-                    )
-                    .await;
+                        }
+                        Err(error) => debug!(
+                            %error,
+                            validator = %node.public_key,
+                            "failed to synchronize the admin chain from validator",
+                        ),
+                    }
                 }
-                check_result = self.check_certificate(&certificate).await?;
                 if matches!(check_result, CheckCertificateResult::FutureEpoch) {
                     Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
                     check_result = self.check_certificate(&certificate).await?;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2234,7 +2234,7 @@ impl<Env: Environment> Client<Env> {
                         "failed to download certificate-for-blob from validator",
                     );
                 }
-                chain_client::Error::BlobRecoveryFailed(blob_id)
+                chain_client::Error::CannotDownloadBlob(blob_id)
             })
         }))
         .buffer_unordered(self.options.max_joined_tasks)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1405,8 +1405,7 @@ where
 ///
 /// The blob-recovery path downloads the publishing certificate from a validator, but
 /// validating it locally yields `CheckCertificateResult::FutureEpoch`. The client must
-/// react by catching up on the admin chain and retrying — instead of failing, let alone
-/// misreporting the failure as `BlobsNotFound` for the originally requested blob.
+/// react by catching up on the admin chain and retrying, so the blob read succeeds.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1399,6 +1399,57 @@ where
     Ok(())
 }
 
+/// Tests that a client whose local view of the admin chain is stale can still use a blob
+/// whose publishing certificate was signed by a committee from an epoch the client has
+/// not heard of yet.
+///
+/// The blob-recovery path downloads the publishing certificate from a validator, but
+/// validating it locally yields `CheckCertificateResult::FutureEpoch`. The client must
+/// react by catching up on the admin chain and retrying — instead of failing, let alone
+/// misreporting the failure as `BlobsNotFound` for the originally requested blob.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_stale_client_reads_blob_published_in_future_epoch<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let publisher = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let stale = builder.add_root_chain(2, Amount::from_tokens(3)).await?;
+    let validators = builder.initial_committee.validators().clone();
+
+    // Move the network to epoch 1. The publisher catches up; `stale` does not.
+    let committee = Committee::new(validators, ResourceControlPolicy::default())?;
+    admin.stage_new_committee(committee).await?;
+    publisher.synchronize_from_validators().await?;
+    publisher.process_inbox().await?;
+    assert_eq!(publisher.chain_info().await?.epoch, Epoch::from(1));
+    assert_eq!(stale.chain_info().await?.epoch, Epoch::ZERO);
+
+    // Publish a data blob under the epoch-1 committee.
+    let blob_bytes = b"future-epoch blob".to_vec();
+    let blob_id = Blob::new(BlobContent::new_data(blob_bytes.clone())).id();
+    let certificate = publisher
+        .publish_data_blob(blob_bytes)
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(certificate.block().header.epoch, Epoch::from(1));
+
+    // The stale client needs the blob: it is missing locally, so the client downloads
+    // the publishing certificate from a validator and must accept it after catching up
+    // on the admin chain, rather than choking on the unknown epoch.
+    stale.read_data_blob(blob_id.hash).await.unwrap().unwrap();
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1657,8 +1657,7 @@ where
         .await;
     assert_matches!(
         result,
-        Err(chain_client::Error::RemoteNodeError(NodeError::BlobsNotFound(not_found_blob_ids)))
-            if not_found_blob_ids == [blob0_id]
+        Err(chain_client::Error::BlobRecoveryFailed(blob_id)) if blob_id == blob0_id
     );
 
     // Take one validator down

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1656,7 +1656,7 @@ where
         .await;
     assert_matches!(
         result,
-        Err(chain_client::Error::BlobRecoveryFailed(blob_id)) if blob_id == blob0_id
+        Err(chain_client::Error::CannotDownloadBlob(blob_id)) if blob_id == blob0_id
     );
 
     // Take one validator down


### PR DESCRIPTION
## Motivation

A client whose local view of the admin chain is stale (e.g. a returning web
wallet whose committee has since rotated) can get permanently stuck: when it
downloads a blob's publishing certificate from a validator, the local
`check_certificate` returns `FutureEpoch` and the recovery fails — silently,
identically for every node — and `update_local_node_with_blobs_from` then
reports a fabricated `BlobsNotFound` for the originally requested blob.

This was observed in production on linera.market: a returning user's wallet
failed to connect with `Blobs not found: [ApplicationDescription …]` even
though every quorum validator served both the blob and its certificate
correctly (verified via direct gRPC). The wallet's local epoch never advances
on its own: nothing reacts to `FutureEpoch`, and the existing sync paths only
fan out to the stale committee, whose members may be dead or lagging. The only
user-side remedy was clearing site data.

## Proposal

- In `receive_sender_certificate`, react to `CheckCertificateResult::FutureEpoch`
  instead of failing: synchronize the admin chain — first from the node(s) that
  served the certificate, since they evidently know the newer epoch even if our
  own committee view is stale or unreachable, then falling back to the known
  committee — and check the certificate again. A per-node sync only counts if
  it actually made the epoch known.
- When blob recovery fails against every validator, surface a dedicated
  `chain_client::Error::BlobRecoveryFailed(BlobId)` rather than fabricating a
  `NodeError::BlobsNotFound` on the client. The per-validator failure reasons
  (committee-epoch errors, connection failures, genuine absence) are already
  logged at `warn!`; the surfaced error no longer fabricates a node error and
  does not depend on any single validator's response.

Known siblings deliberately left for follow-up (same pattern, off the incident
path): `download_and_process_sender_chain` silently drops `FutureEpoch` sender
certificates from its retry queue, and `download_certificates_for_events`
fabricates `EventsNotFound` over per-node committee failures. Under contention
several concurrent recovery closures may each trigger an admin sync; the syncs
are idempotent, so this is redundant work rather than a hazard.

## Test Plan

- New regression test `test_stale_client_reads_blob_published_in_future_epoch`:
  a client pinned at epoch 0 reads a data blob whose publishing certificate was
  signed by the epoch-1 committee. Before the fix it failed with
  `RemoteNodeError(BlobsNotFound(…))` while the per-validator warnings showed
  the real cause ("Cannot accept a certificate from an unknown committee in
  the future"); with the fix it passes on all storage backends.
- `test_finalize_locked_block_with_blobs` updated: reading an unpublished blob
  now surfaces `BlobRecoveryFailed` instead of the fabricated
  `RemoteNodeError(BlobsNotFound)`.
- `cargo test -p linera-core client_tests`: 67 passed, 0 failed.
- `cargo clippy -p linera-core --all-targets`: no warnings.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

The self-heal half landed on `testnet_conway` via #6486; the `BlobRecoveryFailed`
change is backported separately.

## Links

- Error-visibility predecessors (logging only, masking unchanged): #6391, #6398
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
