### PR TITLE
Document GraphQL metadata types in linera-chain

### DIFF
--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -135,106 +135,127 @@ impl SystemOperationMetadata {
 
 /// Transfer operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct TransferOperationMetadata {
+    /// The account owner whose balance is debited.
     pub owner: AccountOwner,
+    /// The account that receives the transferred tokens.
     pub recipient: Account,
+    /// The amount of tokens to transfer.
     pub amount: Amount,
 }
 
 /// Claim operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct ClaimOperationMetadata {
+    /// The account owner whose balance is being claimed.
     pub owner: AccountOwner,
+    /// The chain on which the claimed balance is held.
     pub target_id: ChainId,
+    /// The account that receives the claimed tokens.
     pub recipient: Account,
+    /// The amount of tokens to claim.
     pub amount: Amount,
 }
 
 /// Open chain operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct OpenChainOperationMetadata {
+    /// The initial balance credited to the new chain.
     pub balance: Amount,
+    /// The ownership configuration of the new chain.
     pub ownership: ChainOwnershipMetadata,
+    /// The application permissions of the new chain.
     pub application_permissions: ApplicationPermissionsMetadata,
 }
 
 /// Change ownership operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct ChangeOwnershipOperationMetadata {
+    /// The super owners, who can propose fast blocks in the first round and regular blocks in any round.
     pub super_owners: Vec<AccountOwner>,
+    /// The regular owners, each with the weight that determines how often they are round leader.
     pub owners: Vec<OwnerWithWeight>,
+    /// The leader of the first single-leader round; if unset, that leader is random like other rounds.
     pub first_leader: Option<AccountOwner>,
+    /// The number of rounds in which all owners are allowed to propose blocks.
     pub multi_leader_rounds: i32,
+    /// Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
     pub open_multi_leader_rounds: bool,
+    /// The timeout configuration governing round durations.
     pub timeout_config: TimeoutConfigMetadata,
 }
 
 /// Owner with weight metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct OwnerWithWeight {
+    /// The account owner.
     pub owner: AccountOwner,
+    /// The owner's weight, determining how often they are round leader (a `u64` as a string).
     pub weight: String, // Using String to represent u64 safely in GraphQL
 }
 
 /// Change application permissions operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct ChangeApplicationPermissionsMetadata {
+    /// The new application permissions to set on the chain.
     pub permissions: ApplicationPermissionsMetadata,
 }
 
 /// Admin operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct AdminOperationMetadata {
+    /// The kind of admin operation: "PublishCommitteeBlob", "CreateCommittee" or "RemoveCommittee".
     pub admin_operation_type: String,
+    /// The committee epoch this operation refers to, if applicable.
     pub epoch: Option<i32>,
+    /// The hash of the committee blob, if applicable.
     pub blob_hash: Option<CryptoHash>,
 }
 
 /// Create application operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct CreateApplicationOperationMetadata {
+    /// The ID of the module the application is instantiated from.
     pub module_id: String,
+    /// The application's static parameters, encoded as a hex string.
     pub parameters_hex: String,
+    /// The argument passed to the application's instantiation, encoded as a hex string.
     pub instantiation_argument_hex: String,
+    /// The applications this application depends on and requires to be present.
     pub required_application_ids: Vec<ApplicationId>,
 }
 
 /// Publish data blob operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct PublishDataBlobMetadata {
+    /// The hash of the data blob being published.
     pub blob_hash: CryptoHash,
 }
 
 /// Verify blob operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct VerifyBlobMetadata {
+    /// The ID of the blob whose existence is being verified.
     pub blob_id: String,
 }
 
 /// Publish module operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct PublishModuleMetadata {
+    /// The ID of the module being published.
     pub module_id: String,
 }
 
 /// Update stream metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct UpdateStreamMetadata {
+    /// The application that owns the event stream.
     pub application_id: String,
+    /// The chain on which the events are published.
     pub chain_id: ChainId,
+    /// The identifier of the event stream being updated.
     pub stream_id: String,
+    /// The index of the next event to read from the stream.
     pub next_index: i32,
 }
 
@@ -253,26 +274,30 @@ pub struct SystemMessageMetadata {
 
 /// Credit message metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct CreditMessageMetadata {
+    /// The account owner whose balance is credited on the receiving chain.
     pub target: AccountOwner,
+    /// The amount of tokens being credited.
     pub amount: Amount,
+    /// The account owner the transfer originated from.
     pub source: AccountOwner,
 }
 
 /// Withdraw message metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct WithdrawMessageMetadata {
+    /// The account owner whose balance is debited on the source chain.
     pub owner: AccountOwner,
+    /// The amount of tokens being withdrawn.
     pub amount: Amount,
+    /// The account that receives the withdrawn tokens.
     pub recipient: Account,
 }
 
 /// CheckpointAck message metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct CheckpointAckMessageMetadata {
+    /// The cursor past the last bundle from the recipient that the sender has consumed.
     pub latest_received_cursor: Cursor,
 }
 

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -191,9 +191,9 @@ impl Transaction {
     }
 }
 
+/// GraphQL-compatible structured representation of an operation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
 #[graphql(name = "Operation")]
-#[allow(missing_docs)]
 pub struct OperationMetadata {
     /// The type of operation: "System" or "User"
     pub operation_type: String,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -35,8 +35,17 @@ scalar AccountOwner
 Admin operation metadata.
 """
 type AdminOperationMetadata {
+	"""
+	The kind of admin operation: "PublishCommitteeBlob", "CreateCommittee" or "RemoveCommittee".
+	"""
 	adminOperationType: String!
+	"""
+	The committee epoch this operation refers to, if applicable.
+	"""
 	epoch: Int
+	"""
+	The hash of the committee blob, if applicable.
+	"""
 	blobHash: CryptoHash
 }
 
@@ -464,6 +473,9 @@ type Chains {
 Change application permissions operation metadata.
 """
 type ChangeApplicationPermissionsMetadata {
+	"""
+	The new application permissions to set on the chain.
+	"""
 	permissions: ApplicationPermissionsMetadata!
 }
 
@@ -471,11 +483,29 @@ type ChangeApplicationPermissionsMetadata {
 Change ownership operation metadata.
 """
 type ChangeOwnershipOperationMetadata {
+	"""
+	The super owners, who can propose fast blocks in the first round and regular blocks in any round.
+	"""
 	superOwners: [AccountOwner!]!
+	"""
+	The regular owners, each with the weight that determines how often they are round leader.
+	"""
 	owners: [OwnerWithWeight!]!
+	"""
+	The leader of the first single-leader round; if unset, that leader is random like other rounds.
+	"""
 	firstLeader: AccountOwner
+	"""
+	The number of rounds in which all owners are allowed to propose blocks.
+	"""
 	multiLeaderRounds: Int!
+	"""
+	Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners.
+	"""
 	openMultiLeaderRounds: Boolean!
+	"""
+	The timeout configuration governing round durations.
+	"""
 	timeoutConfig: TimeoutConfigMetadata!
 }
 
@@ -483,6 +513,9 @@ type ChangeOwnershipOperationMetadata {
 CheckpointAck message metadata.
 """
 type CheckpointAckMessageMetadata {
+	"""
+	The cursor past the last bundle from the recipient that the sender has consumed.
+	"""
 	latestReceivedCursor: Cursor!
 }
 
@@ -490,9 +523,21 @@ type CheckpointAckMessageMetadata {
 Claim operation metadata.
 """
 type ClaimOperationMetadata {
+	"""
+	The account owner whose balance is being claimed.
+	"""
 	owner: AccountOwner!
+	"""
+	The chain on which the claimed balance is held.
+	"""
 	targetId: ChainId!
+	"""
+	The account that receives the claimed tokens.
+	"""
 	recipient: AccountOutput!
+	"""
+	The amount of tokens to claim.
+	"""
 	amount: Amount!
 }
 
@@ -533,9 +578,21 @@ type ConfirmedBlock {
 Create application operation metadata.
 """
 type CreateApplicationOperationMetadata {
+	"""
+	The ID of the module the application is instantiated from.
+	"""
 	moduleId: String!
+	"""
+	The application's static parameters, encoded as a hex string.
+	"""
 	parametersHex: String!
+	"""
+	The argument passed to the application's instantiation, encoded as a hex string.
+	"""
 	instantiationArgumentHex: String!
+	"""
+	The applications this application depends on and requires to be present.
+	"""
 	requiredApplicationIds: [ApplicationId!]!
 }
 
@@ -543,8 +600,17 @@ type CreateApplicationOperationMetadata {
 Credit message metadata.
 """
 type CreditMessageMetadata {
+	"""
+	The account owner whose balance is credited on the receiving chain.
+	"""
 	target: AccountOwner!
+	"""
+	The amount of tokens being credited.
+	"""
 	amount: Amount!
+	"""
+	The account owner the transfer originated from.
+	"""
 	source: AccountOwner!
 }
 
@@ -1228,11 +1294,23 @@ scalar Notification
 Open chain operation metadata.
 """
 type OpenChainOperationMetadata {
+	"""
+	The initial balance credited to the new chain.
+	"""
 	balance: Amount!
+	"""
+	The ownership configuration of the new chain.
+	"""
 	ownership: ChainOwnershipMetadata!
+	"""
+	The application permissions of the new chain.
+	"""
 	applicationPermissions: ApplicationPermissionsMetadata!
 }
 
+"""
+GraphQL-compatible structured representation of an operation.
+"""
 type Operation {
 	"""
 	The type of operation: "System" or "User"
@@ -1317,7 +1395,13 @@ type OutgoingMessage {
 Owner with weight metadata.
 """
 type OwnerWithWeight {
+	"""
+	The account owner.
+	"""
 	owner: AccountOwner!
+	"""
+	The owner's weight, determining how often they are round leader (a `u64` as a string).
+	"""
 	weight: String!
 }
 
@@ -1377,6 +1461,9 @@ type PostedMessage {
 Publish data blob operation metadata.
 """
 type PublishDataBlobMetadata {
+	"""
+	The hash of the data blob being published.
+	"""
 	blobHash: CryptoHash!
 }
 
@@ -1384,6 +1471,9 @@ type PublishDataBlobMetadata {
 Publish module operation metadata.
 """
 type PublishModuleMetadata {
+	"""
+	The ID of the module being published.
+	"""
 	moduleId: String!
 }
 
@@ -1651,8 +1741,17 @@ type TransactionMetadata {
 Transfer operation metadata.
 """
 type TransferOperationMetadata {
+	"""
+	The account owner whose balance is debited.
+	"""
 	owner: AccountOwner!
+	"""
+	The account that receives the transferred tokens.
+	"""
 	recipient: AccountOutput!
+	"""
+	The amount of tokens to transfer.
+	"""
 	amount: Amount!
 }
 
@@ -1660,9 +1759,21 @@ type TransferOperationMetadata {
 Update stream metadata.
 """
 type UpdateStreamMetadata {
+	"""
+	The application that owns the event stream.
+	"""
 	applicationId: String!
+	"""
+	The chain on which the events are published.
+	"""
 	chainId: ChainId!
+	"""
+	The identifier of the event stream being updated.
+	"""
 	streamId: String!
+	"""
+	The index of the next event to read from the stream.
+	"""
 	nextIndex: Int!
 }
 
@@ -1670,6 +1781,9 @@ type UpdateStreamMetadata {
 Verify blob operation metadata.
 """
 type VerifyBlobMetadata {
+	"""
+	The ID of the blob whose existence is being verified.
+	"""
 	blobId: String!
 }
 
@@ -1681,8 +1795,17 @@ scalar VmRuntime
 Withdraw message metadata.
 """
 type WithdrawMessageMetadata {
+	"""
+	The account owner whose balance is debited on the source chain.
+	"""
 	owner: AccountOwner!
+	"""
+	The amount of tokens being withdrawn.
+	"""
 	amount: Amount!
+	"""
+	The account that receives the withdrawn tokens.
+	"""
 	recipient: AccountOutput!
 }
 


### PR DESCRIPTION
## Motivation

Follow-up to the `#![deny(missing_docs)]` rollout: the GraphQL operation/message *metadata*
types in `linera-chain` were silenced with a type-level `#[allow(missing_docs)]` to avoid
churning the generated GraphQL schema. This documents them properly instead.

## Proposal

Replace `#[allow(missing_docs)]` with real `///` documentation on the 15 `SimpleObject`
metadata structs in `linera-chain/src/data_types/metadata.rs` and on `OperationMetadata`
in `data_types/mod.rs`, documenting every field. Because these are `async-graphql` types,
their doc comments become GraphQL descriptions, so `linera-service-graphql-client/gql/service_schema.graphql`
is regenerated accordingly (description-only additions: +123 lines, 0 deletions).

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally: `cargo check -p linera-chain --all-features` reports no missing docs;
`linera-schema-export` output matches the committed schema; `cargo +nightly fmt -- --check`
and `RUSTDOCFLAGS="-D warnings" cargo doc -p linera-chain --all-features --no-deps` pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Implements the "document `async-graphql` types" guidance from CONTRIBUTING.md (#6536).
- A `testnet_conway` backport will follow.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
