### PR TITLE
Process cross-chain batches through chain_write (cancellation-safe save + poison recovery)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1280,7 +1280,10 @@ where
     ///
     /// Both update and confirmation requests are handled together so that a
     /// single write-lock acquisition covers all pending work for the chain.
-    pub(crate) async fn process_batch(&mut self, requests: Vec<BatchRequest>) {
+    pub(crate) async fn process_batch(
+        &mut self,
+        requests: Vec<BatchRequest>,
+    ) -> Result<(), WorkerError> {
         let mut update_results = Vec::new();
         let mut confirm_results = Vec::new();
         let mut need_save = false;
@@ -1348,10 +1351,12 @@ where
                 }
             }
         }
+        let mut save_error = None;
         if !need_rollback && need_save {
             if let Err(error) = self.save().await {
                 tracing::error!(%error, "failed to save batch; rolling back");
                 need_rollback = true;
+                save_error = Some(error);
             }
         }
         if need_rollback {
@@ -1361,7 +1366,14 @@ where
             for (result_sender, _) in confirm_results {
                 send_result(result_sender, Err(WorkerError::BatchRolledBack));
             }
-            return;
+            // Surface a *save* failure to the caller so `chain_write` can evict or
+            // reset the worker if it was left poisoned or corrupted. Processing
+            // errors that also trigger a rollback were already reported to their
+            // individual senders and leave the worker healthy, so they return `Ok`.
+            return match save_error {
+                Some(error) => Err(error),
+                None => Ok(()),
+            };
         }
 
         if let Some(height) = max_delivered_height {
@@ -1377,6 +1389,7 @@ where
                 .await;
             send_result(result_sender, result);
         }
+        Ok(())
     }
 
     /// Handles a `RevertConfirm` request: walks backward through

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -64,10 +64,8 @@ impl<S: Storage> std::ops::Deref for ChainStateViewReadGuard<S> {
 pub(crate) use crate::chain_worker::EventSubscriptionsResult;
 use crate::{
     chain_worker::{
-        handle,
-        state::{send_result, ChainWorkerState},
-        BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult, DeliveryNotifier,
-        ProcessConfirmedBlockMode,
+        handle, state::ChainWorkerState, BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult,
+        DeliveryNotifier, ProcessConfirmedBlockMode,
     },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -588,8 +586,9 @@ pub(crate) enum BatchRequest {
 ///
 /// Wrapped in `Shared<BatchFuture>` so that all tasks waiting for
 /// cross-chain operations on the same chain can cooperatively poll a
-/// single driver. The driver loops: wait for an item from the request channel, acquire the
-/// write lock, drain the channel, process all requests in one batch, repeat.
+/// single driver. The driver loops: wait for an item from the request channel,
+/// drain the channel, then process all requests in one batch through
+/// [`WorkerState::chain_write`] (one write lock, one save), repeat.
 #[cfg(not(web))]
 type BatchFuture = pin::Pin<Box<dyn Future<Output = ()> + Send>>;
 #[cfg(web)]
@@ -606,7 +605,8 @@ struct ChainBatchRequestProcessor {
 
 impl ChainBatchRequestProcessor {
     fn create<StorageClient>(
-        state: ChainWorkerArc<StorageClient>,
+        worker: WorkerState<StorageClient>,
+        chain_id: ChainId,
         batch_size_limit: usize,
     ) -> (ChainBatchRequestProcessor, Shared<BatchFuture>)
     where
@@ -616,31 +616,31 @@ impl ChainBatchRequestProcessor {
         let future: BatchFuture = Box::pin(async move {
             while let Some(first) = receiver.recv().await {
                 let mut requests = vec![first];
-                match handle::write_lock(&state).await {
-                    Ok(mut guard) => {
-                        while requests.len() < batch_size_limit {
-                            match receiver.try_recv() {
-                                Ok(request) => requests.push(request),
-                                Err(_) => break,
-                            }
-                        }
-                        #[cfg(with_metrics)]
-                        metrics::CROSS_CHAIN_BATCH_SIZE.observe(requests.len() as f64);
+                while requests.len() < batch_size_limit {
+                    match receiver.try_recv() {
+                        Ok(request) => requests.push(request),
+                        Err(_) => break,
+                    }
+                }
+                #[cfg(with_metrics)]
+                metrics::CROSS_CHAIN_BATCH_SIZE.observe(requests.len() as f64);
+                // Process the batch through `chain_write` so it inherits the same
+                // cancellation safety (the write and `save` run on a detached task)
+                // and recovery (poisoned-worker eviction / corrupted-state reset) as
+                // every other write path, rather than duplicating that logic here.
+                // `process_batch` reports a result to each request's sender on every
+                // internal path; an `Err` here means `chain_write` failed *before*
+                // running the closure — a worker load error, or an already-poisoned
+                // worker that it has now evicted. In that case the request senders are
+                // dropped, which `enqueue_and_drive` surfaces to callers as
+                // `PoisonedWorker`.
+                if let Err(error) = worker
+                    .chain_write(chain_id, move |mut guard| async move {
                         guard.process_batch(requests).await
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "failed to obtain write lock");
-                        for request in requests {
-                            match request {
-                                BatchRequest::Update { result_sender, .. } => {
-                                    send_result(result_sender, Err(WorkerError::PoisonedWorker));
-                                }
-                                BatchRequest::Confirm { result_sender, .. } => {
-                                    send_result(result_sender, Err(WorkerError::PoisonedWorker));
-                                }
-                            }
-                        }
-                    }
+                    })
+                    .await
+                {
+                    tracing::warn!(%chain_id, %error, "cross-chain batch could not be processed");
                 }
             }
         });
@@ -1112,9 +1112,9 @@ where
                 return Ok((batch_processor.sender.clone(), future));
             }
         }
-        let state = self.get_or_create_chain_worker(chain_id).await?;
         let (new_request_processor, new_future) = ChainBatchRequestProcessor::create(
-            state,
+            self.clone(),
+            chain_id,
             self.chain_worker_config.cross_chain_batch_size_limit,
         );
         match self
@@ -1449,7 +1449,12 @@ where
             // return it immediately without driving the batch future further.
             match future::select(pin::pin!(&mut receiver), future).await {
                 Either::Left((result, _)) => {
-                    return result.expect("batch result sender dropped");
+                    // `Ok(inner)` is the normal reply. `Err(Canceled)` means the
+                    // sender was dropped without one — `chain_write` failed before
+                    // `process_batch` ran (e.g. an already-poisoned worker, which it
+                    // has now evicted). Surface it as `PoisonedWorker`; the next
+                    // attempt loads a fresh worker.
+                    return result.unwrap_or(Err(WorkerError::PoisonedWorker));
                 }
                 Either::Right(((), _)) => match receiver.try_recv() {
                     Ok(result) => return result,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -976,6 +976,15 @@ where
     /// until the DB round-trip and `post_save` have fully completed — subsequent
     /// readers, including a freshly-loaded replacement worker, only see the
     /// committed state.
+    ///
+    /// The outcome inspection and recovery dispatch (poisoned-worker eviction and
+    /// corrupted-state reset) also run *inside* the detached task. Otherwise, if the
+    /// caller dropped this future after the detached write produced a recoverable
+    /// error but before the outer `.await` resumed, the recovery would be skipped: a
+    /// `CorruptedChainState` error neither poisons nor evicts the worker, so the chain
+    /// would be left at a partial tip serving stale reads with no `RevertConfirm`
+    /// retransmission. Running recovery in the detached task makes it survive caller
+    /// cancellation, just like the write itself.
     async fn chain_write<R, F, Fut>(&self, chain_id: ChainId, f: F) -> Result<R, WorkerError>
     where
         F: FnOnce(handle::RollbackGuard<StorageClient>) -> Fut
@@ -985,20 +994,23 @@ where
         R: linera_base::task::MaybeSend + 'static,
     {
         let state = self.get_or_create_chain_worker(chain_id).await?;
-        let state_for_task = state.clone();
-        let result = Box::pin(wrap_future(linera_base::task::run_detached(async move {
-            let guard = handle::write_lock(&state_for_task).await?;
-            f(guard).await
-        })))
-        .await;
-        if let Err(error) = &result {
-            if error.must_reload_view() {
-                self.evict_poisoned_worker(chain_id, &state);
-            } else if error.indicates_corrupted_chain_state() {
-                self.spawn_reset_corrupted_chain_state(chain_id, state);
+        let this = self.clone();
+        Box::pin(wrap_future(linera_base::task::run_detached(async move {
+            let result = async {
+                let guard = handle::write_lock(&state).await?;
+                f(guard).await
             }
-        }
-        result
+            .await;
+            if let Err(error) = &result {
+                if error.must_reload_view() {
+                    this.evict_poisoned_worker(chain_id, &state);
+                } else if error.indicates_corrupted_chain_state() {
+                    this.spawn_reset_corrupted_chain_state(chain_id, state);
+                }
+            }
+            result
+        })))
+        .await
     }
 
     /// Spawns a detached task that re-acquires the write lock and recovers the


### PR DESCRIPTION
> **Stacked on #6497** (`ma2bd/chain-write-cancel-safe-recovery`). Review/merge that first; this PR's diff is against it. It depends on #6497 for the recovery behaviour it reuses.

## Motivation

`chain_write` runs every chain write + `save()` on a detached task and (with #6497)
performs poisoned-worker eviction / corrupted-state reset on the result — all
resilient to caller cancellation. The **cross-chain batch path did not use it**.

`ChainBatchRequestProcessor`'s driver acquired its own write lock and called
`process_batch` directly. That driver is a `Shared<BatchFuture>` driven
*cooperatively* by cancellable callers (`enqueue_and_drive`) and is never itself
spawned. Two problems followed:

1. **Torn save (stale reads).** If every in-flight caller for a chain dropped
   while `process_batch` was suspended at its `save().await`, the future — the
   in-flight `write_batch` and the `RollbackGuard` — was dropped mid-save,
   desynchronizing storage from the in-memory view.
2. **No poison/corruption recovery.** `process_batch` swallowed its save error
   (rolled back, replied `BatchRolledBack`, returned `()`). A `must_reload_view`
   DB error left the worker `poisoned` but still cached; the driver never evicted
   it (it had no `WorkerState` handle), and `write_lock`'s poison check returns
   *before* `touch()`, so a continuously-receiving chain could **wedge on
   `PoisonedWorker`** until an unrelated `chain_read`/`chain_write` happened to
   evict it. `CorruptedChainState` was never reset either.

Rather than duplicate the detached-save + recovery logic into the driver, route
the batch through `chain_write`.

## Proposal

- The batch driver coalesces requests as before, then processes them via
  `worker.chain_write(chain_id, |guard| guard.process_batch(requests))` — one
  write lock, one save, now inheriting the detached-save cancellation safety and
  the poisoned-worker eviction / corrupted-state reset from `chain_write`.
- `process_batch` returns `Result<(), WorkerError>`: it still replies to each
  request's sender on every internal path, but now **surfaces the batch-`save`
  error** so `chain_write` can act on it. Per-request processing errors (already
  reported individually) still return `Ok`, so they don't trigger eviction.
- `enqueue_and_drive` maps a dropped sender to `PoisonedWorker` instead of
  panicking: when `chain_write` fails before running the closure (worker load
  error, or an already-poisoned worker it has just evicted), the request senders
  are dropped, and the next attempt loads a fresh worker — i.e. the previously
  wedging case now self-heals.

The driver no longer holds a worker `Arc` (so it no longer blocks TTL reclaim of
a stuck worker); `chain_write` resolves the current cached worker per batch.

Note: `process_batch` only ever reaches the `ChainWorkerState` cross-chain
helpers on the held guard, so running it under `chain_write` introduces no
re-entrancy into the batch driver.

## Test Plan

- `cargo test -p linera-core --lib cross_chain` — all 9 cross-chain tests pass
  (`test_handle_cross_chain_request*`, `test_cross_chain_message_chunking`,
  `test_chunked_cross_chain_gap_detection`, end-to-end client cross-chain tests).
- `cargo clippy -p linera-core` and `cargo +nightly fmt --check` clean.

## Release Plan

These changes should be ported to `main`

## Links

- Depends on #6497.
