### PR TITLE
Add #![deny(missing_docs)] to linera-execution

### DIFF
--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -165,6 +165,7 @@ impl<'a> From<&'a Committee> for CommitteeMinimal<'a> {
 }
 
 impl Committee {
+    /// Creates a new committee from the given validators and resource control policy.
     pub fn new(
         validators: BTreeMap<ValidatorPublicKey, ValidatorState>,
         policy: ResourceControlPolicy,
@@ -194,6 +195,7 @@ impl Committee {
         })
     }
 
+    /// Creates a simple committee for testing, giving each validator equal voting weight.
     #[cfg(with_testing)]
     pub fn make_simple(keys: Vec<(ValidatorPublicKey, AccountPublicKey)>) -> Self {
         let map = keys
@@ -213,6 +215,7 @@ impl Committee {
             .expect("test committee votes should not overflow")
     }
 
+    /// Returns the number of votes held by the given validator, or zero if it is not a member.
     pub fn weight(&self, author: &ValidatorPublicKey) -> u64 {
         match self.validators.get(author) {
             Some(state) => state.votes,
@@ -220,34 +223,41 @@ impl Committee {
         }
     }
 
+    /// Returns an iterator over each validator's account public key and its number of votes.
     pub fn account_keys_and_weights(&self) -> impl Iterator<Item = (AccountPublicKey, u64)> + '_ {
         self.validators
             .values()
             .map(|validator| (validator.account_public_key, validator.votes))
     }
 
+    /// Returns the number of votes required to reach a quorum.
     pub fn quorum_threshold(&self) -> u64 {
         self.quorum_threshold
     }
 
+    /// Returns the number of votes required to reach the validity threshold.
     pub fn validity_threshold(&self) -> u64 {
         self.validity_threshold
     }
 
+    /// Returns the validators in this committee, keyed by their public key.
     pub fn validators(&self) -> &BTreeMap<ValidatorPublicKey, ValidatorState> {
         &self.validators
     }
 
+    /// Returns an iterator over each validator's public key and network address.
     pub fn validator_addresses(&self) -> impl Iterator<Item = (ValidatorPublicKey, &str)> {
         self.validators
             .iter()
             .map(|(name, validator)| (*name, &*validator.network_address))
     }
 
+    /// Returns the total number of votes across all validators.
     pub fn total_votes(&self) -> u64 {
         self.total_votes
     }
 
+    /// Returns the resource control policy of this committee.
     pub fn policy(&self) -> &ResourceControlPolicy {
         &self.policy
     }
@@ -270,6 +280,7 @@ pub struct SharedCommittees {
 }
 
 impl SharedCommittees {
+    /// Creates a new, empty committee cache.
     pub fn new() -> Self {
         Self::default()
     }

--- a/linera-execution/src/evm/mod.rs
+++ b/linera-execution/src/evm/mod.rs
@@ -17,7 +17,9 @@ use revm_context::result::HaltReason;
 use revm_primitives::{Address, U256};
 use thiserror::Error;
 
+/// An error that occurred while executing an EVM application.
 #[derive(Debug, Error)]
+#[allow(missing_docs)]
 pub enum EvmExecutionError {
     #[error(transparent)]
     AmountConversionError(#[from] AmountConversionError),

--- a/linera-execution/src/evm/revm.rs
+++ b/linera-execution/src/evm/revm.rs
@@ -142,7 +142,9 @@ mod metrics {
     });
 }
 
+/// A user contract in a compiled EVM module.
 #[derive(Clone)]
+#[allow(missing_docs)]
 pub enum EvmContractModule {
     #[cfg(with_revm)]
     Revm { module: Vec<u8> },
@@ -203,6 +205,7 @@ impl UserContractModule for EvmContractModule {
 
 /// A user service in a compiled EVM module.
 #[derive(Clone)]
+#[allow(missing_docs)]
 pub enum EvmServiceModule {
     #[cfg(with_revm)]
     Revm { module: Vec<u8> },
@@ -262,6 +265,7 @@ type ContractCtx<'a, Runtime> = MainnetContext<WrapDatabaseRef<&'a mut ContractD
 
 type ServiceCtx<'a, Runtime> = MainnetContext<WrapDatabaseRef<&'a mut ServiceDatabase<Runtime>>>;
 
+/// Converts an EVM address into the corresponding Linera application ID.
 pub fn address_to_user_application_id(address: Address) -> ApplicationId {
     let mut vec = vec![0_u8; 32];
     vec[..20].copy_from_slice(address.as_ref());
@@ -1187,6 +1191,7 @@ impl<Runtime: ServiceRuntime> CallInterceptorService<Runtime> {
     }
 }
 
+/// An instance of a user contract running on the Revm EVM.
 pub struct RevmContractInstance<Runtime> {
     module: Vec<u8>,
     db: ContractDatabase<Runtime>,
@@ -1393,6 +1398,7 @@ impl<Runtime> RevmContractInstance<Runtime>
 where
     Runtime: ContractRuntime,
 {
+    /// Prepares a contract instance from its EVM module and the given runtime.
     pub fn prepare(module: Vec<u8>, runtime: Runtime) -> Self {
         let db = ContractDatabase::new(runtime);
         Self { module, db }
@@ -1565,6 +1571,7 @@ where
     }
 }
 
+/// An instance of a user service running on the Revm EVM.
 pub struct RevmServiceInstance<Runtime> {
     module: Vec<u8>,
     db: ServiceDatabase<Runtime>,
@@ -1574,6 +1581,7 @@ impl<Runtime> RevmServiceInstance<Runtime>
 where
     Runtime: ServiceRuntime,
 {
+    /// Prepares a service instance from its EVM module and the given runtime.
     pub fn prepare(module: Vec<u8>, runtime: Runtime) -> Self {
         let db = ServiceDatabase::new(runtime);
         Self { module, db }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -102,6 +102,7 @@ where
     C: Context + Clone + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
+    /// Computes the cryptographic hash of the execution state.
     pub async fn crypto_hash_mut(&mut self) -> Result<CryptoHash, ViewError> {
         #[derive(Serialize, Deserialize)]
         struct ExecutionStateViewHash([u8; 32]);
@@ -362,6 +363,7 @@ where
     C: Context + Clone + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
+    /// Runs a query against the given application and returns its response.
     pub async fn query_application(
         &mut self,
         context: QueryContext,
@@ -495,6 +497,7 @@ where
         }
     }
 
+    /// Returns the descriptions of all applications registered on this chain.
     pub async fn list_applications(
         &self,
     ) -> Result<Vec<(ApplicationId, ApplicationDescription)>, ExecutionError> {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -1117,6 +1117,7 @@ where
         block_height = %context.height,
         operation_type = %operation.as_ref(),
     ))]
+    /// Executes an operation, dispatching to the system or to a user application.
     pub async fn execute_operation(
         &mut self,
         context: OperationContext,
@@ -1179,6 +1180,7 @@ where
         is_bouncing = %context.is_bouncing,
         message_type = %message.as_ref(),
     ))]
+    /// Executes an incoming message, dispatching to the system or to a user application.
     pub async fn execute_message(
         &mut self,
         context: MessageContext,
@@ -1208,6 +1210,7 @@ where
         Ok(())
     }
 
+    /// Bounces a message back to its sender, returning any attached grant.
     pub fn bounce_message(
         &mut self,
         context: MessageContext,
@@ -1226,6 +1229,7 @@ where
         Ok(())
     }
 
+    /// Sends a refund of the given amount to the account designated to receive grant refunds.
     pub fn send_refund(
         &mut self,
         context: MessageContext,
@@ -1314,6 +1318,7 @@ where
 
 /// Requests to the execution state.
 #[derive(Debug, strum::AsRefStr)]
+#[allow(missing_docs)]
 pub enum ExecutionRequest {
     #[cfg(not(web))]
     LoadContract {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -4,6 +4,9 @@
 //! This module manages the execution of the system application and the user applications in a
 //! Linera chain.
 
+#![deny(missing_docs)]
+
+/// The committee of validators and their voting weights for an epoch.
 pub mod committee;
 pub mod evm;
 mod execution;
@@ -13,7 +16,9 @@ mod graphql;
 mod policy;
 mod resources;
 mod runtime;
+/// The system application implementing core chain functionality.
 pub mod system;
+/// Helpers for writing tests that exercise the execution layer.
 #[cfg(with_testing)]
 pub mod test_utils;
 mod transaction_tracker;
@@ -83,6 +88,8 @@ pub use crate::{
 /// The `Linera.sol` library code to be included in solidity smart
 /// contracts using Linera features.
 pub const LINERA_SOL: &str = include_str!("../solidity/Linera.sol");
+/// The `LineraTypes.sol` library code defining the Solidity types used to
+/// interface with Linera features.
 pub const LINERA_TYPES_SOL: &str = include_str!("../solidity/LineraTypes.sol");
 
 /// The maximum length of a stream name.
@@ -104,6 +111,7 @@ pub type UserServiceInstance = Box<dyn UserService>;
 
 /// A factory trait to obtain a [`UserContract`] from a [`UserContractModule`]
 pub trait UserContractModule: dyn_clone::DynClone + Any + web_thread::Post + Send + Sync {
+    /// Instantiates the contract with the given runtime handle.
     fn instantiate(
         &self,
         runtime: ContractSyncRuntimeHandle,
@@ -120,6 +128,7 @@ dyn_clone::clone_trait_object!(UserContractModule);
 
 /// A factory trait to obtain a [`UserService`] from a [`UserServiceModule`]
 pub trait UserServiceModule: dyn_clone::DynClone + Any + web_thread::Post + Send + Sync {
+    /// Instantiates the service with the given runtime handle.
     fn instantiate(
         &self,
         runtime: ServiceSyncRuntimeHandle,
@@ -152,6 +161,7 @@ impl UserContractCode {
     }
 }
 
+/// A wrapper around a `Vec` that can be converted to and from a JavaScript array.
 pub struct JsVec<T>(pub Vec<T>);
 
 #[cfg(web)]
@@ -230,6 +240,7 @@ const _: () = {
 
 /// A type for errors happening during execution.
 #[derive(Error, Debug, strum::IntoStaticStr)]
+#[allow(missing_docs)]
 pub enum ExecutionError {
     #[error(transparent)]
     ViewError(#[from] ViewError),
@@ -521,32 +532,42 @@ impl Default for ExecutionRuntimeConfig {
 #[cfg_attr(not(web), async_trait)]
 #[cfg_attr(web, async_trait(?Send))]
 pub trait ExecutionRuntimeContext {
+    /// Returns the ID of the chain this context belongs to.
     fn chain_id(&self) -> ChainId;
 
+    /// Returns the thread pool used to run blocking work.
     fn thread_pool(&self) -> &Arc<ThreadPool>;
 
+    /// Returns the configuration options for the execution runtime.
     fn execution_runtime_config(&self) -> ExecutionRuntimeConfig;
 
+    /// Returns the cache of loaded user contracts.
     fn user_contracts(&self) -> &Arc<papaya::HashMap<ApplicationId, UserContractCode>>;
 
+    /// Returns the cache of loaded user services.
     fn user_services(&self) -> &Arc<papaya::HashMap<ApplicationId, UserServiceCode>>;
 
+    /// Loads the contract for the given application, instantiating it if necessary.
     async fn get_user_contract(
         &self,
         description: &ApplicationDescription,
         txn_tracker: &TransactionTracker,
     ) -> Result<UserContractCode, ExecutionError>;
 
+    /// Loads the service for the given application, instantiating it if necessary.
     async fn get_user_service(
         &self,
         description: &ApplicationDescription,
         txn_tracker: &TransactionTracker,
     ) -> Result<UserServiceCode, ExecutionError>;
 
+    /// Returns the blob with the given ID, if it is available.
     async fn get_blob(&self, blob_id: BlobId) -> Result<Option<Arc<Blob>>, ViewError>;
 
+    /// Returns the event with the given ID, if it is available.
     async fn get_event(&self, event_id: EventId) -> Result<Option<Arc<Vec<u8>>>, ViewError>;
 
+    /// Returns the network description, if it is available.
     async fn get_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
 
     /// Returns the committee whose serialized form hashes to `hash`. Returns
@@ -609,16 +630,20 @@ pub trait ExecutionRuntimeContext {
         committee_hashes.into_iter().collect()
     }
 
+    /// Returns whether a blob with the given ID is available.
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
+    /// Returns whether an event with the given ID is available.
     async fn contains_event(&self, event_id: EventId) -> Result<bool, ViewError>;
 
+    /// Adds the given blobs to the context, for use in tests.
     #[cfg(with_testing)]
     async fn add_blobs(
         &self,
         blobs: impl IntoIterator<Item = Blob> + Send,
     ) -> Result<(), ViewError>;
 
+    /// Adds the given events to the context, for use in tests.
     #[cfg(with_testing)]
     async fn add_events(
         &self,
@@ -626,6 +651,7 @@ pub trait ExecutionRuntimeContext {
     ) -> Result<(), ViewError>;
 }
 
+/// The context in which an operation is executed.
 #[derive(Clone, Copy, Debug)]
 pub struct OperationContext {
     /// The current chain ID.
@@ -641,6 +667,7 @@ pub struct OperationContext {
     pub timestamp: Timestamp,
 }
 
+/// The context in which a message is executed.
 #[derive(Clone, Copy, Debug)]
 pub struct MessageContext {
     /// The current chain ID.
@@ -667,6 +694,7 @@ pub struct MessageContext {
     pub timestamp: Timestamp,
 }
 
+/// The context in which stream updates are processed.
 #[derive(Clone, Copy, Debug)]
 pub struct ProcessStreamsContext {
     /// The current chain ID.
@@ -701,6 +729,7 @@ impl From<OperationContext> for ProcessStreamsContext {
     }
 }
 
+/// The context in which a transaction is finalized.
 #[derive(Clone, Copy, Debug)]
 pub struct FinalizeContext {
     /// The current chain ID.
@@ -714,6 +743,7 @@ pub struct FinalizeContext {
     pub round: Option<u32>,
 }
 
+/// The context in which a query is executed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct QueryContext {
     /// The current chain ID.
@@ -724,13 +754,21 @@ pub struct QueryContext {
     pub local_time: Timestamp,
 }
 
+/// The runtime API shared by the contract and service parts of an application.
 pub trait BaseRuntime {
+    /// The pending result of a generic read.
     type Read: fmt::Debug + Send + Sync;
+    /// The pending result of a key existence check.
     type ContainsKey: fmt::Debug + Send + Sync;
+    /// The pending result of a multi-key existence check.
     type ContainsKeys: fmt::Debug + Send + Sync;
+    /// The pending result of reading the values for multiple keys.
     type ReadMultiValuesBytes: fmt::Debug + Send + Sync;
+    /// The pending result of reading the value for a single key.
     type ReadValueBytes: fmt::Debug + Send + Sync;
+    /// The pending result of finding the keys with a given prefix.
     type FindKeysByPrefix: fmt::Debug + Send + Sync;
+    /// The pending result of finding the key-value pairs with a given prefix.
     type FindKeyValuesByPrefix: fmt::Debug + Send + Sync;
 
     /// The current chain ID.
@@ -931,6 +969,7 @@ pub trait BaseRuntime {
     fn send_log(&mut self, message: String, level: tracing::log::Level);
 }
 
+/// The runtime API available to the service part of an application.
 pub trait ServiceRuntime: BaseRuntime {
     /// Queries another application.
     fn try_query_application(
@@ -946,6 +985,7 @@ pub trait ServiceRuntime: BaseRuntime {
     fn check_execution_time(&mut self) -> Result<(), ExecutionError>;
 }
 
+/// The runtime API available to the contract part of an application.
 pub trait ContractRuntime: BaseRuntime {
     /// The authenticated owner for this execution, if there is one.
     fn authenticated_owner(&mut self) -> Result<Option<AccountOwner>, ExecutionError>;
@@ -1117,7 +1157,9 @@ pub enum Operation {
     System(Box<SystemOperation>),
     /// A user operation (in serialized form).
     User {
+        /// The ID of the application this operation targets.
         application_id: ApplicationId,
+        /// The serialized operation.
         #[serde(with = "serde_bytes")]
         #[debug(with = "hex_debug")]
         bytes: Vec<u8>,
@@ -1135,7 +1177,9 @@ pub enum Message {
     System(SystemMessage),
     /// A user message (in serialized form).
     User {
+        /// The ID of the application this message targets.
         application_id: ApplicationId,
+        /// The serialized message.
         #[serde(with = "serde_bytes")]
         #[debug(with = "hex_debug")]
         bytes: Vec<u8>,
@@ -1149,7 +1193,9 @@ pub enum Query {
     System(SystemQuery),
     /// A user query (in serialized form).
     User {
+        /// The ID of the application this query targets.
         application_id: ApplicationId,
+        /// The serialized query.
         #[serde(with = "serde_bytes")]
         #[debug(with = "hex_debug")]
         bytes: Vec<u8>,
@@ -1159,7 +1205,9 @@ pub enum Query {
 /// The outcome of the execution of a query.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct QueryOutcome<Response = QueryResponse> {
+    /// The response returned by the query.
     pub response: Response,
+    /// The operations scheduled by the query, to be included in the next block.
     pub operations: Vec<Operation>,
 }
 
@@ -1289,6 +1337,7 @@ impl OperationContext {
     }
 }
 
+/// An in-memory [`ExecutionRuntimeContext`] implementation used in tests.
 #[cfg(with_testing)]
 #[derive(Clone)]
 pub struct TestExecutionRuntimeContext {
@@ -1303,6 +1352,7 @@ pub struct TestExecutionRuntimeContext {
 
 #[cfg(with_testing)]
 impl TestExecutionRuntimeContext {
+    /// Creates a new test execution runtime context for the given chain.
     pub fn new(chain_id: ChainId, execution_runtime_config: ExecutionRuntimeConfig) -> Self {
         Self {
             chain_id,
@@ -1453,6 +1503,7 @@ impl From<SystemOperation> for Operation {
 }
 
 impl Operation {
+    /// Creates a new system operation.
     pub fn system(operation: SystemOperation) -> Self {
         Operation::System(Box::new(operation))
     }
@@ -1488,6 +1539,7 @@ impl Operation {
         }
     }
 
+    /// Returns the ID of the application this operation targets.
     pub fn application_id(&self) -> GenericApplicationId {
         match self {
             Self::System(_) => GenericApplicationId::System,
@@ -1544,6 +1596,7 @@ impl From<SystemMessage> for Message {
 }
 
 impl Message {
+    /// Creates a new system message.
     pub fn system(message: SystemMessage) -> Self {
         Message::System(message)
     }
@@ -1567,6 +1620,7 @@ impl Message {
         })
     }
 
+    /// Returns the ID of the application this message targets.
     pub fn application_id(&self) -> GenericApplicationId {
         match self {
             Self::System(_) => GenericApplicationId::System,
@@ -1582,6 +1636,7 @@ impl From<SystemQuery> for Query {
 }
 
 impl Query {
+    /// Creates a new system query.
     pub fn system(query: SystemQuery) -> Self {
         Query::System(query)
     }
@@ -1606,6 +1661,7 @@ impl Query {
         })
     }
 
+    /// Returns the ID of the application this query targets.
     pub fn application_id(&self) -> GenericApplicationId {
         match self {
             Self::System(_) => GenericApplicationId::System,
@@ -1639,7 +1695,9 @@ pub enum BlobOrigin {
     /// The blob was published by a confirmed block on the given chain at the
     /// given height.
     Published {
+        /// The chain on which the publishing block was confirmed.
         chain_id: ChainId,
+        /// The height of the publishing block.
         block_height: BlockHeight,
     },
 }
@@ -1670,6 +1728,7 @@ impl BlobState {
 /// The runtime to use for running the application.
 #[derive(Clone, Copy, Display)]
 #[cfg_attr(with_wasm_runtime, derive(Debug, Default))]
+#[allow(missing_docs)]
 pub enum WasmRuntime {
     #[cfg(with_wasmer)]
     #[default]
@@ -1681,8 +1740,10 @@ pub enum WasmRuntime {
     Wasmtime,
 }
 
+/// The runtime to use for running EVM smart contracts.
 #[derive(Clone, Copy, Display)]
 #[cfg_attr(with_revm, derive(Debug, Default))]
+#[allow(missing_docs)]
 pub enum EvmRuntime {
     #[cfg(with_revm)]
     #[default]
@@ -1692,6 +1753,7 @@ pub enum EvmRuntime {
 
 /// Trait used to select a default `WasmRuntime`, if one is available.
 pub trait WithWasmDefault {
+    /// Returns the default `WasmRuntime` if one is available, otherwise leaves the value unchanged.
     fn with_wasm_default(self) -> Self;
 }
 

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -335,6 +335,7 @@ impl ResourceControlPolicy {
         }
     }
 
+    /// Returns the total price to charge for the given resources.
     pub fn total_price(&self, resources: &Resources) -> Result<Amount, ArithmeticError> {
         let mut amount = Amount::ZERO;
         amount.try_add_assign(self.fuel_price(resources.wasm_fuel, VmRuntime::Wasm)?)?;
@@ -439,6 +440,7 @@ impl ResourceControlPolicy {
         u64::try_from(balance.saturating_ratio(fuel_unit)).unwrap_or(u64::MAX)
     }
 
+    /// Checks that the blob's size does not exceed the maximum allowed by this policy.
     pub fn check_blob_size(&self, content: &BlobContent) -> Result<(), ExecutionError> {
         ensure!(
             u64::try_from(content.bytes().len())

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -18,6 +18,7 @@ use serde::Serialize;
 
 use crate::{ExecutionError, Message, Operation, ResourceControlPolicy, SystemExecutionStateView};
 
+/// Tracks and controls the resources used during execution, charging fees against an account.
 #[derive(Clone, Debug, Default)]
 pub struct ResourceController<Account = Amount, Tracker = ResourceTracker> {
     /// The (fixed) policy used to charge fees and control resource usage.
@@ -343,10 +344,13 @@ impl fmt::Display for ResourceTracker {
 
 /// How to access the balance of an account.
 pub trait BalanceHolder {
+    /// Returns the balance of the account.
     fn balance(&self) -> Result<Amount, ArithmeticError>;
 
+    /// Adds the given amount to the balance.
     fn try_add_assign(&mut self, other: Amount) -> Result<(), ArithmeticError>;
 
+    /// Subtracts the given amount from the balance.
     fn try_sub_assign(&mut self, other: Amount) -> Result<(), ArithmeticError>;
 }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -68,6 +68,7 @@ pub struct SyncRuntime<UserInstance: WithContext>(Option<SyncRuntimeHandle<UserI
 
 pub type ContractSyncRuntime = SyncRuntime<UserContractInstance>;
 
+/// The synchronous runtime used to execute service queries.
 pub struct ServiceSyncRuntime {
     runtime: SyncRuntime<UserServiceInstance>,
     current_context: QueryContext,
@@ -78,7 +79,9 @@ pub struct SyncRuntimeHandle<UserInstance: WithContext>(
     Arc<Mutex<SyncRuntimeInternal<UserInstance>>>,
 );
 
+/// A handle to the synchronous runtime used when executing contracts.
 pub type ContractSyncRuntimeHandle = SyncRuntimeHandle<UserContractInstance>;
+/// A handle to the synchronous runtime used when executing services.
 pub type ServiceSyncRuntimeHandle = SyncRuntimeHandle<UserServiceInstance>;
 
 /// Runtime data tracked during the execution of a transaction on the synchronous thread.
@@ -1919,6 +1922,7 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
 }
 
 /// A request to the service runtime actor.
+#[allow(missing_docs)]
 pub enum ServiceRuntimeRequest {
     Query {
         application_id: ApplicationId,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -228,6 +228,7 @@ impl OpenChainConfig {
 
 /// A system operation.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Allocative)]
+#[allow(missing_docs)]
 pub enum SystemOperation {
     /// Transfers `amount` units of value from the given owner's account to the recipient.
     /// If no owner is given, try to take the units out of the unattributed account.
@@ -310,6 +311,7 @@ pub enum SystemOperation {
 
 /// Operations that are only allowed on the admin chain.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Allocative)]
+#[allow(missing_docs)]
 pub enum AdminOperation {
     /// Publishes a new committee as a blob. This can be assigned to an epoch using
     /// [`AdminOperation::CreateCommittee`] in a later block.
@@ -324,6 +326,7 @@ pub enum AdminOperation {
 
 /// A system message meant to be executed on a remote chain.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Allocative)]
+#[allow(missing_docs)]
 pub enum SystemMessage {
     /// Credits `amount` units of value to the account `target` -- unless the message is
     /// bouncing, in which case `source` is credited instead.
@@ -355,6 +358,7 @@ pub struct SystemQuery;
 
 /// The response to a system query.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
 pub struct SystemResponse {
     pub chain_id: ChainId,
     pub balance: Amount,
@@ -364,7 +368,9 @@ pub struct SystemResponse {
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default, Debug, Serialize, Deserialize)]
 pub struct UserData(pub Option<[u8; 32]>);
 
+/// The result of creating a new application.
 #[derive(Debug)]
+#[allow(missing_docs)]
 pub struct CreateApplicationResult {
     pub app_id: ApplicationId,
 }
@@ -702,6 +708,7 @@ where
         }
     }
 
+    /// Transfers `amount` from `source` to `recipient`, debiting the source account.
     pub async fn transfer(
         &mut self,
         authenticated_owner: Option<AccountOwner>,
@@ -732,6 +739,7 @@ where
         self.credit_or_send_message(source, recipient, amount).await
     }
 
+    /// Claims `amount` from `source`'s account on `target_id` and transfers it to `recipient`.
     pub async fn claim(
         &mut self,
         authenticated_owner: Option<AccountOwner>,
@@ -767,6 +775,7 @@ where
         }
     }
 
+    /// Sets the allowance that `spender` may transfer on behalf of `owner` to `amount`.
     pub async fn approve(
         &mut self,
         authenticated_owner: Option<AccountOwner>,
@@ -792,6 +801,7 @@ where
         Ok(())
     }
 
+    /// Transfers `amount` from `owner` to `recipient`, debiting the spender's allowance.
     pub async fn transfer_from(
         &mut self,
         authenticated_owner: Option<AccountOwner>,
@@ -967,6 +977,7 @@ where
         Ok(false)
     }
 
+    /// Handles a query to the system state, returning the system response.
     pub fn handle_query(
         &mut self,
         context: QueryContext,
@@ -1007,10 +1018,12 @@ where
         Ok(child_id)
     }
 
+    /// Marks the chain as closed.
     pub fn close_chain(&mut self) {
         self.closed.set(true);
     }
 
+    /// Creates a new application from the given module and arguments, returning its ID.
     pub async fn create_application(
         &mut self,
         chain_id: ChainId,
@@ -1117,6 +1130,7 @@ where
         Ok(())
     }
 
+    /// Reads the content of the blob with the given ID.
     pub async fn read_blob_content(&self, blob_id: BlobId) -> Result<BlobContent, ExecutionError> {
         match self.context().extra().get_blob(blob_id).await {
             Ok(Some(blob)) => Ok(Arc::unwrap_or_clone(blob).into()),
@@ -1125,6 +1139,7 @@ where
         }
     }
 
+    /// Returns an error unless a blob with the given ID exists.
     pub async fn assert_blob_exists(&mut self, blob_id: BlobId) -> Result<(), ExecutionError> {
         if self.context().extra().contains_blob(blob_id).await? {
             Ok(())

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -33,6 +33,7 @@ use crate::{
     SystemExecutionStateView,
 };
 
+/// Creates a dummy committee with a single test validator.
 pub fn dummy_committee() -> Committee {
     Committee::make_simple(vec![(
         ValidatorPublicKey::test_key(0),
@@ -40,11 +41,13 @@ pub fn dummy_committee() -> Committee {
     )])
 }
 
+/// Creates a dummy committee map containing a single committee at epoch zero.
 pub fn dummy_committees() -> BTreeMap<Epoch, Committee> {
     let committee = dummy_committee();
     BTreeMap::from([(Epoch::ZERO, committee)])
 }
 
+/// Creates a dummy root chain description with the given index, ownership, and balance.
 pub fn dummy_chain_description_with_ownership_and_balance(
     index: u32,
     ownership: ChainOwnership,
@@ -60,6 +63,7 @@ pub fn dummy_chain_description_with_ownership_and_balance(
     ChainDescription::new(origin, config, Timestamp::default())
 }
 
+/// Creates a dummy chain description owned by the given owner, with the maximum balance.
 pub fn dummy_chain_description_with_owner(index: u32, owner: AccountOwner) -> ChainDescription {
     dummy_chain_description_with_ownership_and_balance(
         index,
@@ -68,6 +72,7 @@ pub fn dummy_chain_description_with_owner(index: u32, owner: AccountOwner) -> Ch
     )
 }
 
+/// Creates a dummy chain description with a deterministic single owner and the maximum balance.
 pub fn dummy_chain_description(index: u32) -> ChainDescription {
     let chain_key = AccountPublicKey::test_key(2 * (index % 128) as u8 + 1);
     let ownership = ChainOwnership::single(chain_key.into());
@@ -246,6 +251,7 @@ where
     }
 }
 
+/// Creates the given number of dummy user application registrations for use in tests.
 pub fn create_dummy_user_application_registrations(
     count: u32,
 ) -> anyhow::Result<Vec<(ApplicationId, ApplicationDescription, Blob, Blob)>> {

--- a/linera-execution/src/test_utils/solidity.rs
+++ b/linera-execution/src/test_utils/solidity.rs
@@ -105,6 +105,7 @@ fn get_bytecode_path(
     Ok(hex::decode(&object)?)
 }
 
+/// Compiles a Solidity contract and returns the bytecode of the named contract.
 pub fn compile_solidity_contract(
     source_code: &str,
     file_name: &str,
@@ -120,6 +121,8 @@ pub fn compile_solidity_contract(
     )
 }
 
+/// Compiles a Solidity contract with the given optimizer settings, returning the contract's
+/// bytecode.
 pub fn compile_solidity_contract_with_options(
     source_code: &str,
     file_name: &str,
@@ -161,10 +164,12 @@ pub fn compile_solidity_contract_with_options(
     get_bytecode_path(path, file_name, contract_name, optimizer_runs)
 }
 
+/// Compiles the given Solidity source code and returns the bytecode of the named contract.
 pub fn get_bytecode(source_code: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
     compile_solidity_contract(source_code, "test_code.sol", contract_name, &[])
 }
 
+/// Reads a Solidity file, detects its contract name, and returns the compiled bytecode.
 pub fn load_solidity_example(path: &str) -> anyhow::Result<Vec<u8>> {
     let source_code = std::fs::read_to_string(path)?;
     let contract_name: &str = source_code
@@ -179,11 +184,13 @@ pub fn load_solidity_example(path: &str) -> anyhow::Result<Vec<u8>> {
     get_bytecode(&source_code, contract_name)
 }
 
+/// Reads a Solidity file and returns the compiled bytecode of the contract with the given name.
 pub fn load_solidity_example_by_name(path: &str, contract_name: &str) -> anyhow::Result<Vec<u8>> {
     let source_code = std::fs::read_to_string(path)?;
     get_bytecode(&source_code, contract_name)
 }
 
+/// Writes an EVM module to a temporary file, returning its path and the owning temporary directory.
 pub fn temporary_write_evm_module(module: &[u8]) -> anyhow::Result<(PathBuf, TempDir)> {
     let dir = tempfile::tempdir()?;
     let path = dir.path();
@@ -196,11 +203,13 @@ pub fn temporary_write_evm_module(module: &[u8]) -> anyhow::Result<(PathBuf, Tem
     Ok((evm_contract, dir))
 }
 
+/// Compiles a Solidity example and writes it to a temporary EVM module file, returning its path.
 pub fn get_evm_contract_path(path: &str) -> anyhow::Result<(PathBuf, TempDir)> {
     let module = load_solidity_example(path)?;
     temporary_write_evm_module(&module)
 }
 
+/// Converts a JSON array of byte values into a vector of bytes.
 pub fn value_to_vec_u8(value: &Value) -> Vec<u8> {
     let mut vec: Vec<u8> = Vec::new();
     for val in value.as_array().unwrap() {
@@ -211,6 +220,7 @@ pub fn value_to_vec_u8(value: &Value) -> Vec<u8> {
     vec
 }
 
+/// Reads a `u64` from the last 8 bytes of a 32-byte EVM word encoded as a JSON byte array.
 pub fn read_evm_u64_entry(value: &Value) -> u64 {
     let vec = value_to_vec_u8(value);
     let mut arr = [0_u8; 8];
@@ -218,11 +228,13 @@ pub fn read_evm_u64_entry(value: &Value) -> u64 {
     u64::from_be_bytes(arr)
 }
 
+/// Reads a `U256` from a 32-byte EVM word encoded as a JSON byte array.
 pub fn read_evm_u256_entry(value: &Value) -> U256 {
     let result = value_to_vec_u8(value);
     U256::from_be_slice(&result)
 }
 
+/// Reads an `Address` from the last 20 bytes of a 32-byte EVM word encoded as a JSON byte array.
 pub fn read_evm_address_entry(value: &Value) -> Address {
     let vec = value_to_vec_u8(value);
     let mut arr = [0_u8; 20];

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -23,6 +23,7 @@ use crate::{
 
 /// A system execution state, not represented as a view but as a simple struct.
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
+#[allow(missing_docs)]
 pub struct SystemExecutionState {
     pub description: Option<ChainDescription>,
     pub epoch: Epoch,
@@ -44,6 +45,7 @@ pub struct SystemExecutionState {
 }
 
 impl SystemExecutionState {
+    /// Creates a system execution state from a chain description, with dummy committees.
     pub fn new(description: ChainDescription) -> Self {
         let ownership = description.config().ownership.clone();
         let balance = description.config().balance;
@@ -60,12 +62,15 @@ impl SystemExecutionState {
         }
     }
 
+    /// Creates a dummy system execution state for the chain with the given index, returning it
+    /// together with its chain ID.
     pub fn dummy_chain_state(index: u32) -> (Self, ChainId) {
         let description = dummy_chain_description(index);
         let chain_id = description.id();
         (Self::new(description), chain_id)
     }
 
+    /// Builds an execution state view from this state and returns its cryptographic hash.
     pub async fn into_hash(self) -> CryptoHash {
         let mut view = self.into_view().await;
         view.crypto_hash_mut()
@@ -73,6 +78,7 @@ impl SystemExecutionState {
             .expect("hashing from memory should not fail")
     }
 
+    /// Converts this state into an execution state view backed by an in-memory context.
     pub async fn into_view(self) -> ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>> {
         let chain_id = self
             .description
@@ -83,6 +89,8 @@ impl SystemExecutionState {
             .await
     }
 
+    /// Converts this state into an execution state view for the given chain ID and runtime
+    /// configuration.
     pub async fn into_view_with(
         self,
         chain_id: ChainId,

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -92,11 +92,15 @@ pub struct PreparedCheckpoint {
 /// The [`TransactionTracker`] contents after a transaction has finished.
 #[derive(Debug, Default)]
 pub struct TransactionOutcome {
+    /// The recorded oracle responses.
     #[debug(skip_if = Vec::is_empty)]
     pub oracle_responses: Vec<OracleResponse>,
+    /// The messages to be sent to other chains.
     #[debug(skip_if = Vec::is_empty)]
     pub outgoing_messages: Vec<OutgoingMessage>,
+    /// The index to be assigned to the next created application.
     pub next_application_index: u32,
+    /// The index to be assigned to the next created chain.
     pub next_chain_index: u32,
     /// Events recorded by contracts' `emit` calls.
     pub events: Vec<Event>,
@@ -111,6 +115,7 @@ pub struct TransactionOutcome {
 }
 
 impl TransactionTracker {
+    /// Creates a new [`TransactionTracker`].
     pub fn new(
         local_time: Timestamp,
         transaction_index: u32,
@@ -136,6 +141,7 @@ impl TransactionTracker {
         }
     }
 
+    /// Sets the blobs known to the tracker and returns the updated tracker.
     pub fn with_blobs(mut self, blobs: BTreeMap<BlobId, BlobContent>) -> Self {
         self.blobs = blobs;
         self
@@ -153,44 +159,53 @@ impl TransactionTracker {
         self.prepared_checkpoint.take()
     }
 
+    /// Returns the local time recorded by the tracker.
     pub fn local_time(&self) -> Timestamp {
         self.local_time
     }
 
+    /// Sets the local time recorded by the tracker.
     pub fn set_local_time(&mut self, local_time: Timestamp) {
         self.local_time = local_time;
     }
 
+    /// Returns the index of the current transaction in the block.
     pub fn transaction_index(&self) -> u32 {
         self.transaction_index
     }
 
+    /// Returns the index that would be assigned to the next created application, without consuming it.
     pub fn peek_application_index(&self) -> u32 {
         self.next_application_index
     }
 
+    /// Returns the index to be assigned to the next created application and increments the counter.
     pub fn next_application_index(&mut self) -> u32 {
         let index = self.next_application_index;
         self.next_application_index += 1;
         index
     }
 
+    /// Returns the index to be assigned to the next created chain and increments the counter.
     pub fn next_chain_index(&mut self) -> u32 {
         let index = self.next_chain_index;
         self.next_chain_index += 1;
         index
     }
 
+    /// Records an outgoing message.
     pub fn add_outgoing_message(&mut self, message: OutgoingMessage) {
         self.outgoing_messages.push(message);
     }
 
+    /// Records multiple outgoing messages.
     pub fn add_outgoing_messages(&mut self, messages: impl IntoIterator<Item = OutgoingMessage>) {
         for message in messages {
             self.add_outgoing_message(message);
         }
     }
 
+    /// Records an event emitted on the given stream.
     pub fn add_event(&mut self, stream_id: StreamId, index: u32, value: Vec<u8>) {
         self.events.push(Event {
             stream_id,
@@ -199,6 +214,7 @@ impl TransactionTracker {
         });
     }
 
+    /// Returns the content of the blob with the given ID, if known to the tracker.
     pub fn get_blob_content(&self, blob_id: &BlobId) -> Option<&BlobContent> {
         if let Some(content) = self.blobs.get(blob_id) {
             return Some(content);
@@ -206,10 +222,12 @@ impl TransactionTracker {
         self.previously_created_blobs.get(blob_id)
     }
 
+    /// Records a blob created by this transaction.
     pub fn add_created_blob(&mut self, blob: Blob) {
         self.blobs.insert(blob.id(), blob.into_content());
     }
 
+    /// Records a blob published by this transaction.
     pub fn add_published_blob(&mut self, blob_id: BlobId) {
         self.blobs_published.insert(blob_id);
     }
@@ -219,10 +237,12 @@ impl TransactionTracker {
         self.free_blob_ids.insert(blob_id);
     }
 
+    /// Returns the blobs created by this transaction.
     pub fn created_blobs(&self) -> &BTreeMap<BlobId, BlobContent> {
         &self.blobs
     }
 
+    /// Records the result of the operation.
     pub fn add_operation_result(&mut self, result: Option<Vec<u8>>) {
         self.operation_result = result
     }
@@ -243,6 +263,7 @@ impl TransactionTracker {
         Ok(self.oracle_responses.last().unwrap())
     }
 
+    /// Records that the given range of events on a stream must be processed by the application.
     pub fn add_stream_to_process(
         &mut self,
         application_id: ApplicationId,
@@ -265,6 +286,7 @@ impl TransactionTracker {
             .or_insert_with(|| (previous_index, next_index));
     }
 
+    /// Removes a stream from the set of streams to be processed by the application.
     pub fn remove_stream_to_process(
         &mut self,
         application_id: ApplicationId,
@@ -279,6 +301,7 @@ impl TransactionTracker {
         }
     }
 
+    /// Takes the streams to be processed, grouped by application.
     pub fn take_streams_to_process(&mut self) -> BTreeMap<ApplicationId, Vec<StreamUpdate>> {
         mem::take(&mut self.streams_to_process)
             .into_iter()
@@ -335,6 +358,7 @@ impl TransactionTracker {
         Ok(Some(response))
     }
 
+    /// Consumes the tracker and returns the resulting [`TransactionOutcome`].
     pub fn into_outcome(self) -> Result<TransactionOutcome, ExecutionError> {
         let TransactionTracker {
             replaying_oracle_responses,

--- a/linera-execution/src/wasm/entrypoints.rs
+++ b/linera-execution/src/wasm/entrypoints.rs
@@ -3,6 +3,10 @@
 
 //! Wasm entrypoints for contracts and services.
 
+// The `#[wit_import]` macro generates items (a struct and associated functions) that cannot
+// carry doc comments, so we allow missing docs for this whole module of WIT bindings.
+#![allow(missing_docs)]
+
 use linera_base::data_types::StreamUpdate;
 use linera_witty::wit_import;
 

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -79,6 +79,7 @@ mod metrics {
 
 /// A user contract in a compiled WebAssembly module.
 #[derive(Clone)]
+#[allow(missing_docs)]
 pub enum WasmContractModule {
     #[cfg(with_wasmer)]
     Wasmer {
@@ -145,6 +146,7 @@ impl UserContractModule for WasmContractModule {
 
 /// A user service in a compiled WebAssembly module.
 #[derive(Clone)]
+#[allow(missing_docs)]
 pub enum WasmServiceModule {
     #[cfg(with_wasmer)]
     Wasmer { module: ::wasmer::Module },
@@ -288,6 +290,7 @@ const _: () = {
 
 /// Errors that can occur when executing a user application in a WebAssembly module.
 #[derive(Debug, Error)]
+#[allow(missing_docs)]
 pub enum WasmExecutionError {
     #[error("Failed to load contract Wasm module: {_0}")]
     LoadContractModule(#[source] anyhow::Error),
@@ -353,6 +356,7 @@ pub mod test {
         Ok(())
     }
 
+    /// Returns the contract and service bytecode file paths for the named example application.
     pub fn get_example_bytecode_paths(name: &str) -> Result<(String, String), std::io::Error> {
         let name = name.replace('-', "_");
         static INSTANCE: LazyLock<()> = LazyLock::new(|| build_applications().unwrap());


### PR DESCRIPTION
## Motivation

`linera-execution` was one of the few library crates without `#![deny(missing_docs)]`, so undocumented public items could be added without CI noticing.

## Proposal

Add `#![deny(missing_docs)]` to `linera-execution` and satisfy it:
- Real one-line doc comments on genuine public API (runtime traits and their associated types, context structs, committee/transaction-tracker/runtime methods, test helpers, etc.).
- `#[allow(missing_docs)]` on large, mechanical, self-descriptive types — message/request enums (`ExecutionRequest`, `ServiceRuntimeRequest`), `thiserror`-driven error enums (`ExecutionError`, `WasmExecutionError`, `EvmExecutionError`), the `Wasm*`/`Evm*Module` and runtime-selector enums, and `SystemExecutionState` — matching the existing `linera-base` convention. The `wasm/entrypoints.rs` WIT bindings use a module-level `#![allow(missing_docs)]` because `#[wit_import]` generates items that cannot carry doc comments (same pattern as `linera-sdk`'s generated `wit.rs`).

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied in every configuration CI builds:
- `cargo check -p linera-execution --all-features`
- `cargo check -p linera-execution --no-default-features --features web,wasmer --target wasm32-unknown-unknown`
- `cargo check -p linera-execution --no-default-features` and default features
- `cargo +nightly fmt -- --check` and `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` both pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion backport to `testnet_conway`: documented identically so shared items stay conflict-free.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
