### PR TITLE
Fix JournalingError::must_reload_view to delegate to the inner store error

### DIFF
--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -94,7 +94,11 @@ impl<E: KeyValueStoreError + 'static> KeyValueStoreError for JournalingError<E> 
     const BACKEND: &'static str = "journaling";
 
     fn must_reload_view(&self) -> bool {
-        matches!(self, JournalingError::JournalResolutionFailed(_))
+        match self {
+            JournalingError::Inner(error) => error.must_reload_view(),
+            JournalingError::JournalResolutionFailed(_) => true,
+            JournalingError::BcsError(_) | JournalingError::JournalRequiresExclusiveAccess => false,
+        }
     }
 }
 
@@ -467,5 +471,39 @@ impl<S> JournalingKeyValueStore<S> {
             store,
             has_exclusive_access: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Error)]
+    enum MockError {
+        #[error("requires reload")]
+        MustReload,
+        #[error("benign")]
+        Benign,
+        #[error(transparent)]
+        Bcs(#[from] bcs::Error),
+    }
+
+    impl KeyValueStoreError for MockError {
+        const BACKEND: &'static str = "mock";
+
+        fn must_reload_view(&self) -> bool {
+            matches!(self, MockError::MustReload)
+        }
+    }
+
+    #[test]
+    fn journaling_error_inner_delegates_must_reload_view() {
+        assert!(JournalingError::Inner(MockError::MustReload).must_reload_view());
+        assert!(!JournalingError::Inner(MockError::Benign).must_reload_view());
+        assert!(JournalingError::<MockError>::JournalResolutionFailed(
+            JournalingResolutionError::FailureToRetrieveJournalBlock
+        )
+        .must_reload_view());
+        assert!(!JournalingError::<MockError>::JournalRequiresExclusiveAccess.must_reload_view());
     }
 }


### PR DESCRIPTION
## Motivation

`JournalingError::must_reload_view()` on `main` returns `true` only for the
`JournalResolutionFailed` variant. For `Inner(E)` — an error bubbling up from the
wrapped store — it returns `false`, even when that inner error itself reports
`must_reload_view() == true`.

This is the silent in-memory↔DB state-desync mechanism behind the "Corrupted chain
state" surge on the `testnet_conway` validators (root-caused 2026-06-16…18): a write
error that should poison and reload the chain worker's view is instead classified as
benign, so the in-memory view keeps diverging from durable storage until the drift
leaks into a block outcome.

The fix landed on `testnet_conway` as #6507 but was never forward-ported to `main`.
The other two hotfixes from the same incident are being ported (#6502 merged, #6499
open), but #6499 only touches `worker.rs` and does not carry this change — so `main`
is still vulnerable.

## Proposal

Forward-port #6507: have `must_reload_view` delegate to the inner store error for the
`Inner` variant, keep `JournalResolutionFailed => true`, and explicitly classify
`BcsError` / `JournalRequiresExclusiveAccess` as `false`. Includes the unit test that
pins the behavior of all four variants.

## Test Plan

- New unit test `journaling_error_inner_delegates_must_reload_view` (`linera-views`).
  Verified locally that it **fails on current `main`** (the buggy `matches!` returns
  `false` for `Inner(MustReload)`) and **passes with the fix**.
- `cargo clippy -p linera-views --all-targets` clean.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

  *(Already present on `testnet_conway` via #6507 — this PR brings `main` in line.)*

## Links

- Forward-port of #6507 (merged to `testnet_conway`).
- Same-incident `main` ports: #6502 (merged), #6499 (open).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)