### PR TITLE
[testnet] Export ValueCache occupancy and capacity gauges (backport of #6475)

### DIFF
--- a/linera-cache/src/value_cache.rs
+++ b/linera-cache/src/value_cache.rs
@@ -34,7 +34,17 @@ pub const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 30;
 /// A background task periodically sweeps dead `Weak` entries from the index
 /// to prevent unbounded memory growth.
 pub struct ValueCache<K, V> {
-    cache: Cache<K, crate::Arc<V>>,
+    /// Stable instance name distinguishing this cache in metrics; several
+    /// caches may share the same key/value types within one process.
+    ///
+    /// Must be unique among the `ValueCache` instances of a process:
+    /// instances sharing a name and key/value types report into the same
+    /// metric series, so their gauges would overwrite each other. The name
+    /// is used verbatim as the `cache` Prometheus label value; any UTF-8
+    /// string is valid, but prefer a short, stable `snake_case` identifier
+    /// since dashboards and alerts query it.
+    name: &'static str,
+    cache: Arc<Cache<K, crate::Arc<V>>>,
     weak_index: Arc<papaya::HashMap<K, Weak<V>>>,
 }
 
@@ -43,28 +53,59 @@ where
     K: Hash + Eq + Clone + Send + Sync + 'static,
     V: Send + Sync + 'static,
 {
-    /// Creates a new `ValueCache` with the given bounded-cache capacity
-    /// and cleanup interval for the weak-reference index.
+    /// Creates a new `ValueCache` with the given instance name (used as the
+    /// `cache` metric label), bounded-cache capacity, and cleanup interval
+    /// for the weak-reference index.
     #[cfg(not(web))]
-    pub fn new(size: usize, cleanup_interval_secs: u64) -> Self {
+    pub fn new(name: &'static str, size: usize, cleanup_interval_secs: u64) -> Self {
+        let cache = Arc::new(Cache::new(size));
         let weak_index = Arc::new(papaya::HashMap::new());
+        // Report quick_cache's actual capacity, which may round the requested
+        // size up, so that occupancy (entries / capacity) cannot exceed 1.
+        #[cfg(with_metrics)]
+        metrics::CACHE_CAPACITY
+            .with_label_values(&[name, type_name::<K>(), type_name::<V>()])
+            .set(i64::try_from(cache.capacity()).unwrap_or(i64::MAX));
         Self::spawn_cleanup_task(
             Arc::clone(&weak_index),
+            #[cfg(with_metrics)]
+            (name, Arc::clone(&cache)),
             std::time::Duration::from_secs(cleanup_interval_secs),
         );
         ValueCache {
-            cache: Cache::new(size),
+            name,
+            cache,
             weak_index,
         }
     }
 
     /// Creates a new `ValueCache` (web variant, no background cleanup task).
     #[cfg(web)]
-    pub fn new(size: usize, _cleanup_interval_secs: u64) -> Self {
+    pub fn new(name: &'static str, size: usize, _cleanup_interval_secs: u64) -> Self {
         ValueCache {
-            cache: Cache::new(size),
+            name,
+            cache: Arc::new(Cache::new(size)),
             weak_index: Arc::new(papaya::HashMap::new()),
         }
+    }
+
+    /// Returns the instance name of this cache.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns the number of entries currently held in the bounded cache.
+    ///
+    /// This is the live occupancy (excludes the weak dedup index), and is
+    /// periodically sampled as the `value_cache_entries` gauge for the
+    /// occupancy-vs-capacity diagnosis.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Returns `true` if the bounded cache currently holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.cache.is_empty()
     }
 
     /// Inserts a value into the cache, returning the canonical [`crate::Arc`].
@@ -87,7 +128,7 @@ where
         if value.is_some() {
             self.cache.remove(key);
         }
-        Self::track_cache_usage(value)
+        self.track_cache_usage(value)
     }
 
     /// Returns an [`crate::Arc`] to the value, checking both the bounded
@@ -95,7 +136,7 @@ where
     pub fn get(&self, key: &K) -> Option<crate::Arc<V>> {
         // Tier 1: bounded cache (hot path)
         if let Some(arc) = self.cache.get(key) {
-            return Self::track_cache_usage(Some(arc));
+            return self.track_cache_usage(Some(arc));
         }
 
         // Tier 2: weak index (catches evicted-but-still-held entries)
@@ -105,11 +146,11 @@ where
                 let arc = crate::Arc(arc);
                 // Re-insert into bounded cache for future fast lookups
                 self.cache.insert(key.clone(), arc.clone());
-                return Self::track_cache_usage(Some(arc));
+                return self.track_cache_usage(Some(arc));
             }
         }
 
-        Self::track_cache_usage(None)
+        self.track_cache_usage(None)
     }
 
     /// Returns `true` if the value exists in either the bounded cache or
@@ -138,6 +179,7 @@ where
     #[cfg(not(web))]
     fn spawn_cleanup_task(
         weak_index: Arc<papaya::HashMap<K, Weak<V>>>,
+        #[cfg(with_metrics)] metrics_handle: (&'static str, Arc<Cache<K, crate::Arc<V>>>),
         cleanup_interval: std::time::Duration,
     ) {
         if tokio::runtime::Handle::try_current().is_err() {
@@ -147,8 +189,19 @@ where
             let mut interval = tokio::time::interval(cleanup_interval);
             loop {
                 interval.tick().await;
-                let guard = weak_index.guard();
-                weak_index.retain(|_, weak| weak.strong_count() > 0, &guard);
+                {
+                    let guard = weak_index.guard();
+                    weak_index.retain(|_, weak| weak.strong_count() > 0, &guard);
+                }
+                // Refresh the occupancy gauge on the same cadence as the sweep
+                // (after the guard is dropped); keeps it off the cache hot path.
+                #[cfg(with_metrics)]
+                {
+                    let (name, cache) = &metrics_handle;
+                    metrics::CACHE_ENTRIES
+                        .with_label_values(&[name, type_name::<K>(), type_name::<V>()])
+                        .set(i64::try_from(cache.len()).unwrap_or(i64::MAX));
+                }
             }
         });
     }
@@ -182,7 +235,7 @@ where
         canonical_arc
     }
 
-    fn track_cache_usage(maybe_value: Option<crate::Arc<V>>) -> Option<crate::Arc<V>> {
+    fn track_cache_usage(&self, maybe_value: Option<crate::Arc<V>>) -> Option<crate::Arc<V>> {
         #[cfg(with_metrics)]
         {
             let metric = if maybe_value.is_some() {
@@ -192,7 +245,7 @@ where
             };
 
             metric
-                .with_label_values(&[type_name::<K>(), type_name::<V>()])
+                .with_label_values(&[self.name, type_name::<K>(), type_name::<V>()])
                 .inc();
         }
         maybe_value
@@ -245,22 +298,36 @@ impl<V: Clone + Send + Sync + 'static> ValueCache<CryptoHash, V> {
 mod metrics {
     use std::sync::LazyLock;
 
-    use linera_base::prometheus_util::register_int_counter_vec;
-    use prometheus::IntCounterVec;
+    use linera_base::prometheus_util::{register_int_counter_vec, register_int_gauge_vec};
+    use prometheus::{IntCounterVec, IntGaugeVec};
+
+    /// Shared label set: `cache` is the per-instance name passed to
+    /// [`super::ValueCache::new`], required because several caches may share
+    /// the same key/value types within one process.
+    const LABELS: &[&str] = &["cache", "key_type", "value_type"];
 
     pub static CACHE_HIT_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "value_cache_hit",
-            "Cache hits in `ValueCache`",
-            &["key_type", "value_type"],
-        )
+        register_int_counter_vec("value_cache_hit", "Cache hits in `ValueCache`", LABELS)
     });
 
     pub static CACHE_MISS_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec(
-            "value_cache_miss",
-            "Cache misses in `ValueCache`",
-            &["key_type", "value_type"],
+        register_int_counter_vec("value_cache_miss", "Cache misses in `ValueCache`", LABELS)
+    });
+
+    pub static CACHE_ENTRIES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "value_cache_entries",
+            "Number of entries held in the bounded `ValueCache`, sampled at \
+             each cleanup sweep",
+            LABELS,
+        )
+    });
+
+    pub static CACHE_CAPACITY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "value_cache_capacity",
+            "Maximum number of entries of the bounded `ValueCache`",
+            LABELS,
         )
     });
 }
@@ -299,11 +366,11 @@ mod tests {
     }
 
     fn new_hashed_cache(size: usize) -> ValueCache<CryptoHash, TestValue> {
-        ValueCache::new(size, DEFAULT_CLEANUP_INTERVAL_SECS)
+        ValueCache::new("test_hashed", size, DEFAULT_CLEANUP_INTERVAL_SECS)
     }
 
     fn new_string_cache(size: usize) -> ValueCache<u64, String> {
-        ValueCache::new(size, DEFAULT_CLEANUP_INTERVAL_SECS)
+        ValueCache::new("test_string", size, DEFAULT_CLEANUP_INTERVAL_SECS)
     }
 
     #[test]
@@ -383,6 +450,30 @@ mod tests {
              but has {present_count} entries for capacity {TEST_CACHE_SIZE}"
         );
         assert!(present_count > 0, "cache should still hold some entries");
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let cache = new_string_cache(TEST_CACHE_SIZE);
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+
+        cache.insert(&1, "a".to_string());
+        cache.insert(&2, "b".to_string());
+        assert!(!cache.is_empty());
+        assert_eq!(cache.len(), 2);
+
+        // Filling well beyond capacity caps the bounded-cache occupancy, which
+        // is exactly what the `value_cache_entries` gauge reports. Note that
+        // `len()` counts only the bounded cache, not the weak dedup index.
+        for i in 3..(TEST_CACHE_SIZE as u64 * 3) {
+            cache.insert(&i, format!("v{i}"));
+        }
+        assert!(
+            cache.len() <= TEST_CACHE_SIZE,
+            "bounded-cache occupancy {} must not exceed capacity {TEST_CACHE_SIZE}",
+            cache.len(),
+        );
     }
 
     #[test]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -863,6 +863,7 @@ where
             storage,
             chain_worker_config,
             block_cache: Arc::new(ValueCache::new(
+                "worker_block",
                 block_cache_size,
                 DEFAULT_CLEANUP_INTERVAL_SECS,
             )),

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -421,12 +421,33 @@ impl StorageCaches {
     pub fn new(sizes: StorageCacheConfig) -> Self {
         let interval = sizes.cache_cleanup_interval_secs;
         Self {
-            blob: Arc::new(ValueCache::new(sizes.blob_cache_size, interval)),
-            confirmed_block: Arc::new(ValueCache::new(sizes.confirmed_block_cache_size, interval)),
-            certificate: Arc::new(ValueCache::new(sizes.certificate_cache_size, interval)),
-            certificate_raw: Arc::new(ValueCache::new(sizes.certificate_raw_cache_size, interval)),
-            event: Arc::new(ValueCache::new(sizes.event_cache_size, interval)),
+            blob: Arc::new(ValueCache::new(
+                "storage_blob",
+                sizes.blob_cache_size,
+                interval,
+            )),
+            confirmed_block: Arc::new(ValueCache::new(
+                "storage_confirmed_block",
+                sizes.confirmed_block_cache_size,
+                interval,
+            )),
+            certificate: Arc::new(ValueCache::new(
+                "storage_certificate",
+                sizes.certificate_cache_size,
+                interval,
+            )),
+            certificate_raw: Arc::new(ValueCache::new(
+                "storage_certificate_raw",
+                sizes.certificate_raw_cache_size,
+                interval,
+            )),
+            event: Arc::new(ValueCache::new(
+                "storage_event",
+                sizes.event_cache_size,
+                interval,
+            )),
             block_hash_by_height: Arc::new(ValueCache::new(
+                "storage_block_hash_by_height",
                 sizes.block_hash_by_height_cache_size,
                 interval,
             )),


### PR DESCRIPTION
## Motivation

Backport of #6475 (merged on `main` as 1e3f2684850, approved by @ma2bd) to `testnet_conway`, so the running validators can report cache occupancy. The `ValueCache` instances only export hit/miss counters; a low hit rate alone cannot distinguish a saturated-and-evicting cache (size bump helps) from a cold / low-reuse working set (size bump is useless). The occupancy gauge resolves exactly the cache-sizing questions we have open on testnet-conway (certificate / raw-certificate cache behavior under client sync load).

## Proposal

Cherry-pick of the `main` squash commit, with one adaptation: `testnet_conway` already has #6474, which added a `block_hash_by_height` cache that does not exist on `main`. The conflict resolution gives that cache a metrics name too (`storage_block_hash_by_height`), so the caches introduced by #6474 get occupancy/capacity gauges as well.

As on `main`:
- `value_cache_entries` (sampled at each 30s cleanup sweep, off the hot path) and `value_cache_capacity` (real post-rounding `quick_cache::capacity()`) gauges;
- a `cache` instance label on all four `value_cache_*` metrics, disambiguating instances that share key/value types (`storage_confirmed_block` vs `worker_block`) — instance names: `storage_blob`, `storage_confirmed_block`, `storage_certificate`, `storage_certificate_raw`, `storage_event`, `storage_block_hash_by_height`, `worker_block`.

## Test Plan

`cargo clippy --all-targets -- -D warnings` passes on this branch for `linera-cache` (with `--features metrics` and with `--no-default-features`), `linera-storage`, and `linera-core` — the latter two also prove every `ValueCache::new` call site (including the #6474 one) was adapted to the new signature. `cargo test -p linera-cache --features metrics` passes (18 tests).

## Release Plan

- These changes are already on `main` (#6475); this backports them to the latest `testnet` branch to be released in a validator deployment.