### PR TITLE
Sync the admin chain and retry when receiving a certificate from an unknown epoch (backport of #6481)

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1343,9 +1343,46 @@ impl<Env: Environment> Client<Env> {
         nodes: Option<Vec<RemoteNode<Env::ValidatorNode>>>,
     ) -> Result<(), chain_client::Error> {
         // Verify the certificate before doing any expensive networking.
-        let (max_epoch, committees) = self.admin_committees().await?;
+        let (mut max_epoch, mut committees) = self.admin_committees().await?;
         if let ReceiveCertificateMode::NeedsCheck = mode {
-            Self::check_certificate(max_epoch, &committees, &certificate)?.into_result()?;
+            let mut check_result = Self::check_certificate(max_epoch, &committees, &certificate)?;
+            if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                // The certificate is from an epoch our local view of the admin chain
+                // hasn't caught up to yet. Catch up and check again instead of failing.
+                // Prefer the nodes that gave us the certificate: they evidently know
+                // the newer epoch even if our own committee view is stale or its
+                // members are unreachable. A sync only counts if it actually made the
+                // epoch known; otherwise fall back to the known committee.
+                let admin_chain_id = self.admin_chain_id;
+                let epoch = certificate.block().header.epoch;
+                info!(
+                    %epoch,
+                    "certificate is from an unknown epoch; synchronizing the admin chain"
+                );
+                for node in nodes.iter().flatten() {
+                    match Box::pin(self.synchronize_chain_state_from(node, admin_chain_id)).await {
+                        Ok(()) => {
+                            (max_epoch, committees) = self.admin_committees().await?;
+                            check_result =
+                                Self::check_certificate(max_epoch, &committees, &certificate)?;
+                            if !matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                                break;
+                            }
+                        }
+                        Err(error) => warn!(
+                            %error,
+                            validator = %node.public_key,
+                            "failed to synchronize the admin chain from validator",
+                        ),
+                    }
+                }
+                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                    Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
+                    (max_epoch, committees) = self.admin_committees().await?;
+                    check_result = Self::check_certificate(max_epoch, &committees, &certificate)?;
+                }
+            }
+            check_result.into_result()?;
         }
         // Recover history from the network.
         let nodes = if let Some(nodes) = nodes {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1300,6 +1300,60 @@ where
     Ok(())
 }
 
+/// Tests that a client whose local view of the admin chain is stale can still use a blob
+/// whose publishing certificate was signed by a committee from an epoch the client has
+/// not heard of yet.
+///
+/// The blob-recovery path downloads the publishing certificate from a validator, but
+/// validating it locally yields `CheckCertificateResult::FutureEpoch`. The client must
+/// react by catching up on the admin chain and retrying, instead of failing on the
+/// unknown epoch.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_stale_client_reads_blob_published_in_future_epoch<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let publisher = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let stale = builder.add_root_chain(2, Amount::from_tokens(3)).await?;
+    let validators = builder.initial_committee.validators().clone();
+
+    // Move the network to epoch 1. The publisher catches up; `stale` does not.
+    let committee = Committee::new(validators, ResourceControlPolicy::default());
+    admin.stage_new_committee(committee).await?;
+    publisher.synchronize_from_validators().await?;
+    publisher.process_inbox().await?;
+    assert_eq!(publisher.chain_info().await?.epoch, Epoch::from(1));
+    assert_eq!(stale.chain_info().await?.epoch, Epoch::ZERO);
+
+    // Publish a data blob under the epoch-1 committee.
+    let blob_bytes = b"future-epoch blob".to_vec();
+    let blob_id = Blob::new(BlobContent::new_data(blob_bytes.clone())).id();
+    let certificate = publisher
+        .publish_data_blob(blob_bytes)
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(certificate.block().header.epoch, Epoch::from(1));
+
+    // The stale client needs the blob: it is missing locally, so the client downloads
+    // the publishing certificate from a validator and must accept it after catching up
+    // on the admin chain, rather than choking on the unknown epoch.
+    stale
+        .read_data_blob(blob_id.hash)
+        .await
+        .unwrap_ok_committed();
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## Motivation

Backport of #6481 to `testnet_conway`, **without** the `blob_recovery_error`
error-surfacing change (per request).

A client whose local view of the admin chain is stale (e.g. a returning web
wallet whose committee has since rotated) can get permanently stuck: when it
downloads a blob's publishing certificate from a validator, the local
`check_certificate` returns `FutureEpoch` and recovery fails silently. Nothing
reacts to `FutureEpoch`, so the wallet's local epoch never advances on its own,
and the only user-side remedy was clearing site data. Observed in production on
linera.market.

## Proposal

- In `receive_sender_certificate`, react to `CheckCertificateResult::FutureEpoch`
  instead of failing: synchronize the admin chain — first from the node(s) that
  served the certificate, since they evidently know the newer epoch even if our
  own committee view is stale or unreachable, then falling back to the known
  committee — and check the certificate again. A per-node sync only counts if it
  actually made the epoch known.

Adapted for `testnet_conway`: this branch's `check_certificate` is a synchronous
associated function taking a `(max_epoch, committees)` snapshot, so the self-heal
re-fetches `admin_committees()` after each successful sync before re-checking.

### Deliberately excluded vs #6481

The `blob_recovery_error` change (surfacing `CommitteeSynchronizationError` /
`CommitteeDeprecationError` instead of a fabricated `BlobsNotFound`, plus its unit
tests) is **not** included here. Consequently, on a *failed* self-heal (admin
chain genuinely unreachable) conway still surfaces `BlobsNotFound` rather than the
truthful committee error. The user-facing self-heal is unaffected; only the
error-diagnostics improvement is absent.

## Test Plan

- New regression test `test_stale_client_reads_blob_published_in_future_epoch`:
  a client pinned at epoch 0 reads a data blob whose publishing certificate was
  signed by the epoch-1 committee. It fails before the fix and passes after.
- `cargo test -p linera-core` (memory backend): the new test passes.
- `cargo clippy -p linera-core --all-targets`: no warnings.
- `cargo fmt -- --check` with the pinned nightly (`nightly-2025-04-03`): clean.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Backport of #6481
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
