### PR TITLE
Add #![deny(missing_docs)] to linera-service (backport of #6531)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1066,7 +1066,7 @@ Change the wallet default chain
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>`
+* `<CHAIN_ID>` — The chain to set as the default
 
 
 
@@ -1139,7 +1139,7 @@ Forgets the specified chain's keys. The chain will still be followed by the wall
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>`
+* `<CHAIN_ID>` — The chain whose keys will be forgotten
 
 
 
@@ -1151,7 +1151,7 @@ Forgets the specified chain, including the associated key pair
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>`
+* `<CHAIN_ID>` — The chain to forget
 
 
 
@@ -1233,7 +1233,7 @@ Equivalent to running `cargo test` with the appropriate test runner.
 
 ###### **Arguments:**
 
-* `<PATH>`
+* `<PATH>` — The path of the root of the Linera project to test
 
 
 
@@ -1639,7 +1639,7 @@ Initialize a namespace in the database
 
 ###### **Options:**
 
-* `--genesis <GENESIS_CONFIG_PATH>`
+* `--genesis <GENESIS_CONFIG_PATH>` — The path to the genesis configuration file
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -546,7 +546,7 @@ Deprecates all committees up to and including the specified one
 
 ###### **Arguments:**
 
-* `<EPOCH>`
+* `<EPOCH>` — The highest epoch to deprecate
 
 
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -32,6 +32,9 @@ A unique identifier for a user application
 """
 scalar ApplicationId
 
+"""
+A summary of an application registered on a chain.
+"""
 type ApplicationOverview {
 	id: ApplicationId!
 	description: ApplicationDescription!
@@ -456,8 +459,17 @@ type ChainTipState {
 	numOutgoingMessages: Int!
 }
 
+"""
+The set of chains tracked by the wallet.
+"""
 type Chains {
+	"""
+	The IDs of the tracked chains.
+	"""
 	list: [ChainId!]!
+	"""
+	The default chain of the wallet, if one is set.
+	"""
 	default: ChainId
 }
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -33,9 +33,13 @@ const DEFAULT_BPS: usize = 10;
 /// Specification for a validator to be added to the committee.
 #[derive(Clone, Debug)]
 pub struct ValidatorToAdd {
+    /// The validator's public key.
     pub public_key: ValidatorPublicKey,
+    /// The validator's account public key.
     pub account_key: AccountPublicKey,
+    /// The network address of the validator.
     pub address: String,
+    /// The number of votes assigned to the validator.
     pub votes: u64,
 }
 
@@ -60,6 +64,7 @@ impl std::str::FromStr for ValidatorToAdd {
 
 #[derive(Clone, clap::Args, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
+/// Options controlling the behavior of the benchmark command.
 pub struct BenchmarkOptions {
     /// How many chains to use.
     #[arg(long, default_value_t = DEFAULT_NUM_CHAINS)]
@@ -153,15 +158,18 @@ impl Default for BenchmarkOptions {
 
 #[derive(Clone, clap::Subcommand, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
+/// The benchmarking subcommands.
 pub enum BenchmarkCommand {
     /// Start a single benchmark process, maintaining a given TPS.
     Single {
+        /// The benchmark options.
         #[command(flatten)]
         options: BenchmarkOptions,
     },
 
     /// Run multiple benchmark processes in parallel.
     Multi {
+        /// The benchmark options.
         #[command(flatten)]
         options: BenchmarkOptions,
 
@@ -191,6 +199,7 @@ pub enum BenchmarkCommand {
 }
 
 impl BenchmarkCommand {
+    /// Returns the number of transactions per block configured for this benchmark.
     pub fn transactions_per_block(&self) -> usize {
         match self {
             Self::Single { options } => options.transactions_per_block,
@@ -206,6 +215,7 @@ use crate::util::{
 };
 
 #[derive(Clone, clap::Subcommand)]
+#[allow(missing_docs)]
 pub enum ClientCommand {
     /// Transfer funds
     Transfer {
@@ -1157,6 +1167,7 @@ impl ClientCommand {
 }
 
 #[derive(Clone, clap::Parser)]
+/// The subcommands for managing the storage database.
 pub enum DatabaseToolCommand {
     /// Delete all the namespaces in the database
     DeleteAll,
@@ -1169,6 +1180,7 @@ pub enum DatabaseToolCommand {
 
     /// Initialize a namespace in the database
     Initialize {
+        /// The path to the genesis configuration file.
         #[arg(long = "genesis")]
         genesis_config_path: PathBuf,
     },
@@ -1185,6 +1197,7 @@ pub enum DatabaseToolCommand {
 
 #[expect(clippy::large_enum_variant)]
 #[derive(Clone, clap::Parser)]
+/// The subcommands for managing a local Linera network.
 pub enum NetCommand {
     /// Start a Local Linera Network
     Up {
@@ -1319,6 +1332,7 @@ pub enum NetCommand {
 }
 
 #[derive(Clone, clap::Subcommand)]
+/// The subcommands for managing the wallet.
 pub enum WalletCommand {
     /// Show the contents of the wallet.
     Show {
@@ -1333,7 +1347,10 @@ pub enum WalletCommand {
     },
 
     /// Change the wallet default chain.
-    SetDefault { chain_id: ChainId },
+    SetDefault {
+        /// The chain to set as the default.
+        chain_id: ChainId,
+    },
 
     /// Initialize a wallet from the genesis configuration.
     Init {
@@ -1388,13 +1405,20 @@ pub enum WalletCommand {
 
     /// Forgets the specified chain's keys. The chain will still be followed by the
     /// wallet.
-    ForgetKeys { chain_id: ChainId },
+    ForgetKeys {
+        /// The chain whose keys will be forgotten.
+        chain_id: ChainId,
+    },
 
     /// Forgets the specified chain, including the associated key pair.
-    ForgetChain { chain_id: ChainId },
+    ForgetChain {
+        /// The chain to forget.
+        chain_id: ChainId,
+    },
 }
 
 #[derive(Clone, clap::Subcommand)]
+/// The subcommands for inspecting chains.
 pub enum ChainCommand {
     /// Show the contents of a block.
     ShowBlock {
@@ -1414,6 +1438,7 @@ pub enum ChainCommand {
 }
 
 #[derive(Clone, clap::Parser)]
+/// The subcommands for managing Linera projects.
 pub enum ProjectCommand {
     /// Create a new Linera project.
     New {
@@ -1428,7 +1453,10 @@ pub enum ProjectCommand {
     /// Test a Linera project.
     ///
     /// Equivalent to running `cargo test` with the appropriate test runner.
-    Test { path: Option<PathBuf> },
+    Test {
+        /// The path of the root of the Linera project to test.
+        path: Option<PathBuf>,
+    },
 
     /// Build and publish a Linera project.
     PublishAndCreate {

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -214,8 +214,8 @@ use crate::util::{
     DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS, DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS,
 };
 
+/// The subcommands of the Linera client binary.
 #[derive(Clone, clap::Subcommand)]
-#[allow(missing_docs)]
 pub enum ClientCommand {
     /// Transfer funds
     Transfer {
@@ -257,9 +257,11 @@ pub enum ClientCommand {
         #[arg(long = "from")]
         chain_id: Option<ChainId>,
 
+        /// Options configuring the new chain's ownership.
         #[clap(flatten)]
         ownership_config: ChainOwnershipConfig,
 
+        /// Options configuring the new chain's application permissions.
         #[clap(flatten)]
         application_permissions_config: ApplicationPermissionsConfig,
 
@@ -285,6 +287,7 @@ pub enum ClientCommand {
         #[clap(long)]
         chain_id: Option<ChainId>,
 
+        /// Options configuring the new chain's ownership.
         #[clap(flatten)]
         ownership_config: ChainOwnershipConfig,
     },
@@ -306,6 +309,7 @@ pub enum ClientCommand {
         #[arg(long)]
         chain_id: Option<ChainId>,
 
+        /// Options configuring the new chain's application permissions.
         #[clap(flatten)]
         application_permissions_config: ApplicationPermissionsConfig,
     },
@@ -387,7 +391,10 @@ pub enum ClientCommand {
     },
 
     /// Deprecates all committees up to and including the specified one.
-    RevokeEpochs { epoch: Epoch },
+    RevokeEpochs {
+        /// The highest epoch to deprecate.
+        epoch: Epoch,
+    },
 
     /// View or update the resource control policy
     ResourceControlPolicy {
@@ -770,6 +777,7 @@ pub enum ClientCommand {
 
     /// Run a GraphQL service to explore and extend the chains of the wallet.
     Service {
+        /// Configuration for the chain listener backing the service.
         #[command(flatten)]
         config: ChainListenerConfig,
 

--- a/linera-service/src/cli/common_options.rs
+++ b/linera-service/src/cli/common_options.rs
@@ -59,6 +59,7 @@ pub struct CommonCliOptions {
 }
 
 impl CommonCliOptions {
+    /// Returns the wallet-specific suffix used when resolving paths and environment variables.
     pub fn suffix(&self) -> String {
         self.with_wallet
             .as_ref()
@@ -66,6 +67,7 @@ impl CommonCliOptions {
             .unwrap_or_default()
     }
 
+    /// Resolves the storage configuration from CLI options, environment variables, or defaults.
     pub fn storage_config(&self) -> Result<StorageConfig, Error> {
         if let Some(config) = &self.storage_config {
             return config.parse();
@@ -94,22 +96,27 @@ impl CommonCliOptions {
         }
     }
 
+    /// Returns the path to the wallet file.
     pub fn wallet_path(&self) -> Result<PathBuf, Error> {
         linera_wallet_json::paths::wallet_path(self.wallet_state_path.as_ref(), &self.suffix())
     }
 
+    /// Returns the path to the keystore file.
     pub fn keystore_path(&self) -> Result<PathBuf, Error> {
         linera_wallet_json::paths::keystore_path(self.keystore_path.as_ref(), &self.suffix())
     }
 
+    /// Reads and returns the wallet.
     pub fn wallet(&self) -> Result<Wallet, Error> {
         Ok(Wallet::read(&self.wallet_path()?)?)
     }
 
+    /// Reads and returns the keystore.
     pub fn keystore(&self) -> Result<linera_wallet_json::Keystore, Error> {
         Ok(linera_wallet_json::Keystore::read(&self.keystore_path()?)?)
     }
 
+    /// Creates and saves a new wallet from the given genesis configuration.
     pub fn create_wallet(&self, genesis_config: GenesisConfig) -> Result<Wallet, Error> {
         let wallet_path = self.wallet_path()?;
         if wallet_path.exists() {
@@ -120,6 +127,7 @@ impl CommonCliOptions {
         Ok(wallet)
     }
 
+    /// Creates and saves a new keystore, optionally seeded for deterministic testing.
     pub fn create_keystore(
         &self,
         testing_prng_seed: Option<u64>,

--- a/linera-service/src/cli/mod.rs
+++ b/linera-service/src/cli/mod.rs
@@ -3,8 +3,11 @@
 
 //! Helper module for the Linera CLI binary.
 
+/// The command-line subcommands for the Linera client binary.
 pub mod command;
+/// Options shared across multiple command-line subcommands.
 pub mod common_options;
+/// Helpers for the `net up` command that spins up a local network.
 pub mod net_up_utils;
 pub mod validator;
 pub mod validator_benchmark;

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -104,6 +104,7 @@ impl StorageConfigProvider {
     }
 }
 
+/// Starts a local test network and, optionally, a faucet and block exporter.
 #[expect(clippy::too_many_arguments)]
 #[cfg(feature = "kubernetes")]
 pub async fn handle_net_up_kubernetes(
@@ -185,6 +186,7 @@ pub async fn handle_net_up_kubernetes(
     wait_for_shutdown(shutdown_notifier, &mut net, faucet_service).await
 }
 
+/// Starts a local test network using native processes and, optionally, a faucet and block exporter.
 #[expect(clippy::too_many_arguments)]
 pub async fn handle_net_up_service(
     num_other_initial_chains: u32,

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -45,6 +45,7 @@ impl FromStr for Votes {
 /// Specification for a validator to add or modify.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(missing_docs)]
 pub struct Spec {
     pub public_key: ValidatorPublicKey,
     pub account_key: AccountPublicKey,
@@ -56,6 +57,7 @@ pub struct Spec {
 /// Represents an update to a validator's configuration in batch operations.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(missing_docs)]
 pub struct Change {
     pub account_key: AccountPublicKey,
     pub address: url::Url,
@@ -72,12 +74,14 @@ pub type BatchFile = HashMap<ValidatorPublicKey, Option<Change>>;
 
 /// Structure for batch validator queries from JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
 pub struct QueryBatch {
     pub validators: Vec<Spec>,
 }
 
 /// Validator subcommands.
 #[derive(Debug, Clone, clap::Subcommand)]
+#[allow(missing_docs)]
 pub enum Command {
     Add(Add),
     BatchQuery(BatchQuery),

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -45,11 +45,14 @@ impl FromStr for Votes {
 /// Specification for a validator to add or modify.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(missing_docs)]
 pub struct Spec {
+    /// The validator's public key, identifying it on the network.
     pub public_key: ValidatorPublicKey,
+    /// The public key of the validator's chain account.
     pub account_key: AccountPublicKey,
+    /// The network address at which the validator can be reached.
     pub network_address: url::Url,
+    /// The voting weight assigned to the validator.
     #[serde(default)]
     pub votes: Votes,
 }
@@ -57,10 +60,12 @@ pub struct Spec {
 /// Represents an update to a validator's configuration in batch operations.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(missing_docs)]
 pub struct Change {
+    /// The new public key for the validator's chain account.
     pub account_key: AccountPublicKey,
+    /// The new network address at which the validator can be reached.
     pub address: url::Url,
+    /// The new voting weight assigned to the validator.
     #[serde(default)]
     pub votes: Votes,
 }
@@ -74,12 +79,15 @@ pub type BatchFile = HashMap<ValidatorPublicKey, Option<Change>>;
 
 /// Structure for batch validator queries from JSON file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[allow(missing_docs)]
 pub struct QueryBatch {
+    /// The validators to query.
     pub validators: Vec<Spec>,
 }
 
 /// Validator subcommands.
+// Each variant delegates to a documented args struct; giving the variant its own
+// doc comment would shadow that struct's richer `--help` text, so `missing_docs`
+// is allowed here rather than duplicating those docs.
 #[derive(Debug, Clone, clap::Subcommand)]
 #[allow(missing_docs)]
 pub enum Command {

--- a/linera-service/src/cli/validator_benchmark/mod.rs
+++ b/linera-service/src/cli/validator_benchmark/mod.rs
@@ -34,6 +34,7 @@ use self::{
 };
 
 impl Benchmark {
+    /// Runs the pre-onboarding benchmark against the candidate validator.
     pub async fn run(
         &self,
         context: &mut ClientContext<

--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -10,13 +10,18 @@ use tokio::process::Command;
 
 use crate::cli_wrappers::local_kubernetes_net::BuildMode;
 
+/// A Dockerfile used to build one of the Linera images.
 pub enum Dockerfile {
+    /// The main Linera node Dockerfile.
     Main,
+    /// The indexer Dockerfile.
     Indexer,
+    /// The explorer Dockerfile.
     Explorer,
 }
 
 impl Dockerfile {
+    /// Returns the path to this Dockerfile, relative to the repository root.
     pub fn path(&self) -> &'static str {
         match self {
             Dockerfile::Main => "docker/Dockerfile",
@@ -26,15 +31,18 @@ impl Dockerfile {
     }
 }
 
+/// A Docker image built from the Linera sources.
 pub struct DockerImage {
     name: String,
 }
 
 impl DockerImage {
+    /// Returns the name of the Docker image.
     pub fn name(&self) -> &String {
         &self.name
     }
 
+    /// Builds the Docker image from the given Dockerfile and returns it.
     pub async fn build(
         name: String,
         binaries: BuildArg,

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -36,9 +36,10 @@ static SHARED_LOCAL_KUBERNETES_TESTING_NET: OnceCell<(
 
 /// Whether to build the binaries in debug or release mode.
 #[derive(Clone, clap::Parser, clap::ValueEnum, Debug, Default)]
-#[allow(missing_docs)]
 pub enum BuildMode {
+    /// Builds the binaries in debug mode.
     Debug,
+    /// Builds the binaries in release mode.
     #[default]
     Release,
 }
@@ -58,22 +59,36 @@ impl std::fmt::Display for BuildMode {
 }
 
 /// The information needed to start a [`LocalKubernetesNet`].
-#[allow(missing_docs)]
 pub struct LocalKubernetesNetConfig {
+    /// The network configuration shared by the validators.
     pub network: Network,
+    /// The seed used to make key generation deterministic in tests, if any.
     pub testing_prng_seed: Option<u64>,
+    /// The number of additional chains to create in the genesis configuration.
     pub num_other_initial_chains: u32,
+    /// The initial balance granted to each genesis chain.
     pub initial_amount: Amount,
+    /// The number of validators to start.
     pub num_initial_validators: usize,
+    /// The number of shards to run per validator.
     pub num_shards: usize,
+    /// The source of the binaries baked into the Docker image.
     pub binaries: BuildArg,
+    /// Whether to skip building the Docker image.
     pub no_build: bool,
+    /// The name of the Docker image to run for the validators.
     pub docker_image_name: String,
+    /// The mode used to build the binaries.
     pub build_mode: BuildMode,
+    /// The resource control policy applied by the validators.
     pub policy_config: ResourceControlPolicyConfig,
+    /// The number of block exporters to run per validator.
     pub num_block_exporters: usize,
+    /// The name of the Docker image to run for the indexer.
     pub indexer_image_name: String,
+    /// The name of the Docker image to run for the explorer.
     pub explorer_image_name: String,
+    /// Whether to use dual storage for the validators.
     pub dual_store: bool,
 }
 

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -34,7 +34,9 @@ static SHARED_LOCAL_KUBERNETES_TESTING_NET: OnceCell<(
     ClientWrapper,
 )> = OnceCell::const_new();
 
+/// Whether to build the binaries in debug or release mode.
 #[derive(Clone, clap::Parser, clap::ValueEnum, Debug, Default)]
+#[allow(missing_docs)]
 pub enum BuildMode {
     Debug,
     #[default]
@@ -56,6 +58,7 @@ impl std::fmt::Display for BuildMode {
 }
 
 /// The information needed to start a [`LocalKubernetesNet`].
+#[allow(missing_docs)]
 pub struct LocalKubernetesNetConfig {
     pub network: Network,
     pub testing_prng_seed: Option<u64>,
@@ -102,6 +105,7 @@ pub struct LocalKubernetesNet {
 
 #[cfg(with_testing)]
 impl SharedLocalKubernetesNetTestingConfig {
+    /// Creates a new configuration for a shared local Kubernetes testing network.
     // The second argument is sometimes used locally to use specific binaries for tests.
     pub fn new(network: Network, mut binaries: BuildArg) -> Self {
         if std::env::var("LINERA_TRY_RELEASE_BINARIES").unwrap_or_default() == "true"

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -49,6 +49,8 @@ use crate::{
 /// Maximum allowed number of shards over all validators.
 const MAX_NUMBER_SHARDS: usize = 1000;
 
+/// Whether to process the inbox automatically before an operation.
+#[allow(missing_docs)]
 pub enum ProcessInbox {
     Skip,
     Automatic,
@@ -118,6 +120,8 @@ async fn make_testing_config(database: Database) -> Result<InnerStorageConfig> {
     }
 }
 
+/// A way to obtain the storage configuration for a local network.
+#[allow(missing_docs)]
 pub enum InnerStorageConfigBuilder {
     #[cfg(with_testing)]
     TestConfig,
@@ -127,6 +131,7 @@ pub enum InnerStorageConfigBuilder {
 }
 
 impl InnerStorageConfigBuilder {
+    /// Builds the storage configuration for the given database engine.
     #[cfg_attr(not(with_testing), expect(unused_variables))]
     pub async fn build(self, database: Database) -> Result<InnerStorageConfig> {
         match self {
@@ -140,12 +145,14 @@ impl InnerStorageConfigBuilder {
 /// Path used for the run can come from a path whose lifetime is controlled
 /// by an external user or as a temporary directory
 #[derive(Clone)]
+#[allow(missing_docs)]
 pub enum PathProvider {
     ExternalPath { path_buf: PathBuf },
     TemporaryDirectory { tmp_dir: Arc<TempDir> },
 }
 
 impl PathProvider {
+    /// Returns the path managed by this provider.
     pub fn path(&self) -> &Path {
         match self {
             PathProvider::ExternalPath { path_buf } => path_buf.as_path(),
@@ -153,11 +160,13 @@ impl PathProvider {
         }
     }
 
+    /// Creates a provider backed by a freshly created temporary directory.
     pub fn create_temporary_directory() -> Result<Self> {
         let tmp_dir = Arc::new(tempdir()?);
         Ok(PathProvider::TemporaryDirectory { tmp_dir })
     }
 
+    /// Creates a provider from the given path, or a temporary directory if `None`.
     pub fn from_path_option(path: &Option<String>) -> anyhow::Result<Self> {
         Ok(match path {
             None => {
@@ -174,6 +183,7 @@ impl PathProvider {
 }
 
 /// The information needed to start a [`LocalNet`].
+#[allow(missing_docs)]
 pub struct LocalNetConfig {
     pub database: Database,
     pub network: NetworkConfig,
@@ -194,6 +204,7 @@ pub struct LocalNetConfig {
 
 /// The setup for the block exporters.
 #[derive(Clone, PartialEq)]
+#[allow(missing_docs)]
 pub enum ExportersSetup {
     // Block exporters are meant to be started and managed by the testing framework.
     Local(Vec<BlockExporterConfig>),
@@ -202,6 +213,7 @@ pub enum ExportersSetup {
 }
 
 impl ExportersSetup {
+    /// Creates an exporter setup, connecting to a remote exporter if requested.
     pub fn new(
         with_block_exporter: bool,
         block_exporter_address: String,
@@ -241,6 +253,7 @@ const SERVER_ENV: &str = "LINERA_SERVER_PARAMS";
 
 /// Description of the database engine to use inside a local Linera network.
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[allow(missing_docs)]
 pub enum Database {
     Service,
     ScyllaDb,
@@ -314,6 +327,7 @@ impl Validator {
 
 #[cfg(with_testing)]
 impl LocalNetConfig {
+    /// Creates a configuration for a local test network with default test parameters.
     pub fn new_test(database: Database, network: Network) -> Self {
         let num_shards = 4;
         let num_proxies = 1;
@@ -461,6 +475,7 @@ impl LocalNet {
     }
 
     #[cfg(with_testing)]
+    /// Reads the genesis configuration of the local network.
     pub fn genesis_config(&self) -> Result<linera_client::config::GenesisConfig> {
         let path = self.path_provider.path();
         crate::util::read_json(path.join("genesis.json"))
@@ -486,10 +501,12 @@ impl LocalNet {
         test_offset_port() + 5000 + validator * self.num_shards + exporter_id + 1
     }
 
+    /// Returns the public port of the given proxy of the given validator.
     pub fn proxy_public_port(&self, validator: usize, proxy_id: usize) -> usize {
         test_offset_port() + 4000 + validator * self.num_proxies + proxy_id + 1
     }
 
+    /// Returns the public port of the first proxy of the first validator.
     pub fn first_public_port() -> usize {
         test_offset_port() + 4000 + 1
     }
@@ -795,6 +812,7 @@ impl LocalNet {
         Ok(child)
     }
 
+    /// Waits until the gRPC server at the given port responds as healthy.
     pub async fn ensure_grpc_server_has_started(
         nickname: &str,
         port: usize,
@@ -1004,6 +1022,7 @@ impl LocalNet {
         self.validator_keys.get(&validator)
     }
 
+    /// Generates the configuration and keys for the given validator.
     pub async fn generate_validator_config(&mut self, validator: usize) -> Result<()> {
         let stdout = self
             .command_for_binary("linera-server")
@@ -1023,6 +1042,7 @@ impl LocalNet {
         Ok(())
     }
 
+    /// Terminates the server for the given shard of the given validator.
     pub async fn terminate_server(&mut self, validator: usize, shard: usize) -> Result<()> {
         self.running_validators
             .get_mut(&validator)
@@ -1032,6 +1052,7 @@ impl LocalNet {
         Ok(())
     }
 
+    /// Removes the given validator from the set of running validators.
     pub fn remove_validator(&mut self, validator: usize) -> Result<()> {
         self.running_validators
             .remove(&validator)
@@ -1039,6 +1060,7 @@ impl LocalNet {
         Ok(())
     }
 
+    /// Starts the server for the given shard of the given validator.
     pub async fn start_server(&mut self, validator: usize, shard: usize) -> Result<()> {
         let server = self.run_server(validator, shard).await?;
         self.running_validators

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -50,9 +50,10 @@ use crate::{
 const MAX_NUMBER_SHARDS: usize = 1000;
 
 /// Whether to process the inbox automatically before an operation.
-#[allow(missing_docs)]
 pub enum ProcessInbox {
+    /// Leaves the inbox untouched before the operation.
     Skip,
+    /// Processes the inbox automatically before the operation.
     Automatic,
 }
 
@@ -121,11 +122,13 @@ async fn make_testing_config(database: Database) -> Result<InnerStorageConfig> {
 }
 
 /// A way to obtain the storage configuration for a local network.
-#[allow(missing_docs)]
 pub enum InnerStorageConfigBuilder {
+    /// Derives a fresh test storage configuration for the database engine.
     #[cfg(with_testing)]
     TestConfig,
+    /// Uses a storage configuration that was already created.
     ExistingConfig {
+        /// The storage configuration to use as-is.
         storage_config: InnerStorageConfig,
     },
 }
@@ -145,10 +148,17 @@ impl InnerStorageConfigBuilder {
 /// Path used for the run can come from a path whose lifetime is controlled
 /// by an external user or as a temporary directory
 #[derive(Clone)]
-#[allow(missing_docs)]
 pub enum PathProvider {
-    ExternalPath { path_buf: PathBuf },
-    TemporaryDirectory { tmp_dir: Arc<TempDir> },
+    /// A path supplied by the caller, whose lifetime is managed externally.
+    ExternalPath {
+        /// The externally managed path.
+        path_buf: PathBuf,
+    },
+    /// A temporary directory created and owned by this provider.
+    TemporaryDirectory {
+        /// The temporary directory backing the path.
+        tmp_dir: Arc<TempDir>,
+    },
 }
 
 impl PathProvider {
@@ -183,32 +193,45 @@ impl PathProvider {
 }
 
 /// The information needed to start a [`LocalNet`].
-#[allow(missing_docs)]
 pub struct LocalNetConfig {
+    /// The database engine backing the validators' storage.
     pub database: Database,
+    /// The network configuration shared by the validators.
     pub network: NetworkConfig,
+    /// The seed used to make key generation deterministic in tests, if any.
     pub testing_prng_seed: Option<u64>,
+    /// The storage namespace shared by the validators.
     pub namespace: String,
+    /// The number of additional chains to create in the genesis configuration.
     pub num_other_initial_chains: u32,
+    /// The initial balance granted to each genesis chain.
     pub initial_amount: Amount,
+    /// The number of validators to start.
     pub num_initial_validators: usize,
+    /// The number of shards to run per validator.
     pub num_shards: usize,
+    /// The number of proxies to run per validator.
     pub num_proxies: usize,
+    /// The resource control policy applied by the validators.
     pub policy_config: ResourceControlPolicyConfig,
+    /// The list of hosts that applications are allowed to send HTTP requests to, if restricted.
     pub http_request_allow_list: Option<Vec<String>>,
+    /// The cross-chain message configuration shared by the validators.
     pub cross_chain_config: CrossChainConfig,
+    /// The builder used to obtain the storage configuration.
     pub storage_config_builder: InnerStorageConfigBuilder,
+    /// The provider of the working path for the network.
     pub path_provider: PathProvider,
+    /// The setup describing how block exporters are run or reached.
     pub block_exporters: ExportersSetup,
 }
 
 /// The setup for the block exporters.
 #[derive(Clone, PartialEq)]
-#[allow(missing_docs)]
 pub enum ExportersSetup {
-    // Block exporters are meant to be started and managed by the testing framework.
+    /// Block exporters are meant to be started and managed by the testing framework.
     Local(Vec<BlockExporterConfig>),
-    // Block exporters are already started and we just need to connect to them.
+    /// Block exporters are already started and we just need to connect to them.
     Remote(Vec<ExporterServiceConfig>),
 }
 
@@ -253,10 +276,12 @@ const SERVER_ENV: &str = "LINERA_SERVER_PARAMS";
 
 /// Description of the database engine to use inside a local Linera network.
 #[derive(Copy, Clone, Eq, PartialEq)]
-#[allow(missing_docs)]
 pub enum Database {
+    /// The in-memory storage service.
     Service,
+    /// ScyllaDB-backed storage.
     ScyllaDb,
+    /// Dual storage combining RocksDB and ScyllaDB.
     DualRocksDbScyllaDb,
 }
 

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -63,11 +63,14 @@ pub trait LineraNet {
 
 /// Network protocol in use
 #[derive(Copy, Clone)]
-#[allow(missing_docs)]
 pub enum Network {
+    /// gRPC over cleartext (unencrypted) HTTP/2.
     Grpc,
+    /// gRPC over TLS.
     Grpcs,
+    /// A simple transport protocol over TCP.
     Tcp,
+    /// A simple transport protocol over UDP.
     Udp,
 }
 

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -41,23 +41,29 @@ pub use wallet::{ApplicationWrapper, ClientWrapper, FaucetService, NodeService, 
 /// The information needed to start a Linera net of a particular kind.
 #[async_trait]
 pub trait LineraNetConfig {
+    /// The type of Linera net produced by this configuration.
     type Net: LineraNet + Sized + Send + Sync + 'static;
 
+    /// Starts the Linera net and returns it together with a client to interact with it.
     async fn instantiate(self) -> Result<(Self::Net, ClientWrapper)>;
 }
 
 /// A running Linera net.
 #[async_trait]
 pub trait LineraNet {
+    /// Checks that the net is still running and returns an error otherwise.
     async fn ensure_is_running(&mut self) -> Result<()>;
 
+    /// Creates a new client to interact with the net.
     async fn make_client(&mut self) -> ClientWrapper;
 
+    /// Shuts down the net.
     async fn terminate(&mut self) -> Result<()>;
 }
 
 /// Network protocol in use
 #[derive(Copy, Clone)]
+#[allow(missing_docs)]
 pub enum Network {
     Grpc,
     Grpcs,
@@ -84,6 +90,7 @@ impl Network {
         }
     }
 
+    /// Returns a short lowercase name for the network protocol.
     pub fn short(&self) -> &'static str {
         match self {
             Network::Grpc => "grpc",
@@ -93,6 +100,7 @@ impl Network {
         }
     }
 
+    /// Returns the equivalent network protocol without TLS.
     pub fn drop_tls(&self) -> Self {
         match self {
             Network::Grpc => Network::Grpc,
@@ -102,6 +110,7 @@ impl Network {
         }
     }
 
+    /// Returns the localhost address to use for this network protocol.
     pub fn localhost(&self) -> &'static str {
         match self {
             Network::Grpc | Network::Grpcs => "localhost",

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -14,6 +14,7 @@ use super::{
     OnClientDrop,
 };
 
+/// Configuration for connecting to an external (remote) Linera network in tests.
 pub struct RemoteNetTestingConfig {
     faucet: Faucet,
     close_chains: OnClientDrop,

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -81,6 +81,7 @@ pub struct ClientWrapper {
     wallet: String,
     keystore: String,
     network: Network,
+    /// Provides the working directory for the client and its files.
     pub path_provider: PathProvider,
     on_drop: OnClientDrop,
     extra_args: Vec<String>,
@@ -96,6 +97,7 @@ pub enum OnClientDrop {
 }
 
 impl ClientWrapper {
+    /// Creates a new [`ClientWrapper`], waiting for outgoing messages by default.
     pub fn new(
         path_provider: PathProvider,
         network: Network,
@@ -113,6 +115,7 @@ impl ClientWrapper {
         )
     }
 
+    /// Creates a new [`ClientWrapper`] with the given extra arguments passed to every command.
     pub fn new_with_extra_args(
         path_provider: PathProvider,
         network: Network,
@@ -985,6 +988,7 @@ impl ClientWrapper {
         Ok(new_chain)
     }
 
+    /// Runs `linera open-multi-owner-chain` and returns the new chain's ID.
     pub async fn open_multi_owner_chain(
         &self,
         from: ChainId,
@@ -1011,6 +1015,7 @@ impl ClientWrapper {
         Ok(chain_id)
     }
 
+    /// Runs `linera change-ownership`.
     pub async fn change_ownership(
         &self,
         chain_id: ChainId,
@@ -1067,6 +1072,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera retry-pending-block` and returns the hash of the produced block, if any.
     pub async fn retry_pending_block(
         &self,
         chain_id: Option<ChainId>,
@@ -1112,26 +1118,32 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Loads the wallet from this client's wallet file.
     pub fn load_wallet(&self) -> Result<Wallet> {
         Ok(Wallet::read(&self.wallet_path())?)
     }
 
+    /// Loads the in-memory signer from this client's keystore file.
     pub fn load_keystore(&self) -> Result<InMemorySigner> {
         util::read_json(self.keystore_path())
     }
 
+    /// Returns the path to this client's wallet file.
     pub fn wallet_path(&self) -> PathBuf {
         self.path_provider.path().join(&self.wallet)
     }
 
+    /// Returns the path to this client's keystore file.
     pub fn keystore_path(&self) -> PathBuf {
         self.path_provider.path().join(&self.keystore)
     }
 
+    /// Returns the storage specification string used by this client.
     pub fn storage_path(&self) -> &str {
         &self.storage
     }
 
+    /// Returns the owner of the wallet's default chain, if any.
     pub fn get_owner(&self) -> Option<AccountOwner> {
         let wallet = self.load_wallet().ok()?;
         wallet
@@ -1140,12 +1152,14 @@ impl ClientWrapper {
             .owner
     }
 
+    /// Returns whether the given chain is present in the wallet.
     pub fn is_chain_present_in_wallet(&self, chain: ChainId) -> bool {
         self.load_wallet()
             .ok()
             .is_some_and(|wallet| wallet.get(chain).is_some())
     }
 
+    /// Runs `linera validator add`.
     pub async fn set_validator(
         &self,
         validator_key: &(String, String),
@@ -1166,6 +1180,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera validator remove`.
     pub async fn remove_validator(&self, validator_key: &str) -> Result<()> {
         self.command()
             .await?
@@ -1177,6 +1192,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera validator update` to add, modify, and remove validators in one call.
     pub async fn change_validators(
         &self,
         add_validators: &[(String, String, usize, usize)], // (public_key, account_key, port, votes)
@@ -1243,6 +1259,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera revoke-epochs`.
     pub async fn revoke_epochs(&self, epoch: Epoch) -> Result<()> {
         self.command()
             .await?
@@ -1253,6 +1270,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera resource-control-policy --http-request-allow-list`.
     pub async fn change_http_whitelist(&self, list: &[&str]) -> Result<()> {
         self.command()
             .await?
@@ -1313,6 +1331,7 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Builds the application at `path` with `cargo` and returns its contract and service paths.
     pub async fn build_application(
         &self,
         path: &Path,
@@ -1420,11 +1439,13 @@ impl Drop for ClientWrapper {
 
 #[cfg(with_testing)]
 impl ClientWrapper {
+    /// Builds the example application with the given name and returns its contract and service paths.
     pub async fn build_example(&self, name: &str) -> Result<(PathBuf, PathBuf)> {
         self.build_application(Self::example_path(name)?.as_path(), name, true)
             .await
     }
 
+    /// Returns the path to the example application with the given name.
     pub fn example_path(name: &str) -> Result<PathBuf> {
         Ok(env::current_dir()?.join("../examples/").join(name))
     }
@@ -1460,30 +1481,36 @@ impl NodeService {
         Self { port, child }
     }
 
+    /// Terminates the node service by killing its child process.
     pub async fn terminate(mut self) -> Result<()> {
         self.child.kill().await.context("terminating node service")
     }
 
+    /// Returns the port the node service is listening on.
     pub fn port(&self) -> u16 {
         self.port
     }
 
+    /// Checks that the node service child process is still running.
     pub fn ensure_is_running(&mut self) -> Result<()> {
         self.child.ensure_is_running()
     }
 
+    /// Issues a `processInbox` GraphQL mutation and returns the hashes of the created blocks.
     pub async fn process_inbox(&self, chain_id: &ChainId) -> Result<Vec<CryptoHash>> {
         let query = format!("mutation {{ processInbox(chainId: \"{chain_id}\") }}");
         let mut data = self.query_node(query).await?;
         Ok(serde_json::from_value(data["processInbox"].take())?)
     }
 
+    /// Issues a `sync` GraphQL mutation for the given chain and returns the new block height.
     pub async fn sync(&self, chain_id: &ChainId) -> Result<u64> {
         let query = format!("mutation {{ sync(chainId: \"{chain_id}\") }}");
         let mut data = self.query_node(query).await?;
         Ok(serde_json::from_value(data["sync"].take())?)
     }
 
+    /// Issues a `transfer` GraphQL mutation and returns the resulting block hash.
     pub async fn transfer(
         &self,
         chain_id: ChainId,
@@ -1506,6 +1533,7 @@ impl NodeService {
             .context("missing transfer field in response")
     }
 
+    /// Queries the balance of the given account via GraphQL.
     pub async fn balance(&self, account: &Account) -> Result<Amount> {
         let chain = account.chain_id;
         let owner = account.owner;
@@ -1537,6 +1565,7 @@ impl NodeService {
         }
     }
 
+    /// Returns an [`ApplicationWrapper`] for querying the given application on this node service.
     pub fn make_application<A: ContractAbi>(
         &self,
         chain_id: &ChainId,
@@ -1550,6 +1579,7 @@ impl NodeService {
         Ok(ApplicationWrapper::from(link))
     }
 
+    /// Issues a `publishDataBlob` GraphQL mutation and returns the blob's hash.
     pub async fn publish_data_blob(
         &self,
         chain_id: &ChainId,
@@ -1565,6 +1595,7 @@ impl NodeService {
             .context("missing publishDataBlob field in response")
     }
 
+    /// Issues a `publishModule` GraphQL mutation and returns the new module ID.
     pub async fn publish_module<Abi, Parameters, InstantiationArgument>(
         &self,
         chain_id: &ChainId,
@@ -1589,6 +1620,7 @@ impl NodeService {
         Ok(module_id.with_abi())
     }
 
+    /// Queries the committees of the given chain via GraphQL.
     pub async fn query_committees(&self, chain_id: &ChainId) -> Result<BTreeMap<Epoch, Committee>> {
         let query = format!(
             "query {{ chain(chainId:\"{chain_id}\") {{
@@ -1600,6 +1632,7 @@ impl NodeService {
         Ok(serde_json::from_value(committees)?)
     }
 
+    /// Issues an `eventsFromIndex` GraphQL query for events on the given chain and stream.
     pub async fn events_from_index(
         &self,
         chain_id: &ChainId,
@@ -1618,6 +1651,7 @@ impl NodeService {
         Ok(serde_json::from_value(response)?)
     }
 
+    /// Posts the given GraphQL query to the node service, retrying on timeouts and errors.
     pub async fn query_node(&self, query: impl AsRef<str>) -> Result<Value> {
         let n_try = 5;
         let query = query.as_ref();
@@ -1670,6 +1704,7 @@ impl NodeService {
         );
     }
 
+    /// Issues a `createApplication` GraphQL mutation and returns the new application ID.
     pub async fn create_application<
         Abi: ContractAbi,
         Parameters: Serialize,
@@ -1860,6 +1895,7 @@ impl FaucetService {
         }
     }
 
+    /// Terminates the faucet service by killing its child process.
     pub async fn terminate(mut self) -> Result<()> {
         self.child
             .kill()
@@ -1867,10 +1903,12 @@ impl FaucetService {
             .context("terminating faucet service")
     }
 
+    /// Checks that the faucet service child process is still running.
     pub fn ensure_is_running(&mut self) -> Result<()> {
         self.child.ensure_is_running()
     }
 
+    /// Returns a [`Faucet`] client connected to this running faucet service.
     pub fn instance(&self) -> Faucet {
         Faucet::new(format!("http://localhost:{}/", self.port))
     }
@@ -1883,12 +1921,14 @@ pub struct ApplicationWrapper<A> {
 }
 
 impl<A> ApplicationWrapper<A> {
+    /// Runs the given GraphQL query against the application and returns the response data.
     pub async fn run_graphql_query(&self, query: impl AsRef<str>) -> Result<Value> {
         let query = query.as_ref();
         let value = self.run_json_query(json!({ "query": query })).await?;
         Ok(value["data"].clone())
     }
 
+    /// Posts the given serializable JSON query to the application endpoint, retrying on failure.
     pub async fn run_json_query<T: Serialize>(&self, query: T) -> Result<Value> {
         const MAX_RETRIES: usize = 5;
 
@@ -1932,12 +1972,14 @@ impl<A> ApplicationWrapper<A> {
         unreachable!()
     }
 
+    /// Runs the given string as a GraphQL `query` and returns the response data.
     pub async fn query(&self, query: impl AsRef<str>) -> Result<Value> {
         let query = query.as_ref();
         self.run_graphql_query(&format!("query {{ {query} }}"))
             .await
     }
 
+    /// Runs the given string as a GraphQL `query` and deserializes the named field's value.
     pub async fn query_json<T: DeserializeOwned>(&self, query: impl AsRef<str>) -> Result<T> {
         let query = query.as_ref().trim();
         let name = query
@@ -1948,12 +1990,14 @@ impl<A> ApplicationWrapper<A> {
             .with_context(|| format!("{name} field missing in response"))
     }
 
+    /// Runs the given string as a GraphQL `mutation` and returns the response data.
     pub async fn mutate(&self, mutation: impl AsRef<str>) -> Result<Value> {
         let mutation = mutation.as_ref();
         self.run_graphql_query(&format!("mutation {{ {mutation} }}"))
             .await
     }
 
+    /// Runs several GraphQL mutations in a single aliased `mutation` request.
     pub async fn multiple_mutate(&self, mutations: &[String]) -> Result<Value> {
         let mut out = String::from("mutation {\n");
         for (index, mutation) in mutations.iter().enumerate() {
@@ -1992,6 +2036,7 @@ fn notification_timeout() -> Duration {
 }
 
 #[cfg(with_testing)]
+/// Extension trait for streams of [`Notification`]s, providing helpers to wait for events.
 pub trait NotificationsExt {
     /// Waits for a notification for which `f` returns `Some(t)`, and returns `t`.
     fn wait_for<T>(

--- a/linera-service/src/controller.rs
+++ b/linera-service/src/controller.rs
@@ -27,6 +27,7 @@ use crate::task_processor::{OperatorMap, TaskProcessor};
 /// An update message sent to a TaskProcessor to change its set of applications.
 #[derive(Debug)]
 pub struct Update {
+    /// The new set of applications the processor should handle.
     pub application_ids: Vec<ApplicationId>,
 }
 
@@ -34,6 +35,7 @@ struct ProcessorHandle {
     update_sender: mpsc::UnboundedSender<Update>,
 }
 
+/// Watches a controller chain and spawns task processors for its managed services.
 pub struct Controller<Ctx: ClientContext> {
     chain_id: ChainId,
     controller_id: ApplicationId,
@@ -54,6 +56,7 @@ where
     Ctx::Environment: 'static,
     <Ctx::Environment as linera_core::Environment>::Storage: Clone,
 {
+    /// Creates a new controller for the given controller chain.
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         chain_id: ChainId,
@@ -81,6 +84,7 @@ where
         }
     }
 
+    /// Runs the controller, watching for notifications until cancelled.
     pub async fn run(mut self) {
         info!(
             "Watching for notifications for controller chain {}",

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -3,18 +3,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![recursion_limit = "256"]
+#![deny(missing_docs)]
 
 //! This module provides the executables needed to operate a Linera service, including a placeholder wallet acting as a GraphQL service for user interfaces.
 
 pub mod cli;
 pub mod cli_wrappers;
+/// Configuration types for the service binaries.
 pub mod config;
+/// The controller that orchestrates worker services.
 pub mod controller;
+/// The GraphQL node service exposing wallet and chain state.
 pub mod node_service;
+/// Helpers for creating and building application projects.
 pub mod project;
+/// Tracking of GraphQL subscriptions by query.
 pub mod query_subscription;
+/// Storage backend selection for the service binaries.
 pub mod storage;
 pub mod task_processor;
+/// Assorted helper utilities for the service binaries.
 pub mod util;
 
 pub use linera_wallet_json::PersistentWallet as Wallet;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -112,6 +112,7 @@ impl OutputType for RawJson {
 }
 
 #[derive(SimpleObject, Serialize, Deserialize, Clone)]
+#[allow(missing_docs)]
 pub struct Chains {
     pub list: Vec<ChainId>,
     pub default: Option<ChainId>,
@@ -914,6 +915,7 @@ where
 }
 
 #[derive(SimpleObject)]
+#[allow(missing_docs)]
 pub struct ApplicationOverview {
     id: ApplicationId,
     description: ApplicationDescription,
@@ -1280,11 +1282,13 @@ where
         }
     }
 
+    /// Returns the socket address on which the metrics endpoint is served.
     #[cfg(with_metrics)]
     pub fn metrics_address(&self) -> SocketAddr {
         SocketAddr::from(([0, 0, 0, 0], self.metrics_port.get()))
     }
 
+    /// Builds the GraphQL schema served by the node service.
     pub fn schema(&self) -> NodeServiceSchema<C> {
         let query = QueryRoot {
             context: Arc::clone(&self.context),

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -111,10 +111,12 @@ impl OutputType for RawJson {
     }
 }
 
+/// The set of chains tracked by the wallet.
 #[derive(SimpleObject, Serialize, Deserialize, Clone)]
-#[allow(missing_docs)]
 pub struct Chains {
+    /// The IDs of the tracked chains.
     pub list: Vec<ChainId>,
+    /// The default chain of the wallet, if one is set.
     pub default: Option<ChainId>,
 }
 
@@ -914,8 +916,8 @@ where
     }
 }
 
+/// A summary of an application registered on a chain.
 #[derive(SimpleObject)]
-#[allow(missing_docs)]
 pub struct ApplicationOverview {
     id: ApplicationId,
     description: ApplicationDescription,

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -14,11 +14,13 @@ use current_platform::CURRENT_PLATFORM;
 use fs_err::File;
 use tracing::debug;
 
+/// A Linera application project on disk, rooted at a given directory.
 pub struct Project {
     root: PathBuf,
 }
 
 impl Project {
+    /// Creates a new application project from the template, scaffolding its files.
     pub fn create_new(name: &str, linera_root: Option<&Path>) -> Result<Self> {
         ensure!(
             !name.contains(std::path::is_separator),
@@ -70,6 +72,7 @@ impl Project {
         Ok(Self { root })
     }
 
+    /// Opens an existing application project at the given root directory.
     pub fn from_existing_project(root: PathBuf) -> Result<Self> {
         ensure!(
             root.exists(),
@@ -265,6 +268,7 @@ impl Project {
         (linera_sdk_dep, linera_sdk_dev_dep)
     }
 
+    /// Builds the project's contract and service to Wasm, returning their bytecode paths.
     pub fn build(&self, name: Option<String>) -> Result<(PathBuf, PathBuf), anyhow::Error> {
         let name = match name {
             Some(name) => name,

--- a/linera-service/src/query_subscription.rs
+++ b/linera-service/src/query_subscription.rs
@@ -19,7 +19,9 @@ use tracing::{debug, warn};
 /// A named GraphQL query string registered at startup via `--allow-subscription`.
 #[derive(Clone, Debug)]
 pub struct RegisteredQuery {
+    /// The operation name used to refer to the query.
     pub name: String,
+    /// The full GraphQL query string.
     pub query: String,
 }
 
@@ -64,8 +66,11 @@ pub fn parse_subscription_ttl(s: &str) -> Result<(String, u64), String> {
 /// Identifies a unique subscription target: a named query for a specific chain and application.
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
 pub struct SubscriptionKey {
+    /// The name of the registered query.
     pub name: String,
+    /// The chain the query runs against.
     pub chain_id: ChainId,
+    /// The application the query targets.
     pub application_id: ApplicationId,
 }
 

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -23,12 +23,14 @@ use linera_base::data_types::TimeDelta;
 pub use linera_client::util::*;
 use tracing::debug;
 
-// Exported for readme e2e tests.
+/// Default pause, in seconds, inserted after `linera service` commands in readme e2e tests.
 pub static DEFAULT_PAUSE_AFTER_LINERA_SERVICE_SECS: &str = "3";
+/// Default pause, in seconds, inserted after GraphQL mutations in readme e2e tests.
 pub static DEFAULT_PAUSE_AFTER_GQL_MUTATIONS_SECS: &str = "3";
 
 /// Extension trait for [`tokio::process::Child`].
 pub trait ChildExt: std::fmt::Debug {
+    /// Ensures the child process is still running, returning an error if it has exited.
     fn ensure_is_running(&mut self) -> Result<()>;
 }
 
@@ -42,10 +44,12 @@ impl ChildExt for tokio::process::Child {
     }
 }
 
+/// Reads and deserializes a JSON value from the file at the given path.
 pub fn read_json<T: serde::de::DeserializeOwned>(path: impl Into<std::path::PathBuf>) -> Result<T> {
     Ok(serde_json::from_reader(fs_err::File::open(path)?)?)
 }
 
+/// Expands to the name of the current test function.
 #[cfg(with_testing)]
 #[macro_export]
 macro_rules! test_name {
@@ -56,11 +60,13 @@ macro_rules! test_name {
     };
 }
 
+/// A reader over a Markdown document, used to extract embedded code blocks.
 pub struct Markdown<B> {
     buffer: B,
 }
 
 impl Markdown<BufReader<fs_err::File>> {
+    /// Opens the Markdown file at the given path.
     pub fn new(path: impl AsRef<Path>) -> std::io::Result<Self> {
         let buffer = BufReader::new(fs_err::File::open(path.as_ref())?);
         Ok(Self { buffer })
@@ -71,6 +77,7 @@ impl<B> Markdown<B>
 where
     B: BufRead,
 {
+    /// Extracts the embedded bash and GraphQL code blocks as a runnable bash script.
     #[expect(clippy::while_let_on_iterator)]
     pub fn extract_bash_script_to(
         self,
@@ -159,14 +166,17 @@ pub(crate) async fn graphiql(uri: Uri) -> impl IntoResponse {
     response::Html(source)
 }
 
+/// Parses a string of milliseconds into a [`Duration`].
 pub fn parse_millis(s: &str) -> Result<Duration, ParseIntError> {
     Ok(Duration::from_millis(s.parse()?))
 }
 
+/// Parses a string of milliseconds into a [`TimeDelta`].
 pub fn parse_millis_delta(s: &str) -> Result<TimeDelta, ParseIntError> {
     Ok(TimeDelta::from_millis(s.parse()?))
 }
 
+/// Validates that a string contains only ASCII alphanumeric characters, returning it unchanged.
 pub fn parse_ascii_alphanumeric_string(s: &str) -> Result<String, &'static str> {
     if s.chars().all(|x| x.is_ascii_alphanumeric()) {
         Ok(s.to_string())


### PR DESCRIPTION
## Motivation

Backport to `testnet_conway` of the `linera-service` `#![deny(missing_docs)]` change (#6531).

## Proposal

Same change as #6531, cherry-picked onto `testnet_conway`. Doc strings are identical to the `main` PR for shared items; differences are confined to items that diverge between the branches.

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally that the lint is satisfied (`--all-features`, `--all-targets`) with nightly fmt and `cargo doc -D warnings` passing.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Forward port on `main`: #6531
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)


Notes: `testnet_conway` has additional CLI wrappers not on `main` (`local_kubernetes_net.rs`, `docker.rs`) which were documented the same way; `wallet.rs` keeps this branch's methods (it differs from `main`'s refactor). `CLI.md` was regenerated for the new argument help text. The GraphQL schema is unchanged.
