### PR TITLE
Add #![deny(missing_docs)] to linera-client

### DIFF
--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -58,6 +58,7 @@ pub struct NativeFungibleTransferGenerator {
 }
 
 impl NativeFungibleTransferGenerator {
+    /// Creates a generator that sends native token transfers from the source chain.
     pub fn new(
         source_chain_id: ChainId,
         mut destination_chains: Vec<ChainId>,
@@ -134,6 +135,7 @@ pub struct FungibleTransferGenerator {
 }
 
 impl FungibleTransferGenerator {
+    /// Creates a generator that sends fungible token transfers from the source chain.
     pub fn new(
         application_id: ApplicationId,
         source_chain_id: ChainId,
@@ -194,7 +196,9 @@ impl OperationGenerator for FungibleTransferGenerator {
 const PROXY_LATENCY_P99_THRESHOLD: f64 = 400.0;
 const LATENCY_METRIC_PREFIX: &str = "linera_proxy_request_latency";
 
+/// An error that can occur while running a benchmark.
 #[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum BenchmarkError {
     #[error("Failed to join task: {0}")]
     JoinError(#[from] task::JoinError),
@@ -245,17 +249,21 @@ struct HistogramSnapshot {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+/// Configuration listing the chains to use for a benchmark.
 pub struct BenchmarkConfig {
+    /// The chains to use for the benchmark.
     pub chain_ids: Vec<ChainId>,
 }
 
 impl BenchmarkConfig {
+    /// Loads the benchmark configuration from a YAML file.
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
         let content = std::fs::read_to_string(path)?;
         let config = serde_yaml::from_str(&content)?;
         Ok(config)
     }
 
+    /// Saves the benchmark configuration to a YAML file.
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> anyhow::Result<()> {
         let content = serde_yaml::to_string(self)?;
         std::fs::write(path, content)?;
@@ -263,6 +271,7 @@ impl BenchmarkConfig {
     }
 }
 
+/// Driver for running benchmarks against a network.
 pub struct Benchmark<Env: Environment> {
     _phantom: std::marker::PhantomData<Env>,
 }
@@ -820,6 +829,7 @@ impl<Env: Environment> Benchmark<Env> {
         Ok(())
     }
 
+    /// Returns the chains to benchmark, from the config file if given, otherwise from the wallet.
     pub fn get_all_chains(
         chains_config_path: Option<&Path>,
         benchmark_chains: &[(ChainId, AccountOwner)],
@@ -841,6 +851,7 @@ impl<Env: Environment> Benchmark<Env> {
     }
 }
 
+/// Builds a fungible token transfer operation for the given application.
 pub fn fungible_transfer(
     application_id: ApplicationId,
     chain_id: ChainId,

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -32,6 +32,7 @@ use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::error::{self, Error};
 
+/// The configuration for the chain listener.
 #[derive(Default, Debug, Clone, clap::Args, serde::Serialize, serde::Deserialize, tsify::Tsify)]
 #[serde(rename_all = "camelCase")]
 pub struct ChainListenerConfig {
@@ -65,17 +66,23 @@ pub struct ChainListenerConfig {
 
 type ContextChainClient<C> = ChainClient<<C as ClientContext>::Environment>;
 
+/// The context in which a chain listener operates, providing access to the wallet, storage and client.
 #[cfg_attr(not(web), trait_variant::make(Send + Sync))]
 #[allow(async_fn_in_trait)]
 pub trait ClientContext {
+    /// The execution environment used by the client.
     type Environment: linera_core::Environment;
 
+    /// Returns a reference to the wallet.
     fn wallet(&self) -> &<Self::Environment as linera_core::Environment>::Wallet;
 
+    /// Returns a reference to the storage.
     fn storage(&self) -> &<Self::Environment as linera_core::Environment>::Storage;
 
+    /// Returns a reference to the client.
     fn client(&self) -> &Arc<linera_core::client::Client<Self::Environment>>;
 
+    /// Returns the ID of the admin chain.
     fn admin_chain_id(&self) -> ChainId {
         self.client().admin_chain_id()
     }
@@ -86,6 +93,7 @@ pub trait ClientContext {
         &self,
     ) -> Option<tokio::sync::mpsc::UnboundedSender<(u64, linera_core::client::TimingType)>>;
 
+    /// Gets the timing sender for benchmarking, if available.
     #[cfg(web)]
     fn timing_sender(
         &self,
@@ -93,6 +101,7 @@ pub trait ClientContext {
         None
     }
 
+    /// Creates a chain client for the chain with the given ID, using the wallet's state.
     fn make_chain_client(
         &self,
         chain_id: ChainId,
@@ -118,6 +127,7 @@ pub trait ClientContext {
         }
     }
 
+    /// Adds a newly created chain to the wallet.
     async fn update_wallet_for_new_chain(
         &mut self,
         chain_id: ChainId,
@@ -126,11 +136,14 @@ pub trait ClientContext {
         epoch: Epoch,
     ) -> Result<(), Error>;
 
+    /// Updates the wallet with the latest state of the given chain client.
     async fn update_wallet(&mut self, client: &ContextChainClient<Self>) -> Result<(), Error>;
 }
 
+/// Extension methods for [`ClientContext`].
 #[allow(async_fn_in_trait)]
 pub trait ClientContextExt: ClientContext {
+    /// Returns a chain client for every chain in the wallet.
     async fn clients(&self) -> Result<Vec<ContextChainClient<Self>>, Error> {
         use futures::stream::TryStreamExt as _;
         self.wallet()

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -208,18 +208,30 @@ impl ValidatorQueryResults {
     }
 }
 
+/// The state shared by the client commands: the core client, wallet configuration, and
+/// network timeouts.
 pub struct ClientContext<Env: Environment> {
+    /// The core client used to interact with chains and validators.
     pub client: Arc<Client<Env>>,
+    /// The genesis configuration of the network.
     // TODO(#5083): this doesn't really need to be stored
     pub genesis_config: crate::config::GenesisConfig,
+    /// The timeout for sending requests to validators.
     pub send_timeout: Duration,
+    /// The timeout for receiving responses from validators.
     pub recv_timeout: Duration,
+    /// The delay before retrying a failed request to a validator.
     pub retry_delay: Duration,
+    /// The maximum number of times to retry a failed request to a validator.
     pub max_retries: u32,
+    /// The maximum backoff between retries of a failed request to a validator.
     pub max_backoff: Duration,
+    /// The set of background tasks listening for chain notifications.
     pub chain_listeners: JoinSet,
+    /// The default chain used when no chain is explicitly specified.
     // TODO(#5082): move this into the upstream UI layers (maybe just the CLI)
     pub default_chain: Option<ChainId>,
+    /// The metrics collector, if metrics collection is enabled.
     #[cfg(not(web))]
     pub client_metrics: Option<ClientMetrics>,
 }
@@ -274,6 +286,7 @@ where
     // not worth refactoring this because
     // https://github.com/linera-io/linera-protocol/issues/5082
     // https://github.com/linera-io/linera-protocol/issues/5083
+    /// Creates a new client context from the given storage, wallet, signer, and options.
     #[expect(clippy::too_many_arguments)]
     pub async fn new(
         storage: S,
@@ -385,6 +398,7 @@ impl<Env: Environment> ClientContext<Env> {
             .expect("default chain requested but none set")
     }
 
+    /// Returns the lowest non-admin chain ID in the wallet.
     pub async fn first_non_admin_chain(&self) -> Result<ChainId, Error> {
         let admin_chain_id = self.admin_chain_id();
         let chain_ids = self
@@ -400,6 +414,7 @@ impl<Env: Environment> ClientContext<Env> {
             .expect("No non-admin chain specified in wallet with no non-admin chain"))
     }
 
+    /// Creates a node provider configured with this context's network options.
     // TODO(#5084) this should match the `NodeProvider` from the `Environment`
     pub fn make_node_provider(&self) -> NodeProvider {
         NodeProvider::new(self.make_node_options())
@@ -415,11 +430,13 @@ impl<Env: Environment> ClientContext<Env> {
         }
     }
 
+    /// Returns the client metrics, if metrics collection is enabled.
     #[cfg(not(web))]
     pub fn client_metrics(&self) -> Option<&ClientMetrics> {
         self.client_metrics.as_ref()
     }
 
+    /// Updates the wallet entry for the client's chain from its current chain info.
     pub async fn update_wallet_from_client<Env_: Environment>(
         &self,
         client: &ChainClient<Env_>,
@@ -499,6 +516,7 @@ impl<Env: Environment> ClientContext<Env> {
         Ok(())
     }
 
+    /// Processes the chain's inbox, waiting for round timeouts, and updates the wallet.
     pub async fn process_inbox(
         &mut self,
         chain_client: &ChainClient<Env>,
@@ -535,6 +553,7 @@ impl<Env: Environment> ClientContext<Env> {
         }
     }
 
+    /// Assigns the given chain to the owner, tracking it and recording it in the wallet.
     pub async fn assign_new_chain_to_key(
         &mut self,
         chain_id: ChainId,
@@ -619,6 +638,7 @@ impl<Env: Environment> ClientContext<Env> {
         }
     }
 
+    /// Returns the ownership configuration of the given chain.
     pub async fn ownership(&mut self, chain_id: Option<ChainId>) -> Result<ChainOwnership, Error> {
         let chain_id = chain_id.unwrap_or_else(|| self.default_chain());
         let client = self.make_chain_client(chain_id).await?;
@@ -626,6 +646,7 @@ impl<Env: Environment> ClientContext<Env> {
         Ok(info.manager.ownership)
     }
 
+    /// Changes the ownership configuration of the given chain.
     pub async fn change_ownership(
         &mut self,
         chain_id: Option<ChainId>,
@@ -667,6 +688,7 @@ impl<Env: Environment> ClientContext<Env> {
         Ok(())
     }
 
+    /// Sets the preferred owner used to propose blocks on the given chain.
     pub async fn set_preferred_owner(
         &mut self,
         chain_id: Option<ChainId>,
@@ -682,6 +704,7 @@ impl<Env: Environment> ClientContext<Env> {
         Ok(())
     }
 
+    /// Checks that the validator's version info is compatible with the local version.
     pub async fn check_compatible_version_info(
         &self,
         address: &str,
@@ -708,6 +731,7 @@ impl<Env: Environment> ClientContext<Env> {
         }
     }
 
+    /// Checks that the validator's network description matches the local genesis config.
     pub async fn check_matching_network_description(
         &self,
         address: &str,
@@ -734,6 +758,7 @@ impl<Env: Environment> ClientContext<Env> {
         }
     }
 
+    /// Queries a validator for the given chain's info and verifies its signature.
     pub async fn check_validator_chain_info_response(
         &self,
         public_key: Option<&ValidatorPublicKey>,
@@ -824,6 +849,7 @@ impl<Env: Environment> ClientContext<Env> {
 
 #[cfg(feature = "fs")]
 impl<Env: Environment> ClientContext<Env> {
+    /// Publishes a module from its contract and service bytecode files.
     pub async fn publish_module(
         &mut self,
         chain_client: &ChainClient<Env>,
@@ -879,6 +905,7 @@ impl<Env: Environment> ClientContext<Env> {
         Ok(module_id)
     }
 
+    /// Publishes a data blob loaded from the given file.
     pub async fn publish_data_blob(
         &mut self,
         chain_client: &ChainClient<Env>,
@@ -910,6 +937,7 @@ impl<Env: Environment> ClientContext<Env> {
     }
 
     // TODO(#2490): Consider removing or renaming this.
+    /// Verifies that a data blob with the given hash is available.
     pub async fn read_data_blob(
         &mut self,
         chain_client: &ChainClient<Env>,
@@ -970,6 +998,7 @@ fn strip_snap_frontmatter(content: &str) -> Option<&str> {
 
 #[cfg(not(web))]
 impl<Env: Environment> ClientContext<Env> {
+    /// Prepares the chains and fungible tokens needed to run a benchmark.
     pub async fn prepare_for_benchmark(
         &mut self,
         num_chains: usize,
@@ -1042,6 +1071,7 @@ impl<Env: Environment> ClientContext<Env> {
         Ok(chain_clients)
     }
 
+    /// Closes the benchmark chains, or processes their inboxes and updates the wallet.
     pub async fn wrap_up_benchmark(
         &mut self,
         chain_clients: Vec<ChainClient<Env>>,

--- a/linera-client/src/client_metrics.rs
+++ b/linera-client/src/client_metrics.rs
@@ -7,8 +7,11 @@ use tokio::{sync::mpsc, task, time};
 use tracing::{debug, info, warn};
 
 #[derive(Debug, Clone)]
+/// Configuration for client-side timing metrics collection and reporting.
 pub struct TimingConfig {
+    /// Whether timing metrics collection is enabled.
     pub enabled: bool,
+    /// How often, in seconds, the collected timing data is reported.
     pub report_interval_secs: u64,
 }
 
@@ -23,19 +26,26 @@ impl Default for TimingConfig {
 }
 
 #[derive(Debug, thiserror::Error)]
+/// Errors that can occur while creating or recording client timing metrics.
 pub enum ClientMetricsError {
+    /// A histogram could not be created.
     #[error("Failed to create histogram: {0}")]
     HistogramCreationError(#[from] hdrhistogram::CreationError),
+    /// A value could not be recorded into a histogram.
     #[error("Failed to record histogram: {0}")]
     HistogramRecordError(#[from] hdrhistogram::RecordError),
 }
 
+/// Histograms tracking the time spent in the individual phases of executing a block.
 pub struct ExecuteBlockTimingsHistograms {
+    /// Time taken to submit a block proposal, in milliseconds.
     pub submit_block_proposal_histogram: Histogram<u64>,
+    /// Time taken to update the validators, in milliseconds.
     pub update_validators_histogram: Histogram<u64>,
 }
 
 impl ExecuteBlockTimingsHistograms {
+    /// Creates a new set of block-phase timing histograms.
     pub fn new() -> Result<Self, ClientMetricsError> {
         Ok(Self {
             submit_block_proposal_histogram: Histogram::<u64>::new(2)?,
@@ -44,12 +54,16 @@ impl ExecuteBlockTimingsHistograms {
     }
 }
 
+/// Histograms tracking the time spent executing operations, broken down by sub-phase.
 pub struct ExecuteOperationsTimingsHistograms {
+    /// Time taken to execute a single block, in milliseconds.
     pub execute_block_histogram: Histogram<u64>,
+    /// Nested histograms for the block-execution sub-phases.
     pub execute_block_timings_histograms: ExecuteBlockTimingsHistograms,
 }
 
 impl ExecuteOperationsTimingsHistograms {
+    /// Creates a new set of operation-execution timing histograms.
     pub fn new() -> Result<Self, ClientMetricsError> {
         Ok(Self {
             execute_block_histogram: Histogram::<u64>::new(2)?,
@@ -58,12 +72,16 @@ impl ExecuteOperationsTimingsHistograms {
     }
 }
 
+/// Histograms tracking the time spent processing a whole block, broken down by phase.
 pub struct BlockTimingsHistograms {
+    /// Time taken to execute the operations in a block, in milliseconds.
     pub execute_operations_histogram: Histogram<u64>,
+    /// Nested histograms for the operation-execution sub-phases.
     pub execute_operations_timings_histograms: ExecuteOperationsTimingsHistograms,
 }
 
 impl BlockTimingsHistograms {
+    /// Creates a new set of block timing histograms.
     pub fn new() -> Result<Self, ClientMetricsError> {
         Ok(Self {
             execute_operations_histogram: Histogram::<u64>::new(2)?,
@@ -71,6 +89,7 @@ impl BlockTimingsHistograms {
         })
     }
 
+    /// Records a measured duration into the histogram matching the given timing type.
     pub fn record_timing(
         &mut self,
         duration_ms: u64,
@@ -102,15 +121,20 @@ impl BlockTimingsHistograms {
     }
 }
 
+/// Collects client-side timing metrics and reports them periodically.
 #[cfg(not(web))]
 pub struct ClientMetrics {
+    /// Configuration controlling whether timing collection is enabled and how often it reports.
     pub timing_config: TimingConfig,
+    /// Sender used to forward measured durations and their timing type to the collection task.
     pub timing_sender: mpsc::UnboundedSender<(u64, TimingType)>,
+    /// Handle to the background task that aggregates and reports timing data.
     pub timing_task: task::JoinHandle<()>,
 }
 
 #[cfg(not(web))]
 impl ClientMetrics {
+    /// Creates a new client metrics collector and spawns its background reporting task.
     pub fn new(timing_config: TimingConfig) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         let timing_task = tokio::spawn(Self::timing_collection(

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -28,6 +28,7 @@ use crate::client_metrics::TimingConfig;
 use crate::util;
 
 #[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum Error {
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
@@ -39,6 +40,7 @@ pub enum Error {
 
 util::impl_from_infallible!(Error);
 
+/// Command-line options controlling the behavior of the chain client.
 #[derive(Clone, clap::Parser, serde::Deserialize, tsify::Tsify)]
 #[tsify(from_wasm_abi)]
 #[group(skip)]
@@ -311,6 +313,7 @@ pub struct Options {
     )]
     pub alternative_peers_retry_delay_ms: u64,
 
+    /// Configuration for the chain listener.
     #[serde(flatten)]
     #[clap(flatten)]
     pub chain_listener_config: crate::chain_listener::ChainListenerConfig,
@@ -401,6 +404,7 @@ impl Options {
     }
 }
 
+/// Command-line options for configuring the ownership of a chain.
 #[derive(Debug, Clone, clap::Args)]
 pub struct ChainOwnershipConfig {
     /// A JSON list of the new super owners. Absence of the option leaves the current
@@ -467,6 +471,7 @@ pub struct ChainOwnershipConfig {
 }
 
 impl ChainOwnershipConfig {
+    /// Applies the configured ownership overrides to the given chain ownership.
     pub fn update(self, chain_ownership: &mut ChainOwnership) -> Result<(), Error> {
         let ChainOwnershipConfig {
             super_owners,
@@ -524,6 +529,7 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
     }
 }
 
+/// Command-line options for configuring application permissions on a chain.
 #[derive(Debug, Clone, clap::Args)]
 pub struct ApplicationPermissionsConfig {
     /// A JSON list of applications allowed to execute operations on this chain. If set to null, all
@@ -560,6 +566,7 @@ pub struct ApplicationPermissionsConfig {
 }
 
 impl ApplicationPermissionsConfig {
+    /// Applies the configured permission overrides to the given application permissions.
     pub fn update(self, application_permissions: &mut ApplicationPermissions) {
         if let Some(execute_operations) = self.execute_operations {
             application_permissions.execute_operations = execute_operations;
@@ -580,6 +587,7 @@ impl ApplicationPermissionsConfig {
 }
 
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum ResourceControlPolicyConfig {
     NoFees,
     Testnet,
@@ -590,6 +598,7 @@ pub enum ResourceControlPolicyConfig {
 }
 
 impl ResourceControlPolicyConfig {
+    /// Converts this config into the corresponding resource control policy.
     pub fn into_policy(self) -> ResourceControlPolicy {
         match self {
             ResourceControlPolicyConfig::NoFees => ResourceControlPolicy::no_fees(),

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -30,18 +30,23 @@ pub struct ValidatorConfig {
 /// The private configuration of a validator service.
 #[derive(Serialize, Deserialize)]
 pub struct ValidatorServerConfig {
+    /// The public configuration of the validator.
     pub validator: ValidatorConfig,
+    /// The secret key of the validator.
     pub validator_secret: ValidatorSecretKey,
+    /// The internal network configuration of the validator.
     pub internal_network: ValidatorInternalNetworkConfig,
 }
 
 /// The (public) configuration for all validators.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct CommitteeConfig {
+    /// The public configurations of all validators in the committee.
     pub validators: Vec<ValidatorConfig>,
 }
 
 impl CommitteeConfig {
+    /// Converts this committee config into a `Committee` using the given resource control policy.
     pub fn into_committee(
         self,
         policy: ResourceControlPolicy,

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -6,7 +6,6 @@ use linera_base::{
 };
 use linera_core::node::NodeError;
 use linera_version::VersionInfo;
-use thiserror_context::Context;
 
 #[cfg(not(web))]
 use crate::benchmark::BenchmarkError;
@@ -76,7 +75,20 @@ impl Inner {
     }
 }
 
-thiserror_context::impl_context!(Error(Inner));
+mod context {
+    // `impl_context!` generates a public `Error` newtype (with accessors) that cannot carry
+    // doc comments, so this wrapper module is exempted from the crate's `missing_docs` policy.
+    // `expect` (rather than `allow`) flags this if the macro ever stops generating such items.
+    #![expect(missing_docs)]
+
+    use thiserror_context::Context;
+
+    use super::Inner;
+
+    thiserror_context::impl_context!(Error(Inner));
+}
+
+pub use context::Error;
 
 impl Error {
     pub(crate) fn wallet(error: impl std::error::Error + Send + Sync + 'static) -> Self {

--- a/linera-client/src/lib.rs
+++ b/linera-client/src/lib.rs
@@ -4,19 +4,27 @@
 //! This module provides a convenient library for writing a Linera client application.
 
 #![recursion_limit = "256"]
+#![deny(missing_docs)]
 #![allow(async_fn_in_trait)]
 
+/// Listens for notifications on the chains tracked by a client and reacts to them.
 pub mod chain_listener;
+/// The context bundling the wallet, storage, and configuration a client operates with.
 pub mod client_context;
 pub use client_context::ClientContext;
+/// Prometheus metrics collected by the client.
 #[cfg(not(web))]
 pub mod client_metrics;
+/// Command-line options shared by the client binaries.
 pub mod client_options;
 pub use client_options::Options;
+/// Configuration types for wallets, committees, and validator servers.
 pub mod config;
 mod error;
+/// Assorted parsing and command-line helper utilities.
 pub mod util;
 
+/// Tooling for running throughput benchmarks against a network.
 #[cfg(not(web))]
 pub mod benchmark;
 

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -13,10 +13,12 @@ use linera_base::{
 use linera_core::{data_types::RoundTimeout, node::NotificationStream, worker::Reason};
 use tokio_stream::StreamExt as _;
 
+/// Parses the trimmed string as JSON into a value of type `T`.
 pub fn parse_json<T: serde::de::DeserializeOwned>(s: &str) -> anyhow::Result<T> {
     Ok(serde_json::from_str(s.trim())?)
 }
 
+/// Parses the string as a number of milliseconds into a `Duration`.
 pub fn parse_millis(s: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_millis(s.parse()?))
 }
@@ -30,18 +32,22 @@ pub fn non_zero_duration(d: Duration) -> Option<Duration> {
     }
 }
 
+/// Parses the string as a number of seconds into a `Duration`.
 pub fn parse_secs(s: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_secs(s.parse()?))
 }
 
+/// Parses the string as a number of milliseconds into a `TimeDelta`.
 pub fn parse_millis_delta(s: &str) -> Result<TimeDelta, ParseIntError> {
     Ok(TimeDelta::from_millis(s.parse()?))
 }
 
+/// Parses the JSON string as an optional number of milliseconds into an `Option<TimeDelta>`.
 pub fn parse_json_optional_millis_delta(s: &str) -> anyhow::Result<Option<TimeDelta>> {
     Ok(parse_json::<Option<u64>>(s)?.map(TimeDelta::from_millis))
 }
 
+/// Parses a comma-separated list of chain IDs into a set.
 pub fn parse_chain_set(s: &str) -> Result<HashSet<ChainId>, CryptoError> {
     match s.trim() {
         "" => Ok(HashSet::new()),
@@ -49,6 +55,7 @@ pub fn parse_chain_set(s: &str) -> Result<HashSet<ChainId>, CryptoError> {
     }
 }
 
+/// Parses a comma-separated list of application IDs into a set.
 pub fn parse_app_set(s: &str) -> anyhow::Result<HashSet<GenericApplicationId>> {
     s.trim()
         .split(",")


### PR DESCRIPTION
## Motivation

`linera-client` was one of the few library crates without `#![deny(missing_docs)]`, so undocumented public items could be added without CI noticing.

## Proposal

Add `#![deny(missing_docs)]` to `linera-client` and satisfy it:
- Real one-line doc comments on genuine public API (the `ClientContext`, chain listener, client options, config and metrics types and their methods).
- `#[allow(missing_docs)]` on large, mechanical, self-descriptive types — the `thiserror`-driven error enums (`BenchmarkError`, the clap `ResourceControlPolicyConfig`, etc.) — matching the existing `linera-base` convention.
- The `error.rs` `Error` type is generated by `thiserror_context::impl_context!`, which can't carry doc comments; it is wrapped in a `mod` with `#![expect(missing_docs)]`, matching the existing `linera-persistent` pattern.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied in every configuration CI builds, including `cargo check --all-targets` (so `cfg(test)` modules are covered):
- native consistent feature set (`test,wasmer,wasmtime,fs,metrics,linera-storage/test`) for `--lib` and `--all-targets`
- `--no-default-features --features web-default` on `wasm32-unknown-unknown`
- `cargo +nightly fmt -- --check` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` both pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion backport to `testnet_conway`: documented identically so shared items stay conflict-free.
- Part of the effort to enable `#![deny(missing_docs)]` across the library crates (see linera-execution #6509, linera-core #6512).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
