### PR TITLE
Move msg/op counters into execution state.

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -145,8 +145,9 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     ))
                     .await?;
                 }
-                let num_incoming_bundles = chain.system.num_incoming_bundles.get_mut();
-                *num_incoming_bundles = num_incoming_bundles
+                let counters = chain.system.counters.get_mut();
+                counters.num_incoming_bundles = counters
+                    .num_incoming_bundles
                     .checked_add(1)
                     .ok_or(ArithmeticError::Overflow)?;
             }
@@ -175,8 +176,9 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     .await?
                     .track_operation(operation)
                     .with_execution_context(chain_execution_context)?;
-                let num_operations = chain.system.num_operations.get_mut();
-                *num_operations = num_operations
+                let counters = chain.system.counters.get_mut();
+                counters.num_operations = counters
+                    .num_operations
                     .checked_add(1)
                     .ok_or(ArithmeticError::Overflow)?;
             }
@@ -185,8 +187,9 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         let txn_outcome = txn_tracker
             .into_outcome()
             .with_execution_context(chain_execution_context)?;
-        let num_outgoing_messages = chain.system.num_outgoing_messages.get_mut();
-        *num_outgoing_messages = num_outgoing_messages
+        let counters = chain.system.counters.get_mut();
+        counters.num_outgoing_messages = counters
+            .num_outgoing_messages
             .checked_add(
                 u32::try_from(txn_outcome.outgoing_messages.len())
                     .map_err(|_| ArithmeticError::Overflow)?,

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -145,8 +145,8 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     ))
                     .await?;
                 }
-                let counters = chain.system.counters.get_mut();
-                counters.num_incoming_bundles = counters
+                let progress = chain.system.progress.get_mut();
+                progress.num_incoming_bundles = progress
                     .num_incoming_bundles
                     .checked_add(1)
                     .ok_or(ArithmeticError::Overflow)?;
@@ -176,8 +176,8 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     .await?
                     .track_operation(operation)
                     .with_execution_context(chain_execution_context)?;
-                let counters = chain.system.counters.get_mut();
-                counters.num_operations = counters
+                let progress = chain.system.progress.get_mut();
+                progress.num_operations = progress
                     .num_operations
                     .checked_add(1)
                     .ok_or(ArithmeticError::Overflow)?;
@@ -187,8 +187,8 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         let txn_outcome = txn_tracker
             .into_outcome()
             .with_execution_context(chain_execution_context)?;
-        let counters = chain.system.counters.get_mut();
-        counters.num_outgoing_messages = counters
+        let progress = chain.system.progress.get_mut();
+        progress.num_outgoing_messages = progress
             .num_outgoing_messages
             .checked_add(
                 u32::try_from(txn_outcome.outgoing_messages.len())

--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -7,7 +7,7 @@ use custom_debug_derive::Debug;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency;
 use linera_base::{
-    data_types::{Amount, Blob, BlockHeight, Event, OracleResponse, Timestamp},
+    data_types::{Amount, ArithmeticError, Blob, BlockHeight, Event, OracleResponse, Timestamp},
     ensure,
     identifiers::{AccountOwner, BlobId, ChainId, StreamId},
 };
@@ -145,6 +145,10 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     ))
                     .await?;
                 }
+                let num_incoming_bundles = chain.system.num_incoming_bundles.get_mut();
+                *num_incoming_bundles = num_incoming_bundles
+                    .checked_add(1)
+                    .ok_or(ArithmeticError::Overflow)?;
             }
             Transaction::ExecuteOperation(operation) => {
                 self.resource_controller_mut()
@@ -171,12 +175,23 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     .await?
                     .track_operation(operation)
                     .with_execution_context(chain_execution_context)?;
+                let num_operations = chain.system.num_operations.get_mut();
+                *num_operations = num_operations
+                    .checked_add(1)
+                    .ok_or(ArithmeticError::Overflow)?;
             }
         }
 
         let txn_outcome = txn_tracker
             .into_outcome()
             .with_execution_context(chain_execution_context)?;
+        let num_outgoing_messages = chain.system.num_outgoing_messages.get_mut();
+        *num_outgoing_messages = num_outgoing_messages
+            .checked_add(
+                u32::try_from(txn_outcome.outgoing_messages.len())
+                    .map_err(|_| ArithmeticError::Overflow)?,
+            )
+            .ok_or(ArithmeticError::Overflow)?;
         self.process_txn_outcome(txn_outcome, &mut chain.system, chain_execution_context)
             .await?;
         Ok(())

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -840,7 +840,7 @@ where
             None
         };
 
-        chain.system.timestamp.set(block.timestamp);
+        chain.system.progress.get_mut().timestamp = block.timestamp;
 
         let mut resource_controller = ResourceController::new(
             Arc::new(committee_policy),
@@ -1217,7 +1217,7 @@ where
 
         self.initialize_if_needed(local_time).await?;
 
-        let chain_timestamp = *self.execution_state.system.timestamp.get();
+        let chain_timestamp = self.execution_state.system.progress.get().timestamp;
         ensure!(
             chain_timestamp <= block.timestamp,
             ChainError::InvalidBlockTimestamp {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -21,8 +21,8 @@ use linera_base::{
 };
 use linera_execution::{
     committee::Committee, ExecutionRuntimeContext, ExecutionStateView, Message, Operation,
-    OutgoingMessage, PreparedCheckpoint, Query, QueryContext, QueryOutcome, ResourceController,
-    ResourceTracker, ServiceRuntimeEndpoint, TransactionTracker,
+    PreparedCheckpoint, Query, QueryContext, QueryOutcome, ResourceController, ResourceTracker,
+    ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
     context::Context,
@@ -327,12 +327,6 @@ pub struct ChainTipState {
     pub block_hash: Option<CryptoHash>,
     /// Sequence number tracking blocks.
     pub next_block_height: BlockHeight,
-    /// Number of incoming message bundles.
-    pub num_incoming_bundles: u32,
-    /// Number of operations.
-    pub num_operations: u32,
-    /// Number of outgoing messages.
-    pub num_outgoing_messages: u32,
 }
 
 impl ChainTipState {
@@ -363,50 +357,6 @@ impl ChainTipState {
             }
         );
         Ok(self.next_block_height > height)
-    }
-
-    /// Checks if the measurement counters would be valid.
-    pub fn update_counters(
-        &mut self,
-        transactions: &[Transaction],
-        messages: &[Vec<OutgoingMessage>],
-    ) -> Result<(), ChainError> {
-        let mut num_incoming_bundles = 0u32;
-        let mut num_operations = 0u32;
-
-        for transaction in transactions {
-            match transaction {
-                Transaction::ReceiveMessages(_) => {
-                    num_incoming_bundles = num_incoming_bundles
-                        .checked_add(1)
-                        .ok_or(ArithmeticError::Overflow)?;
-                }
-                Transaction::ExecuteOperation(_) => {
-                    num_operations = num_operations
-                        .checked_add(1)
-                        .ok_or(ArithmeticError::Overflow)?;
-                }
-            }
-        }
-
-        self.num_incoming_bundles = self
-            .num_incoming_bundles
-            .checked_add(num_incoming_bundles)
-            .ok_or(ArithmeticError::Overflow)?;
-
-        self.num_operations = self
-            .num_operations
-            .checked_add(num_operations)
-            .ok_or(ArithmeticError::Overflow)?;
-
-        let num_outgoing_messages = u32::try_from(messages.iter().map(Vec::len).sum::<usize>())
-            .map_err(|_| ArithmeticError::Overflow)?;
-        self.num_outgoing_messages = self
-            .num_outgoing_messages
-            .checked_add(num_outgoing_messages)
-            .ok_or(ArithmeticError::Overflow)?;
-
-        Ok(())
     }
 }
 
@@ -1320,7 +1270,7 @@ where
             (Vec::new(), Vec::new(), Vec::new())
         };
 
-        Self::execute_block_inner(
+        let (outcome, tracker, never_reject_origins) = Self::execute_block_inner(
             &mut self.execution_state,
             &self.block_hashes,
             &mut block,
@@ -1333,10 +1283,9 @@ where
             inbox_cursors,
             outbox_block_hashes,
         )
-        .await
-        .map(|(outcome, tracker, never_reject_origins)| {
-            (block, outcome, tracker, never_reject_origins)
-        })
+        .await?;
+
+        Ok((block, outcome, tracker, never_reject_origins))
     }
 
     /// Snapshots `(origin, next_cursor_to_remove)` for each chain we've received a
@@ -1504,7 +1453,6 @@ where
         let tip = self.tip_state.get_mut();
         tip.block_hash = Some(hash);
         tip.next_block_height.try_add_assign_one()?;
-        tip.update_counters(&block.body.transactions, &block.body.messages)?;
         self.insert_block_hash(block.header.height, hash)?;
         if block.body.starts_with_checkpoint() {
             self.latest_checkpoint_height.set(Some(block.header.height));

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1206,12 +1206,9 @@ where
         // (`manager`, `block_hashes` for height `height`), or (c) outside the
         // protocol state hash so divergence from the producer is fine
         // (inboxes; subsequent blocks reconcile by anticipation if needed).
-        // The `num_*` counters on `ChainTipState` are write-only in current
-        // code, so leaving them at zero has no functional impact.
         let new_tip = ChainTipState {
             block_hash: previous_block_hash,
             next_block_height: height,
-            ..Default::default()
         };
         self.chain.tip_state.set(new_tip.clone());
         // Installing a snapshot establishes the chain's state from scratch (block 0 is never
@@ -2511,11 +2508,6 @@ where
             WorkerError::FastBlockUsingOracles
         );
         let chain = &mut self.chain;
-        // Check if the counters of tip_state would be valid.
-        chain
-            .tip_state
-            .get_mut()
-            .update_counters(&block.body.transactions, &block.body.messages)?;
         // Don't save the changes since the block is not confirmed yet.
         chain.rollback();
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -293,7 +293,7 @@ impl ChainInfo {
             chain_balance: *system_state.balance.get(),
             block_hash: tip_state.block_hash,
             next_block_height: tip_state.next_block_height,
-            timestamp: *view.execution_state.system.timestamp.get(),
+            timestamp: view.execution_state.system.progress.get().timestamp,
             state_hash: Some(view.execution_state.crypto_hash_mut().await?),
             committee_hash: *view.execution_state.system.committee_hash.get(),
             requested_owner_balance: None,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -119,7 +119,7 @@ where
     /// them during transaction execution via [`Self::apply_checkpoint`].
     ///
     /// This is a *pre-block* operation: it must run before the block-level setup mutates
-    /// the chain state (e.g. setting `system.timestamp`), because `dump_content` reads
+    /// the chain state (e.g. setting `system.progress`), because `dump_content` reads
     /// from storage and refuses to run with pending in-memory changes. Splitting the
     /// dump out of the operation handler also guarantees the captured bytes represent
     /// the chain's pre-block state, which is exactly what a bootstrapping node will

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -306,7 +306,7 @@ where
             }
 
             SystemTimestamp { callback } => {
-                let timestamp = *self.state.system.timestamp.get();
+                let timestamp = self.state.system.progress.get().timestamp;
                 callback.respond(timestamp);
             }
 

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -102,6 +102,6 @@ impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
 
     #[graphql(derived(name = "timestamp"))]
     async fn _timestamp(&self) -> &Timestamp {
-        self.timestamp.get()
+        &self.progress.get().timestamp
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -80,7 +80,8 @@ pub use crate::{
         ServiceSyncRuntimeHandle,
     },
     system::{
-        SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery, SystemResponse,
+        ChainCounters, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,
+        SystemResponse,
     },
     transaction_tracker::{PreparedCheckpoint, TransactionOutcome, TransactionTracker},
 };

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -80,7 +80,7 @@ pub use crate::{
         ServiceSyncRuntimeHandle,
     },
     system::{
-        ChainCounters, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,
+        ChainProgress, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,
         SystemResponse,
     },
     transaction_tracker::{PreparedCheckpoint, TransactionOutcome, TransactionTracker},

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -76,10 +76,13 @@ mod metrics {
     });
 }
 
-/// Cumulative counts of transactions and messages processed on a chain, maintained
-/// across blocks. Stored as a single value so that each block updates only one key.
+/// Per-block state of a chain: the timestamp of its most recent block together with
+/// cumulative counts of the transactions and messages processed so far. Stored as a
+/// single value so that each block updates only one key.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Allocative)]
-pub struct ChainCounters {
+pub struct ChainProgress {
+    /// The timestamp of the most recent block.
+    pub timestamp: Timestamp,
     /// Number of incoming message bundles executed so far.
     pub num_incoming_bundles: u32,
     /// Number of operations executed so far.
@@ -109,8 +112,6 @@ pub struct SystemExecutionStateView<C> {
     pub balances: MapView<C, AccountOwner, Amount>,
     /// Allowances for spending from one account by another.
     pub allowances: MapView<C, OwnerSpender, Amount>,
-    /// The timestamp of the most recent block.
-    pub timestamp: RegisterView<C, Timestamp>,
     /// Whether this chain has been closed.
     pub closed: RegisterView<C, bool>,
     /// Permissions for applications on this chain.
@@ -145,8 +146,8 @@ pub struct SystemExecutionStateView<C> {
     /// `CheckpointAck` messages here is what breaks the otherwise-perpetual
     /// notification ping-pong between two chains that ever exchanged a real message.
     pub pending_checkpoint_ack_targets: SetView<C, ChainId>,
-    /// Cumulative counts of incoming bundles, operations and outgoing messages.
-    pub counters: RegisterView<C, ChainCounters>,
+    /// The most recent block's timestamp and cumulative transaction/message counts.
+    pub progress: RegisterView<C, ChainProgress>,
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C> {
@@ -165,7 +166,6 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
             balance: self.balance.with_context(ctx.clone()).await,
             balances: self.balances.with_context(ctx.clone()).await,
             allowances: self.allowances.with_context(ctx.clone()).await,
-            timestamp: self.timestamp.with_context(ctx.clone()).await,
             closed: self.closed.with_context(ctx.clone()).await,
             application_permissions: self.application_permissions.with_context(ctx.clone()).await,
             used_blobs: self.used_blobs.with_context(ctx.clone()).await,
@@ -180,7 +180,7 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
                 .pending_checkpoint_ack_targets
                 .with_context(ctx.clone())
                 .await,
-            counters: self.counters.with_context(ctx.clone()).await,
+            progress: self.progress.with_context(ctx.clone()).await,
         }
     }
 }
@@ -970,7 +970,7 @@ where
             balance,
             application_permissions,
         } = description.config().clone();
-        self.timestamp.set(description.timestamp());
+        self.progress.get_mut().timestamp = description.timestamp();
         self.description.set(Some(description));
         self.epoch.set(epoch);
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -76,6 +76,18 @@ mod metrics {
     });
 }
 
+/// Cumulative counts of transactions and messages processed on a chain, maintained
+/// across blocks. Stored as a single value so that each block updates only one key.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Allocative)]
+pub struct ChainCounters {
+    /// Number of incoming message bundles executed so far.
+    pub num_incoming_bundles: u32,
+    /// Number of operations executed so far.
+    pub num_operations: u32,
+    /// Number of outgoing messages sent so far.
+    pub num_outgoing_messages: u32,
+}
+
 /// A view accessing the execution state of the system of a chain.
 #[derive(Debug, ClonableView, View, Allocative)]
 #[allocative(bound = "C")]
@@ -133,12 +145,8 @@ pub struct SystemExecutionStateView<C> {
     /// `CheckpointAck` messages here is what breaks the otherwise-perpetual
     /// notification ping-pong between two chains that ever exchanged a real message.
     pub pending_checkpoint_ack_targets: SetView<C, ChainId>,
-    /// Number of incoming message bundles executed so far.
-    pub num_incoming_bundles: RegisterView<C, u32>,
-    /// Number of operations executed so far.
-    pub num_operations: RegisterView<C, u32>,
-    /// Number of outgoing messages sent so far.
-    pub num_outgoing_messages: RegisterView<C, u32>,
+    /// Cumulative counts of incoming bundles, operations and outgoing messages.
+    pub counters: RegisterView<C, ChainCounters>,
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C> {
@@ -172,9 +180,7 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
                 .pending_checkpoint_ack_targets
                 .with_context(ctx.clone())
                 .await,
-            num_incoming_bundles: self.num_incoming_bundles.with_context(ctx.clone()).await,
-            num_operations: self.num_operations.with_context(ctx.clone()).await,
-            num_outgoing_messages: self.num_outgoing_messages.with_context(ctx.clone()).await,
+            counters: self.counters.with_context(ctx.clone()).await,
         }
     }
 }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -133,6 +133,12 @@ pub struct SystemExecutionStateView<C> {
     /// `CheckpointAck` messages here is what breaks the otherwise-perpetual
     /// notification ping-pong between two chains that ever exchanged a real message.
     pub pending_checkpoint_ack_targets: SetView<C, ChainId>,
+    /// Number of incoming message bundles executed so far.
+    pub num_incoming_bundles: RegisterView<C, u32>,
+    /// Number of operations executed so far.
+    pub num_operations: RegisterView<C, u32>,
+    /// Number of outgoing messages sent so far.
+    pub num_outgoing_messages: RegisterView<C, u32>,
 }
 
 impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C> {
@@ -166,6 +172,9 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
                 .pending_checkpoint_ack_targets
                 .with_context(ctx.clone())
                 .await,
+            num_incoming_bundles: self.num_incoming_bundles.with_context(ctx.clone()).await,
+            num_operations: self.num_operations.with_context(ctx.clone()).await,
+            num_outgoing_messages: self.num_outgoing_messages.with_context(ctx.clone()).await,
         }
     }
 }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -17,8 +17,8 @@ use linera_views::{context::MemoryContext, views::View};
 
 use super::{dummy_chain_description, dummy_committees, MockApplication, RegisterMockApplication};
 use crate::{
-    committee::Committee, ApplicationDescription, ExecutionRuntimeConfig, ExecutionRuntimeContext,
-    ExecutionStateView, TestExecutionRuntimeContext,
+    committee::Committee, ApplicationDescription, ChainCounters, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, ExecutionStateView, TestExecutionRuntimeContext,
 };
 
 /// A system execution state, not represented as a view but as a simple struct.
@@ -190,9 +190,11 @@ impl SystemExecutionState {
         view.system
             .application_permissions
             .set(application_permissions);
-        view.system.num_incoming_bundles.set(num_incoming_bundles);
-        view.system.num_operations.set(num_operations);
-        view.system.num_outgoing_messages.set(num_outgoing_messages);
+        view.system.counters.set(ChainCounters {
+            num_incoming_bundles,
+            num_operations,
+            num_outgoing_messages,
+        });
         view
     }
 }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -54,6 +54,12 @@ pub struct SystemExecutionState {
     /// The mock applications registered on the chain, indexed by their application ID.
     #[debug(skip_if = BTreeMap::is_empty)]
     pub mock_applications: BTreeMap<ApplicationId, MockApplication>,
+    /// Number of incoming message bundles executed so far.
+    pub num_incoming_bundles: u32,
+    /// Number of operations executed so far.
+    pub num_operations: u32,
+    /// Number of outgoing messages sent so far.
+    pub num_outgoing_messages: u32,
 }
 
 impl SystemExecutionState {
@@ -123,6 +129,9 @@ impl SystemExecutionState {
             application_permissions,
             extra_blobs,
             mock_applications,
+            num_incoming_bundles,
+            num_operations,
+            num_outgoing_messages,
         } = self;
 
         let extra = TestExecutionRuntimeContext::new(chain_id, execution_runtime_config);
@@ -181,6 +190,9 @@ impl SystemExecutionState {
         view.system
             .application_permissions
             .set(application_permissions);
+        view.system.num_incoming_bundles.set(num_incoming_bundles);
+        view.system.num_operations.set(num_operations);
+        view.system.num_outgoing_messages.set(num_outgoing_messages);
         view
     }
 }

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -17,7 +17,7 @@ use linera_views::{context::MemoryContext, views::View};
 
 use super::{dummy_chain_description, dummy_committees, MockApplication, RegisterMockApplication};
 use crate::{
-    committee::Committee, ApplicationDescription, ChainCounters, ExecutionRuntimeConfig,
+    committee::Committee, ApplicationDescription, ChainProgress, ExecutionRuntimeConfig,
     ExecutionRuntimeContext, ExecutionStateView, TestExecutionRuntimeContext,
 };
 
@@ -179,7 +179,6 @@ impl SystemExecutionState {
                 .insert(&account_owner, balance)
                 .expect("insertion of balances should not fail");
         }
-        view.system.timestamp.set(timestamp);
         for blob_id in used_blobs {
             view.system
                 .used_blobs
@@ -190,7 +189,8 @@ impl SystemExecutionState {
         view.system
             .application_permissions
             .set(application_permissions);
-        view.system.counters.set(ChainCounters {
+        view.system.progress.set(ChainProgress {
+            timestamp,
             num_incoming_bundles,
             num_operations,
             num_outgoing_messages,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -460,18 +460,6 @@ type ChainTipState {
 	Sequence number tracking blocks.
 	"""
 	nextBlockHeight: BlockHeight!
-	"""
-	Number of incoming message bundles.
-	"""
-	numIncomingBundles: Int!
-	"""
-	Number of operations.
-	"""
-	numOperations: Int!
-	"""
-	Number of outgoing messages.
-	"""
-	numOutgoingMessages: Int!
 }
 
 """


### PR DESCRIPTION
## Motivation

These are fully determined by block execution on this chain so far.
Checkpoints reset them to 0 when restoring, but not when they are created, so validators don't agree on them.

## Proposal

Move them into the execution state.

## Test Plan

These are not used anywhere, just exposed via GraphQL as part of the chain state.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
