### PR TITLE
Add #![deny(missing_docs)] to linera-version

### DIFF
--- a/linera-version/src/lib.rs
+++ b/linera-version/src/lib.rs
@@ -8,6 +8,8 @@ troubleshooting information and version compatibility checks.
 
 */
 
+#![deny(missing_docs)]
+
 mod serde_pretty;
 pub use serde_pretty::*;
 

--- a/linera-version/src/serde_pretty/type.rs
+++ b/linera-version/src/serde_pretty/type.rs
@@ -1,13 +1,17 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+/// A wrapper that serializes a value of type `T` through a more human-readable
+/// representation type `Repr`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Pretty<T, Repr> {
+    /// The wrapped value.
     pub value: T,
     _phantom: std::marker::PhantomData<fn(Repr) -> Repr>,
 }
 
 impl<T, Repr> Pretty<T, Repr> {
+    /// Wraps the given value.
     pub const fn new(value: T) -> Self {
         Pretty {
             value,
@@ -15,6 +19,7 @@ impl<T, Repr> Pretty<T, Repr> {
         }
     }
 
+    /// Converts the wrapped value into its representation type.
     pub fn repr(self) -> Repr
     where
         Repr: From<T>,

--- a/linera-version/src/version_info/mod.rs
+++ b/linera-version/src/version_info/mod.rs
@@ -4,6 +4,7 @@
 mod r#type;
 pub use r#type::*;
 
+/// The version info baked into this build of Linera.
 pub static VERSION_INFO: VersionInfo = include!(env!("LINERA_VERSION_STATIC_PATH"));
 
 use crate::serde_pretty::Pretty;

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -6,11 +6,15 @@ use std::{io::Read as _, path::PathBuf};
 #[cfg(linera_version_building)]
 use crate::serde_pretty::Pretty;
 
+/// A semantic version number of a crate.
 #[cfg_attr(linera_version_building, derive(serde::Deserialize, serde::Serialize))]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct CrateVersion {
+    /// The major version number.
     pub major: u32,
+    /// The minor version number.
     pub minor: u32,
+    /// The patch version number.
     pub patch: u32,
 }
 
@@ -47,6 +51,7 @@ impl From<CrateVersion> for semver::Version {
     }
 }
 
+/// A hash of an API surface, stored as a hexadecimal string.
 pub type Hash = std::borrow::Cow<'static, str>;
 
 #[cfg_attr(linera_version_building, derive(serde::Deserialize, serde::Serialize))]
@@ -70,7 +75,9 @@ pub struct VersionInfo {
 #[cfg(linera_version_building)]
 async_graphql::scalar!(VersionInfo);
 
+/// An error that can occur while extracting version information.
 #[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum Error {
     #[error("failed to interpret cargo-metadata: {0}")]
     CargoMetadata(#[from] cargo_metadata::Error),
@@ -174,14 +181,19 @@ struct CargoVcsInfoGit {
     sha1: String,
 }
 
+/// The hashes of the protocol's external APIs.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ApiHashes {
+    /// A hash of the RPC API.
     pub rpc: String,
+    /// A hash of the GraphQL API.
     pub graphql: String,
+    /// A hash of the WIT API.
     pub wit: String,
 }
 
 impl VersionInfo {
+    /// Extracts the version info for the current build.
     pub fn get() -> Result<Self, Error> {
         Self::trace_get(
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")),
@@ -259,6 +271,7 @@ impl VersionInfo {
         })
     }
 
+    /// Returns the hashes of the RPC, GraphQL, and WIT APIs.
     pub fn api_hashes(&self) -> ApiHashes {
         ApiHashes {
             rpc: self.rpc_hash.clone().into_owned(),


### PR DESCRIPTION
## Motivation

`linera-version` was one of the few library crates without `#![deny(missing_docs)]`, so undocumented public items could be added without CI noticing.

## Proposal

Add `#![deny(missing_docs)]` to `linera-version` and satisfy it with one-line doc comments on the public types (`VersionInfo`, `CrateVersion`, `ApiHashes`, `Pretty`, the `Hash` alias, `VERSION_INFO`) and their methods, plus `#[allow(missing_docs)]` on the `thiserror`-driven `Error` enum, matching the existing `linera-base` convention.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally: `cargo check --all-features` and `--all-targets` report no missing docs, `cargo +nightly fmt -- --check` and `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` both pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion backport to `testnet_conway`.
- Part of the effort to enable `#![deny(missing_docs)]` across the library crates.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
