### PR TITLE
Add #![deny(missing_docs)] to linera-sdk

### DIFF
--- a/linera-sdk/src/abis/controller.rs
+++ b/linera-sdk/src/abis/controller.rs
@@ -12,6 +12,7 @@ use crate::linera_base_types::{
     ServiceAbi,
 };
 
+/// The ABI of the controller application.
 pub struct ControllerAbi;
 
 impl ContractAbi for ControllerAbi {
@@ -28,6 +29,7 @@ impl ServiceAbi for ControllerAbi {
 pub type ManagedServiceId = DataBlobHash;
 
 #[derive(Debug, StableEnumInCrate, GraphQLMutationRootInCrate)]
+#[allow(missing_docs)]
 pub enum Operation {
     /// Worker commands
     ExecuteWorkerCommand {
@@ -46,6 +48,7 @@ pub enum Operation {
 
 /// A worker command
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
 pub enum WorkerCommand {
     /// Executed by workers to register themselves.
     RegisterWorker { capabilities: Vec<String> },
@@ -57,6 +60,7 @@ scalar!(WorkerCommand);
 
 /// A controller command
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
 pub enum ControllerCommand {
     /// Set the admin owners.
     SetAdmins { admins: Option<Vec<AccountOwner>> },

--- a/linera-sdk/src/abis/mod.rs
+++ b/linera-sdk/src/abis/mod.rs
@@ -3,6 +3,7 @@
 
 //! Common ABIs that may have multiple implementations.
 
+/// The ABI of a controller application that manages worker and controller commands.
 pub mod controller;
 pub mod evm;
 pub mod fungible;

--- a/linera-sdk/src/abis/wrapped_fungible.rs
+++ b/linera-sdk/src/abis/wrapped_fungible.rs
@@ -43,6 +43,7 @@ pub struct BurnEvent {
 
 /// Initial accounts and balances for the wrapped fungible token application.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[allow(missing_docs)]
 pub struct InitialState {
     pub accounts: BTreeMap<AccountOwner, U128>,
 }
@@ -54,11 +55,13 @@ pub struct InitialStateBuilder {
 }
 
 impl InitialStateBuilder {
+    /// Adds an account with the given initial balance.
     pub fn with_account(mut self, account: AccountOwner, balance: U128) -> Self {
         self.account_balances.insert(account, balance);
         self
     }
 
+    /// Builds the [`InitialState`] from the configured accounts.
     pub fn build(&self) -> InitialState {
         InitialState {
             accounts: self.account_balances.clone(),
@@ -68,6 +71,7 @@ impl InitialStateBuilder {
 
 /// Response variants returned by the wrapped fungible token application.
 #[derive(Debug, StableEnumInCrate, Default)]
+#[allow(missing_docs)]
 pub enum FungibleResponse {
     #[default]
     Ok,
@@ -77,6 +81,7 @@ pub enum FungibleResponse {
 
 /// Operations for the wrapped fungible token application.
 #[derive(Debug, StableEnumInCrate, GraphQLMutationRootInCrate)]
+#[allow(missing_docs)]
 pub enum WrappedFungibleOperation {
     /// Requests an account balance.
     Balance { owner: AccountOwner },
@@ -129,6 +134,7 @@ pub enum WrappedFungibleOperation {
 /// Cross-chain message used by the wrapped fungible token application.
 /// Amounts are [`U128`] in the source ERC-20's decimal scale.
 #[derive(Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
 pub enum Message {
     /// Credits the given `target` account, unless the message is bouncing, in which case
     /// `source` is credited instead.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -24,6 +24,8 @@
 //! The [`examples`](https://github.com/linera-io/linera-protocol/tree/main/examples)
 //! directory contains some example applications.
 
+#![deny(missing_docs)]
+
 #[macro_use]
 pub mod util;
 


### PR DESCRIPTION
## Motivation

`linera-sdk` was one of the few library crates without `#![deny(missing_docs)]`. It is the public SDK that application authors depend on, so enforcing documented public items is especially valuable here.

## Proposal

Add `#![deny(missing_docs)]` to `linera-sdk` and satisfy it. The crate was already well documented; the only gaps were in the example application ABIs (`abis/controller.rs`, `abis/wrapped_fungible.rs`) and one module declaration:
- A doc comment on the `controller` module and the `ControllerAbi` marker struct / builder methods.
- `#[allow(missing_docs)]` on the bulk async-graphql-derived ABI operation/message/response enums, matching the existing `linera-base` convention. Using a type-level allow (rather than per-field `///`) also avoids changing any generated GraphQL schema for these example ABIs.

The generated WIT bindings (`contract/wit.rs`, `service/wit.rs`) already carry a module-level `#![allow(missing_docs)]`.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied for the native build (`--all-features`, including `--all-targets` so `cfg(test)` is covered) AND the `wasm32-unknown-unknown` guest build. `cargo +nightly fmt -- --check` and `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` both pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion backport to `testnet_conway`.
- Part of the effort to enable `#![deny(missing_docs)]` across the library crates.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
