### PR TITLE
linera-sdk: derive macro `StableEnum` (backport of #6309)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5787,6 +5787,7 @@ version = "0.15.19"
 dependencies = [
  "convert_case",
  "proc-macro2",
+ "sha3",
  "syn 2.0.105",
 ]
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4128,6 +4128,7 @@ version = "0.15.19"
 dependencies = [
  "convert_case",
  "proc-macro2",
+ "sha3",
  "syn 2.0.100",
 ]
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -5,7 +5,7 @@
 
 mod state;
 
-use counter::CounterAbi;
+use counter::{CounterAbi, CounterOperation};
 use linera_sdk::{
     linera_base_types::WithContractAbi,
     views::{RootView, View},
@@ -54,8 +54,9 @@ impl Contract for CounterContract {
     // ANCHOR_END: instantiate
 
     // ANCHOR: execute_operation
-    async fn execute_operation(&mut self, operation: u64) -> u64 {
-        let new_value = self.state.value.get() + operation;
+    async fn execute_operation(&mut self, operation: CounterOperation) -> u64 {
+        let CounterOperation::Increment { value } = operation;
+        let new_value = self.state.value.get() + value;
         self.state.value.set(new_value);
         new_value
     }
@@ -77,6 +78,7 @@ impl Contract for CounterContract {
 
 #[cfg(test)]
 mod tests {
+    use counter::CounterOperation;
     use futures::FutureExt as _;
     use linera_sdk::{util::BlockingWait, views::View, Contract, ContractRuntime};
 
@@ -98,9 +100,10 @@ mod tests {
             .expect("Initialization of counter state should not await anything");
 
         let increment = 42_308_u64;
+        let operation = CounterOperation::Increment { value: increment };
 
         let response = counter
-            .execute_operation(increment)
+            .execute_operation(operation)
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
@@ -129,9 +132,10 @@ mod tests {
         let mut counter = create_and_instantiate_counter(initial_value);
 
         let increment = 8_u64;
+        let operation = CounterOperation::Increment { value: increment };
 
         let response = counter
-            .execute_operation(increment)
+            .execute_operation(operation)
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -4,13 +4,22 @@
 /*! ABI of the Counter Example Application */
 
 use async_graphql::{Request, Response};
-use linera_sdk::linera_base_types::{ContractAbi, ServiceAbi};
+use linera_sdk::{
+    formats::StableEnum,
+    linera_base_types::{ContractAbi, ServiceAbi},
+};
 
 // ANCHOR: contract_abi
 pub struct CounterAbi;
 
+#[derive(Debug, StableEnum)]
+pub enum CounterOperation {
+    /// Increment the counter by the given value
+    Increment { value: u64 },
+}
+
 impl ContractAbi for CounterAbi {
-    type Operation = u64;
+    type Operation = CounterOperation;
     type Response = u64;
 }
 // ANCHOR_END: contract_abi
@@ -24,10 +33,10 @@ impl ServiceAbi for CounterAbi {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod formats {
-    use linera_sdk::formats::{BcsApplication, Formats};
+    use linera_sdk::formats::{BcsApplication, Formats, TracerExt};
     use serde_reflection::{Samples, Tracer, TracerConfig};
 
-    use super::CounterAbi;
+    use super::{CounterAbi, CounterOperation};
 
     /// The Counter application.
     pub struct CounterApplication;
@@ -44,7 +53,7 @@ pub mod formats {
             let samples = Samples::new();
 
             // Trace the ABI types
-            let (operation, _) = tracer.trace_type::<u64>(&samples)?;
+            let operation = tracer.trace_stable_enum_type::<CounterOperation>(&samples)?;
             let (response, _) = tracer.trace_type::<u64>(&samples)?;
             let (message, _) = tracer.trace_type::<()>(&samples)?;
             let (event_value, _) = tracer.trace_type::<()>(&samples)?;

--- a/examples/counter/src/service.rs
+++ b/examples/counter/src/service.rs
@@ -8,6 +8,7 @@ mod state;
 use std::sync::Arc;
 
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use counter::CounterOperation;
 use linera_sdk::{linera_base_types::WithServiceAbi, views::View, Service, ServiceRuntime};
 
 use self::state::CounterState;
@@ -67,7 +68,8 @@ struct MutationRoot {
 #[Object]
 impl MutationRoot {
     async fn increment(&self, value: u64) -> [u8; 0] {
-        self.runtime.schedule_operation(&value);
+        let operation = CounterOperation::Increment { value };
+        self.runtime.schedule_operation(&operation);
         []
     }
 }

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -5,6 +5,7 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
+use counter::CounterOperation;
 use linera_sdk::test::{QueryOutcome, TestValidator};
 
 /// Test setting a counter and testing its coherency across microchains.
@@ -24,9 +25,10 @@ async fn single_chain_test() {
         .await;
 
     let increment = 15u64;
+    let operation = CounterOperation::Increment { value: increment };
     chain
         .add_block(|block| {
-            block.with_operation(application_id, increment);
+            block.with_operation(application_id, operation);
         })
         .await;
 

--- a/examples/counter/tests/snapshots/format__format.snap
+++ b/examples/counter/tests/snapshots/format__format.snap
@@ -2,8 +2,15 @@
 source: counter/tests/format.rs
 expression: "CounterApplication::formats().unwrap()"
 ---
-REGISTRY: {}
-OPERATION: U64
+REGISTRY:
+  CounterOperation:
+    ENUM:
+      186772159:
+        Increment:
+          STRUCT:
+            - value: U64
+OPERATION:
+  TYPENAME: CounterOperation
 RESPONSE: U64
 MESSAGE: UNIT
 EVENT_VALUE: UNIT

--- a/linera-bridge/contracts/evm-bridge/Cargo.lock
+++ b/linera-bridge/contracts/evm-bridge/Cargo.lock
@@ -3465,6 +3465,7 @@ version = "0.15.19"
 dependencies = [
  "convert_case",
  "proc-macro2",
+ "sha3",
  "syn 2.0.105",
 ]
 

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -157,8 +157,9 @@ where
         .unwrap_ok_committed();
 
     let increment = 5_u64;
+    let counter_operation = counter::CounterOperation::Increment { value: increment };
     creator
-        .execute_operation(Operation::user(application_id, &increment)?)
+        .execute_operation(Operation::user(application_id, &counter_operation)?)
         .await
         .unwrap();
 
@@ -1461,14 +1462,15 @@ async fn test_memory_fuel_limit(wasm_runtime: WasmRuntime) -> anyhow::Result<()>
         .unwrap_ok_committed();
 
     let increment = 5_u64;
+    let operation = counter::CounterOperation::Increment { value: increment };
     publisher
-        .execute_operation(Operation::user(application_id, &increment)?)
+        .execute_operation(Operation::user(application_id, &operation)?)
         .await
         .unwrap_ok_committed();
 
     assert!(publisher
         .execute_operations(
-            vec![Operation::user(application_id, &increment)?; 10],
+            vec![Operation::user(application_id, &operation)?; 10],
             vec![]
         )
         .await

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -239,7 +239,8 @@ where
 
     // Execute an application operation
     let increment = 5_u64;
-    let user_operation = bcs::to_bytes(&increment)?;
+    let counter_operation = counter::CounterOperation::Increment { value: increment };
+    let user_operation = bcs::to_bytes(&counter_operation)?;
     let run_block = make_child_block(&create_certificate.into_value())
         .with_timestamp(3)
         .with_operation(Operation::User {

--- a/linera-sdk-derive/Cargo.toml
+++ b/linera-sdk-derive/Cargo.toml
@@ -18,4 +18,5 @@ proc-macro = true
 [dependencies]
 convert_case = "0.6.0"
 proc-macro2.workspace = true
+sha3.workspace = true
 syn = { workspace = true, features = ["full", "extra-traits"] }

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![deny(missing_docs)]
 
+mod stable_enum;
 mod utils;
 
 use proc_macro::TokenStream;
@@ -31,6 +32,34 @@ pub fn derive_mutation_root(input: TokenStream) -> TokenStream {
 pub fn derive_mutation_root_in_crate(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemEnum);
     generate_mutation_root_code(input, "crate").into()
+}
+
+/// Derive `linera_sdk::formats::StableEnum` for an `enum`. Expands to:
+///
+/// * `serde::Serialize` / `serde::Deserialize` impls in which the variant tag
+///   is the first 4 bytes of `Keccak-256(variant_name)` (read big-endian as
+///   `u32`), with the top 5 bits masked to `00001` so the ULEB128 encoding is
+///   always exactly 4 bytes; and
+/// * a `linera_sdk::formats::StableEnumTrace` impl exposing the per-variant
+///   tags and a `trace_all_variants` method that drives
+///   `serde_reflection::Tracer` without caller-supplied samples.
+#[proc_macro_derive(StableEnum)]
+pub fn derive_stable_enum(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemEnum);
+    stable_enum::generate_all(&input, stable_enum::CrateRoot::LineraSdk)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
+}
+
+/// Same as [`StableEnum`] but referring to the trait through `crate::...`
+/// instead of `::linera_sdk::...`. Used inside the `linera-sdk` crate itself
+/// (and only there).
+#[proc_macro_derive(StableEnumInCrate)]
+pub fn derive_stable_enum_in_crate(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemEnum);
+    stable_enum::generate_all(&input, stable_enum::CrateRoot::Crate)
+        .unwrap_or_else(|err| err.to_compile_error())
+        .into()
 }
 
 fn generate_mutation_root_code(input: ItemEnum, crate_root: &str) -> TokenStream2 {

--- a/linera-sdk-derive/src/stable_enum.rs
+++ b/linera-sdk-derive/src/stable_enum.rs
@@ -1,0 +1,454 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Code generation for the `StableEnum` derive macro.
+//!
+//! Each variant of the input enum is assigned a `u32` "stable tag" computed at
+//! macro-expansion time from the variant's name:
+//!
+//! 1. Compute `Keccak-256(variant_name)`.
+//! 2. Read the first 4 bytes as a big-endian `u32`.
+//! 3. Mask the top 5 bits to `00001`, i.e. `(val & 0x07FF_FFFF) | 0x0800_0000`.
+//!
+//! Step 3 forces the tag into the range `[2^27, 2^28 - 1]`, which is exactly
+//! the range whose ULEB128 encoding is always 4 bytes.
+
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
+use sha3::{Digest, Keccak256};
+use syn::{__private::quote::quote, spanned::Spanned, Error, Fields, ItemEnum, Result, Variant};
+
+/// Where the `StableEnumTrace` trait lives, from the perspective of the code
+/// being generated.
+pub enum CrateRoot {
+    /// Generated code lives outside `linera-sdk`: use `::linera_sdk::...`.
+    LineraSdk,
+    /// Generated code lives inside `linera-sdk`: use `crate::...`.
+    Crate,
+}
+
+impl CrateRoot {
+    fn trait_path(&self) -> TokenStream2 {
+        match self {
+            CrateRoot::LineraSdk => quote! { ::linera_sdk::formats::StableEnumTrace },
+            CrateRoot::Crate => quote! { crate::formats::StableEnumTrace },
+        }
+    }
+
+    /// Path to `serde`, routed through `linera_sdk`'s private re-export so
+    /// downstream crates don't need a direct `serde` dependency.
+    fn serde_path(&self) -> TokenStream2 {
+        match self {
+            CrateRoot::LineraSdk => quote! { ::linera_sdk::formats::__private::serde },
+            CrateRoot::Crate => quote! { crate::formats::__private::serde },
+        }
+    }
+
+    /// Path to `serde_reflection`, routed through `linera_sdk`'s private
+    /// re-export so downstream crates don't need a direct `serde-reflection`
+    /// dependency just to use `#[derive(StableEnum)]`.
+    fn serde_reflection_path(&self) -> TokenStream2 {
+        match self {
+            CrateRoot::LineraSdk => quote! { ::linera_sdk::formats::__private::serde_reflection },
+            CrateRoot::Crate => quote! { crate::formats::__private::serde_reflection },
+        }
+    }
+}
+
+/// Computes the stable tag for a variant name.
+fn compute_tag(variant_name: &str) -> u32 {
+    let hash = Keccak256::digest(variant_name.as_bytes());
+    let val = u32::from_be_bytes([hash[0], hash[1], hash[2], hash[3]]);
+    (val & 0x07FF_FFFF) | 0x0800_0000
+}
+
+/// Computes all variant tags, returning an error on a (vanishingly unlikely) collision.
+fn variant_tags(input: &ItemEnum) -> Result<Vec<(String, u32, &Variant)>> {
+    let mut out = Vec::with_capacity(input.variants.len());
+    for variant in &input.variants {
+        let name = variant.ident.to_string();
+        let tag = compute_tag(&name);
+        if let Some((other_name, _, _)) = out
+            .iter()
+            .find(|(_, t, _): &&(String, u32, &Variant)| *t == tag)
+        {
+            return Err(Error::new(
+                variant.span(),
+                format!(
+                    "Keccak-256 tag collision between variants `{other_name}` and `{name}` \
+                     (tag = {tag:#010x}). Rename one of the variants."
+                ),
+            ));
+        }
+        out.push((name, tag, variant));
+    }
+    Ok(out)
+}
+
+fn reject_generics(input: &ItemEnum) -> Result<()> {
+    if !input.generics.params.is_empty() || input.generics.where_clause.is_some() {
+        return Err(Error::new(
+            input.generics.span(),
+            "#[derive(StableEnum)] does not yet support generic enums",
+        ));
+    }
+    Ok(())
+}
+
+/// Emits the combined `Serialize` + `Deserialize` + `StableEnumTrace` impls.
+pub fn generate_all(input: &ItemEnum, crate_root: CrateRoot) -> Result<TokenStream2> {
+    let ser = generate_serialize(input, &crate_root)?;
+    let de = generate_deserialize(input, &crate_root)?;
+    let tr = generate_trace(input, &crate_root)?;
+    Ok(quote! {
+        #ser
+        #de
+        #tr
+    })
+}
+
+pub fn generate_serialize(input: &ItemEnum, crate_root: &CrateRoot) -> Result<TokenStream2> {
+    reject_generics(input)?;
+    let enum_ident = &input.ident;
+    let enum_name_str = enum_ident.to_string();
+    let tagged = variant_tags(input)?;
+    let serde = crate_root.serde_path();
+
+    let arms = tagged.iter().map(|(name, tag, variant)| {
+        let variant_ident = &variant.ident;
+        let name_lit = name.as_str();
+        match &variant.fields {
+            Fields::Unit => quote! {
+                Self::#variant_ident => #serde::Serializer::serialize_unit_variant(
+                    __serializer, #enum_name_str, #tag, #name_lit,
+                ),
+            },
+            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => quote! {
+                Self::#variant_ident(__f0) => #serde::Serializer::serialize_newtype_variant(
+                    __serializer, #enum_name_str, #tag, #name_lit, __f0,
+                ),
+            },
+            Fields::Unnamed(fields) => {
+                let len = fields.unnamed.len();
+                let idents: Vec<Ident> = (0..len)
+                    .map(|i| Ident::new(&format!("__f{i}"), Span::call_site()))
+                    .collect();
+                quote! {
+                    Self::#variant_ident(#(#idents),*) => {
+                        let mut __tv = #serde::Serializer::serialize_tuple_variant(
+                            __serializer, #enum_name_str, #tag, #name_lit, #len,
+                        )?;
+                        #(
+                            #serde::ser::SerializeTupleVariant::serialize_field(&mut __tv, #idents)?;
+                        )*
+                        #serde::ser::SerializeTupleVariant::end(__tv)
+                    }
+                }
+            }
+            Fields::Named(fields) => {
+                let len = fields.named.len();
+                let field_idents: Vec<&Ident> = fields
+                    .named
+                    .iter()
+                    .map(|f| f.ident.as_ref().expect("named field has ident"))
+                    .collect();
+                let field_strs: Vec<String> = field_idents.iter().map(|i| i.to_string()).collect();
+                quote! {
+                    Self::#variant_ident { #(#field_idents),* } => {
+                        let mut __sv = #serde::Serializer::serialize_struct_variant(
+                            __serializer, #enum_name_str, #tag, #name_lit, #len,
+                        )?;
+                        #(
+                            #serde::ser::SerializeStructVariant::serialize_field(
+                                &mut __sv, #field_strs, #field_idents,
+                            )?;
+                        )*
+                        #serde::ser::SerializeStructVariant::end(__sv)
+                    }
+                }
+            }
+        }
+    });
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl #serde::Serialize for #enum_ident {
+            fn serialize<__S>(&self, __serializer: __S) -> ::core::result::Result<__S::Ok, __S::Error>
+            where
+                __S: #serde::Serializer,
+            {
+                match self {
+                    #(#arms)*
+                }
+            }
+        }
+    })
+}
+
+pub fn generate_deserialize(input: &ItemEnum, crate_root: &CrateRoot) -> Result<TokenStream2> {
+    reject_generics(input)?;
+    let enum_ident = &input.ident;
+    let enum_name_str = enum_ident.to_string();
+    let tagged = variant_tags(input)?;
+    let serde = crate_root.serde_path();
+
+    let variant_name_lits: Vec<String> = tagged.iter().map(|(n, _, _)| n.clone()).collect();
+
+    let arms = tagged.iter().map(|(name, tag, variant)| {
+        let variant_ident = &variant.ident;
+        let name_lit = name.as_str();
+        match &variant.fields {
+            Fields::Unit => quote! {
+                #tag => {
+                    #serde::de::VariantAccess::unit_variant(__variant)?;
+                    ::core::result::Result::Ok(#enum_ident::#variant_ident)
+                }
+            },
+            Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+                let ty = &fields.unnamed.first().unwrap().ty;
+                quote! {
+                    #tag => {
+                        let __inner = #serde::de::VariantAccess::newtype_variant::<#ty>(__variant)?;
+                        ::core::result::Result::Ok(#enum_ident::#variant_ident(__inner))
+                    }
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let len = fields.unnamed.len();
+                let types = fields.unnamed.iter().map(|f| &f.ty).collect::<Vec<_>>();
+                let bindings: Vec<Ident> = (0..len)
+                    .map(|i| Ident::new(&format!("__f{i}"), Span::call_site()))
+                    .collect();
+                let next_elements = bindings.iter().zip(types.iter()).enumerate().map(|(i, (b, t))| {
+                    let expected = format!("tuple variant `{name_lit}` with {len} elements");
+                    quote! {
+                        let #b: #t = #serde::de::SeqAccess::next_element::<#t>(&mut __seq)?
+                            .ok_or_else(|| <__A::Error as #serde::de::Error>::invalid_length(#i, &#expected))?;
+                    }
+                });
+                let expecting_msg = format!("tuple variant `{name_lit}`");
+                quote! {
+                    #tag => {
+                        struct __TupleVisitor;
+                        impl<'de> #serde::de::Visitor<'de> for __TupleVisitor {
+                            type Value = (#(#types,)*);
+                            fn expecting(&self, __f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                                __f.write_str(#expecting_msg)
+                            }
+                            fn visit_seq<__A>(self, mut __seq: __A) -> ::core::result::Result<Self::Value, __A::Error>
+                            where
+                                __A: #serde::de::SeqAccess<'de>,
+                            {
+                                #(#next_elements)*
+                                ::core::result::Result::Ok((#(#bindings,)*))
+                            }
+                        }
+                        let (#(#bindings,)*) = #serde::de::VariantAccess::tuple_variant(
+                            __variant, #len, __TupleVisitor,
+                        )?;
+                        ::core::result::Result::Ok(#enum_ident::#variant_ident(#(#bindings,)*))
+                    }
+                }
+            }
+            Fields::Named(fields) => {
+                let len = fields.named.len();
+                let field_idents: Vec<&Ident> = fields
+                    .named
+                    .iter()
+                    .map(|f| f.ident.as_ref().expect("named field has ident"))
+                    .collect();
+                let field_strs: Vec<String> = field_idents.iter().map(|i| i.to_string()).collect();
+                let types: Vec<_> = fields.named.iter().map(|f| &f.ty).collect();
+                let next_elements = field_idents
+                    .iter()
+                    .zip(types.iter())
+                    .enumerate()
+                    .map(|(i, (b, t))| {
+                        let expected = format!("struct variant `{name_lit}` with {len} fields");
+                        quote! {
+                            let #b: #t = #serde::de::SeqAccess::next_element::<#t>(&mut __seq)?
+                                .ok_or_else(|| <__A::Error as #serde::de::Error>::invalid_length(#i, &#expected))?;
+                        }
+                    });
+                let expecting_msg = format!("struct variant `{name_lit}`");
+                quote! {
+                    #tag => {
+                        struct __StructVisitor;
+                        impl<'de> #serde::de::Visitor<'de> for __StructVisitor {
+                            type Value = (#(#types,)*);
+                            fn expecting(&self, __f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                                __f.write_str(#expecting_msg)
+                            }
+                            fn visit_seq<__A>(self, mut __seq: __A) -> ::core::result::Result<Self::Value, __A::Error>
+                            where
+                                __A: #serde::de::SeqAccess<'de>,
+                            {
+                                #(#next_elements)*
+                                ::core::result::Result::Ok((#(#field_idents,)*))
+                            }
+                        }
+                        const __FIELDS: &[&::core::primitive::str] = &[#(#field_strs),*];
+                        let (#(#field_idents,)*) = #serde::de::VariantAccess::struct_variant(
+                            __variant, __FIELDS, __StructVisitor,
+                        )?;
+                        ::core::result::Result::Ok(#enum_ident::#variant_ident { #(#field_idents,)* })
+                    }
+                }
+            }
+        }
+    });
+
+    let expecting_msg = format!("enum `{enum_name_str}` (stable-tagged)");
+
+    Ok(quote! {
+        #[automatically_derived]
+        impl<'de> #serde::Deserialize<'de> for #enum_ident {
+            fn deserialize<__D>(__deserializer: __D) -> ::core::result::Result<Self, __D::Error>
+            where
+                __D: #serde::Deserializer<'de>,
+            {
+                struct __OuterVisitor;
+                impl<'de> #serde::de::Visitor<'de> for __OuterVisitor {
+                    type Value = #enum_ident;
+                    fn expecting(&self, __f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                        __f.write_str(#expecting_msg)
+                    }
+                    fn visit_enum<__A>(self, __access: __A) -> ::core::result::Result<Self::Value, __A::Error>
+                    where
+                        __A: #serde::de::EnumAccess<'de>,
+                    {
+                        let (__tag, __variant) =
+                            #serde::de::EnumAccess::variant::<::core::primitive::u32>(__access)?;
+                        match __tag {
+                            #(#arms)*
+                            __unknown => ::core::result::Result::Err(
+                                <__A::Error as #serde::de::Error>::custom(::std::format!(
+                                    "unknown stable variant tag for `{}`: {:#010x}",
+                                    #enum_name_str, __unknown,
+                                )),
+                            ),
+                        }
+                    }
+                }
+                const __VARIANTS: &[&::core::primitive::str] = &[#(#variant_name_lits),*];
+                #serde::Deserializer::deserialize_enum(
+                    __deserializer,
+                    #enum_name_str,
+                    __VARIANTS,
+                    __OuterVisitor,
+                )
+            }
+        }
+    })
+}
+
+pub fn generate_trace(input: &ItemEnum, crate_root: &CrateRoot) -> Result<TokenStream2> {
+    reject_generics(input)?;
+    let enum_ident = &input.ident;
+    let enum_name_str = enum_ident.to_string();
+    let tagged = variant_tags(input)?;
+    let trait_path = crate_root.trait_path();
+    let sr = crate_root.serde_reflection_path();
+
+    let variants_const_entries = tagged.iter().map(|(name, tag, _)| {
+        let n = name.as_str();
+        quote! { (#n, #tag) }
+    });
+
+    // For each variant, generate a block that:
+    //   1. calls trace_type_once for each field's type using the caller-supplied samples
+    //   2. constructs the variant and calls trace_value with our scratch samples
+    let blocks = tagged.iter().map(|(_, _, variant)| {
+        let variant_ident = &variant.ident;
+        match &variant.fields {
+            Fields::Unit => quote! {
+                let (__fmt, _) = #sr::Tracer::trace_value(
+                    __tracer,
+                    &mut __scratch,
+                    &#enum_ident::#variant_ident,
+                )?;
+                __format = ::core::option::Option::Some(__fmt);
+            },
+            Fields::Unnamed(fields) => {
+                let bindings: Vec<Ident> = (0..fields.unnamed.len())
+                    .map(|i| Ident::new(&format!("__field_{i}"), Span::call_site()))
+                    .collect();
+                let traces = bindings.iter().zip(fields.unnamed.iter()).map(|(b, f)| {
+                    let ty = &f.ty;
+                    quote! {
+                        let (_, #b): (_, #ty) =
+                            #sr::Tracer::trace_type_once(__tracer, __samples)?;
+                    }
+                });
+                quote! {
+                    #(#traces)*
+                    let (__fmt, _) = #sr::Tracer::trace_value(
+                        __tracer,
+                        &mut __scratch,
+                        &#enum_ident::#variant_ident(#(#bindings),*),
+                    )?;
+                    __format = ::core::option::Option::Some(__fmt);
+                }
+            }
+            Fields::Named(fields) => {
+                let field_idents: Vec<&Ident> = fields
+                    .named
+                    .iter()
+                    .map(|f| f.ident.as_ref().expect("named field has ident"))
+                    .collect();
+                let bindings: Vec<Ident> = field_idents
+                    .iter()
+                    .map(|i| Ident::new(&format!("__field_{i}"), i.span()))
+                    .collect();
+                let traces = bindings.iter().zip(fields.named.iter()).map(|(b, f)| {
+                    let ty = &f.ty;
+                    quote! {
+                        let (_, #b): (_, #ty) =
+                            #sr::Tracer::trace_type_once(__tracer, __samples)?;
+                    }
+                });
+                quote! {
+                    #(#traces)*
+                    let (__fmt, _) = #sr::Tracer::trace_value(
+                        __tracer,
+                        &mut __scratch,
+                        &#enum_ident::#variant_ident {
+                            #( #field_idents: #bindings ),*
+                        },
+                    )?;
+                    __format = ::core::option::Option::Some(__fmt);
+                }
+            }
+        }
+    });
+
+    Ok(quote! {
+        // The impl uses `serde_reflection`, which Linera applications only
+        // depend on for native (non-wasm) builds (e.g. format snapshot tests).
+        #[cfg(not(target_arch = "wasm32"))]
+        #[automatically_derived]
+        impl #trait_path for #enum_ident {
+            const STABLE_VARIANTS: &'static [(&'static ::core::primitive::str, ::core::primitive::u32)] = &[
+                #(#variants_const_entries),*
+            ];
+
+            fn trace_all_variants(
+                __tracer: &mut #sr::Tracer,
+                __samples: &#sr::Samples,
+            ) -> #sr::Result<#sr::Format> {
+                // `trace_value` requires `&mut Samples` even though we have no
+                // need to feed its recordings back to the caller, so we use a
+                // scratch instance here.
+                let mut __scratch = #sr::Samples::default();
+                let mut __format: ::core::option::Option<#sr::Format> =
+                    ::core::option::Option::None;
+                #({ #blocks })*
+                __format.ok_or_else(|| #sr::Error::Custom(
+                    ::std::format!(
+                        "stable enum `{}` has no variants",
+                        #enum_name_str,
+                    ),
+                ))
+            }
+        }
+    })
+}

--- a/linera-sdk/src/formats.rs
+++ b/linera-sdk/src/formats.rs
@@ -3,10 +3,22 @@
 
 //! Support the declaration of the binary formats used by an application.
 
-use serde::{Deserialize, Serialize};
+/// Re-exports the `#[derive(StableEnum)]` macro for stable-tagged enums.
+pub use linera_sdk_derive::StableEnum;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+/// Private re-exports of crates referenced by the macros in `linera-sdk-derive`.
+/// Lets downstream crates use the macros without taking direct dependencies on
+/// the crates being re-exported. Not part of the public API; do not use
+/// directly.
+#[doc(hidden)]
+pub mod __private {
+    pub use serde;
+    pub use serde_reflection;
+}
 use serde_reflection::{
     json_converter::{DeserializationContext, EmptyEnvironment},
-    Format, Registry,
+    Format, Registry, Samples, Tracer,
 };
 
 /// The serde formats used by an application. The exact serde encoding in use must be
@@ -33,6 +45,67 @@ pub trait BcsApplication {
 
     /// Returns the serde formats for this application's ABI types.
     fn formats() -> serde_reflection::Result<Formats>;
+}
+
+/// Companion trait of [`StableEnum`]: exposes each variant's stable tag and
+/// provides the implementation backing
+/// [`TracerExt::trace_stable_enum_type`]. Implemented by the
+/// `#[derive(StableEnum)]` macro.
+///
+/// The derive auto-generates `trace_all_variants` by calling
+/// [`Tracer::trace_type_once`] for each field type to obtain a sample value,
+/// then [`Tracer::trace_value`] to record the variant. As a result, every
+/// field type must implement [`serde::de::DeserializeOwned`] (or otherwise be
+/// traceable by [`Tracer::trace_type_once`]). Nested `StableEnum` fields are
+/// not supported automatically — pre-trace them with
+/// `trace_stable_enum_type::<NestedEnum>` first.
+pub trait StableEnumTrace: Sized + Serialize {
+    /// The `(variant_name, variant_tag)` pairs in declaration order.
+    const STABLE_VARIANTS: &'static [(&'static str, u32)];
+
+    /// Trace each variant of `Self` into `tracer`'s registry. The default
+    /// derive implementation is sufficient for most cases.
+    fn trace_all_variants(
+        tracer: &mut Tracer,
+        samples: &Samples,
+    ) -> serde_reflection::Result<Format>;
+}
+
+/// Marker trait for enums whose variant tags on the wire are derived from
+/// `Keccak-256(variant_name)`. Apply with `#[derive(StableEnum)]`.
+///
+/// The blanket impl below covers every type for which all three of
+/// [`Serialize`], [`DeserializeOwned`], and [`StableEnumTrace`] are
+/// implemented — `#[derive(StableEnum)]` emits all three at once.
+pub trait StableEnum: StableEnumTrace + Serialize + DeserializeOwned {}
+
+impl<T> StableEnum for T where T: StableEnumTrace + Serialize + DeserializeOwned {}
+
+/// Extension methods on [`Tracer`] for tracing enums whose variant tags are
+/// not contiguous starting at zero.
+///
+/// The standard [`Tracer::trace_type`] discovers an enum's variants by probing
+/// `0, 1, 2, …` until each `u32` index has been seen. With Keccak-derived
+/// stable tags those indices are not consecutive (they live in `[2^27, 2^28)`),
+/// so probing never terminates. This trait delegates to the enum's
+/// [`StableEnumTrace`] impl, which drives tracing variant-by-variant via the
+/// enum's [`Serialize`] impl.
+pub trait TracerExt {
+    /// Trace every variant of a stable-tagged enum, returning the enum's
+    /// [`Format`] for use in [`Formats::operation`], [`Formats::response`],
+    /// etc.
+    fn trace_stable_enum_type<T>(&mut self, samples: &Samples) -> serde_reflection::Result<Format>
+    where
+        T: StableEnumTrace;
+}
+
+impl TracerExt for Tracer {
+    fn trace_stable_enum_type<T>(&mut self, samples: &Samples) -> serde_reflection::Result<Format>
+    where
+        T: StableEnumTrace,
+    {
+        T::trace_all_variants(self, samples)
+    }
 }
 
 /// Decode BCS-serialized `bytes` into a [`serde_json::Value`], guided by `format`
@@ -76,7 +149,7 @@ impl Formats {
 mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use serde_reflection::{Samples, Tracer, TracerConfig};
+    use serde_reflection::{ContainerFormat, Samples, Tracer, TracerConfig};
 
     use super::*;
 
@@ -220,5 +293,87 @@ mod tests {
         let (format, registry) = trace_format::<u64>();
         // u64 needs 8 bytes; only provide 3.
         assert!(bcs_to_json(&[1, 2, 3], &format, &registry).is_err());
+    }
+
+    #[test]
+    fn stable_enum_round_trip() {
+        use linera_sdk_derive::StableEnumInCrate;
+
+        #[derive(Debug, PartialEq, StableEnumInCrate)]
+        enum Op {
+            Increment,
+            Set { value: u64 },
+            Add(i64, i64),
+            Echo(String),
+        }
+
+        // Wire format: each variant tag is exactly 4 ULEB128 bytes.
+        for c in [
+            Op::Increment,
+            Op::Set { value: 99 },
+            Op::Add(2, 3),
+            Op::Echo("hi".into()),
+        ] {
+            let bytes = bcs::to_bytes(&c).unwrap();
+            assert!(bytes.len() >= 4, "tag must be at least 4 bytes: {c:?}");
+            // 4-byte ULEB128: first 3 bytes have continuation bit, 4th doesn't.
+            assert_eq!(bytes[0] & 0x80, 0x80, "byte 0 has continuation");
+            assert_eq!(bytes[1] & 0x80, 0x80, "byte 1 has continuation");
+            assert_eq!(bytes[2] & 0x80, 0x80, "byte 2 has continuation");
+            assert_eq!(bytes[3] & 0x80, 0x00, "byte 3 terminates");
+
+            let back: Op = bcs::from_bytes(&bytes).unwrap();
+            assert_eq!(back, c);
+        }
+
+        // Unknown tags must be rejected.
+        let bogus = bcs::to_bytes(&0u32).unwrap();
+        assert!(bcs::from_bytes::<Op>(&bogus).is_err());
+
+        // Tags published in the trait const match what BCS actually emits.
+        for &(name, tag) in <Op as StableEnumTrace>::STABLE_VARIANTS {
+            let sample = match name {
+                "Increment" => bcs::to_bytes(&Op::Increment).unwrap(),
+                "Set" => bcs::to_bytes(&Op::Set { value: 0 }).unwrap(),
+                "Add" => bcs::to_bytes(&Op::Add(0, 0)).unwrap(),
+                "Echo" => bcs::to_bytes(&Op::Echo(String::new())).unwrap(),
+                _ => unreachable!(),
+            };
+            let decoded = decode_uleb_u32(&sample[..4]);
+            assert_eq!(decoded, tag, "variant {name} tag mismatch");
+        }
+
+        // Tracing via the extension trait records the Keccak tags in the registry.
+        let mut tracer = Tracer::new(TracerConfig::default());
+        let samples = Samples::new();
+        let format = tracer.trace_stable_enum_type::<Op>(&samples).unwrap();
+        let registry = tracer.registry().unwrap();
+        match registry.get("Op").unwrap() {
+            ContainerFormat::Enum(variants) => {
+                let mut keys: Vec<_> = variants.keys().copied().collect();
+                keys.sort();
+                let mut expected: Vec<u32> = <Op as StableEnumTrace>::STABLE_VARIANTS
+                    .iter()
+                    .map(|(_, t)| *t)
+                    .collect();
+                expected.sort();
+                assert_eq!(keys, expected);
+            }
+            _ => panic!("expected enum"),
+        }
+
+        // End-to-end: bcs_to_json works against the reflected registry.
+        let bytes = bcs::to_bytes(&Op::Set { value: 99 }).unwrap();
+        let value = bcs_to_json(&bytes, &format, &registry).unwrap();
+        assert_eq!(value, json!({ "Set": { "value": 99 } }));
+    }
+
+    /// Decode a 4-byte (exactly) ULEB128 sequence into a `u32`.
+    fn decode_uleb_u32(bytes: &[u8]) -> u32 {
+        let b0 = (bytes[0] & 0x7f) as u32;
+        let b1 = (bytes[1] & 0x7f) as u32;
+        let b2 = (bytes[2] & 0x7f) as u32;
+        let b3 = bytes[3] as u32;
+        b0 | (b1 << 7) | (b2 << 14) | (b3 << 21)
     }
 }

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2412,6 +2412,7 @@ version = "0.15.19"
 dependencies = [
  "convert_case",
  "proc-macro2",
+ "sha3",
  "syn 2.0.106",
 ]
 

--- a/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
+++ b/linera-sdk/tests/fixtures/meta-counter/src/contract.rs
@@ -94,7 +94,8 @@ impl Contract for MetaCounterContract {
             Message::Increment(value) => {
                 let counter_id = self.counter_id();
                 log::trace!("executing {} via {:?}", value, counter_id);
-                self.runtime.call_application(true, counter_id, &value);
+                let operation = counter::CounterOperation::Increment { value };
+                self.runtime.call_application(true, counter_id, &operation);
             }
         }
     }

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1941,7 +1941,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 async fn test_publish_module_with_formats_registers_formats(
     config: impl LineraNetConfig,
 ) -> Result<()> {
-    use counter::{formats::CounterApplication, CounterAbi};
+    use counter::{formats::CounterApplication, CounterAbi, CounterOperation};
     use linera_sdk::{
         abis::formats_registry::FormatsRegistryAbi,
         formats::{BcsApplication, Formats},
@@ -2009,10 +2009,10 @@ async fn test_publish_module_with_formats_registers_formats(
     // JSON using the formats fetched from the registry. This exercises the
     // exact path the explorer relies on: registry-stored Formats →
     // Formats::decode_operation on user-operation bytes.
-    let sample_operation: u64 = 42;
+    let sample_operation = CounterOperation::Increment { value: 42 };
     let operation_bytes = bcs::to_bytes(&sample_operation)?;
     let decoded = stored_formats.decode_operation(&operation_bytes)?;
-    assert_eq!(decoded, serde_json::json!(sample_operation));
+    assert_eq!(decoded, serde_json::to_value(&sample_operation)?);
 
     node_service.ensure_is_running()?;
 


### PR DESCRIPTION
## Motivation

Backport of #6309 to `testnet_conway`. This is the prerequisite for backporting #6314 (apply `StableEnum` to all ABI Operation/Response enums), which the release plan calls for.

## Proposal

Cherry-pick #6309, which adds the `#[derive(StableEnum)]` / `StableEnumInCrate` macros to `linera-sdk-derive` plus the companion `StableEnumTrace`/`StableEnum` traits and `TracerExt::trace_stable_enum_type` in `linera-sdk::formats`. Stable enums lock each variant tag to a 4-byte Keccak-derived ULEB128 value, decoupling the wire format from declaration order.

### Conway-specific adaptations

The cherry-pick did not apply cleanly because conway's `counter` example still uses `type Operation = u64` — the `CounterOperation` enum on `main` was introduced by the unrelated #6264 (application introspection), which is not on `testnet_conway`. I applied **only** the operation-enum migration that #6309 depends on, leaving conway's other differences (ANCHOR docs, `QueryRoot`, non-`Arc` service state) untouched:

- `examples/counter` (`lib.rs`, `contract.rs`, `service.rs`, `tests/single_chain.rs`): migrate the operation type from `u64` to `CounterOperation::Increment { value }` and add `#[derive(StableEnum)]`.
- `linera-sdk/tests/fixtures/meta-counter/src/contract.rs` and `linera-core/src/unit_tests/wasm_client_tests.rs`: wrap the cross-application / user operations in `CounterOperation::Increment` so the wire format matches the migrated contract.
- Lockfiles refreshed for the new `sha3` dependency edge on `linera-sdk-derive` (root, `examples`, and `linera-sdk/tests/fixtures`).

## Test Plan

- `linera-sdk` unit tests pass, including `formats::tests::stable_enum_round_trip`.
- All `counter` example tests pass, including the `format` snapshot test (regenerated Keccak tag) and the `single_chain` end-to-end test (real wasm round-trip of `CounterOperation`).
- `cargo check -p linera-core --tests --features wasmer` compiles (covers `wasm_client_tests` and the `meta-counter` fixture).
- `cargo +nightly fmt --check` and `cargo clippy` clean on the root, `examples`, and fixtures workspaces; all three lockfiles verified `--locked`-consistent.

## Release Plan

- These changes should be backported to the latest `testnet` branch (this PR targets `testnet_conway`).

## Links

- Backport of #6309
- Prerequisite for backporting #6314
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
