### PR TITLE
Improve relayer resiliency

### DIFF
--- a/docker/bridge-entrypoint.sh
+++ b/docker/bridge-entrypoint.sh
@@ -24,7 +24,7 @@ set -- linera-bridge serve \
     --max-retries="${MAX_RETRIES:-10}" \
     --blob-cache-size="${BLOB_CACHE_SIZE:-1000}" \
     --confirmed-block-cache-size="${CONFIRMED_BLOCK_CACHE_SIZE:-1000}" \
-    --lite-certificate-cache-size="${LITE_CERTIFICATE_CACHE_SIZE:-1000}" \
+    --certificate-cache-size="${CERTIFICATE_CACHE_SIZE:-1000}" \
     --certificate-raw-cache-size="${CERTIFICATE_RAW_CACHE_SIZE:-1000}" \
     --event-cache-size="${EVENT_CACHE_SIZE:-1000}"
 

--- a/docker/bridge-entrypoint.sh
+++ b/docker/bridge-entrypoint.sh
@@ -28,6 +28,14 @@ set -- linera-bridge serve \
     --certificate-raw-cache-size="${CERTIFICATE_RAW_CACHE_SIZE:-1000}" \
     --event-cache-size="${EVENT_CACHE_SIZE:-1000}"
 
+# Optional: override the EVM receipt poll interval. Only pass the flag when set,
+# so an unset env keeps clap's default (alloy's host-based interval). Useful
+# against a local node reached by a non-loopback host (e.g. Docker `anvil`),
+# which alloy otherwise treats as remote and polls every 7s.
+if [ -n "${EVM_POLL_INTERVAL_MS:-}" ]; then
+    set -- "$@" --evm-poll-interval-ms="$EVM_POLL_INTERVAL_MS"
+fi
+
 # LINERA_WALLET, LINERA_KEYSTORE, LINERA_STORAGE are read directly by clap
 # via `env = "..."`, so they don't need explicit --flags here.
 

--- a/docker/docker-compose.bridge-test.yml
+++ b/docker/docker-compose.bridge-test.yml
@@ -263,6 +263,10 @@ services:
       - MONITOR_SCAN_INTERVAL=${MONITOR_SCAN_INTERVAL:-5}
       - MONITOR_START_BLOCK=${MONITOR_START_BLOCK:-0}
       - MAX_RETRIES=${MAX_RETRIES:-10}
+      # Anvil is reached via the non-loopback host `anvil`, which alloy treats as
+      # remote (7s receipt poll). Match anvil's ~1s block time so settlement is
+      # fast locally.
+      - EVM_POLL_INTERVAL_MS=${EVM_POLL_INTERVAL_MS:-200}
     volumes:
       - bridge-shared:/shared
     depends_on:

--- a/docker/docker-compose.bridge-test.yml
+++ b/docker/docker-compose.bridge-test.yml
@@ -236,7 +236,10 @@ services:
     entrypoint: ["sh", "-c"]
     command:
       - |
-        rm -f /shared/setup-complete
+        # The setup script clears /shared/setup-complete at the start of each
+        # run, so we only wait here — never delete it. This lets the relay
+        # restart standalone (reusing the marker) instead of hanging until the
+        # next full setup run.
         echo "Waiting for setup to complete..."
         while [ ! -f /shared/setup-complete ]; do sleep 1; done
 

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -150,6 +150,19 @@ fi
 mkdir -p "$SHARED_DIR"
 echo "  Shared dir: $SHARED_DIR"
 
+# ── Invalidate this run's prior outputs ──
+# Clearing setup-complete here means a fresh setup
+# run re-gates the relay until this run finishes, while a standalone relay
+# restart keeps the existing marker and starts immediately. Also drop the stale
+# IDs/addresses this script produces so nothing reads last run's values mid-run.
+# Files written by the init containers (light-client-address, bridge-chain-id,
+# relay-owner, relay-wallet) are intentionally left untouched.
+echo "Clearing stale setup outputs..."
+dc_exec --user root foundry-tools sh -c \
+    "rm -f /shared/setup-complete /shared/wrapped-app-id /shared/bridge-app-id /shared/bridge-address"
+rm -f "$SHARED_DIR"/wrapped-app-id "$SHARED_DIR"/bridge-app-id "$SHARED_DIR"/bridge-address
+rm -f "$OUTPUT_FILE"
+
 echo "=== Bridge Demo Setup ==="
 echo ""
 echo "Configuration:"

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -363,10 +363,14 @@ echo "$BRIDGE_ADDRESS" > "$SHARED_DIR/bridge-address"
 
 # ── 8. Register the bridge ↔ wrapped relationship on both sides ──
 echo "Registering the bridge as the wrapped-fungible authorized caller..."
-# BCS: WrappedFungibleOperation::RegisterAuthorizedCaller (variant 8) + 32-byte
-# bridge app ID. Submitted on the WRAPPED app, on the mint (bridge) chain — the
-# relay wallet owns that chain.
-REGISTER_CALLER_HEX="08${BRIDGE_APP_ID}"
+# WrappedFungibleOperation::RegisterAuthorizedCaller + 32-byte bridge app ID,
+# submitted on the WRAPPED app, on the mint (bridge) chain — the relay wallet
+# owns that chain. The operation enum derives `StableEnum`, so the wire tag is
+# not the BCS variant index but a 4-byte ULEB128 of the variant's stable tag:
+# keccak256(name)[0..4] as big-endian u32, masked (v & 0x07FFFFFF) | 0x08000000.
+# RegisterAuthorizedCaller → tag 170732950 → ULEB128 0x96dbb451. Regenerate with
+# `cast keccak RegisterAuthorizedCaller` if the variant is ever renamed.
+REGISTER_CALLER_HEX="96dbb451${BRIDGE_APP_ID}"
 dc_exec linera-network env \
     LINERA_WALLET=/shared/relay-wallet/wallet.json \
     LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \
@@ -377,8 +381,10 @@ dc_exec linera-network env \
     --chain-id "$BRIDGE_CHAIN_ID" 2>&1
 
 echo "Registering FungibleBridge address in evm-bridge..."
-# BCS: BridgeOperation::RegisterFungibleBridge (variant 2) + 20-byte EVM address.
-REGISTER_BRIDGE_HEX="02${BRIDGE_ADDR_HEX}"
+# BridgeOperation::RegisterFungibleBridge + 20-byte EVM address. Same StableEnum
+# encoding as above: RegisterFungibleBridge → tag 230758129 → ULEB128 0xf1ad846e.
+# Regenerate with `cast keccak RegisterFungibleBridge` if the variant is renamed.
+REGISTER_BRIDGE_HEX="f1ad846e${BRIDGE_ADDR_HEX}"
 dc_exec linera-network env \
     LINERA_WALLET=/shared/relay-wallet/wallet.json \
     LINERA_KEYSTORE=/shared/relay-wallet/keystore.json \

--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -151,6 +151,15 @@ struct ServeOptions {
     /// Defaults to `bridge_relay.sqlite3` next to the RocksDB storage directory.
     #[arg(long)]
     sqlite_path: Option<std::path::PathBuf>,
+
+    /// Override the EVM provider's receipt poll interval, in milliseconds.
+    /// When unset, alloy picks the interval from the RPC URL: ~250ms for a
+    /// loopback host (localhost/127.0.0.1/::1), 7s otherwise. A local node
+    /// reached via a non-loopback host (e.g. a Docker service name like
+    /// `anvil`) is treated as remote and gets the slow 7s default, so set this
+    /// to match the node's block time for fast local settlement.
+    #[arg(long)]
+    evm_poll_interval_ms: Option<u64>,
 }
 
 fn main() -> Result<()> {
@@ -204,6 +213,8 @@ impl ServeOptions {
             self.monitor_start_block,
             self.max_retries,
             self.sqlite_path.as_deref(),
+            self.evm_poll_interval_ms
+                .map(std::time::Duration::from_millis),
         ))
         .await
     }

--- a/linera-bridge/src/monitor/db.rs
+++ b/linera-bridge/src/monitor/db.rs
@@ -35,6 +35,11 @@ use sqlx::{
 use super::{PendingBurn, PendingDeposit};
 use crate::proof::DepositKey;
 
+/// `scan_cursors.name` for the highest fully-scanned Linera block height.
+pub(crate) const CURSOR_LINERA_HEIGHT: &str = "last_scanned_linera_height";
+/// `scan_cursors.name` for the highest fully-scanned EVM block number.
+pub(crate) const CURSOR_EVM_BLOCK: &str = "last_scanned_evm_block";
+
 /// Persistent SQLite store for bridging requests.
 pub struct BridgeDb {
     pool: SqlitePool,
@@ -142,6 +147,15 @@ impl BridgeDb {
         .execute(&self.pool)
         .await?;
 
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS scan_cursors (
+                name   TEXT PRIMARY KEY,
+                value  INTEGER NOT NULL
+            )",
+        )
+        .execute(&self.pool)
+        .await?;
+
         Ok(())
     }
 
@@ -227,6 +241,55 @@ impl BridgeDb {
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Persists a scan cursor (a monotonic high-water mark) by name.
+    pub async fn save_cursor(&self, name: &str, value: u64) -> Result<()> {
+        sqlx::query("INSERT OR REPLACE INTO scan_cursors (name, value) VALUES (?, ?)")
+            .bind(name)
+            .bind(value as i64)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Loads a scan cursor by name, or `None` if it has never been persisted.
+    pub async fn load_cursor(&self, name: &str) -> Result<Option<u64>> {
+        let row: Option<(i64,)> = sqlx::query_as("SELECT value FROM scan_cursors WHERE name = ?")
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.map(|(v,)| v as u64))
+    }
+
+    /// Whether the burn at `(height, event_index)` is already recorded as
+    /// completed. `failed` burns return `false` so the retry path can requeue
+    /// them.
+    pub async fn is_burn_completed(&self, height: BlockHeight, event_index: u32) -> Result<bool> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT status FROM finished_burns WHERE linera_height = ? AND event_index = ?",
+        )
+        .bind(height.0 as i64)
+        .bind(event_index as i64)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(matches!(row, Some((status,)) if status == "completed"))
+    }
+
+    /// Whether the given deposit is already recorded as completed. `failed`
+    /// deposits return `false` so the retry path can requeue them.
+    pub async fn is_deposit_completed(&self, key: &DepositKey) -> Result<bool> {
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT status FROM finished_deposits
+             WHERE source_chain_id = ? AND block_hash = ? AND tx_index = ? AND log_index = ?",
+        )
+        .bind(key.source_chain_id as i64)
+        .bind(key.block_hash.as_slice())
+        .bind(key.tx_index as i64)
+        .bind(key.log_index as i64)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(matches!(row, Some((status,)) if status == "completed"))
     }
 
     /// Inserts a new pending burn. Ignores duplicates (idempotent).
@@ -971,5 +1034,84 @@ mod tests {
 
         std::fs::remove_file(&path).ok(); // Best-effort post-test cleanup.
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn scan_cursor_roundtrips_and_defaults_to_none() {
+        let db = BridgeDb::open_in_memory().await.unwrap();
+        assert_eq!(db.load_cursor(CURSOR_LINERA_HEIGHT).await.unwrap(), None);
+
+        db.save_cursor(CURSOR_LINERA_HEIGHT, 17).await.unwrap();
+        assert_eq!(
+            db.load_cursor(CURSOR_LINERA_HEIGHT).await.unwrap(),
+            Some(17)
+        );
+
+        // Saving again overwrites (INSERT OR REPLACE), and cursors are independent.
+        db.save_cursor(CURSOR_LINERA_HEIGHT, 42).await.unwrap();
+        db.save_cursor(CURSOR_EVM_BLOCK, 9).await.unwrap();
+        assert_eq!(
+            db.load_cursor(CURSOR_LINERA_HEIGHT).await.unwrap(),
+            Some(42)
+        );
+        assert_eq!(db.load_cursor(CURSOR_EVM_BLOCK).await.unwrap(), Some(9));
+    }
+
+    #[tokio::test]
+    async fn is_burn_completed_only_true_for_completed_status() {
+        let db = BridgeDb::open_in_memory().await.unwrap();
+        let burn = test_burn(); // height 100, event_index 0
+
+        // Absent → false.
+        assert!(!db
+            .is_burn_completed(burn.height, burn.event_index)
+            .await
+            .unwrap());
+
+        // Pending (not yet finished) → false.
+        db.insert_burn(&burn).await.unwrap();
+        assert!(!db
+            .is_burn_completed(burn.height, burn.event_index)
+            .await
+            .unwrap());
+
+        // Completed → true.
+        db.update_burn_status(burn.height, burn.event_index, "completed")
+            .await
+            .unwrap();
+        assert!(db
+            .is_burn_completed(burn.height, burn.event_index)
+            .await
+            .unwrap());
+
+        // Failed → false (so the retry path can requeue it).
+        let failed = PendingBurn {
+            event_index: 1,
+            ..test_burn()
+        };
+        db.insert_burn(&failed).await.unwrap();
+        db.update_burn_status(failed.height, failed.event_index, "failed")
+            .await
+            .unwrap();
+        assert!(!db
+            .is_burn_completed(failed.height, failed.event_index)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn is_deposit_completed_only_true_for_completed_status() {
+        let db = BridgeDb::open_in_memory().await.unwrap();
+        let deposit = test_deposit();
+
+        assert!(!db.is_deposit_completed(&deposit.key).await.unwrap());
+
+        db.insert_deposit(&deposit).await.unwrap();
+        assert!(!db.is_deposit_completed(&deposit.key).await.unwrap());
+
+        db.update_deposit_status(&deposit.key, "completed")
+            .await
+            .unwrap();
+        assert!(db.is_deposit_completed(&deposit.key).await.unwrap());
     }
 }

--- a/linera-bridge/src/monitor/evm.rs
+++ b/linera-bridge/src/monitor/evm.rs
@@ -230,7 +230,7 @@ async fn evm_scan_iteration(
     }
 
     let mut state = monitor.write().await;
-    state.last_scanned_evm_block = current_block;
+    state.advance_evm_cursor(current_block).await;
     crate::relay::metrics::set_last_scanned_evm_block(current_block);
 
     if tracked_any {

--- a/linera-bridge/src/monitor/linera.rs
+++ b/linera-bridge/src/monitor/linera.rs
@@ -455,7 +455,7 @@ async fn linera_scan_iteration<E: Environment>(
 
     {
         let mut state = monitor.write().await;
-        state.last_scanned_linera_height = current_height;
+        state.advance_linera_cursor(current_height).await;
     }
     crate::relay::metrics::set_last_scanned_linera_height(current_height.0);
 

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -220,19 +220,29 @@ impl MonitorState {
     /// Uses Entry API instead of insert() to avoid overwriting existing entries
     /// that may have accumulated retry state.
     pub async fn track_deposit(&mut self, pending: PendingDeposit) -> bool {
-        match self.deposits.entry(pending.key.clone()) {
-            Entry::Occupied(_) => false,
-            Entry::Vacant(e) => {
-                if let Some(db) = &self.db {
-                    if let Err(error) = db.insert_deposit(&pending).await {
-                        tracing::warn!(?error, "Failed to persist deposit to SQLite");
-                    }
+        if self.deposits.contains_key(&pending.key) {
+            return false;
+        }
+        // Skip deposits already settled in a previous run (see `track_burn`).
+        if let Some(db) = &self.db {
+            match db.is_deposit_completed(&pending.key).await {
+                Ok(true) => return false,
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        ?error,
+                        "finished_deposits lookup failed; treating deposit as new"
+                    );
                 }
-                e.insert(Tracked::new(pending));
-                crate::relay::metrics::deposit_detected();
-                true
+            }
+            if let Err(error) = db.insert_deposit(&pending).await {
+                tracing::warn!(?error, "Failed to persist deposit to SQLite");
             }
         }
+        self.deposits
+            .insert(pending.key.clone(), Tracked::new(pending));
+        crate::relay::metrics::deposit_detected();
+        true
     }
 
     pub async fn complete_deposit(&mut self, key: &DepositKey) {
@@ -254,19 +264,30 @@ impl MonitorState {
     /// that may have accumulated retry state.
     pub async fn track_burn(&mut self, pending: PendingBurn) -> bool {
         let key = (pending.height, pending.event_index);
-        match self.burns.entry(key) {
-            Entry::Occupied(_) => false,
-            Entry::Vacant(e) => {
-                if let Some(db) = &self.db {
-                    if let Err(error) = db.insert_burn(&pending).await {
-                        tracing::warn!(?error, "Failed to persist burn to SQLite");
-                    }
+        if self.burns.contains_key(&key) {
+            return false;
+        }
+        // Skip burns already settled in a previous run. The durable record lives
+        // in `finished_burns`; the in-memory map starts empty after a restart,
+        // so without this guard a re-scan would re-track and re-settle them.
+        if let Some(db) = &self.db {
+            match db
+                .is_burn_completed(pending.height, pending.event_index)
+                .await
+            {
+                Ok(true) => return false,
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(?error, "finished_burns lookup failed; treating burn as new");
                 }
-                e.insert(Tracked::new(pending));
-                crate::relay::metrics::burn_detected();
-                true
+            }
+            if let Err(error) = db.insert_burn(&pending).await {
+                tracing::warn!(?error, "Failed to persist burn to SQLite");
             }
         }
+        self.burns.insert(key, Tracked::new(pending));
+        crate::relay::metrics::burn_detected();
+        true
     }
 
     pub async fn complete_burn(&mut self, height: BlockHeight, event_index: u32) {
@@ -431,12 +452,47 @@ impl MonitorState {
             self.burns
                 .insert((b.height, b.event_index), Tracked::new(b));
         }
+
+        // Resume scanning from the persisted cursors instead of re-scanning from
+        // genesis, so already-settled burns/deposits are not re-discovered and
+        // re-submitted. `last_scanned_evm_block` keeps the larger of the
+        // persisted cursor and the configured `monitor_start_block` floor.
+        if let Some(height) = db.load_cursor(db::CURSOR_LINERA_HEIGHT).await? {
+            self.last_scanned_linera_height = BlockHeight(height);
+        }
+        if let Some(block) = db.load_cursor(db::CURSOR_EVM_BLOCK).await? {
+            self.last_scanned_evm_block = self.last_scanned_evm_block.max(block);
+        }
+
         tracing::info!(
             deposits = n_deposits,
             burns = n_burns,
+            last_scanned_linera_height = %self.last_scanned_linera_height,
+            last_scanned_evm_block = self.last_scanned_evm_block,
             "Recovered pending bridge requests from SQLite WAL"
         );
         Ok(())
+    }
+
+    /// Advances the Linera scan cursor and persists it so a restart resumes from
+    /// here instead of re-scanning from genesis.
+    pub async fn advance_linera_cursor(&mut self, height: BlockHeight) {
+        self.last_scanned_linera_height = height;
+        if let Some(db) = &self.db {
+            if let Err(error) = db.save_cursor(db::CURSOR_LINERA_HEIGHT, height.0).await {
+                tracing::warn!(?error, "Failed to persist Linera scan cursor");
+            }
+        }
+    }
+
+    /// Advances the EVM scan cursor and persists it (see `advance_linera_cursor`).
+    pub async fn advance_evm_cursor(&mut self, block: u64) {
+        self.last_scanned_evm_block = block;
+        if let Some(db) = &self.db {
+            if let Err(error) = db.save_cursor(db::CURSOR_EVM_BLOCK, block).await {
+                tracing::warn!(?error, "Failed to persist EVM scan cursor");
+            }
+        }
     }
 
     /// Bumps the deposit's retry counter; if the bump exhausts `max_retries`,

--- a/linera-bridge/src/relay/evm.rs
+++ b/linera-bridge/src/relay/evm.rs
@@ -168,7 +168,7 @@ impl<P: Provider> EvmClient<P> {
     ) -> Result<()> {
         let args = ProvenEvents::new(cert, tx_index, positions_in_tx);
         let bridge = IFungibleBridge::new(self.bridge_addr, &self.provider);
-        tracing::info!(
+        tracing::debug!(
             tx_index,
             count = positions_in_tx.len(),
             "Calling processBurns on FungibleBridge..."

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -195,6 +195,24 @@ pub async fn run(
     chain_client.synchronize_from_validators().await?;
     tracing::info!(%chain_id, %chain_owner, "Bridge chain registered and synced");
 
+    // Drain any inbox messages that arrived while the relay was down. The serve
+    // loop only processes the inbox on live `NewIncomingBundle` notifications,
+    // so messages delivered during downtime (notably user burns, which arrive
+    // as `BridgeMessage::Burn` and only emit their `BurnEvent` once the bridge
+    // chain processes them) would otherwise sit unprocessed until the next
+    // incoming bundle. The periodic drain in `serve_loop` is the steady-state
+    // safety net; this handles the gap at startup.
+    match Box::pin(chain_client.process_inbox()).await {
+        Ok((certs, _)) if !certs.is_empty() => {
+            tracing::info!(
+                count = certs.len(),
+                "Drained inbox messages accumulated before startup"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => tracing::warn!("Startup inbox drain failed: {e}"),
+    }
+
     Box::pin(serve_loop(
         chain_client,
         rpc_url,
@@ -462,6 +480,14 @@ async fn serve_loop<E: Environment + 'static>(
         "Relay is ready"
     );
 
+    // Safety-net inbox drain. Notification delivery can be missed (relay down,
+    // stream hiccup), and a missed `NewIncomingBundle` would otherwise strand
+    // its messages until the next one. Reuse the monitor's scan interval as the
+    // drain cadence; an empty inbox makes `process_inbox` a cheap no-op.
+    let mut inbox_drain_interval = tokio::time::interval(monitor_scan_interval);
+    // Consume the immediate first tick — the startup drain above already ran.
+    inbox_drain_interval.tick().await;
+
     // ── Main loop: process chain operations + notifications ──
     tracing::info!("Listening for chain operations and notifications...");
     loop {
@@ -483,6 +509,22 @@ async fn serve_loop<E: Environment + 'static>(
             }
             result = &mut admin_server_handle => {
                 anyhow::bail!("Admin HTTP server exited unexpectedly: {result:?}");
+            }
+            _ = inbox_drain_interval.tick() => {
+                // Periodic safety net for a missed `NewIncomingBundle`: sync and
+                // drain the inbox so stranded messages (e.g. user burns) are
+                // eventually processed even without a fresh notification.
+                if let Err(e) = chain_client.synchronize_from_validators().await {
+                    tracing::warn!("Periodic sync before inbox drain failed: {e}");
+                } else {
+                    match chain_client.process_inbox().await {
+                        Ok((certs, _)) if !certs.is_empty() => {
+                            tracing::info!(count = certs.len(), "Periodic inbox drain processed messages");
+                        }
+                        Ok(_) => {}
+                        Err(e) => tracing::warn!("Periodic inbox drain failed: {e}"),
+                    }
+                }
             }
             notification = notifications.next() => {
                 let notification = match notification {

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -102,6 +102,7 @@ pub async fn run(
     monitor_start_block: u64,
     max_retries: u32,
     sqlite_path: Option<&Path>,
+    evm_poll_interval: Option<Duration>,
 ) -> Result<()> {
     tracing::info!("Starting bridge relay server...");
 
@@ -208,6 +209,7 @@ pub async fn run(
         monitor_start_block,
         max_retries,
         sqlite_path,
+        evm_poll_interval,
         Path::new(db_path),
         admin_chain_id,
         admin_chain_height,
@@ -263,6 +265,7 @@ async fn serve_loop<E: Environment + 'static>(
     monitor_start_block: u64,
     max_retries: u32,
     sqlite_path_override: Option<&Path>,
+    evm_poll_interval: Option<Duration>,
     storage_dir: &Path,
     admin_chain_id: ChainId,
     admin_chain_height: BlockHeight,
@@ -279,6 +282,16 @@ async fn serve_loop<E: Environment + 'static>(
         .wallet(evm_wallet)
         .with_simple_nonce_management()
         .connect_http(rpc_url.parse().context("invalid RPC URL")?);
+
+    // Alloy derives the receipt poll interval from the RPC host: ~250ms for a
+    // loopback address, 7s otherwise. A local node reached via a non-loopback
+    // host (e.g. the Docker service name `anvil`) is treated as remote, so each
+    // settlement tx would wait ~7s despite sub-second block times. Override when
+    // configured so local settlement keeps pace with the node.
+    if let Some(interval) = evm_poll_interval {
+        provider.client().set_poll_interval(interval);
+        tracing::info!(?interval, "Overrode EVM provider poll interval");
+    }
 
     let light_client_addr: Option<Address> = evm_light_client_address
         .map(|s| s.parse())

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -507,7 +507,7 @@ async fn serve_loop<E: Environment + 'static>(
                     continue;
                 }
 
-                tracing::info!("Received NewIncomingBundle, processing inbox...");
+                tracing::debug!("Received NewIncomingBundle, processing inbox...");
 
                 if let Err(e) = chain_client.synchronize_from_validators().await {
                     tracing::error!("Failed to synchronize: {e}");
@@ -527,7 +527,7 @@ async fn serve_loop<E: Environment + 'static>(
                     continue;
                 }
 
-                tracing::info!(count = certs.len(), "Processed inbox certificates");
+                tracing::debug!(count = certs.len(), "Processed inbox certificates");
             }
 
             Some(op) = op_rx.recv() => {

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -309,6 +309,7 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
             0,                                 // monitor_start_block
             5,                                 // max_retries
             None,
+            None,
         ))
         .await
     });

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -221,6 +221,7 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
             0,
             5,
             Some(sqlite_path_for_relay.as_path()),
+            None,
         ))
         .await
     });

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -177,6 +177,7 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
             0,                                 // monitor_start_block
             5,                                 // max_retries
             None,
+            None,
         ))
         .await
     });

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -250,6 +250,7 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
             0,
             5,
             Some(sqlite_path_for_relay.as_path()),
+            None,
         ))
         .await
     });

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -224,6 +224,7 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
             0,
             5,
             Some(sqlite_path_for_relay.as_path()),
+            None,
         ))
         .await
     });

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -212,6 +212,7 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
             0,
             5,
             Some(sqlite_path_for_relay.as_path()),
+            None,
         ))
         .await
     });

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1055,7 +1055,7 @@ impl<Env: Environment> ChainClient<Env> {
                 .await;
         }
 
-        info!("find_received_certificates finished");
+        trace!("find_received_certificates finished");
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

The bridge relayer wasn't restart-safe: messages that arrived while it was down
were never processed, and on restart it re-scanned both chains from scratch and
re-submitted every historical transfer. Separately, the local dockerized demo
had a few breakages (operation encoding, a renamed CLI flag, setup-marker
ownership) and slow EVM settlement.

## Proposal

Make the relayer resilient across restarts:
- Drain the bridge chain inbox on startup (and periodically), so transfers
  received during downtime are eventually processed rather than stranded.
- Persist the EVM/Linera scan cursors and resume from them, so a restart no
  longer re-discovers and re-settles already-finished work.

Fix and harden the local demo:
- Correct the registration-operation encoding and the relayer entrypoint flags.
- Give setup ownership of clearing stale state, so the relayer can restart on its
  own instead of requiring a full re-setup.
- Allow overriding the EVM poll interval (off by default) so local settlement
  isn't bottlenecked by alloy's remote-host default.

Also lowers a few noisy steady-state log lines.

## Test Plan

- `cargo test -p linera-bridge --features relay` (149 passed; adds tests for the
  cursor persistence and dedup guards) and `clippy --all-targets`, clean.
- Manual: against the local demo, stop the relayer mid-flow, burn more, restart —
  stranded burns settle and balances reconcile, and restarts no longer re-submit
  finished transfers.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
