### PR TITLE
[testnet] Return a dedicated CannotDownloadBlob error instead of fabricating BlobsNotFound

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -317,7 +317,7 @@ pub enum Error {
     },
 
     #[error("No validator provided a usable certificate registering blob {0}")]
-    BlobRecoveryFailed(BlobId),
+    CannotDownloadBlob(BlobId),
 
     #[error(transparent)]
     BcsError(#[from] bcs::Error),

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -316,6 +316,9 @@ pub enum Error {
         target_next_block_height: BlockHeight,
     },
 
+    #[error("No validator provided a usable certificate registering blob {0}")]
+    BlobRecoveryFailed(BlobId),
+
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2179,7 +2179,7 @@ impl<Env: Environment> Client<Env> {
                             "failed to download certificate-for-blob from validator",
                         );
                     }
-                    chain_client::Error::BlobRecoveryFailed(blob_id)
+                    chain_client::Error::CannotDownloadBlob(blob_id)
                 },
                 timeout,
             )

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2179,7 +2179,7 @@ impl<Env: Environment> Client<Env> {
                             "failed to download certificate-for-blob from validator",
                         );
                     }
-                    chain_client::Error::from(NodeError::BlobsNotFound(vec![blob_id]))
+                    chain_client::Error::BlobRecoveryFailed(blob_id)
                 },
                 timeout,
             )

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1561,7 +1561,7 @@ where
         .await;
     assert_matches!(
         result,
-        Err(chain_client::Error::BlobRecoveryFailed(blob_id)) if blob_id == blob0_id
+        Err(chain_client::Error::CannotDownloadBlob(blob_id)) if blob_id == blob0_id
     );
 
     // Take one validator down

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1561,8 +1561,7 @@ where
         .await;
     assert_matches!(
         result,
-        Err(chain_client::Error::RemoteNodeError(NodeError::BlobsNotFound(not_found_blob_ids)))
-            if not_found_blob_ids == [blob0_id]
+        Err(chain_client::Error::BlobRecoveryFailed(blob_id)) if blob_id == blob0_id
     );
 
     // Take one validator down


### PR DESCRIPTION
## Motivation

Follow-up to #6486 (the self-heal backport) addressing the review feedback on
#6481. `testnet_conway` currently still fabricates a `NodeError::BlobsNotFound`
on the client when blob recovery fails against every validator, which is
misleading: the blob may well exist on the network, and the real per-validator
causes (committee-epoch mismatch, connection failures, genuine absence) are
hidden behind a fake node error.

## Proposal

When blob recovery fails against every validator, surface a dedicated
`chain_client::Error::BlobRecoveryFailed(BlobId)` rather than fabricating a
`NodeError::BlobsNotFound` on the client. The per-validator failure reasons are
already logged at `warn!`; the surfaced error no longer fabricates a node error
and does not depend on any single validator's response.

This is the `BlobRecoveryFailed` change that #6486 deliberately excluded, now
applied on top of it. Equivalent to the corresponding change in #6481.

## Test Plan

- `test_finalize_locked_block_with_blobs` updated: reading an unpublished blob
  now surfaces `BlobRecoveryFailed` instead of the fabricated
  `RemoteNodeError(BlobsNotFound)`.
- `cargo test -p linera-core client_tests`: 62 passed, 0 failed.
- `cargo clippy -p linera-core --all-targets`: no warnings.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Backport of the error-surfacing nit from #6481
- Follows #6486 (self-heal)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
