### PR TITLE
Checkpoints with events

### DIFF
--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -97,8 +97,57 @@ impl Contract for SocialContract {
                         self.execute_comment_event(key, update.chain_id, comment)
                             .await;
                     }
+                    // Apply each post from the summary that we don't already have, so a
+                    // subscriber that joined after the checkpoint catches up. The guard
+                    // avoids clobbering likes and comments a subscriber already tracked.
+                    Event::Summary { recent_posts } => {
+                        for (index, post) in recent_posts {
+                            let key = Key {
+                                timestamp: post.timestamp,
+                                author: update.chain_id,
+                                index,
+                            };
+                            if self
+                                .state
+                                .received_posts
+                                .get(&key)
+                                .await
+                                .expect("Failed to read post")
+                                .is_none()
+                            {
+                                self.execute_post_event(update.chain_id, index, post);
+                            }
+                        }
+                    }
                 }
             }
+        }
+    }
+
+    async fn summarize_events(&mut self, updates: Vec<StreamUpdate>) {
+        /// The number of recent posts to retain in a checkpoint summary.
+        const SUMMARY_POST_COUNT: usize = 10;
+        for update in updates {
+            assert_eq!(update.stream_id.stream_name, STREAM_NAME.into());
+            assert_eq!(
+                update.stream_id.application_id,
+                self.runtime.application_id().forget_abi().into()
+            );
+            let count = self.state.own_posts.count();
+            let start = count.saturating_sub(SUMMARY_POST_COUNT);
+            let posts = self
+                .state
+                .own_posts
+                .read(start..count)
+                .await
+                .expect("Failed to read own posts");
+            let recent_posts = posts
+                .into_iter()
+                .enumerate()
+                .map(|(offset, post)| ((start + offset) as u32, post))
+                .collect();
+            self.runtime
+                .emit(STREAM_NAME.into(), &Event::Summary { recent_posts });
         }
     }
 

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -108,6 +108,11 @@ pub enum Event {
     Like { key: Key },
     /// A user commented on a post
     Comment { key: Key, comment: String },
+    /// A summary emitted at a checkpoint, carrying the most recent posts on the stream.
+    /// Older events may be dropped after the checkpoint; this lets a subscriber that joins
+    /// afterwards still receive those posts. Each entry is the post's index in the author's
+    /// own-post log paired with the post itself.
+    Summary { recent_posts: Vec<(u32, OwnPost)> },
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/examples/social/tests/snapshots/format__format.snap
+++ b/examples/social/tests/snapshots/format__format.snap
@@ -35,6 +35,14 @@ REGISTRY:
             - key:
                 TYPENAME: Key
             - comment: STR
+      3:
+        Summary:
+          STRUCT:
+            - recent_posts:
+                SEQ:
+                  TUPLE:
+                    - U32
+                    - TYPENAME: OwnPost
   Key:
     STRUCT:
       - timestamp:

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -15,7 +15,7 @@ use linera_base::{
     },
     ensure,
     hashed::Hashed,
-    identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, StreamId},
+    identifiers::{AccountOwner, ApplicationId, BlobType, ChainId, GenericApplicationId, StreamId},
     ownership::ChainOwnership,
     time::{Duration, Instant},
 };
@@ -1564,27 +1564,34 @@ where
     }
 
     /// Validates the chain-state-level preconditions for a `SystemOperation::Checkpoint`:
-    /// no event stream tracker is set.
+    /// no *system* event stream tracker is set.
     ///
     /// The structural invariant that Checkpoint must be the *first* transaction in its
     /// block is enforced unconditionally in `execute_block`, independently of these
-    /// preconditions. Sender-side event conditions (no events ever published) are
-    /// validated inside `ExecutionStateView::prepare_checkpoint`. Outgoing messages
-    /// and consumed incoming bundles are no longer preconditions: the on-chain
-    /// `unfinalized_message_blocks` map and the per-inbox `restored_cursor` (seeded
-    /// from the checkpoint's oracle response) together carry everything a
-    /// bootstrapping node needs.
+    /// preconditions. Sender-side event conditions are validated inside
+    /// `ExecutionStateView::prepare_checkpoint`. Outgoing messages and consumed incoming
+    /// bundles are no longer preconditions: the on-chain `unfinalized_message_blocks` map
+    /// and the per-inbox `restored_cursor` (seeded from the checkpoint's oracle response)
+    /// together carry everything a bootstrapping node needs.
+    ///
+    /// User event streams are summarized by the checkpoint, so a tracker for one no longer
+    /// blocks checkpointing. System event streams (the admin chain's epoch streams) are not
+    /// yet summarized, so a tracker for one still does.
     async fn check_checkpoint_preconditions(&self) -> Result<(), ChainError> {
-        let mut had_event_tracker = false;
+        let mut had_system_event_tracker = false;
         self.next_expected_events
-            .for_each_index_while(|_| {
-                had_event_tracker = true;
-                Ok(false)
+            .for_each_index_while(|stream_id| {
+                if matches!(stream_id.application_id, GenericApplicationId::System) {
+                    had_system_event_tracker = true;
+                    Ok(false)
+                } else {
+                    Ok(true)
+                }
             })
             .await?;
         ensure!(
-            !had_event_tracker,
-            ChainError::CheckpointPreconditionFailed("chain has consumed events")
+            !had_system_event_tracker,
+            ChainError::CheckpointPreconditionFailed("chain has consumed system events")
         );
 
         Ok(())

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1566,17 +1566,10 @@ where
     /// Validates the chain-state-level preconditions for a `SystemOperation::Checkpoint`:
     /// no *system* event stream tracker is set.
     ///
-    /// The structural invariant that Checkpoint must be the *first* transaction in its
+    /// The structural invariant that `Checkpoint` must be the *first* transaction in its
     /// block is enforced unconditionally in `execute_block`, independently of these
     /// preconditions. Sender-side event conditions are validated inside
-    /// `ExecutionStateView::prepare_checkpoint`. Outgoing messages and consumed incoming
-    /// bundles are no longer preconditions: the on-chain `unfinalized_message_blocks` map
-    /// and the per-inbox `restored_cursor` (seeded from the checkpoint's oracle response)
-    /// together carry everything a bootstrapping node needs.
-    ///
-    /// User event streams are summarized by the checkpoint, so a tracker for one no longer
-    /// blocks checkpointing. System event streams (the admin chain's epoch streams) are not
-    /// yet summarized, so a tracker for one still does.
+    /// `ExecutionStateView::prepare_checkpoint`.
     async fn check_checkpoint_preconditions(&self) -> Result<(), ChainError> {
         let mut had_system_event_tracker = false;
         self.next_expected_events

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1174,6 +1174,22 @@ where
             let mut inbox = self.chain.inboxes.try_load_entry_mut(&origin).await?;
             inbox.restore_from_checkpoint(cursor).await?;
         }
+        // Seed `next_expected_events` from the restored per-stream event counts. Re-executing
+        // the checkpoint re-emits each summarized stream's summary event; without this seed
+        // the summary's index would look like a gap on the freshly-restored node, so the
+        // tracker would never advance and future events on that stream would never be
+        // delivered to subscribers. The counts are contiguous, so this matches the producer's
+        // tracker as of just before the checkpoint block.
+        for (stream_id, count) in self
+            .chain
+            .execution_state
+            .system
+            .stream_event_counts
+            .index_values()
+            .await?
+        {
+            self.chain.next_expected_events.insert(&stream_id, count)?;
+        }
         // We reset `execution_state` (via restore), `tip_state`, `block_hashes`
         // (for outbox-referenced pre-checkpoint heights), and the outbox views.
         // The other `ChainStateView` fields are either (a) already default for

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -1109,10 +1109,10 @@ where
         application_id: application_id.forget_abi().into(),
         stream_name: StreamName(b"posts".to_vec()),
     };
-    let [summary_event] = &checkpoint_cert.block().body.events[..] else {
+    let [checkpoint_events] = &checkpoint_cert.block().body.events[..] else {
         panic!("checkpoint should emit a single transaction's events");
     };
-    let [summary_event] = &summary_event[..] else {
+    let [summary_event] = &checkpoint_events[..] else {
         panic!("checkpoint should emit a single summary event");
     };
     assert_eq!(summary_event.stream_id, posts_stream);

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -28,8 +28,8 @@ use linera_base::{
         OracleResponse, Round, TimeDelta, Timestamp,
     },
     identifiers::{
-        Account, AccountOwner, ApplicationId, BlobId, BlobType, DataBlobHash, ModuleId, StreamId,
-        StreamName,
+        Account, AccountOwner, ApplicationId, BlobId, BlobType, DataBlobHash, EventId, ModuleId,
+        StreamId, StreamName,
     },
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
@@ -1058,6 +1058,151 @@ where
     );
 
     Ok(())
+}
+
+/// A chain that has published user events (here: `social` posts) and also sent a cross-chain
+/// message can still checkpoint. The checkpoint calls `summarize_events`, which emits a
+/// summary event, and a fresh follower bootstraps from the checkpoint to the same state hash
+/// — downloading the recertified message block but skipping the pre-checkpoint event block.
+async fn run_test_checkpoint_with_events<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
+    let producer = builder.add_root_chain(1, Amount::from_tokens(7)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = producer.chain_id();
+
+    // Deploy the social app and publish one event (a post) on its `posts` stream.
+    let module_id = producer.publish_wasm_example("social").await?;
+    let module_id = module_id.with_abi::<social::SocialAbi, (), ()>();
+    let (application_id, _) = producer
+        .create_application(module_id, &(), &(), vec![])
+        .await
+        .unwrap_ok_committed();
+    let post = social::Operation::Post {
+        text: "hello".to_string(),
+        image_url: None,
+    };
+    let post_cert = producer
+        .execute_operation(Operation::user(application_id, &post)?)
+        .await
+        .unwrap_ok_committed();
+
+    // Also send a cross-chain message, so the chain has both events and an unfinalized
+    // outgoing-message block at checkpoint time.
+    let transfer_cert = producer
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // The checkpoint is allowed despite the published user events, and `summarize_events`
+    // emits a summary of the `posts` stream as the checkpoint block's only event. The post
+    // sits at index 0, so the summary (carrying the recent posts) lands at index 1.
+    let checkpoint_cert = producer.checkpoint().await.unwrap().unwrap();
+    let posts_stream = StreamId {
+        application_id: application_id.forget_abi().into(),
+        stream_name: StreamName(b"posts".to_vec()),
+    };
+    let [summary_event] = &checkpoint_cert.block().body.events[..] else {
+        panic!("checkpoint should emit a single transaction's events");
+    };
+    let [summary_event] = &summary_event[..] else {
+        panic!("checkpoint should emit a single summary event");
+    };
+    assert_eq!(summary_event.stream_id, posts_stream);
+    assert_eq!(summary_event.index, 1);
+    let social::Event::Summary { recent_posts } = bcs::from_bytes(&summary_event.value)? else {
+        panic!("the checkpoint event should be a summary");
+    };
+    assert_eq!(recent_posts.len(), 1);
+    assert_eq!(recent_posts[0].0, 0);
+    assert_eq!(recent_posts[0].1.text, "hello");
+
+    let producer_state_hash = producer
+        .chain_info()
+        .await?
+        .state_hash
+        .expect("producer should expose a state hash after the checkpoint");
+
+    // A fresh follower bootstraps from the checkpoint and must reach the same state hash —
+    // re-executing the checkpoint re-runs `summarize_events`, re-emitting the summary.
+    let follower = builder
+        .make_client_with_options(
+            chain_id,
+            None,
+            BlockHeight::ZERO,
+            chain_client::Options::test_default(),
+            true,
+        )
+        .await?;
+    follower.synchronize_from_validators().await?;
+    assert_eq!(
+        follower.chain_info().await?.state_hash,
+        Some(producer_state_hash),
+    );
+
+    // The follower downloaded the recertified message block but skipped the pre-checkpoint
+    // event block: old events are no longer guaranteed, only the summary in the checkpoint.
+    let follower_storage = follower.storage_client();
+    assert!(
+        follower_storage
+            .contains_certificate(transfer_cert.hash())
+            .await?,
+        "follower should download the recertified message block",
+    );
+    assert!(
+        !follower_storage
+            .contains_certificate(post_cert.hash())
+            .await?,
+        "follower should skip the pre-checkpoint event block",
+    );
+    assert!(
+        follower_storage
+            .contains_certificate(checkpoint_cert.hash())
+            .await?,
+    );
+
+    // The summary event is available on the follower, re-emitted by re-executing the
+    // checkpoint, even though the original post event's block was never downloaded. It still
+    // carries the post, so a subscriber that joins after the checkpoint recovers it.
+    let summary = follower_storage
+        .read_event(EventId {
+            chain_id,
+            stream_id: posts_stream.clone(),
+            index: 1,
+        })
+        .await?
+        .expect("the summary event should be available after bootstrap");
+    let social::Event::Summary { recent_posts } = bcs::from_bytes(&summary)? else {
+        panic!("the checkpoint event should be a summary");
+    };
+    assert_eq!(recent_posts.len(), 1);
+    assert_eq!(recent_posts[0].1.text, "hello");
+
+    // The follower's per-stream event tracker was seeded from the restored counts during
+    // bootstrap and advanced past the re-emitted summary (post at index 0, summary at index
+    // 1), so it sits at 2 — matching the producer and ready to deliver future events.
+    let follower_expected = follower
+        .client
+        .local_node
+        .next_expected_events(chain_id, vec![posts_stream.clone()])
+        .await?;
+    assert_eq!(follower_expected.get(&posts_stream), Some(&2));
+
+    Ok(())
+}
+
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
+#[test_log::test(tokio::test)]
+async fn test_memory_checkpoint_with_events(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
+    run_test_checkpoint_with_events(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]

--- a/linera-execution/src/evm/inputs.rs
+++ b/linera-execution/src/evm/inputs.rs
@@ -46,6 +46,8 @@ alloy_sol_types::sol! {
     }
 
     function process_streams(InternalStreamUpdate[] internal_streams);
+
+    function summarize_events(InternalStreamUpdate[] internal_streams);
 }
 
 fn crypto_hash_to_internal_crypto_hash(hash: CryptoHash) -> B256 {
@@ -151,6 +153,11 @@ pub(crate) const EXECUTE_MESSAGE_SELECTOR: &[u8] = &[173, 125, 234, 205];
 /// only from a submitted message
 pub(crate) const PROCESS_STREAMS_SELECTOR: &[u8] = &[254, 72, 102, 28];
 
+/// This is the selector of `summarize_events`, which is called by the system on a
+/// checkpoint and never from a submitted operation.
+pub(crate) const SUMMARIZE_EVENTS_SELECTOR: &[u8] =
+    &<summarize_eventsCall as alloy_sol_types::SolCall>::SELECTOR;
+
 /// This is the selector of `instantiate` that should be called
 /// only when creating a new instance of a shared contract
 pub(crate) const INSTANTIATE_SELECTOR: &[u8] = &[156, 163, 60, 158];
@@ -163,6 +170,10 @@ pub(crate) fn forbid_execute_operation_origin(vec: &[u8]) -> Result<(), EvmExecu
     ensure!(
         vec != PROCESS_STREAMS_SELECTOR,
         EvmExecutionError::IllegalOperationCall("function process_streams".to_string(),)
+    );
+    ensure!(
+        vec != SUMMARIZE_EVENTS_SELECTOR,
+        EvmExecutionError::IllegalOperationCall("function summarize_events".to_string(),)
     );
     ensure!(
         vec != INSTANTIATE_SELECTOR,
@@ -229,6 +240,15 @@ pub(crate) fn get_revm_process_streams_bytes(streams: Vec<StreamUpdate>) -> Vec<
     let internal_streams = streams.into_iter().map(StreamUpdate::into).collect();
 
     let fct_call = process_streamsCall { internal_streams };
+    fct_call.abi_encode()
+}
+
+pub(crate) fn get_revm_summarize_events_bytes(streams: Vec<StreamUpdate>) -> Vec<u8> {
+    use alloy_sol_types::SolCall;
+
+    let internal_streams = streams.into_iter().map(StreamUpdate::into).collect();
+
+    let fct_call = summarize_eventsCall { internal_streams };
     fct_call.abi_encode()
 }
 

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -73,9 +73,9 @@ use crate::{
         inputs::{
             ensure_message_length, ensure_selector_presence, forbid_execute_operation_origin,
             get_revm_execute_message_bytes, get_revm_instantiation_bytes,
-            get_revm_process_streams_bytes, has_selector, EXECUTE_MESSAGE_SELECTOR, FAUCET_ADDRESS,
-            INSTANTIATE_SELECTOR, PRECOMPILE_ADDRESS, PROCESS_STREAMS_SELECTOR, SERVICE_ADDRESS,
-            ZERO_ADDRESS,
+            get_revm_process_streams_bytes, get_revm_summarize_events_bytes, has_selector,
+            EXECUTE_MESSAGE_SELECTOR, FAUCET_ADDRESS, INSTANTIATE_SELECTOR, PRECOMPILE_ADDRESS,
+            PROCESS_STREAMS_SELECTOR, SERVICE_ADDRESS, SUMMARIZE_EVENTS_SELECTOR, ZERO_ADDRESS,
         },
     },
     BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, DataBlobHash, EvmExecutionError,
@@ -1335,6 +1335,20 @@ where
         let caller = Address::ZERO;
         let value = U256::ZERO;
         self.execute_no_return_operation(operation, "process_streams", value, caller)
+    }
+
+    fn summarize_events(&mut self, streams: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
+        self.db.inner.set_contract_address()?;
+        let operation = get_revm_summarize_events_bytes(streams);
+        ensure_selector_presence(
+            &self.module,
+            SUMMARIZE_EVENTS_SELECTOR,
+            "function summarize_events(Linera.StreamUpdate[] memory streams)",
+        )?;
+        // For summarize_events, authenticated_owner and authenticated_called_id are None.
+        let caller = Address::ZERO;
+        let value = U256::ZERO;
+        self.execute_no_return_operation(operation, "summarize_events", value, caller)
     }
 
     fn finalize(&mut self) -> Result<(), ExecutionError> {

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -304,6 +304,7 @@ pub enum UserAction {
     Operation(OperationContext, Vec<u8>),
     Message(MessageContext, Vec<u8>),
     ProcessStreams(ProcessStreamsContext, Vec<StreamUpdate>),
+    SummarizeEvents(ProcessStreamsContext, Vec<StreamUpdate>),
 }
 
 impl UserAction {
@@ -312,6 +313,7 @@ impl UserAction {
             UserAction::Instantiate(context, _) => context.authenticated_owner,
             UserAction::Operation(context, _) => context.authenticated_owner,
             UserAction::ProcessStreams(_, _) => None,
+            UserAction::SummarizeEvents(_, _) => None,
             UserAction::Message(context, _) => context.authenticated_owner,
         }
     }
@@ -321,6 +323,7 @@ impl UserAction {
             UserAction::Instantiate(context, _) => context.height,
             UserAction::Operation(context, _) => context.height,
             UserAction::ProcessStreams(context, _) => context.height,
+            UserAction::SummarizeEvents(context, _) => context.height,
             UserAction::Message(context, _) => context.height,
         }
     }
@@ -330,6 +333,7 @@ impl UserAction {
             UserAction::Instantiate(context, _) => context.round,
             UserAction::Operation(context, _) => context.round,
             UserAction::ProcessStreams(context, _) => context.round,
+            UserAction::SummarizeEvents(context, _) => context.round,
             UserAction::Message(context, _) => context.round,
         }
     }
@@ -339,6 +343,7 @@ impl UserAction {
             UserAction::Instantiate(context, _) => context.timestamp,
             UserAction::Operation(context, _) => context.timestamp,
             UserAction::ProcessStreams(context, _) => context.timestamp,
+            UserAction::SummarizeEvents(context, _) => context.timestamp,
             UserAction::Message(context, _) => context.timestamp,
         }
     }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -128,8 +128,8 @@ where
         maximum_blob_size: u64,
     ) -> Result<Vec<Blob>, ExecutionError> {
         // User event streams are summarized and pruned by the checkpoint itself (see
-        // `ExecutionStateActor`'s checkpoint handler), so they no longer block checkpointing.
-        // System event streams (e.g. the epoch streams on the admin chain) are not yet
+        // `ExecutionStateActor`'s checkpoint handler), so they do not block checkpointing.
+        // System event streams (e.g. the epoch streams on the admin chain) are not
         // summarized, so a chain that published any is still not allowed to checkpoint.
         let mut had_system_event_block = false;
         self.previous_event_blocks

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -13,7 +13,7 @@ use linera_base::{
     crypto::{BcsHashable, CryptoHash},
     data_types::{Blob, BlobContent, BlockHeight, OracleResponse, StreamUpdate},
     ensure,
-    identifiers::{AccountOwner, BlobId, BlobType, ChainId, StreamId},
+    identifiers::{AccountOwner, BlobId, BlobType, ChainId, GenericApplicationId, StreamId},
     time::Instant,
 };
 use linera_views::{
@@ -127,16 +127,24 @@ where
         &mut self,
         maximum_blob_size: u64,
     ) -> Result<Vec<Blob>, ExecutionError> {
-        let mut had_event_block = false;
+        // User event streams are summarized and pruned by the checkpoint itself (see
+        // `ExecutionStateActor`'s checkpoint handler), so they no longer block checkpointing.
+        // System event streams (e.g. the epoch streams on the admin chain) are not yet
+        // summarized, so a chain that published any is still not allowed to checkpoint.
+        let mut had_system_event_block = false;
         self.previous_event_blocks
-            .for_each_index_while(|_| {
-                had_event_block = true;
-                Ok(false)
+            .for_each_index_while(|stream_id| {
+                if matches!(stream_id.application_id, GenericApplicationId::System) {
+                    had_system_event_block = true;
+                    Ok(false)
+                } else {
+                    Ok(true)
+                }
             })
             .await?;
         ensure!(
-            !had_event_block,
-            ExecutionError::CheckpointPreconditionFailed("chain has published events")
+            !had_system_event_block,
+            ExecutionError::CheckpointPreconditionFailed("chain has published system events")
         );
 
         let (bytes, _content_hash) = self.inner.dump_content().await?;

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -985,7 +985,9 @@ where
         );
         let is_free = matches!(
             &action,
-            UserAction::Message(..) | UserAction::ProcessStreams(..)
+            UserAction::Message(..)
+                | UserAction::ProcessStreams(..)
+                | UserAction::SummarizeEvents(..)
         ) && self
             .resource_controller
             .policy()

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -910,10 +910,11 @@ where
     /// The work list is exactly the set of user streams currently in `previous_event_blocks`:
     /// the previous checkpoint cleared the map, so an entry means the stream published a
     /// summary at (or any event since) the previous checkpoint. Each application may emit a
-    /// fresh summary event, which re-anchors its stream to the checkpoint height (without a
-    /// recertification link to the now-unguaranteed older blocks). A stream whose application
-    /// emits nothing is dropped from `previous_event_blocks` and is effectively closed: it
-    /// won't be summarized again unless it publishes new events.
+    /// fresh summary event; the block-level event-stream bookkeeping then re-anchors that
+    /// stream to the checkpoint height (with no recertification link to the now-unguaranteed
+    /// older blocks, since the map was cleared here). A stream whose application emits nothing
+    /// stays dropped and is effectively closed: it won't be summarized again unless it
+    /// publishes new events.
     async fn summarize_events_at_checkpoint(
         &mut self,
         context: OperationContext,
@@ -930,28 +931,25 @@ where
                 .get(&stream_id)
                 .await?
                 .unwrap_or(0);
-            let previous_index = self
-                .state
-                .system
-                .event_stream_checkpoint_index
-                .get(&stream_id)
-                .await?
-                .unwrap_or(0);
+            // A summary is an absolute-state snapshot, so the application is not handed an
+            // incremental range to fold in; `previous_index` is left at 0.
             updates_by_app
                 .entry(application_id)
                 .or_default()
                 .push(StreamUpdate {
                     chain_id: context.chain_id,
                     stream_id,
-                    previous_index,
+                    previous_index: 0,
                     next_index,
                 });
         }
 
+        // Drop every pre-checkpoint anchor. Only user streams are present, since
+        // `prepare_checkpoint` rejects chains that published system events.
+        self.state.previous_event_blocks.clear();
+
         let process_context = ProcessStreamsContext::from(context);
-        let mut work_streams = Vec::new();
         for (application_id, updates) in updates_by_app {
-            work_streams.extend(updates.iter().map(|update| update.stream_id.clone()));
             self.run_user_action(
                 application_id,
                 UserAction::SummarizeEvents(process_context, updates),
@@ -959,24 +957,6 @@ where
                 None,
             )
             .await?;
-        }
-
-        // Record the new per-stream index (including any summary just emitted) and drop the
-        // pre-checkpoint anchor. Streams that were re-summarized are re-anchored to the
-        // checkpoint height by the block-level event-stream bookkeeping after execution.
-        for stream_id in work_streams {
-            let count = self
-                .state
-                .system
-                .stream_event_counts
-                .get(&stream_id)
-                .await?
-                .unwrap_or(0);
-            self.state
-                .system
-                .event_stream_checkpoint_index
-                .insert(&stream_id, count)?;
-            self.state.previous_event_blocks.remove(&stream_id)?;
         }
         Ok(())
     }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -15,11 +15,12 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, OracleResponse,
-        Timestamp,
+        StreamUpdate, Timestamp,
     },
     ensure, hex_debug, hex_vec_debug, http,
     identifiers::{
-        Account, AccountOwner, BlobId, BlobType, ChainId, EventId, OwnerSpender, StreamId,
+        Account, AccountOwner, BlobId, BlobType, ChainId, EventId, GenericApplicationId,
+        OwnerSpender, StreamId,
     },
     ownership::ChainOwnership,
     time::Instant,
@@ -903,6 +904,83 @@ where
         }
     }
 
+    /// Calls `summarize_events` for every application that has published events to one of its
+    /// streams since the previous checkpoint, then drops those streams' pre-checkpoint anchors.
+    ///
+    /// The work list is exactly the set of user streams currently in `previous_event_blocks`:
+    /// the previous checkpoint cleared the map, so an entry means the stream published a
+    /// summary at (or any event since) the previous checkpoint. Each application may emit a
+    /// fresh summary event, which re-anchors its stream to the checkpoint height (without a
+    /// recertification link to the now-unguaranteed older blocks). A stream whose application
+    /// emits nothing is dropped from `previous_event_blocks` and is effectively closed: it
+    /// won't be summarized again unless it publishes new events.
+    async fn summarize_events_at_checkpoint(
+        &mut self,
+        context: OperationContext,
+    ) -> Result<(), ExecutionError> {
+        let mut updates_by_app = BTreeMap::<ApplicationId, Vec<StreamUpdate>>::new();
+        for stream_id in self.state.previous_event_blocks.indices().await? {
+            let GenericApplicationId::User(application_id) = stream_id.application_id else {
+                continue;
+            };
+            let next_index = self
+                .state
+                .system
+                .stream_event_counts
+                .get(&stream_id)
+                .await?
+                .unwrap_or(0);
+            let previous_index = self
+                .state
+                .system
+                .event_stream_checkpoint_index
+                .get(&stream_id)
+                .await?
+                .unwrap_or(0);
+            updates_by_app
+                .entry(application_id)
+                .or_default()
+                .push(StreamUpdate {
+                    chain_id: context.chain_id,
+                    stream_id,
+                    previous_index,
+                    next_index,
+                });
+        }
+
+        let process_context = ProcessStreamsContext::from(context);
+        let mut work_streams = Vec::new();
+        for (application_id, updates) in updates_by_app {
+            work_streams.extend(updates.iter().map(|update| update.stream_id.clone()));
+            self.run_user_action(
+                application_id,
+                UserAction::SummarizeEvents(process_context, updates),
+                None,
+                None,
+            )
+            .await?;
+        }
+
+        // Record the new per-stream index (including any summary just emitted) and drop the
+        // pre-checkpoint anchor. Streams that were re-summarized are re-anchored to the
+        // checkpoint height by the block-level event-stream bookkeeping after execution.
+        for stream_id in work_streams {
+            let count = self
+                .state
+                .system
+                .stream_event_counts
+                .get(&stream_id)
+                .await?
+                .unwrap_or(0);
+            self.state
+                .system
+                .event_stream_checkpoint_index
+                .insert(&stream_id, count)?;
+            self.state.previous_event_blocks.remove(&stream_id)?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn run_user_action(
         &mut self,
         application_id: ApplicationId,
@@ -1077,6 +1155,7 @@ where
                     self.state
                         .apply_checkpoint(prepared, self.txn_tracker)
                         .await?;
+                    self.summarize_events_at_checkpoint(context).await?;
                 }
                 op => {
                     let new_application = self

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -486,6 +486,10 @@ pub trait UserContract {
     /// Reacts to new events on streams this application subscribes to.
     fn process_streams(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError>;
 
+    /// Gives the application a chance to emit a summary event for each of its own streams
+    /// that published events since the previous checkpoint.
+    fn summarize_events(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError>;
+
     /// Finishes execution of the current transaction.
     fn finalize(&mut self) -> Result<(), ExecutionError>;
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1137,6 +1137,9 @@ impl ContractSyncRuntimeHandle {
             UserAction::ProcessStreams(_context, updates) => {
                 code.process_streams(updates).map(|()| None)
             }
+            UserAction::SummarizeEvents(_context, updates) => {
+                code.summarize_events(updates).map(|()| None)
+            }
         };
 
         let result = self.execute(application_id, signer, closure)?;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -133,10 +133,6 @@ pub struct SystemExecutionStateView<C> {
     /// `CheckpointAck` messages here is what breaks the otherwise-perpetual
     /// notification ping-pong between two chains that ever exchanged a real message.
     pub pending_checkpoint_ack_targets: SetView<C, ChainId>,
-    /// For each stream this chain writes to, the number of events it contained as of the
-    /// most recent checkpoint. This is the first index that the next checkpoint's
-    /// `summarize_events` call considers un-summarized for that stream.
-    pub event_stream_checkpoint_index: MapView<C, StreamId, u32>,
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C> {
@@ -168,10 +164,6 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
                 .await,
             pending_checkpoint_ack_targets: self
                 .pending_checkpoint_ack_targets
-                .with_context(ctx.clone())
-                .await,
-            event_stream_checkpoint_index: self
-                .event_stream_checkpoint_index
                 .with_context(ctx.clone())
                 .await,
         }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -133,6 +133,10 @@ pub struct SystemExecutionStateView<C> {
     /// `CheckpointAck` messages here is what breaks the otherwise-perpetual
     /// notification ping-pong between two chains that ever exchanged a real message.
     pub pending_checkpoint_ack_targets: SetView<C, ChainId>,
+    /// For each stream this chain writes to, the number of events it contained as of the
+    /// most recent checkpoint. This is the first index that the next checkpoint's
+    /// `summarize_events` call considers un-summarized for that stream.
+    pub event_stream_checkpoint_index: MapView<C, StreamId, u32>,
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C> {
@@ -164,6 +168,10 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
                 .await,
             pending_checkpoint_ack_targets: self
                 .pending_checkpoint_ack_targets
+                .with_context(ctx.clone())
+                .await,
+            event_stream_checkpoint_index: self
+                .event_stream_checkpoint_index
                 .with_context(ctx.clone())
                 .await,
         }

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -132,6 +132,11 @@ type ProcessStreamHandler = Box<
         + Send
         + Sync,
 >;
+type SummarizeEventsHandler = Box<
+    dyn FnOnce(&mut ContractSyncRuntimeHandle, Vec<StreamUpdate>) -> Result<(), ExecutionError>
+        + Send
+        + Sync,
+>;
 type FinalizeHandler =
     Box<dyn FnOnce(&mut ContractSyncRuntimeHandle) -> Result<(), ExecutionError> + Send + Sync>;
 type HandleQueryHandler = Box<
@@ -151,6 +156,8 @@ pub enum ExpectedCall {
     ExecuteMessage(#[debug(skip)] ExecuteMessageHandler),
     /// An expected call to [`UserContract::process_streams`].
     ProcessStreams(#[debug(skip)] ProcessStreamHandler),
+    /// An expected call to [`UserContract::summarize_events`].
+    SummarizeEvents(#[debug(skip)] SummarizeEventsHandler),
     /// An expected call to [`UserContract::finalize`].
     Finalize(#[debug(skip)] FinalizeHandler),
     /// An expected call to [`UserService::handle_query`].
@@ -164,6 +171,7 @@ impl Display for ExpectedCall {
             ExpectedCall::ExecuteOperation(_) => "execute_operation",
             ExpectedCall::ExecuteMessage(_) => "execute_message",
             ExpectedCall::ProcessStreams(_) => "process_streams",
+            ExpectedCall::SummarizeEvents(_) => "summarize_events",
             ExpectedCall::Finalize(_) => "finalize",
             ExpectedCall::HandleQuery(_) => "handle_query",
         };
@@ -218,6 +226,18 @@ impl ExpectedCall {
             + 'static,
     ) -> Self {
         ExpectedCall::ProcessStreams(Box::new(handler))
+    }
+
+    /// Creates an [`ExpectedCall`] to the [`MockApplicationInstance`]'s
+    /// [`UserContract::summarize_events`] implementation, which is handled by the provided
+    /// `handler`.
+    pub fn summarize_events(
+        handler: impl FnOnce(&mut ContractSyncRuntimeHandle, Vec<StreamUpdate>) -> Result<(), ExecutionError>
+            + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        ExpectedCall::SummarizeEvents(Box::new(handler))
     }
 
     /// Creates an [`ExpectedCall`] to the [`MockApplicationInstance`]'s [`UserContract::finalize`]
@@ -315,6 +335,16 @@ impl UserContract for MockApplicationInstance<ContractSyncRuntimeHandle> {
                 "Expected a call to `process_streams`, got a call to `{unexpected_call}` instead."
             ),
             None => panic!("Unexpected call to `process_streams`"),
+        }
+    }
+
+    fn summarize_events(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
+        match self.next_expected_call() {
+            Some(ExpectedCall::SummarizeEvents(handler)) => handler(&mut self.runtime, updates),
+            Some(unexpected_call) => panic!(
+                "Expected a call to `summarize_events`, got a call to `{unexpected_call}` instead."
+            ),
+            None => panic!("Unexpected call to `summarize_events`"),
         }
     }
 

--- a/linera-execution/src/wasm/entrypoints.rs
+++ b/linera-execution/src/wasm/entrypoints.rs
@@ -13,6 +13,7 @@ pub trait ContractEntrypoints {
     fn execute_operation(operation: Vec<u8>) -> Vec<u8>;
     fn execute_message(message: Vec<u8>);
     fn process_streams(streams: Vec<StreamUpdate>);
+    fn summarize_events(streams: Vec<StreamUpdate>);
     fn finalize();
 }
 

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -181,6 +181,14 @@ where
     }
 
     #[instrument(skip_all)]
+    fn summarize_events(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
+        ContractEntrypoints::new(&mut self.instance)
+            .summarize_events(updates)
+            .map_err(WasmExecutionError::from)?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
     fn finalize(&mut self) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .finalize()

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -167,6 +167,14 @@ where
     }
 
     #[instrument(skip_all)]
+    fn summarize_events(&mut self, updates: Vec<StreamUpdate>) -> Result<(), ExecutionError> {
+        ContractEntrypoints::new(&mut self.instance)
+            .summarize_events(updates)
+            .map_err(WasmExecutionError::from)?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
     fn finalize(&mut self) -> Result<(), ExecutionError> {
         ContractEntrypoints::new(&mut self.instance)
             .finalize()

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -98,6 +98,19 @@ macro_rules! contract {
                 )
             }
 
+            fn summarize_events(updates: Vec<
+                $crate::contract::wit::exports::linera::app::contract_entrypoints::StreamUpdate,
+            >) {
+                use $crate::util::BlockingWait as _;
+                $crate::contract::run_async_entrypoint::<$contract, _, _>(
+                    unsafe { &mut CONTRACT },
+                    move |contract| {
+                        let updates = updates.into_iter().map(Into::into).collect();
+                        contract.summarize_events(updates).blocking_wait()
+                    },
+                )
+            }
+
             fn finalize() {
                 use $crate::util::BlockingWait as _;
 

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -133,6 +133,16 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// subscribes to.
     async fn process_streams(&mut self, _updates: Vec<StreamUpdate>) {}
 
+    /// Summarizes the application's own event streams at a checkpoint.
+    ///
+    /// This is called when a checkpoint is created, once for each of the application's own
+    /// streams that published events since the previous checkpoint. The application may emit
+    /// a summary event to such a stream: after the checkpoint, only the latest summary is
+    /// guaranteed to remain available, while older events may eventually be dropped. An
+    /// application that emits no summary lets the stream's older events lapse; a stream that
+    /// is not summarized at a checkpoint is effectively closed.
+    async fn summarize_events(&mut self, _updates: Vec<StreamUpdate>) {}
+
     /// Finishes the execution of the current transaction.
     ///
     /// This is called once at the end of the transaction, to allow all applications that

--- a/linera-sdk/wit/contract-entrypoints.wit
+++ b/linera-sdk/wit/contract-entrypoints.wit
@@ -5,6 +5,7 @@ interface contract-entrypoints {
     execute-operation: func(operation: list<u8>) -> list<u8>;
     execute-message: func(message: list<u8>);
     process-streams: func(streams: list<stream-update>);
+    summarize-events: func(streams: list<stream-update>);
     finalize: func();
 
     record application-id {


### PR DESCRIPTION
## Motivation

Events currently disable checkpoints.

## Proposal

Allow checkpoints on chains with events, as long as they are not _system_ events. (I.e. the admin chain still cannot be checkpointed for now.)

To keep checkpoints from growing indefinitely, events from before the latest checkpoints are not guaranteed to be available anymore. Applications are given the opportunity to publish summary events at each checkpoint.

If an application's summary code fails, the checkpoint block fails. This will be addressed later: https://github.com/linera-io/linera-protocol/issues/6492

## Test Plan

A test was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Part of #460.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
