### PR TITLE
Add #![deny(missing_docs)] to linera-exporter (backport of #6529)

### DIFF
--- a/linera-exporter/src/common.rs
+++ b/linera-exporter/src/common.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 use tokio_util::sync::{CancellationToken, WaitForCancellationFutureOwned};
 use tonic::Status;
 
+/// Errors that can occur while running the block exporter.
 #[derive(thiserror::Error, Debug)]
+#[allow(missing_docs)]
 pub enum ExporterError {
     #[error("received an invalid notification.")]
     BadNotification(BadNotificationKind),
@@ -53,7 +55,9 @@ pub enum ExporterError {
     GenericError(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
+/// The reason a notification was rejected as invalid.
 #[derive(Debug)]
+#[allow(missing_docs)]
 pub enum BadNotificationKind {
     InvalidChainId {
         #[debug(skip_if = Option::is_none)]
@@ -72,13 +76,17 @@ impl From<BadNotificationKind> for ExporterError {
     }
 }
 
+/// A block together with the blobs it depends on, in canonical order.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CanonicalBlock {
+    /// The blobs required by the block.
     pub blobs: Box<[BlobId]>,
+    /// The hash of the block.
     pub block_hash: CryptoHash,
 }
 
 impl CanonicalBlock {
+    /// Creates a new canonical block from a block hash and its blobs.
     pub fn new(hash: CryptoHash, blobs: &[BlobId]) -> CanonicalBlock {
         CanonicalBlock {
             block_hash: hash,
@@ -87,20 +95,28 @@ impl CanonicalBlock {
     }
 }
 
+/// A fully-qualified block identifier holding its hash, chain and height.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
 pub struct BlockId {
+    /// The hash of the block.
     pub hash: CryptoHash,
+    /// The chain the block belongs to.
     pub chain_id: ChainId,
+    /// The height of the block within its chain.
     pub height: BlockHeight,
 }
 
+/// A lightweight block identifier holding only its hash and height.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LiteBlockId {
+    /// The hash of the block.
     pub hash: CryptoHash,
+    /// The height of the block within its chain.
     pub height: BlockHeight,
 }
 
 impl BlockId {
+    /// Creates a new block identifier from its chain, hash and height.
     pub fn new(chain_id: ChainId, hash: CryptoHash, height: BlockHeight) -> BlockId {
         BlockId {
             hash,
@@ -109,6 +125,7 @@ impl BlockId {
         }
     }
 
+    /// Creates a block identifier from a confirmed block.
     pub fn from_confirmed_block(block: &ConfirmedBlock) -> BlockId {
         BlockId::new(block.chain_id(), block.inner().hash(), block.height())
     }
@@ -126,12 +143,14 @@ impl From<BlockId> for LiteBlockId {
     }
 }
 
+/// A cancellation signal that resolves once the underlying token is cancelled.
 #[derive(Clone)]
 pub struct ExporterCancellationSignal {
     token: CancellationToken,
 }
 
 impl ExporterCancellationSignal {
+    /// Creates a new cancellation signal from the given token.
     pub fn new(token: CancellationToken) -> Self {
         Self { token }
     }
@@ -146,6 +165,7 @@ impl IntoFuture for ExporterCancellationSignal {
     }
 }
 
+/// Returns the socket address listening on all interfaces for the given port.
 pub fn get_address(port: u16) -> SocketAddr {
     SocketAddr::from(([0, 0, 0, 0], port))
 }

--- a/linera-exporter/src/config.rs
+++ b/linera-exporter/src/config.rs
@@ -50,7 +50,7 @@ pub struct DestinationConfig {
     pub committee_destination: bool,
 }
 
-// Each destination has an ID and a configuration.
+/// A unique identifier for an export destination, combining its address and kind.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DestinationId {
     address: String,
@@ -63,6 +63,7 @@ impl DestinationId {
         Self { address, kind }
     }
 
+    /// Creates a new validator destination ID from the address.
     pub fn validator(address: String) -> Self {
         Self {
             address,
@@ -84,6 +85,7 @@ impl DestinationId {
 /// The uri to provide export services to.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Destination {
+    /// An indexer destination served over gRPC.
     Indexer {
         /// The gRPC network protocol.
         tls: TlsConfig,
@@ -92,12 +94,14 @@ pub enum Destination {
         /// The port number of the target destination.
         port: u16,
     },
+    /// A validator destination served over gRPC.
     Validator {
         /// The host name of the target destination (IP or hostname).
         endpoint: String,
         /// The port number of the target destination.
         port: u16,
     },
+    /// A logging destination that writes to a file.
     Logging {
         /// The log file path.
         file_name: String,
@@ -286,6 +290,7 @@ impl Default for LimitsConfig {
 }
 
 impl Destination {
+    /// Returns the address string for this destination.
     pub fn address(&self) -> String {
         match &self {
             Destination::Indexer {
@@ -309,6 +314,7 @@ impl Destination {
         }
     }
 
+    /// Returns the [`DestinationId`] identifying this destination.
     pub fn id(&self) -> DestinationId {
         let kind = match self {
             Destination::Indexer { .. } => DestinationKind::Indexer,

--- a/linera-exporter/src/exporter_service.rs
+++ b/linera-exporter/src/exporter_service.rs
@@ -14,6 +14,7 @@ use tracing::info;
 
 use crate::common::{get_address, BadNotificationKind, BlockId, ExporterError};
 
+/// The gRPC service that receives block notifications and forwards them to the block processor.
 pub struct ExporterService {
     block_processor_sender: UnboundedSender<BlockId>,
 }
@@ -55,12 +56,14 @@ impl NotifierService for ExporterService {
 }
 
 impl ExporterService {
+    /// Creates a new exporter service forwarding notifications to the given sender.
     pub fn new(sender: UnboundedSender<BlockId>) -> ExporterService {
         ExporterService {
             block_processor_sender: sender,
         }
     }
 
+    /// Runs the notification server until the cancellation token is triggered.
     pub async fn run(
         self,
         cancellation_token: CancellationToken,

--- a/linera-exporter/src/lib.rs
+++ b/linera-exporter/src/lib.rs
@@ -3,14 +3,23 @@
 
 //! Block exporter for the Linera protocol.
 
+#![deny(missing_docs)]
+
+/// Shared data types used across the exporter.
 pub mod common;
 pub mod config;
+/// The gRPC service that serves exported blocks.
 pub mod exporter_service;
+/// Prometheus metrics for the exporter.
 #[cfg(with_metrics)]
 pub mod metrics;
+/// The run loops that drive block export to each destination.
 pub mod runloops;
+/// The persistent state tracking export progress.
 pub mod state;
+/// Storage backends for the exporter.
 pub mod storage;
+/// Assorted helper utilities.
 pub mod util;
 
 #[cfg(test)]

--- a/linera-exporter/src/runloops/indexer/mod.rs
+++ b/linera-exporter/src/runloops/indexer/mod.rs
@@ -5,6 +5,9 @@ mod client;
 mod conversions;
 pub(crate) mod indexer_exporter;
 
+/// The gRPC client and message types generated from the indexer proto definitions.
 pub mod indexer_api {
+    // Generated gRPC bindings; the generated items cannot carry doc comments.
+    #![allow(missing_docs)]
     tonic::include_proto!("indexer.linera_indexer");
 }

--- a/linera-exporter/src/runloops/mod.rs
+++ b/linera-exporter/src/runloops/mod.rs
@@ -32,6 +32,7 @@ mod validator_exporter;
 #[cfg(test)]
 pub use indexer::indexer_api;
 
+/// Spawns the block processor on a dedicated thread and returns a sender for new block IDs.
 pub fn start_block_processor_task<S, F>(
     storage: S,
     shutdown_signal: F,

--- a/linera-exporter/src/state.rs
+++ b/linera-exporter/src/state.rs
@@ -50,6 +50,8 @@ impl<C> BlockExporterStateView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
 {
+    /// Loads the exporter state, registering any new destinations, and returns it along with the
+    /// canonical state and destination states.
     pub async fn initiate(
         context: C,
         destinations: Vec<DestinationId>,
@@ -85,10 +87,12 @@ where
         Ok((view, canonical_state, states))
     }
 
+    /// Records a blob as seen and indexed by the exporter.
     pub fn index_blob(&mut self, blob: BlobId) -> Result<(), ExporterError> {
         Ok(self.blob_state.insert(&blob)?)
     }
 
+    /// Advances the chain's processed height to the given block, returning whether it was indexed.
     pub async fn index_block(&mut self, block: BlockId) -> Result<bool, ExporterError> {
         if let Some(last_processed) = self.chain_states.get_mut(&block.chain_id).await? {
             let expected_block_height = last_processed
@@ -110,6 +114,7 @@ where
         }
     }
 
+    /// Registers a chain from its initial block at height zero.
     pub async fn initialize_chain(&mut self, block: BlockId) -> Result<(), ExporterError> {
         ensure!(
             block.height == BlockHeight::ZERO,
@@ -125,6 +130,7 @@ where
         Ok(())
     }
 
+    /// Returns the highest block already processed for the given chain, if any.
     pub async fn get_chain_status(
         &self,
         chain_id: &ChainId,
@@ -132,27 +138,33 @@ where
         Ok(self.chain_states.get(chain_id).await?)
     }
 
+    /// Returns whether the given blob has already been indexed.
     pub async fn is_blob_indexed(&self, blob: BlobId) -> Result<bool, ExporterError> {
         Ok(self.blob_state.contains(&blob).await?)
     }
 
+    /// Sets the exporter state for all destinations.
     pub fn set_destination_states(&mut self, destination_states: DestinationStates) {
         self.destination_states.set(destination_states);
     }
 
+    /// Returns the exporter state for all destinations.
     pub fn get_destination_states(&self) -> &DestinationStates {
         self.destination_states.get()
     }
 
+    /// Records the latest committee blob ID processed by the exporter.
     pub fn set_latest_committee_blob(&mut self, blob_id: BlobId) {
         self.latest_committee_blob.set(Some(blob_id));
     }
 
+    /// Returns the latest committee blob ID processed by the exporter, if any.
     pub fn get_latest_committee_blob(&self) -> Option<BlobId> {
         *self.latest_committee_blob.get()
     }
 }
 
+/// The per-destination export progress, tracking the number of blocks exported to each destination.
 #[derive(Debug, Clone)]
 pub struct DestinationStates {
     states: Arc<papaya::HashMap<DestinationId, Arc<AtomicU64>>>,
@@ -213,6 +225,7 @@ impl<'de> Deserialize<'de> for DestinationStates {
 }
 
 impl DestinationStates {
+    /// Returns the state counter for the given destination, panicking if it is absent.
     pub fn load_state(&self, id: &DestinationId) -> Arc<AtomicU64> {
         let pinned = self.states.pin();
         pinned
@@ -221,14 +234,17 @@ impl DestinationStates {
             .clone()
     }
 
+    /// Returns the state counter for the given destination, if present.
     pub fn get(&self, id: &DestinationId) -> Option<Arc<AtomicU64>> {
         self.states.pin().get(id).cloned()
     }
 
+    /// Inserts the state counter for the given destination.
     pub fn insert(&mut self, id: DestinationId, state: Arc<AtomicU64>) {
         self.states.pin().insert(id, state);
     }
 
+    /// Returns an iterator over each destination and its current state value.
     pub fn iter(&self) -> impl Iterator<Item = (DestinationId, u64)> + '_ {
         let pinned = self.states.pin();
         pinned
@@ -238,6 +254,7 @@ impl DestinationStates {
             .into_iter()
     }
 
+    /// Sets the state value for the given destination, returning the previous value if present.
     pub fn set(&self, id: &DestinationId, value: u64) -> Option<u64> {
         self.states
             .pin()

--- a/linera-exporter/src/util.rs
+++ b/linera-exporter/src/util.rs
@@ -3,6 +3,7 @@
 
 use std::{num::ParseIntError, time::Duration};
 
+/// Parses a string of milliseconds into a [`Duration`].
 pub fn parse_millis(s: &str) -> Result<Duration, ParseIntError> {
     let millis = s.parse::<u64>()?;
     Ok(Duration::from_millis(millis))


### PR DESCRIPTION
## Motivation

Backport to `testnet_conway` of the `linera-exporter` `#![deny(missing_docs)]` change (#6529).

## Proposal

Same change as #6529, cherry-picked onto `testnet_conway`. Doc strings are identical to the `main` PR for shared items; differences are confined to items that diverge between the branches.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied (`--all-features`, `--all-targets`) with nightly fmt and `cargo doc -D warnings` passing.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Forward port on `main`: #6529
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
