### PR TITLE
Log re-execution progress when resetting a corrupted chain

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -45,7 +45,7 @@ use linera_views::{
     views::{ReplaceContext as _, RootView as _, View as _},
 };
 use tokio::sync::oneshot;
-use tracing::{debug, instrument, trace, warn};
+use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
@@ -1558,8 +1558,16 @@ where
         );
 
         // 4. Re-load certificates one at a time by hash and re-process them.
+        let num_confirmed = hashes.len();
+        let num_preprocessed = preprocessed.len();
         for (index, hash) in hashes.into_iter().enumerate() {
             let height = BlockHeight(index as u64);
+            if index % 1000 == 0 {
+                info!(
+                    %chain_id, confirmed = index, total = num_confirmed,
+                    "Re-executing confirmed blocks after reset"
+                );
+            }
             let cert = self
                 .storage
                 .read_certificate(hash)
@@ -1569,7 +1577,13 @@ where
             Box::pin(self.process_confirmed_block(cert, ProcessConfirmedBlockMode::Execute, None))
                 .await?;
         }
-        for (height, hash) in preprocessed {
+        for (index, (height, hash)) in preprocessed.into_iter().enumerate() {
+            if index % 1000 == 0 {
+                info!(
+                    %chain_id, preprocessed = index, total = num_preprocessed,
+                    "Re-preprocessing blocks after reset"
+                );
+            }
             let cert = self
                 .storage
                 .read_certificate(hash)


### PR DESCRIPTION
## Motivation

There are some very long chains in the testnet; re-executing them can take a long time, and it might be hard to tell from the logs that that's going on.

## Proposal

Add INFO progress logs every 1000 blocks to both replay loops in `reset_and_reexecute_chain`, so resetting a long chain shows steady progress with a total to gauge completion.

## Test Plan

(Only logs)

## Release Plan

- Maybe port to `main`.
- Hotfix validators.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
