### PR TITLE
Document data and config structs instead of allowing missing_docs

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -728,7 +728,11 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 
   Default value: `no-fees`
 
-  Possible values: `no-fees`, `testnet`
+  Possible values:
+  - `no-fees`:
+    Charges nothing for any resource, with no usage limits
+  - `testnet`:
+    Uses the fees and limits that match the public Testnet
 
 * `--wasm-fuel-unit-price <WASM_FUEL_UNIT_PRICE>` — Set the price per unit of Wasm fuel. (This will overwrite value from `--policy-config`)
 * `--evm-fuel-unit-price <EVM_FUEL_UNIT_PRICE>` — Set the price per unit of EVM fuel. (This will overwrite value from `--policy-config`)
@@ -1313,7 +1317,11 @@ Start a Local Linera Network
 
   Default value: `no-fees`
 
-  Possible values: `no-fees`, `testnet`
+  Possible values:
+  - `no-fees`:
+    Charges nothing for any resource, with no usage limits
+  - `testnet`:
+    Uses the fees and limits that match the public Testnet
 
 * `--cross-chain-queue-size <QUEUE_SIZE>` — Number of cross-chain messages allowed before dropping them
 

--- a/linera-bridge/src/block_proof.rs
+++ b/linera-bridge/src/block_proof.rs
@@ -165,13 +165,18 @@ impl EventInclusionProof {
 /// Both EVM entrypoints prove the same thing — that these events belong to a block the validators
 /// signed; only the action taken on success (release burns vs. install a committee, which also
 /// takes a committee blob) differs. The relay and the contract tests build calls from this.
-#[allow(missing_docs)]
 pub struct ProvenEvents {
+    /// Hash of the registered block these events belong to.
     pub block_hash: B256,
+    /// BCS encodings of the proven events, in `positions` order.
     pub event_bcs: Vec<Bytes>,
+    /// Index of the transaction whose events are being proven.
     pub tx_index: u32,
+    /// Number of transactions in the block (length of the outer `events` vector).
     pub num_txs: u32,
+    /// Number of events in transaction `tx_index` (length of its inner vector).
     pub num_events_in_tx: u32,
+    /// Positions (ascending) of the proven events within transaction `tx_index`.
     pub positions: Vec<u32>,
     /// Inner siblings followed by outer siblings; the contract splits this single array at
     /// `num_events_in_tx - positions.len()` (see [`EventInclusionProof::siblings`]).

--- a/linera-bridge/src/monitor/mod.rs
+++ b/linera-bridge/src/monitor/mod.rs
@@ -77,12 +77,16 @@ pub async fn query_wrapped_fungible_decimals<E: Environment>(
 
 /// A pending deposit detected by the EVM scanner, sent to the retry loop.
 #[derive(Debug, Clone, serde::Serialize)]
-#[allow(missing_docs)]
 pub struct PendingDeposit {
+    /// Replay-protection key identifying this deposit `(source_chain_id, block_hash, tx_index, log_index)`.
     pub key: DepositKey,
+    /// Hash of the EVM transaction that emitted the `DepositInitiated` event.
     pub tx_hash: B256,
+    /// EVM address that initiated the deposit.
     pub depositor: Address,
+    /// Amount of tokens deposited, in the source ERC-20's base units.
     pub amount: U256,
+    /// Per-depositor nonce assigned by the bridge contract.
     pub nonce: U256,
 }
 
@@ -120,14 +124,18 @@ pub struct PendingBurn {
 
 /// Wraps a pending bridging request with tracking metadata.
 #[derive(Debug, Clone, serde::Serialize)]
-#[allow(missing_docs)]
 pub struct Tracked<T: Clone> {
+    /// The underlying pending bridging request being tracked.
     #[serde(flatten)]
     pub value: T,
+    /// Whether this request has been successfully forwarded to the other chain.
     pub forwarded: bool,
+    /// Whether this request exhausted its retry budget and was marked failed.
     pub failed: bool,
+    /// Number of retry attempts made so far.
     #[serde(skip)]
     pub retry_count: u32,
+    /// Instant of the most recent retry attempt, used to gate exponential backoff.
     #[serde(skip)]
     pub last_retry_at: Option<Instant>,
 }
@@ -686,13 +694,18 @@ impl MonitorState {
 
 /// A snapshot of the monitor's pending/completed counts and scan cursors.
 #[derive(Debug, Clone, serde::Serialize)]
-#[allow(missing_docs)]
 pub struct StatusSummary {
+    /// Number of tracked deposits not yet forwarded to Linera.
     pub deposits_pending: usize,
+    /// Number of tracked deposits already forwarded to Linera.
     pub deposits_completed: usize,
+    /// Number of tracked burns not yet forwarded to the EVM chain.
     pub burns_pending: usize,
+    /// Number of tracked burns already forwarded to the EVM chain.
     pub burns_forwarded: usize,
+    /// Highest EVM block number the deposit scanner has processed.
     pub last_scanned_evm_block: u64,
+    /// Highest Linera block height the burn scanner has processed.
     pub last_scanned_linera_height: BlockHeight,
 }
 

--- a/linera-bridge/src/proof/mod.rs
+++ b/linera-bridge/src/proof/mod.rs
@@ -81,10 +81,12 @@ use linera_base::{
 
 /// A decoded log from an EVM transaction receipt.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(missing_docs)]
 pub struct ReceiptLog {
+    /// Address of the contract that emitted the log.
     pub address: Address,
+    /// Indexed log topics; `topics[0]` is the event signature hash.
     pub topics: Vec<B256>,
+    /// Non-indexed log data (the ABI-encoded event payload).
     pub data: Vec<u8>,
 }
 
@@ -94,15 +96,22 @@ pub struct ReceiptLog {
 /// canonical `linera-base` types, while Ethereum-side values use `alloy`
 /// primitive types (`Address`, `B256`, `U256`).
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(missing_docs)]
 pub struct DepositEvent {
+    /// EVM chain ID the deposit originated on.
     pub source_chain_id: U256,
+    /// Linera chain the wrapped tokens should be minted on.
     pub target_chain_id: ChainId,
+    /// Linera application (the wrapped-fungible app) that should receive the deposit.
     pub target_application_id: ApplicationId,
+    /// Linera account owner credited with the minted tokens.
     pub target_account_owner: AccountOwner,
+    /// EVM address that initiated the deposit (indexed event parameter).
     pub depositor: Address,
+    /// Address of the deposited ERC-20 token contract.
     pub token: Address,
+    /// Amount deposited, in the token's base units.
     pub amount: U256,
+    /// Per-depositor nonce assigned by the bridge contract.
     pub nonce: U256,
 }
 
@@ -113,11 +122,14 @@ pub struct DepositEvent {
 #[derive(
     Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Deserialize, serde::Serialize,
 )]
-#[allow(missing_docs)]
 pub struct DepositKey {
+    /// EVM chain ID the deposit originated on.
     pub source_chain_id: u64,
+    /// Hash of the EVM block containing the deposit transaction.
     pub block_hash: B256,
+    /// Index of the deposit transaction within its block.
     pub tx_index: u64,
+    /// Index of the `DepositInitiated` log within the transaction's receipt.
     pub log_index: u64,
 }
 

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -270,9 +270,10 @@ impl TransactionMetadata {
     SimpleObject,
     Allocative,
 )]
-#[allow(missing_docs)]
 pub struct ChainAndHeight {
+    /// The chain that the block belongs to.
     pub chain_id: ChainId,
+    /// The height of the block within that chain.
     pub height: BlockHeight,
 }
 
@@ -437,10 +438,13 @@ pub enum OriginalProposal {
 // to have it for auditing purposes.
 #[derive(Clone, Debug, Serialize, Deserialize, Allocative)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
-#[allow(missing_docs)]
 pub struct BlockProposal {
+    /// The signed content of the proposal: the proposed block, the round, and any
+    /// execution outcome from a previous round.
     pub content: ProposalContent,
+    /// The proposer's signature over `content`.
     pub signature: AccountSignature,
+    /// The earlier proposal being retried, if this proposal is a retry in a later round.
     #[debug(skip_if = Option::is_none)]
     pub original_proposal: Option<OriginalProposal>,
 }
@@ -538,10 +542,12 @@ pub struct BlockExecutionOutcome {
 
 /// The hash and chain ID of a `CertificateValue`.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Allocative)]
-#[allow(missing_docs)]
 pub struct LiteValue {
+    /// The hash of the `CertificateValue`.
     pub value_hash: CryptoHash,
+    /// The chain that the value belongs to.
     pub chain_id: ChainId,
+    /// The kind of certificate this value is for.
     pub kind: CertificateKind,
 }
 
@@ -564,10 +570,12 @@ pub struct VoteValue(CryptoHash, Round, CertificateKind);
 /// A vote on a statement from a validator.
 #[derive(Allocative, Clone, Debug, Serialize, Deserialize)]
 #[serde(bound(deserialize = "T: Deserialize<'de>"))]
-#[allow(missing_docs)]
 pub struct Vote<T> {
+    /// The value being voted for.
     pub value: T,
+    /// The consensus round in which the vote was cast.
     pub round: Round,
+    /// The validator's signature over the value hash, round and certificate kind.
     pub signature: ValidatorSignature,
 }
 
@@ -607,10 +615,12 @@ impl<T> Vote<T> {
 /// A vote on a statement from a validator, represented as a `LiteValue`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
-#[allow(missing_docs)]
 pub struct LiteVote {
+    /// The value being voted for, as a `LiteValue`.
     pub value: LiteValue,
+    /// The consensus round in which the vote was cast.
     pub round: Round,
+    /// The validator's signature over the value hash, round and certificate kind.
     pub signature: ValidatorSignature,
 }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -586,13 +586,17 @@ impl ApplicationPermissionsConfig {
     }
 }
 
+/// A named preset selecting which resource control policy the chain should use.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
-#[allow(missing_docs)]
 pub enum ResourceControlPolicyConfig {
+    /// Charges nothing for any resource, with no usage limits.
     NoFees,
+    /// Uses the fees and limits that match the public Testnet.
     Testnet,
+    /// Charges only for fuel, leaving all other resources free (for testing).
     #[cfg(with_testing)]
     OnlyFuel,
+    /// Charges a small non-zero amount in every fee category (for testing).
     #[cfg(with_testing)]
     AllCategories,
 }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -23,23 +23,35 @@ use crate::{
 
 /// A system execution state, not represented as a view but as a simple struct.
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
-#[allow(missing_docs)]
 pub struct SystemExecutionState {
+    /// The description of the chain, if it has been created.
     pub description: Option<ChainDescription>,
+    /// The current epoch the chain is operating in.
     pub epoch: Epoch,
+    /// The ID of the admin chain, if known.
     pub admin_chain_id: Option<ChainId>,
+    /// The committees of validators, indexed by the epoch in which they are active.
     pub committees: BTreeMap<Epoch, Committee>,
+    /// The ownership configuration of the chain.
     pub ownership: ChainOwnership,
+    /// The chain's main balance.
     pub balance: Amount,
+    /// The per-owner balances held on the chain.
     #[debug(skip_if = BTreeMap::is_empty)]
     pub balances: BTreeMap<AccountOwner, Amount>,
+    /// The latest timestamp recorded for the chain.
     pub timestamp: Timestamp,
+    /// The set of blobs that have been used by the chain.
     pub used_blobs: BTreeSet<BlobId>,
+    /// Whether the chain has been closed.
     #[debug(skip_if = Not::not)]
     pub closed: bool,
+    /// The application permissions configured on the chain.
     pub application_permissions: ApplicationPermissions,
+    /// Additional blobs to make available to the chain's execution context.
     #[debug(skip_if = Vec::is_empty)]
     pub extra_blobs: Vec<Blob>,
+    /// The mock applications registered on the chain, indexed by their application ID.
     #[debug(skip_if = BTreeMap::is_empty)]
     pub mock_applications: BTreeMap<ApplicationId, MockApplication>,
 }

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -144,9 +144,10 @@ pub enum NetworkProtocol {
 
 /// The TLS configuration for the gRPC protocol.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[allow(missing_docs)]
 pub enum TlsConfig {
+    /// Communicate over plaintext, without TLS encryption.
     ClearText,
+    /// Communicate over TLS-encrypted connections.
     Tls,
 }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -253,7 +253,13 @@ scalar Bytecode
 A chain ID with a block height.
 """
 type ChainAndHeight {
+	"""
+	The chain that the block belongs to.
+	"""
 	chainId: ChainId!
+	"""
+	The height of the block within that chain.
+	"""
 	height: BlockHeight!
 }
 


### PR DESCRIPTION
## Motivation

Follow-up to the `#![deny(missing_docs)]` rollout: several plain data/config structs were
silenced with a type-level `#[allow(missing_docs)]`. These are genuine public data types, so
they should be documented rather than allowed.

## Proposal

Replace `#[allow(missing_docs)]` with real `///` documentation (type + every field/variant) on:
- `linera-chain`: `ChainAndHeight`, `BlockProposal`, `LiteValue`, `Vote`, `LiteVote`
- `linera-bridge`: `PendingDeposit`, `Tracked`, `StatusSummary`, `ReceiptLog`, `DepositEvent`, `DepositKey`, `ProvenEvents`
- `linera-rpc`: `TlsConfig`
- `linera-execution`: `SystemExecutionState` (test helper)
- `linera-client`: `ResourceControlPolicyConfig`

`ResourceControlPolicyConfig` is a clap `ValueEnum`, so its variant docs become CLI value
help; `CLI.md` is regenerated accordingly.

This leaves only the `#[allow(missing_docs)]` cases sanctioned by CONTRIBUTING.md (generated
code, `thiserror` error enums, and large mechanical message/operation enums).

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally: `cargo check` reports no missing docs for linera-chain/bridge/rpc/execution
(`--all-features`) and linera-client (consistent feature set); `cargo +nightly fmt -- --check`
and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` pass; `CLI.md` matches `linera help-markdown`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Implements the documentation guidance from CONTRIBUTING.md (#6536).
- A `testnet_conway` backport will follow.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
