### PR TITLE
[testnet] CI: pin cargo-rdme to 1.5.0 to fix readme lint on the pinned toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -488,7 +488,9 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install cargo-rdme
       run: |
-        cargo install cargo-rdme --locked
+        # Pinned: cargo-rdme 1.5.1's lockfile pulls zmij 1.0.21, which needs
+        # Rust >= 1.88 and does not build on this branch's pinned toolchain.
+        cargo install cargo-rdme --locked --version 1.5.0
     - name: Check for outdated README.md
       run: |
         set -e


### PR DESCRIPTION
## Motivation

The `lint-check-for-outdated-readme` job is now failing deterministically on every `testnet_conway` PR. `cargo install cargo-rdme --locked` resolves to the freshly released cargo-rdme 1.5.1, whose lockfile pulls `zmij 1.0.21`, which uses `hint::select_unpredictable` — stabilized in Rust 1.88. This branch's pinned toolchains (stable 1.86.0, nightly-2025-04-03) cannot build it, so the install step exits 101 before the README check even runs. The same job passed on this branch as recently as 2026-06-11 (PRs #6474, #6476) and broke on 2026-06-12 (#6488), bracketing the upstream release. `main` is unaffected (toolchain 1.95).

## Proposal

Pin the tool: `cargo install cargo-rdme --locked --version 1.5.0`, with a comment explaining why. cargo-rdme 1.5.0 declares `rust-version = 1.86.0`.

## Test Plan

Verified locally that `cargo install cargo-rdme --locked --version 1.5.0` builds successfully on rustc 1.86.0 (this branch's stable pin) and the binary runs. This PR's own `lint-check-for-outdated-readme` job exercises the pinned install directly, so its CI result is the end-to-end proof.

## Release Plan

- CI-only change on `testnet_conway`; nothing to deploy. `main` does not need this (newer toolchain), though the pin could be ported there for reproducibility if desired.