### PR TITLE
Fix JournalingError::must_reload_view to delegate to the inner store error

### DIFF
--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -145,7 +145,11 @@ impl<E: KeyValueStoreError + 'static> KeyValueStoreError for JournalingError<E> 
     const BACKEND: &'static str = "journaling";
 
     fn must_reload_view(&self) -> bool {
-        matches!(self, JournalingError::JournalResolutionFailed(_))
+        match self {
+            JournalingError::Inner(error) => error.must_reload_view(),
+            JournalingError::JournalResolutionFailed(_) => true,
+            JournalingError::BcsError(_) | JournalingError::JournalRequiresExclusiveAccess => false,
+        }
     }
 }
 
@@ -571,5 +575,39 @@ impl<S> JournalingKeyValueStore<S> {
             store,
             has_exclusive_access: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Error)]
+    enum MockError {
+        #[error("requires reload")]
+        MustReload,
+        #[error("benign")]
+        Benign,
+        #[error(transparent)]
+        Bcs(#[from] bcs::Error),
+    }
+
+    impl KeyValueStoreError for MockError {
+        const BACKEND: &'static str = "mock";
+
+        fn must_reload_view(&self) -> bool {
+            matches!(self, MockError::MustReload)
+        }
+    }
+
+    #[test]
+    fn journaling_error_inner_delegates_must_reload_view() {
+        assert!(JournalingError::Inner(MockError::MustReload).must_reload_view());
+        assert!(!JournalingError::Inner(MockError::Benign).must_reload_view());
+        assert!(JournalingError::<MockError>::JournalResolutionFailed(
+            JournalingResolutionError::FailureToRetrieveJournalBlock
+        )
+        .must_reload_view());
+        assert!(!JournalingError::<MockError>::JournalRequiresExclusiveAccess.must_reload_view());
     }
 }


### PR DESCRIPTION
## Motivation

A chain worker can silently end up with an **in-memory execution state that is behind the durable database**, with no error surfaced. The worker keeps serving the stale state until it is reloaded, which manifests blocks later as `CorruptedChainState` ("computed block outcome differs from the certificate") on a per-validator, near-disjoint set of chains.

The cause is an error-classification gap. The production storage error type is `ValueSplittingError<JournalingError<ScyllaDbStoreInternalError>>`. When a `write_batch` fails — notably a Scylla timeout, where the batch *may or may not* have committed — `ScyllaDbStoreInternalError::must_reload_view()` correctly returns `true` so the worker is poisoned and reloads from the DB, and `ValueSplittingError::must_reload_view()` delegates correctly. But `JournalingError::must_reload_view()` only returned `true` for `JournalResolutionFailed` and did **not** delegate for its `Inner(E)` variant. On the journaling fast path (ordinary small writes), the inner store error is wrapped as `JournalingError::Inner(_)`, so `must_reload_view()` returned `false` and the backend's classification was shadowed.

Consequence: on such a write error, `save()` short-circuits before `post_save` (the in-memory view is later rolled back to the old value while the DB may already hold the new one), the worker is **not** poisoned, and it keeps running with a stale view — undetected, since `state_hash` is zeroed on this network. This became possible when poisoning was made conditional on `must_reload_view()` (#6333); previously `save()` poisoned on any error, so the silent desync could not occur.

## Proposal

Make `JournalingError::must_reload_view()` delegate to the wrapped backend error for the `Inner(E)` variant, mirroring `ValueSplittingError` and `DualStoreError`. `JournalResolutionFailed` keeps returning `true` (a failed resolution leaves storage possibly inconsistent); `BcsError` / `JournalRequiresExclusiveAccess` return `false`.

I audited every `must_reload_view` impl in `linera-views`: the only inner errors that ever return `true` are `ScyllaDbStoreInternalError::WriteBatchExecutionError` (exactly the case we want to reload on) and an explicitly-flagged `ViewError::StoreError { must_reload_view: true }` — so the delegation cannot over-poison on a benign error.

## Test Plan

New unit test `journaling_error_inner_delegates_must_reload_view`: `Inner` delegates (true for a reload-requiring inner error, false for a benign one), `JournalResolutionFailed` is `true`, `JournalRequiresExclusiveAccess` is `false`. `cargo test -p linera-views` and `cargo clippy -p linera-views --all-targets` are green.

> Draft note: this is a confirmed classification bug that reproduces exactly the observed silent in-memory↔DB desync. I have **not** yet confirmed in production metrics that the triggering Scylla `WriteBatchExecutionError` actually fires on the affected validators (storage-proxy write-error counters there are ~0; read timeouts are present), so it is not yet proven to be the sole cause of the current corruption. Worth landing regardless, and pairing with historical-hash localization to confirm.

## Release Plan

- Hotfix `testnet_conway`.
- Port to `main`.