### PR TITLE
Save and restore `ChainTipState` counters across checkpoints

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1418,24 +1418,47 @@ pub enum OracleResponse {
         /// storage before applying the checkpoint, otherwise subsequent operations on
         /// the chain could try to read blob content the node doesn't actually have.
         used_blobs: Vec<BlobId>,
-        /// Hashes of every block on this chain that the chain's outboxes still reference
-        /// at the time of the checkpoint — i.e. the heights with cross-chain messages
-        /// that recipients haven't acknowledged yet. The current-epoch certificate over
-        /// the checkpoint block transitively certifies these older blocks: a node that
-        /// later receives one of these block's bytes can verify the bytes hash to a
-        /// hash in this set, without trusting the (possibly revoked) validator
-        /// signatures on the older block's own certificate.
-        outbox_block_hashes: Vec<CryptoHash>,
-        /// For each chain whose messages we've consumed, the `next_cursor_to_remove`
-        /// of the corresponding inbox. A bootstrapping node uses these to seed each
-        /// inbox's `restored_cursor`, so subsequent sender re-pushes below that cursor
-        /// are silently dropped (their effects are already baked into the restored
-        /// execution state).
-        inbox_cursors: Vec<(ChainId, Cursor)>,
+        /// The chain's non-execution-state bookkeeping at the time of the checkpoint, so
+        /// a bootstrapping node can restore the chain's outbox, inbox, and tip-counter
+        /// state without replaying the pre-checkpoint blocks.
+        summary: CheckpointSummary,
     },
 }
 
 impl BcsHashable<'_> for OracleResponse {}
+
+/// The chain's non-execution-state bookkeeping captured by a checkpoint. It is recorded
+/// in [`OracleResponse::Checkpoint`] and also collected pre-block by the checkpoint hook,
+/// so a bootstrapping node can restore the chain's outbox, inbox, and tip-counter state
+/// without replaying the pre-checkpoint blocks.
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Allocative)]
+pub struct CheckpointSummary {
+    /// Hashes of every block on this chain that the chain's outboxes still reference
+    /// at the time of the checkpoint — i.e. the heights with cross-chain messages
+    /// that recipients haven't acknowledged yet. The current-epoch certificate over
+    /// the checkpoint block transitively certifies these older blocks: a node that
+    /// later receives one of these block's bytes can verify the bytes hash to a
+    /// hash in this set, without trusting the (possibly revoked) validator
+    /// signatures on the older block's own certificate.
+    pub outbox_block_hashes: Vec<CryptoHash>,
+    /// For each chain whose messages we've consumed, the `next_cursor_to_remove`
+    /// of the corresponding inbox. A bootstrapping node uses these to seed each
+    /// inbox's `restored_cursor`, so subsequent sender re-pushes below that cursor
+    /// are silently dropped (their effects are already baked into the restored
+    /// execution state).
+    pub inbox_cursors: Vec<(ChainId, Cursor)>,
+    /// The chain's cumulative `num_incoming_bundles` counter as of just before the
+    /// checkpoint block. A bootstrapping node seeds `ChainTipState` with this instead
+    /// of resetting it to zero; re-executing the checkpoint block then advances it
+    /// exactly as on a node that processed every block, so all nodes agree.
+    pub num_incoming_bundles: u32,
+    /// The chain's cumulative `num_operations` counter as of just before the
+    /// checkpoint block. Seeded like `num_incoming_bundles`.
+    pub num_operations: u32,
+    /// The chain's cumulative `num_outgoing_messages` counter as of just before the
+    /// checkpoint block. Seeded like `num_incoming_bundles`.
+    pub num_outgoing_messages: u32,
+}
 
 /// Description of a user application.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize, WitType, WitLoad, WitStore)]

--- a/linera-bridge/src/solidity/BridgeTypes.sol
+++ b/linera-bridge/src/solidity/BridgeTypes.sol
@@ -463,6 +463,54 @@ library BridgeTypes {
         return value;
     }
 
+    struct CheckpointSummary {
+        CryptoHash[] outbox_block_hashes;
+        tuple_ChainId_Cursor[] inbox_cursors;
+        uint32 num_incoming_bundles;
+        uint32 num_operations;
+        uint32 num_outgoing_messages;
+    }
+
+    function bcs_serialize_CheckpointSummary(CheckpointSummary memory input) internal pure returns (bytes memory) {
+        bytes memory result = bcs_serialize_seq_CryptoHash(input.outbox_block_hashes);
+        result = abi.encodePacked(result, bcs_serialize_seq_tuple_ChainId_Cursor(input.inbox_cursors));
+        result = abi.encodePacked(result, bcs_serialize_uint32(input.num_incoming_bundles));
+        result = abi.encodePacked(result, bcs_serialize_uint32(input.num_operations));
+        return abi.encodePacked(result, bcs_serialize_uint32(input.num_outgoing_messages));
+    }
+
+    function bcs_deserialize_offset_CheckpointSummary(uint256 pos, bytes memory input)
+        internal
+        pure
+        returns (uint256, CheckpointSummary memory)
+    {
+        uint256 new_pos;
+        CryptoHash[] memory outbox_block_hashes;
+        (new_pos, outbox_block_hashes) = bcs_deserialize_offset_seq_CryptoHash(pos, input);
+        tuple_ChainId_Cursor[] memory inbox_cursors;
+        (new_pos, inbox_cursors) = bcs_deserialize_offset_seq_tuple_ChainId_Cursor(new_pos, input);
+        uint32 num_incoming_bundles;
+        (new_pos, num_incoming_bundles) = bcs_deserialize_offset_uint32(new_pos, input);
+        uint32 num_operations;
+        (new_pos, num_operations) = bcs_deserialize_offset_uint32(new_pos, input);
+        uint32 num_outgoing_messages;
+        (new_pos, num_outgoing_messages) = bcs_deserialize_offset_uint32(new_pos, input);
+        return (
+            new_pos,
+            CheckpointSummary(
+                outbox_block_hashes, inbox_cursors, num_incoming_bundles, num_operations, num_outgoing_messages
+            )
+        );
+    }
+
+    function bcs_deserialize_CheckpointSummary(bytes memory input) internal pure returns (CheckpointSummary memory) {
+        uint256 new_pos;
+        CheckpointSummary memory value;
+        (new_pos, value) = bcs_deserialize_offset_CheckpointSummary(0, input);
+        require(new_pos == input.length, "incomplete deserialization");
+        return value;
+    }
+
     struct CryptoHash {
         bytes32 value;
     }
@@ -991,8 +1039,7 @@ library BridgeTypes {
     struct OracleResponse_Checkpoint {
         CryptoHash[] execution_state_blobs;
         BlobId[] used_blobs;
-        CryptoHash[] outbox_block_hashes;
-        tuple_ChainId_Cursor[] inbox_cursors;
+        CheckpointSummary summary;
     }
 
     function bcs_serialize_OracleResponse_Checkpoint(OracleResponse_Checkpoint memory input)
@@ -1002,8 +1049,7 @@ library BridgeTypes {
     {
         bytes memory result = bcs_serialize_seq_CryptoHash(input.execution_state_blobs);
         result = abi.encodePacked(result, bcs_serialize_seq_BlobId(input.used_blobs));
-        result = abi.encodePacked(result, bcs_serialize_seq_CryptoHash(input.outbox_block_hashes));
-        return abi.encodePacked(result, bcs_serialize_seq_tuple_ChainId_Cursor(input.inbox_cursors));
+        return abi.encodePacked(result, bcs_serialize_CheckpointSummary(input.summary));
     }
 
     function bcs_deserialize_offset_OracleResponse_Checkpoint(uint256 pos, bytes memory input)
@@ -1016,12 +1062,9 @@ library BridgeTypes {
         (new_pos, execution_state_blobs) = bcs_deserialize_offset_seq_CryptoHash(pos, input);
         BlobId[] memory used_blobs;
         (new_pos, used_blobs) = bcs_deserialize_offset_seq_BlobId(new_pos, input);
-        CryptoHash[] memory outbox_block_hashes;
-        (new_pos, outbox_block_hashes) = bcs_deserialize_offset_seq_CryptoHash(new_pos, input);
-        tuple_ChainId_Cursor[] memory inbox_cursors;
-        (new_pos, inbox_cursors) = bcs_deserialize_offset_seq_tuple_ChainId_Cursor(new_pos, input);
-        return
-            (new_pos, OracleResponse_Checkpoint(execution_state_blobs, used_blobs, outbox_block_hashes, inbox_cursors));
+        CheckpointSummary memory summary;
+        (new_pos, summary) = bcs_deserialize_offset_CheckpointSummary(new_pos, input);
+        return (new_pos, OracleResponse_Checkpoint(execution_state_blobs, used_blobs, summary));
     }
 
     function bcs_deserialize_OracleResponse_Checkpoint(bytes memory input)

--- a/linera-bridge/tests/snapshots/format__format.yaml.snap
+++ b/linera-bridge/tests/snapshots/format__format.yaml.snap
@@ -110,6 +110,19 @@ CertificateKind:
 ChainId:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
+CheckpointSummary:
+  STRUCT:
+    - outbox_block_hashes:
+        SEQ:
+          TYPENAME: CryptoHash
+    - inbox_cursors:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ChainId
+            - TYPENAME: Cursor
+    - num_incoming_bundles: U32
+    - num_operations: U32
+    - num_outgoing_messages: U32
 CryptoHash:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -200,14 +213,8 @@ OracleResponse:
           - used_blobs:
               SEQ:
                 TYPENAME: BlobId
-          - outbox_block_hashes:
-              SEQ:
-                TYPENAME: CryptoHash
-          - inbox_cursors:
-              SEQ:
-                TUPLE:
-                  - TYPENAME: ChainId
-                  - TYPENAME: Cursor
+          - summary:
+              TYPENAME: CheckpointSummary
 Response:
   STRUCT:
     - status: U16

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -10,8 +10,9 @@ use allocative::Allocative;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
-        ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Cursor,
-        Epoch, NonCanonicalBTreeMap, NonCanonicalBTreeSet, OracleResponse, Timestamp,
+        ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
+        CheckpointSummary, Cursor, Epoch, NonCanonicalBTreeMap, NonCanonicalBTreeSet,
+        OracleResponse, Timestamp,
     },
     ensure,
     hashed::Hashed,
@@ -838,8 +839,7 @@ where
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         exec_policy: BundleExecutionPolicy,
         checkpoint_origin_cursors: Vec<(ChainId, Cursor)>,
-        checkpoint_inbox_cursors: Vec<(ChainId, Cursor)>,
-        checkpoint_outbox_block_hashes: Vec<CryptoHash>,
+        checkpoint_summary: CheckpointSummary,
     ) -> Result<(BlockExecutionOutcome, ResourceTracker, HashSet<ChainId>), ChainError> {
         // AutoRetry is incompatible with replaying oracle responses because discarding or
         // rejecting bundles would change which transactions execute.
@@ -883,8 +883,7 @@ where
             Some(PreparedCheckpoint {
                 blobs,
                 origin_cursors: checkpoint_origin_cursors,
-                inbox_cursors: checkpoint_inbox_cursors,
-                outbox_block_hashes: checkpoint_outbox_block_hashes,
+                summary: checkpoint_summary,
             })
         } else {
             None
@@ -1309,15 +1308,25 @@ where
                 "Checkpoint must be the first transaction in its block",
             )
         );
-        let (origin_cursors, inbox_cursors, outbox_block_hashes) = if block.starts_with_checkpoint()
-        {
+        let (origin_cursors, summary) = if block.starts_with_checkpoint() {
             self.check_checkpoint_preconditions().await?;
             let origin_cursors = self.collect_inbox_cursors().await?;
             let inbox_cursors = self.collect_all_inbox_cursors().await?;
-            let hashes = self.collect_unfinalized_block_hashes().await?;
-            (origin_cursors, inbox_cursors, hashes)
+            let outbox_block_hashes = self.collect_unfinalized_block_hashes().await?;
+            // Snapshot the tip counters as of just before this block, so the oracle
+            // response can carry them and a bootstrapping node can seed `ChainTipState`
+            // with the same values instead of resetting them to zero.
+            let tip = self.tip_state.get();
+            let summary = CheckpointSummary {
+                outbox_block_hashes,
+                inbox_cursors,
+                num_incoming_bundles: tip.num_incoming_bundles,
+                num_operations: tip.num_operations,
+                num_outgoing_messages: tip.num_outgoing_messages,
+            };
+            (origin_cursors, summary)
         } else {
-            (Vec::new(), Vec::new(), Vec::new())
+            (Vec::new(), CheckpointSummary::default())
         };
 
         Self::execute_block_inner(
@@ -1330,8 +1339,7 @@ where
             replaying_oracle_responses,
             policy,
             origin_cursors,
-            inbox_cursors,
-            outbox_block_hashes,
+            summary,
         )
         .await
         .map(|(outcome, tracker, never_reject_origins)| {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1080,12 +1080,19 @@ where
         blobs: BTreeMap<BlobId, Blob>,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
-        let (bytes, chain_id, height, previous_block_hash, outbox_block_hashes, inbox_cursors) = {
+        let (
+            bytes,
+            chain_id,
+            height,
+            previous_block_hash,
+            outbox_block_hashes,
+            inbox_cursors,
+            tip_counters,
+        ) = {
             let block = certificate.block();
             let Some(OracleResponse::Checkpoint {
                 execution_state_blobs,
-                outbox_block_hashes,
-                inbox_cursors,
+                summary,
                 ..
             }) = block.body.oracle_responses.first().and_then(|r| r.first())
             else {
@@ -1109,8 +1116,13 @@ where
                 block.header.chain_id,
                 block.header.height,
                 block.header.previous_block_hash,
-                outbox_block_hashes.clone(),
-                inbox_cursors.clone(),
+                summary.outbox_block_hashes.clone(),
+                summary.inbox_cursors.clone(),
+                (
+                    summary.num_incoming_bundles,
+                    summary.num_operations,
+                    summary.num_outgoing_messages,
+                ),
             )
         };
         // Every pre-checkpoint sender block the oracle response names must already
@@ -1206,12 +1218,16 @@ where
         // (`manager`, `block_hashes` for height `height`), or (c) outside the
         // protocol state hash so divergence from the producer is fine
         // (inboxes; subsequent blocks reconcile by anticipation if needed).
-        // The `num_*` counters on `ChainTipState` are write-only in current
-        // code, so leaving them at zero has no functional impact.
+        // The `num_*` counters are seeded from the oracle response (their values
+        // as of just before the checkpoint block); re-executing the checkpoint
+        // block then advances them exactly as on the producer, so all nodes agree.
+        let (num_incoming_bundles, num_operations, num_outgoing_messages) = tip_counters;
         let new_tip = ChainTipState {
             block_hash: previous_block_hash,
             next_block_height: height,
-            ..Default::default()
+            num_incoming_bundles,
+            num_operations,
+            num_outgoing_messages,
         };
         self.chain.tip_state.set(new_tip.clone());
         // Installing a snapshot establishes the chain's state from scratch (block 0 is never

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -22,7 +22,7 @@ use linera_chain::{
     data_types::{IncomingBundle, MessageAction, MessageBundle, PostedMessage, Transaction},
     manager::LockingBlock,
     types::Timeout,
-    ChainError, ChainExecutionContext,
+    ChainError, ChainExecutionContext, ChainTipState,
 };
 use linera_execution::{
     committee::Committee, system::SystemOperation, ExecutionError, Message, MessageKind, Operation,
@@ -4253,10 +4253,7 @@ where
     let checkpoint_2 = producer.checkpoint().await.unwrap().unwrap();
     let block = checkpoint_2.block();
     let outbox_block_hashes = match block.body.oracle_responses.first().and_then(|t| t.first()) {
-        Some(OracleResponse::Checkpoint {
-            outbox_block_hashes,
-            ..
-        }) => outbox_block_hashes.clone(),
+        Some(OracleResponse::Checkpoint { summary, .. }) => summary.outbox_block_hashes.clone(),
         other => panic!("expected OracleResponse::Checkpoint, got {other:?}"),
     };
     assert!(
@@ -4362,10 +4359,7 @@ where
         .first()
         .and_then(|t| t.first())
     {
-        Some(OracleResponse::Checkpoint {
-            outbox_block_hashes,
-            ..
-        }) => outbox_block_hashes.clone(),
+        Some(OracleResponse::Checkpoint { summary, .. }) => summary.outbox_block_hashes.clone(),
         other => panic!("Expected OracleResponse::Checkpoint, got {other:?}"),
     };
     assert_eq!(outbox_block_hashes, vec![transfer_0.hash()]);
@@ -4464,6 +4458,24 @@ where
             Epoch::from(1),
             "validator 0's chain should be at epoch 1 after the checkpoint restore",
         );
+
+        // Validator 0 bootstrapped from the checkpoint, skipping the normal execution
+        // of the pre-checkpoint blocks, whereas validators 2 and 3 executed every
+        // block. The checkpoint's oracle response carries the producer's pre-checkpoint
+        // `ChainTipState` counters, so after seeding them and re-executing the
+        // post-checkpoint blocks validator 0's tip — counters included — must match a
+        // validator that never skipped a block.
+        let validator_2_key = builder.node(2).name();
+        let validator_2_storage = builder
+            .validator_storages
+            .get(&validator_2_key)
+            .expect("validator 2 storage")
+            .clone();
+        let honest_view = validator_2_storage.load_chain(chain_id).await?;
+        assert_eq!(chain_view.tip_state.get(), honest_view.tip_state.get());
+        // The pre-checkpoint blocks really did move the counters, so this is a
+        // meaningful check rather than a comparison of two zeroed-out tips.
+        assert_ne!(*chain_view.tip_state.get(), ChainTipState::default());
     }
 
     Ok(())

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -1192,11 +1192,10 @@ where
     // The checkpoint certifies both unacked outgoing transfers and records inbox cursors.
     let (outbox_block_hashes, inbox_cursors) =
         match block.body.oracle_responses.first().and_then(|t| t.first()) {
-            Some(OracleResponse::Checkpoint {
-                outbox_block_hashes,
-                inbox_cursors,
-                ..
-            }) => (outbox_block_hashes.clone(), inbox_cursors.clone()),
+            Some(OracleResponse::Checkpoint { summary, .. }) => (
+                summary.outbox_block_hashes.clone(),
+                summary.inbox_cursors.clone(),
+            ),
             other => panic!("expected OracleResponse::Checkpoint, got {other:?}"),
         };
     assert_eq!(

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -176,8 +176,7 @@ where
         let PreparedCheckpoint {
             blobs,
             origin_cursors,
-            inbox_cursors,
-            outbox_block_hashes,
+            summary,
         } = prepared;
         let execution_state_blobs = blobs.iter().map(|blob| blob.id().hash).collect();
         let used_blobs = self.system.used_blobs.indices().await?;
@@ -187,8 +186,7 @@ where
         txn_tracker.replay_oracle_response(OracleResponse::Checkpoint {
             execution_state_blobs,
             used_blobs,
-            outbox_block_hashes,
-            inbox_cursors,
+            summary,
         })?;
         for (origin, latest_received_cursor) in origin_cursors {
             txn_tracker.add_outgoing_message(OutgoingMessage::new(

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -9,8 +9,10 @@ use std::{
 
 use custom_debug_derive::Debug;
 use linera_base::{
-    crypto::CryptoHash,
-    data_types::{Blob, BlobContent, Cursor, Event, OracleResponse, StreamUpdate, Timestamp},
+    data_types::{
+        Blob, BlobContent, CheckpointSummary, Cursor, Event, OracleResponse, StreamUpdate,
+        Timestamp,
+    },
     ensure,
     identifiers::{ApplicationId, BlobId, ChainId, StreamId},
 };
@@ -77,17 +79,14 @@ pub struct PreparedCheckpoint {
     /// position past the last bundle we've consumed. Used to emit a
     /// `SystemMessage::CheckpointAck` to each origin so the origin can later trim its
     /// outbox dump. This is the delta over the previous checkpoint, filtered by
-    /// `pending_checkpoint_ack_targets` to break the notification ping-pong.
+    /// `pending_checkpoint_ack_targets` to break the notification ping-pong. Unlike
+    /// [`Self::summary`], this is *not* part of the certified oracle response: it only
+    /// routes the acknowledgement messages this block emits.
     pub origin_cursors: Vec<(ChainId, Cursor)>,
-    /// For *every* inbox with a non-default `next_cursor_to_remove`, the cursor itself.
-    /// A bootstrapping node uses these to seed each inbox's `restored_cursor`, so a
-    /// sender that hasn't seen the matching `CheckpointAck` yet and re-pushes an
-    /// already-consumed bundle is a silent no-op rather than a duplicate consumption.
-    pub inbox_cursors: Vec<(ChainId, Cursor)>,
-    /// Hashes of every block on this chain that the chain's outboxes still reference,
-    /// taken before the block runs. Included in the oracle response so the checkpoint
-    /// block's certificate transitively certifies those older blocks.
-    pub outbox_block_hashes: Vec<CryptoHash>,
+    /// The chain's non-execution-state bookkeeping, recorded verbatim in the
+    /// [`OracleResponse::Checkpoint`] so a bootstrapping node can restore the chain's
+    /// outbox, inbox, and tip-counter state.
+    pub summary: CheckpointSummary,
 }
 
 /// The [`TransactionTracker`] contents after a transaction has finished.

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use linera_base::data_types::{Blob, BlockHeight, Bytecode};
+use linera_base::data_types::{Blob, BlockHeight, Bytecode, CheckpointSummary};
 #[cfg(with_testing)]
 use linera_base::vm::VmRuntime;
 use linera_views::context::MemoryContext;
@@ -162,8 +162,7 @@ async fn execute_checkpoint_publishes_blob_and_records_oracle_response() -> anyh
         PreparedCheckpoint {
             blobs,
             origin_cursors: Vec::new(),
-            inbox_cursors: Vec::new(),
-            outbox_block_hashes: Vec::new(),
+            summary: CheckpointSummary::default(),
         },
         &mut txn_tracker,
     )
@@ -184,8 +183,7 @@ async fn execute_checkpoint_publishes_blob_and_records_oracle_response() -> anyh
         OracleResponse::Checkpoint {
             execution_state_blobs: vec![blob.id().hash],
             used_blobs: vec![],
-            outbox_block_hashes: vec![],
-            inbox_cursors: vec![],
+            summary: CheckpointSummary::default(),
         }
     );
 
@@ -242,8 +240,7 @@ async fn checkpoint_roundtrip_via_separate_view_yields_matching_hash() -> anyhow
             PreparedCheckpoint {
                 blobs,
                 origin_cursors: Vec::new(),
-                inbox_cursors: Vec::new(),
-                outbox_block_hashes: Vec::new(),
+                summary: CheckpointSummary::default(),
             },
             &mut txn_tracker,
         )
@@ -308,8 +305,7 @@ async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyho
         PreparedCheckpoint {
             blobs,
             origin_cursors: vec![(origin_a, cursor_a), (origin_b, cursor_b)],
-            inbox_cursors: Vec::new(),
-            outbox_block_hashes: Vec::new(),
+            summary: CheckpointSummary::default(),
         },
         &mut txn_tracker,
     )

--- a/linera-indexer/lib/src/db/postgres/mod.rs
+++ b/linera-indexer/lib/src/db/postgres/mod.rs
@@ -451,14 +451,12 @@ impl PostgresDatabase {
                 OracleResponse::Checkpoint {
                     execution_state_blobs,
                     used_blobs,
-                    outbox_block_hashes,
-                    inbox_cursors,
+                    summary,
                 } => {
                     let serialized = bincode::serialize(&(
                         execution_state_blobs,
                         used_blobs,
-                        outbox_block_hashes,
-                        inbox_cursors,
+                        summary,
                     ))
                     .map_err(|e| {
                         PostgresError::Serialization(format!("Failed to serialize checkpoint: {e}"))

--- a/linera-indexer/lib/src/db/sqlite/mod.rs
+++ b/linera-indexer/lib/src/db/sqlite/mod.rs
@@ -449,14 +449,12 @@ impl SqliteDatabase {
                 OracleResponse::Checkpoint {
                     execution_state_blobs,
                     used_blobs,
-                    outbox_block_hashes,
-                    inbox_cursors,
+                    summary,
                 } => {
                     let serialized = bincode::serialize(&(
                         execution_state_blobs,
                         used_blobs,
-                        outbox_block_hashes,
-                        inbox_cursors,
+                        summary,
                     ))
                     .map_err(|e| {
                         SqliteError::Serialization(format!("Failed to serialize checkpoint: {e}"))

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -444,6 +444,19 @@ ChainOwnership:
     - open_multi_leader_rounds: BOOL
     - timeout_config:
         TYPENAME: TimeoutConfig
+CheckpointSummary:
+  STRUCT:
+    - outbox_block_hashes:
+        SEQ:
+          TYPENAME: CryptoHash
+    - inbox_cursors:
+        SEQ:
+          TUPLE:
+            - TYPENAME: ChainId
+            - TYPENAME: Cursor
+    - num_incoming_bundles: U32
+    - num_operations: U32
+    - num_outgoing_messages: U32
 ConfirmedBlockCertificate:
   STRUCT:
     - value:
@@ -899,14 +912,8 @@ OracleResponse:
           - used_blobs:
               SEQ:
                 TYPENAME: BlobId
-          - outbox_block_hashes:
-              SEQ:
-                TYPENAME: CryptoHash
-          - inbox_cursors:
-              SEQ:
-                TUPLE:
-                  - TYPENAME: ChainId
-                  - TYPENAME: Cursor
+          - summary:
+              TYPENAME: CheckpointSummary
 OriginalProposal:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

Checkpoints don't save the `num_incoming_bundles`, `num_operations`, and `num_outgoing_messages` counters in `ChainTipState`; a node that bootstrapped from a checkpoint resets them to zero, so nodes could disagree on these values.

## Proposal

Record the counters (as of just before the checkpoint block) in `OracleResponse::Checkpoint` so a bootstrapping node seeds them instead of resetting to zero. Re-executing the checkpoint block then advances them exactly as on a node that processed every block, so all nodes agree.

Bundle the checkpoint's non-execution-state bookkeeping (outbox block hashes, inbox cursors, and the tip counters) into a new `CheckpointSummary` struct, shared between `OracleResponse::Checkpoint` and `PreparedCheckpoint` instead of being passed around as loose fields. `origin_cursors` stays separate: it only routes the block's `CheckpointAck` messages and is deliberately excluded from the certified response.

## Test Plan

`test_proposal_pushes_checkpoint_to_lagging_validator` was extended.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
