### PR TITLE
Add #![deny(missing_docs)] to linera-service

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -568,7 +568,7 @@ Deprecates all committees up to and including the specified one
 
 ###### **Arguments:**
 
-* `<EPOCH>`
+* `<EPOCH>` — The highest epoch to deprecate
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -1072,7 +1072,7 @@ Change the wallet default chain
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>`
+* `<CHAIN_ID>` — The chain to set as the default
 
 
 
@@ -1147,7 +1147,7 @@ Forgets the specified chain's keys. The chain will still be followed by the wall
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>`
+* `<CHAIN_ID>` — The chain whose keys will be forgotten
 
 
 
@@ -1159,7 +1159,7 @@ Forgets the specified chain, including the associated key pair. The default chai
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>`
+* `<CHAIN_ID>` — The chain to forget
 
 
 
@@ -1242,7 +1242,7 @@ Equivalent to running `cargo test` with the appropriate test runner.
 
 ###### **Arguments:**
 
-* `<PATH>`
+* `<PATH>` — The path of the root of the Linera project to test
 
 
 
@@ -1651,7 +1651,7 @@ Initialize a namespace in the database
 
 ###### **Options:**
 
-* `--genesis <GENESIS_CONFIG_PATH>`
+* `--genesis <GENESIS_CONFIG_PATH>` — The path to the genesis configuration file
 
 
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -55,6 +55,9 @@ A unique identifier for a user application
 """
 scalar ApplicationId
 
+"""
+A summary of an application registered on a chain.
+"""
 type ApplicationOverview {
 	id: ApplicationId!
 	description: ApplicationDescription!
@@ -455,8 +458,17 @@ type ChainTipState {
 	numOutgoingMessages: Int!
 }
 
+"""
+The set of chains tracked by the wallet.
+"""
 type Chains {
+	"""
+	The IDs of the tracked chains.
+	"""
 	list: [ChainId!]!
+	"""
+	The default chain of the wallet, if one is set.
+	"""
 	default: ChainId
 }
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -33,9 +33,13 @@ const DEFAULT_BPS: usize = 10;
 /// Specification for a validator to be added to the committee.
 #[derive(Clone, Debug)]
 pub struct ValidatorToAdd {
+    /// The validator's public key.
     pub public_key: ValidatorPublicKey,
+    /// The validator's account public key.
     pub account_key: AccountPublicKey,
+    /// The network address of the validator.
     pub address: String,
+    /// The number of votes assigned to the validator.
     pub votes: u64,
 }
 
@@ -60,6 +64,7 @@ impl std::str::FromStr for ValidatorToAdd {
 
 #[derive(Clone, clap::Args, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
+/// Options controlling the behavior of the benchmark command.
 pub struct BenchmarkOptions {
     /// How many chains to use.
     #[arg(long, default_value_t = DEFAULT_NUM_CHAINS)]
@@ -153,15 +158,18 @@ impl Default for BenchmarkOptions {
 
 #[derive(Clone, clap::Subcommand, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
+/// The benchmarking subcommands.
 pub enum BenchmarkCommand {
     /// Start a single benchmark process, maintaining a given TPS.
     Single {
+        /// The benchmark options.
         #[command(flatten)]
         options: BenchmarkOptions,
     },
 
     /// Run multiple benchmark processes in parallel.
     Multi {
+        /// The benchmark options.
         #[command(flatten)]
         options: BenchmarkOptions,
 
@@ -191,6 +199,7 @@ pub enum BenchmarkCommand {
 }
 
 impl BenchmarkCommand {
+    /// Returns the number of transactions per block configured for this benchmark.
     pub fn transactions_per_block(&self) -> usize {
         match self {
             Self::Single { options } => options.transactions_per_block,
@@ -341,6 +350,7 @@ pub struct ResourceControlPolicyOverrides {
 }
 
 #[derive(Clone, clap::Subcommand)]
+#[allow(missing_docs)]
 pub enum ClientCommand {
     /// Transfer funds
     Transfer {
@@ -1139,6 +1149,7 @@ impl ClientCommand {
 }
 
 #[derive(Clone, clap::Parser)]
+/// The subcommands for managing the storage database.
 pub enum DatabaseToolCommand {
     /// Delete all the namespaces in the database
     DeleteAll,
@@ -1151,6 +1162,7 @@ pub enum DatabaseToolCommand {
 
     /// Initialize a namespace in the database
     Initialize {
+        /// The path to the genesis configuration file.
         #[arg(long = "genesis")]
         genesis_config_path: PathBuf,
     },
@@ -1170,6 +1182,7 @@ pub enum DatabaseToolCommand {
 
 #[expect(clippy::large_enum_variant)]
 #[derive(Clone, clap::Parser)]
+/// The subcommands for managing a local Linera network.
 pub enum NetCommand {
     /// Start a Local Linera Network
     Up {
@@ -1259,6 +1272,7 @@ pub enum NetCommand {
 }
 
 #[derive(Clone, clap::Subcommand)]
+/// The subcommands for managing the wallet.
 pub enum WalletCommand {
     /// Show the contents of the wallet.
     Show {
@@ -1273,7 +1287,10 @@ pub enum WalletCommand {
     },
 
     /// Change the wallet default chain.
-    SetDefault { chain_id: ChainId },
+    SetDefault {
+        /// The chain to set as the default.
+        chain_id: ChainId,
+    },
 
     /// Initialize a wallet from the genesis configuration.
     Init {
@@ -1330,14 +1347,21 @@ pub enum WalletCommand {
 
     /// Forgets the specified chain's keys. The chain will still be followed by the
     /// wallet.
-    ForgetKeys { chain_id: ChainId },
+    ForgetKeys {
+        /// The chain whose keys will be forgotten.
+        chain_id: ChainId,
+    },
 
     /// Forgets the specified chain, including the associated key pair. The default
     /// chain cannot be forgotten; switch to another chain with `set-default` first.
-    ForgetChain { chain_id: ChainId },
+    ForgetChain {
+        /// The chain to forget.
+        chain_id: ChainId,
+    },
 }
 
 #[derive(Clone, clap::Subcommand)]
+/// The subcommands for inspecting chains.
 pub enum ChainCommand {
     /// Show the contents of a block.
     ShowBlock {
@@ -1357,6 +1381,7 @@ pub enum ChainCommand {
 }
 
 #[derive(Clone, clap::Parser)]
+/// The subcommands for managing Linera projects.
 pub enum ProjectCommand {
     /// Create a new Linera project.
     New {
@@ -1376,7 +1401,10 @@ pub enum ProjectCommand {
     /// Test a Linera project.
     ///
     /// Equivalent to running `cargo test` with the appropriate test runner.
-    Test { path: Option<PathBuf> },
+    Test {
+        /// The path of the root of the Linera project to test.
+        path: Option<PathBuf>,
+    },
 
     /// Build and publish a Linera project.
     PublishAndCreate {

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -349,8 +349,8 @@ pub struct ResourceControlPolicyOverrides {
     pub flags: Option<Vec<String>>,
 }
 
+/// The subcommands of the Linera client binary.
 #[derive(Clone, clap::Subcommand)]
-#[allow(missing_docs)]
 pub enum ClientCommand {
     /// Transfer funds
     Transfer {
@@ -396,9 +396,11 @@ pub enum ClientCommand {
         #[arg(long = "from")]
         chain_id: Option<ChainId>,
 
+        /// Options configuring the new chain's ownership.
         #[clap(flatten)]
         ownership_config: ChainOwnershipConfig,
 
+        /// Options configuring the new chain's application permissions.
         #[clap(flatten)]
         application_permissions_config: ApplicationPermissionsConfig,
 
@@ -428,6 +430,7 @@ pub enum ClientCommand {
         #[clap(long)]
         chain_id: Option<ChainId>,
 
+        /// Options configuring the new chain's ownership.
         #[clap(flatten)]
         ownership_config: ChainOwnershipConfig,
     },
@@ -449,6 +452,7 @@ pub enum ClientCommand {
         #[arg(long)]
         chain_id: Option<ChainId>,
 
+        /// Options configuring the new chain's application permissions.
         #[clap(flatten)]
         application_permissions_config: ApplicationPermissionsConfig,
     },
@@ -536,10 +540,14 @@ pub enum ClientCommand {
     },
 
     /// Deprecates all committees up to and including the specified one.
-    RevokeEpochs { epoch: Epoch },
+    RevokeEpochs {
+        /// The highest epoch to deprecate.
+        epoch: Epoch,
+    },
 
     /// View or update the resource control policy
     ResourceControlPolicy {
+        /// Overrides for individual resource control policy parameters.
         #[command(flatten)]
         overrides: ResourceControlPolicyOverrides,
     },
@@ -756,6 +764,7 @@ pub enum ClientCommand {
 
     /// Run a GraphQL service to explore and extend the chains of the wallet.
     Service {
+        /// Configuration for the chain listener backing the service.
         #[command(flatten)]
         config: ChainListenerConfig,
 

--- a/linera-service/src/cli/common_options.rs
+++ b/linera-service/src/cli/common_options.rs
@@ -59,6 +59,7 @@ pub struct CommonCliOptions {
 }
 
 impl CommonCliOptions {
+    /// Returns the wallet-specific suffix used when resolving paths and environment variables.
     pub fn suffix(&self) -> String {
         self.with_wallet
             .as_ref()
@@ -66,6 +67,7 @@ impl CommonCliOptions {
             .unwrap_or_default()
     }
 
+    /// Resolves the storage configuration from CLI options, environment variables, or defaults.
     pub fn storage_config(&self) -> Result<StorageConfig, Error> {
         if let Some(config) = &self.storage_config {
             return config.parse();
@@ -94,22 +96,27 @@ impl CommonCliOptions {
         }
     }
 
+    /// Returns the path to the wallet file.
     pub fn wallet_path(&self) -> Result<PathBuf, Error> {
         linera_wallet_json::paths::wallet_path(self.wallet_state_path.as_ref(), &self.suffix())
     }
 
+    /// Returns the path to the keystore file.
     pub fn keystore_path(&self) -> Result<PathBuf, Error> {
         linera_wallet_json::paths::keystore_path(self.keystore_path.as_ref(), &self.suffix())
     }
 
+    /// Reads and returns the wallet.
     pub fn wallet(&self) -> Result<Wallet, Error> {
         Ok(Wallet::read(&self.wallet_path()?)?)
     }
 
+    /// Reads and returns the keystore.
     pub fn keystore(&self) -> Result<linera_wallet_json::Keystore, Error> {
         Ok(linera_wallet_json::Keystore::read(&self.keystore_path()?)?)
     }
 
+    /// Creates and saves a new wallet from the given genesis configuration.
     pub fn create_wallet(&self, genesis_config: GenesisConfig) -> Result<Wallet, Error> {
         let wallet_path = self.wallet_path()?;
         if wallet_path.exists() {
@@ -120,6 +127,7 @@ impl CommonCliOptions {
         Ok(wallet)
     }
 
+    /// Creates and saves a new keystore, optionally seeded for deterministic testing.
     pub fn create_keystore(
         &self,
         testing_prng_seed: Option<u64>,

--- a/linera-service/src/cli/mod.rs
+++ b/linera-service/src/cli/mod.rs
@@ -3,8 +3,11 @@
 
 //! Helper module for the Linera CLI binary.
 
+/// The command-line subcommands for the Linera client binary.
 pub mod command;
+/// Options shared across multiple command-line subcommands.
 pub mod common_options;
+/// Helpers for the `net up` command that spins up a local network.
 pub mod net_up_utils;
 pub mod validator;
 pub mod validator_benchmark;

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -98,6 +98,7 @@ impl StorageConfigProvider {
     }
 }
 
+/// Starts a local test network and, optionally, a faucet and block exporter.
 #[expect(clippy::too_many_arguments)]
 pub async fn handle_net_up_service(
     num_other_initial_chains: u32,

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -45,6 +45,7 @@ impl FromStr for Votes {
 /// Specification for a validator to add or modify.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(missing_docs)]
 pub struct Spec {
     pub public_key: ValidatorPublicKey,
     pub account_key: AccountPublicKey,
@@ -56,6 +57,7 @@ pub struct Spec {
 /// Represents an update to a validator's configuration in batch operations.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(missing_docs)]
 pub struct Change {
     pub account_key: AccountPublicKey,
     pub address: url::Url,
@@ -72,12 +74,14 @@ pub type BatchFile = HashMap<ValidatorPublicKey, Option<Change>>;
 
 /// Structure for batch validator queries from JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
 pub struct QueryBatch {
     pub validators: Vec<Spec>,
 }
 
 /// Validator subcommands.
 #[derive(Debug, Clone, clap::Subcommand)]
+#[allow(missing_docs)]
 pub enum Command {
     Add(Add),
     BatchQuery(BatchQuery),

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -45,11 +45,14 @@ impl FromStr for Votes {
 /// Specification for a validator to add or modify.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(missing_docs)]
 pub struct Spec {
+    /// Public key identifying the validator.
     pub public_key: ValidatorPublicKey,
+    /// Account public key for receiving payments and rewards.
     pub account_key: AccountPublicKey,
+    /// Network address where the validator can be reached.
     pub network_address: url::Url,
+    /// Voting weight for consensus.
     #[serde(default)]
     pub votes: Votes,
 }
@@ -57,10 +60,12 @@ pub struct Spec {
 /// Represents an update to a validator's configuration in batch operations.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(missing_docs)]
 pub struct Change {
+    /// Account public key for receiving payments and rewards.
     pub account_key: AccountPublicKey,
+    /// Network address where the validator can be reached.
     pub address: url::Url,
+    /// Voting weight for consensus.
     #[serde(default)]
     pub votes: Votes,
 }
@@ -74,12 +79,15 @@ pub type BatchFile = HashMap<ValidatorPublicKey, Option<Change>>;
 
 /// Structure for batch validator queries from JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_docs)]
 pub struct QueryBatch {
+    /// The validator specifications to query.
     pub validators: Vec<Spec>,
 }
 
 /// Validator subcommands.
+// Each variant delegates to a documented args struct; giving the variant its own
+// doc comment would shadow that struct's richer `--help` text, so `missing_docs`
+// is allowed here rather than duplicating those docs.
 #[derive(Debug, Clone, clap::Subcommand)]
 #[allow(missing_docs)]
 pub enum Command {

--- a/linera-service/src/cli/validator_benchmark/mod.rs
+++ b/linera-service/src/cli/validator_benchmark/mod.rs
@@ -34,6 +34,7 @@ use self::{
 };
 
 impl Benchmark {
+    /// Runs the pre-onboarding benchmark against the candidate validator.
     pub async fn run(
         &self,
         context: &mut ClientContext<

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -50,9 +50,10 @@ use crate::{
 const MAX_NUMBER_SHARDS: usize = 1000;
 
 /// Whether to process the inbox automatically before an operation.
-#[allow(missing_docs)]
 pub enum ProcessInbox {
+    /// Leaves the inbox untouched before the operation.
     Skip,
+    /// Processes the inbox automatically before the operation.
     Automatic,
 }
 
@@ -121,11 +122,13 @@ async fn make_testing_config(database: Database) -> Result<InnerStorageConfig> {
 }
 
 /// A way to obtain the storage configuration for a local network.
-#[allow(missing_docs)]
 pub enum InnerStorageConfigBuilder {
+    /// Builds a fresh test configuration for the selected database engine.
     #[cfg(with_testing)]
     TestConfig,
+    /// Uses a storage configuration that has already been built.
     ExistingConfig {
+        /// The pre-built storage configuration to use.
         storage_config: InnerStorageConfig,
     },
 }
@@ -145,10 +148,17 @@ impl InnerStorageConfigBuilder {
 /// Path used for the run can come from a path whose lifetime is controlled
 /// by an external user or as a temporary directory
 #[derive(Clone)]
-#[allow(missing_docs)]
 pub enum PathProvider {
-    ExternalPath { path_buf: PathBuf },
-    TemporaryDirectory { tmp_dir: Arc<TempDir> },
+    /// A path whose lifetime is managed by an external caller.
+    ExternalPath {
+        /// The externally managed path.
+        path_buf: PathBuf,
+    },
+    /// A temporary directory whose lifetime is managed by this provider.
+    TemporaryDirectory {
+        /// The temporary directory, removed when the last reference is dropped.
+        tmp_dir: Arc<TempDir>,
+    },
 }
 
 impl PathProvider {
@@ -183,22 +193,36 @@ impl PathProvider {
 }
 
 /// The information needed to start a [`LocalNet`].
-#[allow(missing_docs)]
 pub struct LocalNetConfig {
+    /// The storage backend used by the validators.
     pub database: Database,
+    /// The network protocols used for the validators' internal and external endpoints.
     pub network: NetworkConfig,
+    /// The seed used to make key generation deterministic in tests, if any.
     pub testing_prng_seed: Option<u64>,
+    /// The namespace used for the validators' storage.
     pub namespace: String,
+    /// The number of additional chains to create in the genesis configuration.
     pub num_other_initial_chains: u32,
+    /// The initial balance assigned to each chain in the genesis configuration.
     pub initial_amount: Amount,
+    /// The number of validators to start initially.
     pub num_initial_validators: usize,
+    /// The number of shards to run per validator.
     pub num_shards: usize,
+    /// The number of proxies to run per validator.
     pub num_proxies: usize,
+    /// The resource control policy applied to the network.
     pub policy_config: ResourceControlPolicyConfig,
+    /// The list of hosts that applications are allowed to make HTTP requests to, if restricted.
     pub http_request_allow_list: Option<Vec<String>>,
+    /// The configuration for cross-chain message queuing between validators.
     pub cross_chain_config: CrossChainConfig,
+    /// The builder that produces the storage configuration for the network.
     pub storage_config_builder: InnerStorageConfigBuilder,
+    /// The provider for the working directory of the network.
     pub path_provider: PathProvider,
+    /// The setup describing how block exporters are started or connected to.
     pub block_exporters: ExportersSetup,
     /// Optional directory where the `linera`, `linera-proxy`, and `linera-server` binaries
     /// are located. If `None`, binaries are resolved from the current binary's directory.
@@ -207,11 +231,10 @@ pub struct LocalNetConfig {
 
 /// The setup for the block exporters.
 #[derive(Clone, PartialEq)]
-#[allow(missing_docs)]
 pub enum ExportersSetup {
-    // Block exporters are meant to be started and managed by the testing framework.
+    /// Block exporters are meant to be started and managed by the testing framework.
     Local(Vec<BlockExporterConfig>),
-    // Block exporters are already started and we just need to connect to them.
+    /// Block exporters are already started and we just need to connect to them.
     Remote(Vec<ExporterServiceConfig>),
 }
 
@@ -257,10 +280,12 @@ const SERVER_ENV: &str = "LINERA_SERVER_PARAMS";
 
 /// Description of the database engine to use inside a local Linera network.
 #[derive(Copy, Clone, Eq, PartialEq)]
-#[allow(missing_docs)]
 pub enum Database {
+    /// The storage service backend.
     Service,
+    /// The ScyllaDB backend.
     ScyllaDb,
+    /// The dual backend combining RocksDB and ScyllaDB.
     DualRocksDbScyllaDb,
 }
 

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -49,6 +49,8 @@ use crate::{
 /// Maximum allowed number of shards over all validators.
 const MAX_NUMBER_SHARDS: usize = 1000;
 
+/// Whether to process the inbox automatically before an operation.
+#[allow(missing_docs)]
 pub enum ProcessInbox {
     Skip,
     Automatic,
@@ -118,6 +120,8 @@ async fn make_testing_config(database: Database) -> Result<InnerStorageConfig> {
     }
 }
 
+/// A way to obtain the storage configuration for a local network.
+#[allow(missing_docs)]
 pub enum InnerStorageConfigBuilder {
     #[cfg(with_testing)]
     TestConfig,
@@ -127,6 +131,7 @@ pub enum InnerStorageConfigBuilder {
 }
 
 impl InnerStorageConfigBuilder {
+    /// Builds the storage configuration for the given database engine.
     #[cfg_attr(not(with_testing), expect(unused_variables))]
     pub async fn build(self, database: Database) -> Result<InnerStorageConfig> {
         match self {
@@ -140,12 +145,14 @@ impl InnerStorageConfigBuilder {
 /// Path used for the run can come from a path whose lifetime is controlled
 /// by an external user or as a temporary directory
 #[derive(Clone)]
+#[allow(missing_docs)]
 pub enum PathProvider {
     ExternalPath { path_buf: PathBuf },
     TemporaryDirectory { tmp_dir: Arc<TempDir> },
 }
 
 impl PathProvider {
+    /// Returns the path managed by this provider.
     pub fn path(&self) -> &Path {
         match self {
             PathProvider::ExternalPath { path_buf } => path_buf.as_path(),
@@ -153,11 +160,13 @@ impl PathProvider {
         }
     }
 
+    /// Creates a provider backed by a freshly created temporary directory.
     pub fn create_temporary_directory() -> Result<Self> {
         let tmp_dir = Arc::new(tempdir()?);
         Ok(PathProvider::TemporaryDirectory { tmp_dir })
     }
 
+    /// Creates a provider from the given path, or a temporary directory if `None`.
     pub fn from_path_option(path: &Option<String>) -> anyhow::Result<Self> {
         Ok(match path {
             None => {
@@ -174,6 +183,7 @@ impl PathProvider {
 }
 
 /// The information needed to start a [`LocalNet`].
+#[allow(missing_docs)]
 pub struct LocalNetConfig {
     pub database: Database,
     pub network: NetworkConfig,
@@ -197,6 +207,7 @@ pub struct LocalNetConfig {
 
 /// The setup for the block exporters.
 #[derive(Clone, PartialEq)]
+#[allow(missing_docs)]
 pub enum ExportersSetup {
     // Block exporters are meant to be started and managed by the testing framework.
     Local(Vec<BlockExporterConfig>),
@@ -205,6 +216,7 @@ pub enum ExportersSetup {
 }
 
 impl ExportersSetup {
+    /// Creates an exporter setup, connecting to a remote exporter if requested.
     pub fn new(
         with_block_exporter: bool,
         block_exporter_address: String,
@@ -245,6 +257,7 @@ const SERVER_ENV: &str = "LINERA_SERVER_PARAMS";
 
 /// Description of the database engine to use inside a local Linera network.
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[allow(missing_docs)]
 pub enum Database {
     Service,
     ScyllaDb,
@@ -318,6 +331,7 @@ impl Validator {
 
 #[cfg(with_testing)]
 impl LocalNetConfig {
+    /// Creates a configuration for a local test network with default test parameters.
     pub fn new_test(database: Database, network: Network) -> Self {
         let num_shards = 4;
         let num_proxies = 1;
@@ -475,6 +489,7 @@ impl LocalNet {
     }
 
     #[cfg(with_testing)]
+    /// Reads the genesis configuration of the local network.
     pub fn genesis_config(&self) -> Result<linera_client::config::GenesisConfig> {
         let path = self.path_provider.path();
         crate::util::read_json(path.join("genesis.json"))
@@ -500,10 +515,12 @@ impl LocalNet {
         test_offset_port() + 3000 + validator * self.num_shards + exporter_id + 1
     }
 
+    /// Returns the public port of the given proxy of the given validator.
     pub fn proxy_public_port(&self, validator: usize, proxy_id: usize) -> usize {
         test_offset_port() + 4000 + validator * self.num_proxies + proxy_id + 1
     }
 
+    /// Returns the public port of the first proxy of the first validator.
     pub fn first_public_port() -> usize {
         test_offset_port() + 4000 + 1
     }
@@ -813,6 +830,7 @@ impl LocalNet {
         Ok(child)
     }
 
+    /// Waits until the gRPC server at the given port responds as healthy.
     pub async fn ensure_grpc_server_has_started(
         nickname: &str,
         port: usize,
@@ -1027,6 +1045,7 @@ impl LocalNet {
         self.validator_keys.get(&validator)
     }
 
+    /// Generates the configuration and keys for the given validator.
     pub async fn generate_validator_config(&mut self, validator: usize) -> Result<()> {
         let stdout = self
             .command_for_binary("linera-server")
@@ -1046,6 +1065,7 @@ impl LocalNet {
         Ok(())
     }
 
+    /// Terminates the server for the given shard of the given validator.
     pub async fn terminate_server(&mut self, validator: usize, shard: usize) -> Result<()> {
         self.running_validators
             .get_mut(&validator)
@@ -1055,6 +1075,7 @@ impl LocalNet {
         Ok(())
     }
 
+    /// Removes the given validator from the set of running validators.
     pub fn remove_validator(&mut self, validator: usize) -> Result<()> {
         self.running_validators
             .remove(&validator)
@@ -1062,6 +1083,7 @@ impl LocalNet {
         Ok(())
     }
 
+    /// Starts the server for the given shard of the given validator.
     pub async fn start_server(&mut self, validator: usize, shard: usize) -> Result<()> {
         let server = self.run_server(validator, shard).await?;
         self.running_validators

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -22,23 +22,29 @@ pub use wallet::{ApplicationWrapper, ClientWrapper, FaucetService, NodeService, 
 /// The information needed to start a Linera net of a particular kind.
 #[async_trait]
 pub trait LineraNetConfig {
+    /// The type of Linera net produced by this configuration.
     type Net: LineraNet + Sized + Send + Sync + 'static;
 
+    /// Starts the Linera net and returns it together with a client to interact with it.
     async fn instantiate(self) -> Result<(Self::Net, ClientWrapper)>;
 }
 
 /// A running Linera net.
 #[async_trait]
 pub trait LineraNet {
+    /// Checks that the net is still running and returns an error otherwise.
     async fn ensure_is_running(&mut self) -> Result<()>;
 
+    /// Creates a new client to interact with the net.
     async fn make_client(&mut self) -> ClientWrapper;
 
+    /// Shuts down the net.
     async fn terminate(&mut self) -> Result<()>;
 }
 
 /// Network protocol in use
 #[derive(Copy, Clone)]
+#[allow(missing_docs)]
 pub enum Network {
     Grpc,
     Grpcs,
@@ -65,6 +71,7 @@ impl Network {
         }
     }
 
+    /// Returns a short lowercase name for the network protocol.
     pub fn short(&self) -> &'static str {
         match self {
             Network::Grpc => "grpc",
@@ -74,6 +81,7 @@ impl Network {
         }
     }
 
+    /// Returns the equivalent network protocol without TLS.
     pub fn drop_tls(&self) -> Self {
         match self {
             Network::Grpc => Network::Grpc,
@@ -83,6 +91,7 @@ impl Network {
         }
     }
 
+    /// Returns the localhost address to use for this network protocol.
     pub fn localhost(&self) -> &'static str {
         match self {
             Network::Grpc | Network::Grpcs => "localhost",

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -44,11 +44,14 @@ pub trait LineraNet {
 
 /// Network protocol in use
 #[derive(Copy, Clone)]
-#[allow(missing_docs)]
 pub enum Network {
+    /// gRPC over cleartext (no TLS).
     Grpc,
+    /// gRPC secured with TLS.
     Grpcs,
+    /// Simple transport over TCP.
     Tcp,
+    /// Simple transport over UDP.
     Udp,
 }
 

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -14,6 +14,7 @@ use super::{
     OnClientDrop,
 };
 
+/// Configuration for connecting to an external (remote) Linera network in tests.
 pub struct RemoteNetTestingConfig {
     faucet: Faucet,
     close_chains: OnClientDrop,

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -80,6 +80,7 @@ pub struct ClientWrapper {
     keystore: String,
     max_pending_message_bundles: usize,
     network: Network,
+    /// Provides the working directory for the client's files.
     pub path_provider: PathProvider,
     on_drop: OnClientDrop,
     extra_args: Vec<String>,
@@ -95,6 +96,7 @@ pub enum OnClientDrop {
 }
 
 impl ClientWrapper {
+    /// Creates a new client wrapper with the default extra arguments.
     pub fn new(
         path_provider: PathProvider,
         network: Network,
@@ -113,6 +115,7 @@ impl ClientWrapper {
         )
     }
 
+    /// Creates a new client wrapper with the given extra arguments and binary directory.
     pub fn new_with_extra_args(
         path_provider: PathProvider,
         network: Network,
@@ -1015,6 +1018,7 @@ impl ClientWrapper {
         Ok(new_chain)
     }
 
+    /// Runs `linera open-multi-owner-chain` and returns the new chain's ID.
     pub async fn open_multi_owner_chain(
         &self,
         from: ChainId,
@@ -1041,6 +1045,7 @@ impl ClientWrapper {
         Ok(chain_id)
     }
 
+    /// Runs `linera change-ownership` to set the super owners and owners of a chain.
     pub async fn change_ownership(
         &self,
         chain_id: ChainId,
@@ -1064,6 +1069,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera change-application-permissions` for the given chain.
     pub async fn change_application_permissions(
         &self,
         chain_id: ChainId,
@@ -1114,6 +1120,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera retry-pending-block` for the given chain.
     pub async fn retry_pending_block(
         &self,
         chain_id: Option<ChainId>,
@@ -1159,26 +1166,32 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Reads the wallet from disk.
     pub fn load_wallet(&self) -> Result<Wallet> {
         Ok(Wallet::read(&self.wallet_path())?)
     }
 
+    /// Reads the keystore from disk.
     pub fn load_keystore(&self) -> Result<InMemorySigner> {
         util::read_json(self.keystore_path())
     }
 
+    /// Returns the path to the wallet file.
     pub fn wallet_path(&self) -> PathBuf {
         self.path_provider.path().join(&self.wallet)
     }
 
+    /// Returns the path to the keystore file.
     pub fn keystore_path(&self) -> PathBuf {
         self.path_provider.path().join(&self.keystore)
     }
 
+    /// Returns the storage configuration string.
     pub fn storage_path(&self) -> &str {
         &self.storage
     }
 
+    /// Returns the owner of the wallet's default chain, if any.
     pub fn get_owner(&self) -> Option<AccountOwner> {
         let wallet = self.load_wallet().ok()?;
         wallet
@@ -1187,12 +1200,14 @@ impl ClientWrapper {
             .owner
     }
 
+    /// Returns whether the given chain is present in the wallet.
     pub fn is_chain_present_in_wallet(&self, chain: ChainId) -> bool {
         self.load_wallet()
             .ok()
             .is_some_and(|wallet| wallet.get(chain).is_some())
     }
 
+    /// Runs `linera validator add` for the given validator key, port, and number of votes.
     pub async fn set_validator(
         &self,
         validator_key: &(String, String),
@@ -1213,6 +1228,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera validator remove` for the given validator public key.
     pub async fn remove_validator(&self, validator_key: &str) -> Result<()> {
         self.command()
             .await?
@@ -1224,6 +1240,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera validator update` to add, modify, and remove validators in one batch.
     pub async fn change_validators(
         &self,
         add_validators: &[(String, String, usize, usize)], // (public_key, account_key, port, votes)
@@ -1290,6 +1307,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera revoke-epochs` up to the given epoch.
     pub async fn revoke_epochs(&self, epoch: Epoch) -> Result<()> {
         self.command()
             .await?
@@ -1300,6 +1318,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera resource-control-policy` with the given overrides.
     pub async fn set_resource_control_policy(
         &self,
         overrides: ResourceControlPolicyOverrides,
@@ -1493,6 +1512,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Builds the application at the given path with `cargo` and returns the contract and service paths.
     pub async fn build_application(
         &self,
         path: &Path,
@@ -1602,20 +1622,24 @@ impl Drop for ClientWrapper {
 
 #[cfg(with_testing)]
 impl ClientWrapper {
+    /// Builds the example application with the given name from the `examples` directory.
     pub async fn build_example(&self, name: &str) -> Result<(PathBuf, PathBuf)> {
         self.build_application(Self::example_path(name)?.as_path(), name, true)
             .await
     }
 
+    /// Builds the test example application with the given name from the test fixtures.
     pub async fn build_test_example(&self, name: &str) -> Result<(PathBuf, PathBuf)> {
         self.build_application(Self::test_example_path(name)?.as_path(), name, true)
             .await
     }
 
+    /// Returns the path to the example application with the given name.
     pub fn example_path(name: &str) -> Result<PathBuf> {
         Ok(env::current_dir()?.join("../examples/").join(name))
     }
 
+    /// Returns the path to the test example application with the given name.
     pub fn test_example_path(name: &str) -> Result<PathBuf> {
         Ok(env::current_dir()?
             .join("../linera-sdk/tests/fixtures/")
@@ -1679,6 +1703,7 @@ fn log_unexpected_exit(child: &mut Child, service_kind: &str, port: u16) {
     }
 }
 
+/// A running node service that can be queried over GraphQL.
 pub struct NodeService {
     port: u16,
     child: Child,
@@ -1702,31 +1727,37 @@ impl NodeService {
         }
     }
 
+    /// Terminates the node service process.
     pub async fn terminate(mut self) -> Result<()> {
         self.terminated = true;
         self.child.kill().await.context("terminating node service")
     }
 
+    /// Returns the port the node service is listening on.
     pub fn port(&self) -> u16 {
         self.port
     }
 
+    /// Checks that the node service process is still running.
     pub fn ensure_is_running(&mut self) -> Result<()> {
         self.child.ensure_is_running()
     }
 
+    /// Runs the `processInbox` GraphQL mutation for the given chain.
     pub async fn process_inbox(&self, chain_id: &ChainId) -> Result<Vec<CryptoHash>> {
         let query = format!("mutation {{ processInbox(chainId: \"{chain_id}\") }}");
         let mut data = self.query_node(query).await?;
         Ok(serde_json::from_value(data["processInbox"].take())?)
     }
 
+    /// Runs the `sync` GraphQL mutation for the given chain.
     pub async fn sync(&self, chain_id: &ChainId) -> Result<u64> {
         let query = format!("mutation {{ sync(chainId: \"{chain_id}\") }}");
         let mut data = self.query_node(query).await?;
         Ok(serde_json::from_value(data["sync"].take())?)
     }
 
+    /// Transfers the given amount from an owner to a recipient via the `transfer` mutation.
     pub async fn transfer(
         &self,
         chain_id: ChainId,
@@ -1749,6 +1780,7 @@ impl NodeService {
             .context("missing transfer field in response")
     }
 
+    /// Queries the balance of the given account.
     pub async fn balance(&self, account: &Account) -> Result<Amount> {
         let chain = account.chain_id;
         let owner = account.owner;
@@ -1780,6 +1812,7 @@ impl NodeService {
         }
     }
 
+    /// Returns an [`ApplicationWrapper`] for querying the given application over GraphQL.
     pub fn make_application<A: ContractAbi>(
         &self,
         chain_id: &ChainId,
@@ -1793,6 +1826,7 @@ impl NodeService {
         Ok(ApplicationWrapper::from(link))
     }
 
+    /// Publishes a data blob to the given chain via the `publishDataBlob` mutation.
     pub async fn publish_data_blob(
         &self,
         chain_id: &ChainId,
@@ -1808,6 +1842,7 @@ impl NodeService {
             .context("missing publishDataBlob field in response")
     }
 
+    /// Publishes a module to the given chain via the `publishModule` mutation.
     pub async fn publish_module<Abi, Parameters, InstantiationArgument>(
         &self,
         chain_id: &ChainId,
@@ -1832,6 +1867,7 @@ impl NodeService {
         Ok(module_id.with_abi())
     }
 
+    /// Queries the committee hash of the given chain.
     pub async fn query_committee_hash(&self, chain_id: &ChainId) -> Result<Option<CryptoHash>> {
         let query = format!(
             "query {{ chain(chainId:\"{chain_id}\") {{
@@ -1843,6 +1879,7 @@ impl NodeService {
         Ok(serde_json::from_value(hash)?)
     }
 
+    /// Queries the current epoch of the given chain.
     pub async fn query_chain_epoch(&self, chain_id: &ChainId) -> Result<Epoch> {
         let query = format!(
             "query {{ chain(chainId:\"{chain_id}\") {{
@@ -1854,6 +1891,7 @@ impl NodeService {
         Ok(serde_json::from_value(epoch)?)
     }
 
+    /// Queries the events of the given stream starting from the given index.
     pub async fn events_from_index(
         &self,
         chain_id: &ChainId,
@@ -1872,6 +1910,7 @@ impl NodeService {
         Ok(serde_json::from_value(response)?)
     }
 
+    /// Posts the given GraphQL query to the node service, retrying on transient errors.
     pub async fn query_node(&self, query: impl AsRef<str>) -> Result<Value> {
         let n_try = 5;
         let query = query.as_ref();
@@ -1924,6 +1963,7 @@ impl NodeService {
         );
     }
 
+    /// Creates an application from a published module via the `createApplication` mutation.
     pub async fn create_application<
         Abi: ContractAbi,
         Parameters: Serialize,
@@ -2124,6 +2164,7 @@ impl FaucetService {
         }
     }
 
+    /// Terminates the faucet service process.
     pub async fn terminate(mut self) -> Result<()> {
         self.terminated = true;
         self.child
@@ -2132,10 +2173,12 @@ impl FaucetService {
             .context("terminating faucet service")
     }
 
+    /// Checks that the faucet service process is still running.
     pub fn ensure_is_running(&mut self) -> Result<()> {
         self.child.ensure_is_running()
     }
 
+    /// Returns a [`Faucet`] client pointing at this service.
     pub fn instance(&self) -> Faucet {
         Faucet::new(format!("http://localhost:{}/", self.port))
     }
@@ -2148,12 +2191,14 @@ pub struct ApplicationWrapper<A> {
 }
 
 impl<A> ApplicationWrapper<A> {
+    /// Posts the given GraphQL query and returns the `data` field of the response.
     pub async fn run_graphql_query(&self, query: impl AsRef<str>) -> Result<Value> {
         let query = query.as_ref();
         let value = self.run_json_query(json!({ "query": query })).await?;
         Ok(value["data"].clone())
     }
 
+    /// Posts the given JSON request to the application, retrying on transient errors.
     pub async fn run_json_query<T: Serialize>(&self, query: T) -> Result<Value> {
         const MAX_RETRIES: usize = 5;
 
@@ -2197,12 +2242,14 @@ impl<A> ApplicationWrapper<A> {
         unreachable!()
     }
 
+    /// Runs the given string as a GraphQL query, wrapping it in `query { ... }`.
     pub async fn query(&self, query: impl AsRef<str>) -> Result<Value> {
         let query = query.as_ref();
         self.run_graphql_query(&format!("query {{ {query} }}"))
             .await
     }
 
+    /// Runs the given GraphQL query and deserializes the named field of the response.
     pub async fn query_json<T: DeserializeOwned>(&self, query: impl AsRef<str>) -> Result<T> {
         let query = query.as_ref().trim();
         let name = query
@@ -2213,12 +2260,14 @@ impl<A> ApplicationWrapper<A> {
             .with_context(|| format!("{name} field missing in response"))
     }
 
+    /// Runs the given string as a GraphQL mutation, wrapping it in `mutation { ... }`.
     pub async fn mutate(&self, mutation: impl AsRef<str>) -> Result<Value> {
         let mutation = mutation.as_ref();
         self.run_graphql_query(&format!("mutation {{ {mutation} }}"))
             .await
     }
 
+    /// Runs several GraphQL mutations as aliased fields in a single `mutation` request.
     pub async fn multiple_mutate(&self, mutations: &[String]) -> Result<Value> {
         let mut out = String::from("mutation {\n");
         for (index, mutation) in mutations.iter().enumerate() {
@@ -2256,6 +2305,7 @@ fn notification_timeout() -> Duration {
     }
 }
 
+/// Extension trait for waiting on specific notifications from a stream.
 #[cfg(with_testing)]
 pub trait NotificationsExt {
     /// Waits for a notification for which `f` returns `Some(t)`, and returns `t`.

--- a/linera-service/src/controller.rs
+++ b/linera-service/src/controller.rs
@@ -33,6 +33,7 @@ use crate::task_processor::{OperatorMap, TaskProcessor};
 /// An update message sent to a TaskProcessor to change its set of applications.
 #[derive(Debug)]
 pub struct Update {
+    /// The new set of applications the processor should handle.
     pub application_ids: Vec<ApplicationId>,
 }
 
@@ -40,6 +41,7 @@ struct ProcessorHandle {
     update_sender: mpsc::UnboundedSender<Update>,
 }
 
+/// Watches a controller chain and spawns task processors for its managed services.
 pub struct Controller<Ctx: ClientContext> {
     chain_id: ChainId,
     controller_id: ApplicationId,
@@ -68,6 +70,7 @@ where
     Ctx::Environment: 'static,
     <Ctx::Environment as linera_core::Environment>::Storage: Clone,
 {
+    /// Creates a new controller for the given controller chain.
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         chain_id: ChainId,
@@ -97,6 +100,7 @@ where
         }
     }
 
+    /// Runs the controller, watching for notifications until cancelled.
     pub async fn run(mut self) {
         info!(
             "Watching for notifications for controller chain {}",

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -5,16 +5,24 @@
 //! This module provides the executables needed to operate a Linera service, including a placeholder wallet acting as a GraphQL service for user interfaces.
 
 #![recursion_limit = "256"]
+#![deny(missing_docs)]
 
 pub mod cli;
 pub mod cli_wrappers;
+/// Configuration types for the service binaries.
 pub mod config;
+/// The controller that orchestrates worker services.
 pub mod controller;
+/// The GraphQL node service exposing wallet and chain state.
 pub mod node_service;
+/// Helpers for creating and building application projects.
 pub mod project;
+/// Tracking of GraphQL subscriptions by query.
 pub mod query_subscription;
+/// Storage backend selection for the service binaries.
 pub mod storage;
 pub mod task_processor;
 pub mod tracing;
+/// Assorted helper utilities for the service binaries.
 pub mod util;
 pub use linera_wallet_json::PersistentWallet as Wallet;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -112,6 +112,7 @@ impl OutputType for RawJson {
 }
 
 #[derive(SimpleObject, Serialize, Deserialize, Clone)]
+#[allow(missing_docs)]
 pub struct Chains {
     pub list: Vec<ChainId>,
     pub default: Option<ChainId>,
@@ -1003,6 +1004,7 @@ impl<S: Storage> ChainStateExtendedView<S> {
 }
 
 #[derive(SimpleObject)]
+#[allow(missing_docs)]
 pub struct ApplicationOverview {
     id: ApplicationId,
     description: ApplicationDescription,
@@ -1379,11 +1381,13 @@ where
         }
     }
 
+    /// Returns the socket address on which the metrics endpoint is served.
     #[cfg(with_metrics)]
     pub fn metrics_address(&self) -> SocketAddr {
         SocketAddr::from(([0, 0, 0, 0], self.metrics_port.get()))
     }
 
+    /// Builds the GraphQL schema served by the node service.
     pub fn schema(&self) -> NodeServiceSchema<C> {
         let query = QueryRoot {
             context: Arc::clone(&self.context),

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -111,10 +111,12 @@ impl OutputType for RawJson {
     }
 }
 
+/// The set of chains tracked by the wallet.
 #[derive(SimpleObject, Serialize, Deserialize, Clone)]
-#[allow(missing_docs)]
 pub struct Chains {
+    /// The IDs of the tracked chains.
     pub list: Vec<ChainId>,
+    /// The default chain of the wallet, if one is set.
     pub default: Option<ChainId>,
 }
 
@@ -1003,8 +1005,8 @@ impl<S: Storage> ChainStateExtendedView<S> {
     }
 }
 
+/// A summary of an application registered on a chain.
 #[derive(SimpleObject)]
-#[allow(missing_docs)]
 pub struct ApplicationOverview {
     id: ApplicationId,
     description: ApplicationDescription,

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -14,11 +14,13 @@ use current_platform::CURRENT_PLATFORM;
 use fs_err::File;
 use tracing::debug;
 
+/// A Linera application project on disk, rooted at a given directory.
 pub struct Project {
     root: PathBuf,
 }
 
 impl Project {
+    /// Creates a new application project from the template, scaffolding its files.
     pub fn create_new(
         name: &str,
         linera_root: Option<&Path>,
@@ -80,6 +82,7 @@ impl Project {
         Ok(Self { root })
     }
 
+    /// Opens an existing application project at the given root directory.
     pub fn from_existing_project(root: &Path) -> Result<Self> {
         let root = root.canonicalize().with_context(|| {
             format!(
@@ -283,6 +286,7 @@ impl Project {
         (linera_sdk_dep, linera_sdk_dev_dep)
     }
 
+    /// Builds the project's contract and service to Wasm, returning their bytecode paths.
     pub fn build(&self, name: Option<String>) -> Result<(PathBuf, PathBuf), anyhow::Error> {
         let name = match name {
             Some(name) => name,

--- a/linera-service/src/query_subscription.rs
+++ b/linera-service/src/query_subscription.rs
@@ -19,7 +19,9 @@ use tracing::{debug, warn};
 /// A named GraphQL query string registered at startup via `--allow-subscription`.
 #[derive(Clone, Debug)]
 pub struct RegisteredQuery {
+    /// The operation name used to refer to the query.
     pub name: String,
+    /// The full GraphQL query string.
     pub query: String,
 }
 
@@ -64,8 +66,11 @@ pub fn parse_subscription_ttl(s: &str) -> Result<(String, u64), String> {
 /// Identifies a unique subscription target: a named query for a specific chain and application.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct SubscriptionKey {
+    /// The name of the registered query.
     pub name: String,
+    /// The chain the query runs against.
     pub chain_id: ChainId,
+    /// The application the query targets.
     pub application_id: ApplicationId,
 }
 

--- a/linera-service/src/tracing/mod.rs
+++ b/linera-service/src/tracing/mod.rs
@@ -3,6 +3,7 @@
 
 //! This module provides unified handling for tracing subscribers within Linera binaries.
 
+/// Support for emitting traces in the Chrome tracing format.
 pub mod chrome;
 pub mod opentelemetry;
 

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -18,12 +18,14 @@ use linera_base::data_types::TimeDelta;
 pub use linera_client::util::*;
 use tracing::debug;
 
-// Exported for readme e2e tests.
+/// Default pause, in seconds, inserted after `linera service` commands in readme e2e tests.
 pub static DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS: &str = "3";
+/// Default pause, in seconds, inserted after GraphQL mutations in readme e2e tests.
 pub static DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS: &str = "3";
 
 /// Extension trait for [`tokio::process::Child`].
 pub trait ChildExt: std::fmt::Debug {
+    /// Ensures the child process is still running, returning an error if it has exited.
     fn ensure_is_running(&mut self) -> Result<()>;
 }
 
@@ -37,10 +39,12 @@ impl ChildExt for tokio::process::Child {
     }
 }
 
+/// Reads and deserializes a JSON value from the file at the given path.
 pub fn read_json<T: serde::de::DeserializeOwned>(path: impl Into<std::path::PathBuf>) -> Result<T> {
     Ok(serde_json::from_reader(fs_err::File::open(path)?)?)
 }
 
+/// Expands to the name of the current test function.
 #[cfg(with_testing)]
 #[macro_export]
 macro_rules! test_name {
@@ -51,11 +55,13 @@ macro_rules! test_name {
     };
 }
 
+/// A reader over a Markdown document, used to extract embedded code blocks.
 pub struct Markdown<B> {
     buffer: B,
 }
 
 impl Markdown<BufReader<fs_err::File>> {
+    /// Opens the Markdown file at the given path.
     pub fn new(path: impl AsRef<Path>) -> std::io::Result<Self> {
         let buffer = BufReader::new(fs_err::File::open(path.as_ref())?);
         Ok(Self { buffer })
@@ -66,6 +72,7 @@ impl<B> Markdown<B>
 where
     B: BufRead,
 {
+    /// Extracts the embedded bash and GraphQL code blocks as a runnable bash script.
     #[expect(clippy::while_let_on_iterator)]
     pub fn extract_bash_script_to(
         self,
@@ -154,6 +161,7 @@ pub(crate) async fn graphiql(uri: Uri) -> impl IntoResponse {
     response::Html(source)
 }
 
+/// Parses a string of milliseconds into a [`Duration`].
 pub fn parse_millis(s: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_millis(s.parse()?))
 }
@@ -167,10 +175,12 @@ pub fn non_zero_duration(d: Duration) -> Option<Duration> {
     }
 }
 
+/// Parses a string of milliseconds into a [`TimeDelta`].
 pub fn parse_millis_delta(s: &str) -> Result<TimeDelta, ParseIntError> {
     Ok(TimeDelta::from_millis(s.parse()?))
 }
 
+/// Validates that a string contains only ASCII alphanumeric characters, returning it unchanged.
 pub fn parse_ascii_alphanumeric_string(s: &str) -> Result<String, &'static str> {
     if s.chars().all(|x| x.is_ascii_alphanumeric()) {
         Ok(s.to_string())


### PR DESCRIPTION
## Motivation

`linera-service` was one of the few crates without `#![deny(missing_docs)]`, so undocumented public items could be added without CI noticing.

## Proposal

Add `#![deny(missing_docs)]` to `linera-service` and satisfy it:
- Real one-line doc comments on the public API (CLI commands/options, the CLI test wrappers like `ClientWrapper`/`NodeService`/`LocalNet`, config/util/project helpers, module declarations).
- `#[allow(missing_docs)]` on bulk mechanical/clap-derived command enums and self-descriptive config structs, matching the existing `linera-base` convention (also avoids inventing clap help text).
- The two async-graphql `SimpleObject` types in `node_service.rs` (`Chains`, `ApplicationOverview`) use `#[allow(missing_docs)]` so the change leaves the checked-in `service_schema.graphql` byte-for-byte unchanged.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied for `--all-features` and `--all-targets` (so `cfg(test)` is covered), that `cargo run --bin linera-schema-export` still matches `linera-service-graphql-client/gql/service_schema.graphql`, and that `cargo +nightly fmt -- --check` and `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion backport to `testnet_conway`.
- Final crate in the effort to enable `#![deny(missing_docs)]` across the library crates.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
