### PR TITLE
Support remote module registration by authorized admins in the formats-registry example

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2716,8 +2716,10 @@ name = "formats-registry"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
+ "insta",
  "linera-sdk",
  "serde",
+ "serde-reflection",
  "serde_json",
  "tokio",
 ]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2717,6 +2717,7 @@ version = "0.1.0"
 dependencies = [
  "async-graphql",
  "linera-sdk",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/examples/formats-registry/Cargo.toml
+++ b/examples/formats-registry/Cargo.toml
@@ -9,8 +9,13 @@ async-graphql.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+serde-reflection.workspace = true
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+insta.workspace = true
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+serde-reflection.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 

--- a/examples/formats-registry/Cargo.toml
+++ b/examples/formats-registry/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 async-graphql.workspace = true
 linera-sdk.workspace = true
+serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }

--- a/examples/formats-registry/README.md
+++ b/examples/formats-registry/README.md
@@ -18,7 +18,7 @@ The application's operations all carry the `owner` on whose behalf they run:
 
 ```rust
 enum Operation {
-    Write { owner: AccountOwner, module_id: ModuleId, value: Vec<u8> },
+    Write { owner: AccountOwner, module_id: ModuleId, blob_hash: DataBlobHash },
     SetAdmins { owner: AccountOwner, admins: Option<Vec<AccountOwner>> },
 }
 ```
@@ -48,17 +48,24 @@ This mirrors the policy used by `examples/controller`. To bootstrap, an admin fi
 runs `SetAdmins` locally on the creation chain; afterwards, the listed admins can
 register modules remotely from their own chains.
 
-`Write` stores `value` in a `MapView<ModuleId, Vec<u8>>` keyed by `module_id`,
-asserting first that no entry exists yet — entries are **immutable** (first-write-wins;
-a `ModuleId` cannot be overwritten).
+`Write` carries the [`DataBlobHash`](../../linera-base/src/identifiers.rs) of an
+immutable [`DataBlob`](../../linera-base/src/data_types.rs) holding the formats
+description. The caller publishes that data blob (e.g. `linera
+publish-module-with-formats` emits a `PublishDataBlob` operation in the same block);
+the contract `assert`s the blob exists and records its hash in a
+`MapView<ModuleId, DataBlobHash>` keyed by `module_id`, after checking that no entry
+exists yet — entries are **immutable** (first-write-wins; a `ModuleId` cannot be
+overwritten). Only the 32-byte hash travels to the creation chain inside the `Message`,
+so state stays compact (one hash per `ModuleId`) and identical values are
+content-addressed and deduplicated by the blob layer.
 
 The service exposes:
 
 - `query { read(moduleId: "...") }` — returns the bytes registered for `moduleId`, or
-  `null` if none.
+  `null` if none. Internally it reads the stored hash and fetches the data blob.
 - `query { admins }` — returns the configured admin accounts, or `null` if none.
-- `mutation { write(owner: "...", moduleId: "...", value: [u8]) }` — schedules a
-  `Write` operation.
+- `mutation { write(owner: "...", moduleId: "...", blobHash: "...") }` — schedules a
+  `Write` operation (the data blob must be published separately).
 - `mutation { setAdmins(owner: "...", admins: ["..."]) }` — schedules a `SetAdmins`
   operation (pass `null` to clear the set).
 
@@ -119,17 +126,18 @@ echo "http://localhost:$PORT/chains/$CHAIN/applications/$LINERA_APPLICATION_ID"
 
 Open the printed URL to land in a GraphiQL session connected to the registry.
 
-To register the bytes for a module (replace `<MODULE_ID_HEX>` and `<OWNER>` accordingly;
-`ModuleId` and `AccountOwner` are encoded as strings and `value` is a JSON array of byte
-values). `<OWNER>` must be the chain's signer; once an admin set is configured it must
-also be one of the admins:
+To register a module's formats, first publish the formats description as a data blob
+(e.g. `linera publish-data-blob <FILE>`, which prints the `<BLOB_HASH>`), then bind it
+(replace `<MODULE_ID_HEX>`, `<OWNER>` and `<BLOB_HASH>` accordingly; `ModuleId`,
+`AccountOwner` and `DataBlobHash` are encoded as strings). `<OWNER>` must be the chain's
+signer; once an admin set is configured it must also be one of the admins:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN/applications/$LINERA_APPLICATION_ID
 mutation {
   write(
     owner: "<OWNER>",
     moduleId: "<MODULE_ID_HEX>",
-    value: [1, 2, 3, 4]
+    blobHash: "<BLOB_HASH>"
   )
 }
 ```

--- a/examples/formats-registry/README.md
+++ b/examples/formats-registry/README.md
@@ -14,32 +14,53 @@ for display.
 
 ## How It Works
 
-The application has a single operation:
+The application's operations all carry the `owner` on whose behalf they run:
 
 ```rust
 enum Operation {
-    Write { module_id: ModuleId, value: Vec<u8> },
+    Write { owner: AccountOwner, module_id: ModuleId, value: Vec<u8> },
+    SetAdmins { owner: AccountOwner, admins: Option<Vec<AccountOwner>> },
 }
 ```
 
-When `Write` is executed, the contract:
+`Write` is intentionally kept as the first variant with the exact fields of
+[`linera_sdk::abis::formats_registry::Operation::Write`](../../linera-sdk/src/abis/formats_registry.rs),
+so that the operation produced by `linera publish-module-with-formats` decodes
+correctly here. Extra, implementation-specific admin commands (here `SetAdmins`) are
+appended after it.
 
-1. Asserts that no entry exists yet for `module_id` (entries are **immutable** —
-   first-write-wins; a `ModuleId` cannot be overwritten).
-2. Publishes `value` as an immutable [`DataBlob`](../../linera-base/src/data_types.rs)
-   via `runtime.create_data_blob(value)`.
-3. Stores the resulting `DataBlobHash` in a `MapView<ModuleId, DataBlobHash>` keyed by
-   `module_id`.
+### Authorization and remote registration
 
-The state is therefore compact (one hash per `ModuleId`), and every registered value
-benefits from the usual content-addressed deduplication of the blob layer.
+A module can be registered from any chain, but every mutation is ultimately applied on
+the application's **creation chain**, where a single admin policy is enforced:
+
+1. On the chain where the operation is submitted, the contract calls
+   `runtime.check_account_permission(owner)` to verify the declared `owner` really
+   signed (or is the caller of) the operation.
+2. If the current chain is the creation chain, the operation is executed locally.
+   Otherwise it is forwarded to the creation chain as a cross-chain `Message`.
+3. On the creation chain, the security policy is applied before any state change:
+   - if an admin set has been configured, `owner` must be one of the admins;
+   - if no admin set exists yet, the operation is allowed only when it originates
+     locally — remote requests are refused until admins are configured.
+
+This mirrors the policy used by `examples/controller`. To bootstrap, an admin first
+runs `SetAdmins` locally on the creation chain; afterwards, the listed admins can
+register modules remotely from their own chains.
+
+`Write` stores `value` in a `MapView<ModuleId, Vec<u8>>` keyed by `module_id`,
+asserting first that no entry exists yet — entries are **immutable** (first-write-wins;
+a `ModuleId` cannot be overwritten).
 
 The service exposes:
 
-- `query { get(moduleId: "...") }` — returns the bytes registered for `moduleId`, or
-  `null` if none. Internally, the service reads the hash from the map and then calls
-  `runtime.read_data_blob(hash)` to fetch the blob.
-- `mutation { write(moduleId: "...", value: [u8]) }` — schedules a `Write` operation.
+- `query { read(moduleId: "...") }` — returns the bytes registered for `moduleId`, or
+  `null` if none.
+- `query { admins }` — returns the configured admin accounts, or `null` if none.
+- `mutation { write(owner: "...", moduleId: "...", value: [u8]) }` — schedules a
+  `Write` operation.
+- `mutation { setAdmins(owner: "...", admins: ["..."]) }` — schedules a `SetAdmins`
+  operation (pass `null` to clear the set).
 
 ## Setup and Deployment
 
@@ -98,12 +119,15 @@ echo "http://localhost:$PORT/chains/$CHAIN/applications/$LINERA_APPLICATION_ID"
 
 Open the printed URL to land in a GraphiQL session connected to the registry.
 
-To register the bytes for a module (replace `<MODULE_ID_HEX>` and `<BYTES>` accordingly;
-`ModuleId` is encoded as a hex string and `value` is a JSON array of byte values):
+To register the bytes for a module (replace `<MODULE_ID_HEX>` and `<OWNER>` accordingly;
+`ModuleId` and `AccountOwner` are encoded as strings and `value` is a JSON array of byte
+values). `<OWNER>` must be the chain's signer; once an admin set is configured it must
+also be one of the admins:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN/applications/$LINERA_APPLICATION_ID
 mutation {
   write(
+    owner: "<OWNER>",
     moduleId: "<MODULE_ID_HEX>",
     value: [1, 2, 3, 4]
   )
@@ -114,7 +138,7 @@ To read it back:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN/applications/$LINERA_APPLICATION_ID
 query {
-  get(moduleId: "<MODULE_ID_HEX>")
+  read(moduleId: "<MODULE_ID_HEX>")
 }
 ```
 

--- a/examples/formats-registry/src/contract.rs
+++ b/examples/formats-registry/src/contract.rs
@@ -5,8 +5,8 @@
 
 mod state;
 
+use formats_registry::{FormatsRegistryAbi, Message, Operation};
 use linera_sdk::{
-    abis::formats_registry::{FormatsRegistryAbi, Operation},
     linera_base_types::WithContractAbi,
     views::{RootView, View},
     Contract, ContractRuntime,
@@ -26,7 +26,7 @@ impl WithContractAbi for FormatsRegistryContract {
 }
 
 impl Contract for FormatsRegistryContract {
-    type Message = ();
+    type Message = Message;
     type InstantiationArgument = ();
     type Parameters = ();
     type EventValue = ();
@@ -43,8 +43,66 @@ impl Contract for FormatsRegistryContract {
     }
 
     async fn execute_operation(&mut self, operation: Operation) {
-        match operation {
-            Operation::Write { module_id, value } => {
+        // Authenticate that the declared owner really signed (or is the caller of)
+        // this operation.
+        let owner = operation.owner();
+        self.runtime
+            .check_account_permission(owner)
+            .expect("Failed to authenticate the owner of the operation");
+
+        let message = operation.into_message();
+        let creator_chain_id = self.runtime.application_creator_chain_id();
+        if self.runtime.chain_id() == creator_chain_id {
+            self.execute_locally(message).await;
+        } else {
+            // The registry only mutates state on its creation chain; forward the
+            // request there so the admin policy is applied in a single place.
+            self.runtime
+                .prepare_message(message)
+                .send_to(creator_chain_id);
+        }
+    }
+
+    async fn execute_message(&mut self, message: Message) {
+        assert_eq!(
+            self.runtime.chain_id(),
+            self.runtime.application_creator_chain_id(),
+            "Registry messages can only be executed on the application's creation chain"
+        );
+        self.execute_locally(message).await;
+    }
+
+    async fn store(self) {
+        self.state
+            .save_and_drop()
+            .await
+            .expect("Failed to save state");
+    }
+}
+
+impl FormatsRegistryContract {
+    /// Applies the admin security policy and then performs the requested mutation.
+    /// This always runs on the application's creation chain.
+    async fn execute_locally(&mut self, message: Message) {
+        let owner = message.owner();
+        if let Some(admins) = self.state.admins.get() {
+            assert!(
+                admins.contains(&owner),
+                "Operation can only be executed by an authorized admin account. Got {owner}"
+            );
+        } else {
+            // No admin set has been configured yet: everyone is allowed, but only
+            // locally. Remote requests are refused until admins are configured.
+            assert!(
+                self.runtime.message_origin_chain_id().is_none(),
+                "Refusing to execute a remote operation before any admin is configured",
+            );
+        }
+
+        match message {
+            Message::Write {
+                module_id, value, ..
+            } => {
                 let existing = self.state.formats.get(&module_id).await.expect("storage");
                 assert!(
                     existing.is_none(),
@@ -55,17 +113,11 @@ impl Contract for FormatsRegistryContract {
                     .insert(&module_id, value)
                     .expect("storage");
             }
+            Message::SetAdmins { admins, .. } => {
+                self.state
+                    .admins
+                    .set(admins.map(|admins| admins.into_iter().collect()));
+            }
         }
-    }
-
-    async fn execute_message(&mut self, _message: ()) {
-        panic!("formats-registry does not support cross-chain messages");
-    }
-
-    async fn store(self) {
-        self.state
-            .save_and_drop()
-            .await
-            .expect("Failed to save state");
     }
 }

--- a/examples/formats-registry/src/contract.rs
+++ b/examples/formats-registry/src/contract.rs
@@ -102,16 +102,26 @@ impl FormatsRegistryContract {
 
         match message {
             Message::Write {
-                module_id, value, ..
+                module_id,
+                blob_hash,
+                ..
             } => {
                 let existing = self.state.formats.get(&module_id).await.expect("storage");
                 assert!(
                     existing.is_none(),
                     "formats are already registered for this module"
                 );
+                // For a remote write the blob was published in an earlier block on the
+                // submitting chain; require it here so it is available on (and retained
+                // by) the creation chain. For a local write the blob is published in
+                // this same block and cannot be asserted yet, but it is persisted by
+                // the caller's `PublishDataBlob`.
+                if self.runtime.message_origin_chain_id().is_some() {
+                    self.runtime.assert_data_blob_exists(blob_hash);
+                }
                 self.state
                     .formats
-                    .insert(&module_id, value)
+                    .insert(&module_id, blob_hash)
                     .expect("storage");
             }
             Message::SetAdmins { admins, .. } => {

--- a/examples/formats-registry/src/contract.rs
+++ b/examples/formats-registry/src/contract.rs
@@ -5,6 +5,7 @@
 
 mod state;
 
+use async_graphql::ComplexObject;
 use formats_registry::{FormatsRegistryAbi, Message, Operation};
 use linera_sdk::{
     linera_base_types::WithContractAbi,
@@ -121,3 +122,7 @@ impl FormatsRegistryContract {
         }
     }
 }
+
+/// This implementation is only nonempty in the service.
+#[ComplexObject]
+impl FormatsRegistryState {}

--- a/examples/formats-registry/src/lib.rs
+++ b/examples/formats-registry/src/lib.rs
@@ -99,3 +99,51 @@ impl Message {
         }
     }
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod formats {
+    use linera_sdk::{
+        formats::{BcsApplication, Formats},
+        linera_base_types::{AccountOwner, ModuleId, VmRuntime},
+    };
+    use serde_reflection::{Samples, Tracer, TracerConfig};
+
+    use super::{FormatsRegistryAbi, Message, Operation};
+
+    /// The Formats Registry application.
+    pub struct FormatsRegistryApplication;
+
+    impl BcsApplication for FormatsRegistryApplication {
+        type Abi = FormatsRegistryAbi;
+
+        fn formats() -> serde_reflection::Result<Formats> {
+            let mut tracer = Tracer::new(
+                TracerConfig::default()
+                    .record_samples_for_newtype_structs(true)
+                    .record_samples_for_tuple_structs(true),
+            );
+            let samples = Samples::new();
+
+            // Trace the ABI types
+            let (operation, _) = tracer.trace_type::<Operation>(&samples)?;
+            let (response, _) = tracer.trace_type::<()>(&samples)?;
+            let (message, _) = tracer.trace_type::<Message>(&samples)?;
+            let (event_value, _) = tracer.trace_type::<()>(&samples)?;
+
+            // Trace additional supporting types (notably all enums) to populate the registry
+            tracer.trace_type::<AccountOwner>(&samples)?;
+            tracer.trace_type::<ModuleId>(&samples)?;
+            tracer.trace_type::<VmRuntime>(&samples)?;
+
+            let registry = tracer.registry()?;
+
+            Ok(Formats {
+                registry,
+                operation,
+                response,
+                message,
+                event_value,
+            })
+        }
+    }
+}

--- a/examples/formats-registry/src/lib.rs
+++ b/examples/formats-registry/src/lib.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/*! ABI of the Formats Registry Example Application */
+
+use async_graphql::{Request, Response};
+use linera_sdk::linera_base_types::{AccountOwner, ContractAbi, ModuleId, ServiceAbi};
+use serde::{Deserialize, Serialize};
+
+/// The ABI of the formats-registry example application.
+pub struct FormatsRegistryAbi;
+
+impl ContractAbi for FormatsRegistryAbi {
+    type Operation = Operation;
+    type Response = ();
+}
+
+impl ServiceAbi for FormatsRegistryAbi {
+    type Query = Request;
+    type QueryResponse = Response;
+}
+
+/// Operations accepted by the contract.
+///
+/// `Write` is kept as the first variant with exactly the fields of
+/// [`linera_sdk::abis::formats_registry::Operation::Write`], so the operation
+/// produced by `linera publish-module-with-formats` decodes correctly here. Extra,
+/// implementation-specific admin commands are appended after it.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Operation {
+    /// Register `value` for `module_id`, on behalf of `owner`. A given `module_id`
+    /// may only be written once.
+    Write {
+        owner: AccountOwner,
+        module_id: ModuleId,
+        value: Vec<u8>,
+    },
+    /// Set the admin accounts authorized to run admin commands (including remote
+    /// `Write`s). Passing `None` clears the set, restoring creation-chain-only
+    /// access.
+    SetAdmins {
+        owner: AccountOwner,
+        admins: Option<Vec<AccountOwner>>,
+    },
+}
+
+/// Messages exchanged between chains of the same application instance. Each variant
+/// mirrors the corresponding [`Operation`] and is sent to the application's creation
+/// chain to be executed there.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Message {
+    /// Remote counterpart of [`Operation::Write`].
+    Write {
+        owner: AccountOwner,
+        module_id: ModuleId,
+        value: Vec<u8>,
+    },
+    /// Remote counterpart of [`Operation::SetAdmins`].
+    SetAdmins {
+        owner: AccountOwner,
+        admins: Option<Vec<AccountOwner>>,
+    },
+}
+
+impl Operation {
+    /// The account on whose behalf the operation is executed.
+    pub fn owner(&self) -> AccountOwner {
+        match self {
+            Operation::Write { owner, .. } | Operation::SetAdmins { owner, .. } => *owner,
+        }
+    }
+
+    /// Converts the operation into the cross-chain message that performs it on the
+    /// creation chain.
+    pub fn into_message(self) -> Message {
+        match self {
+            Operation::Write {
+                owner,
+                module_id,
+                value,
+            } => Message::Write {
+                owner,
+                module_id,
+                value,
+            },
+            Operation::SetAdmins { owner, admins } => Message::SetAdmins { owner, admins },
+        }
+    }
+}
+
+impl Message {
+    /// The account on whose behalf the message is executed.
+    pub fn owner(&self) -> AccountOwner {
+        match self {
+            Message::Write { owner, .. } | Message::SetAdmins { owner, .. } => *owner,
+        }
+    }
+}

--- a/examples/formats-registry/src/lib.rs
+++ b/examples/formats-registry/src/lib.rs
@@ -6,7 +6,7 @@
 use async_graphql::{Request, Response};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ContractAbi, ModuleId, ServiceAbi},
+    linera_base_types::{AccountOwner, ContractAbi, DataBlobHash, ModuleId, ServiceAbi},
 };
 use serde::{Deserialize, Serialize};
 
@@ -31,12 +31,13 @@ impl ServiceAbi for FormatsRegistryAbi {
 /// implementation-specific admin commands are appended after it.
 #[derive(Clone, Debug, Deserialize, Serialize, GraphQLMutationRoot)]
 pub enum Operation {
-    /// Register `value` for `module_id`, on behalf of `owner`. A given `module_id`
-    /// may only be written once.
+    /// Register the data blob `blob_hash` (holding the formats description) for
+    /// `module_id`, on behalf of `owner`. The caller must publish that data blob in
+    /// the same block. A given `module_id` may only be written once.
     Write {
         owner: AccountOwner,
         module_id: ModuleId,
-        value: Vec<u8>,
+        blob_hash: DataBlobHash,
     },
     /// Set the admin accounts authorized to run admin commands (including remote
     /// `Write`s). Passing `None` clears the set, restoring creation-chain-only
@@ -52,11 +53,12 @@ pub enum Operation {
 /// chain to be executed there.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Message {
-    /// Remote counterpart of [`Operation::Write`].
+    /// Remote counterpart of [`Operation::Write`]. The payload is published as a data
+    /// blob on the submitting chain, so only its `blob_hash` travels across chains.
     Write {
         owner: AccountOwner,
         module_id: ModuleId,
-        value: Vec<u8>,
+        blob_hash: DataBlobHash,
     },
     /// Remote counterpart of [`Operation::SetAdmins`].
     SetAdmins {
@@ -80,11 +82,11 @@ impl Operation {
             Operation::Write {
                 owner,
                 module_id,
-                value,
+                blob_hash,
             } => Message::Write {
                 owner,
                 module_id,
-                value,
+                blob_hash,
             },
             Operation::SetAdmins { owner, admins } => Message::SetAdmins { owner, admins },
         }

--- a/examples/formats-registry/src/lib.rs
+++ b/examples/formats-registry/src/lib.rs
@@ -4,7 +4,10 @@
 /*! ABI of the Formats Registry Example Application */
 
 use async_graphql::{Request, Response};
-use linera_sdk::linera_base_types::{AccountOwner, ContractAbi, ModuleId, ServiceAbi};
+use linera_sdk::{
+    graphql::GraphQLMutationRoot,
+    linera_base_types::{AccountOwner, ContractAbi, ModuleId, ServiceAbi},
+};
 use serde::{Deserialize, Serialize};
 
 /// The ABI of the formats-registry example application.
@@ -26,7 +29,7 @@ impl ServiceAbi for FormatsRegistryAbi {
 /// [`linera_sdk::abis::formats_registry::Operation::Write`], so the operation
 /// produced by `linera publish-module-with-formats` decodes correctly here. Extra,
 /// implementation-specific admin commands are appended after it.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, GraphQLMutationRoot)]
 pub enum Operation {
     /// Register `value` for `module_id`, on behalf of `owner`. A given `module_id`
     /// may only be written once.

--- a/examples/formats-registry/src/service.rs
+++ b/examples/formats-registry/src/service.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use formats_registry::{FormatsRegistryAbi, Operation};
 use linera_sdk::{
+    graphql::GraphQLMutationRoot,
     linera_base_types::{AccountOwner, ModuleId, WithServiceAbi},
     views::View,
     Service, ServiceRuntime,
@@ -46,9 +47,7 @@ impl Service for FormatsRegistryService {
             QueryRoot {
                 state: self.state.clone(),
             },
-            MutationRoot {
-                runtime: self.runtime.clone(),
-            },
+            Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
         .finish();
@@ -76,27 +75,5 @@ impl QueryRoot {
             .get()
             .as_ref()
             .map(|admins| admins.iter().copied().collect())
-    }
-}
-
-struct MutationRoot {
-    runtime: Arc<ServiceRuntime<FormatsRegistryService>>,
-}
-
-#[Object]
-impl MutationRoot {
-    async fn write(&self, owner: AccountOwner, module_id: ModuleId, value: Vec<u8>) -> [u8; 0] {
-        self.runtime.schedule_operation(&Operation::Write {
-            owner,
-            module_id,
-            value,
-        });
-        []
-    }
-
-    async fn set_admins(&self, owner: AccountOwner, admins: Option<Vec<AccountOwner>>) -> [u8; 0] {
-        self.runtime
-            .schedule_operation(&Operation::SetAdmins { owner, admins });
-        []
     }
 }

--- a/examples/formats-registry/src/service.rs
+++ b/examples/formats-registry/src/service.rs
@@ -8,9 +8,9 @@ mod state;
 use std::sync::Arc;
 
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use formats_registry::{FormatsRegistryAbi, Operation};
 use linera_sdk::{
-    abis::formats_registry::{FormatsRegistryAbi, Operation},
-    linera_base_types::{ModuleId, WithServiceAbi},
+    linera_base_types::{AccountOwner, ModuleId, WithServiceAbi},
     views::View,
     Service, ServiceRuntime,
 };
@@ -64,8 +64,18 @@ struct QueryRoot {
 impl QueryRoot {
     /// Returns the bytes registered for the given module, or `None` if the
     /// module has no entry yet.
-    async fn get(&self, module_id: ModuleId) -> Option<Vec<u8>> {
+    async fn read(&self, module_id: ModuleId) -> Option<Vec<u8>> {
         self.state.formats.get(&module_id).await.unwrap()
+    }
+
+    /// Returns the configured admin accounts, or `None` if no admin set has been
+    /// configured yet.
+    async fn admins(&self) -> Option<Vec<AccountOwner>> {
+        self.state
+            .admins
+            .get()
+            .as_ref()
+            .map(|admins| admins.iter().copied().collect())
     }
 }
 
@@ -75,9 +85,18 @@ struct MutationRoot {
 
 #[Object]
 impl MutationRoot {
-    async fn write(&self, module_id: ModuleId, value: Vec<u8>) -> [u8; 0] {
+    async fn write(&self, owner: AccountOwner, module_id: ModuleId, value: Vec<u8>) -> [u8; 0] {
+        self.runtime.schedule_operation(&Operation::Write {
+            owner,
+            module_id,
+            value,
+        });
+        []
+    }
+
+    async fn set_admins(&self, owner: AccountOwner, admins: Option<Vec<AccountOwner>>) -> [u8; 0] {
         self.runtime
-            .schedule_operation(&Operation::Write { module_id, value });
+            .schedule_operation(&Operation::SetAdmins { owner, admins });
         []
     }
 }

--- a/examples/formats-registry/src/service.rs
+++ b/examples/formats-registry/src/service.rs
@@ -7,7 +7,7 @@ mod state;
 
 use std::sync::Arc;
 
-use async_graphql::{ComplexObject, EmptySubscription, Schema};
+use async_graphql::{ComplexObject, Context, EmptySubscription, Schema};
 use formats_registry::{FormatsRegistryAbi, Operation};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
@@ -48,6 +48,7 @@ impl Service for FormatsRegistryService {
             Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
+        .data(self.runtime.clone())
         .finish()
         .execute(query)
         .await
@@ -57,8 +58,13 @@ impl Service for FormatsRegistryService {
 #[ComplexObject]
 impl FormatsRegistryState {
     /// Returns the bytes registered for the given module, or `None` if the module
-    /// has no entry yet.
-    async fn read(&self, module_id: ModuleId) -> Option<Vec<u8>> {
-        self.formats.get(&module_id).await.expect("storage")
+    /// has no entry yet. Reads the registered hash from state and fetches the
+    /// corresponding data blob.
+    async fn read(&self, ctx: &Context<'_>, module_id: ModuleId) -> Option<Vec<u8>> {
+        let blob_hash = self.formats.get(&module_id).await.expect("storage")?;
+        let runtime = ctx
+            .data::<Arc<ServiceRuntime<FormatsRegistryService>>>()
+            .expect("the runtime is available in the GraphQL context");
+        Some(runtime.read_data_blob(blob_hash))
     }
 }

--- a/examples/formats-registry/src/service.rs
+++ b/examples/formats-registry/src/service.rs
@@ -7,11 +7,11 @@ mod state;
 
 use std::sync::Arc;
 
-use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use async_graphql::{ComplexObject, EmptySubscription, Schema};
 use formats_registry::{FormatsRegistryAbi, Operation};
 use linera_sdk::{
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, ModuleId, WithServiceAbi},
+    linera_base_types::{ModuleId, WithServiceAbi},
     views::View,
     Service, ServiceRuntime,
 };
@@ -42,38 +42,23 @@ impl Service for FormatsRegistryService {
         }
     }
 
-    async fn handle_query(&self, request: Request) -> Response {
-        let schema = Schema::build(
-            QueryRoot {
-                state: self.state.clone(),
-            },
+    async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse {
+        Schema::build(
+            self.state.clone(),
             Operation::mutation_root(self.runtime.clone()),
             EmptySubscription,
         )
-        .finish();
-        schema.execute(request).await
+        .finish()
+        .execute(query)
+        .await
     }
 }
 
-struct QueryRoot {
-    state: Arc<FormatsRegistryState>,
-}
-
-#[Object]
-impl QueryRoot {
-    /// Returns the bytes registered for the given module, or `None` if the
-    /// module has no entry yet.
+#[ComplexObject]
+impl FormatsRegistryState {
+    /// Returns the bytes registered for the given module, or `None` if the module
+    /// has no entry yet.
     async fn read(&self, module_id: ModuleId) -> Option<Vec<u8>> {
-        self.state.formats.get(&module_id).await.unwrap()
-    }
-
-    /// Returns the configured admin accounts, or `None` if no admin set has been
-    /// configured yet.
-    async fn admins(&self) -> Option<Vec<AccountOwner>> {
-        self.state
-            .admins
-            .get()
-            .as_ref()
-            .map(|admins| admins.iter().copied().collect())
+        self.formats.get(&module_id).await.expect("storage")
     }
 }

--- a/examples/formats-registry/src/state.rs
+++ b/examples/formats-registry/src/state.rs
@@ -1,9 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+
 use linera_sdk::{
-    linera_base_types::ModuleId,
-    views::{linera_views, MapView, RootView, ViewStorageContext},
+    linera_base_types::{AccountOwner, ModuleId},
+    views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 
 #[derive(RootView)]
@@ -11,4 +13,8 @@ use linera_sdk::{
 pub struct FormatsRegistryState {
     /// Maps a `ModuleId` to the bytes of its registered formats description.
     pub formats: MapView<ModuleId, Vec<u8>>,
+    /// The admin accounts authorized to run admin commands and remote writes.
+    /// `None` means no admin set has been configured yet, in which case only the
+    /// creation chain can mutate the registry.
+    pub admins: RegisterView<Option<HashSet<AccountOwner>>>,
 }

--- a/examples/formats-registry/src/state.rs
+++ b/examples/formats-registry/src/state.rs
@@ -4,7 +4,7 @@
 use std::collections::HashSet;
 
 use linera_sdk::{
-    linera_base_types::{AccountOwner, ModuleId},
+    linera_base_types::{AccountOwner, DataBlobHash, ModuleId},
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 
@@ -12,8 +12,10 @@ use linera_sdk::{
 #[graphql(complex)]
 #[view(context = ViewStorageContext)]
 pub struct FormatsRegistryState {
-    /// Maps a `ModuleId` to the bytes of its registered formats description.
-    pub formats: MapView<ModuleId, Vec<u8>>,
+    /// Maps a `ModuleId` to the hash of the data blob holding its registered formats
+    /// description. Exposed through the service's `read` query rather than directly.
+    #[graphql(skip)]
+    pub formats: MapView<ModuleId, DataBlobHash>,
     /// The admin accounts authorized to run admin commands and remote writes.
     /// `None` means no admin set has been configured yet, in which case only the
     /// creation chain can mutate the registry.

--- a/examples/formats-registry/src/state.rs
+++ b/examples/formats-registry/src/state.rs
@@ -8,7 +8,8 @@ use linera_sdk::{
     views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
 };
 
-#[derive(RootView)]
+#[derive(RootView, async_graphql::SimpleObject)]
+#[graphql(complex)]
 #[view(context = ViewStorageContext)]
 pub struct FormatsRegistryState {
     /// Maps a `ModuleId` to the bytes of its registered formats description.

--- a/examples/formats-registry/tests/format.rs
+++ b/examples/formats-registry/tests/format.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! ABI format test for the formats-registry application.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use formats_registry::formats::FormatsRegistryApplication;
+use linera_sdk::formats::BcsApplication;
+
+#[test]
+fn test_format() {
+    insta::assert_yaml_snapshot!("format", FormatsRegistryApplication::formats().unwrap());
+}

--- a/examples/formats-registry/tests/remote_registration.rs
+++ b/examples/formats-registry/tests/remote_registration.rs
@@ -7,7 +7,7 @@
 
 use formats_registry::{FormatsRegistryAbi, Operation};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, ModuleId},
+    linera_base_types::{AccountOwner, Blob, DataBlobHash, ModuleId},
     test::{QueryOutcome, TestValidator},
 };
 
@@ -52,20 +52,25 @@ async fn remote_admin_can_register() {
         })
         .await;
 
-    // The remote admin submits a write on its own chain; it is forwarded to the
-    // creation chain as a cross-chain message.
+    // The remote admin submits a write on its own chain; it publishes the data blob
+    // there and the write is forwarded to the creation chain as a cross-chain message.
     let value = vec![9u8, 8, 7];
+    let blob = Blob::new_data(value.clone());
+    let blob_hash = DataBlobHash(blob.id().hash);
     remote_chain
-        .add_block(|block| {
-            block.with_operation(
-                application_id,
-                Operation::Write {
-                    owner: remote_owner,
-                    module_id,
-                    value: value.clone(),
-                },
-            );
-        })
+        .add_block_with_blobs(
+            |block| {
+                block.with_data_blob(&blob).with_operation(
+                    application_id,
+                    Operation::Write {
+                        owner: remote_owner,
+                        module_id,
+                        blob_hash,
+                    },
+                );
+            },
+            vec![blob.clone()],
+        )
         .await;
 
     // The creation chain processes the forwarded message and stores the value.
@@ -112,17 +117,22 @@ async fn remote_non_admin_is_rejected() {
         })
         .await;
 
+    let blob = Blob::new_data(vec![1u8, 2, 3]);
+    let blob_hash = DataBlobHash(blob.id().hash);
     let (write_certificate, _) = remote_chain
-        .add_block(|block| {
-            block.with_operation(
-                application_id,
-                Operation::Write {
-                    owner: remote_owner,
-                    module_id,
-                    value: vec![1, 2, 3],
-                },
-            );
-        })
+        .add_block_with_blobs(
+            |block| {
+                block.with_data_blob(&blob).with_operation(
+                    application_id,
+                    Operation::Write {
+                        owner: remote_owner,
+                        module_id,
+                        blob_hash,
+                    },
+                );
+            },
+            vec![blob.clone()],
+        )
         .await;
 
     // The creation chain refuses to execute the forwarded write from a non-admin.

--- a/examples/formats-registry/tests/remote_registration.rs
+++ b/examples/formats-registry/tests/remote_registration.rs
@@ -1,0 +1,138 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cross-chain integration tests for remote module registration by admins.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use formats_registry::{FormatsRegistryAbi, Operation};
+use linera_sdk::{
+    linera_base_types::{AccountOwner, ModuleId},
+    test::{QueryOutcome, TestValidator},
+};
+
+/// Returns the GraphQL hex form of a `ModuleId`, as expected by the
+/// service's `read(moduleId: ...)` query.
+fn module_id_to_hex(module_id: &ModuleId) -> String {
+    serde_json::to_value(module_id)
+        .expect("ModuleId serializes to a JSON string")
+        .as_str()
+        .expect("ModuleId serializes to a JSON string")
+        .to_owned()
+}
+
+/// An admin operating from a remote chain can register a module: the write is
+/// forwarded to the creation chain and applied there.
+#[tokio::test(flavor = "multi_thread")]
+async fn remote_admin_can_register() {
+    let (validator, module_id) =
+        TestValidator::with_current_module::<FormatsRegistryAbi, (), ()>().await;
+    let mut creator_chain = validator.new_chain().await;
+    let creator_owner = AccountOwner::from(creator_chain.public_key());
+    let application_id = creator_chain
+        .create_application(module_id, (), (), vec![])
+        .await;
+    let module_id = module_id.forget_abi();
+
+    let remote_chain = validator.new_chain().await;
+    let remote_owner = AccountOwner::from(remote_chain.public_key());
+
+    // The creator authorizes the remote owner as an admin. This is allowed because
+    // no admin set has been configured yet and the operation runs locally on the
+    // creation chain.
+    creator_chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::SetAdmins {
+                    owner: creator_owner,
+                    admins: Some(vec![remote_owner]),
+                },
+            );
+        })
+        .await;
+
+    // The remote admin submits a write on its own chain; it is forwarded to the
+    // creation chain as a cross-chain message.
+    let value = vec![9u8, 8, 7];
+    remote_chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::Write {
+                    owner: remote_owner,
+                    module_id,
+                    value: value.clone(),
+                },
+            );
+        })
+        .await;
+
+    // The creation chain processes the forwarded message and stores the value.
+    creator_chain.handle_received_messages().await;
+
+    let module_id_hex = module_id_to_hex(&module_id);
+    let query = format!(r#"query {{ read(moduleId: "{module_id_hex}") }}"#);
+    let QueryOutcome { response, .. } = creator_chain.graphql_query(application_id, &*query).await;
+    let bytes: Vec<u8> = response["read"]
+        .as_array()
+        .expect("read must return an array")
+        .iter()
+        .map(|v| v.as_u64().expect("byte") as u8)
+        .collect();
+    assert_eq!(bytes, value);
+}
+
+/// A non-admin operating from a remote chain cannot register a module: the
+/// forwarded message is rejected when executed on the creation chain.
+#[tokio::test(flavor = "multi_thread")]
+async fn remote_non_admin_is_rejected() {
+    let (validator, module_id) =
+        TestValidator::with_current_module::<FormatsRegistryAbi, (), ()>().await;
+    let mut creator_chain = validator.new_chain().await;
+    let creator_owner = AccountOwner::from(creator_chain.public_key());
+    let application_id = creator_chain
+        .create_application(module_id, (), (), vec![])
+        .await;
+    let module_id = module_id.forget_abi();
+
+    let remote_chain = validator.new_chain().await;
+    let remote_owner = AccountOwner::from(remote_chain.public_key());
+
+    // Admins are configured, but the remote owner is not among them.
+    creator_chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::SetAdmins {
+                    owner: creator_owner,
+                    admins: Some(vec![creator_owner]),
+                },
+            );
+        })
+        .await;
+
+    let (write_certificate, _) = remote_chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::Write {
+                    owner: remote_owner,
+                    module_id,
+                    value: vec![1, 2, 3],
+                },
+            );
+        })
+        .await;
+
+    // The creation chain refuses to execute the forwarded write from a non-admin.
+    let result = creator_chain
+        .try_add_block(|block| {
+            block.with_messages_from(&write_certificate);
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "a non-admin remote write must be rejected on the creation chain"
+    );
+}

--- a/examples/formats-registry/tests/single_chain.rs
+++ b/examples/formats-registry/tests/single_chain.rs
@@ -7,7 +7,7 @@
 
 use formats_registry::{FormatsRegistryAbi, Operation};
 use linera_sdk::{
-    linera_base_types::{AccountOwner, AccountSecretKey, ModuleId},
+    linera_base_types::{AccountOwner, AccountSecretKey, Blob, DataBlobHash, ModuleId},
     test::{QueryOutcome, TestValidator},
 };
 
@@ -32,17 +32,22 @@ async fn write_then_read() {
     let module_id = module_id.forget_abi();
 
     let value = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+    let blob = Blob::new_data(value.clone());
+    let blob_hash = DataBlobHash(blob.id().hash);
     chain
-        .add_block(|block| {
-            block.with_operation(
-                application_id,
-                Operation::Write {
-                    owner,
-                    module_id,
-                    value: value.clone(),
-                },
-            );
-        })
+        .add_block_with_blobs(
+            |block| {
+                block.with_data_blob(&blob).with_operation(
+                    application_id,
+                    Operation::Write {
+                        owner,
+                        module_id,
+                        blob_hash,
+                    },
+                );
+            },
+            vec![blob.clone()],
+        )
         .await;
 
     let module_id_hex = module_id_to_hex(&module_id);
@@ -84,19 +89,26 @@ async fn second_write_is_rejected() {
     let application_id = chain.create_application(module_id, (), (), vec![]).await;
     let module_id = module_id.forget_abi();
 
+    let blob = Blob::new_data(vec![0xAA]);
+    let blob_hash = DataBlobHash(blob.id().hash);
     chain
-        .add_block(|block| {
-            block.with_operation(
-                application_id,
-                Operation::Write {
-                    owner,
-                    module_id,
-                    value: vec![0xAA],
-                },
-            );
-        })
+        .add_block_with_blobs(
+            |block| {
+                block.with_data_blob(&blob).with_operation(
+                    application_id,
+                    Operation::Write {
+                        owner,
+                        module_id,
+                        blob_hash,
+                    },
+                );
+            },
+            vec![blob.clone()],
+        )
         .await;
 
+    // The data blob is already in storage, so the second write needs no new blob; it
+    // must still be rejected because the module is already registered.
     let result = chain
         .try_add_block(|block| {
             block.with_operation(
@@ -104,7 +116,7 @@ async fn second_write_is_rejected() {
                 Operation::Write {
                     owner,
                     module_id,
-                    value: vec![0xBB],
+                    blob_hash,
                 },
             );
         })
@@ -148,7 +160,9 @@ async fn admin_policy_gates_local_writes() {
         .expect("admins must be an array");
     assert_eq!(admins.len(), 1);
 
-    // The chain's signer is no longer an admin, so its write is rejected.
+    // The chain's signer is no longer an admin, so its write is rejected at the admin
+    // check (before the blob is ever looked at).
+    let blob_hash = DataBlobHash(Blob::new_data(vec![0xAA]).id().hash);
     let result = chain
         .try_add_block(|block| {
             block.with_operation(
@@ -156,7 +170,7 @@ async fn admin_policy_gates_local_writes() {
                 Operation::Write {
                     owner,
                     module_id,
-                    value: vec![0xAA],
+                    blob_hash,
                 },
             );
         })

--- a/examples/formats-registry/tests/single_chain.rs
+++ b/examples/formats-registry/tests/single_chain.rs
@@ -5,14 +5,15 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
+use formats_registry::{FormatsRegistryAbi, Operation};
 use linera_sdk::{
-    abis::formats_registry::{FormatsRegistryAbi, Operation},
+    linera_base_types::{AccountOwner, AccountSecretKey, ModuleId},
     test::{QueryOutcome, TestValidator},
 };
 
 /// Returns the GraphQL hex form of a `ModuleId`, as expected by the
-/// service's `get(moduleId: ...)` query.
-fn module_id_to_hex(module_id: &linera_sdk::linera_base_types::ModuleId) -> String {
+/// service's `read(moduleId: ...)` query.
+fn module_id_to_hex(module_id: &ModuleId) -> String {
     serde_json::to_value(module_id)
         .expect("ModuleId serializes to a JSON string")
         .as_str()
@@ -22,10 +23,11 @@ fn module_id_to_hex(module_id: &linera_sdk::linera_base_types::ModuleId) -> Stri
 
 /// Writes a value for a `ModuleId` and reads it back through the service.
 #[tokio::test(flavor = "multi_thread")]
-async fn write_then_get() {
+async fn write_then_read() {
     let (validator, module_id) =
         TestValidator::with_current_module::<FormatsRegistryAbi, (), ()>().await;
     let mut chain = validator.new_chain().await;
+    let owner = AccountOwner::from(chain.public_key());
     let application_id = chain.create_application(module_id, (), (), vec![]).await;
     let module_id = module_id.forget_abi();
 
@@ -35,6 +37,7 @@ async fn write_then_get() {
             block.with_operation(
                 application_id,
                 Operation::Write {
+                    owner,
                     module_id,
                     value: value.clone(),
                 },
@@ -43,12 +46,12 @@ async fn write_then_get() {
         .await;
 
     let module_id_hex = module_id_to_hex(&module_id);
-    let query = format!(r#"query {{ get(moduleId: "{module_id_hex}") }}"#);
+    let query = format!(r#"query {{ read(moduleId: "{module_id_hex}") }}"#);
     let QueryOutcome { response, .. } = chain.graphql_query(application_id, &*query).await;
 
-    let bytes: Vec<u8> = response["get"]
+    let bytes: Vec<u8> = response["read"]
         .as_array()
-        .expect("get must return an array")
+        .expect("read must return an array")
         .iter()
         .map(|v| v.as_u64().expect("byte") as u8)
         .collect();
@@ -57,7 +60,7 @@ async fn write_then_get() {
 
 /// Querying a `ModuleId` that has never been written returns `null`.
 #[tokio::test(flavor = "multi_thread")]
-async fn get_unknown_module_returns_null() {
+async fn read_unknown_module_returns_null() {
     let (validator, module_id) =
         TestValidator::with_current_module::<FormatsRegistryAbi, (), ()>().await;
     let mut chain = validator.new_chain().await;
@@ -65,10 +68,10 @@ async fn get_unknown_module_returns_null() {
     let module_id = module_id.forget_abi();
 
     let module_id_hex = module_id_to_hex(&module_id);
-    let query = format!(r#"query {{ get(moduleId: "{module_id_hex}") }}"#);
+    let query = format!(r#"query {{ read(moduleId: "{module_id_hex}") }}"#);
     let QueryOutcome { response, .. } = chain.graphql_query(application_id, &*query).await;
 
-    assert!(response["get"].is_null());
+    assert!(response["read"].is_null());
 }
 
 /// Writing twice for the same `ModuleId` is rejected (entries are immutable).
@@ -77,6 +80,7 @@ async fn second_write_is_rejected() {
     let (validator, module_id) =
         TestValidator::with_current_module::<FormatsRegistryAbi, (), ()>().await;
     let mut chain = validator.new_chain().await;
+    let owner = AccountOwner::from(chain.public_key());
     let application_id = chain.create_application(module_id, (), (), vec![]).await;
     let module_id = module_id.forget_abi();
 
@@ -85,6 +89,7 @@ async fn second_write_is_rejected() {
             block.with_operation(
                 application_id,
                 Operation::Write {
+                    owner,
                     module_id,
                     value: vec![0xAA],
                 },
@@ -97,6 +102,7 @@ async fn second_write_is_rejected() {
             block.with_operation(
                 application_id,
                 Operation::Write {
+                    owner,
                     module_id,
                     value: vec![0xBB],
                 },
@@ -106,5 +112,57 @@ async fn second_write_is_rejected() {
     assert!(
         result.is_err(),
         "second Write for the same ModuleId must be rejected"
+    );
+}
+
+/// Once an admin set is configured, writes are gated on admin membership — even on
+/// the creation chain. An admin can write; a non-admin signer cannot.
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_policy_gates_local_writes() {
+    let (validator, module_id) =
+        TestValidator::with_current_module::<FormatsRegistryAbi, (), ()>().await;
+    let mut chain = validator.new_chain().await;
+    let owner = AccountOwner::from(chain.public_key());
+    let application_id = chain.create_application(module_id, (), (), vec![]).await;
+    let module_id = module_id.forget_abi();
+
+    // Restrict admins to a third party that is not the chain's signer.
+    let other_admin = AccountOwner::from(AccountSecretKey::generate().public());
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::SetAdmins {
+                    owner,
+                    admins: Some(vec![other_admin]),
+                },
+            );
+        })
+        .await;
+
+    let QueryOutcome { response, .. } = chain
+        .graphql_query(application_id, "query { admins }")
+        .await;
+    let admins = response["admins"]
+        .as_array()
+        .expect("admins must be an array");
+    assert_eq!(admins.len(), 1);
+
+    // The chain's signer is no longer an admin, so its write is rejected.
+    let result = chain
+        .try_add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::Write {
+                    owner,
+                    module_id,
+                    value: vec![0xAA],
+                },
+            );
+        })
+        .await;
+    assert!(
+        result.is_err(),
+        "a non-admin signer must not be able to write once admins are set"
     );
 }

--- a/examples/formats-registry/tests/snapshots/format__format.snap
+++ b/examples/formats-registry/tests/snapshots/format__format.snap
@@ -23,6 +23,9 @@ REGISTRY:
       TUPLEARRAY:
         CONTENT: U8
         SIZE: 32
+  DataBlobHash:
+    NEWTYPESTRUCT:
+      TYPENAME: CryptoHash
   Message:
     ENUM:
       0:
@@ -32,8 +35,8 @@ REGISTRY:
                 TYPENAME: AccountOwner
             - module_id:
                 TYPENAME: ModuleId
-            - value:
-                SEQ: U8
+            - blob_hash:
+                TYPENAME: DataBlobHash
       1:
         SetAdmins:
           STRUCT:
@@ -60,8 +63,8 @@ REGISTRY:
                 TYPENAME: AccountOwner
             - module_id:
                 TYPENAME: ModuleId
-            - value:
-                SEQ: U8
+            - blob_hash:
+                TYPENAME: DataBlobHash
       1:
         SetAdmins:
           STRUCT:

--- a/examples/formats-registry/tests/snapshots/format__format.snap
+++ b/examples/formats-registry/tests/snapshots/format__format.snap
@@ -1,0 +1,85 @@
+---
+source: formats-registry/tests/format.rs
+expression: "FormatsRegistryApplication::formats().unwrap()"
+---
+REGISTRY:
+  AccountOwner:
+    ENUM:
+      0:
+        Reserved:
+          NEWTYPE: U8
+      1:
+        Address32:
+          NEWTYPE:
+            TYPENAME: CryptoHash
+      2:
+        Address20:
+          NEWTYPE:
+            TUPLEARRAY:
+              CONTENT: U8
+              SIZE: 20
+  CryptoHash:
+    NEWTYPESTRUCT:
+      TUPLEARRAY:
+        CONTENT: U8
+        SIZE: 32
+  Message:
+    ENUM:
+      0:
+        Write:
+          STRUCT:
+            - owner:
+                TYPENAME: AccountOwner
+            - module_id:
+                TYPENAME: ModuleId
+            - value:
+                SEQ: U8
+      1:
+        SetAdmins:
+          STRUCT:
+            - owner:
+                TYPENAME: AccountOwner
+            - admins:
+                OPTION:
+                  SEQ:
+                    TYPENAME: AccountOwner
+  ModuleId:
+    STRUCT:
+      - contract_blob_hash:
+          TYPENAME: CryptoHash
+      - service_blob_hash:
+          TYPENAME: CryptoHash
+      - vm_runtime:
+          TYPENAME: VmRuntime
+  Operation:
+    ENUM:
+      0:
+        Write:
+          STRUCT:
+            - owner:
+                TYPENAME: AccountOwner
+            - module_id:
+                TYPENAME: ModuleId
+            - value:
+                SEQ: U8
+      1:
+        SetAdmins:
+          STRUCT:
+            - owner:
+                TYPENAME: AccountOwner
+            - admins:
+                OPTION:
+                  SEQ:
+                    TYPENAME: AccountOwner
+  VmRuntime:
+    ENUM:
+      0:
+        Wasm: UNIT
+      1:
+        Evm: UNIT
+OPERATION:
+  TYPENAME: Operation
+RESPONSE: UNIT
+MESSAGE:
+  TYPENAME: Message
+EVENT_VALUE: UNIT

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -959,7 +959,7 @@ impl<Env: Environment> ClientContext<Env> {
         let owner = chain_client
             .preferred_owner()
             .ok_or(error::Inner::ChainOwnership)?;
-        let (blobs, module_id, registry_op_bytes) = self
+        let (blobs, module_id, formats_blob_hash, registry_op_bytes) = self
             .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
 
@@ -973,6 +973,9 @@ impl<Env: Environment> ClientContext<Env> {
                     .execute_operations(
                         vec![
                             Operation::system(SystemOperation::PublishModule { module_id }),
+                            Operation::system(SystemOperation::PublishDataBlob {
+                                blob_hash: formats_blob_hash,
+                            }),
                             Operation::User {
                                 application_id: registry_application_id,
                                 bytes: registry_op_bytes,
@@ -1014,7 +1017,7 @@ impl<Env: Environment> ClientContext<Env> {
         let owner = chain_client
             .preferred_owner()
             .ok_or(error::Inner::ChainOwnership)?;
-        let (blobs, module_id, registry_op_bytes) = self
+        let (blobs, module_id, formats_blob_hash, registry_op_bytes) = self
             .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
 
@@ -1032,6 +1035,9 @@ impl<Env: Environment> ClientContext<Env> {
                         .execute_operations(
                             vec![
                                 Operation::system(SystemOperation::PublishModule { module_id }),
+                                Operation::system(SystemOperation::PublishDataBlob {
+                                    blob_hash: formats_blob_hash,
+                                }),
                                 Operation::User {
                                     application_id: registry_application_id,
                                     bytes: registry_op_bytes,
@@ -1083,8 +1089,16 @@ impl<Env: Environment> ClientContext<Env> {
         service: &Path,
         vm_runtime: VmRuntime,
         formats: &Path,
-    ) -> Result<(Vec<linera_base::data_types::Blob>, ModuleId, Vec<u8>), Error> {
-        let (blobs, module_id) = load_bytecode_blobs(contract, service, vm_runtime).await?;
+    ) -> Result<
+        (
+            Vec<linera_base::data_types::Blob>,
+            ModuleId,
+            CryptoHash,
+            Vec<u8>,
+        ),
+        Error,
+    > {
+        let (mut blobs, module_id) = load_bytecode_blobs(contract, service, vm_runtime).await?;
 
         info!("Loading formats from {formats:?}");
         let parsed = read_formats_from_snap(formats)?;
@@ -1094,13 +1108,18 @@ impl<Env: Environment> ClientContext<Env> {
                 format!("failed to serialize Formats as JSON: {e}"),
             )
         })?;
+        // Publish the formats description as a data blob and bind its hash in the
+        // registry write; the caller adds the matching `PublishDataBlob` operation.
+        let formats_blob = linera_base::data_types::Blob::new_data(value);
+        let formats_blob_hash = formats_blob.id().hash;
+        blobs.push(formats_blob);
         let registry_op = linera_sdk::abis::formats_registry::Operation::Write {
             owner,
             module_id,
-            value,
+            blob_hash: linera_base::identifiers::DataBlobHash(formats_blob_hash),
         };
         let registry_op_bytes = bcs::to_bytes(&registry_op)?;
-        Ok((blobs, module_id, registry_op_bytes))
+        Ok((blobs, module_id, formats_blob_hash, registry_op_bytes))
     }
 }
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -956,8 +956,11 @@ impl<Env: Environment> ClientContext<Env> {
         formats: PathBuf,
         registry_application_id: ApplicationId,
     ) -> Result<ModuleId, Error> {
+        let owner = chain_client
+            .preferred_owner()
+            .ok_or(error::Inner::ChainOwnership)?;
         let (blobs, module_id, registry_op_bytes) = self
-            .prepare_bcs_publication(&contract, &service, vm_runtime, &formats)
+            .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
 
         info!("Publishing module and registering its formats");
@@ -1008,8 +1011,11 @@ impl<Env: Environment> ClientContext<Env> {
         instantiation_argument: Vec<u8>,
         required_application_ids: Vec<ApplicationId>,
     ) -> Result<(ApplicationId, ModuleId), Error> {
+        let owner = chain_client
+            .preferred_owner()
+            .ok_or(error::Inner::ChainOwnership)?;
         let (blobs, module_id, registry_op_bytes) = self
-            .prepare_bcs_publication(&contract, &service, vm_runtime, &formats)
+            .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
 
         info!("Publishing module, registering its formats and creating the application");
@@ -1069,9 +1075,10 @@ impl<Env: Environment> ClientContext<Env> {
     }
 
     /// Loads the bytecode files and the SNAP file, builds the bytecode blobs and
-    /// the BCS-encoded formats-registry write operation.
+    /// the BCS-encoded formats-registry write operation authorized by `owner`.
     async fn prepare_bcs_publication(
         &self,
+        owner: AccountOwner,
         contract: &Path,
         service: &Path,
         vm_runtime: VmRuntime,
@@ -1087,7 +1094,11 @@ impl<Env: Environment> ClientContext<Env> {
                 format!("failed to serialize Formats as JSON: {e}"),
             )
         })?;
-        let registry_op = linera_sdk::abis::formats_registry::Operation::Write { module_id, value };
+        let registry_op = linera_sdk::abis::formats_registry::Operation::Write {
+            owner,
+            module_id,
+            value,
+        };
         let registry_op_bytes = bcs::to_bytes(&registry_op)?;
         Ok((blobs, module_id, registry_op_bytes))
     }

--- a/linera-explorer/README.md
+++ b/linera-explorer/README.md
@@ -42,7 +42,7 @@ formats for a given application:
   application itself.
 
 When both are set, the explorer will, for each user application it observes,
-issue `query { get(moduleId: "<hex>") }` against the registry. If the registry
+issue `query { read(moduleId: "<hex>") }` against the registry. If the registry
 returns a payload, the explorer deserializes it as `Formats` and uses it to
 decode BCS bytes shown in the Applications and block detail views.
 

--- a/linera-explorer/src/formats.rs
+++ b/linera-explorer/src/formats.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use crate::{js_utils::log_str, reqwest_client};
 
-/// Issues `query { get(moduleId: "<hex>") }` against the formats-registry
+/// Issues `query { read(moduleId: "<hex>") }` against the formats-registry
 /// application service and parses the returned bytes as a JSON-encoded
 /// [`Formats`]. Returns `Ok(None)` if the registry has no entry for that
 /// module.
@@ -22,7 +22,7 @@ pub async fn fetch_formats(
     module_id_hex: &str,
 ) -> Result<Option<Formats>> {
     let url = format!("{node}/chains/{chain_id_hex}/applications/{registry_app_id}");
-    let query = format!(r#"{{"query":"query {{ get(moduleId: \"{module_id_hex}\") }}"}}"#);
+    let query = format!(r#"{{"query":"query {{ read(moduleId: \"{module_id_hex}\") }}"}}"#);
     log_str(&format!("fetch_formats: POST {url}"));
     log_str(&format!("fetch_formats: body {query}"));
     let response = reqwest_client()
@@ -39,12 +39,12 @@ pub async fn fetch_formats(
     if let Some(errors) = response.get("errors") {
         return Err(anyhow!("formats registry query failed: {errors}"));
     }
-    let get = &response["data"]["get"];
-    if get.is_null() {
+    let read = &response["data"]["read"];
+    if read.is_null() {
         log_str("fetch_formats: registry returned null (no entry for this module)");
         return Ok(None);
     }
-    let bytes: Vec<u8> = get
+    let bytes: Vec<u8> = read
         .as_array()
         .ok_or_else(|| anyhow!("formats registry returned non-array bytes"))?
         .iter()

--- a/linera-sdk/src/abis/formats_registry.rs
+++ b/linera-sdk/src/abis/formats_registry.rs
@@ -8,7 +8,7 @@
 use async_graphql::{Request, Response};
 use serde::{Deserialize, Serialize};
 
-use crate::linera_base_types::{ContractAbi, ModuleId, ServiceAbi};
+use crate::linera_base_types::{AccountOwner, ContractAbi, ModuleId, ServiceAbi};
 
 /// The ABI of the formats-registry application.
 pub struct FormatsRegistryAbi;
@@ -24,10 +24,20 @@ impl ServiceAbi for FormatsRegistryAbi {
 }
 
 /// Operations accepted by the formats-registry contract.
+///
+/// This is the minimal interface relied upon by `linera
+/// publish-module-with-formats`. A concrete registry implementation (see
+/// `examples/formats-registry`) may define its own, richer `Operation` enum with
+/// extra admin commands; as long as `Write` stays the first variant with the same
+/// fields, its BCS encoding remains compatible with the operation produced here.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[allow(missing_docs)]
 pub enum Operation {
-    /// Publish `value` as a data blob and bind it to `module_id`. A given
-    /// `module_id` may only be written once.
-    Write { module_id: ModuleId, value: Vec<u8> },
+    /// Publish `value` as a data blob and bind it to `module_id`, on behalf of
+    /// `owner`. A given `module_id` may only be written once.
+    Write {
+        owner: AccountOwner,
+        module_id: ModuleId,
+        value: Vec<u8>,
+    },
 }

--- a/linera-sdk/src/abis/formats_registry.rs
+++ b/linera-sdk/src/abis/formats_registry.rs
@@ -8,7 +8,7 @@
 use async_graphql::{Request, Response};
 use serde::{Deserialize, Serialize};
 
-use crate::linera_base_types::{AccountOwner, ContractAbi, ModuleId, ServiceAbi};
+use crate::linera_base_types::{AccountOwner, ContractAbi, DataBlobHash, ModuleId, ServiceAbi};
 
 /// The ABI of the formats-registry application.
 pub struct FormatsRegistryAbi;
@@ -33,11 +33,12 @@ impl ServiceAbi for FormatsRegistryAbi {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[allow(missing_docs)]
 pub enum Operation {
-    /// Publish `value` as a data blob and bind it to `module_id`, on behalf of
-    /// `owner`. A given `module_id` may only be written once.
+    /// Bind the data blob `blob_hash` (holding the BCS formats description) to
+    /// `module_id`, on behalf of `owner`. The caller is expected to publish that data
+    /// blob in the same block. A given `module_id` may only be written once.
     Write {
         owner: AccountOwner,
         module_id: ModuleId,
-        value: Vec<u8>,
+        blob_hash: DataBlobHash,
     },
 }

--- a/linera-sdk/src/formats.rs
+++ b/linera-sdk/src/formats.rs
@@ -37,7 +37,7 @@ pub trait BcsApplication {
 
 /// Decode BCS-serialized `bytes` into a [`serde_json::Value`], guided by `format`
 /// and the container `registry`.
-pub fn bcs_to_json(
+fn bcs_to_json(
     bytes: &[u8],
     format: &Format,
     registry: &Registry,

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -142,6 +142,17 @@ impl BlockBuilder {
         self.with_system_operation(SystemOperation::ChangeApplicationPermissions(permissions))
     }
 
+    /// Publishes the given data `blob` in this block.
+    ///
+    /// The same [`Blob`] must also be passed to
+    /// [`ActiveChain::add_block_with_blobs`](super::ActiveChain::add_block_with_blobs) so it is
+    /// available when the block is executed.
+    pub fn with_data_blob(&mut self, blob: &Blob) -> &mut Self {
+        self.with_system_operation(SystemOperation::PublishDataBlob {
+            blob_hash: blob.id().hash,
+        })
+    }
+
     /// Adds a user `operation` to this block.
     ///
     /// The operation is serialized using [`bcs`] and added to the block, marked to be executed by

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2022,6 +2022,133 @@ async fn test_publish_module_with_formats_registers_formats(
     Ok(())
 }
 
+/// A remote admin registers a module's formats from its own chain. The `Write` is
+/// forwarded to the registry's creation chain as a cross-chain message; the payload is
+/// published as a data blob on the remote chain, so this exercises that the creation
+/// chain can assert and read that blob across chains.
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(CloseChains) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_publish_module_with_formats_remote_registration(
+    config: impl LineraNetConfig,
+) -> Result<()> {
+    use counter::{formats::CounterApplication, CounterAbi};
+    use linera_sdk::{
+        abis::formats_registry::FormatsRegistryAbi,
+        formats::{BcsApplication, Formats},
+    };
+
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let (mut net, admin_client) = config.instantiate().await?;
+    let admin_chain = admin_client.load_wallet()?.default_chain().unwrap();
+    let admin_owner = admin_client.get_owner().unwrap();
+
+    // The registry application lives on the admin client's chain (its creation chain).
+    let (registry_contract, registry_service) =
+        admin_client.build_example("formats-registry").await?;
+    let registry_app_id = admin_client
+        .publish_and_create::<FormatsRegistryAbi, (), ()>(
+            registry_contract,
+            registry_service,
+            VmRuntime::Wasm,
+            &(),
+            &(),
+            &[],
+            None,
+        )
+        .await?;
+
+    // A remote operator on its own chain.
+    let remote_client = net.make_client().await;
+    remote_client.wallet_init(None).await?;
+    let remote_chain = admin_client
+        .open_and_assign(&remote_client, Amount::from_tokens(10))
+        .await?;
+    let remote_owner = remote_client.get_owner().unwrap();
+    remote_client
+        .set_preferred_owner(remote_chain, Some(remote_owner))
+        .await?;
+    remote_client.sync(remote_chain).await?;
+
+    // Run the creation chain's node service. We process its inbox explicitly so we can
+    // observe the forwarded write being applied.
+    let admin_port = get_node_port().await;
+    let mut admin_node_service = admin_client
+        .run_node_service(admin_port, ProcessInbox::Skip)
+        .await?;
+    let mut admin_notifications = admin_node_service.notifications(admin_chain).await?;
+    let registry = admin_node_service.make_application(&admin_chain, &registry_app_id)?;
+
+    // Authorize the remote owner as an admin. This runs locally on the creation chain,
+    // which is allowed because no admin set has been configured yet.
+    registry
+        .mutate(format!(
+            "setAdmins(owner: {}, admins: [{}])",
+            admin_owner.to_value(),
+            remote_owner.to_value(),
+        ))
+        .await?;
+
+    // The remote admin publishes a module and registers its formats from its own chain;
+    // the registry `Write` is forwarded to the creation chain as a cross-chain message.
+    let (contract, service) = remote_client.build_example("counter").await?;
+    let formats =
+        ClientWrapper::example_path("counter")?.join("tests/snapshots/format__format.snap");
+    let module_id = remote_client
+        .publish_module_with_formats::<CounterAbi, (), u64>(
+            contract,
+            service,
+            formats,
+            registry_app_id.forget_abi(),
+            VmRuntime::Wasm,
+            None,
+        )
+        .await?;
+
+    // Wait for the forwarded write to reach the creation chain, then apply it.
+    admin_notifications
+        .wait_for_bundle(remote_chain, None)
+        .await?;
+    assert!(
+        !admin_node_service
+            .process_inbox(&admin_chain)
+            .await?
+            .is_empty(),
+        "the creation chain should process the forwarded write"
+    );
+
+    // Read the formats back: the creation chain must be able to fetch the data blob the
+    // remote chain published.
+    let module_id_hex = serde_json::to_value(module_id.forget_abi())?
+        .as_str()
+        .expect("ModuleId serializes to a JSON string")
+        .to_owned();
+    let response = registry
+        .query(format!(r#"read(moduleId: "{module_id_hex}")"#))
+        .await?;
+    let stored_bytes: Vec<u8> = response["read"]
+        .as_array()
+        .expect("read must return a JSON array of bytes")
+        .iter()
+        .map(|byte| byte.as_u64().expect("byte") as u8)
+        .collect();
+
+    let stored_formats: Formats = serde_json::from_slice(&stored_bytes)?;
+    let expected_formats = CounterApplication::formats().unwrap();
+    assert_eq!(stored_formats, expected_formats);
+
+    admin_node_service.ensure_is_running()?;
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
 #[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_test_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1992,11 +1992,11 @@ async fn test_publish_module_with_formats_registers_formats(
         .expect("ModuleId serializes to a JSON string")
         .to_owned();
     let response = registry_application
-        .query(format!(r#"get(moduleId: "{module_id_hex}")"#))
+        .query(format!(r#"read(moduleId: "{module_id_hex}")"#))
         .await?;
-    let stored_bytes: Vec<u8> = response["get"]
+    let stored_bytes: Vec<u8> = response["read"]
         .as_array()
-        .expect("get must return a JSON array of bytes")
+        .expect("read must return a JSON array of bytes")
         .iter()
         .map(|byte| byte.as_u64().expect("byte") as u8)
         .collect();


### PR DESCRIPTION
## Motivation

`linera publish-module-with-formats` takes the application ID of a `FormatsRegistryAbi` implementation, but the current `examples/formats-registry` assumes the caller can execute operations directly on the application's creation chain. This prevents registering a module's formats from a remote chain, even for trusted operators. Separately, the registry stored each formats description inline in its state, even though its docs described storing it as a content-addressed data blob.

## Proposal

Take inspiration from `examples/controller` to support remote module registration gated by a configurable set of admins, and store the formats description as a client-published data blob:

- **Formats stored as data blobs.** `linera publish-module-with-formats` now publishes the BCS `Formats` description as a `DataBlob` (a `PublishDataBlob` operation in the same block), and the registry `Write` carries only its `DataBlobHash`. The contract records the hash in a `MapView<ModuleId, DataBlobHash>`, so state stays compact (one hash per `ModuleId`) and identical descriptions are content-addressed and deduplicated. The service's `read` query dereferences the hash via `read_data_blob`, so it still returns the bytes and consumers are unchanged.
  - The blob is published by the **client**, not created by the contract: a blob created by a contract during execution is not supplied to validators during block proposal (it fails with `BlobsNotFound`), whereas a `PublishDataBlob` blob is persisted and available across chains.
- **SDK ABI** (`linera-sdk/src/abis/formats_registry.rs`): `Operation::Write` now carries an `owner: AccountOwner` and a `blob_hash: DataBlobHash`. It is kept as the first variant so its BCS encoding stays compatible with richer, implementation-specific `Operation` enums.
- **CLI** (`linera-client/src/client_context.rs`): `publish-module-with-formats` and `publish-bcs-application` fill `owner` with the publishing chain's `preferred_owner()` (erroring if none is set), publish the formats blob, and reference its hash.
- **Example contract**: on `Write`, the contract calls `runtime.check_account_permission(owner)`, then compares the current chain with the application's creation chain; if remote, it forwards a `Message` to the creation chain. The creation chain runs `execute_locally`, which applies a security policy mirroring `ControllerContract::execute_controller_command_locally` (admins-set ⇒ `owner` must be a member; admins-unset ⇒ local-only, remote refused) before recording the hash. It asserts the blob exists only on the cross-chain path, where the blob was published in an earlier block; a locally-published blob shares the block and cannot be asserted yet, but is persisted by the caller's `PublishDataBlob`.
- **Authorized admins**: tracked in an `admins: RegisterView<Option<HashSet<AccountOwner>>>` and configured via a new `SetAdmins` admin command.
- **Extensibility**: the example now defines its own `Operation`/`Message`/ABI in `src/lib.rs`, starting with `Write` and appending implementation-specific commands (`SetAdmins`); the SDK enum stays minimal for the CLI.
- **Test helper**: adds `BlockBuilder::with_data_blob` so in-process example tests can publish a data blob alongside an operation.

Drive-by nits also addressed: the service GraphQL query `get` is renamed to `read`, and `linera_sdk::formats::bcs_to_json` is made private.

## Test Plan

- `cargo check` (linera-sdk, linera-client), `cargo clippy -p formats-registry --all-targets`, and `cargo +nightly fmt --check` all pass.
- `cargo test -p formats-registry` passes (6 tests):
  - `single_chain`: `write_then_read`, `read_unknown_module_returns_null`, `second_write_is_rejected`, `admin_policy_gates_local_writes`.
  - `remote_registration`: `remote_admin_can_register`, `remote_non_admin_is_rejected`.
- `cargo test -p linera-service --test linera_net_tests --features storage-service test_publish_module_with_formats` passes (2 network tests):
  - `test_publish_module_with_formats_registers_formats` (local registration).
  - `test_publish_module_with_formats_remote_registration` (remote registration across two chains, exercising cross-chain data-blob availability).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
