### PR TITLE
Decode/encode well-known linera-base primitives as human-readable JSON in the BCS-to-JSON converter (port of #6547 to main)

### DIFF
--- a/examples/amm/tests/format.rs
+++ b/examples/amm/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", AmmApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", AmmApplication::pruned_formats().unwrap());
 }

--- a/examples/amm/tests/snapshots/format__format.snap
+++ b/examples/amm/tests/snapshots/format__format.snap
@@ -1,34 +1,8 @@
 ---
 source: amm/tests/format.rs
-expression: "AmmApplication::formats().unwrap()"
+expression: "AmmApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  Amount:
-    NEWTYPESTRUCT: U128
-  ApplicationId:
-    STRUCT:
-      - application_description_hash:
-          TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   Message:
     ENUM:
       0:

--- a/examples/call-evm-counter/tests/format.rs
+++ b/examples/call-evm-counter/tests/format.rs
@@ -10,5 +10,8 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", CallEvmCounterApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!(
+        "format",
+        CallEvmCounterApplication::pruned_formats().unwrap()
+    );
 }

--- a/examples/call-evm-counter/tests/snapshots/format__format.snap
+++ b/examples/call-evm-counter/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: call-evm-counter/tests/format.rs
-expression: "CallEvmCounterApplication::formats().unwrap()"
+expression: "CallEvmCounterApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   CallCounterOperation:

--- a/examples/controller/tests/format.rs
+++ b/examples/controller/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", ControllerApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", ControllerApplication::pruned_formats().unwrap());
 }

--- a/examples/controller/tests/snapshots/format__format.snap
+++ b/examples/controller/tests/snapshots/format__format.snap
@@ -1,23 +1,8 @@
 ---
 source: controller/tests/format.rs
-expression: "ControllerApplication::formats().unwrap()"
+expression: "ControllerApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
   BlockHeight:
     NEWTYPESTRUCT: U64
   ChainId:
@@ -81,11 +66,6 @@ REGISTRY:
                     - TYPENAME: ChainId
                     - SEQ:
                         TYPENAME: ChainId
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   DataBlobHash:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash

--- a/examples/counter-no-graphql/tests/format.rs
+++ b/examples/counter-no-graphql/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", CounterApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", CounterApplication::pruned_formats().unwrap());
 }

--- a/examples/counter-no-graphql/tests/snapshots/format__format.snap
+++ b/examples/counter-no-graphql/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: counter-no-graphql/tests/format.rs
-expression: "CounterApplication::formats().unwrap()"
+expression: "CounterApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   CounterOperation:

--- a/examples/counter/tests/format.rs
+++ b/examples/counter/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", CounterApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", CounterApplication::pruned_formats().unwrap());
 }

--- a/examples/counter/tests/snapshots/format__format.snap
+++ b/examples/counter/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: counter/tests/format.rs
-expression: "CounterApplication::formats().unwrap()"
+expression: "CounterApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   CounterOperation:

--- a/examples/crowd-funding/tests/format.rs
+++ b/examples/crowd-funding/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", CrowdFundingApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", CrowdFundingApplication::pruned_formats().unwrap());
 }

--- a/examples/crowd-funding/tests/snapshots/format__format.snap
+++ b/examples/crowd-funding/tests/snapshots/format__format.snap
@@ -1,30 +1,8 @@
 ---
 source: crowd-funding/tests/format.rs
-expression: "CrowdFundingApplication::formats().unwrap()"
+expression: "CrowdFundingApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  Amount:
-    NEWTYPESTRUCT: U128
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   InstantiationArgument:
     STRUCT:
       - owner:

--- a/examples/ethereum-tracker/tests/format.rs
+++ b/examples/ethereum-tracker/tests/format.rs
@@ -10,5 +10,8 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", EthereumTrackerApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!(
+        "format",
+        EthereumTrackerApplication::pruned_formats().unwrap()
+    );
 }

--- a/examples/ethereum-tracker/tests/snapshots/format__format.snap
+++ b/examples/ethereum-tracker/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: ethereum-tracker/tests/format.rs
-expression: "EthereumTrackerApplication::formats().unwrap()"
+expression: "EthereumTrackerApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   InstantiationArgument:

--- a/examples/fungible/tests/format.rs
+++ b/examples/fungible/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", FungibleApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", FungibleApplication::pruned_formats().unwrap());
 }

--- a/examples/fungible/tests/snapshots/format__format.snap
+++ b/examples/fungible/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: fungible/tests/format.rs
-expression: "FungibleApplication::formats().unwrap()"
+expression: "FungibleApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   Account:
@@ -9,31 +9,9 @@ REGISTRY:
           TYPENAME: ChainId
       - owner:
           TYPENAME: AccountOwner
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  Amount:
-    NEWTYPESTRUCT: U128
   ChainId:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   FungibleOperation:
     ENUM:
       142627141:

--- a/examples/gen-nft/tests/format.rs
+++ b/examples/gen-nft/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", GenNftApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", GenNftApplication::pruned_formats().unwrap());
 }

--- a/examples/gen-nft/tests/snapshots/format__format.snap
+++ b/examples/gen-nft/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: gen-nft/tests/format.rs
-expression: "GenNftApplication::formats().unwrap()"
+expression: "GenNftApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   Account:
@@ -9,29 +9,9 @@ REGISTRY:
           TYPENAME: ChainId
       - owner:
           TYPENAME: AccountOwner
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
   ChainId:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   Message:
     ENUM:
       0:

--- a/examples/hex-game/tests/format.rs
+++ b/examples/hex-game/tests/format.rs
@@ -10,5 +10,5 @@ use linera_sdk::formats::BcsApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", HexApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", HexApplication::pruned_formats().unwrap());
 }

--- a/examples/hex-game/tests/snapshots/format__format.snap
+++ b/examples/hex-game/tests/snapshots/format__format.snap
@@ -1,25 +1,8 @@
 ---
 source: hex-game/tests/format.rs
-expression: "HexApplication::formats().unwrap()"
+expression: "HexApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  Amount:
-    NEWTYPESTRUCT: U128
   Board:
     STRUCT:
       - cells:
@@ -47,11 +30,6 @@ REGISTRY:
           TYPENAME: Timestamp
       - block_delay:
           TYPENAME: TimeDelta
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   HexOutcome:
     ENUM:
       211312752:

--- a/examples/llm/tests/format.rs
+++ b/examples/llm/tests/format.rs
@@ -10,5 +10,5 @@ use llm::formats::LlmApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", LlmApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", LlmApplication::pruned_formats().unwrap());
 }

--- a/examples/llm/tests/snapshots/format__format.snap
+++ b/examples/llm/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: llm/tests/format.rs
-expression: "LlmApplication::formats().unwrap()"
+expression: "LlmApplication::pruned_formats().unwrap()"
 ---
 REGISTRY: {}
 OPERATION: UNIT

--- a/examples/matching-engine/tests/format.rs
+++ b/examples/matching-engine/tests/format.rs
@@ -10,5 +10,8 @@ use matching_engine::formats::MatchingEngineApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", MatchingEngineApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!(
+        "format",
+        MatchingEngineApplication::pruned_formats().unwrap()
+    );
 }

--- a/examples/matching-engine/tests/snapshots/format__format.snap
+++ b/examples/matching-engine/tests/snapshots/format__format.snap
@@ -1,34 +1,8 @@
 ---
 source: matching-engine/tests/format.rs
-expression: "MatchingEngineApplication::formats().unwrap()"
+expression: "MatchingEngineApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  Amount:
-    NEWTYPESTRUCT: U128
-  ApplicationId:
-    STRUCT:
-      - application_description_hash:
-          TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   Message:
     ENUM:
       0:

--- a/examples/native-fungible/tests/format.rs
+++ b/examples/native-fungible/tests/format.rs
@@ -10,5 +10,8 @@ use native_fungible::formats::NativeFungibleApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", NativeFungibleApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!(
+        "format",
+        NativeFungibleApplication::pruned_formats().unwrap()
+    );
 }

--- a/examples/native-fungible/tests/snapshots/format__format.snap
+++ b/examples/native-fungible/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: native-fungible/tests/format.rs
-expression: "NativeFungibleApplication::formats().unwrap()"
+expression: "NativeFungibleApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   Account:
@@ -15,31 +15,9 @@ REGISTRY:
           TYPENAME: AccountOwner
       - value:
           TYPENAME: Amount
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  Amount:
-    NEWTYPESTRUCT: U128
   ChainId:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   FungibleOperation:
     ENUM:
       142627141:

--- a/examples/non-fungible/tests/format.rs
+++ b/examples/non-fungible/tests/format.rs
@@ -10,5 +10,5 @@ use non_fungible::formats::NonFungibleApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", NonFungibleApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", NonFungibleApplication::pruned_formats().unwrap());
 }

--- a/examples/non-fungible/tests/snapshots/format__format.snap
+++ b/examples/non-fungible/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: non-fungible/tests/format.rs
-expression: "NonFungibleApplication::formats().unwrap()"
+expression: "NonFungibleApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   Account:
@@ -9,29 +9,9 @@ REGISTRY:
           TYPENAME: ChainId
       - owner:
           TYPENAME: AccountOwner
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
   ChainId:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   DataBlobHash:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash

--- a/examples/rfq/tests/format.rs
+++ b/examples/rfq/tests/format.rs
@@ -10,5 +10,5 @@ use rfq::formats::RfqApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", RfqApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", RfqApplication::pruned_formats().unwrap());
 }

--- a/examples/rfq/tests/snapshots/format__format.snap
+++ b/examples/rfq/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: rfq/tests/format.rs
-expression: "RfqApplication::formats().unwrap()"
+expression: "RfqApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   Account:
@@ -9,35 +9,9 @@ REGISTRY:
           TYPENAME: ChainId
       - owner:
           TYPENAME: AccountOwner
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  Amount:
-    NEWTYPESTRUCT: U128
-  ApplicationId:
-    STRUCT:
-      - application_description_hash:
-          TYPENAME: CryptoHash
   ChainId:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   Message:
     ENUM:
       0:

--- a/examples/social/tests/format.rs
+++ b/examples/social/tests/format.rs
@@ -10,5 +10,5 @@ use social::formats::SocialApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", SocialApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!("format", SocialApplication::pruned_formats().unwrap());
 }

--- a/examples/social/tests/snapshots/format__format.snap
+++ b/examples/social/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: social/tests/format.rs
-expression: "SocialApplication::formats().unwrap()"
+expression: "SocialApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   ChainId:
@@ -11,11 +11,6 @@ REGISTRY:
       - text: STR
       - chain_id:
           TYPENAME: ChainId
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   Event:
     ENUM:
       0:

--- a/examples/task-processor/tests/format.rs
+++ b/examples/task-processor/tests/format.rs
@@ -10,5 +10,8 @@ use task_processor::formats::TaskProcessorApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", TaskProcessorApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!(
+        "format",
+        TaskProcessorApplication::pruned_formats().unwrap()
+    );
 }

--- a/examples/task-processor/tests/snapshots/format__format.snap
+++ b/examples/task-processor/tests/snapshots/format__format.snap
@@ -1,16 +1,11 @@
 ---
 source: task-processor/tests/format.rs
-expression: "TaskProcessorApplication::formats().unwrap()"
+expression: "TaskProcessorApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   ChainId:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   Message:
     ENUM:
       0:

--- a/examples/wrapped-fungible/tests/format.rs
+++ b/examples/wrapped-fungible/tests/format.rs
@@ -10,5 +10,8 @@ use wrapped_fungible::formats::WrappedFungibleApplication;
 
 #[test]
 fn test_format() {
-    insta::assert_yaml_snapshot!("format", WrappedFungibleApplication::formats().unwrap());
+    insta::assert_yaml_snapshot!(
+        "format",
+        WrappedFungibleApplication::pruned_formats().unwrap()
+    );
 }

--- a/examples/wrapped-fungible/tests/snapshots/format__format.snap
+++ b/examples/wrapped-fungible/tests/snapshots/format__format.snap
@@ -1,6 +1,6 @@
 ---
 source: wrapped-fungible/tests/format.rs
-expression: "WrappedFungibleApplication::formats().unwrap()"
+expression: "WrappedFungibleApplication::pruned_formats().unwrap()"
 ---
 REGISTRY:
   Account:
@@ -9,25 +9,6 @@ REGISTRY:
           TYPENAME: ChainId
       - owner:
           TYPENAME: AccountOwner
-  AccountOwner:
-    ENUM:
-      0:
-        Reserved:
-          NEWTYPE: U8
-      1:
-        Address32:
-          NEWTYPE:
-            TYPENAME: CryptoHash
-      2:
-        Address20:
-          NEWTYPE:
-            TUPLEARRAY:
-              CONTENT: U8
-              SIZE: 20
-  ApplicationId:
-    STRUCT:
-      - application_description_hash:
-          TYPENAME: CryptoHash
   BurnEvent:
     STRUCT:
       - target:
@@ -38,11 +19,6 @@ REGISTRY:
   ChainId:
     NEWTYPESTRUCT:
       TYPENAME: CryptoHash
-  CryptoHash:
-    NEWTYPESTRUCT:
-      TUPLEARRAY:
-        CONTENT: U8
-        SIZE: 32
   FungibleResponse:
     ENUM:
       142627141:

--- a/linera-sdk/src/formats.rs
+++ b/linera-sdk/src/formats.rs
@@ -16,8 +16,13 @@ pub mod __private {
     pub use serde;
     pub use serde_reflection;
 }
+#[cfg(not(target_arch = "wasm32"))]
+use serde_reflection::TracerConfig;
 use serde_reflection::{
-    json_converter::{DeserializationContext, EmptyEnvironment},
+    json_converter::{
+        DeserializationContext, DeserializationEnvironment, SerializationContext,
+        SerializationEnvironment, SymbolTableEnvironment,
+    },
     Format, Registry, Samples, Tracer,
 };
 
@@ -43,8 +48,21 @@ pub trait BcsApplication {
     /// Link the public Abi of application for good measure.
     type Abi;
 
-    /// Returns the serde formats for this application's ABI types.
+    /// Returns the serde formats for this application's ABI types. The returned
+    /// registry is self-contained: it describes every type structurally, including
+    /// the well-known linera-base primitives.
     fn formats() -> serde_reflection::Result<Formats>;
+
+    /// Like [`formats`](Self::formats), but with the well-known linera-base primitives
+    /// pruned from the registry (see [`Formats::prune_known_primitives`]) so that they
+    /// decode to their human-readable form via [`LineraEnvironment`]. This is the form
+    /// meant to be published to a formats registry.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn pruned_formats() -> Result<Formats, PruneError> {
+        let mut formats = Self::formats()?;
+        formats.prune_known_primitives()?;
+        Ok(formats)
+    }
 }
 
 /// Companion trait of [`StableEnum`]: exposes each variant's stable tag and
@@ -110,7 +128,11 @@ impl TracerExt for Tracer {
 
 /// Decode BCS-serialized `bytes` into a [`serde_json::Value`], guided by `format`
 /// and the container `registry`.
-pub fn bcs_to_json(
+///
+/// Well-known linera-base primitives that are absent from `registry` (because they
+/// were removed by [`Formats::prune_known_primitives`]) are decoded into their
+/// human-readable representation by [`LineraEnvironment`].
+fn bcs_to_json(
     bytes: &[u8],
     format: &Format,
     registry: &Registry,
@@ -118,9 +140,168 @@ pub fn bcs_to_json(
     let context = DeserializationContext {
         format: format.clone(),
         registry,
-        environment: &EmptyEnvironment,
+        environment: &LineraEnvironment,
     };
     bcs::from_bytes_seed(context, bytes)
+}
+
+/// Encode a [`serde_json::Value`] into BCS `bytes`, guided by `format` and the
+/// container `registry`. This is the inverse of [`bcs_to_json`].
+///
+/// Well-known linera-base primitives that are absent from `registry` are read from
+/// their human-readable representation by [`LineraEnvironment`].
+fn json_to_bcs(
+    value: &serde_json::Value,
+    format: &Format,
+    registry: &Registry,
+) -> bcs::Result<Vec<u8>> {
+    let context = SerializationContext {
+        value,
+        format,
+        registry,
+        environment: &LineraEnvironment,
+    };
+    bcs::to_bytes(&context)
+}
+
+/// Decodes the BCS form of a value as the concrete type `T`, then re-encodes it as
+/// JSON using `T`'s human-readable serialization.
+fn primitive_to_json<'de, T, D>(deserializer: D) -> Result<serde_json::Value, String>
+where
+    T: serde::Deserialize<'de> + serde::Serialize,
+    D: serde::Deserializer<'de>,
+{
+    let value = T::deserialize(deserializer).map_err(|error| error.to_string())?;
+    serde_json::to_value(&value).map_err(|error| error.to_string())
+}
+
+/// Reads a value's human-readable JSON representation into the concrete type `T`, then
+/// serializes it with `serializer` (its BCS form). Inverse of [`primitive_to_json`].
+fn primitive_from_json<T, S>(value: &serde_json::Value, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+    S: serde::Serializer,
+{
+    let value: T = T::deserialize(value).map_err(serde::ser::Error::custom)?;
+    value.serialize(serializer)
+}
+
+/// Declares the linera-base primitives whose human-readable serde representation
+/// differs from their BCS one. This single list drives both [`LineraEnvironment`]
+/// (decoding) and the canonical-format check used by
+/// [`Formats::prune_known_primitives`], so the two can never drift apart.
+macro_rules! known_human_readable_primitives {
+    ($($name:literal => $ty:ty),* $(,)?) => {
+        /// The registry names of the linera-base primitives handled by
+        /// [`LineraEnvironment`]. These are exactly the types whose human-readable
+        /// serde representation differs from their BCS form *and* whose BCS form is a
+        /// named container (so it can be matched by name in a traced registry).
+        pub const KNOWN_PRIMITIVE_NAMES: &[&str] = &[$($name),*];
+
+        /// A [`json_converter`](serde_reflection::json_converter) environment that
+        /// decodes the BCS form of well-known linera-base primitives into their
+        /// human-readable JSON representation (e.g. a `CryptoHash` as a hex string, an
+        /// `Amount` as a decimal string, an `AccountOwner` as its canonical address).
+        ///
+        /// It only takes effect for names that are *absent* from the registry being
+        /// decoded; see [`Formats::prune_known_primitives`].
+        #[derive(Clone, Copy, Debug, Default)]
+        pub struct LineraEnvironment;
+
+        impl SymbolTableEnvironment for LineraEnvironment {}
+
+        impl<'de> DeserializationEnvironment<'de> for LineraEnvironment {
+            fn deserialize<D>(
+                &self,
+                name: String,
+                deserializer: D,
+            ) -> Result<serde_json::Value, String>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                match name.as_str() {
+                    $( $name => primitive_to_json::<$ty, D>(deserializer), )*
+                    _ => Err(format!("No external definition available for {name}")),
+                }
+            }
+        }
+
+        impl SerializationEnvironment for LineraEnvironment {
+            fn serialize<S>(
+                &self,
+                name: &str,
+                value: &serde_json::Value,
+                serializer: S,
+            ) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match name {
+                    $( $name => primitive_from_json::<$ty, S>(value, serializer), )*
+                    _ => Err(serde::ser::Error::custom(format!(
+                        "No external serializer available for {name}"
+                    ))),
+                }
+            }
+        }
+
+        /// Traces the canonical BCS format of every known primitive, used to verify
+        /// the correspondence before pruning.
+        #[cfg(not(target_arch = "wasm32"))]
+        fn expected_primitive_registry() -> serde_reflection::Result<Registry> {
+            let mut tracer = Tracer::new(
+                TracerConfig::default()
+                    .record_samples_for_newtype_structs(true)
+                    .record_samples_for_tuple_structs(true),
+            );
+            let samples = Samples::new();
+            $( tracer.trace_type::<$ty>(&samples)?; )*
+            // Supporting enums reached only through the primitives above; they must be
+            // traced explicitly so all of their variants are recorded.
+            tracer.trace_type::<crate::linera_base_types::VmRuntime>(&samples)?;
+            tracer.trace_type::<crate::linera_base_types::BlobType>(&samples)?;
+            tracer.trace_type::<crate::linera_base_types::GenericApplicationId>(&samples)?;
+            tracer.registry()
+        }
+    };
+}
+
+// NOTE: The cryptographic key and signature types (`Ed25519PublicKey`,
+// `Secp256k1PublicKey`, `EvmPublicKey`, and their `*Signature` counterparts) also have
+// a customized human-readable serde representation, but their `Deserialize` validates
+// the bytes (e.g. that a compressed point is on the curve), so `serde_reflection`
+// cannot trace them from dummy bytes and we cannot verify their format before pruning.
+// Supporting them would require feeding valid samples to the tracer; deferred for now.
+// They also do not currently appear in any application's operation/message ABI.
+known_human_readable_primitives! {
+    "CryptoHash" => crate::linera_base_types::CryptoHash,
+    "AccountOwner" => crate::linera_base_types::AccountOwner,
+    "Amount" => crate::linera_base_types::Amount,
+    "Epoch" => crate::linera_base_types::Epoch,
+    "BlobId" => crate::linera_base_types::BlobId,
+    "StreamId" => crate::linera_base_types::StreamId,
+    "ModuleId" => crate::linera_base_types::ModuleId,
+    "ApplicationId" => crate::linera_base_types::ApplicationId,
+}
+
+/// An error raised while pruning known primitives from a [`Formats`] registry.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, thiserror::Error)]
+pub enum PruneError {
+    /// The canonical formats of the known primitives could not be computed.
+    #[error("failed to compute the canonical primitive formats: {0}")]
+    Reflection(#[from] serde_reflection::Error),
+    /// A known primitive name is present in the registry but with a format that does
+    /// not match the canonical linera-base one (e.g. a name collision or a layout
+    /// change). Nothing is pruned in that case.
+    #[error(
+        "registry entry for `{name}` does not match the canonical linera-base format; \
+         refusing to prune"
+    )]
+    Mismatch {
+        /// The name of the offending registry entry.
+        name: String,
+    },
 }
 
 impl Formats {
@@ -143,13 +324,72 @@ impl Formats {
     pub fn decode_event_value(&self, bytes: &[u8]) -> bcs::Result<serde_json::Value> {
         bcs_to_json(bytes, &self.event_value, &self.registry)
     }
+
+    /// Encode a JSON operation value into its BCS bytes. Inverse of
+    /// [`decode_operation`](Self::decode_operation).
+    pub fn encode_operation(&self, value: &serde_json::Value) -> bcs::Result<Vec<u8>> {
+        json_to_bcs(value, &self.operation, &self.registry)
+    }
+
+    /// Encode a JSON operation response value into its BCS bytes. Inverse of
+    /// [`decode_response`](Self::decode_response).
+    pub fn encode_response(&self, value: &serde_json::Value) -> bcs::Result<Vec<u8>> {
+        json_to_bcs(value, &self.response, &self.registry)
+    }
+
+    /// Encode a JSON message value into its BCS bytes. Inverse of
+    /// [`decode_message`](Self::decode_message).
+    pub fn encode_message(&self, value: &serde_json::Value) -> bcs::Result<Vec<u8>> {
+        json_to_bcs(value, &self.message, &self.registry)
+    }
+
+    /// Encode a JSON event value into its BCS bytes. Inverse of
+    /// [`decode_event_value`](Self::decode_event_value).
+    pub fn encode_event_value(&self, value: &serde_json::Value) -> bcs::Result<Vec<u8>> {
+        json_to_bcs(value, &self.event_value, &self.registry)
+    }
+
+    /// Removes the registry entries for the well-known linera-base primitives (see
+    /// [`KNOWN_PRIMITIVE_NAMES`]) so that decoding falls back to [`LineraEnvironment`],
+    /// which renders them in their human-readable form.
+    ///
+    /// Before removing anything, this verifies that each such entry actually matches
+    /// the canonical BCS format of the corresponding linera-base type. If any entry is
+    /// present with a different format — for instance because an application defined a
+    /// distinct type with a colliding name — this returns [`PruneError::Mismatch`] and
+    /// leaves the registry untouched.
+    ///
+    /// This is meant to be called from snapshot tests (and any other code that
+    /// generates the stored [`Formats`]) so that the human-readable rendering is baked
+    /// into the published formats.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn prune_known_primitives(&mut self) -> Result<(), PruneError> {
+        let expected = expected_primitive_registry()?;
+        // Verify everything first so a mismatch never leaves the registry half-pruned.
+        for name in KNOWN_PRIMITIVE_NAMES {
+            let (Some(actual), Some(expected_format)) =
+                (self.registry.get(*name), expected.get(*name))
+            else {
+                continue;
+            };
+            if actual != expected_format {
+                return Err(PruneError::Mismatch {
+                    name: (*name).to_string(),
+                });
+            }
+        }
+        for name in KNOWN_PRIMITIVE_NAMES {
+            self.registry.remove(*name);
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use serde_reflection::{ContainerFormat, Samples, Tracer, TracerConfig};
+    use serde_reflection::{Samples, Tracer, TracerConfig};
 
     use super::*;
 
@@ -252,6 +492,7 @@ mod tests {
         let (operation, op_registry) = trace_format::<Operation>();
         let (response, resp_registry) = trace_format::<Response>();
 
+        // Combine the two registries so the same `Formats` can decode both types.
         let mut registry = op_registry;
         registry.extend(resp_registry);
 
@@ -278,23 +519,142 @@ mod tests {
             json!({ "ok": true })
         );
 
+        // Empty BCS for the `()` unit type.
         let unit_bytes = bcs::to_bytes(&()).unwrap();
         assert_eq!(formats.decode_message(&unit_bytes).unwrap(), json!(null));
         assert_eq!(
             formats.decode_event_value(&unit_bytes).unwrap(),
             json!(null)
         );
+
+        // The encode helpers are the inverse of the decode helpers.
+        assert_eq!(
+            formats.encode_operation(&json!({ "Echo": "hi" })).unwrap(),
+            op_bytes
+        );
+        assert_eq!(
+            formats.encode_response(&json!({ "ok": true })).unwrap(),
+            resp_bytes
+        );
+        assert_eq!(formats.encode_message(&json!(null)).unwrap(), unit_bytes);
+        assert_eq!(
+            formats.encode_event_value(&json!(null)).unwrap(),
+            unit_bytes
+        );
     }
 
     #[test]
     fn malformed_bytes_return_error() {
         let (format, registry) = trace_format::<u64>();
+        // u64 needs 8 bytes; only provide 3.
         assert!(bcs_to_json(&[1, 2, 3], &format, &registry).is_err());
+    }
+
+    #[test]
+    fn expected_registry_builds() {
+        let registry = expected_primitive_registry().unwrap();
+        for name in KNOWN_PRIMITIVE_NAMES {
+            assert!(registry.contains_key(*name), "missing {name}");
+        }
+    }
+
+    #[test]
+    fn known_primitives_decode_as_human_readable() {
+        use std::str::FromStr as _;
+
+        use crate::linera_base_types::{AccountOwner, Amount, CryptoHash, ModuleId, VmRuntime};
+
+        #[derive(Serialize, Deserialize)]
+        struct Sample {
+            owner: AccountOwner,
+            amount: Amount,
+            hash: CryptoHash,
+            module: Option<ModuleId>,
+        }
+
+        let hash = CryptoHash::from_str(&"ab".repeat(32)).unwrap();
+        let value = Sample {
+            owner: AccountOwner::Address32(hash),
+            amount: Amount::from_tokens(5),
+            hash,
+            module: Some(ModuleId::new(hash, hash, VmRuntime::Wasm)),
+        };
+
+        // Trace `Sample` plus the nested multi-variant enums, so every variant of
+        // `AccountOwner` and `VmRuntime` is recorded (a single `trace_type` pass over a
+        // struct only samples one variant per nested enum).
+        let mut tracer = Tracer::new(
+            TracerConfig::default()
+                .record_samples_for_newtype_structs(true)
+                .record_samples_for_tuple_structs(true),
+        );
+        let samples = Samples::new();
+        let (operation, _) = tracer.trace_type::<Sample>(&samples).unwrap();
+        tracer.trace_type::<AccountOwner>(&samples).unwrap();
+        tracer.trace_type::<VmRuntime>(&samples).unwrap();
+        let registry = tracer.registry().unwrap();
+
+        let unit = Format::Unit;
+        let mut formats = Formats {
+            registry,
+            operation,
+            response: unit.clone(),
+            message: unit.clone(),
+            event_value: unit,
+        };
+
+        // Tracing this value embeds CryptoHash/AccountOwner/Amount/ModuleId structurally.
+        let bytes = bcs::to_bytes(&value).unwrap();
+        assert!(formats.registry.contains_key("CryptoHash"));
+
+        // After pruning, those primitives are decoded by `LineraEnvironment` into the
+        // exact human-readable JSON their own `Serialize` would produce.
+        formats.prune_known_primitives().unwrap();
+        assert!(!formats.registry.contains_key("CryptoHash"));
+        assert!(!formats.registry.contains_key("AccountOwner"));
+
+        let decoded = formats.decode_operation(&bytes).unwrap();
+        let expected = serde_json::to_value(&value).unwrap();
+        assert_eq!(decoded, expected);
+        // Sanity-check the human-readable shape: a hex hash and a decimal amount string.
+        assert_eq!(decoded["hash"], json!("ab".repeat(32)));
+        assert_eq!(decoded["amount"], json!(value.amount.to_string()));
+
+        // Encoding is the inverse of decoding: the human-readable JSON re-encodes to
+        // exactly the original BCS bytes.
+        let reencoded = formats.encode_operation(&decoded).unwrap();
+        assert_eq!(reencoded, bytes);
+    }
+
+    #[test]
+    fn prune_rejects_colliding_format() {
+        use serde_reflection::ContainerFormat;
+
+        // A registry where `CryptoHash` is (wrongly) bound to a different format.
+        let mut registry = Registry::new();
+        registry.insert(
+            "CryptoHash".to_string(),
+            ContainerFormat::NewTypeStruct(Box::new(Format::U64)),
+        );
+        let unit = Format::Unit;
+        let mut formats = Formats {
+            registry,
+            operation: Format::TypeName("CryptoHash".to_string()),
+            response: unit.clone(),
+            message: unit.clone(),
+            event_value: unit,
+        };
+
+        let error = formats.prune_known_primitives().unwrap_err();
+        assert!(matches!(error, PruneError::Mismatch { name } if name == "CryptoHash"));
+        // The registry is left untouched on mismatch.
+        assert!(formats.registry.contains_key("CryptoHash"));
     }
 
     #[test]
     fn stable_enum_round_trip() {
         use linera_sdk_derive::StableEnumInCrate;
+        use serde_reflection::ContainerFormat;
 
         #[derive(Debug, PartialEq, StableEnumInCrate)]
         enum Op {


### PR DESCRIPTION
## Motivation

Port of #6547 (which targets `testnet_conway`) to `main`.

When the formats-registry / explorer decodes BCS payloads to JSON via `serde_reflection`'s `json_converter`, well-known linera-base primitives come out in their *binary* shape — a `CryptoHash` as a 32-element byte array, an `Amount` as a number, an `AccountOwner` as `{Address32: [...]}` — because the traced registry describes the BCS form, not the human-readable one each type defines via `is_human_readable()`. We also lacked the inverse direction (JSON → BCS), which is useful for tooling and tests.

## Proposal

Provide a "better" `json_converter` environment so those primitives round-trip through their human-readable representation, using **route (a)**: the well-known names are removed from the stored registry so (de)serialization falls back to the environment.

- **`LineraEnvironment`** (`linera-sdk/src/formats.rs`): implements both `DeserializationEnvironment` and `SerializationEnvironment`. On decode it turns a known primitive's BCS bytes into the concrete type and emits `serde_json::to_value` of it (human-readable); on encode it reads the human-readable JSON back into the concrete type and serializes its BCS form. It only fires for names *absent* from the registry, so it is a no-op on un-pruned registries.
- **`Formats::prune_known_primitives`** (non-wasm): before removing anything, it traces each primitive's canonical BCS `ContainerFormat` and compares it to the registry entry, returning `PruneError::Mismatch { name }` (and pruning nothing) on a collision/drift; only then does it remove the verified entries.
- **`BcsApplication::pruned_formats`**: a default trait method returning `formats()` with the primitives pruned — the single, drift-free entry point for the publishable/human-readable form. `formats()` stays the faithful, self-contained reflection.
- **Encoding API**: `Formats::{encode_operation, encode_response, encode_message, encode_event_value}` as inverses of the existing `decode_*` helpers. The internal `bcs_to_json` / `json_to_bcs` are private.
- A single macro is the source of truth for the `name => Type` list, generating the decoder, the encoder, and the canonical-format tracer so they can't drift.
- The example `tests/format.rs` snapshot tests now use `App::pruned_formats()`, so the published formats render primitives in human-readable form.

This port preserves `main`'s existing `StableEnum` / `TracerExt` machinery in `formats.rs` (not present on `testnet_conway`); the two features are independent.

### Scope / limitations (documented in-code)

Supported, verifiable primitives: `CryptoHash, AccountOwner, Amount, Epoch, BlobId, StreamId, ModuleId, ApplicationId`. Excluded for now:
- **Crypto keys/signatures** (`Secp256k1PublicKey`, `EvmPublicKey`, …): their `Deserialize` validates curve-point validity, so `serde_reflection` cannot trace them from dummy bytes and we cannot verify their format before pruning. They also don't appear in any application ABI. Supporting them needs sample-based tracing (future work).
- **`U128`** (anonymous `u128` in BCS) and **`Blob`** (serializes as `BlobContent`) — not addressable by registry name.

## Test Plan

- `cargo test -p linera-sdk --lib formats` — 10/10 pass (the json_converter suite, including an `encode(decode(bcs)) == bcs` inverse check, plus main's existing `stable_enum_round_trip`).
- `cargo +nightly fmt --check` and `cargo clippy -p linera-sdk` clean.
- Regenerated all example `format` snapshots (`INSTA_UPDATE=force cargo test -p <example> --test format`). `gen-nft` and `llm` can't be built in the dev sandbox (their ML deps need a CPU `fullfp16` feature); `llm`'s prune is a verified no-op (its ABI references no such primitive), and `gen-nft`'s snapshot was updated by hand to match the deterministic prune output (CI builds both and will verify).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Ports #6547
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
