### PR TITLE
Add historical execution-state hashing behind FLAG_HISTORICAL_HASH(_SHADOW)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5363,7 +5363,6 @@ dependencies = [
  "linera-base",
  "linera-execution",
  "linera-views",
- "linera-views-derive",
  "linera-wasm-instrument",
  "linera-wasmer",
  "linera-wasmer-compiler-singlepass",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4064,7 +4064,6 @@ dependencies = [
  "futures",
  "linera-base",
  "linera-views",
- "linera-views-derive",
  "linera-wasm-instrument",
  "linera-wasmer",
  "linera-wasmer-compiler-singlepass",

--- a/linera-bridge/contracts/evm-bridge/Cargo.lock
+++ b/linera-bridge/contracts/evm-bridge/Cargo.lock
@@ -3401,7 +3401,6 @@ dependencies = [
  "futures",
  "linera-base",
  "linera-views",
- "linera-views-derive",
  "linera-wasm-instrument",
  "linera-wasmer",
  "linera-wasmer-compiler-singlepass",

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -4104,7 +4104,6 @@ dependencies = [
  "futures",
  "linera-base",
  "linera-views",
- "linera-views-derive",
  "linera-wasm-instrument",
  "linera-wasmer",
  "linera-wasmer-compiler-singlepass",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -55,7 +55,6 @@ hex = { workspace = true, optional = true }
 js-sys = { workspace = true, optional = true }
 linera-base = { workspace = true, features = ["reqwest"] }
 linera-views.workspace = true
-linera-views-derive.workspace = true
 linera-witty = { workspace = true, features = ["log", "macros"] }
 lru.workspace = true
 oneshot.workspace = true

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -175,24 +175,11 @@ where
                 self.system.pre_save(&mut batch)?;
                 self.users.pre_save(&mut batch)?;
                 self.stream_event_counts.pre_save(&mut batch)?;
-                Self::make_hash(Some(stored), &batch)?
+                make_historical_hash(Some(stored), &batch)?
             }
         };
         self.historical_hash.set(Some(hash));
         Ok(hash)
-    }
-
-    /// Extends a stored hash with a batch: `SHA3-256(stored || bcs(batch))`. An empty batch
-    /// leaves the hash unchanged. Mirrors `HistoricallyHashableView::make_hash`.
-    fn make_hash(stored: Option<HasherOutput>, batch: &Batch) -> Result<HasherOutput, ViewError> {
-        let stored = stored.unwrap_or_default();
-        if batch.is_empty() {
-            return Ok(stored);
-        }
-        let mut hasher = linera_views::sha3::Sha3_256::default();
-        hasher.update_with_bytes(stored.as_ref())?;
-        hasher.update_with_bcs_bytes(&batch)?;
-        Ok(hasher.finalize())
     }
 
     /// Wraps a raw 32-byte hash into a domain-separated [`CryptoHash`], matching the convention
@@ -203,6 +190,23 @@ where
         impl BcsHashable<'_> for ExecutionStateViewHash {}
         CryptoHash::new(&ExecutionStateViewHash(hash.into()))
     }
+}
+
+/// Extends a stored hash with a batch: `SHA3-256(stored || bcs(batch))`. An empty batch leaves the
+/// hash unchanged. Mirrors `HistoricallyHashableView::make_hash`. Changing this function changes
+/// consensus-visible execution-state hashes — see `make_historical_hash_matches_recorded_value`.
+fn make_historical_hash(
+    stored: Option<HasherOutput>,
+    batch: &Batch,
+) -> Result<HasherOutput, ViewError> {
+    let stored = stored.unwrap_or_default();
+    if batch.is_empty() {
+        return Ok(stored);
+    }
+    let mut hasher = linera_views::sha3::Sha3_256::default();
+    hasher.update_with_bytes(stored.as_ref())?;
+    hasher.update_with_bcs_bytes(&batch)?;
+    Ok(hasher.finalize())
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for ExecutionStateView<C> {
@@ -496,5 +500,44 @@ where
             applications.push((app_id, application_description));
         }
         Ok(applications)
+    }
+}
+
+#[cfg(test)]
+mod historical_hash_tests {
+    use linera_views::{batch::Batch, common::HasherOutput};
+
+    use super::make_historical_hash;
+
+    const RECORDED_CHAIN_HASH: [u8; 32] = [
+        148, 130, 122, 191, 71, 219, 62, 147, 185, 157, 252, 71, 40, 90, 125, 182, 36, 55, 7, 233,
+        90, 114, 77, 56, 106, 151, 21, 246, 183, 174, 65, 74,
+    ];
+
+    /// Golden test pinning the historical-hash chaining primitive. The recorded value is the
+    /// SHA3-256 of `stored || bcs(batch)`; a change to either the algorithm or the `Batch`
+    /// serialization would alter consensus-visible execution-state hashes and break this test
+    /// deliberately.
+    #[test]
+    fn make_historical_hash_matches_recorded_value() {
+        let stored: HasherOutput = [7u8; 32].into();
+        let mut batch = Batch::new();
+        batch.put_key_value_bytes(vec![0, 1, 2], vec![3, 4, 5]);
+        batch.put_key_value_bytes(vec![6, 7], vec![8]);
+
+        let hash = make_historical_hash(Some(stored), &batch).unwrap();
+        assert_eq!(<[u8; 32]>::from(hash), RECORDED_CHAIN_HASH);
+
+        // An empty batch is a no-op: the stored hash is returned unchanged.
+        assert_eq!(
+            make_historical_hash(Some(stored), &Batch::new()).unwrap(),
+            stored,
+        );
+        // A `None` stored hash behaves like all-zeros, so the same batch over `None` differs from
+        // the same batch over a non-zero stored hash.
+        assert_ne!(
+            make_historical_hash(None, &batch).unwrap(),
+            make_historical_hash(Some(stored), &batch).unwrap(),
+        );
     }
 }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -10,6 +10,7 @@ use linera_base::{
     data_types::{BlobContent, BlockHeight, StreamUpdate},
     identifiers::{AccountOwner, BlobId, StreamId},
     time::Instant,
+    visit_allocative_simple,
 };
 use linera_views::{
     batch::Batch,
@@ -58,7 +59,7 @@ pub struct ExecutionStateView<C> {
     /// cheaply from the batch that block persists. Appended last so that existing chains load it
     /// as `None` without moving the storage keys of the other fields, and deliberately excluded
     /// from the hand-written [`HashableView`] impl below (so it never hashes itself).
-    #[allocative(skip)]
+    #[allocative(visit = visit_allocative_simple)]
     pub historical_hash: RegisterView<C, Option<HasherOutput>>,
 }
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -12,14 +12,16 @@ use linera_base::{
     time::Instant,
 };
 use linera_views::{
+    batch::Batch,
+    common::HasherOutput,
     context::Context,
     key_value_store_view::KeyValueStoreView,
     map_view::MapView,
     reentrant_collection_view::HashedReentrantCollectionView,
-    views::{ClonableView, HashableView as _, ReplaceContext, View},
+    register_view::RegisterView,
+    views::{ClonableView, HashableView, Hasher as _, ReplaceContext, View},
     ViewError,
 };
-use linera_views_derive::HashableView;
 #[cfg(with_testing)]
 use {
     crate::{
@@ -36,11 +38,12 @@ use crate::{
     system::SystemExecutionStateView, ApplicationDescription, ApplicationId, BcsHashable,
     Deserialize, ExecutionError, ExecutionRuntimeContext, JsVec, MessageContext, OperationContext,
     ProcessStreamsContext, Query, QueryContext, QueryOutcome, Serialize, ServiceSyncRuntime,
-    Timestamp, TransactionTracker, FLAG_ZERO_HASH,
+    Timestamp, TransactionTracker, FLAG_HISTORICAL_HASH, FLAG_HISTORICAL_HASH_SHADOW,
+    FLAG_ZERO_HASH,
 };
 
 /// A view accessing the execution state of a chain.
-#[derive(Debug, ClonableView, HashableView, Allocative)]
+#[derive(Debug, ClonableView, View, Allocative)]
 #[allocative(bound = "C")]
 pub struct ExecutionStateView<C> {
     /// System application.
@@ -49,6 +52,56 @@ pub struct ExecutionStateView<C> {
     pub users: HashedReentrantCollectionView<C, ApplicationId, KeyValueStoreView<C>>,
     /// The number of events in the streams that this chain is writing to.
     pub stream_event_counts: MapView<C, StreamId, u32>,
+    /// Rolling *historical* hash of the execution state, used when `FLAG_HISTORICAL_HASH`
+    /// (or its shadow variant) is active. `None` until the first block after activation, which
+    /// seeds it from the full content hash (via [`HashableView`]); subsequent blocks extend it
+    /// cheaply from the batch that block persists. Appended last so that existing chains load it
+    /// as `None` without moving the storage keys of the other fields, and deliberately excluded
+    /// from the hand-written [`HashableView`] impl below (so it never hashes itself).
+    #[allocative(skip)]
+    pub historical_hash: RegisterView<C, Option<HasherOutput>>,
+}
+
+/// Selects how [`ExecutionStateView::crypto_hash_mut`] computes the execution-state hash,
+/// based on the feature flags in the current committee's policy.
+#[derive(Clone, Copy, Debug)]
+enum HashingMode {
+    /// Report an all-zeros hash without hashing the state (`FLAG_ZERO_HASH`).
+    Zero,
+    /// Full content hash of the state on every block (the default, legacy behavior).
+    Legacy,
+    /// Rolling historical hash. In shadow mode (`enforce == false`) the hash is computed,
+    /// persisted and logged but the reported hash stays all-zeros.
+    Historical { enforce: bool },
+}
+
+/// Hashes only the content fields of [`ExecutionStateView`], mirroring the `HashableView`
+/// derive but omitting the appended `historical_hash` register. Keeping this by hand means the
+/// rolling hash never feeds back into the content hash that seeds it.
+impl<C> HashableView for ExecutionStateView<C>
+where
+    C: Context + Clone + 'static,
+    C::Extra: ExecutionRuntimeContext,
+{
+    type Hasher = linera_views::sha3::Sha3_256;
+
+    async fn hash_mut(&mut self) -> Result<HasherOutput, ViewError> {
+        use std::io::Write as _;
+        let mut hasher = Self::Hasher::default();
+        hasher.write_all(self.system.hash_mut().await?.as_ref())?;
+        hasher.write_all(self.users.hash_mut().await?.as_ref())?;
+        hasher.write_all(self.stream_event_counts.hash_mut().await?.as_ref())?;
+        Ok(hasher.finalize())
+    }
+
+    async fn hash(&self) -> Result<HasherOutput, ViewError> {
+        use std::io::Write as _;
+        let mut hasher = Self::Hasher::default();
+        hasher.write_all(self.system.hash().await?.as_ref())?;
+        hasher.write_all(self.users.hash().await?.as_ref())?;
+        hasher.write_all(self.stream_event_counts.hash().await?.as_ref())?;
+        Ok(hasher.finalize())
+    }
 }
 
 impl<C> ExecutionStateView<C>
@@ -57,26 +110,98 @@ where
     C::Extra: ExecutionRuntimeContext,
 {
     pub async fn crypto_hash_mut(&mut self) -> Result<CryptoHash, ViewError> {
-        if self
-            .system
-            .current_committee()
-            .await?
-            .is_some_and(|(_epoch, committee)| {
-                committee
-                    .policy()
-                    .http_request_allow_list
-                    .contains(FLAG_ZERO_HASH)
-            })
-        {
-            Ok(CryptoHash::from([0; 32]))
-        } else {
-            #[derive(Serialize, Deserialize)]
-            struct ExecutionStateViewHash([u8; 32]);
-            impl BcsHashable<'_> for ExecutionStateViewHash {}
-            self.hash_mut()
-                .await
-                .map(|hash| CryptoHash::new(&ExecutionStateViewHash(hash.into())))
+        match self.hashing_mode().await? {
+            HashingMode::Zero => Ok(CryptoHash::from([0; 32])),
+            HashingMode::Legacy => {
+                let hash = self.hash_mut().await?;
+                Ok(Self::wrap_state_hash(hash))
+            }
+            HashingMode::Historical { enforce } => {
+                let hash = self.advance_historical_hash().await?;
+                let wrapped = Self::wrap_state_hash(hash);
+                if enforce {
+                    Ok(wrapped)
+                } else {
+                    // Shadow mode: populate and surface the rolling hash so it can be compared
+                    // across validators, but keep reporting an all-zeros hash so that it is not
+                    // yet enforced in consensus.
+                    tracing::info!(
+                        chain_id = %self.context().extra().chain_id(),
+                        historical_state_hash = %wrapped,
+                        "computed historical execution-state hash in shadow mode",
+                    );
+                    Ok(CryptoHash::from([0; 32]))
+                }
+            }
         }
+    }
+
+    /// Decides which hashing scheme applies, based on the feature flags in the current
+    /// committee's content policy. With no active committee, falls back to legacy hashing
+    /// (matching the previous behavior).
+    async fn hashing_mode(&self) -> Result<HashingMode, ViewError> {
+        let Some((_epoch, committee)) = self.system.current_committee().await? else {
+            return Ok(HashingMode::Legacy);
+        };
+        let flags = &committee.policy().http_request_allow_list;
+        let mode = if flags.contains(FLAG_ZERO_HASH) {
+            HashingMode::Zero
+        } else if flags.contains(FLAG_HISTORICAL_HASH) {
+            HashingMode::Historical { enforce: true }
+        } else if flags.contains(FLAG_HISTORICAL_HASH_SHADOW) {
+            HashingMode::Historical { enforce: false }
+        } else {
+            HashingMode::Legacy
+        };
+        Ok(mode)
+    }
+
+    /// Computes the next rolling historical hash and stores it in `historical_hash`.
+    ///
+    /// On the first block after activation (`historical_hash` is `None`) the hash is seeded from
+    /// a full content hash of the state, which — because [`HashableView::hash_mut`] reflects the
+    /// in-memory state — already includes this block's changes. Every subsequent block extends
+    /// the stored hash with the batch it is about to persist, so the cost is proportional to the
+    /// block's writes rather than the whole state.
+    async fn advance_historical_hash(&mut self) -> Result<HasherOutput, ViewError> {
+        let hash = match *self.historical_hash.get() {
+            None => self.hash_mut().await?,
+            Some(stored) => {
+                // Hash only the content fields' pending writes. The `historical_hash` register is
+                // intentionally excluded so the rolling hash never depends on its own value (it
+                // may still be a pending, unsaved write at this point). This mirrors `main`, where
+                // the wrapper's hash key sits outside the hashed inner view.
+                let mut batch = Batch::new();
+                self.system.pre_save(&mut batch)?;
+                self.users.pre_save(&mut batch)?;
+                self.stream_event_counts.pre_save(&mut batch)?;
+                Self::make_hash(Some(stored), &batch)?
+            }
+        };
+        self.historical_hash.set(Some(hash));
+        Ok(hash)
+    }
+
+    /// Extends a stored hash with a batch: `SHA3-256(stored || bcs(batch))`. An empty batch
+    /// leaves the hash unchanged. Mirrors `HistoricallyHashableView::make_hash`.
+    fn make_hash(stored: Option<HasherOutput>, batch: &Batch) -> Result<HasherOutput, ViewError> {
+        let stored = stored.unwrap_or_default();
+        if batch.is_empty() {
+            return Ok(stored);
+        }
+        let mut hasher = linera_views::sha3::Sha3_256::default();
+        hasher.update_with_bytes(stored.as_ref())?;
+        hasher.update_with_bcs_bytes(&batch)?;
+        Ok(hasher.finalize())
+    }
+
+    /// Wraps a raw 32-byte hash into a domain-separated [`CryptoHash`], matching the convention
+    /// used on `main` for the execution-state hash.
+    fn wrap_state_hash(hash: HasherOutput) -> CryptoHash {
+        #[derive(Serialize, Deserialize)]
+        struct ExecutionStateViewHash([u8; 32]);
+        impl BcsHashable<'_> for ExecutionStateViewHash {}
+        CryptoHash::new(&ExecutionStateViewHash(hash.into()))
     }
 }
 
@@ -91,6 +216,7 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for ExecutionStateView<C> {
             system: self.system.with_context(ctx.clone()).await,
             users: self.users.with_context(ctx.clone()).await,
             stream_event_counts: self.stream_event_counts.with_context(ctx.clone()).await,
+            historical_hash: self.historical_hash.with_context(ctx.clone()).await,
         }
     }
 }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -111,8 +111,12 @@ where
 {
     pub async fn crypto_hash_mut(&mut self) -> Result<CryptoHash, ViewError> {
         match self.hashing_mode().await? {
-            HashingMode::Zero => Ok(CryptoHash::from([0; 32])),
+            HashingMode::Zero => {
+                self.reset_historical_hash();
+                Ok(CryptoHash::from([0; 32]))
+            }
             HashingMode::Legacy => {
+                self.reset_historical_hash();
                 let hash = self.hash_mut().await?;
                 Ok(Self::wrap_state_hash(hash))
             }
@@ -180,6 +184,16 @@ where
         };
         self.historical_hash.set(Some(hash));
         Ok(hash)
+    }
+
+    /// Drops any stored rolling hash while historical hashing is inactive. This keeps inactive
+    /// chains free of stale state and, crucially, forces a fresh full-content re-seed if historical
+    /// hashing is ever re-activated: otherwise the chain would be extended from a hash that predates
+    /// the blocks executed while it was inactive, which no longer reflects the state.
+    fn reset_historical_hash(&mut self) {
+        if self.historical_hash.get().is_some() {
+            self.historical_hash.set(None);
+        }
     }
 
     /// Wraps a raw 32-byte hash into a domain-separated [`CryptoHash`], matching the convention

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -88,19 +88,31 @@ where
 
     async fn hash_mut(&mut self) -> Result<HasherOutput, ViewError> {
         use std::io::Write as _;
+        let Self {
+            system,
+            users,
+            stream_event_counts,
+            historical_hash: _,
+        } = self;
         let mut hasher = Self::Hasher::default();
-        hasher.write_all(self.system.hash_mut().await?.as_ref())?;
-        hasher.write_all(self.users.hash_mut().await?.as_ref())?;
-        hasher.write_all(self.stream_event_counts.hash_mut().await?.as_ref())?;
+        hasher.write_all(system.hash_mut().await?.as_ref())?;
+        hasher.write_all(users.hash_mut().await?.as_ref())?;
+        hasher.write_all(stream_event_counts.hash_mut().await?.as_ref())?;
         Ok(hasher.finalize())
     }
 
     async fn hash(&self) -> Result<HasherOutput, ViewError> {
         use std::io::Write as _;
+        let Self {
+            system,
+            users,
+            stream_event_counts,
+            historical_hash: _,
+        } = self;
         let mut hasher = Self::Hasher::default();
-        hasher.write_all(self.system.hash().await?.as_ref())?;
-        hasher.write_all(self.users.hash().await?.as_ref())?;
-        hasher.write_all(self.stream_event_counts.hash().await?.as_ref())?;
+        hasher.write_all(system.hash().await?.as_ref())?;
+        hasher.write_all(users.hash().await?.as_ref())?;
+        hasher.write_all(stream_event_counts.hash().await?.as_ref())?;
         Ok(hasher.finalize())
     }
 }
@@ -172,14 +184,20 @@ where
         let hash = match *self.historical_hash.get() {
             None => self.hash_mut().await?,
             Some(stored) => {
-                // Hash only the content fields' pending writes. The `historical_hash` register is
-                // intentionally excluded so the rolling hash never depends on its own value (it
-                // may still be a pending, unsaved write at this point). This mirrors `main`, where
-                // the wrapper's hash key sits outside the hashed inner view.
+                // Hash only the content fields' pending writes. `historical_hash` is intentionally
+                // excluded so the rolling hash never depends on its own (possibly still pending)
+                // value. This mirrors `main`, where the wrapper's hash key sits outside the hashed
+                // inner view.
+                let Self {
+                    system,
+                    users,
+                    stream_event_counts,
+                    historical_hash: _,
+                } = self;
                 let mut batch = Batch::new();
-                self.system.pre_save(&mut batch)?;
-                self.users.pre_save(&mut batch)?;
-                self.stream_event_counts.pre_save(&mut batch)?;
+                system.pre_save(&mut batch)?;
+                users.pre_save(&mut batch)?;
+                stream_event_counts.pre_save(&mut batch)?;
                 make_historical_hash(Some(stored), &batch)?
             }
         };

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -93,6 +93,19 @@ const MAX_STREAM_NAME_LEN: usize = 64;
 /// returned to be all zeros.
 // Note: testnet-only! This should not survive to mainnet.
 pub const FLAG_ZERO_HASH: &str = "FLAG_ZERO_HASH.linera.network";
+/// The flag that, if present in `http_request_allow_list` field of the content policy of the
+/// current committee, switches the execution-state hash to *historical hashing*: the first block
+/// after activation seeds the rolling hash from a full content hash (via [`HashableView`]), and
+/// every subsequent block extends it cheaply from the written batch. Takes effect only when
+/// `FLAG_ZERO_HASH` is absent. Enforced in consensus.
+// Note: testnet-only! This should not survive to mainnet.
+pub const FLAG_HISTORICAL_HASH: &str = "FLAG_HISTORICAL_HASH.linera.network";
+/// Like [`FLAG_HISTORICAL_HASH`], but in *shadow* mode: the rolling historical hash is computed,
+/// persisted and logged, yet the state hash reported to consensus stays all-zeros. This lets a
+/// network populate and cross-check historical hashes across validators (comparing the logged
+/// values) before enforcing them. Ignored if `FLAG_ZERO_HASH` or `FLAG_HISTORICAL_HASH` is present.
+// Note: testnet-only! This should not survive to mainnet.
+pub const FLAG_HISTORICAL_HASH_SHADOW: &str = "FLAG_HISTORICAL_HASH_SHADOW.linera.network";
 /// The flag that deactivates charging for bouncing messages. If this is present, outgoing
 /// messages are free of charge if they are bouncing, and operation outcomes are counted only
 /// by payload size, so that rejecting messages is free.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -95,7 +95,7 @@ const MAX_STREAM_NAME_LEN: usize = 64;
 pub const FLAG_ZERO_HASH: &str = "FLAG_ZERO_HASH.linera.network";
 /// The flag that, if present in `http_request_allow_list` field of the content policy of the
 /// current committee, switches the execution-state hash to *historical hashing*: the first block
-/// after activation seeds the rolling hash from a full content hash (via [`HashableView`]), and
+/// after activation seeds the rolling hash from a full content hash (via `HashableView`), and
 /// every subsequent block extends it cheaply from the written batch. Takes effect only when
 /// `FLAG_ZERO_HASH` is absent. Enforced in consensus.
 // Note: testnet-only! This should not survive to mainnet.

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -237,14 +237,71 @@ async fn historical_hashing_is_deterministic() -> anyhow::Result<()> {
         Ok((seed, chained))
     }
 
-    let (seed_a, chained_a) = run(42).await?;
-    let (seed_b, chained_b) = run(42).await?;
+    let (seed_a, chained_a) = Box::pin(run(42)).await?;
+    let (seed_b, chained_b) = Box::pin(run(42)).await?;
     assert_eq!(seed_a, seed_b);
     assert_eq!(chained_a, chained_b);
 
-    let (seed_c, chained_c) = run(99).await?;
+    let (seed_c, chained_c) = Box::pin(run(99)).await?;
     assert_eq!(seed_a, seed_c); // seed is computed before the differing mutation
     assert_ne!(chained_a, chained_c); // the differing mutation changes the chained hash
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn historical_hashing_persists_and_chains_across_reload() -> anyhow::Result<()> {
+    use linera_views::{
+        batch::Batch, context::Context as _, store::WritableKeyValueStore as _, views::View as _,
+    };
+
+    // Flushes a view's pending changes to its (shared) store and clears the in-memory dirty state,
+    // exactly as the core save lifecycle does between blocks.
+    async fn save(view: &mut ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>) {
+        let mut batch = Batch::new();
+        view.pre_save(&mut batch).unwrap();
+        view.context().store().write_batch(batch).await.unwrap();
+        view.post_save();
+    }
+
+    // The committee lives in a `HashedLazyRegisterView`, which the ad-hoc `save` helper above does
+    // not round-trip (production persists the whole `RootView`). So the enforce flag is
+    // re-installed in memory after every reload; this is a test-harness concern, not a property of
+    // the historical hashing itself, whose rolling hash lives in a plain `RegisterView`.
+    let zero_hash = CryptoHash::from([0u8; 32]);
+
+    // Persist a chain's pre-activation content. The `historical_hash` register is never written,
+    // mirroring a chain created before activation.
+    let (mut view, _) = new_view_and_context().await;
+    let context = view.context().clone();
+    save(&mut view).await;
+
+    // Reload as a pre-activation chain: the appended field is absent in storage, so it loads as
+    // `None` without any migration (format compatibility).
+    let mut view = ExecutionStateView::load(context.clone()).await?;
+    assert!(view.historical_hash.get().is_none());
+
+    // Block 1 — seed, then persist and reload. The seeded rolling hash must survive the round-trip.
+    install_committee_with_flag(&mut view, FLAG_HISTORICAL_HASH);
+    let seed = view.crypto_hash_mut().await?;
+    assert_ne!(seed, zero_hash);
+    let seed_raw = *view.historical_hash.get();
+    assert!(seed_raw.is_some());
+    save(&mut view).await;
+    let mut view = ExecutionStateView::load(context.clone()).await?;
+    assert_eq!(*view.historical_hash.get(), seed_raw); // rolling hash round-trips
+
+    // Block 2 — mutate and chain *from the reloaded* stored hash. The result differs from the seed
+    // (the chain advanced) and persists across the next reload.
+    install_committee_with_flag(&mut view, FLAG_HISTORICAL_HASH);
+    view.system.timestamp.set(Timestamp::from(42));
+    let chained = view.crypto_hash_mut().await?;
+    assert_ne!(chained, seed);
+    assert_ne!(chained, zero_hash);
+    let chained_raw = *view.historical_hash.get();
+    save(&mut view).await;
+    let view = ExecutionStateView::load(context.clone()).await?;
+    assert_eq!(*view.historical_hash.get(), chained_raw);
 
     Ok(())
 }

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -225,6 +225,22 @@ async fn historical_hashing_shadow_reports_zero_but_advances() -> anyhow::Result
 }
 
 #[tokio::test]
+async fn legacy_hash_matches_pre_change_value() -> anyhow::Result<()> {
+    // Regression golden: with no historical/zero flag, `crypto_hash_mut` must reproduce exactly the
+    // value the pre-change `#[derive(HashableView)]` implementation produced for this fixed state.
+    // The constant was captured from the `testnet_conway` base (commit 801ca8f118) before this
+    // change. Any drift here would silently change the legacy execution-state hash, which is
+    // consensus-breaking, so this test must only change deliberately.
+    let (mut view, _) = new_view_and_context().await;
+    let recorded = CryptoHash::from([
+        146, 2, 171, 91, 66, 52, 95, 140, 217, 91, 65, 171, 135, 96, 184, 168, 137, 188, 74, 230,
+        101, 129, 37, 163, 165, 5, 233, 111, 203, 213, 151, 165,
+    ]);
+    assert_eq!(view.crypto_hash_mut().await?, recorded);
+    Ok(())
+}
+
+#[tokio::test]
 async fn historical_hashing_resets_when_deactivated() -> anyhow::Result<()> {
     let zero_hash = CryptoHash::from([0u8; 32]);
     let (mut view, _) = new_view_and_context().await;

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -225,6 +225,30 @@ async fn historical_hashing_shadow_reports_zero_but_advances() -> anyhow::Result
 }
 
 #[tokio::test]
+async fn historical_hashing_resets_when_deactivated() -> anyhow::Result<()> {
+    let zero_hash = CryptoHash::from([0u8; 32]);
+    let (mut view, _) = new_view_and_context().await;
+
+    // Activate and seed: the rolling hash is populated.
+    install_committee_with_flag(&mut view, FLAG_HISTORICAL_HASH);
+    assert_ne!(view.crypto_hash_mut().await?, zero_hash);
+    assert!(view.historical_hash.get().is_some());
+
+    // Deactivate (back to zero-hashing): the stored rolling hash is dropped so it cannot be
+    // extended later from a stale anchor.
+    install_committee_with_flag(&mut view, FLAG_ZERO_HASH);
+    assert_eq!(view.crypto_hash_mut().await?, zero_hash);
+    assert!(view.historical_hash.get().is_none());
+
+    // Re-activate: a fresh seed is produced (non-zero, populated again).
+    install_committee_with_flag(&mut view, FLAG_HISTORICAL_HASH);
+    assert_ne!(view.crypto_hash_mut().await?, zero_hash);
+    assert!(view.historical_hash.get().is_some());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn historical_hashing_is_deterministic() -> anyhow::Result<()> {
     // Two runs with identical state and identical operations must agree; a different operation
     // must diverge.

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::data_types::{Blob, BlockHeight, Bytecode};
+use linera_base::data_types::{Blob, BlockHeight, Bytecode, Timestamp};
 #[cfg(with_testing)]
 use linera_base::vm::VmRuntime;
 use linera_views::context::MemoryContext;
@@ -9,7 +9,7 @@ use linera_views::context::MemoryContext;
 use super::*;
 use crate::{
     test_utils::dummy_chain_description, ExecutionStateView, TestExecutionRuntimeContext,
-    FLAG_ZERO_HASH,
+    FLAG_HISTORICAL_HASH, FLAG_HISTORICAL_HASH_SHADOW, FLAG_ZERO_HASH,
 };
 
 /// Returns an execution state view and a matching operation context, for epoch 1, with root
@@ -158,6 +158,93 @@ async fn hashing_test() -> anyhow::Result<()> {
     view.system.epoch.set(Epoch(1));
     // Starting from this epoch, the hash should be all zeros.
     assert_eq!(view.crypto_hash_mut().await?, zero_hash);
+
+    Ok(())
+}
+
+/// Installs a single committee at epoch 1 (the epoch `new_view_and_context` uses) whose content
+/// policy carries `flag`, so that `crypto_hash_mut` selects the corresponding hashing mode.
+fn install_committee_with_flag(
+    view: &mut ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>,
+    flag: &str,
+) {
+    let mut committee = Committee::default();
+    committee
+        .policy_mut()
+        .http_request_allow_list
+        .insert(flag.to_owned());
+    let mut committees = BTreeMap::new();
+    committees.insert(Epoch(1), committee);
+    view.system.committees.set(committees);
+    view.system.epoch.set(Epoch(1));
+}
+
+#[tokio::test]
+async fn historical_hashing_enforce_seeds_then_chains() -> anyhow::Result<()> {
+    let zero_hash = CryptoHash::from([0u8; 32]);
+    let (mut view, _) = new_view_and_context().await;
+    install_committee_with_flag(&mut view, FLAG_HISTORICAL_HASH);
+
+    // The first block seeds the rolling hash: a non-zero hash is reported and the register is
+    // populated.
+    assert!(view.historical_hash.get().is_none());
+    let seed = view.crypto_hash_mut().await?;
+    assert_ne!(seed, zero_hash);
+    let seed_raw = *view.historical_hash.get();
+    assert!(seed_raw.is_some());
+
+    // A later block with a content change extends the chain: a different, still non-zero hash,
+    // and the stored rolling hash advances.
+    view.system.timestamp.set(Timestamp::from(42));
+    let chained = view.crypto_hash_mut().await?;
+    assert_ne!(chained, zero_hash);
+    assert_ne!(chained, seed);
+    assert_ne!(*view.historical_hash.get(), seed_raw);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn historical_hashing_shadow_reports_zero_but_advances() -> anyhow::Result<()> {
+    let zero_hash = CryptoHash::from([0u8; 32]);
+    let (mut view, _) = new_view_and_context().await;
+    install_committee_with_flag(&mut view, FLAG_HISTORICAL_HASH_SHADOW);
+
+    // Shadow mode reports an all-zeros hash to consensus...
+    let reported = view.crypto_hash_mut().await?;
+    assert_eq!(reported, zero_hash);
+    // ...yet still computes and stores the rolling hash for cross-validator comparison.
+    let seed_raw = *view.historical_hash.get();
+    assert!(seed_raw.is_some());
+
+    view.system.timestamp.set(Timestamp::from(42));
+    assert_eq!(view.crypto_hash_mut().await?, zero_hash);
+    assert_ne!(*view.historical_hash.get(), seed_raw);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn historical_hashing_is_deterministic() -> anyhow::Result<()> {
+    // Two runs with identical state and identical operations must agree; a different operation
+    // must diverge.
+    async fn run(timestamp: u64) -> anyhow::Result<(CryptoHash, CryptoHash)> {
+        let (mut view, _) = new_view_and_context().await;
+        install_committee_with_flag(&mut view, FLAG_HISTORICAL_HASH);
+        let seed = view.crypto_hash_mut().await?;
+        view.system.timestamp.set(Timestamp::from(timestamp));
+        let chained = view.crypto_hash_mut().await?;
+        Ok((seed, chained))
+    }
+
+    let (seed_a, chained_a) = run(42).await?;
+    let (seed_b, chained_b) = run(42).await?;
+    assert_eq!(seed_a, seed_b);
+    assert_eq!(chained_a, chained_b);
+
+    let (seed_c, chained_c) = run(99).await?;
+    assert_eq!(seed_a, seed_c); // seed is computed before the differing mutation
+    assert_ne!(chained_a, chained_c); // the differing mutation changes the chained hash
 
     Ok(())
 }

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2350,7 +2350,6 @@ dependencies = [
  "futures",
  "linera-base",
  "linera-views",
- "linera-views-derive",
  "linera-wasm-instrument",
  "linera-wasmer",
  "linera-wasmer-compiler-singlepass",


### PR DESCRIPTION
## Motivation

`testnet_conway` currently runs with `FLAG_ZERO_HASH`, which skips execution-state hashing
entirely (the reported `state_hash` is all-zeros). We want to switch the network to *historical
hashing* — a rolling hash that is seeded once from a full content hash and then extended cheaply
from each block's write batch — without breaking the existing storage format and without a
network-wide migration or reset.

Wrapping `ExecutionStateView` directly in `HistoricallyHashableView` is not viable here: that
wrapper re-tags the inner view under `KeyTag::Inner`, shifting every existing execution-state key
by one prefix byte, which would require migrating every chain's storage.

## Proposal

Add historical hashing to `ExecutionStateView` *in place*, gated by new committee-policy flags, so
the storage layout of the existing fields is unchanged:

- New flags (parallel to `FLAG_ZERO_HASH`):
  - `FLAG_HISTORICAL_HASH` — enforced historical hashing.
  - `FLAG_HISTORICAL_HASH_SHADOW` — compute, persist and log the rolling hash, but keep reporting
    an all-zeros hash so it is **not** enforced in consensus. This lets validators cross-check
    their historical hashes (by comparing the logged values) before enforcement.
- `ExecutionStateView` now derives `View` (instead of `HashableView`) and gains an appended
  `historical_hash: RegisterView<C, Option<HasherOutput>>`. Appending the field gives it a fresh
  key tag, so existing chains load it as `None` with no migration and no movement of the other
  fields' keys. `HashableView` is hand-written over only the content fields so the rolling hash
  never feeds back into the content hash that seeds it.
- `crypto_hash_mut` selects a mode from the current committee's policy:
  - **Zero** (`FLAG_ZERO_HASH`) — unchanged.
  - **Historical** — on the first block after activation (`historical_hash == None`) the hash is
    seeded from the full content hash via `HashableView::hash_mut` (which already reflects this
    block's changes); every later block extends the stored hash with `SHA3-256(stored || bcs(batch))`
    over only the content fields' pending writes. In shadow mode the value is computed, stored and
    logged but a zero hash is reported.
  - **Legacy** — the previous full-content hash (value unchanged from before).
  - In both **Zero** and **Legacy** modes the stored rolling hash is dropped if present, so a chain
    that is deactivated and later re-activated re-seeds from a fresh full-content hash rather than
    extending a stale anchor that predates the blocks executed while it was inactive. Chains that
    were never activated store nothing (a `None` register writes no key).

The hashing convention mirrors `main` (same `ExecutionStateViewHash` wrapping and `make_hash`
chaining), with the one deliberate difference that the seed reuses the existing `HashableView`
content hash rather than `main`'s `dump_content` byte-scan.

## Test Plan

New unit tests in `linera-execution` (all green; `cargo clippy` and nightly `cargo fmt` clean):

- `historical_hashing_enforce_seeds_then_chains` — first block seeds (non-zero, populates the
  register); a later content change extends the chain to a different non-zero hash.
- `historical_hashing_shadow_reports_zero_but_advances` — shadow mode reports zero but still
  advances the stored rolling hash.
- `historical_hashing_is_deterministic` — identical state + operations agree; a differing
  operation diverges.
- `historical_hashing_resets_when_deactivated` — activate→seed, deactivate (rolling hash dropped),
  re-activate (re-seeded), confirming reactivation does not extend a stale anchor.
- `historical_hashing_persists_and_chains_across_reload` — e2e through the save/reload lifecycle:
  an existing chain loads the appended field as `None` (format compatibility), then the rolling
  hash is seeded, persisted, reloaded, chained across the reload boundary, and persisted again.
- `make_historical_hash_matches_recorded_value` — golden test pinning the chaining primitive to a
  recorded value, so any change to the algorithm or `Batch` serialization (i.e. any
  consensus-visible hash change) fails deliberately.

Rollout sequence on the live network: deploy → reconfigure to `FLAG_HISTORICAL_HASH_SHADOW` and
compare the logged `historical_state_hash` across validators for an epoch (this also surfaces any
latent execution-state divergence as a log mismatch rather than a chain halt) → reconfigure to
`FLAG_HISTORICAL_HASH` to enforce.

## Release Plan

- This PR targets `testnet_conway` directly, so there is nothing to backport. The new flags are
  testnet-only (like `FLAG_ZERO_HASH`, they should not survive to mainnet), so they are **not**
  intended to be forward-ported to `main`.
- No new SDK or storage migration is required: the appended `historical_hash` field loads as
  `None` on existing chains and stores nothing until activated.
- Activation is gated behind a committee-policy flag and changes the consensus-visible `state_hash`
  once enabled, so it is rolled out network-wide via a validator reconfiguration (shadow first,
  then enforce).

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
