### PR TITLE
Fix multi-leader jitter target receding instead of anchoring to round start

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -38,7 +38,7 @@ use linera_chain::{
         BlockProposal, BundleExecutionPolicy, BundleFailurePolicy, ChainAndHeight, IncomingBundle,
         ProposedBlock, Transaction,
     },
-    manager::LockingBlock,
+    manager::{ChainManagerInfo, LockingBlock},
     types::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, Timeout, TimeoutCertificate,
         ValidatedBlock,
@@ -228,6 +228,10 @@ pub struct ChainClient<Env: Environment> {
     /// Sender chain IDs whose bundles were discarded due to the never-reject policy.
     /// These origins are excluded from `process_inbox` until the client is restarted.
     skipped_origins: Arc<papaya::HashSet<ChainId>>,
+    /// The `(round, timestamp)` at which we first observed the current multi-leader round
+    /// while computing the jitter target, used to anchor the proposal delay when the
+    /// round's start cannot be derived from its timeout (see `multi_leader_jitter_target`).
+    jitter_round_anchor: Arc<std::sync::Mutex<Option<(Round, Timestamp)>>>,
 }
 
 impl<Env: Environment> Clone for ChainClient<Env> {
@@ -241,8 +245,61 @@ impl<Env: Environment> Clone for ChainClient<Env> {
             initial_block_hash: self.initial_block_hash,
             timing_sender: self.timing_sender.clone(),
             skipped_origins: self.skipped_origins.clone(),
+            jitter_round_anchor: self.jitter_round_anchor.clone(),
         }
     }
+}
+
+/// Returns the timestamp at which `owner` should propose in `round`, to spread out
+/// concurrent proposals from honest clients in a multi-leader round. Returns `None` if the
+/// owner should propose immediately (jitter disabled, the round is not a multi-leader round,
+/// the owner is the preferred proposer, or the jitter target is already in the past).
+///
+/// The delay is deterministic per `(owner, round)` and is anchored at the round's start time,
+/// so that retrying after an interrupting notification does not extend the wait further. The
+/// round start is derived from the round timeout when available; otherwise — e.g. a non-final
+/// multi-leader round, which has no timeout — it is anchored to the time the round was first
+/// observed, remembered in `round_anchor`. Anchoring to the current time in that case would
+/// make `propose_at` recede by `delay` on every call, so the owner would never reach it and
+/// never propose (the liveness bug this guards against).
+pub(crate) fn multi_leader_jitter_target(
+    jitter_enabled: bool,
+    manager: &ChainManagerInfo,
+    owner: &AccountOwner,
+    round: Round,
+    now: Timestamp,
+    round_anchor: &std::sync::Mutex<Option<(Round, Timestamp)>>,
+) -> Option<Timestamp> {
+    if !jitter_enabled {
+        return None;
+    }
+    let ownership = &manager.ownership;
+    let delay = ownership.multi_leader_proposal_delay(owner, round)?;
+    if delay == TimeDelta::ZERO {
+        return None;
+    }
+    let derived_start = if round == manager.current_round {
+        match (manager.round_timeout, ownership.round_timeout(round)) {
+            (Some(end), Some(duration)) => Some(end.saturating_sub(duration)),
+            _ => None,
+        }
+    } else {
+        None
+    };
+    let round_start = derived_start.unwrap_or_else(|| {
+        let mut anchor = round_anchor
+            .lock()
+            .expect("jitter_round_anchor mutex poisoned");
+        match *anchor {
+            Some((remembered_round, start)) if remembered_round == round => start,
+            _ => {
+                *anchor = Some((round, now));
+                now
+            }
+        }
+    });
+    let propose_at = round_start.saturating_add(delay);
+    (propose_at > now).then_some(propose_at)
 }
 
 /// Error type for [`ChainClient`].
@@ -390,6 +447,7 @@ impl<Env: Environment> ChainClient<Env> {
             initial_next_block_height,
             timing_sender,
             skipped_origins: Arc::new(papaya::HashSet::new()),
+            jitter_round_anchor: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -2410,39 +2468,24 @@ impl<Env: Environment> ChainClient<Env> {
         ))
     }
 
-    /// Returns the timestamp at which `owner` should propose in `round`, to spread out
-    /// concurrent proposals from honest clients in a multi-leader round. Returns `None` if
-    /// the owner should propose immediately (either because the round is not a multi-leader
-    /// round, the owner is the preferred proposer, or the jitter target is already in the past).
-    ///
-    /// The delay is deterministic per `(owner, round)` and is anchored at the round's start
-    /// time when known, so that retrying after an interrupting notification does not extend
-    /// the wait further.
+    /// Returns the timestamp at which `owner` should propose in `round`, reading the current
+    /// time and the per-round anchor from this client and delegating to
+    /// [`multi_leader_jitter_target`].
     fn multi_leader_jitter_target(
         &self,
         info: &ChainInfo,
         owner: &AccountOwner,
         round: Round,
     ) -> Option<Timestamp> {
-        if !self.options.multi_leader_jitter {
-            return None;
-        }
-        let ownership = &info.manager.ownership;
-        let delay = ownership.multi_leader_proposal_delay(owner, round)?;
-        if delay == TimeDelta::ZERO {
-            return None;
-        }
         let now = self.storage_client().clock().current_time();
-        let round_start = if round == info.manager.current_round {
-            match (info.manager.round_timeout, ownership.round_timeout(round)) {
-                (Some(end), Some(duration)) => end.saturating_sub(duration),
-                _ => now,
-            }
-        } else {
-            now
-        };
-        let propose_at = round_start.saturating_add(delay);
-        (propose_at > now).then_some(propose_at)
+        multi_leader_jitter_target(
+            self.options.multi_leader_jitter,
+            &info.manager,
+            owner,
+            round,
+            now,
+            &self.jitter_round_anchor,
+        )
     }
 
     /// Discards the pending block proposal, if any, so that a fresh block can be

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2501,6 +2501,107 @@ where
     Ok(())
 }
 
+/// Regression test for the multi-leader jitter liveness bug.
+///
+/// In a non-final multi-leader round (which has no round timeout, so the round start cannot
+/// be derived from a deadline), the jitter target must be anchored to a fixed point — the
+/// time the round was first observed — not recomputed from the current time on every call.
+/// The original code anchored to `now` in that case, so `propose_at` receded by `delay` on
+/// every call and the owner never reached it: the chain wedged in the round, never proposing.
+#[test]
+fn multi_leader_jitter_target_is_anchored_not_receding() {
+    use std::sync::Mutex;
+
+    use linera_chain::manager::ChainManagerInfo;
+
+    // Large base timeout so the hash-derived jitter delay is comfortably non-trivial.
+    let timeout_config = TimeoutConfig {
+        base_timeout: TimeDelta::from_secs(1000),
+        ..TimeoutConfig::default()
+    };
+    // `multi_leader_rounds = 3` makes `MultiLeader(1)` a non-final multi-leader round: it has
+    // no round timeout, which is the branch that used to fall back to `now`.
+    let owner_a: AccountOwner = AccountSecretKey::generate().public().into();
+    let owner_b: AccountOwner = AccountSecretKey::generate().public().into();
+    let ownership = ChainOwnership::multiple([(owner_a, 100), (owner_b, 100)], 3, timeout_config);
+    let round = Round::MultiLeader(1);
+
+    // Use a non-preferred owner; the preferred one has delay zero and proposes immediately.
+    let owner = [owner_a, owner_b]
+        .into_iter()
+        .find(|owner| {
+            !matches!(
+                ownership.multi_leader_proposal_delay(owner, round),
+                None | Some(TimeDelta::ZERO)
+            )
+        })
+        .expect("one of two distinct owners must be non-preferred at this round");
+    let delay = ownership
+        .multi_leader_proposal_delay(&owner, round)
+        .expect("non-preferred owner has a delay");
+
+    let manager = ChainManagerInfo {
+        ownership,
+        current_round: round,
+        round_timeout: None,
+        ..ChainManagerInfo::default()
+    };
+    let anchor = Mutex::new(None);
+
+    let t0 = Timestamp::from(1_000_000);
+    let target1 =
+        chain_client::multi_leader_jitter_target(true, &manager, &owner, round, t0, &anchor)
+            .expect("non-preferred owner must wait before proposing");
+    assert_eq!(target1, t0.saturating_add(delay));
+
+    // Advance the clock (still before the target) and recompute: the target must NOT move.
+    let later = t0.saturating_add(TimeDelta::from_micros(delay.as_micros() / 2));
+    let target2 =
+        chain_client::multi_leader_jitter_target(true, &manager, &owner, round, later, &anchor)
+            .expect("still waiting before the anchored target");
+    assert_eq!(
+        target1, target2,
+        "jitter target must stay anchored to the round start, not recede with the clock"
+    );
+
+    // Once the clock reaches the anchored target, the owner proposes (returns `None`).
+    let at_target =
+        chain_client::multi_leader_jitter_target(true, &manager, &owner, round, target1, &anchor);
+    assert!(
+        at_target.is_none(),
+        "at the anchored target the owner must propose, not keep waiting"
+    );
+
+    // A different round re-anchors to when it was first seen rather than reusing the stale one.
+    let other_round = Round::MultiLeader(2);
+    if let Some(other_delay) = manager
+        .ownership
+        .multi_leader_proposal_delay(&owner, other_round)
+        .filter(|delay| *delay != TimeDelta::ZERO)
+    {
+        let manager2 = ChainManagerInfo {
+            current_round: other_round,
+            round_timeout: None,
+            ..manager.clone()
+        };
+        let first_seen = target1.saturating_add(TimeDelta::from_secs(1));
+        let other_target = chain_client::multi_leader_jitter_target(
+            true,
+            &manager2,
+            &owner,
+            other_round,
+            first_seen,
+            &anchor,
+        )
+        .expect("new round must wait");
+        assert_eq!(
+            other_target,
+            first_seen.saturating_add(other_delay),
+            "a new round anchors to the time it was first observed"
+        );
+    }
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]


### PR DESCRIPTION
## Motivation

Forward-port of #6431 (which targeted `testnet_conway`) to `main`. The bug it fixes exists on `main` too.

**This is an experimental alternative solution to a full revert as in #6455**

On 2026-05-29 several PM market chains froze: each was stuck in a multi-leader round, never committing a block, which crash-looped the workers via the idle-chain liveness probe. Disabling multi-leader jitter on the workers recovered them, pinpointing the jitter path.

Root cause is in `multi_leader_jitter_target` (`linera-core/src/client/chain_client/mod.rs`) added by #6338. It anchors the proposal delay to the **current time** whenever the round start cannot be derived from a round timeout:
- `ChainOwnership::round_timeout(round)` returns `None` for every multi-leader round **except the last** (`linera-base/src/ownership.rs`). The affected chains run `multi_leader_rounds = 1000`, so this is essentially every round.
- It also falls back to `now` when proposing in a round different from the manager's current round (the conflict-bump case).

With the anchor at `now`, `propose_at = now + delay` is recomputed on every call. On a busy chain `process_inbox` runs constantly — each inbox notification interrupts the wait and re-evaluates — so the target recedes by `delay` every time and the non-preferred sole proposer **never reaches it**. `round_for_new_proposal` returns `WaitForTimeout` forever, the worker never proposes, and the chain wedges.

## Proposal

When the round start cannot be derived from a timeout, anchor to the time the round was **first observed** (remembered per round in a new in-memory `jitter_round_anchor` field) instead of `now`. Then `propose_at` is a fixed point the clock catches up to: the worker waits out the jitter delay once and proposes. The `round_timeout − duration` derivation is unchanged where it already worked (single-leader rounds, final multi-leader round).

The pure timing logic is extracted into a free `multi_leader_jitter_target` function (the method becomes a thin adapter reading the clock + anchor) so it can be unit-tested.

**Backward compatible:** this changes only local proposal *timing* — no wire format, consensus rule, or persisted state changes. Mixed-version clients/validators interoperate.

## Test Plan

- New regression test `multi_leader_jitter_target_is_anchored_not_receding`: in a non-final multi-leader round, the target stays fixed as the clock advances, and the owner proposes once the clock reaches it.
- `cargo clippy -p linera-core --all-targets` clean; `cargo +nightly fmt --check` clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- original PR (testnet_conway): #6431
- introduced by: #6338
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
