### PR TITLE
Fix a race in test_controller between worker registration and the admin workers assertion

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -5520,8 +5520,22 @@ async fn test_controller(config: impl LineraNetConfig) -> Result<()> {
     );
 
     let admin_app = admin_node_service.make_application(&admin_chain, &controller_id)?;
-    let response = admin_app.query("workers { keys }").await?;
-    let worker_keys: Vec<String> = serde_json::from_value(response["workers"]["keys"].clone())?;
+    // A worker's registration only lands in the admin chain's `workers` map once the
+    // admin chain has processed the cross-chain message, which can be after the worker
+    // already sees itself as registered locally. Poll until both registrations arrive.
+    let worker_keys = loop {
+        let response = admin_app.query("workers { keys }").await?;
+        let worker_keys: Vec<String> = serde_json::from_value(response["workers"]["keys"].clone())?;
+        if worker_keys.len() >= 2 {
+            break worker_keys;
+        }
+        admin_notifications
+            .wait_for_block(None)
+            .await
+            .unwrap_or_else(|_| {
+                panic!("timed out waiting for both worker registrations on {admin_chain}")
+            });
+    };
     assert_eq!(
         worker_keys.len(),
         2,


### PR DESCRIPTION
## Motivation

The daily E2E health-check against testnet-conway failed `test_controller::remote_net_grpc` with
`Expected exactly 2 workers, got 1`. The test polls each worker's *local* controller state until it
shows the worker registered, then immediately asserts that the *admin chain's* `workers` map has 2
entries. A worker's registration only lands on the admin chain once the cross-chain message is
processed there, which can be after the worker already sees itself as registered locally — so the
assertion races message delivery on a live network.

## Proposal

Replace the one-shot assertion with the same poll-drain pattern the test already uses for the two
registration waits: re-query `workers { keys }` after each admin-chain block notification until both
registrations have arrived (`wait_for_block` is bounded by the notification timeout, so a genuine
failure still panics with a clear message instead of hanging).

## Test Plan

- `cargo clippy -p linera-service --tests --features remote-net -- -D warnings` passes.
- The failure was observed in the testnet-conway daily health-check on 2026-06-11 (attempt 2);
  the race window is closed by construction — the loop only concludes after the admin chain has
  processed both registration messages.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- Backport PR: https://github.com/linera-io/linera-protocol/pull/6487
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

