### PR TITLE
linera-views: export RocksDB statistics as Prometheus metrics

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -308,6 +308,25 @@ Client implementation and command-line tool for the Linera blockchain
 * `--storage-replication-factor <STORAGE_REPLICATION_FACTOR>` — The replication factor for the keyspace
 
   Default value: `1`
+* `--rocksdb-enable-statistics` — Enable RocksDB's internal statistics collection and export them as Prometheus metrics. Off by default; enable it on nodes whose metrics are scraped
+* `--rocksdb-statistics-level <ROCKSDB_STATISTICS_LEVEL>` — The level of detail collected when `--rocksdb-enable-statistics` is set. Higher levels collect more, and more expensive, data
+
+  Default value: `except-histogram-or-timers`
+
+  Possible values:
+  - `disable-all`:
+    Collect nothing
+  - `except-histogram-or-timers`:
+    Collect tickers (counters) only; skip all histograms and timers
+  - `except-timers`:
+    Collect tickers and histograms, but skip timer statistics
+  - `except-detailed-timers`:
+    Collect everything except mutex-lock and compression timing
+  - `except-time-for-mutex`:
+    Collect everything except the counters requiring time inside the mutex lock
+  - `all`:
+    Collect everything, including mutex operation timing
+
 * `--wasm-runtime <WASM_RUNTIME>` — The WebAssembly runtime to use
 * `--with-application-logs` — Output log messages from contract execution
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use

--- a/CLI.md
+++ b/CLI.md
@@ -309,24 +309,9 @@ Client implementation and command-line tool for the Linera blockchain
 
   Default value: `1`
 * `--rocksdb-enable-statistics` — Enable RocksDB's internal statistics collection and export them as Prometheus metrics. Off by default; enable it on nodes whose metrics are scraped
-* `--rocksdb-statistics-level <ROCKSDB_STATISTICS_LEVEL>` — The level of detail collected when `--rocksdb-enable-statistics` is set. Higher levels collect more, and more expensive, data
+* `--rocksdb-statistics-level <ROCKSDB_STATISTICS_LEVEL>` — The level of detail collected when `--rocksdb-enable-statistics` is set. Higher levels collect more, and more expensive, data. One of: `disable-all`, `except-histogram-or-timers`, `except-timers`, `except-detailed-timers`, `except-time-for-mutex`, `all`
 
   Default value: `except-histogram-or-timers`
-
-  Possible values:
-  - `disable-all`:
-    Collect nothing
-  - `except-histogram-or-timers`:
-    Collect tickers (counters) only; skip all histograms and timers
-  - `except-timers`:
-    Collect tickers and histograms, but skip timer statistics
-  - `except-detailed-timers`:
-    Collect everything except mutex-lock and compression timing
-  - `except-time-for-mutex`:
-    Collect everything except the counters requiring time inside the mutex lock
-  - `all`:
-    Collect everything, including mutex operation timing
-
 * `--wasm-runtime <WASM_RUNTIME>` — The WebAssembly runtime to use
 * `--with-application-logs` — Output log messages from contract execution
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6049,6 +6049,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "test-case",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4212,6 +4212,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.65",

--- a/linera-bridge/contracts/evm-bridge/Cargo.lock
+++ b/linera-bridge/contracts/evm-bridge/Cargo.lock
@@ -3889,6 +3889,7 @@ dependencies = [
  "serde",
  "sha3 0.10.9",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -226,6 +226,8 @@ async fn create_rocksdb_storage(
             path_with_guard: PathWithGuard::new(path.to_path_buf()),
             spawn_mode: RocksDbSpawnMode::get_spawn_mode_from_runtime(),
             max_stream_queries: 10,
+            enable_statistics: false,
+            statistics_level: Default::default(),
         },
         storage_cache_config: StorageCacheConfig {
             max_cache_size: 10_000_000,

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -4450,6 +4450,7 @@ dependencies = [
  "serde",
  "sha3 0.10.9",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -113,6 +113,8 @@ impl RocksDbRunner {
             spawn_mode,
             path_with_guard,
             max_stream_queries: config.client.max_stream_queries,
+            enable_statistics: false,
+            statistics_level: Default::default(),
         };
         let store_config = RocksDbStoreConfig {
             inner_config,

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2572,6 +2572,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -1,13 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::str::FromStr as _;
-
 use linera_storage::{StorageCacheConfig, DEFAULT_CLEANUP_INTERVAL_SECS};
-use linera_views::{
-    lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig,
-    rocks_db::RocksDbStatisticsLevel,
-};
+use linera_views::lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig;
+#[cfg(feature = "rocksdb")]
+use {linera_views::rocks_db::RocksDbStatisticsLevel, std::str::FromStr as _};
 
 /// Command-line options shared by all storage backends, controlling concurrency
 /// limits and cache sizes.
@@ -91,6 +88,7 @@ pub struct CommonStorageOptions {
 
     /// Enable RocksDB's internal statistics collection and export them as Prometheus
     /// metrics. Off by default; enable it on nodes whose metrics are scraped.
+    #[cfg(feature = "rocksdb")]
     #[arg(long, global = true)]
     pub rocksdb_enable_statistics: bool,
 
@@ -98,6 +96,7 @@ pub struct CommonStorageOptions {
     /// levels collect more, and more expensive, data. One of: `disable-all`,
     /// `except-histogram-or-timers`, `except-timers`, `except-detailed-timers`,
     /// `except-time-for-mutex`, `all`.
+    #[cfg(feature = "rocksdb")]
     #[arg(
         long,
         default_value = "except-histogram-or-timers",

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -1,8 +1,13 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::str::FromStr as _;
+
 use linera_storage::{StorageCacheConfig, DEFAULT_CLEANUP_INTERVAL_SECS};
-use linera_views::lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig;
+use linera_views::{
+    lru_prefix_cache::StorageCacheConfig as ViewsStorageCacheConfig,
+    rocks_db::RocksDbStatisticsLevel,
+};
 
 /// Command-line options shared by all storage backends, controlling concurrency
 /// limits and cache sizes.
@@ -90,42 +95,16 @@ pub struct CommonStorageOptions {
     pub rocksdb_enable_statistics: bool,
 
     /// The level of detail collected when `--rocksdb-enable-statistics` is set. Higher
-    /// levels collect more, and more expensive, data.
-    #[arg(long, default_value = "except-histogram-or-timers", global = true)]
-    pub rocksdb_statistics_level: RocksDbStatisticsLevelArg,
-}
-
-/// The RocksDB statistics collection level, selectable on the command line.
-#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
-#[clap(rename_all = "kebab-case")]
-pub enum RocksDbStatisticsLevelArg {
-    /// Collect nothing.
-    DisableAll,
-    /// Collect tickers (counters) only; skip all histograms and timers.
-    #[default]
-    ExceptHistogramOrTimers,
-    /// Collect tickers and histograms, but skip timer statistics.
-    ExceptTimers,
-    /// Collect everything except mutex-lock and compression timing.
-    ExceptDetailedTimers,
-    /// Collect everything except the counters requiring time inside the mutex lock.
-    ExceptTimeForMutex,
-    /// Collect everything, including mutex operation timing.
-    All,
-}
-
-#[cfg(feature = "rocksdb")]
-impl From<RocksDbStatisticsLevelArg> for linera_views::rocks_db::RocksDbStatisticsLevel {
-    fn from(level: RocksDbStatisticsLevelArg) -> Self {
-        match level {
-            RocksDbStatisticsLevelArg::DisableAll => Self::DisableAll,
-            RocksDbStatisticsLevelArg::ExceptHistogramOrTimers => Self::ExceptHistogramOrTimers,
-            RocksDbStatisticsLevelArg::ExceptTimers => Self::ExceptTimers,
-            RocksDbStatisticsLevelArg::ExceptDetailedTimers => Self::ExceptDetailedTimers,
-            RocksDbStatisticsLevelArg::ExceptTimeForMutex => Self::ExceptTimeForMutex,
-            RocksDbStatisticsLevelArg::All => Self::All,
-        }
-    }
+    /// levels collect more, and more expensive, data. One of: `disable-all`,
+    /// `except-histogram-or-timers`, `except-timers`, `except-detailed-timers`,
+    /// `except-time-for-mutex`, `all`.
+    #[arg(
+        long,
+        default_value = "except-histogram-or-timers",
+        value_parser = RocksDbStatisticsLevel::from_str,
+        global = true
+    )]
+    pub rocksdb_statistics_level: RocksDbStatisticsLevel,
 }
 
 impl CommonStorageOptions {
@@ -169,14 +148,14 @@ mod tests {
     use clap::Parser as _;
     use linera_views::rocks_db::RocksDbStatisticsLevel;
 
-    use super::{CommonStorageOptions, RocksDbStatisticsLevelArg};
+    use super::CommonStorageOptions;
 
     #[test]
     fn statistics_disabled_by_default() {
         let options = CommonStorageOptions::with_defaults();
         assert!(!options.rocksdb_enable_statistics);
         assert_eq!(
-            RocksDbStatisticsLevel::from(options.rocksdb_statistics_level),
+            options.rocksdb_statistics_level,
             RocksDbStatisticsLevel::ExceptHistogramOrTimers,
         );
     }
@@ -191,38 +170,18 @@ mod tests {
         ]);
         assert!(options.rocksdb_enable_statistics);
         assert_eq!(
-            RocksDbStatisticsLevel::from(options.rocksdb_statistics_level),
-            RocksDbStatisticsLevel::All,
+            options.rocksdb_statistics_level,
+            RocksDbStatisticsLevel::All
         );
     }
 
     #[test]
-    fn level_arg_maps_one_to_one() {
-        let cases = [
-            (
-                RocksDbStatisticsLevelArg::DisableAll,
-                RocksDbStatisticsLevel::DisableAll,
-            ),
-            (
-                RocksDbStatisticsLevelArg::ExceptHistogramOrTimers,
-                RocksDbStatisticsLevel::ExceptHistogramOrTimers,
-            ),
-            (
-                RocksDbStatisticsLevelArg::ExceptTimers,
-                RocksDbStatisticsLevel::ExceptTimers,
-            ),
-            (
-                RocksDbStatisticsLevelArg::ExceptDetailedTimers,
-                RocksDbStatisticsLevel::ExceptDetailedTimers,
-            ),
-            (
-                RocksDbStatisticsLevelArg::ExceptTimeForMutex,
-                RocksDbStatisticsLevel::ExceptTimeForMutex,
-            ),
-            (RocksDbStatisticsLevelArg::All, RocksDbStatisticsLevel::All),
-        ];
-        for (arg, expected) in cases {
-            assert_eq!(RocksDbStatisticsLevel::from(arg), expected);
-        }
+    fn rejects_unknown_level() {
+        assert!(CommonStorageOptions::try_parse_from([
+            "test",
+            "--rocksdb-statistics-level",
+            "not-a-level",
+        ])
+        .is_err());
     }
 }

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -83,6 +83,49 @@ pub struct CommonStorageOptions {
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1", global = true)]
     pub storage_replication_factor: u32,
+
+    /// Enable RocksDB's internal statistics collection and export them as Prometheus
+    /// metrics. Off by default; enable it on nodes whose metrics are scraped.
+    #[arg(long, global = true)]
+    pub rocksdb_enable_statistics: bool,
+
+    /// The level of detail collected when `--rocksdb-enable-statistics` is set. Higher
+    /// levels collect more, and more expensive, data.
+    #[arg(long, default_value = "except-histogram-or-timers", global = true)]
+    pub rocksdb_statistics_level: RocksDbStatisticsLevelArg,
+}
+
+/// The RocksDB statistics collection level, selectable on the command line.
+#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum RocksDbStatisticsLevelArg {
+    /// Collect nothing.
+    DisableAll,
+    /// Collect tickers (counters) only; skip all histograms and timers.
+    #[default]
+    ExceptHistogramOrTimers,
+    /// Collect tickers and histograms, but skip timer statistics.
+    ExceptTimers,
+    /// Collect everything except mutex-lock and compression timing.
+    ExceptDetailedTimers,
+    /// Collect everything except the counters requiring time inside the mutex lock.
+    ExceptTimeForMutex,
+    /// Collect everything, including mutex operation timing.
+    All,
+}
+
+#[cfg(feature = "rocksdb")]
+impl From<RocksDbStatisticsLevelArg> for linera_views::rocks_db::RocksDbStatisticsLevel {
+    fn from(level: RocksDbStatisticsLevelArg) -> Self {
+        match level {
+            RocksDbStatisticsLevelArg::DisableAll => Self::DisableAll,
+            RocksDbStatisticsLevelArg::ExceptHistogramOrTimers => Self::ExceptHistogramOrTimers,
+            RocksDbStatisticsLevelArg::ExceptTimers => Self::ExceptTimers,
+            RocksDbStatisticsLevelArg::ExceptDetailedTimers => Self::ExceptDetailedTimers,
+            RocksDbStatisticsLevelArg::ExceptTimeForMutex => Self::ExceptTimeForMutex,
+            RocksDbStatisticsLevelArg::All => Self::All,
+        }
+    }
 }
 
 impl CommonStorageOptions {
@@ -117,6 +160,69 @@ impl CommonStorageOptions {
             max_cache_value_size: self.storage_max_cache_value_size,
             max_cache_find_keys_size: self.storage_max_cache_find_keys_size,
             max_cache_find_key_values_size: self.storage_max_cache_find_key_values_size,
+        }
+    }
+}
+
+#[cfg(all(test, feature = "rocksdb"))]
+mod tests {
+    use clap::Parser as _;
+    use linera_views::rocks_db::RocksDbStatisticsLevel;
+
+    use super::{CommonStorageOptions, RocksDbStatisticsLevelArg};
+
+    #[test]
+    fn statistics_disabled_by_default() {
+        let options = CommonStorageOptions::with_defaults();
+        assert!(!options.rocksdb_enable_statistics);
+        assert_eq!(
+            RocksDbStatisticsLevel::from(options.rocksdb_statistics_level),
+            RocksDbStatisticsLevel::ExceptHistogramOrTimers,
+        );
+    }
+
+    #[test]
+    fn parses_enable_flag_and_level() {
+        let options = CommonStorageOptions::parse_from([
+            "test",
+            "--rocksdb-enable-statistics",
+            "--rocksdb-statistics-level",
+            "all",
+        ]);
+        assert!(options.rocksdb_enable_statistics);
+        assert_eq!(
+            RocksDbStatisticsLevel::from(options.rocksdb_statistics_level),
+            RocksDbStatisticsLevel::All,
+        );
+    }
+
+    #[test]
+    fn level_arg_maps_one_to_one() {
+        let cases = [
+            (
+                RocksDbStatisticsLevelArg::DisableAll,
+                RocksDbStatisticsLevel::DisableAll,
+            ),
+            (
+                RocksDbStatisticsLevelArg::ExceptHistogramOrTimers,
+                RocksDbStatisticsLevel::ExceptHistogramOrTimers,
+            ),
+            (
+                RocksDbStatisticsLevelArg::ExceptTimers,
+                RocksDbStatisticsLevel::ExceptTimers,
+            ),
+            (
+                RocksDbStatisticsLevelArg::ExceptDetailedTimers,
+                RocksDbStatisticsLevel::ExceptDetailedTimers,
+            ),
+            (
+                RocksDbStatisticsLevelArg::ExceptTimeForMutex,
+                RocksDbStatisticsLevel::ExceptTimeForMutex,
+            ),
+            (RocksDbStatisticsLevelArg::All, RocksDbStatisticsLevel::All),
+        ];
+        for (arg, expected) in cases {
+            assert_eq!(RocksDbStatisticsLevel::from(arg), expected);
         }
     }
 }

--- a/linera-storage-runtime/src/storage_config.rs
+++ b/linera-storage-runtime/src/storage_config.rs
@@ -339,7 +339,7 @@ impl StorageConfig {
                     path_with_guard,
                     max_stream_queries: options.storage_max_stream_queries,
                     enable_statistics: options.rocksdb_enable_statistics,
-                    statistics_level: options.rocksdb_statistics_level.into(),
+                    statistics_level: options.rocksdb_statistics_level,
                 };
                 let config = linera_views::rocks_db::RocksDbStoreConfig {
                     inner_config,
@@ -372,7 +372,7 @@ impl StorageConfig {
                     path_with_guard: path_with_guard.clone(),
                     max_stream_queries: options.storage_max_stream_queries,
                     enable_statistics: options.rocksdb_enable_statistics,
-                    statistics_level: options.rocksdb_statistics_level.into(),
+                    statistics_level: options.rocksdb_statistics_level,
                 };
                 let first_config = linera_views::rocks_db::RocksDbStoreConfig {
                     inner_config,

--- a/linera-storage-runtime/src/storage_config.rs
+++ b/linera-storage-runtime/src/storage_config.rs
@@ -338,6 +338,8 @@ impl StorageConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard,
                     max_stream_queries: options.storage_max_stream_queries,
+                    enable_statistics: options.rocksdb_enable_statistics,
+                    statistics_level: options.rocksdb_statistics_level.into(),
                 };
                 let config = linera_views::rocks_db::RocksDbStoreConfig {
                     inner_config,
@@ -369,6 +371,8 @@ impl StorageConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard: path_with_guard.clone(),
                     max_stream_queries: options.storage_max_stream_queries,
+                    enable_statistics: options.rocksdb_enable_statistics,
+                    statistics_level: options.rocksdb_statistics_level.into(),
                 };
                 let first_config = linera_views::rocks_db::RocksDbStoreConfig {
                     inner_config,

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -681,6 +681,8 @@ async fn main() {
                 spawn_mode,
                 path_with_guard,
                 max_stream_queries,
+                enable_statistics: false,
+                statistics_level: Default::default(),
             };
             let storage_cache_config = StorageCacheConfig {
                 max_cache_size,

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -55,6 +55,7 @@ scylla = { workspace = true, optional = true }
 serde.workspace = true
 sha3.workspace = true
 static_assertions.workspace = true
+strum.workspace = true
 sysinfo.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -310,6 +310,42 @@ impl WithError for RocksDbDatabaseInternal {
     type Error = RocksDbStoreInternalError;
 }
 
+/// The level of detail collected by RocksDB's internal statistics.
+///
+/// This mirrors [`rocksdb::statistics::StatsLevel`]. The levels are nested: each one
+/// collects a superset of the data collected by the previous one, at increasing cost.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RocksDbStatisticsLevel {
+    /// Collect nothing.
+    DisableAll,
+    /// Collect tickers (counters) only; skip all histograms and timers.
+    #[default]
+    ExceptHistogramOrTimers,
+    /// Collect tickers and histograms, but skip timer statistics.
+    ExceptTimers,
+    /// Collect everything except time spent inside the mutex lock and on compression.
+    ExceptDetailedTimers,
+    /// Collect everything except the counters that require taking time inside the mutex lock.
+    ExceptTimeForMutex,
+    /// Collect everything, including the duration of mutex operations.
+    All,
+}
+
+impl RocksDbStatisticsLevel {
+    fn to_rocksdb(self) -> rocksdb::statistics::StatsLevel {
+        use rocksdb::statistics::StatsLevel;
+        match self {
+            Self::DisableAll => StatsLevel::DisableAll,
+            Self::ExceptHistogramOrTimers => StatsLevel::ExceptHistogramOrTimers,
+            Self::ExceptTimers => StatsLevel::ExceptTimers,
+            Self::ExceptDetailedTimers => StatsLevel::ExceptDetailedTimers,
+            Self::ExceptTimeForMutex => StatsLevel::ExceptTimeForMutex,
+            Self::All => StatsLevel::All,
+        }
+    }
+}
+
 /// The initial configuration of the system
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RocksDbStoreInternalConfig {
@@ -319,6 +355,14 @@ pub struct RocksDbStoreInternalConfig {
     pub spawn_mode: RocksDbSpawnMode,
     /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
+    /// Whether to enable RocksDB's internal statistics collection and export it as
+    /// Prometheus metrics. Disabled by default to avoid overhead in clients that do not
+    /// scrape metrics; enabled explicitly for the workers.
+    #[serde(default)]
+    pub enable_statistics: bool,
+    /// The level of detail collected when `enable_statistics` is set.
+    #[serde(default)]
+    pub statistics_level: RocksDbStatisticsLevel,
 }
 
 impl RocksDbDatabaseInternal {
@@ -436,11 +480,17 @@ impl RocksDbStoreInternal {
         // Don't use random access pattern since we do prefix scans
         options.set_advise_random_on_open(false);
 
-        let db = DB::open(&options, path_buf)?;
-        let executor = RocksDbStoreExecutor {
-            db: Arc::new(db),
-            start_key,
-        };
+        if config.enable_statistics {
+            options.enable_statistics();
+            options.set_statistics_level(config.statistics_level.to_rocksdb());
+        }
+
+        let db = Arc::new(DB::open(&options, path_buf)?);
+        #[cfg(with_metrics)]
+        if config.enable_statistics {
+            statistics_metrics::register(Arc::new(options), db.clone());
+        }
+        let executor = RocksDbStoreExecutor { db, start_key };
         Ok(RocksDbStoreInternal {
             executor,
             path_with_guard,
@@ -448,6 +498,256 @@ impl RocksDbStoreInternal {
             spawn_mode,
             root_key_written: Arc::new(AtomicBool::new(false)),
         })
+    }
+}
+
+/// Exports RocksDB's internal statistics as Prometheus metrics.
+///
+/// The collector reads the values lazily at scrape time: cumulative tickers via
+/// `get_ticker_count` and instantaneous LSM state via `GetIntProperty`. Neither requires
+/// the (more expensive) histogram/timer statistics levels.
+#[cfg(with_metrics)]
+mod statistics_metrics {
+    use std::sync::{Arc, OnceLock};
+
+    use prometheus::{
+        core::{Collector, Desc},
+        proto::MetricFamily,
+        IntGauge,
+    };
+    use rocksdb::{statistics::Ticker, Options};
+
+    use super::DB;
+
+    enum Source {
+        Ticker(Ticker),
+        Property(&'static str),
+    }
+
+    struct Entry {
+        source: Source,
+        gauge: IntGauge,
+    }
+
+    fn definitions() -> Vec<(&'static str, &'static str, Source)> {
+        vec![
+            (
+                "linera_rocksdb_block_cache_hit",
+                "Cumulative RocksDB block cache hits since open",
+                Source::Ticker(Ticker::BlockCacheHit),
+            ),
+            (
+                "linera_rocksdb_block_cache_miss",
+                "Cumulative RocksDB block cache misses since open",
+                Source::Ticker(Ticker::BlockCacheMiss),
+            ),
+            (
+                "linera_rocksdb_compact_read_bytes",
+                "Cumulative bytes read during compaction since open",
+                Source::Ticker(Ticker::CompactReadBytes),
+            ),
+            (
+                "linera_rocksdb_compact_write_bytes",
+                "Cumulative bytes written during compaction since open",
+                Source::Ticker(Ticker::CompactWriteBytes),
+            ),
+            (
+                "linera_rocksdb_flush_write_bytes",
+                "Cumulative bytes written during flushes since open",
+                Source::Ticker(Ticker::FlushWriteBytes),
+            ),
+            (
+                "linera_rocksdb_stall_micros",
+                "Cumulative write-stall time in microseconds since open",
+                Source::Ticker(Ticker::StallMicros),
+            ),
+            (
+                "linera_rocksdb_bytes_written",
+                "Cumulative user bytes written since open",
+                Source::Ticker(Ticker::BytesWritten),
+            ),
+            (
+                "linera_rocksdb_bytes_read",
+                "Cumulative user bytes read since open",
+                Source::Ticker(Ticker::BytesRead),
+            ),
+            (
+                "linera_rocksdb_wal_bytes",
+                "Cumulative bytes written to the write-ahead log since open",
+                Source::Ticker(Ticker::WalFileBytes),
+            ),
+            (
+                "linera_rocksdb_bloom_filter_useful",
+                "Cumulative count of reads avoided by the bloom filter since open",
+                Source::Ticker(Ticker::BloomFilterUseful),
+            ),
+            (
+                "linera_rocksdb_memtable_hit",
+                "Cumulative memtable hits since open",
+                Source::Ticker(Ticker::MemtableHit),
+            ),
+            (
+                "linera_rocksdb_memtable_miss",
+                "Cumulative memtable misses since open",
+                Source::Ticker(Ticker::MemtableMiss),
+            ),
+            (
+                "linera_rocksdb_number_keys_written",
+                "Cumulative number of keys written since open",
+                Source::Ticker(Ticker::NumberKeysWritten),
+            ),
+            (
+                "linera_rocksdb_num_files_at_level0",
+                "Number of files at level 0",
+                Source::Property("rocksdb.num-files-at-level0"),
+            ),
+            (
+                "linera_rocksdb_estimate_pending_compaction_bytes",
+                "Estimated bytes pending compaction",
+                Source::Property("rocksdb.estimate-pending-compaction-bytes"),
+            ),
+            (
+                "linera_rocksdb_num_running_compactions",
+                "Number of currently running compactions",
+                Source::Property("rocksdb.num-running-compactions"),
+            ),
+            (
+                "linera_rocksdb_num_running_flushes",
+                "Number of currently running flushes",
+                Source::Property("rocksdb.num-running-flushes"),
+            ),
+            (
+                "linera_rocksdb_is_write_stopped",
+                "Whether writes are currently stopped (1) or not (0)",
+                Source::Property("rocksdb.is-write-stopped"),
+            ),
+            (
+                "linera_rocksdb_actual_delayed_write_rate",
+                "Current delayed write rate in bytes/s (0 when not delayed)",
+                Source::Property("rocksdb.actual-delayed-write-rate"),
+            ),
+            (
+                "linera_rocksdb_cur_size_all_mem_tables",
+                "Approximate size in bytes of all active and unflushed memtables",
+                Source::Property("rocksdb.cur-size-all-mem-tables"),
+            ),
+            (
+                "linera_rocksdb_num_immutable_mem_table",
+                "Number of immutable memtables not yet flushed",
+                Source::Property("rocksdb.num-immutable-mem-table"),
+            ),
+            (
+                "linera_rocksdb_live_sst_files_size",
+                "Total size in bytes of all live SST files",
+                Source::Property("rocksdb.live-sst-files-size"),
+            ),
+            (
+                "linera_rocksdb_total_sst_files_size",
+                "Total size in bytes of all SST files including obsolete ones",
+                Source::Property("rocksdb.total-sst-files-size"),
+            ),
+            (
+                "linera_rocksdb_estimate_num_keys",
+                "Estimated number of keys in the database",
+                Source::Property("rocksdb.estimate-num-keys"),
+            ),
+            (
+                "linera_rocksdb_block_cache_usage",
+                "Memory in bytes used by the block cache",
+                Source::Property("rocksdb.block-cache-usage"),
+            ),
+            (
+                "linera_rocksdb_block_cache_capacity",
+                "Capacity in bytes of the block cache",
+                Source::Property("rocksdb.block-cache-capacity"),
+            ),
+        ]
+    }
+
+    struct RocksDbStatisticsCollector {
+        options: Arc<Options>,
+        db: Arc<DB>,
+        entries: Vec<Entry>,
+    }
+
+    impl RocksDbStatisticsCollector {
+        fn new(options: Arc<Options>, db: Arc<DB>) -> Self {
+            let entries = definitions()
+                .into_iter()
+                .map(|(name, help, source)| Entry {
+                    source,
+                    gauge: IntGauge::new(name, help)
+                        .expect("RocksDB statistics metric name is valid"),
+                })
+                .collect();
+            Self {
+                options,
+                db,
+                entries,
+            }
+        }
+    }
+
+    impl Collector for RocksDbStatisticsCollector {
+        fn desc(&self) -> Vec<&Desc> {
+            self.entries
+                .iter()
+                .flat_map(|entry| entry.gauge.desc())
+                .collect()
+        }
+
+        fn collect(&self) -> Vec<MetricFamily> {
+            self.entries
+                .iter()
+                .flat_map(|entry| {
+                    let value = match &entry.source {
+                        Source::Ticker(ticker) => self.options.get_ticker_count(*ticker) as i64,
+                        Source::Property(property) => {
+                            self.db
+                                .property_int_value(*property)
+                                .ok()
+                                .flatten()
+                                .unwrap_or(0) as i64
+                        }
+                    };
+                    entry.gauge.set(value);
+                    entry.gauge.collect()
+                })
+                .collect()
+        }
+    }
+
+    pub(super) fn register(options: Arc<Options>, db: Arc<DB>) {
+        static REGISTERED: OnceLock<()> = OnceLock::new();
+        if REGISTERED.set(()).is_err() {
+            tracing::warn!(
+                "RocksDB statistics collector is already registered; skipping additional store"
+            );
+            return;
+        }
+        let collector = RocksDbStatisticsCollector::new(options, db);
+        if let Err(error) = prometheus::register(Box::new(collector)) {
+            tracing::warn!("failed to register the RocksDB statistics collector: {error}");
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::collections::HashSet;
+
+        use super::{definitions, IntGauge};
+
+        #[test]
+        fn definitions_build_unique_valid_gauges() {
+            let definitions = definitions();
+            assert!(!definitions.is_empty());
+            let mut names = HashSet::new();
+            for (name, help, _source) in &definitions {
+                assert!(!help.is_empty(), "metric {name} has empty help text");
+                assert!(names.insert(*name), "duplicate metric name: {name}");
+                IntGauge::new(*name, *help).expect("metric definition should be valid");
+            }
+        }
     }
 }
 
@@ -692,6 +992,8 @@ impl TestKeyValueDatabase for RocksDbDatabaseInternal {
             path_with_guard,
             spawn_mode,
             max_stream_queries,
+            enable_statistics: false,
+            statistics_level: RocksDbStatisticsLevel::default(),
         })
     }
 }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -314,8 +314,9 @@ impl WithError for RocksDbDatabaseInternal {
 ///
 /// This mirrors [`rocksdb::statistics::StatsLevel`]. The levels are nested: each one
 /// collects a superset of the data collected by the previous one, at increasing cost.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize, strum::EnumString)]
 #[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum RocksDbStatisticsLevel {
     /// Collect nothing.
     DisableAll,
@@ -343,6 +344,38 @@ impl RocksDbStatisticsLevel {
             Self::ExceptTimeForMutex => StatsLevel::ExceptTimeForMutex,
             Self::All => StatsLevel::All,
         }
+    }
+}
+
+#[cfg(test)]
+mod statistics_level_tests {
+    use std::str::FromStr as _;
+
+    use super::RocksDbStatisticsLevel;
+
+    #[test]
+    fn parses_kebab_case_names() {
+        let cases = [
+            ("disable-all", RocksDbStatisticsLevel::DisableAll),
+            (
+                "except-histogram-or-timers",
+                RocksDbStatisticsLevel::ExceptHistogramOrTimers,
+            ),
+            ("except-timers", RocksDbStatisticsLevel::ExceptTimers),
+            (
+                "except-detailed-timers",
+                RocksDbStatisticsLevel::ExceptDetailedTimers,
+            ),
+            (
+                "except-time-for-mutex",
+                RocksDbStatisticsLevel::ExceptTimeForMutex,
+            ),
+            ("all", RocksDbStatisticsLevel::All),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(RocksDbStatisticsLevel::from_str(name), Ok(expected));
+        }
+        assert!(RocksDbStatisticsLevel::from_str("not-a-level").is_err());
     }
 }
 


### PR DESCRIPTION
## Motivation

RocksDB backs the Linera client's local store, and the PM workers *are* the client — so it's
now production-critical infrastructure. Yet the binary exports nothing about RocksDB's internal
engine state (block-cache effectiveness, compaction / write amplification, write stalls, LSM
structure). We have the metering-wrapper operation latencies but not the engine internals needed
to understand or tune RocksDB — e.g. the write-stall / compaction behaviour behind recent worker
incidents. Validators get rich ScyllaDB dashboards; the client's RocksDB deserves the same.

## Proposal

Add opt-in export of RocksDB's internal statistics as Prometheus metrics, off by default:

- Two flags on `CommonStorageOptions`: `--rocksdb-enable-statistics` (default off) and
  `--rocksdb-statistics-level` (default `except-histogram-or-timers`; one of the six RocksDB
  `StatsLevel`s). Off by default so clients that don't scrape metrics pay nothing; enabled
  explicitly on the workers.
- `RocksDbStoreInternalConfig` gains `enable_statistics` + `statistics_level` (`#[serde(default)]`),
  wired in `build()` to `enable_statistics()` / `set_statistics_level()`.
- A lazy Prometheus `Collector` (behind `with_metrics`) that reads cumulative tickers
  (`get_ticker_count`) and instantaneous LSM state (`GetIntProperty`) at scrape time — no
  background task — exporting `linera_rocksdb_*` metrics: block-cache hit/miss, compaction
  read/write bytes, write-stall micros, flush bytes, bloom/memtable hits, plus L0 file count,
  pending-compaction bytes, write-stopped, SST sizes, memtable size, etc.

The default level (tickers only) is cheap — the op-latency histograms (the expensive part) are
deliberately skipped, since we already export them from the metering wrapper; bumping the level
turns on the engine histograms for latency investigation. Cumulative tickers are exported as
gauges (the `prometheus` crate's `IntCounter` can't be set to an external absolute without
stateful delta-tracking); they're monotonic so `rate()` works across restarts. No format-defining
option is touched — this only toggles statistics collection.

## Test Plan

- Unit tests: the level `ValueEnum` parses and maps 1:1 to the views enum; statistics are off by
  default; the collector's metric definitions build unique, valid gauges.
- `cargo clippy --all-targets -- -D warnings` clean on `linera-views` and `linera-storage-runtime`;
  `cargo fmt`; `cargo doc` strict; `cargo machete`; `CLI.md` regenerated.
- The default-off path leaves `build()` behaviour identical (the new blocks are no-ops when
  `enable_statistics` is false).

## Release Plan
- These changes should be backported to the latest `testnet` branch (the workers run on
  `testnet_conway`). No SDK or validator hotfix needed — this is client/worker observability only.

## Links

- Complements #6477 (RocksDB/ScyllaDB tuning-option passthrough): these metrics provide the
  observability to drive those tuning knobs. No logical dependency; the overlapping files will be
  rebased on whichever lands first.
- Follow-up: a RocksDB Grafana dashboard once the metrics are live; optionally expose `PerfContext`
  for deep latency profiling.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
