### PR TITLE
Log re-execution progress when resetting a corrupted chain (#6504)

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -49,7 +49,7 @@ use linera_views::{
     views::{ReplaceContext as _, RootView as _, View as _},
 };
 use tokio::sync::oneshot;
-use tracing::{debug, instrument, trace, warn};
+use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
@@ -1779,10 +1779,22 @@ where
         //    first one lands on the wiped, height-0 chain with a tip gap: if it is a checkpoint
         //    `process_confirmed_block` installs its snapshot before executing, and otherwise
         //    (height 0) it executes directly. The remaining blocks are contiguous.
+        let total = block_hashes
+            .iter()
+            .filter(|(height, _)| *height >= restore_from)
+            .count();
+        let mut replayed = 0;
         for (height, hash) in block_hashes {
             if height < restore_from {
                 continue;
             }
+            if replayed % 1000 == 0 {
+                info!(
+                    %chain_id, replayed, total,
+                    "Re-executing confirmed blocks after reset"
+                );
+            }
+            replayed += 1;
             let cert = self
                 .storage
                 .read_certificate(hash)


### PR DESCRIPTION
Port of #6504.

## Motivation

There are some very long chains in the testnet; re-executing them can take a long time, and it might be hard to tell from the logs that that's going on.

## Proposal

Add INFO progress logs every 1000 blocks to both replay loops in `reset_and_reexecute_chain`, so resetting a long chain shows steady progress with a total to gauge completion.

## Test Plan

(Only logs)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- `testnet_conway` PR: #6504.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
