### PR TITLE
Run chain_write recovery dispatch inside the detached task

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -984,6 +984,15 @@ where
     /// until the DB round-trip and `post_save` have fully completed — subsequent
     /// readers, including a freshly-loaded replacement worker, only see the
     /// committed state.
+    ///
+    /// The outcome inspection and recovery dispatch (poisoned-worker eviction and
+    /// corrupted-state reset) also run *inside* the detached task. Otherwise, if the
+    /// caller dropped this future after the detached write produced a recoverable
+    /// error but before the outer `.await` resumed, the recovery would be skipped: a
+    /// `CorruptedChainState` error neither poisons nor evicts the worker, so the chain
+    /// would be left at a partial tip serving stale reads with no `RevertConfirm`
+    /// retransmission. Running recovery in the detached task makes it survive caller
+    /// cancellation, just like the write itself.
     async fn chain_write<R, F, Fut>(&self, chain_id: ChainId, f: F) -> Result<R, WorkerError>
     where
         F: FnOnce(handle::RollbackGuard<StorageClient>) -> Fut
@@ -993,20 +1002,23 @@ where
         R: linera_base::task::MaybeSend + 'static,
     {
         let state = self.get_or_create_chain_worker(chain_id).await?;
-        let state_for_task = state.clone();
-        let result = Box::pin(wrap_future(linera_base::task::run_detached(async move {
-            let guard = handle::write_lock(&state_for_task).await?;
-            f(guard).await
-        })))
-        .await;
-        if let Err(error) = &result {
-            if error.must_reload_view() {
-                self.evict_poisoned_worker(chain_id, &state);
-            } else if error.indicates_corrupted_chain_state() {
-                self.spawn_reset_corrupted_chain_state(chain_id, state);
+        let this = self.clone();
+        Box::pin(wrap_future(linera_base::task::run_detached(async move {
+            let result = async {
+                let guard = handle::write_lock(&state).await?;
+                f(guard).await
             }
-        }
-        result
+            .await;
+            if let Err(error) = &result {
+                if error.must_reload_view() {
+                    this.evict_poisoned_worker(chain_id, &state);
+                } else if error.indicates_corrupted_chain_state() {
+                    this.spawn_reset_corrupted_chain_state(chain_id, state);
+                }
+            }
+            result
+        })))
+        .await
     }
 
     /// Spawns a detached task that re-acquires the write lock and recovers the


### PR DESCRIPTION
## Motivation

`main` version of #6497 (which targets `testnet_conway`).

`chain_write` runs the write and `save()` on a detached task (via `run_detached`)
so that caller cancellation cannot tear the save apart mid-flight. However, the
result inspection and recovery dispatch (`if let Err(error) = &result { … }`) ran
in the **outer, cancellable** future, after `.await`ing the detached task.

On native, `run_detached` awaits a `JoinHandle`; if the caller drops the
`chain_write` future while the spawned task is still running, the task detaches
and finishes the write, but its `result` is dropped and the recovery block never
runs. The consequences differ by error kind:

- `must_reload_view()` (poisoned worker): mostly self-healing — the next
  `read_lock`/`write_lock` hits `check_not_poisoned()`, returns `PoisonedWorker`
  (whose `must_reload_view()` is `true`), and the worker is evicted. Fail-closed.
- `indicates_corrupted_chain_state()` (`CorruptedChainState`): **not**
  self-healing — this error neither poisons nor evicts the worker. If
  `spawn_reset_corrupted_chain_state` is skipped, the chain is left at a partial
  tip serving **stale reads**, and the `RevertConfirm` retransmission that repairs
  cross-chain consistency never fires. The doc-comment claimed the reset "survives
  cancellation", but that only holds once it is spawned — the spawn call itself sat
  in the cancellable path.

## Proposal

Move the outcome inspection and recovery dispatch *inside* the detached task, so
that — like the write itself — they cannot be skipped by caller cancellation.
`WorkerState: Clone`, so the worker is cloned into the task; `chain_id` and the
worker `Arc` are `'static`. Behaviour is otherwise unchanged.

## Test Plan

- CI (build, clippy, existing `linera-core` worker tests).
- `cargo check -p linera-core` and `cargo +nightly fmt --check` pass locally.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.
- Already applied to `testnet_conway` in #6497.

## Links

- `testnet_conway` counterpart: #6497.
- Follow-up (routes the cross-chain batch path through `chain_write`): #6498.
