### PR TITLE
Add #![deny(missing_docs)] to linera-core

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -79,6 +79,7 @@ use crate::{
     worker::{Notification, Reason, WorkerError},
 };
 
+/// Options that configure the behavior of a [`ChainClient`].
 #[derive(Debug, Clone)]
 pub struct Options {
     /// Maximum number of pending message bundles processed at a time in a block.
@@ -149,6 +150,7 @@ struct ConsensusStateSnapshot {
 
 #[cfg(with_testing)]
 impl Options {
+    /// Returns a default set of options for use in tests.
     pub fn test_default() -> Self {
         use super::{
             DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE, DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
@@ -241,6 +243,7 @@ impl<Env: Environment> Clone for ChainClient<Env> {
 
 /// Error type for [`ChainClient`].
 #[derive(Debug, Error)]
+#[allow(missing_docs)]
 pub enum Error {
     #[error("Local node operation failed: {0}")]
     LocalNodeError(#[from] LocalNodeError),
@@ -363,12 +366,14 @@ impl From<Infallible> for Error {
 }
 
 impl Error {
+    /// Wraps a signer error into a [`Error::Signer`] variant.
     pub fn signer_failure(err: impl signer::Error + 'static) -> Self {
         Self::Signer(Box::new(err))
     }
 }
 
 impl<Env: Environment> ChainClient<Env> {
+    /// Creates a new [`ChainClient`] for the given chain.
     pub fn new(
         client: Arc<Client<Env>>,
         chain_id: ChainId,
@@ -1883,6 +1888,7 @@ impl<Env: Environment> ChainClient<Env> {
         self.transfer(owner, amount, recipient).await
     }
 
+    /// Fetches the latest chain info for this chain from the validators.
     #[instrument(level = "trace")]
     pub async fn fetch_chain_info(&self) -> Result<Box<ChainInfo>, Error> {
         let validators = self.client.validator_nodes().await?;
@@ -1939,6 +1945,7 @@ impl<Env: Environment> ChainClient<Env> {
             .map_err(Into::into)
     }
 
+    /// Synchronizes this chain's state from the validators, including received messages.
     pub async fn synchronize_from_validators(&self) -> Result<Box<ChainInfo>, Error> {
         if self.is_follow_only() {
             return self.client.synchronize_chain_state(self.chain_id).await;
@@ -2913,6 +2920,7 @@ impl<Env: Environment> ChainClient<Env> {
         .await
     }
 
+    /// Reads the confirmed block with the given hash from storage.
     #[instrument(level = "trace", skip(hash))]
     pub async fn read_confirmed_block(
         &self,
@@ -2926,6 +2934,7 @@ impl<Env: Environment> ChainClient<Env> {
             .map(|b| b.into_std())
     }
 
+    /// Reads the confirmed block certificate with the given hash from storage.
     #[instrument(level = "trace", skip(hash))]
     pub async fn read_certificate(
         &self,
@@ -3468,6 +3477,7 @@ impl<Env: Environment> ChainClient<Env> {
 
 #[cfg(with_testing)]
 impl<Env: Environment> ChainClient<Env> {
+    /// Processes a notification received from the given validator.
     pub async fn process_notification_from(
         &self,
         notification: Notification,

--- a/linera-core/src/client/chain_client/state.rs
+++ b/linera-core/src/client/chain_client/state.rs
@@ -26,6 +26,7 @@ pub struct State {
 }
 
 impl State {
+    /// Creates a new chain client [`State`] with the given pending proposal and follow-only mode.
     pub fn new(pending_proposal: Option<PendingProposal>, follow_only: bool) -> State {
         State {
             proposal_mutex: Arc::new(Mutex::new(pending_proposal)),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -60,6 +60,7 @@ use crate::{
     ChainWorkerConfig, ProcessConfirmedBlockMode, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
+/// The client for interacting with a single chain.
 pub mod chain_client;
 pub use chain_client::ChainClient;
 
@@ -128,13 +129,20 @@ mod metrics {
     });
 }
 
+/// Default number of certificates to download in a single batch.
 pub static DEFAULT_CERTIFICATE_DOWNLOAD_BATCH_SIZE: u64 = 500;
+/// Default number of certificates to upload in a single batch.
 pub static DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE: usize = 500;
+/// Default number of sender-chain certificates to download in a single batch.
 pub static DEFAULT_SENDER_CERTIFICATE_DOWNLOAD_BATCH_SIZE: usize = 20_000;
+/// Default maximum number of concurrent event stream queries.
 pub static DEFAULT_MAX_EVENT_STREAM_QUERIES: usize = 1000;
+/// Default maximum number of certificate batch downloads to run concurrently.
 pub static DEFAULT_MAX_CONCURRENT_BATCH_DOWNLOADS: usize = 1;
 
+/// Identifies which operation a timing measurement refers to.
 #[derive(Debug, Clone, Copy)]
+#[allow(missing_docs)]
 pub enum TimingType {
     ExecuteOperations,
     ExecuteBlock,
@@ -207,6 +215,7 @@ impl ListeningMode {
         }
     }
 
+    /// Widens this mode to also cover the given mode, keeping the more inclusive of the two.
     pub fn extend(&mut self, other: Option<ListeningMode>) {
         match (self, other) {
             (_, None) => (),
@@ -239,6 +248,7 @@ impl ListeningMode {
         matches!(self, ListeningMode::FullChain)
     }
 
+    /// Returns whether this mode requires synchronizing the chain's own state.
     pub fn should_sync_chain_state(&self) -> bool {
         match self {
             ListeningMode::FullChain | ListeningMode::FollowChain => true,
@@ -438,6 +448,7 @@ impl<Env: Environment> Client<Env> {
         Ok(results.into_iter().next().flatten())
     }
 
+    /// Returns the provider used to connect to validator nodes.
     pub fn validator_node_provider(&self) -> &Env::Network {
         self.environment.network()
     }
@@ -2405,7 +2416,9 @@ impl Drop for AbortOnDrop {
 /// A pending proposed block, together with its published blobs.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct PendingProposal {
+    /// The proposed block.
     pub block: ProposedBlock,
+    /// The blobs published by the proposed block.
     pub blobs: Vec<Blob>,
     /// The execution outcome from the AutoRetry execution, used as a sanity check
     /// against the committed execution outcome.

--- a/linera-core/src/client/requests_scheduler/mod.rs
+++ b/linera-core/src/client/requests_scheduler/mod.rs
@@ -15,12 +15,19 @@ pub use scheduler::RequestsScheduler;
 pub use scoring::ScoringWeights;
 
 // Module constants - default values for RequestsSchedulerConfig
+/// Default maximum number of requests allowed to be in flight at once.
 pub const MAX_IN_FLIGHT_REQUESTS: usize = 100;
+/// Default maximum expected latency in milliseconds, used for score normalization.
 pub const MAX_ACCEPTED_LATENCY_MS: f64 = 5000.0;
+/// Default time-to-live for cached responses, in milliseconds.
 pub const CACHE_TTL_MS: u64 = 2000;
+/// Default maximum number of entries in the cache.
 pub const CACHE_MAX_SIZE: usize = 1000;
+/// Default maximum latency for an in-flight request before we stop deduplicating it, in milliseconds.
 pub const MAX_REQUEST_TTL_MS: u64 = 200;
+/// Default smoothing factor for the Exponential Moving Averages of latency.
 pub const ALPHA_SMOOTHING_FACTOR: f64 = 0.1;
+/// Default delay in milliseconds between starting requests to different peers.
 pub const STAGGERED_DELAY_MS: u64 = 150;
 
 /// Configuration for the `RequestsScheduler`.

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -355,6 +355,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
         Ok(blobs.into_iter().collect::<Option<Vec<_>>>())
     }
 
+    /// Downloads a range of certificates, starting at the given height, from the given validator.
     pub async fn download_certificates(
         &self,
         peer: &RemoteNode<Env::ValidatorNode>,
@@ -431,6 +432,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
         })
     }
 
+    /// Downloads the certificates at the given heights from the given validator.
     pub async fn download_certificates_by_heights(
         &self,
         peer: &RemoteNode<Env::ValidatorNode>,
@@ -454,6 +456,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
         .await
     }
 
+    /// Downloads the certificate that published the given blob, from the given validator.
     pub async fn download_certificate_for_blob(
         &self,
         peer: &RemoteNode<Env::ValidatorNode>,
@@ -467,6 +470,7 @@ impl<Env: Environment> RequestsScheduler<Env> {
         .await
     }
 
+    /// Downloads a pending blob from the given validator.
     pub async fn download_pending_blob(
         &self,
         peer: &RemoteNode<Env::ValidatorNode>,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -67,6 +67,7 @@ pub struct ChainInfoQuery {
 }
 
 impl ChainInfoQuery {
+    /// Creates a query for the given chain that requests no optional information.
     pub fn new(chain_id: ChainId) -> Self {
         Self {
             chain_id,
@@ -83,41 +84,49 @@ impl ChainInfoQuery {
         }
     }
 
+    /// Also requests the height of the most recent checkpoint block.
     pub fn with_latest_checkpoint_height(mut self) -> Self {
         self.request_latest_checkpoint_height = true;
         self
     }
 
+    /// Also requests the messages waiting to be picked in the next block.
     pub fn with_pending_message_bundles(mut self) -> Self {
         self.request_pending_message_bundles = true;
         self
     }
 
+    /// Also requests the certificate hashes sent at the given block heights.
     pub fn with_sent_certificate_hashes_by_heights(mut self, heights: Vec<BlockHeight>) -> Self {
         self.request_sent_certificate_hashes_by_heights = heights;
         self
     }
 
+    /// Also requests the previous event blocks for the given streams.
     pub fn with_previous_event_blocks(mut self, stream_ids: Vec<StreamId>) -> Self {
         self.request_previous_event_blocks = stream_ids;
         self
     }
 
+    /// Also requests the received log entries, excluding the first `n`.
     pub fn with_received_log_excluding_first_n(mut self, n: u64) -> Self {
         self.request_received_log_excluding_first_n = Some(n);
         self
     }
 
+    /// Also requests the values from the chain manager, not just the votes.
     pub fn with_manager_values(mut self) -> Self {
         self.request_manager_values = true;
         self
     }
 
+    /// Also requests a timeout vote for the given height and round, if appropriate.
     pub fn with_timeout(mut self, height: BlockHeight, round: Round) -> Self {
         self.request_leader_timeout = Some((height, round));
         self
     }
 
+    /// Also requests a vote to switch to fallback mode, if appropriate.
     #[cfg(with_testing)]
     pub fn with_fallback(mut self) -> Self {
         self.request_fallback = true;
@@ -125,6 +134,7 @@ impl ChainInfoQuery {
     }
 }
 
+/// Information about a chain, returned in response to a [`ChainInfoQuery`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct ChainInfo {
@@ -194,7 +204,9 @@ impl ChainInfo {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct ChainInfoResponse {
+    /// The information about the chain.
     pub info: Box<ChainInfo>,
+    /// The validator's signature over the chain information, if signed.
     pub signature: Option<ValidatorSignature>,
 }
 
@@ -211,6 +223,7 @@ pub struct ShardInfo {
 /// An internal request between chains within a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
+#[allow(missing_docs)]
 pub enum CrossChainRequest {
     /// Communicate a number of confirmed blocks from the sender to the recipient.
     /// Blocks must be given by increasing heights.
@@ -264,6 +277,7 @@ impl CrossChainRequest {
 }
 
 impl ChainInfo {
+    /// Builds a [`ChainInfo`] from the given chain state view.
     pub async fn from_chain_view<C, S>(view: &mut ChainStateView<C>) -> Result<Self, ViewError>
     where
         C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
@@ -294,6 +308,7 @@ impl ChainInfo {
 }
 
 impl ChainInfoResponse {
+    /// Creates a response from the given [`ChainInfo`], signing it if a key pair is provided.
     pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&ValidatorSecretKey>) -> Self {
         let info = Box::new(info.into());
         let signature = key_pair.map(|kp| ValidatorSignature::new(&*info, kp));
@@ -306,6 +321,7 @@ impl ChainInfoResponse {
         self.signature = Some(ValidatorSignature::new(&*self.info, key_pair));
     }
 
+    /// Verifies that the response is correctly signed by the given validator.
     pub fn check(&self, public_key: ValidatorPublicKey) -> Result<(), CryptoError> {
         match self.signature.as_ref() {
             Some(sig) => sig.check(&*self.info, public_key),
@@ -319,7 +335,9 @@ impl BcsSignable<'_> for ChainInfo {}
 /// Request for downloading certificates by heights.
 #[derive(Clone)]
 pub struct CertificatesByHeightRequest {
+    /// The chain whose certificates are requested.
     pub chain_id: ChainId,
+    /// The block heights of the requested certificates.
     pub heights: Vec<BlockHeight>,
 }
 
@@ -385,10 +403,14 @@ pub enum ClientOutcome<T> {
     Conflict(Box<ConfirmedBlockCertificate>),
 }
 
+/// The time at which the current round times out, and the round and height it applies to.
 #[derive(Debug)]
 pub struct RoundTimeout {
+    /// The timestamp at which the current round times out.
     pub timestamp: Timestamp,
+    /// The round that this timeout applies to.
     pub current_round: Round,
+    /// The height of the next block to be added to the chain.
     pub next_block_height: BlockHeight,
 }
 
@@ -403,6 +425,7 @@ impl fmt::Display for RoundTimeout {
 }
 
 impl<T> ClientOutcome<T> {
+    /// Returns the committed value, panicking on a timeout or conflict.
     #[cfg(with_testing)]
     pub fn unwrap(self) -> T {
         match self {
@@ -414,6 +437,7 @@ impl<T> ClientOutcome<T> {
         }
     }
 
+    /// Returns the committed value, panicking with `msg` on a timeout or conflict.
     pub fn expect(self, msg: &'static str) -> T {
         match self {
             ClientOutcome::Committed(t) => t,
@@ -421,6 +445,7 @@ impl<T> ClientOutcome<T> {
         }
     }
 
+    /// Applies `f` to the committed value, leaving other outcomes unchanged.
     pub fn map<F, S>(self, f: F) -> ClientOutcome<S>
     where
         F: FnOnce(T) -> S,
@@ -432,6 +457,7 @@ impl<T> ClientOutcome<T> {
         }
     }
 
+    /// Applies the fallible `f` to the committed value, leaving other outcomes unchanged.
     pub fn try_map<F, S>(self, f: F) -> Result<ClientOutcome<S>, chain_client::Error>
     where
         F: FnOnce(T) -> Result<S, chain_client::Error>,

--- a/linera-core/src/environment/mod.rs
+++ b/linera-core/src/environment/mod.rs
@@ -1,44 +1,67 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! The runtime environment (storage, network, signer and wallet) used by the client.
+
+/// The wallet abstraction tracking the set of chains followed by the client.
 pub mod wallet;
 
 use linera_base::util::traits::AutoTraits;
 
 trait_set::trait_set! {
+    /// The provider of validator nodes used to communicate with the network.
     pub trait Network = crate::node::ValidatorNodeProvider + AutoTraits;
+    /// The signer used to sign blocks and other messages on behalf of chain owners.
     pub trait Signer = linera_base::crypto::Signer + AutoTraits;
     // TODO(#5064): we shouldn't hard-code `Send` + `Sync` here
+    /// The persistent storage backend for chains and certificates.
     pub trait Storage = linera_storage::Storage + Clone + AutoTraits;
+    /// The wallet tracking the set of chains followed by the client.
     pub trait Wallet = wallet::Wallet + AutoTraits;
 }
 
+/// The collection of services (storage, network, signer and wallet) available to the client.
 pub trait Environment: AutoTraits {
+    /// The persistent storage backend.
     type Storage: Storage<Context = Self::StorageContext>;
+    /// The provider of validator nodes.
     type Network: Network<Node = Self::ValidatorNode>;
+    /// The signer used to sign on behalf of chain owners.
     type Signer: Signer;
+    /// The wallet tracking the chains followed by the client.
     type Wallet: Wallet;
 
+    /// The validator node type produced by the network provider.
     type ValidatorNode: crate::node::ValidatorNode + AutoTraits + Clone;
     // TODO(#5064): we shouldn't hard-code `Send` + `Sync` here
+    /// The storage context used by the storage backend.
     type StorageContext: linera_views::context::Context<Extra: linera_execution::ExecutionRuntimeContext>
         + AutoTraits;
 
+    /// Returns a reference to the storage backend.
     fn storage(&self) -> &Self::Storage;
+    /// Returns a reference to the network provider.
     fn network(&self) -> &Self::Network;
+    /// Returns a reference to the signer.
     fn signer(&self) -> &Self::Signer;
+    /// Returns a reference to the wallet.
     fn wallet(&self) -> &Self::Wallet;
 }
 
+/// A concrete [`Environment`] assembled from its individual components.
 pub struct Impl<
     Storage,
     Network,
     Signer = linera_base::crypto::InMemorySigner,
     Wallet = wallet::Memory,
 > {
+    /// The persistent storage backend.
     pub storage: Storage,
+    /// The provider of validator nodes.
     pub network: Network,
+    /// The signer used to sign on behalf of chain owners.
     pub signer: Signer,
+    /// The wallet tracking the chains followed by the client.
     pub wallet: Wallet,
 }
 
@@ -70,10 +93,15 @@ impl<St: Storage, N: Network, Si: Signer, W: Wallet> Environment for Impl<St, N,
 
 cfg_if::cfg_if! {
     if #[cfg(with_testing)] {
+        /// An in-memory storage backend used in tests.
         pub type TestStorage = linera_storage::DbStorage<linera_views::memory::MemoryDatabase, linera_storage::TestClock>;
+        /// A network provider backed by in-memory test nodes.
         pub type TestNetwork = crate::test_utils::NodeProvider<TestStorage>;
+        /// An in-memory signer used in tests.
         pub type TestSigner = linera_base::crypto::InMemorySigner;
+        /// An in-memory wallet used in tests.
         pub type TestWallet = crate::wallet::Memory;
+        /// A fully in-memory [`Environment`] used in tests.
         pub type Test = Impl<TestStorage, TestNetwork, TestSigner, TestWallet>;
     }
 }

--- a/linera-core/src/environment/mod.rs
+++ b/linera-core/src/environment/mod.rs
@@ -13,7 +13,6 @@ trait_set::trait_set! {
     pub trait Network = crate::node::ValidatorNodeProvider + AutoTraits;
     /// The signer used to sign blocks and other messages on behalf of chain owners.
     pub trait Signer = linera_base::crypto::Signer + AutoTraits;
-    // TODO(#5064): we shouldn't hard-code `Send` + `Sync` here
     /// The persistent storage backend for chains and certificates.
     pub trait Storage = linera_storage::Storage + Clone + AutoTraits;
     /// The wallet tracking the set of chains followed by the client.
@@ -33,7 +32,6 @@ pub trait Environment: AutoTraits {
 
     /// The validator node type produced by the network provider.
     type ValidatorNode: crate::node::ValidatorNode + AutoTraits + Clone;
-    // TODO(#5064): we shouldn't hard-code `Send` + `Sync` here
     /// The storage context used by the storage backend.
     type StorageContext: linera_views::context::Context<Extra: linera_execution::ExecutionRuntimeContext>
         + AutoTraits;

--- a/linera-core/src/environment/wallet/memory.rs
+++ b/linera-core/src/environment/wallet/memory.rs
@@ -30,14 +30,17 @@ impl Serialize for Memory {
 }
 
 impl Memory {
+    /// Returns the state of the chain with the given ID, if it is tracked.
     pub fn get(&self, id: ChainId) -> Option<Chain> {
         self.0.pin().get(&id).cloned()
     }
 
+    /// Inserts or replaces the state of the given chain, returning the previous state if any.
     pub fn insert(&self, id: ChainId, chain: Chain) -> Option<Chain> {
         self.0.pin().insert(id, chain).cloned()
     }
 
+    /// Inserts the given chain only if it is not already tracked, returning the existing state otherwise.
     pub fn try_insert(&self, id: ChainId, chain: Chain) -> Option<Chain> {
         match self.0.pin().try_insert(id, chain) {
             Ok(_inserted) => None,
@@ -45,10 +48,12 @@ impl Memory {
         }
     }
 
+    /// Removes the chain with the given ID, returning its previous state if any.
     pub fn remove(&self, id: ChainId) -> Option<Chain> {
         self.0.pin().remove(&id).cloned()
     }
 
+    /// Returns all tracked chains and their states.
     pub fn items(&self) -> Vec<(ChainId, Chain)> {
         self.0
             .pin()
@@ -57,10 +62,12 @@ impl Memory {
             .collect::<Vec<_>>()
     }
 
+    /// Returns the IDs of all tracked chains.
     pub fn chain_ids(&self) -> Vec<ChainId> {
         self.0.pin().keys().copied().collect::<Vec<_>>()
     }
 
+    /// Returns the IDs of the tracked chains that have an owner configured.
     pub fn owned_chain_ids(&self) -> Vec<ChainId> {
         self.0
             .pin()
@@ -69,6 +76,7 @@ impl Memory {
             .collect::<Vec<_>>()
     }
 
+    /// Applies a closure to the given chain if it is tracked, returning the closure's result.
     pub fn mutate<R>(&self, chain_id: ChainId, mutate: impl Fn(&mut Chain) -> R) -> Option<R> {
         use papaya::Operation::*;
 

--- a/linera-core/src/environment/wallet/mod.rs
+++ b/linera-core/src/environment/wallet/mod.rs
@@ -15,7 +15,9 @@ use crate::{client::PendingProposal, data_types::ChainInfo};
 mod memory;
 pub use memory::Memory;
 
+/// The locally tracked state of a single chain.
 #[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
+#[allow(missing_docs)]
 pub struct Chain {
     pub owner: Option<AccountOwner>,
     pub block_hash: Option<CryptoHash>,
@@ -81,17 +83,25 @@ impl Chain {
 /// A trait for the wallet (i.e. set of chain states) tracked by the client.
 #[cfg_attr(not(web), trait_variant::make(Send))]
 pub trait Wallet {
+    /// The error type returned by the wallet's operations.
     type Error: std::error::Error + Send + Sync;
+    /// Returns the state of the chain with the given ID, if it is tracked.
     async fn get(&self, id: ChainId) -> Result<Option<Chain>, Self::Error>;
+    /// Removes the chain with the given ID, returning its previous state if any.
     async fn remove(&self, id: ChainId) -> Result<Option<Chain>, Self::Error>;
+    /// Returns a stream over all tracked chains and their states.
     fn items(&self) -> impl Stream<Item = Result<(ChainId, Chain), Self::Error>>;
+    /// Inserts or replaces the state of the given chain, returning the previous state if any.
     async fn insert(&self, id: ChainId, chain: Chain) -> Result<Option<Chain>, Self::Error>;
+    /// Inserts the given chain only if it is not already tracked, returning the existing state otherwise.
     async fn try_insert(&self, id: ChainId, chain: Chain) -> Result<Option<Chain>, Self::Error>;
 
+    /// Returns a stream over the IDs of all tracked chains.
     fn chain_ids(&self) -> impl Stream<Item = Result<ChainId, Self::Error>> {
         self.items().map(|result| result.map(|kv| kv.0))
     }
 
+    /// Returns a stream over the IDs of the tracked chains that have an owner.
     fn owned_chain_ids(&self) -> impl Stream<Item = Result<ChainId, Self::Error>> {
         self.items()
             .try_filter_map(|(id, chain)| async move { Ok(chain.owner.map(|_| id)) })

--- a/linera-core/src/genesis_config.rs
+++ b/linera-core/src/genesis_config.rs
@@ -15,7 +15,9 @@ use linera_execution::committee::Committee;
 use linera_storage::Storage;
 use serde::{Deserialize, Serialize};
 
+/// An error that can occur while building or applying a [`GenesisConfig`].
 #[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum Error {
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
@@ -43,11 +45,16 @@ fn make_chain(
     ChainDescription::new(origin, config, timestamp)
 }
 
+/// The initial configuration of a Linera network, defining its genesis state.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GenesisConfig {
+    /// The initial committee of validators.
     pub committee: Committee,
+    /// The timestamp of the genesis block.
     pub timestamp: Timestamp,
+    /// The descriptions of the chains created at genesis, the first of which is the admin chain.
     pub chains: Vec<ChainDescription>,
+    /// The name of the network.
     pub network_name: String,
 }
 
@@ -71,6 +78,7 @@ impl GenesisConfig {
         }
     }
 
+    /// Adds a new root chain with the given public key and balance, and returns its description.
     pub fn add_root_chain(
         &mut self,
         public_key: AccountPublicKey,
@@ -86,14 +94,17 @@ impl GenesisConfig {
         description
     }
 
+    /// Returns the description of the admin chain.
     pub fn admin_chain_description(&self) -> &ChainDescription {
         &self.chains[0]
     }
 
+    /// Returns the ID of the admin chain.
     pub fn admin_chain_id(&self) -> ChainId {
         self.admin_chain_description().id()
     }
 
+    /// Writes the committee, network description and genesis chains to storage.
     pub async fn initialize_storage<S>(&self, storage: &mut S) -> Result<(), Error>
     where
         S: Storage + Clone + 'static,
@@ -129,16 +140,19 @@ impl GenesisConfig {
         Ok(())
     }
 
+    /// Returns the cryptographic hash of this genesis configuration.
     pub fn hash(&self) -> CryptoHash {
         CryptoHash::new(self)
     }
 
+    /// Returns the committee serialized as a blob.
     pub fn committee_blob(&self) -> Blob {
         Blob::new_committee(
             bcs::to_bytes(&self.committee).expect("serializing a committee should succeed"),
         )
     }
 
+    /// Returns the network description derived from this genesis configuration.
     pub fn network_description(&self) -> NetworkDescription {
         NetworkDescription {
             name: self.network_name.clone(),

--- a/linera-core/src/join_set_ext.rs
+++ b/linera-core/src/join_set_ext.rs
@@ -17,6 +17,7 @@ mod implementation {
 
     use super::*;
 
+    /// The set of tasks spawned on the current thread in a Web environment.
     #[derive(Default)]
     pub struct JoinSet(Vec<oneshot::Receiver<()>>);
 
@@ -76,6 +77,7 @@ mod implementation {
 
     use super::*;
 
+    /// The set of tasks spawned on the Tokio runtime.
     pub type JoinSet = tokio::task::JoinSet<()>;
 
     /// An extension trait for the [`JoinSet`] type.

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -5,22 +5,29 @@
 //! This module defines the core Linera protocol.
 
 #![recursion_limit = "256"]
+#![deny(missing_docs)]
 // We conditionally add autotraits to the traits here.
 #![allow(async_fn_in_trait)]
 
 mod chain_worker;
 pub use chain_worker::{ChainWorkerConfig, ProcessConfirmedBlockMode};
+/// The high-level client for interacting with chains and validators.
 pub mod client;
 pub use client::Client;
+/// Data types exchanged between clients, workers, and validator nodes.
 pub mod data_types;
 pub mod join_set_ext;
 mod local_node;
+/// Traits for communicating with validator nodes.
 pub mod node;
+/// Utilities for notifying subscribers about chain events.
 pub mod notifier;
 mod remote_node;
+/// Helpers for writing tests against the core protocol.
 #[cfg(with_testing)]
 #[path = "unit_tests/test_utils.rs"]
 pub mod test_utils;
+/// The worker that validates and processes blocks and certificates for chains.
 pub mod worker;
 
 pub(crate) mod updater;
@@ -30,7 +37,9 @@ pub use updater::DEFAULT_QUORUM_GRACE_PERIOD;
 
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};
 
+/// The execution environment tying together storage, networking, signing, and the wallet.
 pub mod environment;
+/// The genesis configuration describing a network's initial chains and committee.
 pub mod genesis_config;
 pub use environment::{
     wallet::{self, Wallet},

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -50,6 +50,7 @@ where
 
 /// Error type for the operations on a local node.
 #[derive(Debug, Error)]
+#[allow(missing_docs)]
 pub enum LocalNodeError {
     #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -45,6 +45,7 @@ pub type BlobStream = BoxStream<'static, Result<BlobContent, NodeError>>;
 
 /// Whether to wait for the delivery of outgoing cross-chain messages.
 #[derive(Debug, Default, Clone, Copy)]
+#[allow(missing_docs)]
 pub enum CrossChainMessageDelivery {
     #[default]
     NonBlocking,
@@ -55,8 +56,10 @@ pub enum CrossChainMessageDelivery {
 #[allow(async_fn_in_trait)]
 #[cfg_attr(not(web), trait_variant::make(Send))]
 pub trait ValidatorNode {
+    /// The type of stream of notifications returned when subscribing.
     type NotificationStream: Stream<Item = Notification> + Unpin + MaybeSend;
 
+    /// Returns the address of this validator node.
     fn address(&self) -> String;
 
     /// Proposes a new block.
@@ -106,8 +109,8 @@ pub trait ValidatorNode {
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;
 
-    // Uploads a blob. Returns an error if the validator has not seen a
-    // certificate using this blob.
+    /// Uploads a blob. Returns an error if the validator has not seen a
+    /// certificate using this blob.
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError>;
 
     /// Uploads the blobs to the validator.
@@ -147,6 +150,7 @@ pub trait ValidatorNode {
         blob: BlobContent,
     ) -> Result<ChainInfoResponse, NodeError>;
 
+    /// Downloads the confirmed block certificate with the given hash.
     async fn download_certificate(
         &self,
         hash: CryptoHash,
@@ -198,10 +202,13 @@ pub trait ValidatorNode {
 /// Turn an address into a validator node.
 #[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 pub trait ValidatorNodeProvider: 'static {
+    /// The type of validator node produced by this provider.
     type Node: ValidatorNode + MaybeSend + MaybeSync + Clone + 'static;
 
+    /// Creates a node from a validator's address.
     fn make_node(&self, address: &str) -> Result<Self::Node, NodeError>;
 
+    /// Creates a node for each validator in the committee.
     fn make_nodes(
         &self,
         committee: &Committee,
@@ -213,6 +220,7 @@ pub trait ValidatorNodeProvider: 'static {
         self.make_nodes_from_list(validator_addresses)
     }
 
+    /// Creates a node for each validator in the given list of public keys and addresses.
     fn make_nodes_from_list<A>(
         &self,
         validators: impl IntoIterator<Item = (ValidatorPublicKey, A)>,
@@ -233,6 +241,7 @@ pub trait ValidatorNodeProvider: 'static {
 /// This error is meant to be serialized over the network and aggregated by clients (i.e.
 /// clients will track validator votes on each error value).
 #[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash)]
+#[allow(missing_docs)]
 pub enum NodeError {
     #[error("Cryptographic error: {error}")]
     CryptoError { error: String },
@@ -419,6 +428,7 @@ impl From<tonic::Status> for NodeError {
 }
 
 impl CrossChainMessageDelivery {
+    /// Creates a new value, blocking on outgoing message delivery if requested.
     pub fn new(wait_for_outgoing_messages: bool) -> Self {
         if wait_for_outgoing_messages {
             CrossChainMessageDelivery::Blocking
@@ -427,6 +437,7 @@ impl CrossChainMessageDelivery {
         }
     }
 
+    /// Returns whether to wait for the delivery of outgoing cross-chain messages.
     pub fn wait_for_outgoing_messages(self) -> bool {
         match self {
             CrossChainMessageDelivery::NonBlocking => false,

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -132,6 +132,7 @@ impl Notifier for Arc<std::sync::Mutex<Vec<worker::Notification>>> {
 }
 
 #[cfg(test)]
+/// Unit tests for the [`Notifier`].
 pub mod tests {
     use std::{
         sync::{atomic::Ordering, Arc},

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -105,7 +105,9 @@ where
     }
 }
 
+/// A type that can dispatch notifications produced by the worker.
 pub trait Notifier: Clone + Send + 'static {
+    /// Dispatches the given notifications to the interested clients.
     fn notify(&self, notifications: &[worker::Notification]);
 }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -67,7 +67,9 @@ use crate::{
     },
 };
 
+/// The kind of misbehavior a test validator simulates.
 #[derive(Debug, PartialEq, Clone, Copy)]
+#[allow(missing_docs)]
 pub enum FaultType {
     Honest,
     Offline,
@@ -92,6 +94,7 @@ where
     notifier: Arc<ChannelNotifier<Notification>>,
 }
 
+/// A client used by tests to talk to an in-process `LocalValidator`.
 #[derive(Clone)]
 pub struct LocalValidatorClient<S>
 where
@@ -340,10 +343,12 @@ where
         }
     }
 
+    /// Returns the validator's public key.
     pub fn name(&self) -> ValidatorPublicKey {
         self.public_key
     }
 
+    /// Returns the validator's currently configured [`FaultType`].
     pub fn fault_type(&self) -> FaultType {
         self.fault_type
     }
@@ -755,6 +760,7 @@ where
     }
 }
 
+/// A [`ValidatorNodeProvider`] holding the in-process test validator clients.
 #[derive(Clone)]
 pub struct NodeProvider<S>(Arc<std::sync::Mutex<Vec<LocalValidatorClient<S>>>>)
 where
@@ -820,6 +826,7 @@ where
 // * When using `LocalValidatorClient`, clients communicate with an exact quorum then stop.
 // * Most tests have 1 faulty validator out 4 so that there is exactly only 1 quorum to
 // communicate with.
+#[allow(missing_docs)]
 pub struct TestBuilder<B: StorageBuilder> {
     storage_builder: B,
     pub initial_committee: Committee,
@@ -834,12 +841,16 @@ pub struct TestBuilder<B: StorageBuilder> {
     pub signer: TestSigner,
 }
 
+/// Builds storage instances of a specific backend for use in tests.
 #[async_trait]
 pub trait StorageBuilder {
+    /// The storage type produced by this builder.
     type Storage: Storage + Clone + Send + Sync + 'static;
 
+    /// Builds a new storage instance.
     async fn build(&mut self) -> Result<Self::Storage, anyhow::Error>;
 
+    /// Returns the test clock shared by all storages built here.
     fn clock(&self) -> &TestClock;
 }
 
@@ -875,6 +886,7 @@ impl GenesisStorageBuilder {
     }
 }
 
+/// A chain client wired up to the in-process test validator network.
 pub type ChainClient<S> = crate::client::ChainClient<crate::environment::Impl<S, NodeProvider<S>>>;
 
 impl<S: Storage + Clone + Send + Sync + 'static> ChainClient<S> {
@@ -902,6 +914,7 @@ impl<B> TestBuilder<B>
 where
     B: StorageBuilder,
 {
+    /// Creates a test setup with `count` validators, `with_faulty_validators` of which are faulty.
     pub async fn new(
         mut storage_builder: B,
         count: usize,
@@ -961,6 +974,7 @@ where
         })
     }
 
+    /// Replaces the initial committee's resource control policy.
     pub fn with_policy(mut self, policy: ResourceControlPolicy) -> Self {
         let validators = self.initial_committee.validators().clone();
         self.initial_committee =
@@ -968,6 +982,7 @@ where
         self
     }
 
+    /// Sets the cross-chain message chunk limit on every validator in the test setup.
     pub fn with_cross_chain_message_chunk_limit(self, limit: usize) -> Self {
         let validator_clients = self.node_provider.0.lock().unwrap();
         for validator in validator_clients.iter() {
@@ -990,6 +1005,7 @@ where
             .map(|client| client.fault_type())
     }
 
+    /// Sets the [`FaultType`] for the validators at the given indexes.
     pub fn set_fault_type(&mut self, indexes: impl AsRef<[usize]>, fault_type: FaultType) {
         let mut faulty_validators = vec![];
         let mut validator_clients = self.node_provider.0.lock().unwrap();
@@ -1083,6 +1099,7 @@ where
         self.make_client(chain_id, None, BlockHeight::ZERO).await
     }
 
+    /// Returns the public key and balance of each genesis root chain.
     pub fn genesis_chains(&self) -> Vec<(AccountPublicKey, Amount)> {
         let mut result = Vec::new();
         for (i, genesis_account) in self.genesis_storage_builder.accounts.iter().enumerate() {
@@ -1098,6 +1115,7 @@ where
         result
     }
 
+    /// Returns the admin chain's ID, panicking if it has not been initialized.
     pub fn admin_chain_id(&self) -> ChainId {
         self.admin_description
             .as_ref()
@@ -1105,18 +1123,22 @@ where
             .id()
     }
 
+    /// Returns the admin chain description, if the admin chain has been initialized.
     pub fn admin_description(&self) -> Option<&ChainDescription> {
         self.admin_description.as_ref()
     }
 
+    /// Returns a clone of the node provider backing this test setup.
     pub fn make_node_provider(&self) -> NodeProvider<B::Storage> {
         self.node_provider.clone()
     }
 
+    /// Returns a clone of the validator client at the given index.
     pub fn node(&mut self, index: usize) -> LocalValidatorClient<B::Storage> {
         self.node_provider.0.lock().unwrap()[index].clone()
     }
 
+    /// Builds a fresh storage seeded with the network description and genesis chains.
     pub async fn make_storage(&mut self) -> anyhow::Result<B::Storage> {
         let storage = self.storage_builder.build().await?;
         let network_description = self.network_description.as_ref().unwrap();
@@ -1132,6 +1154,7 @@ where
         Ok(self.genesis_storage_builder.build(storage).await)
     }
 
+    /// Creates a chain client for the given chain with the given client options.
     pub async fn make_client_with_options(
         &mut self,
         chain_id: ChainId,
@@ -1179,6 +1202,7 @@ where
         ))
     }
 
+    /// Creates a chain client for the given chain with default test options.
     pub async fn make_client(
         &mut self,
         chain_id: ChainId,
@@ -1309,6 +1333,7 @@ impl CommonStorageBuilder {
     }
 }
 
+/// A [`StorageBuilder`] backed by in-memory storage.
 #[derive(Default)]
 pub struct MemoryStorageBuilder {
     inner: CommonStorageBuilder,
@@ -1339,6 +1364,7 @@ impl StorageBuilder for MemoryStorageBuilder {
 }
 
 #[cfg(feature = "rocksdb")]
+/// A [`StorageBuilder`] backed by RocksDB storage.
 pub struct RocksDbStorageBuilder {
     inner: CommonStorageBuilder,
     _permit: SemaphorePermit<'static>,
@@ -1346,6 +1372,7 @@ pub struct RocksDbStorageBuilder {
 
 #[cfg(feature = "rocksdb")]
 impl RocksDbStorageBuilder {
+    /// Creates a [`RocksDbStorageBuilder`], acquiring a concurrency permit.
     pub async fn new() -> Self {
         Self {
             inner: CommonStorageBuilder::default(),
@@ -1380,6 +1407,7 @@ impl StorageBuilder for RocksDbStorageBuilder {
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "storage-service"))]
+/// A [`StorageBuilder`] backed by the storage service.
 #[derive(Default)]
 pub struct ServiceStorageBuilder {
     inner: CommonStorageBuilder,
@@ -1418,6 +1446,7 @@ impl StorageBuilder for ServiceStorageBuilder {
 }
 
 #[cfg(feature = "scylladb")]
+/// A [`StorageBuilder`] backed by ScyllaDB storage.
 #[derive(Default)]
 pub struct ScyllaDbStorageBuilder {
     inner: CommonStorageBuilder,
@@ -1449,6 +1478,7 @@ impl StorageBuilder for ScyllaDbStorageBuilder {
     }
 }
 
+/// Helpers for asserting on [`ClientOutcome`] results in tests.
 pub trait ClientOutcomeResultExt<T, E> {
     /// Unwraps the result and panics if it's not `Committed`.
     /// Use this when you expect the operation to succeed without conflicts.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -72,7 +72,9 @@ use crate::{
     notifier::Notifier,
 };
 
+/// The default maximum number of confirmed blocks kept in the worker's block cache.
 pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 5_000;
+/// The default maximum number of execution state views kept in the worker's cache.
 pub const DEFAULT_EXECUTION_STATE_CACHE_SIZE: usize = 10_000;
 
 #[cfg(test)]
@@ -282,6 +284,7 @@ pub struct NetworkActions {
 }
 
 impl NetworkActions {
+    /// Merges the cross-chain requests and notifications from `other` into these actions.
     pub fn extend(&mut self, other: NetworkActions) {
         self.cross_chain_requests.extend(other.cross_chain_requests);
         self.notifications.extend(other.notifications);
@@ -290,6 +293,7 @@ impl NetworkActions {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 /// Notification that a chain has a new certified block or a new message.
+#[allow(missing_docs)]
 pub struct Notification {
     pub chain_id: ChainId,
     pub reason: Reason,
@@ -302,6 +306,7 @@ doc_scalar!(
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 /// Reason for the notification.
+#[allow(missing_docs)]
 pub enum Reason {
     NewBlock {
         height: BlockHeight,
@@ -328,6 +333,7 @@ pub enum Reason {
 
 /// Error type for worker operations.
 #[derive(Debug, Error, strum::IntoStaticStr)]
+#[allow(missing_docs)]
 pub enum WorkerError {
     #[error(transparent)]
     CryptoError(#[from] CryptoError),
@@ -750,6 +756,7 @@ where
         self.chain_worker_config.cross_chain_message_chunk_limit = limit;
     }
 
+    /// Returns an instance configured to allow reverting confirmed blocks.
     #[cfg(with_testing)]
     #[instrument(level = "trace", skip(self, value))]
     pub fn with_allow_revert_confirm(mut self, value: bool) -> Self {
@@ -757,6 +764,7 @@ where
         self
     }
 
+    /// Returns the worker's nickname.
     #[instrument(level = "trace", skip(self))]
     pub fn nickname(&self) -> &str {
         &self.chain_worker_config.nickname
@@ -809,7 +817,9 @@ where
 
 #[allow(async_fn_in_trait)]
 #[cfg_attr(not(web), trait_variant::make(Send))]
+/// A certificate value that the worker knows how to process.
 pub trait ProcessableCertificate: CertificateValue + Sized + 'static {
+    /// Processes a certificate carrying this value on the given worker.
     async fn process_certificate<S: Storage + Clone + 'static>(
         worker: &WorkerState<S>,
         certificate: GenericCertificate<Self>,
@@ -899,6 +909,8 @@ where
 
     #[instrument(level = "trace", skip(self, certificate, notifier))]
     #[inline]
+    /// Processes a certificate fully, dispatching any resulting cross-chain requests
+    /// and emitting notifications through the given notifier.
     pub async fn fully_handle_certificate_with_notifications<T>(
         &self,
         certificate: GenericCertificate<T>,
@@ -1316,6 +1328,7 @@ where
         chain_id = %chain_id,
         application_id = %application_id
     ))]
+    /// Returns the description of the given application on the given chain.
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
@@ -1546,6 +1559,7 @@ where
         chain_id = format!("{:.8}", proposal.content.block.chain_id),
         height = %proposal.content.block.height,
     ))]
+    /// Handles a block proposal, validating it and preparing the chain to vote on it.
     pub async fn handle_block_proposal(
         &self,
         proposal: BlockProposal,
@@ -1696,6 +1710,7 @@ where
         nick = self.nickname(),
         chain_id = format!("{:.8}", query.chain_id)
     ))]
+    /// Handles a query about a chain's state and returns the requested information.
     pub async fn handle_chain_info_query(
         &self,
         query: ChainInfoQuery,
@@ -1717,6 +1732,7 @@ where
         nick = self.nickname(),
         chain_id = format!("{:.8}", chain_id)
     ))]
+    /// Downloads a blob that a pending block on the given chain depends on.
     pub async fn download_pending_blob(
         &self,
         chain_id: ChainId,
@@ -1740,6 +1756,7 @@ where
         nick = self.nickname(),
         chain_id = format!("{:.8}", chain_id)
     ))]
+    /// Handles a blob that a pending block depends on, adding it to the chain worker.
     pub async fn handle_pending_blob(
         &self,
         chain_id: ChainId,
@@ -1764,6 +1781,7 @@ where
         nick = self.nickname(),
         chain_id = format!("{:.8}", request.target_chain_id())
     ))]
+    /// Handles a cross-chain request received from another chain or shard.
     pub async fn handle_cross_chain_request(
         &self,
         request: CrossChainRequest,


### PR DESCRIPTION
## Motivation

`linera-core` was one of the few library crates without `#![deny(missing_docs)]`, so undocumented public items could be added without CI noticing.

## Proposal

Add `#![deny(missing_docs)]` to `linera-core` and satisfy it:
- Real one-line doc comments on genuine public API (the worker, the validator-node and environment traits and their associated types, `ChainClient`/`Client` methods, data types and their fields, genesis config, scheduler, test helpers, etc.).
- `#[allow(missing_docs)]` on large, mechanical, self-descriptive types — the `thiserror`-driven error enums (`WorkerError`, `NodeError`, `ChainClient`'s `Error`, `LocalNodeError`, genesis `Error`), the `CrossChainRequest`/`CrossChainMessageDelivery`/`Reason`/`Notification`/`TimingType`/`FaultType` enums and a couple of bulk test/data structs — matching the existing `linera-base` convention.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied in every configuration CI builds:
- `cargo check -p linera-core --all-features`
- `cargo check -p linera-core --no-default-features --features web,wasmer --target wasm32-unknown-unknown`
- `cargo check -p linera-core --no-default-features` and default features
- `cargo +nightly fmt -- --check` and `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` both pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion backport to `testnet_conway`: documented identically so shared items stay conflict-free.
- Follows the same approach as the `linera-execution` change (#6509).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
