### PR TITLE
Add #![deny(missing_docs)] to linera-chain (backport of #6520)

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -39,10 +39,12 @@ impl ValidatedBlock {
         Self(Hashed::new(block))
     }
 
+    /// Creates a `ValidatedBlock` from an already-hashed `Block`.
     pub fn from_hashed(block: Hashed<Block>) -> Self {
         Self(block)
     }
 
+    /// Returns a reference to the hashed [`Block`] contained in this `ValidatedBlock`.
     pub fn inner(&self) -> &Hashed<Block> {
         &self.0
     }
@@ -57,18 +59,22 @@ impl ValidatedBlock {
         self.0.into_inner()
     }
 
+    /// Returns a static string identifying this value kind, for logging.
     pub fn to_log_str(&self) -> &'static str {
         "validated_block"
     }
 
+    /// Returns the ID of the chain this block belongs to.
     pub fn chain_id(&self) -> ChainId {
         self.0.inner().header.chain_id
     }
 
+    /// Returns the height of this block.
     pub fn height(&self) -> BlockHeight {
         self.0.inner().header.height
     }
 
+    /// Returns the epoch this block belongs to.
     pub fn epoch(&self) -> Epoch {
         self.0.inner().header.epoch
     }
@@ -96,18 +102,22 @@ impl ConfirmedBlock {
 }
 
 impl ConfirmedBlock {
+    /// Creates a new `ConfirmedBlock` from a `Block`.
     pub fn new(block: Block) -> Self {
         Self(Hashed::new(block))
     }
 
+    /// Creates a `ConfirmedBlock` from an already-hashed `Block`.
     pub fn from_hashed(block: Hashed<Block>) -> Self {
         Self(block)
     }
 
+    /// Returns a reference to the hashed `Block` contained in this `ConfirmedBlock`.
     pub fn inner(&self) -> &Hashed<Block> {
         &self.0
     }
 
+    /// Consumes this `ConfirmedBlock`, returning the hashed `Block` it contains.
     pub fn into_inner(self) -> Hashed<Block> {
         self.0
     }
@@ -122,18 +132,22 @@ impl ConfirmedBlock {
         self.0.into_inner()
     }
 
+    /// Returns the ID of the chain this block belongs to.
     pub fn chain_id(&self) -> ChainId {
         self.0.inner().header.chain_id
     }
 
+    /// Returns the height of this block.
     pub fn height(&self) -> BlockHeight {
         self.0.inner().header.height
     }
 
+    /// Returns the timestamp of this block.
     pub fn timestamp(&self) -> Timestamp {
         self.0.inner().header.timestamp
     }
 
+    /// Returns a static string identifying this value kind, for logging.
     pub fn to_log_str(&self) -> &'static str {
         "confirmed_block"
     }
@@ -166,6 +180,8 @@ impl From<Hashed<Block>> for ValidatedBlock {
     }
 }
 
+/// A request to move on to the next consensus round, certified when no block is confirmed in
+/// time.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Allocative)]
 #[serde(transparent)]
 pub struct Timeout(Hashed<TimeoutInner>);
@@ -179,6 +195,7 @@ pub(crate) struct TimeoutInner {
 }
 
 impl Timeout {
+    /// Creates a new `Timeout` for the given chain, height and epoch.
     pub fn new(chain_id: ChainId, height: BlockHeight, epoch: Epoch) -> Self {
         let inner = TimeoutInner {
             chain_id,
@@ -188,18 +205,22 @@ impl Timeout {
         Self(Hashed::new(inner))
     }
 
+    /// Returns a static string identifying this value kind, for logging.
     pub fn to_log_str(&self) -> &'static str {
         "timeout"
     }
 
+    /// Returns the ID of the chain this timeout applies to.
     pub fn chain_id(&self) -> ChainId {
         self.0.inner().chain_id
     }
 
+    /// Returns the block height this timeout applies to.
     pub fn height(&self) -> BlockHeight {
         self.0.inner().height
     }
 
+    /// Returns the epoch this timeout applies to.
     pub fn epoch(&self) -> Epoch {
         self.0.inner().epoch
     }
@@ -407,6 +428,7 @@ impl BlockBody {
 }
 
 impl Block {
+    /// Creates a new `Block` from a proposed block and its execution outcome.
     pub fn new(block: ProposedBlock, outcome: BlockExecutionOutcome) -> Self {
         let transactions_hash = hashing::hash_vec(&block.transactions);
         let messages_hash = hashing::hash_vec_vec(&outcome.messages);
@@ -598,6 +620,7 @@ impl Block {
             && *previous_block_hash == self.header.previous_block_hash
     }
 
+    /// Splits this block back into the proposed block and its execution outcome.
     pub fn into_proposal(self) -> (ProposedBlock, BlockExecutionOutcome) {
         let proposed_block = ProposedBlock {
             chain_id: self.header.chain_id,
@@ -630,6 +653,8 @@ impl Block {
 
 impl BcsHashable<'_> for Block {}
 
+/// Hashable wrapper around the lookup table mapping each recipient chain to the previous
+/// block that sent it messages.
 #[derive(Serialize, Deserialize)]
 pub struct PreviousMessageBlocksMap<'a> {
     inner: Cow<'a, BTreeMap<ChainId, (CryptoHash, BlockHeight)>>,
@@ -637,6 +662,8 @@ pub struct PreviousMessageBlocksMap<'a> {
 
 impl<'de> BcsHashable<'de> for PreviousMessageBlocksMap<'de> {}
 
+/// Hashable wrapper around the lookup table mapping each stream to the previous block that
+/// published events to it.
 #[derive(Serialize, Deserialize)]
 pub struct PreviousEventBlocksMap<'a> {
     inner: Cow<'a, BTreeMap<StreamId, (CryptoHash, BlockHeight)>>,

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -33,6 +33,7 @@ impl GenericCertificate<ConfirmedBlock> {
             .message_bundles_for(recipient, certificate_hash)
     }
 
+    /// Returns the total number of outgoing messages in the certified block.
     #[cfg(with_testing)]
     pub fn outgoing_message_count(&self) -> usize {
         self.block().messages().iter().map(Vec::len).sum()

--- a/linera-chain/src/certificate/generic.rs
+++ b/linera-chain/src/certificate/generic.rs
@@ -17,6 +17,7 @@ use crate::{data_types::LiteValue, ChainError};
 #[derive(Debug)]
 pub struct GenericCertificate<T: CertificateValue> {
     value: T,
+    /// The round in which the value was certified.
     pub round: Round,
     signatures: Vec<(ValidatorPublicKey, ValidatorSignature)>,
 }
@@ -33,6 +34,7 @@ impl<T: Allocative + CertificateValue> Allocative for GenericCertificate<T> {
 }
 
 impl<T: CertificateValue> GenericCertificate<T> {
+    /// Creates a new certificate from a value, round and list of signatures.
     pub fn new(
         value: T,
         round: Round,
@@ -72,10 +74,12 @@ impl<T: CertificateValue> GenericCertificate<T> {
         self.value.hash()
     }
 
+    /// Returns the list of signatures on the certified value.
     pub fn signatures(&self) -> &Vec<(ValidatorPublicKey, ValidatorSignature)> {
         &self.signatures
     }
 
+    /// Returns a mutable reference to the list of signatures on the certified value.
     #[cfg(with_testing)]
     pub fn signatures_mut(&mut self) -> &mut Vec<(ValidatorPublicKey, ValidatorSignature)> {
         &mut self.signatures
@@ -117,6 +121,7 @@ impl<T: CertificateValue> GenericCertificate<T> {
         Ok(())
     }
 
+    /// Returns the `LiteCertificate` corresponding to this certificate, without the value.
     pub fn lite_certificate(&self) -> crate::certificate::LiteCertificate<'_>
     where
         T: CertificateValue,

--- a/linera-chain/src/certificate/lite.rs
+++ b/linera-chain/src/certificate/lite.rs
@@ -44,6 +44,7 @@ impl Allocative for LiteCertificate<'_> {
 }
 
 impl LiteCertificate<'_> {
+    /// Creates a new lite certificate from a value, round and list of signatures.
     pub fn new(
         value: LiteValue,
         round: Round,

--- a/linera-chain/src/certificate/mod.rs
+++ b/linera-chain/src/certificate/mod.rs
@@ -52,6 +52,7 @@ pub enum Certificate {
 }
 
 impl Certificate {
+    /// Returns the consensus round in which this certificate was created.
     pub fn round(&self) -> Round {
         match self {
             Certificate::Validated(cert) => cert.round,
@@ -60,6 +61,7 @@ impl Certificate {
         }
     }
 
+    /// Returns the block height this certificate applies to.
     pub fn height(&self) -> BlockHeight {
         match self {
             Certificate::Validated(cert) => cert.value().block().header.height,
@@ -68,6 +70,7 @@ impl Certificate {
         }
     }
 
+    /// Returns the ID of the chain this certificate applies to.
     pub fn chain_id(&self) -> ChainId {
         match self {
             Certificate::Validated(cert) => cert.value().block().header.chain_id,
@@ -76,6 +79,7 @@ impl Certificate {
         }
     }
 
+    /// Returns the validator signatures that certify this value.
     pub fn signatures(&self) -> &Vec<(ValidatorPublicKey, ValidatorSignature)> {
         match self {
             Certificate::Validated(cert) => cert.signatures(),
@@ -85,25 +89,34 @@ impl Certificate {
     }
 }
 
+/// The kind of value a certificate certifies.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Hash, Eq, PartialEq, Allocative)]
 #[repr(u8)]
+#[allow(missing_docs)]
 pub enum CertificateKind {
     Timeout = 0,
     Validated = 1,
     Confirmed = 2,
 }
 
+/// A value that can be certified by a quorum of validators.
 pub trait CertificateValue: Clone {
+    /// The kind of certificate this value produces.
     const KIND: CertificateKind;
 
+    /// Returns the ID of the chain this value applies to.
     fn chain_id(&self) -> ChainId;
 
+    /// Returns the epoch this value belongs to.
     fn epoch(&self) -> Epoch;
 
+    /// Returns the block height this value applies to.
     fn height(&self) -> BlockHeight;
 
+    /// Returns the IDs of all blobs required to validate this value.
     fn required_blob_ids(&self) -> BTreeSet<BlobId>;
 
+    /// Returns the hash that uniquely identifies this value.
     fn hash(&self) -> CryptoHash;
 }
 

--- a/linera-chain/src/certificate/validated.rs
+++ b/linera-chain/src/certificate/validated.rs
@@ -15,6 +15,7 @@ use super::{generic::GenericCertificate, Certificate};
 use crate::block::{Block, ConversionError, ValidatedBlock};
 
 impl GenericCertificate<ValidatedBlock> {
+    /// Returns the total number of outgoing messages in the certified block.
     #[cfg(with_testing)]
     pub fn outgoing_message_count(&self) -> usize {
         self.block().messages().iter().map(Vec::len).sum()

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -424,6 +424,7 @@ where
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
     ))]
+    /// Executes the given query against an application on this chain.
     pub async fn query_application(
         &mut self,
         local_time: Timestamp,
@@ -445,6 +446,7 @@ where
         chain_id = %self.chain_id(),
         application_id = %application_id
     ))]
+    /// Returns the description of the application with the given ID.
     pub async fn describe_application(
         &mut self,
         application_id: ApplicationId,
@@ -461,6 +463,8 @@ where
         target = %target,
         height = %height
     ))]
+    /// Marks all messages sent to `target` up to the given height as received, returning whether
+    /// the outbox changed.
     pub async fn mark_messages_as_received(
         &mut self,
         target: &ChainId,
@@ -651,6 +655,7 @@ where
         }
     }
 
+    /// Returns the current epoch and committee of this chain.
     pub async fn current_committee(&self) -> Result<(Epoch, Arc<Committee>), ChainError> {
         self.execution_state
             .system
@@ -659,6 +664,7 @@ where
             .ok_or_else(|| ChainError::InactiveChain(self.chain_id()))
     }
 
+    /// Returns the ownership configuration of this chain.
     pub async fn ownership(&self) -> Result<&ChainOwnership, ChainError> {
         Ok(self.execution_state.system.ownership.get().await?)
     }

--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -131,6 +131,7 @@ impl SystemOperationMetadata {
 
 /// Transfer operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct TransferOperationMetadata {
     pub owner: AccountOwner,
     pub recipient: Account,
@@ -139,6 +140,7 @@ pub struct TransferOperationMetadata {
 
 /// Claim operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct ClaimOperationMetadata {
     pub owner: AccountOwner,
     pub target_id: ChainId,
@@ -148,6 +150,7 @@ pub struct ClaimOperationMetadata {
 
 /// Open chain operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct OpenChainOperationMetadata {
     pub balance: Amount,
     pub ownership: ChainOwnershipMetadata,
@@ -156,6 +159,7 @@ pub struct OpenChainOperationMetadata {
 
 /// Change ownership operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct ChangeOwnershipOperationMetadata {
     pub super_owners: Vec<AccountOwner>,
     pub owners: Vec<OwnerWithWeight>,
@@ -166,6 +170,7 @@ pub struct ChangeOwnershipOperationMetadata {
 
 /// Owner with weight metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct OwnerWithWeight {
     pub owner: AccountOwner,
     pub weight: String, // Using String to represent u64 safely in GraphQL
@@ -173,12 +178,14 @@ pub struct OwnerWithWeight {
 
 /// Change application permissions operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct ChangeApplicationPermissionsMetadata {
     pub permissions: ApplicationPermissionsMetadata,
 }
 
 /// Admin operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct AdminOperationMetadata {
     pub admin_operation_type: String,
     pub epoch: Option<i32>,
@@ -187,6 +194,7 @@ pub struct AdminOperationMetadata {
 
 /// Create application operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct CreateApplicationOperationMetadata {
     pub module_id: String,
     pub parameters_hex: String,
@@ -196,24 +204,28 @@ pub struct CreateApplicationOperationMetadata {
 
 /// Publish data blob operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct PublishDataBlobMetadata {
     pub blob_hash: CryptoHash,
 }
 
 /// Verify blob operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct VerifyBlobMetadata {
     pub blob_id: String,
 }
 
 /// Publish module operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct PublishModuleMetadata {
     pub module_id: String,
 }
 
 /// Update stream metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct UpdateStreamMetadata {
     pub chain_id: ChainId,
     pub stream_id: String,
@@ -233,6 +245,7 @@ pub struct SystemMessageMetadata {
 
 /// Credit message metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct CreditMessageMetadata {
     pub target: AccountOwner,
     pub amount: Amount,
@@ -241,6 +254,7 @@ pub struct CreditMessageMetadata {
 
 /// Withdraw message metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
+#[allow(missing_docs)]
 pub struct WithdrawMessageMetadata {
     pub owner: AccountOwner,
     pub amount: Amount,

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -119,6 +119,7 @@ impl ProposedBlock {
         })
     }
 
+    /// Checks that the serialized size of this block does not exceed the given maximum.
     pub fn check_proposal_size(&self, maximum_block_proposal_size: u64) -> Result<(), ChainError> {
         let size = bcs::serialized_size(self)?;
         ensure!(
@@ -154,6 +155,7 @@ pub enum Transaction {
 impl BcsHashable<'_> for Transaction {}
 
 impl Transaction {
+    /// Returns the incoming bundle, if this transaction receives messages.
     pub fn incoming_bundle(&self) -> Option<&IncomingBundle> {
         match self {
             Transaction::ReceiveMessages(bundle) => Some(bundle),
@@ -162,6 +164,7 @@ impl Transaction {
     }
 }
 
+/// GraphQL-compatible metadata about an operation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
 #[graphql(name = "Operation")]
 pub struct OperationMetadata {
@@ -209,6 +212,7 @@ pub struct TransactionMetadata {
 }
 
 impl TransactionMetadata {
+    /// Builds GraphQL-compatible metadata from a transaction.
     pub fn from_transaction(transaction: &Transaction) -> Self {
         match transaction {
             Transaction::ReceiveMessages(bundle) => TransactionMetadata {
@@ -239,6 +243,7 @@ impl TransactionMetadata {
     SimpleObject,
     Allocative,
 )]
+#[allow(missing_docs)]
 pub struct ChainAndHeight {
     pub chain_id: ChainId,
     pub height: BlockHeight,
@@ -261,6 +266,8 @@ impl IncomingBundle {
         self.bundle.messages.iter()
     }
 
+    /// Applies the message policy to this bundle, returning `None` if it is dropped,
+    /// or the bundle with a possibly updated action otherwise.
     #[instrument(level = "trace", skip(self))]
     pub fn apply_policy(mut self, policy: &MessagePolicy) -> Option<IncomingBundle> {
         if let Some(chain_ids) = &policy.restrict_chain_ids_to {
@@ -418,6 +425,7 @@ pub enum OriginalProposal {
     Fast(AccountSignature),
     /// A validated block certificate from an earlier round.
     Regular {
+        /// The validated block certificate.
         certificate: LiteCertificate<'static>,
     },
 }
@@ -427,6 +435,7 @@ pub enum OriginalProposal {
 // to have it for auditing purposes.
 #[derive(Clone, Debug, Serialize, Deserialize, Allocative)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
+#[allow(missing_docs)]
 pub struct BlockProposal {
     pub content: ProposalContent,
     pub signature: AccountSignature,
@@ -455,6 +464,7 @@ pub struct PostedMessage {
     pub message: Message,
 }
 
+/// Extension trait for converting an `OutgoingMessage` into a `PostedMessage`.
 pub trait OutgoingMessageExt {
     /// Returns the posted message, i.e. the outgoing message without the destination.
     fn into_posted(self, index: u32) -> PostedMessage;
@@ -529,6 +539,7 @@ pub struct BlockExecutionOutcome {
 
 /// The hash and chain ID of a `CertificateValue`.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Allocative)]
+#[allow(missing_docs)]
 pub struct LiteValue {
     pub value_hash: CryptoHash,
     pub chain_id: ChainId,
@@ -536,6 +547,7 @@ pub struct LiteValue {
 }
 
 impl LiteValue {
+    /// Creates a `LiteValue` from a certificate value.
     pub fn new<T: CertificateValue>(value: &T) -> Self {
         LiteValue {
             value_hash: value.hash(),
@@ -546,12 +558,14 @@ impl LiteValue {
 }
 
 //(deuszx): pub is temp.
+/// The value a validator signs when voting: the value hash, round and certificate kind.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub struct VoteValue(CryptoHash, Round, CertificateKind);
 
 /// A vote on a statement from a validator.
 #[derive(Allocative, Clone, Debug, Serialize, Deserialize)]
 #[serde(bound(deserialize = "T: Deserialize<'de>"))]
+#[allow(missing_docs)]
 pub struct Vote<T> {
     pub value: T,
     pub round: Round,
@@ -594,6 +608,7 @@ impl<T> Vote<T> {
 /// A vote on a statement from a validator, represented as a `LiteValue`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
+#[allow(missing_docs)]
 pub struct LiteVote {
     pub value: LiteValue,
     pub round: Round,
@@ -614,22 +629,26 @@ impl LiteVote {
         })
     }
 
+    /// Returns the kind of certificate this vote is for.
     pub fn kind(&self) -> CertificateKind {
         self.value.kind
     }
 }
 
 impl MessageBundle {
+    /// Returns whether all messages in this bundle can be skipped.
     pub fn is_skippable(&self) -> bool {
         self.messages.iter().all(PostedMessage::is_skippable)
     }
 
+    /// Returns whether any message in this bundle is protected.
     pub fn is_protected(&self) -> bool {
         self.messages.iter().any(PostedMessage::is_protected)
     }
 }
 
 impl PostedMessage {
+    /// Returns whether this message can be skipped.
     pub fn is_skippable(&self) -> bool {
         match self.kind {
             MessageKind::Protected | MessageKind::Tracked => false,
@@ -637,24 +656,29 @@ impl PostedMessage {
         }
     }
 
+    /// Returns whether this message is protected.
     pub fn is_protected(&self) -> bool {
         matches!(self.kind, MessageKind::Protected)
     }
 
+    /// Returns whether this message is tracked.
     pub fn is_tracked(&self) -> bool {
         matches!(self.kind, MessageKind::Tracked)
     }
 
+    /// Returns whether this message is bouncing.
     pub fn is_bouncing(&self) -> bool {
         matches!(self.kind, MessageKind::Bouncing)
     }
 }
 
 impl BlockExecutionOutcome {
+    /// Combines this outcome with a proposed block into a full block.
     pub fn with(self, block: ProposedBlock) -> Block {
         Block::new(block, self)
     }
 
+    /// Returns the IDs of all blobs referenced by oracle responses in this outcome.
     pub fn oracle_blob_ids(&self) -> HashSet<BlobId> {
         let mut required_blob_ids = HashSet::new();
         for responses in &self.oracle_responses {
@@ -668,12 +692,14 @@ impl BlockExecutionOutcome {
         required_blob_ids
     }
 
+    /// Returns whether any transaction in this outcome recorded oracle responses.
     pub fn has_oracle_responses(&self) -> bool {
         self.oracle_responses
             .iter()
             .any(|responses| !responses.is_empty())
     }
 
+    /// Returns an iterator over the IDs of all blobs created in this outcome.
     pub fn iter_created_blobs_ids(&self) -> impl Iterator<Item = BlobId> + '_ {
         self.blobs.iter().flatten().map(|blob| blob.id())
     }
@@ -692,6 +718,7 @@ pub struct ProposalContent {
 }
 
 impl BlockProposal {
+    /// Creates a new block proposal, signed by the given owner.
     pub async fn new_initial<S: Signer + ?Sized>(
         owner: AccountOwner,
         round: Round,
@@ -712,6 +739,7 @@ impl BlockProposal {
         })
     }
 
+    /// Creates a proposal that retries a fast-round proposal in a later round.
     pub async fn new_retry_fast<S: Signer + ?Sized>(
         owner: AccountOwner,
         round: Round,
@@ -732,6 +760,7 @@ impl BlockProposal {
         })
     }
 
+    /// Creates a proposal that retries a validated block from an earlier round.
     pub async fn new_retry_regular<S: Signer>(
         owner: AccountOwner,
         round: Round,
@@ -764,10 +793,12 @@ impl BlockProposal {
         }
     }
 
+    /// Verifies the signature on this proposal.
     pub fn check_signature(&self) -> Result<(), CryptoError> {
         self.signature.verify(&self.content)
     }
 
+    /// Returns the IDs of the blobs that must be available to validate this proposal.
     pub fn required_blob_ids(&self) -> impl Iterator<Item = BlobId> + '_ {
         self.content.block.published_blob_ids().into_iter().chain(
             self.content
@@ -777,6 +808,7 @@ impl BlockProposal {
         )
     }
 
+    /// Returns the IDs of the blobs that are required or created by this proposal.
     pub fn expected_blob_ids(&self) -> impl Iterator<Item = BlobId> + '_ {
         self.content.block.published_blob_ids().into_iter().chain(
             self.content.outcome.iter().flat_map(|outcome| {
@@ -838,6 +870,7 @@ impl LiteVote {
     }
 }
 
+/// Helper for aggregating validator signatures on a value into a certificate.
 pub struct SignatureAggregator<'a, T: CertificateValue> {
     committee: &'a Committee,
     weight: u64,

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -164,9 +164,9 @@ impl Transaction {
     }
 }
 
-/// GraphQL-compatible metadata about an operation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
 #[graphql(name = "Operation")]
+#[allow(missing_docs)]
 pub struct OperationMetadata {
     /// The type of operation: "System" or "User"
     pub operation_type: String,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -3,15 +3,20 @@
 
 //! This module manages the state of a Linera chain, including cross-chain communication.
 
+#![deny(missing_docs)]
+
+/// Block types and the wrappers that pair them with their execution outcomes.
 pub mod block;
 mod certificate;
 
+/// Convenience re-exports of the public block and certificate types.
 pub mod types {
     pub use super::{block::*, certificate::*};
 }
 
 mod block_tracker;
 mod chain;
+/// Data types exchanged while proposing, voting on, and confirming blocks.
 pub mod data_types;
 mod inbox;
 pub mod manager;
@@ -32,7 +37,9 @@ use linera_execution::ExecutionError;
 use linera_views::ViewError;
 use thiserror::Error;
 
+/// An error that occurred while validating or executing a block on a chain.
 #[derive(Error, Debug, strum::IntoStaticStr)]
+#[allow(missing_docs)]
 pub enum ChainError {
     #[error("Cryptographic error: {0}")]
     CryptoError(#[from] CryptoError),
@@ -233,8 +240,10 @@ impl ChainError {
     }
 }
 
+/// The phase of block execution during which an error occurred.
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
+#[allow(missing_docs)]
 pub enum ChainExecutionContext {
     Query,
     DescribeApplication,
@@ -243,7 +252,9 @@ pub enum ChainExecutionContext {
     Block,
 }
 
+/// Extension trait for attaching a [`ChainExecutionContext`] to an execution error.
 pub trait ExecutionResultExt<T> {
+    /// Converts the error into a [`ChainError`], tagging it with the given execution context.
     fn with_execution_context(self, context: ChainExecutionContext) -> Result<T, ChainError>;
 }
 

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -102,10 +102,13 @@ use crate::{
 /// The result of verifying a (valid) query.
 #[derive(Eq, PartialEq)]
 pub enum Outcome {
+    /// The query is accepted and should be acted upon.
     Accept,
+    /// The query can be skipped without further action.
     Skip,
 }
 
+/// A reference to a vote for either a validated or a confirmed block.
 pub type ValidatedOrConfirmedVote<'a> = Either<&'a Vote<ValidatedBlock>, &'a Vote<ConfirmedBlock>>;
 
 /// The latest block that validators may have voted to confirm: this is either the block proposal
@@ -130,6 +133,7 @@ impl LockingBlock {
         }
     }
 
+    /// Returns the ID of the chain this locking block belongs to.
     pub fn chain_id(&self) -> ChainId {
         match self {
             Self::Fast(proposal) => proposal.content.block.chain_id,

--- a/linera-chain/src/test/mod.rs
+++ b/linera-chain/src/test/mod.rs
@@ -158,6 +158,7 @@ impl BlockTestExt for ProposedBlock {
     }
 }
 
+/// Helper trait to simplify creating certificates from votes in tests.
 pub trait VoteTestExt<T: CertificateValue>: Sized {
     /// Returns a certificate for a committee consisting only of this validator.
     fn into_certificate(self, public_key: ValidatorPublicKey) -> GenericCertificate<T>;
@@ -183,6 +184,7 @@ impl<T: CertificateValue> VoteTestExt<T> for Vote<T> {
 
 /// Helper trait to simplify constructing messages for tests.
 pub trait MessageTestExt: Sized {
+    /// Wraps the message into a [`PostedMessage`] with the given index and kind.
     fn to_posted(self, index: u32, kind: MessageKind) -> PostedMessage;
 }
 

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -49,6 +49,7 @@ use crate::{
 };
 
 impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
+    /// Creates an in-memory chain state view for the given chain, for use in tests.
     pub async fn new(chain_id: ChainId) -> Self {
         let exec_runtime_context =
             TestExecutionRuntimeContext::new(chain_id, ExecutionRuntimeConfig::default());


### PR DESCRIPTION
## Motivation

Backport of #6520 to `testnet_conway`: enable `#![deny(missing_docs)]` on `linera-chain` so the testnet branch stays in sync and future doc coverage is enforced there too.

## Proposal

Same change as #6520, cherry-picked onto `testnet_conway`. Doc strings are identical to the `main` PR for every item the two branches share; differences are confined to items that diverge between the branches (e.g. `main`-only `BlockBodyField`/`BlockHeader::verifies`, `Transaction::is_update_stream`/`is_checkpoint`, `MessageBundle::cursor`, `CheckpointAckMessageMetadata`, and the `apply_policy`/`to_posted` signatures). This keeps the two branches as close as possible so subsequent backports in this area remain conflict-free.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally as in #6520 (`--all-features`/`--all-targets`, `web,linera-execution/wasmer` on `wasm32`, nightly fmt, and `cargo doc -D warnings`).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Forward port on `main`: #6520
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
