### PR TITLE
Add #![deny(missing_docs)] to linera-rpc (backport of #6521)

### DIFF
--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -24,9 +24,12 @@ use crate::grpc::GrpcClient;
 #[cfg(with_simple_network)]
 use crate::simple::SimpleClient;
 
+/// A client for communicating with a validator over one of the supported networks.
 #[derive(Clone)]
 pub enum Client {
+    /// A client using the gRPC network.
     Grpc(Box<GrpcClient>),
+    /// A client using the simple (UDP or TCP) network.
     #[cfg(with_simple_network)]
     Simple(SimpleClient),
 }

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(with_simple_network)]
 use crate::simple;
 
+/// The configuration for cross-chain message delivery.
 #[derive(Clone, Debug, Parser)]
 #[cfg_attr(with_testing, derive(PartialEq))]
 pub struct CrossChainConfig {
@@ -45,6 +46,7 @@ impl Default for CrossChainConfig {
 }
 
 impl CrossChainConfig {
+    /// Returns the command-line arguments corresponding to this configuration.
     pub fn to_args(&self) -> Vec<String> {
         vec![
             "--cross-chain-queue-size".to_string(),
@@ -63,6 +65,7 @@ impl CrossChainConfig {
     }
 }
 
+/// The configuration for notification delivery to proxies.
 #[derive(Clone, Debug, Parser)]
 pub struct NotificationConfig {
     /// Size of the broadcast channel buffer for notifications
@@ -78,6 +81,7 @@ pub struct NotificationConfig {
     pub notification_max_in_flight: usize,
 }
 
+/// The index of a shard within a validator.
 pub type ShardId = usize;
 
 /// The network configuration of a shard.
@@ -92,10 +96,12 @@ pub struct ShardConfig {
 }
 
 impl ShardConfig {
+    /// Returns the `host:port` address of the shard.
     pub fn address(&self) -> String {
         format!("{}:{}", self.host, self.port)
     }
 
+    /// Returns the HTTP URL of the shard.
     pub fn http_address(&self) -> String {
         format!("http://{}:{}", self.host, self.port)
     }
@@ -115,6 +121,7 @@ pub struct ProxyConfig {
 }
 
 impl ProxyConfig {
+    /// Returns the internal URL used by shards to reach the proxy over the given protocol.
     pub fn internal_address(&self, protocol: &NetworkProtocol) -> String {
         format!(
             "{}://{}:{}",
@@ -128,12 +135,16 @@ impl ProxyConfig {
 /// The network protocol.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum NetworkProtocol {
+    /// The simple TCP/UDP transport protocol.
     #[cfg(with_simple_network)]
     Simple(simple::TransportProtocol),
+    /// The gRPC protocol, with the given TLS configuration.
     Grpc(TlsConfig),
 }
 
+/// The TLS configuration for the gRPC protocol.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum TlsConfig {
     ClearText,
     Tls,
@@ -177,6 +188,7 @@ pub struct ValidatorInternalNetworkPreConfig<P> {
 }
 
 impl<P> ValidatorInternalNetworkPreConfig<P> {
+    /// Returns a copy of this configuration with the protocol replaced by the given one.
     pub fn clone_with_protocol<Q>(&self, protocol: Q) -> ValidatorInternalNetworkPreConfig<Q> {
         ValidatorInternalNetworkPreConfig {
             public_key: self.public_key,
@@ -189,6 +201,7 @@ impl<P> ValidatorInternalNetworkPreConfig<P> {
 }
 
 impl ValidatorInternalNetworkConfig {
+    /// Returns the URLs of the configured block exporters.
     pub fn exporter_addresses(&self) -> Vec<String> {
         self.block_exporters
             .iter()
@@ -200,6 +213,7 @@ impl ValidatorInternalNetworkConfig {
 }
 
 impl ValidatorPublicNetworkConfig {
+    /// Returns the public HTTP URL of the validator.
     pub fn http_address(&self) -> String {
         format!("{}://{}:{}", self.protocol.scheme(), self.host, self.port)
     }
@@ -217,6 +231,7 @@ pub struct ValidatorPublicNetworkPreConfig<P> {
 }
 
 impl<P> ValidatorPublicNetworkPreConfig<P> {
+    /// Returns a copy of this configuration with the protocol replaced by the given one.
     pub fn clone_with_protocol<Q>(&self, protocol: Q) -> ValidatorPublicNetworkPreConfig<Q> {
         ValidatorPublicNetworkPreConfig {
             protocol,
@@ -299,6 +314,7 @@ impl<P> ValidatorInternalNetworkPreConfig<P> {
         (s.finish() as ShardId) % self.shards.len()
     }
 
+    /// Returns the [`ShardConfig`] for the given shard id.
     pub fn shard(&self, shard_id: ShardId) -> &ShardConfig {
         &self.shards[shard_id]
     }
@@ -319,6 +335,7 @@ pub struct ExporterServiceConfig {
 }
 
 impl ExporterServiceConfig {
+    /// Creates a new [`ExporterServiceConfig`] from the given host and port.
     pub fn new(host: String, port: u16) -> ExporterServiceConfig {
         ExporterServiceConfig { host, port }
     }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -68,6 +68,7 @@ use crate::{
     HandleTimeoutCertificateRequest, HandleValidatedCertificateRequest,
 };
 
+/// A gRPC client for communicating with a validator node.
 #[derive(Clone)]
 pub struct GrpcClient {
     address: String,
@@ -82,6 +83,7 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
+    /// Creates a new gRPC client for the validator at the given address.
     pub fn new(
         address: String,
         channel: transport::Channel,
@@ -103,6 +105,7 @@ impl GrpcClient {
         }
     }
 
+    /// Returns the address of the validator this client connects to.
     pub fn address(&self) -> &str {
         &self.address
     }

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 
 #[derive(Error, Debug)]
+#[allow(missing_docs)]
 pub enum GrpcProtoConversionError {
     #[error(transparent)]
     BincodeError(#[from] bincode::Error),
@@ -1167,7 +1168,11 @@ impl TryFrom<api::PreviousEventBlocksResponse> for BTreeMap<StreamId, (BlockHeig
 }
 
 #[cfg(test)]
+/// Tests for the gRPC protobuf conversions.
 pub mod tests {
+    // Test helpers in this module don't need individual documentation.
+    #![allow(missing_docs)]
+
     use std::{borrow::Cow, fmt::Debug};
 
     use linera_base::{

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -4,9 +4,11 @@
 mod client;
 mod conversions;
 mod node_provider;
+/// A pool of reusable gRPC transport channels.
 pub mod pool;
 #[cfg(with_server)]
 mod server;
+/// Transport-level configuration and channel construction for gRPC.
 pub mod transport;
 
 pub use client::*;
@@ -15,11 +17,15 @@ pub use node_provider::*;
 #[cfg(with_server)]
 pub use server::*;
 
+/// The gRPC service and message types generated from `proto/rpc.proto`.
 pub mod api {
+    // Generated gRPC bindings; the generated items cannot carry doc comments.
+    #![allow(missing_docs)]
     tonic::include_proto!("rpc.v1");
 }
 
 #[derive(thiserror::Error, Debug)]
+#[allow(missing_docs)]
 pub enum GrpcError {
     #[error("failed to connect to address: {0}")]
     ConnectionFailed(#[from] transport::Error),
@@ -36,6 +42,7 @@ pub enum GrpcError {
 }
 
 const MEBIBYTE: usize = 1024 * 1024;
+/// The maximum gRPC message size, in bytes.
 pub const GRPC_MAX_MESSAGE_SIZE: usize = 16 * MEBIBYTE;
 
 /// Limit of gRPC message size up to which we will try to populate with data when estimating.

--- a/linera-rpc/src/grpc/node_provider.rs
+++ b/linera-rpc/src/grpc/node_provider.rs
@@ -13,6 +13,7 @@ use crate::{
     node_provider::NodeOptions,
 };
 
+/// A node provider that creates gRPC clients backed by a shared connection pool.
 #[derive(Clone)]
 pub struct GrpcNodeProvider {
     pool: GrpcConnectionPool,
@@ -26,6 +27,7 @@ pub struct GrpcNodeProvider {
 }
 
 impl GrpcNodeProvider {
+    /// Creates a new [`GrpcNodeProvider`] with the given node options.
     pub fn new(options: NodeOptions) -> Self {
         let transport_options = transport::Options::from(&options);
         let retry_delay = options.retry_delay;

--- a/linera-rpc/src/grpc/pool.rs
+++ b/linera-rpc/src/grpc/pool.rs
@@ -15,6 +15,7 @@ pub struct GrpcConnectionPool {
 }
 
 impl GrpcConnectionPool {
+    /// Creates a new connection pool with the given transport options.
     pub fn new(options: transport::Options) -> Self {
         Self {
             options,
@@ -22,11 +23,13 @@ impl GrpcConnectionPool {
         }
     }
 
+    /// Sets the connection timeout for channels created by this pool.
     pub fn with_connect_timeout(mut self, connect_timeout: impl Into<Option<Duration>>) -> Self {
         self.options.connect_timeout = connect_timeout.into();
         self
     }
 
+    /// Sets the request timeout for channels created by this pool.
     pub fn with_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
         self.options.timeout = timeout.into();
         self

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -269,6 +269,7 @@ impl BatchForwarder {
     }
 }
 
+/// A gRPC server exposing a validator's worker as a network service.
 #[derive(Clone)]
 pub struct GrpcServer<S>
 where
@@ -281,11 +282,13 @@ where
     notification_sender: NotificationSender,
 }
 
+/// A handle to a running [`GrpcServer`] task.
 pub struct GrpcServerHandle {
     handle: TaskHandle<Result<(), GrpcError>>,
 }
 
 impl GrpcServerHandle {
+    /// Waits for the server task to complete.
     pub async fn join(self) -> Result<(), GrpcError> {
         self.handle.await?
     }
@@ -309,9 +312,11 @@ impl Drop for ServerRequestCancellationGuard {
     }
 }
 
+/// A Tower layer that records Prometheus metrics for gRPC requests.
 #[derive(Clone)]
 pub struct GrpcPrometheusMetricsMiddlewareLayer;
 
+/// The Tower service produced by [`GrpcPrometheusMetricsMiddlewareLayer`].
 #[derive(Clone)]
 pub struct GrpcPrometheusMetricsMiddlewareService<T> {
     service: T,
@@ -383,6 +388,7 @@ impl<S> GrpcServer<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
+    /// Spawns the gRPC server on the given host and port, returning a handle to the task.
     #[expect(clippy::too_many_arguments)]
     pub fn spawn(
         host: String,
@@ -1105,6 +1111,7 @@ where
 /// Types which are proxyable and expose the appropriate methods to be handled
 /// by the `GrpcProxy`
 pub trait GrpcProxyable {
+    /// Returns the chain ID this message is destined for, if any.
     fn chain_id(&self) -> Option<ChainId>;
 }
 

--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -3,9 +3,12 @@
 
 use crate::NodeOptions;
 
+/// Configuration for creating gRPC transport channels.
 #[derive(Clone, Debug, Default)]
 pub struct Options {
+    /// The maximum time to wait when establishing a connection.
     pub connect_timeout: Option<linera_base::time::Duration>,
+    /// The maximum time to wait for a request to complete.
     pub timeout: Option<linera_base::time::Duration>,
 }
 
@@ -22,6 +25,7 @@ cfg_if::cfg_if! {
     if #[cfg(web)] {
         pub use tonic_web_wasm_client::{Client as Channel, Error};
 
+        /// Creates a transport channel for the given address.
         pub fn create_channel(address: String, _options: &Options) -> Result<Channel, Error> {
             // TODO(#1817): this should respect `options`
             Ok(tonic_web_wasm_client::Client::new(address))
@@ -29,6 +33,7 @@ cfg_if::cfg_if! {
     } else {
         pub use tonic::transport::{Channel, Error};
 
+        /// Creates a transport channel for the given address.
         pub fn create_channel(
             address: String,
             options: &Options,

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -6,57 +6,77 @@
 //! This module provides network abstractions and the data schemas for remote procedure
 //! calls (RPCs) in the Linera protocol.
 
+#![deny(missing_docs)]
 // `tracing::instrument` is not compatible with this nightly Clippy lint
 #![allow(unknown_lints)]
 
+/// Network configuration types for validators, shards, and cross-chain messaging.
 pub mod config;
+/// Construction of validator-node clients from network configuration.
 pub mod node_provider;
 
+/// A network-agnostic client for talking to a validator node.
 pub mod client;
 
 mod cross_chain_message_queue;
 mod message;
+/// Propagation of OpenTelemetry trace context across RPC boundaries.
 #[cfg(feature = "opentelemetry")]
 pub mod propagation;
+/// The simple custom-TCP/UDP network transport.
 #[cfg(with_simple_network)]
 pub mod simple;
 
+/// The gRPC network transport.
 pub mod grpc;
 
 pub use client::Client;
 pub use message::RpcMessage;
 pub use node_provider::{NodeOptions, NodeProvider, DEFAULT_MAX_BACKOFF};
 
+/// A request to handle a lite certificate.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct HandleLiteCertRequest<'a> {
+    /// The lite certificate to handle.
     pub certificate: linera_chain::types::LiteCertificate<'a>,
+    /// Whether to wait for the resulting cross-chain messages to be delivered.
     pub wait_for_outgoing_messages: bool,
 }
 
+/// A request to handle a confirmed-block certificate.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct HandleConfirmedCertificateRequest {
+    /// The confirmed-block certificate to handle.
     pub certificate: linera_chain::types::ConfirmedBlockCertificate,
+    /// Whether to wait for the resulting cross-chain messages to be delivered.
     pub wait_for_outgoing_messages: bool,
 }
 
+/// A request to handle a validated-block certificate.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct HandleValidatedCertificateRequest {
+    /// The validated-block certificate to handle.
     pub certificate: linera_chain::types::ValidatedBlockCertificate,
 }
 
+/// A request to handle a timeout certificate.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
 pub struct HandleTimeoutCertificateRequest {
+    /// The timeout certificate to handle.
     pub certificate: linera_chain::types::TimeoutCertificate,
 }
 
+/// The protobuf file descriptor set for the RPC service, used for gRPC reflection.
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("file_descriptor_set");
 
+/// A self-signed TLS certificate (PEM), generated at build time for local testing.
 #[cfg(not(target_arch = "wasm32"))]
 pub const CERT_PEM: &str = include_str!(concat!(env!("OUT_DIR"), "/self_signed_cert.pem"));
+/// The private key (PEM) matching [`CERT_PEM`], generated at build time for local testing.
 #[cfg(not(target_arch = "wasm32"))]
 pub const KEY_PEM: &str = include_str!(concat!(env!("OUT_DIR"), "/private_key.pem"));
 

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -25,8 +25,10 @@ use crate::{
     HandleValidatedCertificateRequest,
 };
 
+/// An RPC message exchanged between clients, proxies and validators.
 #[derive(Clone, Serialize, Deserialize, Debug)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
+#[allow(missing_docs)]
 pub enum RpcMessage {
     // Inbound
     BlockProposal(Box<BlockProposal>),

--- a/linera-rpc/src/node_provider.rs
+++ b/linera-rpc/src/node_provider.rs
@@ -18,6 +18,7 @@ pub struct NodeProvider {
 }
 
 impl NodeProvider {
+    /// Creates a new [`NodeProvider`] with the given node options.
     pub fn new(options: NodeOptions) -> Self {
         Self {
             grpc: GrpcNodeProvider::new(options),
@@ -53,12 +54,18 @@ impl ValidatorNodeProvider for NodeProvider {
 /// - <https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md>
 pub const DEFAULT_MAX_BACKOFF: Duration = Duration::from_secs(30);
 
+/// Options for configuring the clients created by a node provider.
 #[derive(Copy, Clone)]
 pub struct NodeOptions {
+    /// The maximum time to wait when sending a request.
     pub send_timeout: Duration,
+    /// The maximum time to wait when receiving a response.
     pub recv_timeout: Duration,
+    /// The delay between retries.
     pub retry_delay: Duration,
+    /// The maximum number of retries for a request.
     pub max_retries: u32,
+    /// The maximum backoff delay between retries.
     pub max_backoff: Duration,
 }
 

--- a/linera-rpc/src/propagation.rs
+++ b/linera-rpc/src/propagation.rs
@@ -93,6 +93,7 @@ pub struct ExtractedOtelContext(pub Context);
 /// This trait abstracts over `http::Request` and `tonic::Request` to allow
 /// generic functions that work with either request type.
 pub trait HasOtelContext {
+    /// Returns the extracted OpenTelemetry context, if present.
     fn get_otel_context(&self) -> Option<&ExtractedOtelContext>;
 }
 

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -31,6 +31,7 @@ use crate::{
     RpcMessage,
 };
 
+/// A client communicating with validators over a simple (UDP or TCP) transport.
 #[derive(Clone)]
 pub struct SimpleClient {
     network: ValidatorPublicNetworkPreConfig<TransportProtocol>,

--- a/linera-rpc/src/simple/codec.rs
+++ b/linera-rpc/src/simple/codec.rs
@@ -85,6 +85,7 @@ impl Decoder for Codec {
 
 /// Errors that can arise during transmission or reception of [`RpcMessage`]s.
 #[derive(Debug, Error)]
+#[allow(missing_docs)]
 pub enum Error {
     #[error("I/O error in the underlying transport: {0}")]
     IoError(#[from] io::Error),

--- a/linera-rpc/src/simple/node_provider.rs
+++ b/linera-rpc/src/simple/node_provider.rs
@@ -13,6 +13,7 @@ use crate::{config::ValidatorPublicNetworkPreConfig, node_provider::NodeOptions}
 pub struct SimpleNodeProvider(NodeOptions);
 
 impl SimpleNodeProvider {
+    /// Creates a new [`SimpleNodeProvider`] with the given node options.
     pub fn new(options: NodeOptions) -> Self {
         Self(options)
     }

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -23,6 +23,7 @@ use crate::{
     cross_chain_message_queue, RpcMessage,
 };
 
+/// A server handling RPC requests over a simple (UDP or TCP) transport.
 #[derive(Clone)]
 pub struct Server<S>
 where
@@ -43,6 +44,7 @@ impl<S> Server<S>
 where
     S: Storage,
 {
+    /// Creates a new server with the given network configuration and worker state.
     pub fn new(
         network: ValidatorInternalNetworkPreConfig<TransportProtocol>,
         host: String,
@@ -63,10 +65,12 @@ where
         }
     }
 
+    /// Returns the number of packets processed so far.
     pub fn packets_processed(&self) -> u64 {
         self.packets_processed
     }
 
+    /// Returns the number of user errors encountered so far.
     pub fn user_errors(&self) -> u64 {
         self.user_errors
     }
@@ -122,6 +126,7 @@ where
         .await;
     }
 
+    /// Spawns the server, returning a handle to track its completion.
     pub fn spawn(
         mut self,
         shutdown_signal: CancellationToken,

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -33,10 +33,12 @@ pub const DEFAULT_MAX_DATAGRAM_SIZE: &str = "65507";
 /// Number of tasks to spawn before attempting to reap some finished tasks to prevent memory leaks.
 const REAP_TASKS_THRESHOLD: usize = 100;
 
-// Supported transport protocols.
+/// The transport protocols supported by the simple network.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TransportProtocol {
+    /// The UDP transport protocol.
     Udp,
+    /// The TCP transport protocol.
     Tcp,
 }
 
@@ -55,6 +57,7 @@ impl std::fmt::Display for TransportProtocol {
 }
 
 impl TransportProtocol {
+    /// Returns the URL scheme name for this transport protocol.
     pub fn scheme(&self) -> &'static str {
         match self {
             TransportProtocol::Udp => "udp",
@@ -65,6 +68,7 @@ impl TransportProtocol {
 
 /// A pool of (outgoing) data streams.
 pub trait ConnectionPool: Send {
+    /// Sends a message to the given address, opening a connection if necessary.
     fn send_message_to<'a>(
         &'a mut self,
         message: RpcMessage,
@@ -79,6 +83,7 @@ pub trait ConnectionPool: Send {
 /// may exist at the same time and handle separate requests concurrently.
 #[async_trait]
 pub trait MessageHandler: Clone {
+    /// Handles a single request message, returning an optional response.
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage>;
 
     /// Handles a batch blob download request by streaming one
@@ -91,10 +96,12 @@ pub trait MessageHandler: Clone {
 /// The result of spawning a server is oneshot channel to track completion, and the set of
 /// executing tasks.
 pub struct ServerHandle {
+    /// The handle tracking completion of the server task.
     pub handle: TaskHandle<Result<(), std::io::Error>>,
 }
 
 impl ServerHandle {
+    /// Waits for the server task to finish.
     pub async fn join(self) -> Result<(), std::io::Error> {
         self.handle.await.map_err(|_| {
             std::io::Error::new(


### PR DESCRIPTION
## Motivation

Backport of #6521 to `testnet_conway`: enable `#![deny(missing_docs)]` on `linera-rpc` so the testnet branch stays in sync and future doc coverage is enforced there too.

## Proposal

Same change as #6521, cherry-picked onto `testnet_conway`. Doc strings are identical to the `main` PR for every item the two branches share; differences are confined to items that diverge between the branches (e.g. the `main`-only `ShardInfo` type and the different ordering of the `propagation`/`simple` modules). This keeps the two branches as close as possible so subsequent backports in this area remain conflict-free.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally as in #6521 (`--all-features`/`--all-targets`, `web-default,linera-execution/wasmer` on `wasm32`, nightly fmt, and `cargo doc -D warnings`).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Forward port on `main`: #6521
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
