### PR TITLE
Make `process_batches` handle corruption/rollback errors correctly (#6501)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1500,11 +1500,15 @@ where
     ///
     /// Both update and confirmation requests are handled together so that a
     /// single write-lock acquisition covers all pending work for the chain.
-    pub(crate) async fn process_batch(&mut self, requests: Vec<BatchRequest>) {
+    pub(crate) async fn process_batch(
+        &mut self,
+        requests: Vec<BatchRequest>,
+    ) -> Result<(), WorkerError> {
         let mut update_results = Vec::new();
         let mut confirm_results = Vec::new();
         let mut need_save = false;
         let mut need_rollback = false;
+        let mut recovery_error = None;
         let mut max_delivered_height: Option<BlockHeight> = None;
 
         for request in requests {
@@ -1526,7 +1530,9 @@ where
                         Ok(update_result) => update_result,
                         Err(error) => {
                             need_rollback = true;
-                            send_result(result_sender, Err(error));
+                            let (recovery, to_send) = classify_processing_error(error);
+                            recovery_error = recovery_error.or(recovery);
+                            send_result(result_sender, Err(to_send));
                             continue;
                         }
                     };
@@ -1562,16 +1568,20 @@ where
                         }
                         Err(error) => {
                             need_rollback = true;
-                            send_result(result_sender, Err(error));
+                            let (recovery, to_send) = classify_processing_error(error);
+                            recovery_error = recovery_error.or(recovery);
+                            send_result(result_sender, Err(to_send));
                         }
                     }
                 }
             }
         }
+        let mut save_error = None;
         if !need_rollback && need_save {
             if let Err(error) = self.save().await {
                 tracing::error!(%error, "failed to save batch; rolling back");
                 need_rollback = true;
+                save_error = Some(error);
             }
         }
         if need_rollback {
@@ -1581,7 +1591,19 @@ where
             for (result_sender, _) in confirm_results {
                 send_result(result_sender, Err(WorkerError::BatchRolledBack));
             }
-            return;
+            // Surface an error that left the worker poisoned or the chain state
+            // corrupted so `chain_write` can evict or reset it. A `must_reload_view`
+            // error only reaches us from a failed `save`, since resolving the journal
+            // (the operation that raises it) happens only in `write_batch`. A
+            // processing step instead can raise `CorruptedChainState` while reconciling
+            // outboxes or message counters (see `confirm_updated_recipient`), which
+            // calls for a reset rather than eviction. Ordinary processing errors (bad
+            // height, validation failures) leave the worker healthy after rollback, so
+            // they return `Ok` and were already reported to their individual senders.
+            return match save_error.or(recovery_error) {
+                Some(error) => Err(error),
+                None => Ok(()),
+            };
         }
 
         if let Some(height) = max_delivered_height {
@@ -1597,6 +1619,7 @@ where
                 .await;
             send_result(result_sender, result);
         }
+        Ok(())
     }
 
     /// Handles a `RevertConfirm` request: walks backward through
@@ -2707,6 +2730,21 @@ where
                 Err(WorkerError::PoisonedWorker)
             }
         }
+    }
+}
+
+/// Classifies an error returned while processing a single cross-chain batch request.
+///
+/// If the error indicates a poisoned worker or corrupted chain state, it is returned
+/// as the first element so `process_batch` can hand it to `chain_write` for recovery
+/// (eviction or reset), and the originating caller is told `BatchRolledBack` so it
+/// retries against a freshly loaded worker. Any other error leaves the worker healthy
+/// after rollback and is reported to the caller unchanged.
+fn classify_processing_error(error: WorkerError) -> (Option<WorkerError>, WorkerError) {
+    if error.must_reload_view() || error.indicates_corrupted_chain_state() {
+        (Some(error), WorkerError::BatchRolledBack)
+    } else {
+        (None, error)
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -64,10 +64,8 @@ impl<S: Storage> std::ops::Deref for ChainStateViewReadGuard<S> {
 pub(crate) use crate::chain_worker::EventSubscriptionsResult;
 use crate::{
     chain_worker::{
-        handle,
-        state::{send_result, ChainWorkerState},
-        BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult, DeliveryNotifier,
-        ProcessConfirmedBlockMode,
+        handle, state::ChainWorkerState, BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult,
+        DeliveryNotifier, ProcessConfirmedBlockMode,
     },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -486,7 +484,7 @@ impl WorkerError {
 
     /// Returns `true` if this error indicates that the chain worker's in-memory
     /// state may be inconsistent and must be evicted from the cache.
-    fn must_reload_view(&self) -> bool {
+    pub(crate) fn must_reload_view(&self) -> bool {
         matches!(
             self,
             WorkerError::PoisonedWorker
@@ -500,7 +498,7 @@ impl WorkerError {
     /// Returns `true` if this error indicates that the chain's persisted state is
     /// internally inconsistent, so the worker should consider resetting and
     /// re-executing it from storage.
-    fn indicates_corrupted_chain_state(&self) -> bool {
+    pub(crate) fn indicates_corrupted_chain_state(&self) -> bool {
         matches!(
             self,
             WorkerError::ChainError(chain_error)
@@ -580,8 +578,9 @@ pub(crate) enum BatchRequest {
 ///
 /// Wrapped in `Shared<BatchFuture>` so that all tasks waiting for
 /// cross-chain operations on the same chain can cooperatively poll a
-/// single driver. The driver loops: wait for an item from the request channel, acquire the
-/// write lock, drain the channel, process all requests in one batch, repeat.
+/// single driver. The driver loops: wait for an item from the request channel,
+/// drain the channel, then process all requests in one batch through
+/// [`WorkerState::chain_write`] (one write lock, one save), repeat.
 #[cfg(not(web))]
 type BatchFuture = pin::Pin<Box<dyn Future<Output = ()> + Send>>;
 #[cfg(web)]
@@ -598,7 +597,8 @@ struct ChainBatchRequestProcessor {
 
 impl ChainBatchRequestProcessor {
     fn create<StorageClient>(
-        state: ChainWorkerArc<StorageClient>,
+        worker: WorkerState<StorageClient>,
+        chain_id: ChainId,
         batch_size_limit: usize,
     ) -> (ChainBatchRequestProcessor, Shared<BatchFuture>)
     where
@@ -608,31 +608,31 @@ impl ChainBatchRequestProcessor {
         let future: BatchFuture = Box::pin(async move {
             while let Some(first) = receiver.recv().await {
                 let mut requests = vec![first];
-                match handle::write_lock(&state).await {
-                    Ok(mut guard) => {
-                        while requests.len() < batch_size_limit {
-                            match receiver.try_recv() {
-                                Ok(request) => requests.push(request),
-                                Err(_) => break,
-                            }
-                        }
-                        #[cfg(with_metrics)]
-                        metrics::CROSS_CHAIN_BATCH_SIZE.observe(requests.len() as f64);
+                while requests.len() < batch_size_limit {
+                    match receiver.try_recv() {
+                        Ok(request) => requests.push(request),
+                        Err(_) => break,
+                    }
+                }
+                #[cfg(with_metrics)]
+                metrics::CROSS_CHAIN_BATCH_SIZE.observe(requests.len() as f64);
+                // Process the batch through `chain_write` so it inherits the same
+                // cancellation safety (the write and `save` run on a detached task)
+                // and recovery (poisoned-worker eviction / corrupted-state reset) as
+                // every other write path, rather than duplicating that logic here.
+                // `process_batch` reports a result to each request's sender on every
+                // internal path; an `Err` here means `chain_write` failed *before*
+                // running the closure — a worker load error, or an already-poisoned
+                // worker that it has now evicted. In that case the request senders are
+                // dropped, which `enqueue_and_drive` surfaces to callers as
+                // `PoisonedWorker`.
+                if let Err(error) = worker
+                    .chain_write(chain_id, move |mut guard| async move {
                         guard.process_batch(requests).await
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "failed to obtain write lock");
-                        for request in requests {
-                            match request {
-                                BatchRequest::Update { result_sender, .. } => {
-                                    send_result(result_sender, Err(WorkerError::PoisonedWorker));
-                                }
-                                BatchRequest::Confirm { result_sender, .. } => {
-                                    send_result(result_sender, Err(WorkerError::PoisonedWorker));
-                                }
-                            }
-                        }
-                    }
+                    })
+                    .await
+                {
+                    tracing::warn!(%chain_id, %error, "cross-chain batch could not be processed");
                 }
             }
         });
@@ -1108,9 +1108,9 @@ where
                 return Ok((batch_processor.sender.clone(), future));
             }
         }
-        let state = self.get_or_create_chain_worker(chain_id).await?;
         let (new_request_processor, new_future) = ChainBatchRequestProcessor::create(
-            state,
+            self.clone(),
+            chain_id,
             self.chain_worker_config.cross_chain_batch_size_limit,
         );
         match self
@@ -1448,7 +1448,12 @@ where
             // return it immediately without driving the batch future further.
             match future::select(pin::pin!(&mut receiver), future).await {
                 Either::Left((result, _)) => {
-                    return result.expect("batch result sender dropped");
+                    // `Ok(inner)` is the normal reply. `Err(Canceled)` means the
+                    // sender was dropped without one — `chain_write` failed before
+                    // `process_batch` ran (e.g. an already-poisoned worker, which it
+                    // has now evicted). Surface it as `PoisonedWorker`; the next
+                    // attempt loads a fresh worker.
+                    return result.unwrap_or(Err(WorkerError::PoisonedWorker));
                 }
                 Either::Right(((), _)) => match receiver.try_recv() {
                     Ok(result) => return result,


### PR DESCRIPTION
Port of #6501. (Cherry-picked, with no conflicts.)

This is #6498 plus one commit.

## Motivation

`process_batch` is not using `chain_write`, so it doesn't handle poison or inconsistent chain state errors.

## Proposal

Route the cross-chain batch driver's write step through `chain_write` so it inherits the same guarantees as every other write path, instead of acquiring its own lock and saving directly.

- `process_batch` now returns `Result<(), WorkerError>`. On a save failure it still rolls back and replies `BatchRolledBack` to all callers, but now also returns the save error so the caller can act on it.
- The batch driver (`ChainBatchRequestProcessor::create`) no longer calls `handle::write_lock` + `process_batch` itself. It drains the channel to coalesce requests, then calls `worker.chain_write(chain_id, |guard| guard.process_batch(requests))`. This gives the batch save cancellation safety and recovery.
- The driver captures the `WorkerState` and chain ID rather than a pinned `ChainWorkerArc`, so it no longer blocks TTL reclaim — `chain_write` re-resolves the worker per batch, which is also why a retry after eviction picks up a fresh worker.
- `enqueue_and_drive` maps a dropped result sender (meaning `chain_write` failed before `process_batch` ran, e.g. an already-poisoned-and-now-evicted worker) to `PoisonedWorker` instead of panicking.

The second commit closes one more gap: `process_batch` only surfaced save failures to `chain_write` and swallowed errors raised during processing.
- A _read_ can return a `must_reload_view` store error or a `CorruptedChainState` error before `save` is ever reached. Previously that error went only to the originating request's sender and `process_batch` returned `Ok`, so `chain_write` never evicted/reset the worker — the chain stays wedged until some unrelated write path tripped the same error.
- New `classify_processing_error` helper: if a processing error reports `must_reload_view()` or `indicates_corrupted_chain_state()`, it's captured in `recovery_error` (handed to `chain_write` for eviction/reset) and the caller gets `BatchRolledBack` to retry against a fresh worker. Any other processing error is unchanged — caller still gets the exact error and the worker stays healthy.
- The rollback return became `save_error.or(recovery_error)`, so both failure sources flow to recovery.

A caller whose request triggered a recoverable error now sees `BatchRolledBack` (retryable) rather than the raw `ViewError`, matching what the save-failure path already does to all callers.

## Test Plan

CI
It's hard to fully test issues like cancellation safety and DB corruptions in general.

## Release Plan

- Nothing to do.

## Links

- PR to `testnet_conway`: #6501
- Based on #6498.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)