### PR TITLE
Document GraphQL metadata types in linera-chain (backport of #6537)

### DIFF
--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -131,104 +131,123 @@ impl SystemOperationMetadata {
 
 /// Transfer operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct TransferOperationMetadata {
+    /// The account owner sending the tokens.
     pub owner: AccountOwner,
+    /// The account receiving the transferred tokens.
     pub recipient: Account,
+    /// The amount of tokens to transfer.
     pub amount: Amount,
 }
 
 /// Claim operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct ClaimOperationMetadata {
+    /// The account owner claiming the tokens.
     pub owner: AccountOwner,
+    /// The chain from which the tokens are claimed.
     pub target_id: ChainId,
+    /// The account receiving the claimed tokens.
     pub recipient: Account,
+    /// The amount of tokens to claim.
     pub amount: Amount,
 }
 
 /// Open chain operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct OpenChainOperationMetadata {
+    /// The initial balance credited to the new chain.
     pub balance: Amount,
+    /// The ownership configuration of the new chain.
     pub ownership: ChainOwnershipMetadata,
+    /// The application permissions of the new chain.
     pub application_permissions: ApplicationPermissionsMetadata,
 }
 
 /// Change ownership operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct ChangeOwnershipOperationMetadata {
+    /// The owners with full control over the chain in every round.
     pub super_owners: Vec<AccountOwner>,
+    /// The regular owners and their voting weights.
     pub owners: Vec<OwnerWithWeight>,
+    /// The number of initial rounds in which all owners can propose blocks.
     pub multi_leader_rounds: i32,
+    /// Whether anyone can propose blocks during the multi-leader rounds.
     pub open_multi_leader_rounds: bool,
+    /// The configuration of round timeouts.
     pub timeout_config: TimeoutConfigMetadata,
 }
 
 /// Owner with weight metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct OwnerWithWeight {
+    /// The account owner.
     pub owner: AccountOwner,
+    /// The owner's voting weight, as a string to safely represent a `u64` in GraphQL.
     pub weight: String, // Using String to represent u64 safely in GraphQL
 }
 
 /// Change application permissions operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct ChangeApplicationPermissionsMetadata {
+    /// The new application permissions to set on the chain.
     pub permissions: ApplicationPermissionsMetadata,
 }
 
 /// Admin operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct AdminOperationMetadata {
+    /// The type of admin operation (e.g. `PublishCommitteeBlob`, `CreateCommittee`, `RemoveCommittee`).
     pub admin_operation_type: String,
+    /// The epoch the operation applies to, when relevant.
     pub epoch: Option<i32>,
+    /// The hash of the committee blob, when relevant.
     pub blob_hash: Option<CryptoHash>,
 }
 
 /// Create application operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct CreateApplicationOperationMetadata {
+    /// The ID of the module the application is instantiated from.
     pub module_id: String,
+    /// The application parameters, hex-encoded.
     pub parameters_hex: String,
+    /// The instantiation argument, hex-encoded.
     pub instantiation_argument_hex: String,
+    /// The IDs of the applications that this application depends on.
     pub required_application_ids: Vec<ApplicationId>,
 }
 
 /// Publish data blob operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct PublishDataBlobMetadata {
+    /// The hash of the published data blob.
     pub blob_hash: CryptoHash,
 }
 
 /// Verify blob operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct VerifyBlobMetadata {
+    /// The ID of the blob whose existence is verified.
     pub blob_id: String,
 }
 
 /// Publish module operation metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct PublishModuleMetadata {
+    /// The ID of the published module.
     pub module_id: String,
 }
 
 /// Update stream metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct UpdateStreamMetadata {
+    /// The chain that publishes the event stream.
     pub chain_id: ChainId,
+    /// The ID of the event stream.
     pub stream_id: String,
+    /// The next event index to read from the stream.
     pub next_index: i32,
 }
 
@@ -245,19 +264,23 @@ pub struct SystemMessageMetadata {
 
 /// Credit message metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct CreditMessageMetadata {
+    /// The account owner credited with the tokens.
     pub target: AccountOwner,
+    /// The amount of tokens credited.
     pub amount: Amount,
+    /// The account owner the tokens originate from.
     pub source: AccountOwner,
 }
 
 /// Withdraw message metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
-#[allow(missing_docs)]
 pub struct WithdrawMessageMetadata {
+    /// The account owner the tokens are withdrawn from.
     pub owner: AccountOwner,
+    /// The amount of tokens withdrawn.
     pub amount: Amount,
+    /// The account receiving the withdrawn tokens.
     pub recipient: Account,
 }
 

--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -164,9 +164,9 @@ impl Transaction {
     }
 }
 
+/// GraphQL-compatible structured representation of an operation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, SimpleObject)]
 #[graphql(name = "Operation")]
-#[allow(missing_docs)]
 pub struct OperationMetadata {
     /// The type of operation: "System" or "User"
     pub operation_type: String,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -12,8 +12,17 @@ scalar AccountOwner
 Admin operation metadata.
 """
 type AdminOperationMetadata {
+	"""
+	The type of admin operation (e.g. `PublishCommitteeBlob`, `CreateCommittee`, `RemoveCommittee`).
+	"""
 	adminOperationType: String!
+	"""
+	The epoch the operation applies to, when relevant.
+	"""
 	epoch: Int
+	"""
+	The hash of the committee blob, when relevant.
+	"""
 	blobHash: CryptoHash
 }
 
@@ -477,6 +486,9 @@ type Chains {
 Change application permissions operation metadata.
 """
 type ChangeApplicationPermissionsMetadata {
+	"""
+	The new application permissions to set on the chain.
+	"""
 	permissions: ApplicationPermissionsMetadata!
 }
 
@@ -484,10 +496,25 @@ type ChangeApplicationPermissionsMetadata {
 Change ownership operation metadata.
 """
 type ChangeOwnershipOperationMetadata {
+	"""
+	The owners with full control over the chain in every round.
+	"""
 	superOwners: [AccountOwner!]!
+	"""
+	The regular owners and their voting weights.
+	"""
 	owners: [OwnerWithWeight!]!
+	"""
+	The number of initial rounds in which all owners can propose blocks.
+	"""
 	multiLeaderRounds: Int!
+	"""
+	Whether anyone can propose blocks during the multi-leader rounds.
+	"""
 	openMultiLeaderRounds: Boolean!
+	"""
+	The configuration of round timeouts.
+	"""
 	timeoutConfig: TimeoutConfigMetadata!
 }
 
@@ -495,9 +522,21 @@ type ChangeOwnershipOperationMetadata {
 Claim operation metadata.
 """
 type ClaimOperationMetadata {
+	"""
+	The account owner claiming the tokens.
+	"""
 	owner: AccountOwner!
+	"""
+	The chain from which the tokens are claimed.
+	"""
 	targetId: ChainId!
+	"""
+	The account receiving the claimed tokens.
+	"""
 	recipient: Account!
+	"""
+	The amount of tokens to claim.
+	"""
 	amount: Amount!
 }
 
@@ -538,9 +577,21 @@ type ConfirmedBlock {
 Create application operation metadata.
 """
 type CreateApplicationOperationMetadata {
+	"""
+	The ID of the module the application is instantiated from.
+	"""
 	moduleId: String!
+	"""
+	The application parameters, hex-encoded.
+	"""
 	parametersHex: String!
+	"""
+	The instantiation argument, hex-encoded.
+	"""
 	instantiationArgumentHex: String!
+	"""
+	The IDs of the applications that this application depends on.
+	"""
 	requiredApplicationIds: [ApplicationId!]!
 }
 
@@ -548,8 +599,17 @@ type CreateApplicationOperationMetadata {
 Credit message metadata.
 """
 type CreditMessageMetadata {
+	"""
+	The account owner credited with the tokens.
+	"""
 	target: AccountOwner!
+	"""
+	The amount of tokens credited.
+	"""
 	amount: Amount!
+	"""
+	The account owner the tokens originate from.
+	"""
 	source: AccountOwner!
 }
 
@@ -1053,11 +1113,23 @@ scalar Notification
 Open chain operation metadata.
 """
 type OpenChainOperationMetadata {
+	"""
+	The initial balance credited to the new chain.
+	"""
 	balance: Amount!
+	"""
+	The ownership configuration of the new chain.
+	"""
 	ownership: ChainOwnershipMetadata!
+	"""
+	The application permissions of the new chain.
+	"""
 	applicationPermissions: ApplicationPermissionsMetadata!
 }
 
+"""
+GraphQL-compatible structured representation of an operation.
+"""
 type Operation {
 	"""
 	The type of operation: "System" or "User"
@@ -1142,7 +1214,13 @@ type OutgoingMessage {
 Owner with weight metadata.
 """
 type OwnerWithWeight {
+	"""
+	The account owner.
+	"""
 	owner: AccountOwner!
+	"""
+	The owner's voting weight, as a string to safely represent a `u64` in GraphQL.
+	"""
 	weight: String!
 }
 
@@ -1206,6 +1284,9 @@ type PostedMessage {
 Publish data blob operation metadata.
 """
 type PublishDataBlobMetadata {
+	"""
+	The hash of the published data blob.
+	"""
 	blobHash: CryptoHash!
 }
 
@@ -1213,6 +1294,9 @@ type PublishDataBlobMetadata {
 Publish module operation metadata.
 """
 type PublishModuleMetadata {
+	"""
+	The ID of the published module.
+	"""
 	moduleId: String!
 }
 
@@ -1479,8 +1563,17 @@ type TransactionMetadata {
 Transfer operation metadata.
 """
 type TransferOperationMetadata {
+	"""
+	The account owner sending the tokens.
+	"""
 	owner: AccountOwner!
+	"""
+	The account receiving the transferred tokens.
+	"""
 	recipient: Account!
+	"""
+	The amount of tokens to transfer.
+	"""
 	amount: Amount!
 }
 
@@ -1488,8 +1581,17 @@ type TransferOperationMetadata {
 Update stream metadata.
 """
 type UpdateStreamMetadata {
+	"""
+	The chain that publishes the event stream.
+	"""
 	chainId: ChainId!
+	"""
+	The ID of the event stream.
+	"""
 	streamId: String!
+	"""
+	The next event index to read from the stream.
+	"""
 	nextIndex: Int!
 }
 
@@ -1497,6 +1599,9 @@ type UpdateStreamMetadata {
 Verify blob operation metadata.
 """
 type VerifyBlobMetadata {
+	"""
+	The ID of the blob whose existence is verified.
+	"""
 	blobId: String!
 }
 
@@ -1508,8 +1613,17 @@ scalar VmRuntime
 Withdraw message metadata.
 """
 type WithdrawMessageMetadata {
+	"""
+	The account owner the tokens are withdrawn from.
+	"""
 	owner: AccountOwner!
+	"""
+	The amount of tokens withdrawn.
+	"""
 	amount: Amount!
+	"""
+	The account receiving the withdrawn tokens.
+	"""
 	recipient: Account!
 }
 


### PR DESCRIPTION
## Motivation

Backport of #6537 to `testnet_conway`: document the GraphQL operation/message metadata types instead of allowing `missing_docs`.

## Proposal

Same as #6537, applied to `testnet_conway`'s metadata types (which differ somewhat from `main`'s — e.g. no `CheckpointAckMessageMetadata`, different `ChangeOwnershipOperationMetadata` fields). All type-level `#[allow(missing_docs)]` in `linera-chain/src/data_types/metadata.rs` (and `OperationMetadata`) are replaced with real field docs, and `service_schema.graphql` is regenerated (description-only additions).

No code logic, signatures, or formatting were changed.

## Test Plan

CI. Verified locally: `cargo check -p linera-chain --all-features` reports no missing docs; schema matches `linera-schema-export`; nightly fmt and `cargo doc -D warnings` pass.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Forward port on `main`: #6537
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
