### PR TITLE
Add #![deny(missing_docs)] to linera-explorer

### DIFF
--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -7,6 +7,7 @@
 // UI-facing crate; floating-point/UI casts are intentional and not
 // protocol-relevant.
 #![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+#![deny(missing_docs)]
 
 mod entrypoint;
 mod formats;
@@ -158,13 +159,19 @@ pub struct GQuery<T> {
     payload: Option<T>,
 }
 
+/// The network protocol used to reach a service.
 pub enum Protocol {
+    /// Plain HTTP(S).
     Http,
+    /// A WebSocket connection.
     Websocket,
 }
 
+/// The kind of endpoint to connect to.
 pub enum AddressKind {
+    /// A Linera node service.
     Node,
+    /// A Linera indexer.
     Indexer,
 }
 
@@ -749,6 +756,7 @@ async fn route_aux(
     }
 }
 
+/// Routes a request from the JavaScript UI to the appropriate handler and updates the app state.
 #[wasm_bindgen]
 pub async fn route(app: JsValue, path: JsValue, args: JsValue) {
     let path = path.as_string();
@@ -759,12 +767,14 @@ pub async fn route(app: JsValue, path: JsValue, args: JsValue) {
     route_aux(&app, &data, &path, &args, false).await
 }
 
+/// Returns a shortened, debug-formatted representation of a crypto hash string.
 #[wasm_bindgen]
 pub fn short_crypto_hash(s: &str) -> String {
     let hash = CryptoHash::from_str(s).expect("not a crypto hash");
     format!("{hash:?}")
 }
 
+/// Returns a shortened representation of an application ID string.
 #[wasm_bindgen]
 pub fn short_app_id(s: &str) -> String {
     if s.len() <= 12 {


### PR DESCRIPTION
## Motivation

`linera-explorer` was one of the few crates without `#![deny(missing_docs)]`, so undocumented public items could be added without CI noticing.

## Proposal

Add `#![deny(missing_docs)]` to `linera-explorer` and satisfy it with concise one-line doc comments on the public API, and `#[allow(missing_docs)]` on bulk mechanical/`thiserror`/generated types where appropriate (matching the existing `linera-base` convention).

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied in the relevant build configurations (`--all-features`, `--all-targets` so `cfg(test)` is covered, plus the `wasm32-unknown-unknown` target), with `cargo +nightly fmt -- --check` and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passing.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion backport to `testnet_conway`.
- Part of the effort to enable `#![deny(missing_docs)]` across the library crates.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
