### PR TITLE
Clean dist before building the @linera npm SDK packages to prevent stale artifacts

### DIFF
--- a/web/@linera/client/build.bash
+++ b/web/@linera/client/build.bash
@@ -48,6 +48,9 @@ else
     echo "wasm-split not found, skipping (debug wasm and stripping disabled)" >&2
 fi
 
+# Start from a clean dist so stale artifacts from a previous build can never be
+# published (dist/ is gitignored and rebuilt fresh on `prepare`/publish).
+rm -rf dist
 mkdir -p dist
 cp -r src/wasm dist/
 

--- a/web/@linera/client/package.json
+++ b/web/@linera/client/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "install": "true",
     "build": "bash build.bash --release",
+    "clean": "rm -rf dist",
     "prepare": "pnpm build",
     "lint": "pnpm build && cargo fmt --check && cargo clippy",
     "test": "pnpm exec vitest --run",

--- a/web/@linera/metamask/package.json
+++ b/web/@linera/metamask/package.json
@@ -12,7 +12,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "pnpm exec tsc -p tsconfig.build.json",
+    "build": "pnpm run clean && pnpm exec tsc -p tsconfig.build.json",
     "clean": "rm -rf dist",
     "ci": "pnpm run build",
     "prepare": "pnpm run build"


### PR DESCRIPTION
## Motivation

`web/@linera/client`'s `dist/` is gitignored and rebuilt on `prepare`/publish, but `build.bash` never cleans it. `tsc` overwrites the files it emits, but anything no longer produced by the build — the emitted output of a renamed/deleted source module, or a hand-written declaration the build stops copying — lingers in the publisher's local `dist/` and gets packaged into the next `npm publish`.

This already bit the SDK: a stale `dist/signer/Signer.d.ts` was published in `0.15.19` (fixed for `testnet_conway` in #6514). `main` is safe for that specific file (it compiles `Signer.ts` fresh each build), but the underlying hazard — a published artifact that is not a pure function of source — remains, and the sibling SDK package `@linera/metamask` has the same gap.

## Proposal

Make cleaning part of every SDK npm build:

- `@linera/client`: `rm -rf dist` at the start of `build.bash`, plus a matching `"clean": "rm -rf dist"` script for parity/manual use (`build.bash` stays self-cleaning regardless of how it is invoked).
- `@linera/metamask`: it already has a `"clean": "rm -rf dist"` script but never ran it — wire it in: `"build": "pnpm run clean && pnpm exec tsc -p tsconfig.build.json"`.

No behavior change for a clean checkout; every publish becomes a pure function of source.

## Test Plan

- Build-script/`package.json`-only changes; CI runs the full `pnpm build` for both packages, now starting from an empty `dist/`.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK.

Build hygiene only; no protocol or storage format change.

## Links

- Related `testnet_conway` fix (stale `Signer.d.ts` in published `0.15.19`): #6514
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
