### PR TITLE
Add #![deny(missing_docs)] to linera-sdk (backport of #6526)

### DIFF
--- a/linera-sdk/src/abis/controller.rs
+++ b/linera-sdk/src/abis/controller.rs
@@ -11,6 +11,7 @@ use crate::linera_base_types::{
     AccountOwner, ApplicationId, ChainId, ContractAbi, DataBlobHash, MessagePolicy, ServiceAbi,
 };
 
+/// The ABI of the controller application.
 pub struct ControllerAbi;
 
 impl ContractAbi for ControllerAbi {
@@ -27,6 +28,7 @@ impl ServiceAbi for ControllerAbi {
 pub type ManagedServiceId = DataBlobHash;
 
 #[derive(Debug, Deserialize, Serialize, GraphQLMutationRootInCrate)]
+#[allow(missing_docs)]
 pub enum Operation {
     /// Worker commands
     ExecuteWorkerCommand {
@@ -42,6 +44,7 @@ pub enum Operation {
 
 /// A worker command
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
 pub enum WorkerCommand {
     /// Executed by workers to register themselves.
     RegisterWorker { capabilities: Vec<String> },
@@ -53,6 +56,7 @@ scalar!(WorkerCommand);
 
 /// A controller command
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
 pub enum ControllerCommand {
     /// Set the admin owners.
     SetAdmins { admins: Option<Vec<AccountOwner>> },
@@ -133,6 +137,7 @@ scalar!(LocalWorkerState);
 
 /// Messages that can be exchanged across chains from the same application instance.
 #[derive(Clone, Debug, Deserialize, Serialize, GraphQLMutationRootInCrate)]
+#[allow(missing_docs)]
 pub enum Message {
     // -- Message to the controller chain --
     ExecuteWorkerCommand {
@@ -159,6 +164,7 @@ pub enum Message {
     },
 }
 
+/// Serialization format descriptors for the controller ABI types.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod formats {
     use serde_reflection::{Samples, Tracer, TracerConfig};

--- a/linera-sdk/src/abis/formats_registry.rs
+++ b/linera-sdk/src/abis/formats_registry.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::linera_base_types::{ContractAbi, ModuleId, ServiceAbi};
 
+/// The ABI of the formats-registry application.
 pub struct FormatsRegistryAbi;
 
 impl ContractAbi for FormatsRegistryAbi {
@@ -24,6 +25,7 @@ impl ServiceAbi for FormatsRegistryAbi {
 
 /// Operations accepted by the formats-registry contract.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[allow(missing_docs)]
 pub enum Operation {
     /// Publish `value` as a data blob and bind it to `module_id`. A given
     /// `module_id` may only be written once.

--- a/linera-sdk/src/abis/mod.rs
+++ b/linera-sdk/src/abis/mod.rs
@@ -3,6 +3,7 @@
 
 //! Common ABIs that may have multiple implementations.
 
+/// The ABI of a controller application that manages worker and controller commands.
 pub mod controller;
 pub mod evm;
 pub mod formats_registry;

--- a/linera-sdk/src/abis/wrapped_fungible.rs
+++ b/linera-sdk/src/abis/wrapped_fungible.rs
@@ -44,6 +44,7 @@ pub struct BurnEvent {
 
 /// Initial accounts and balances for the wrapped fungible token application.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[allow(missing_docs)]
 pub struct InitialState {
     pub accounts: BTreeMap<AccountOwner, U128>,
 }
@@ -55,11 +56,13 @@ pub struct InitialStateBuilder {
 }
 
 impl InitialStateBuilder {
+    /// Adds an account with the given initial balance.
     pub fn with_account(mut self, account: AccountOwner, balance: U128) -> Self {
         self.account_balances.insert(account, balance);
         self
     }
 
+    /// Builds the [`InitialState`] from the configured accounts.
     pub fn build(&self) -> InitialState {
         InitialState {
             accounts: self.account_balances.clone(),
@@ -69,6 +72,7 @@ impl InitialStateBuilder {
 
 /// Response variants returned by the wrapped fungible token application.
 #[derive(Debug, Deserialize, Serialize, Default)]
+#[allow(missing_docs)]
 pub enum FungibleResponse {
     #[default]
     Ok,
@@ -78,6 +82,7 @@ pub enum FungibleResponse {
 
 /// Operations for the wrapped fungible token application.
 #[derive(Debug, Deserialize, Serialize, GraphQLMutationRootInCrate)]
+#[allow(missing_docs)]
 pub enum WrappedFungibleOperation {
     /// Requests an account balance.
     Balance { owner: AccountOwner },
@@ -129,6 +134,7 @@ pub enum WrappedFungibleOperation {
 /// Cross-chain message used by the wrapped fungible token application.
 /// Amounts are [`U128`] in the source ERC-20's decimal scale.
 #[derive(Debug, Deserialize, Serialize)]
+#[allow(missing_docs)]
 pub enum Message {
     /// Credits the given `target` account, unless the message is bouncing, in which case
     /// `source` is credited instead.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -24,6 +24,8 @@
 //! The [`examples`](https://github.com/linera-io/linera-protocol/tree/main/examples)
 //! directory contains some example applications.
 
+#![deny(missing_docs)]
+
 #[macro_use]
 pub mod util;
 


### PR DESCRIPTION
## Motivation

Backport of #6526 to `testnet_conway`: enable `#![deny(missing_docs)]` on `linera-sdk` so the testnet branch stays in sync and future doc coverage is enforced there too.

## Proposal

Same change as #6526, cherry-picked onto `testnet_conway`. Doc strings are identical to the `main` PR for shared items. `testnet_conway` has a few additional example-app ABI items not present on `main` (a `controller::Message` enum, the `controller::formats` module, and the whole `formats_registry` ABI), which are documented/`#[allow(missing_docs)]`-annotated the same way. The ABI enums also keep `testnet_conway`'s `Deserialize, Serialize` derives rather than `main`'s `StableEnumInCrate`.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally as in #6526 (native `--all-features`/`--all-targets`, `wasm32-unknown-unknown` guest build, nightly fmt, and `cargo doc -D warnings`).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Forward port on `main`: #6526
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
