### PR TITLE
Remove the unused EvmLightClient

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,7 +5125,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber 0.3.19",
- "url",
  "wrapped-fungible",
 ]
 

--- a/linera-bridge/Cargo.toml
+++ b/linera-bridge/Cargo.toml
@@ -23,7 +23,6 @@ offchain = [
     "dep:op-alloy-network",
     "dep:thiserror",
     "dep:tokio",
-    "dep:url",
 ]
 codegen = [
     "offchain",
@@ -86,7 +85,6 @@ bcs = { workspace = true, optional = true }
 linera-execution = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true, features = ["full"] }
-url = { workspace = true, optional = true }
 
 clap = { workspace = true, optional = true }
 fs-err = { workspace = true, optional = true }

--- a/linera-bridge/src/evm/client.rs
+++ b/linera-bridge/src/evm/client.rs
@@ -1,100 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! EVM client for relaying committee changes to a LightClient contract.
+//! Helpers for deriving EVM-facing validator keys from a Linera committee blob.
 
-use alloy::{
-    network::{Ethereum, EthereumWallet},
-    primitives::{keccak256, Address, Bytes, TxHash},
-    providers::{
-        fillers::{
-            BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
-            WalletFiller,
-        },
-        Provider, ProviderBuilder, RootProvider,
-    },
-    rpc::types::TransactionRequest,
-    signers::local::PrivateKeySigner,
-};
-use alloy_sol_types::SolCall;
+use alloy::primitives::{keccak256, Address};
 use linera_base::crypto::ValidatorPublicKey;
 use linera_execution::committee::Committee;
-use url::Url;
-
-use super::light_client::addCommitteeCall;
-
-/// Client for interacting with a deployed LightClient contract on an EVM chain.
-#[expect(clippy::type_complexity)]
-pub struct EvmLightClient {
-    provider: FillProvider<
-        JoinFill<
-            JoinFill<
-                alloy::providers::Identity,
-                JoinFill<GasFiller, JoinFill<BlobGasFiller, JoinFill<NonceFiller, ChainIdFiller>>>,
-            >,
-            WalletFiller<EthereumWallet>,
-        >,
-        RootProvider<Ethereum>,
-    >,
-    contract_address: Address,
-}
-
-impl EvmLightClient {
-    /// Creates a new EVM light client.
-    ///
-    /// - `endpoint`: HTTP JSON-RPC URL of the EVM node
-    /// - `contract_address`: deployed LightClient contract address
-    /// - `private_key`: hex-encoded private key for signing transactions
-    pub fn new(
-        endpoint: &str,
-        contract_address: Address,
-        private_key: &str,
-    ) -> anyhow::Result<Self> {
-        let rpc_url = Url::parse(endpoint)?;
-        let signer: PrivateKeySigner = private_key.parse()?;
-        let wallet = EthereumWallet::from(signer);
-        let provider = ProviderBuilder::new().wallet(wallet).connect_http(rpc_url);
-
-        Ok(Self {
-            provider,
-            contract_address,
-        })
-    }
-
-    /// Calls `LightClient.addCommittee()` on the EVM chain.
-    ///
-    /// Extracts uncompressed validator keys from the committee blob internally,
-    /// then submits the transaction to the LightClient contract.
-    ///
-    /// - `certificate_bytes`: BCS-serialized `ConfirmedBlockCertificate`
-    /// - `committee_blob`: raw committee blob bytes (BCS-serialized `Committee`)
-    pub async fn add_committee(
-        &self,
-        certificate_bytes: &[u8],
-        committee_blob: &[u8],
-    ) -> anyhow::Result<TxHash> {
-        let validator_keys = extract_validator_keys(committee_blob)?;
-
-        let call = addCommitteeCall {
-            data: Bytes::copy_from_slice(certificate_bytes),
-            committeeBlob: Bytes::copy_from_slice(committee_blob),
-            validators: validator_keys.into_iter().map(Bytes::from).collect(),
-        };
-
-        let tx = TransactionRequest::default()
-            .to(self.contract_address)
-            .input(call.abi_encode().into());
-
-        let receipt = self
-            .provider
-            .send_transaction(tx)
-            .await?
-            .get_receipt()
-            .await?;
-
-        Ok(receipt.transaction_hash)
-    }
-}
 
 /// Extracts uncompressed validator public keys from a BCS-serialized committee blob.
 ///

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -4060,7 +4060,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "url",
  "wrapped-fungible",
 ]
 


### PR DESCRIPTION
## Motivation

EvmLightClient has had no callers since the bridge was backported to main (#5670). Because it is `pub`, the dead_code lint never flagged it, and its `use url::Url` kept the `url` dependency referenced, so `cargo machete` saw it as used. Removing the struct lets us drop `url` from the manifest.

## Proposal

Remove it.

The validator-key-derivation helpers it lived alongside (extract_validator_keys, validator_evm_address, validator_uncompressed_key) stay — they are used by the relay, the tests, and the contracts.


## Test Plan

CI

## Release Plan

- These changes should be backported to the latest `testnet` branch

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
