### PR TITLE
Encode formats-registry blobs as BCS and add an extract-formats tool

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2749,6 +2749,7 @@ dependencies = [
  "insta",
  "linera-client",
  "linera-sdk",
+ "log",
  "serde",
  "serde-reflection",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -671,7 +671,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -687,7 +687,7 @@ dependencies = [
  "alloy-transport",
  "reqwest 0.12.23",
  "serde_json",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
 ]
@@ -1186,7 +1186,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1265,6 +1265,15 @@ checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
 dependencies = [
  "serde",
  "thiserror 1.0.65",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1868,6 +1877,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2673,6 +2691,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,8 +2743,11 @@ dependencies = [
 name = "formats-registry"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-graphql",
+ "bcs",
  "insta",
+ "linera-client",
  "linera-sdk",
  "serde",
  "serde-reflection",
@@ -2787,6 +2818,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3252,6 +3293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "crossbeam-channel",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3458,9 +3513,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -3988,6 +4043,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "linera-client"
+version = "0.15.19"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "cfg_aliases",
+ "clap",
+ "fs-err",
+ "fs4",
+ "futures",
+ "hdrhistogram",
+ "linera-base",
+ "linera-chain",
+ "linera-core",
+ "linera-execution",
+ "linera-rpc",
+ "linera-sdk",
+ "linera-storage",
+ "linera-version",
+ "linera-views",
+ "num-format",
+ "papaya",
+ "prometheus-parse",
+ "rand 0.8.5",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
+ "thiserror 1.0.65",
+ "thiserror-context",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "trait-variant",
+ "tsify",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "linera-core"
 version = "0.15.19"
 dependencies = [
@@ -4094,6 +4190,45 @@ name = "linera-parity-wasm"
 version = "0.45.1-linera.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9198100e9ce61acd3c714a2e61eb19fc5b8e2178dd645e2d9061e61e6e1feef"
+
+[[package]]
+name = "linera-rpc"
+version = "0.15.19"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bcs",
+ "bincode",
+ "bytes",
+ "cfg-if",
+ "cfg_aliases",
+ "clap",
+ "ed25519-dalek",
+ "futures",
+ "http 1.1.0",
+ "linera-base",
+ "linera-chain",
+ "linera-core",
+ "linera-execution",
+ "linera-storage",
+ "linera-version",
+ "papaya",
+ "prost",
+ "rand 0.8.5",
+ "rcgen",
+ "serde",
+ "thiserror 1.0.65",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-health",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tonic-reflection",
+ "tonic-web-wasm-client",
+ "tower 0.4.13",
+ "tracing",
+]
 
 [[package]]
 name = "linera-sdk"
@@ -4418,6 +4553,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4775,6 +4916,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,6 +5118,16 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -5218,6 +5379,18 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.65",
+]
+
+[[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -5502,6 +5675,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48406db8ac1f3cbc7dcdb56ec355343817958a356ff430259bb07baf7607e1e1"
+dependencies = [
+ "pem",
+ "ring",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "reborrow"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5616,7 +5801,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -5624,7 +5809,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -5632,7 +5817,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -5659,7 +5844,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
@@ -5818,6 +6003,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
@@ -5825,7 +6023,7 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -5837,8 +6035,22 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.13",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5851,12 +6063,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -6195,6 +6427,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap 1.9.3",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.5.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -6635,7 +6892,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -6689,6 +6946,12 @@ checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
  "thiserror-impl 2.0.17",
 ]
+
+[[package]]
+name = "thiserror-context"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4cf778b0694c0adf030668380054b3a382f1e5e6a2e9a0b54bc5e677045bca"
 
 [[package]]
 name = "thiserror-impl"
@@ -6862,7 +7125,17 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.41",
  "tokio",
 ]
 
@@ -6958,11 +7231,13 @@ dependencies = [
  "socket2 0.6.0",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6975,6 +7250,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tonic-health"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ff0636fef47afb3ec02818f5bceb4377b8abb9d6a386aeade18bd6212f8eb7"
+dependencies = [
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -7002,6 +7290,56 @@ dependencies = [
  "syn 2.0.100",
  "tempfile",
  "tonic-build",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf0685a51e6d02b502ba0764002e766b7f3042aed13d9234925b6ffbfa3fca7"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "tonic-web-wasm-client"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898cd44be5e23e59d2956056538f1d6b3c5336629d384ffd2d92e76f87fb98ff"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "httparse",
+ "js-sys",
+ "pin-project",
+ "thiserror 2.0.17",
+ "tonic",
+ "tower-service",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7036,7 +7374,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -7283,6 +7621,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -7601,6 +7945,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"
@@ -8054,6 +8407,24 @@ name = "xxhash-rust"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a5cbf750400958819fb6178eaa83bee5cd9c29a26a40cc241df8c70fdd46984"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/examples/formats-registry/Cargo.toml
+++ b/examples/formats-registry/Cargo.toml
@@ -10,6 +10,9 @@ linera-sdk.workspace = true
 serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+anyhow.workspace = true
+bcs.workspace = true
+linera-client = { path = "../../linera-client", features = ["fs"] }
 serde-reflection.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -26,3 +29,7 @@ path = "src/contract.rs"
 [[bin]]
 name = "formats_registry_service"
 path = "src/service.rs"
+
+[[bin]]
+name = "extract-formats"
+path = "src/extract_formats.rs"

--- a/examples/formats-registry/Cargo.toml
+++ b/examples/formats-registry/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 async-graphql.workspace = true
 linera-sdk.workspace = true
+log.workspace = true
 serde.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/examples/formats-registry/README.md
+++ b/examples/formats-registry/README.md
@@ -127,10 +127,19 @@ echo "http://localhost:$PORT/chains/$CHAIN/applications/$LINERA_APPLICATION_ID"
 Open the printed URL to land in a GraphiQL session connected to the registry.
 
 To register a module's formats, first publish the formats description as a data blob
-(e.g. `linera publish-data-blob <FILE>`, which prints the `<BLOB_HASH>`), then bind it
-(replace `<MODULE_ID_HEX>`, `<OWNER>` and `<BLOB_HASH>` accordingly; `ModuleId`,
-`AccountOwner` and `DataBlobHash` are encoded as strings). `<OWNER>` must be the chain's
-signer; once an admin set is configured it must also be one of the admins:
+(e.g. `linera publish-data-blob <FILE>`, which prints the `<BLOB_HASH>`). The blob file
+is the BCS serialization of the application's `Formats`; the `extract-formats` binary in
+this example turns an app's SNAP snapshot into such a file ready for
+`linera publish-data-blob`:
+
+```bash
+cargo run --bin extract-formats -- ../counter/tests/snapshots/format__format.snap counter-formats.bcs
+```
+
+Then bind the published blob to the module with the mutation below (replace
+`<MODULE_ID_HEX>`, `<OWNER>` and `<BLOB_HASH>` accordingly; `ModuleId`, `AccountOwner`
+and `DataBlobHash` are encoded as strings). `<OWNER>` must be the chain's signer; once
+an admin set is configured it must also be one of the admins:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN/applications/$LINERA_APPLICATION_ID
 mutation {

--- a/examples/formats-registry/src/contract.rs
+++ b/examples/formats-registry/src/contract.rs
@@ -8,6 +8,7 @@ mod state;
 use async_graphql::ComplexObject;
 use formats_registry::{FormatsRegistryAbi, Message, Operation};
 use linera_sdk::{
+    formats::Formats,
     linera_base_types::WithContractAbi,
     views::{RootView, View},
     Contract, ContractRuntime,
@@ -44,12 +45,32 @@ impl Contract for FormatsRegistryContract {
     }
 
     async fn execute_operation(&mut self, operation: Operation) {
+        log::info!(
+            "Processing operation on chain {}: {operation:?}",
+            self.runtime.chain_id()
+        );
+
         // Authenticate that the declared owner really signed (or is the caller of)
         // this operation.
         let owner = operation.owner();
         self.runtime
             .check_account_permission(owner)
             .expect("Failed to authenticate the owner of the operation");
+
+        // Read the formats data blob on the chain submitting the operation and require
+        // it to deserialize as `Formats`. This both proves the blob is available on
+        // (and retained by) the submitting chain and validates that it actually holds
+        // a well-formed formats description. The client publishes the blob in an
+        // earlier block, so it is already committed here whether the write is applied
+        // locally or forwarded to the creation chain. Doing this on the operation side
+        // (rather than when a forwarded message is executed) also gives the submitter
+        // immediate feedback.
+        if let Operation::Write { blob_hash, .. } = &operation {
+            let bytes = self.runtime.read_data_blob(*blob_hash);
+            let formats = linera_sdk::bcs::from_bytes::<Formats>(&bytes)
+                .expect("the registered data blob must hold a BCS-encoded Formats");
+            log::debug!("Registering formats: {formats:?}");
+        }
 
         let message = operation.into_message();
         let creator_chain_id = self.runtime.application_creator_chain_id();
@@ -65,6 +86,11 @@ impl Contract for FormatsRegistryContract {
     }
 
     async fn execute_message(&mut self, message: Message) {
+        log::info!(
+            "Processing message on chain {}: {message:?}",
+            self.runtime.chain_id()
+        );
+
         assert_eq!(
             self.runtime.chain_id(),
             self.runtime.application_creator_chain_id(),
@@ -111,14 +137,9 @@ impl FormatsRegistryContract {
                     existing.is_none(),
                     "formats are already registered for this module"
                 );
-                // For a remote write the blob was published in an earlier block on the
-                // submitting chain; require it here so it is available on (and retained
-                // by) the creation chain. For a local write the blob is published in
-                // this same block and cannot be asserted yet, but it is persisted by
-                // the caller's `PublishDataBlob`.
-                if self.runtime.message_origin_chain_id().is_some() {
-                    self.runtime.assert_data_blob_exists(blob_hash);
-                }
+                // Blob existence is asserted on the operation side (see
+                // `execute_operation`), so by the time the write is applied here the
+                // blob has already been required on the submitting chain.
                 self.state
                     .formats
                     .insert(&module_id, blob_hash)

--- a/examples/formats-registry/src/contract.rs
+++ b/examples/formats-registry/src/contract.rs
@@ -58,13 +58,7 @@ impl Contract for FormatsRegistryContract {
             .expect("Failed to authenticate the owner of the operation");
 
         // Read the formats data blob on the chain submitting the operation and require
-        // it to deserialize as `Formats`. This both proves the blob is available on
-        // (and retained by) the submitting chain and validates that it actually holds
-        // a well-formed formats description. The client publishes the blob in an
-        // earlier block, so it is already committed here whether the write is applied
-        // locally or forwarded to the creation chain. Doing this on the operation side
-        // (rather than when a forwarded message is executed) also gives the submitter
-        // immediate feedback.
+        // it to deserialize as `Formats`.
         if let Operation::Write { blob_hash, .. } = &operation {
             let bytes = self.runtime.read_data_blob(*blob_hash);
             let formats = linera_sdk::bcs::from_bytes::<Formats>(&bytes)

--- a/examples/formats-registry/src/extract_formats.rs
+++ b/examples/formats-registry/src/extract_formats.rs
@@ -38,8 +38,8 @@ fn main() -> anyhow::Result<()> {
 
     let formats = read_formats_from_snap(&input)
         .with_context(|| format!("failed to read formats from {input:?}"))?;
-    // Serialize exactly as `ClientContext::prepare_bcs_publication` does, so the data
-    // blob produced from this file matches the hash bound in the registry write.
+    // BCS-serialize the formats the same way the client does when publishing, so the
+    // data blob produced from this file matches the hash bound in the registry write.
     let blob = bcs::to_bytes(&formats).context("failed to serialize formats as BCS")?;
     std::fs::write(&output, &blob)
         .with_context(|| format!("failed to write blob file {output:?}"))?;

--- a/examples/formats-registry/src/extract_formats.rs
+++ b/examples/formats-registry/src/extract_formats.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Extracts the formats of an application from a SNAP file and writes them as a
+//! BCS-encoded file ready to be published as a data blob with
+//! `linera publish-data-blob`.
+//!
+//! The SNAP file is the YAML snapshot produced by the `format` test of the example
+//! applications (e.g. `examples/<app>/tests/snapshots/format__format.snap`). The
+//! output is the exact byte payload that `linera publish-module-with-formats` binds
+//! in the formats registry, so the blob published from it has the hash the registry
+//! expects.
+//!
+//! Usage:
+//!
+//! ```bash
+//! extract-formats <SNAP_FILE> <OUTPUT_BLOB_FILE>
+//! ```
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
+
+#[cfg(not(target_arch = "wasm32"))]
+use anyhow::{bail, Context as _};
+#[cfg(not(target_arch = "wasm32"))]
+use linera_client::client_context::read_formats_from_snap;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() -> anyhow::Result<()> {
+    let mut args = std::env::args_os().skip(1);
+    let (Some(input), Some(output), None) = (args.next(), args.next(), args.next()) else {
+        bail!("usage: extract-formats <SNAP_FILE> <OUTPUT_BLOB_FILE>");
+    };
+    let input = PathBuf::from(input);
+    let output = PathBuf::from(output);
+
+    let formats = read_formats_from_snap(&input)
+        .with_context(|| format!("failed to read formats from {input:?}"))?;
+    // Serialize exactly as `ClientContext::prepare_bcs_publication` does, so the data
+    // blob produced from this file matches the hash bound in the registry write.
+    let blob = bcs::to_bytes(&formats).context("failed to serialize formats as BCS")?;
+    std::fs::write(&output, &blob)
+        .with_context(|| format!("failed to write blob file {output:?}"))?;
+
+    println!(
+        "Wrote {} bytes of formats from {input:?} to {output:?}; \
+         publish it with `linera publish-data-blob {}`",
+        blob.len(),
+        output.display(),
+    );
+    Ok(())
+}

--- a/examples/formats-registry/src/service.rs
+++ b/examples/formats-registry/src/service.rs
@@ -43,10 +43,7 @@ impl Service for FormatsRegistryService {
     }
 
     async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse {
-        log::info!(
-            "Handling query on chain {}",
-            self.runtime.chain_id()
-        );
+        log::info!("Handling query on chain {}", self.runtime.chain_id());
         Schema::build(
             self.state.clone(),
             Operation::mutation_root(self.runtime.clone()),

--- a/examples/formats-registry/src/service.rs
+++ b/examples/formats-registry/src/service.rs
@@ -43,6 +43,10 @@ impl Service for FormatsRegistryService {
     }
 
     async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse {
+        log::info!(
+            "Handling query on chain {}",
+            self.runtime.chain_id()
+        );
         Schema::build(
             self.state.clone(),
             Operation::mutation_root(self.runtime.clone()),

--- a/examples/formats-registry/src/state.rs
+++ b/examples/formats-registry/src/state.rs
@@ -13,8 +13,10 @@ use linera_sdk::{
 #[view(context = ViewStorageContext)]
 pub struct FormatsRegistryState {
     /// Maps a `ModuleId` to the hash of the data blob holding its registered formats
-    /// description. Exposed through the service's `read` query rather than directly.
-    #[graphql(skip)]
+    /// description. Exposed directly so callers can test membership or fetch the
+    /// stored `DataBlobHash` (e.g. `formats { entry(key: "<MODULE_ID>") { value } }`)
+    /// without downloading the blob; the service's `read` query additionally returns
+    /// the decoded blob contents.
     pub formats: MapView<ModuleId, DataBlobHash>,
     /// The admin accounts authorized to run admin commands and remote writes.
     /// `None` means no admin set has been configured yet, in which case only the

--- a/examples/formats-registry/tests/remote_registration.rs
+++ b/examples/formats-registry/tests/remote_registration.rs
@@ -5,8 +5,9 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use formats_registry::{FormatsRegistryAbi, Operation};
+use formats_registry::{formats::FormatsRegistryApplication, FormatsRegistryAbi, Operation};
 use linera_sdk::{
+    formats::BcsApplication,
     linera_base_types::{AccountOwner, Blob, DataBlobHash, ModuleId},
     test::{QueryOutcome, TestValidator},
 };
@@ -19,6 +20,18 @@ fn module_id_to_hex(module_id: &ModuleId) -> String {
         .as_str()
         .expect("ModuleId serializes to a JSON string")
         .to_owned()
+}
+
+/// Builds a data blob holding the BCS-encoded `Formats` of this application, which is
+/// what the contract now requires every registered blob to deserialize to. Returns
+/// the blob and its raw bytes.
+fn formats_blob() -> (Blob, Vec<u8>) {
+    let value = linera_sdk::bcs::to_bytes(
+        &FormatsRegistryApplication::formats().expect("formats trace should succeed"),
+    )
+    .expect("Formats should serialize as BCS");
+    let blob = Blob::new_data(value.clone());
+    (blob, value)
 }
 
 /// An admin operating from a remote chain can register a module: the write is
@@ -52,25 +65,30 @@ async fn remote_admin_can_register() {
         })
         .await;
 
-    // The remote admin submits a write on its own chain; it publishes the data blob
-    // there and the write is forwarded to the creation chain as a cross-chain message.
-    let value = vec![9u8, 8, 7];
-    let blob = Blob::new_data(value.clone());
+    // The remote admin publishes the data blob on its own chain in one block, then
+    // submits the write in the next block; the write is forwarded to the creation
+    // chain as a cross-chain message.
+    let (blob, value) = formats_blob();
     let blob_hash = DataBlobHash(blob.id().hash);
     remote_chain
         .add_block_with_blobs(
             |block| {
-                block.with_data_blob(&blob).with_operation(
-                    application_id,
-                    Operation::Write {
-                        owner: remote_owner,
-                        module_id,
-                        blob_hash,
-                    },
-                );
+                block.with_data_blob(&blob);
             },
             vec![blob.clone()],
         )
+        .await;
+    remote_chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::Write {
+                    owner: remote_owner,
+                    module_id,
+                    blob_hash,
+                },
+            );
+        })
         .await;
 
     // The creation chain processes the forwarded message and stores the value.
@@ -117,22 +135,27 @@ async fn remote_non_admin_is_rejected() {
         })
         .await;
 
-    let blob = Blob::new_data(vec![1u8, 2, 3]);
+    let (blob, _value) = formats_blob();
     let blob_hash = DataBlobHash(blob.id().hash);
-    let (write_certificate, _) = remote_chain
+    remote_chain
         .add_block_with_blobs(
             |block| {
-                block.with_data_blob(&blob).with_operation(
-                    application_id,
-                    Operation::Write {
-                        owner: remote_owner,
-                        module_id,
-                        blob_hash,
-                    },
-                );
+                block.with_data_blob(&blob);
             },
             vec![blob.clone()],
         )
+        .await;
+    let (write_certificate, _) = remote_chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::Write {
+                    owner: remote_owner,
+                    module_id,
+                    blob_hash,
+                },
+            );
+        })
         .await;
 
     // The creation chain refuses to execute the forwarded write from a non-admin.

--- a/examples/formats-registry/tests/single_chain.rs
+++ b/examples/formats-registry/tests/single_chain.rs
@@ -5,8 +5,9 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use formats_registry::{FormatsRegistryAbi, Operation};
+use formats_registry::{formats::FormatsRegistryApplication, FormatsRegistryAbi, Operation};
 use linera_sdk::{
+    formats::BcsApplication,
     linera_base_types::{AccountOwner, AccountSecretKey, Blob, DataBlobHash, ModuleId},
     test::{QueryOutcome, TestValidator},
 };
@@ -21,6 +22,18 @@ fn module_id_to_hex(module_id: &ModuleId) -> String {
         .to_owned()
 }
 
+/// Builds a data blob holding the BCS-encoded `Formats` of this application, which is
+/// what the contract now requires every registered blob to deserialize to. Returns
+/// the blob and its raw bytes.
+fn formats_blob() -> (Blob, Vec<u8>) {
+    let value = linera_sdk::bcs::to_bytes(
+        &FormatsRegistryApplication::formats().expect("formats trace should succeed"),
+    )
+    .expect("Formats should serialize as BCS");
+    let blob = Blob::new_data(value.clone());
+    (blob, value)
+}
+
 /// Writes a value for a `ModuleId` and reads it back through the service.
 #[tokio::test(flavor = "multi_thread")]
 async fn write_then_read() {
@@ -31,23 +44,31 @@ async fn write_then_read() {
     let application_id = chain.create_application(module_id, (), (), vec![]).await;
     let module_id = module_id.forget_abi();
 
-    let value = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
-    let blob = Blob::new_data(value.clone());
+    let (blob, value) = formats_blob();
     let blob_hash = DataBlobHash(blob.id().hash);
+
+    // Publish the formats blob in its own block first, so it is committed before the
+    // `Write` operation reads and validates it.
     chain
         .add_block_with_blobs(
             |block| {
-                block.with_data_blob(&blob).with_operation(
-                    application_id,
-                    Operation::Write {
-                        owner,
-                        module_id,
-                        blob_hash,
-                    },
-                );
+                block.with_data_blob(&blob);
             },
             vec![blob.clone()],
         )
+        .await;
+
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::Write {
+                    owner,
+                    module_id,
+                    blob_hash,
+                },
+            );
+        })
         .await;
 
     let module_id_hex = module_id_to_hex(&module_id);
@@ -89,22 +110,27 @@ async fn second_write_is_rejected() {
     let application_id = chain.create_application(module_id, (), (), vec![]).await;
     let module_id = module_id.forget_abi();
 
-    let blob = Blob::new_data(vec![0xAA]);
+    let (blob, _value) = formats_blob();
     let blob_hash = DataBlobHash(blob.id().hash);
     chain
         .add_block_with_blobs(
             |block| {
-                block.with_data_blob(&blob).with_operation(
-                    application_id,
-                    Operation::Write {
-                        owner,
-                        module_id,
-                        blob_hash,
-                    },
-                );
+                block.with_data_blob(&blob);
             },
             vec![blob.clone()],
         )
+        .await;
+    chain
+        .add_block(|block| {
+            block.with_operation(
+                application_id,
+                Operation::Write {
+                    owner,
+                    module_id,
+                    blob_hash,
+                },
+            );
+        })
         .await;
 
     // The data blob is already in storage, so the second write needs no new blob; it
@@ -160,9 +186,21 @@ async fn admin_policy_gates_local_writes() {
         .expect("admins must be an array");
     assert_eq!(admins.len(), 1);
 
-    // The chain's signer is no longer an admin, so its write is rejected at the admin
-    // check (before the blob is ever looked at).
-    let blob_hash = DataBlobHash(Blob::new_data(vec![0xAA]).id().hash);
+    // Publish a valid formats blob so the write gets past the operation-side blob
+    // validation and is rejected specifically by the admin policy.
+    let (blob, _value) = formats_blob();
+    let blob_hash = DataBlobHash(blob.id().hash);
+    chain
+        .add_block_with_blobs(
+            |block| {
+                block.with_data_blob(&blob);
+            },
+            vec![blob.clone()],
+        )
+        .await;
+
+    // The chain's signer is no longer an admin, so its write is rejected by the admin
+    // policy applied on the creation chain.
     let result = chain
         .try_add_block(|block| {
             block.with_operation(

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -959,9 +959,24 @@ impl<Env: Environment> ClientContext<Env> {
         let owner = chain_client
             .preferred_owner()
             .ok_or(error::Inner::ChainOwnership)?;
-        let (blobs, module_id, formats_blob_hash, registry_op_bytes) = self
+        let (blobs, formats_blob_bytes, module_id, registry_op_bytes) = self
             .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
+
+        // Publish the formats data blob in its own block first, so it is committed
+        // before the registry `Write` operation asserts its existence.
+        info!("Publishing the formats data blob");
+        self.apply_client_command(chain_client, |chain_client| {
+            let formats_blob_bytes = formats_blob_bytes.clone();
+            let chain_client = chain_client.clone();
+            async move {
+                chain_client
+                    .publish_data_blob(formats_blob_bytes)
+                    .await
+                    .context("Failed to publish the formats data blob")
+            }
+        })
+        .await?;
 
         info!("Publishing module and registering its formats");
         self.apply_client_command(chain_client, |chain_client| {
@@ -973,9 +988,6 @@ impl<Env: Environment> ClientContext<Env> {
                     .execute_operations(
                         vec![
                             Operation::system(SystemOperation::PublishModule { module_id }),
-                            Operation::system(SystemOperation::PublishDataBlob {
-                                blob_hash: formats_blob_hash,
-                            }),
                             Operation::User {
                                 application_id: registry_application_id,
                                 bytes: registry_op_bytes,
@@ -1017,9 +1029,24 @@ impl<Env: Environment> ClientContext<Env> {
         let owner = chain_client
             .preferred_owner()
             .ok_or(error::Inner::ChainOwnership)?;
-        let (blobs, module_id, formats_blob_hash, registry_op_bytes) = self
+        let (blobs, formats_blob_bytes, module_id, registry_op_bytes) = self
             .prepare_bcs_publication(owner, &contract, &service, vm_runtime, &formats)
             .await?;
+
+        // Publish the formats data blob in its own block first, so it is committed
+        // before the registry `Write` operation asserts its existence.
+        info!("Publishing the formats data blob");
+        self.apply_client_command(chain_client, |chain_client| {
+            let formats_blob_bytes = formats_blob_bytes.clone();
+            let chain_client = chain_client.clone();
+            async move {
+                chain_client
+                    .publish_data_blob(formats_blob_bytes)
+                    .await
+                    .context("Failed to publish the formats data blob")
+            }
+        })
+        .await?;
 
         info!("Publishing module, registering its formats and creating the application");
         let application_id = self
@@ -1035,9 +1062,6 @@ impl<Env: Environment> ClientContext<Env> {
                         .execute_operations(
                             vec![
                                 Operation::system(SystemOperation::PublishModule { module_id }),
-                                Operation::system(SystemOperation::PublishDataBlob {
-                                    blob_hash: formats_blob_hash,
-                                }),
                                 Operation::User {
                                     application_id: registry_application_id,
                                     bytes: registry_op_bytes,
@@ -1080,8 +1104,11 @@ impl<Env: Environment> ClientContext<Env> {
         Ok((application_id, module_id))
     }
 
-    /// Loads the bytecode files and the SNAP file, builds the bytecode blobs and
-    /// the BCS-encoded formats-registry write operation authorized by `owner`.
+    /// Loads the bytecode files and the SNAP file, building the bytecode blobs, the
+    /// BCS-encoded formats data blob, and the formats-registry write operation
+    /// authorized by `owner`. The formats blob is returned separately from the
+    /// bytecode blobs because the caller publishes it in its own block first (so it
+    /// is committed before the registry `Write` operation asserts its existence).
     async fn prepare_bcs_publication(
         &self,
         owner: AccountOwner,
@@ -1092,29 +1119,26 @@ impl<Env: Environment> ClientContext<Env> {
     ) -> Result<
         (
             Vec<linera_base::data_types::Blob>,
+            Vec<u8>,
             ModuleId,
-            CryptoHash,
             Vec<u8>,
         ),
         Error,
     > {
-        let (mut blobs, module_id) = load_bytecode_blobs(contract, service, vm_runtime).await?;
+        let (blobs, module_id) = load_bytecode_blobs(contract, service, vm_runtime).await?;
 
         info!("Loading formats from {formats:?}");
         let parsed = read_formats_from_snap(formats)?;
-        let value = bcs::to_bytes(&parsed)?;
-        // Publish the formats description as a data blob and bind its hash in the
-        // registry write; the caller adds the matching `PublishDataBlob` operation.
-        let formats_blob = linera_base::data_types::Blob::new_data(value);
-        let formats_blob_hash = formats_blob.id().hash;
-        blobs.push(formats_blob);
+        let formats_blob_bytes = bcs::to_bytes(&parsed)?;
+        let formats_blob_hash =
+            CryptoHash::new(&BlobContent::new_data(formats_blob_bytes.clone()));
         let registry_op = linera_sdk::abis::formats_registry::Operation::Write {
             owner,
             module_id,
             blob_hash: linera_base::identifiers::DataBlobHash(formats_blob_hash),
         };
         let registry_op_bytes = bcs::to_bytes(&registry_op)?;
-        Ok((blobs, module_id, formats_blob_hash, registry_op_bytes))
+        Ok((blobs, formats_blob_bytes, module_id, registry_op_bytes))
     }
 }
 
@@ -1147,10 +1171,9 @@ async fn load_bytecode_blobs(
 /// Parses the `Formats` description of an application from a SNAP file (the YAML
 /// snapshot produced by the `format` test of the example applications). The body
 /// between the `---` frontmatter delimiters is deserialized as
-/// [`linera_sdk::formats::Formats`]. BCS-serializing the result yields exactly the
-/// data-blob payload that [`ClientContext::prepare_bcs_publication`] binds in the
-/// formats registry, so external tooling can produce a blob file ready for
-/// `linera publish-data-blob` (see the `extract-formats` binary in the
+/// [`linera_sdk::formats::Formats`]. BCS-serializing the result yields the data-blob
+/// payload the formats registry expects, so external tooling can produce a blob file
+/// ready for `linera publish-data-blob` (see the `extract-formats` binary in the
 /// `formats-registry` example).
 #[cfg(all(feature = "fs", not(web)))]
 pub fn read_formats_from_snap(path: &Path) -> Result<linera_sdk::formats::Formats, Error> {

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -1102,12 +1102,7 @@ impl<Env: Environment> ClientContext<Env> {
 
         info!("Loading formats from {formats:?}");
         let parsed = read_formats_from_snap(formats)?;
-        let value = serde_json::to_vec(&parsed).map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("failed to serialize Formats as JSON: {e}"),
-            )
-        })?;
+        let value = bcs::to_bytes(&parsed)?;
         // Publish the formats description as a data blob and bind its hash in the
         // registry write; the caller adds the matching `PublishDataBlob` operation.
         let formats_blob = linera_base::data_types::Blob::new_data(value);
@@ -1149,8 +1144,16 @@ async fn load_bytecode_blobs(
     Ok(create_bytecode_blobs(contract_bytecode, service_bytecode, vm_runtime).await)
 }
 
+/// Parses the `Formats` description of an application from a SNAP file (the YAML
+/// snapshot produced by the `format` test of the example applications). The body
+/// between the `---` frontmatter delimiters is deserialized as
+/// [`linera_sdk::formats::Formats`]. BCS-serializing the result yields exactly the
+/// data-blob payload that [`ClientContext::prepare_bcs_publication`] binds in the
+/// formats registry, so external tooling can produce a blob file ready for
+/// `linera publish-data-blob` (see the `extract-formats` binary in the
+/// `formats-registry` example).
 #[cfg(all(feature = "fs", not(web)))]
-fn read_formats_from_snap(path: &Path) -> Result<linera_sdk::formats::Formats, Error> {
+pub fn read_formats_from_snap(path: &Path) -> Result<linera_sdk::formats::Formats, Error> {
     let content = fs::read_to_string(path).map_err(|e| {
         std::io::Error::new(e.kind(), format!("failed to read SNAP file {path:?}: {e}"))
     })?;

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -1130,8 +1130,7 @@ impl<Env: Environment> ClientContext<Env> {
         info!("Loading formats from {formats:?}");
         let parsed = read_formats_from_snap(formats)?;
         let formats_blob_bytes = bcs::to_bytes(&parsed)?;
-        let formats_blob_hash =
-            CryptoHash::new(&BlobContent::new_data(formats_blob_bytes.clone()));
+        let formats_blob_hash = CryptoHash::new(&BlobContent::new_data(formats_blob_bytes.clone()));
         let registry_op = linera_sdk::abis::formats_registry::Operation::Write {
             owner,
             module_id,

--- a/linera-explorer/src/formats.rs
+++ b/linera-explorer/src/formats.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use crate::{js_utils::log_str, reqwest_client};
 
 /// Issues `query { read(moduleId: "<hex>") }` against the formats-registry
-/// application service and parses the returned bytes as a JSON-encoded
+/// application service and parses the returned bytes as a BCS-encoded
 /// [`Formats`]. Returns `Ok(None)` if the registry has no entry for that
 /// module.
 pub async fn fetch_formats(
@@ -54,7 +54,7 @@ pub async fn fetch_formats(
                 .ok_or_else(|| anyhow!("formats registry returned non-u8 byte"))
         })
         .collect::<Result<_>>()?;
-    let formats: Formats = serde_json::from_slice(&bytes)
-        .context("registry bytes did not deserialize as Formats JSON")?;
+    let formats: Formats = linera_sdk::bcs::from_bytes(&bytes)
+        .context("registry bytes did not deserialize as Formats BCS")?;
     Ok(Some(formats))
 }

--- a/linera-service-graphql-client/gql/service_mutations.graphql
+++ b/linera-service-graphql-client/gql/service_mutations.graphql
@@ -1,0 +1,13 @@
+# Mutations are kept in a separate document from queries/subscriptions.
+#
+# graphql_client embeds the whole query document into every request, and
+# async-graphql validates every operation definition in that document against
+# the server schema. A node service started with `--read-only` builds its schema
+# with an empty mutation root, so any document that *defines* a mutation is
+# rejected ("Schema is not configured for mutations") even when the executed
+# operation is a plain query. Isolating mutations here keeps the read-only
+# queries (Chain, Blocks, Applications, ...) usable against such a service.
+
+mutation Transfer($chainId: ChainId!, $owner: AccountOwner!, $recipient_chain: ChainId!, $recipient_account: AccountOwner!, $amount: Amount!) {
+  transfer(chainId: $chainId, owner: $owner, recipient: { chain_id: $recipient_chain, owner: $recipient_account }, amount: $amount)
+}

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -607,7 +607,3 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
 subscription Notifications($chainId: ChainId!) {
   notifications(chainId: $chainId)
 }
-
-mutation Transfer($chainId: ChainId!, $owner: AccountOwner!, $recipient_chain: ChainId!, $recipient_account: AccountOwner!, $amount: Amount!) {
-  transfer(chainId: $chainId, owner: $owner, recipient: { chain_id: $recipient_chain, owner: $recipient_account }, amount: $amount)
-}

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -146,10 +146,12 @@ pub struct Block;
 )]
 pub struct Notifications;
 
+// Kept in a separate document so that the read-only query/subscription requests
+// do not carry a mutation definition (which a `--read-only` node rejects).
 #[derive(GraphQLQuery)]
 #[graphql(
     schema_path = "gql/service_schema.graphql",
-    query_path = "gql/service_requests.graphql",
+    query_path = "gql/service_mutations.graphql",
     response_derives = "Debug, Serialize, Clone"
 )]
 pub struct Transfer;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2001,7 +2001,7 @@ async fn test_publish_module_with_formats_registers_formats(
         .map(|byte| byte.as_u64().expect("byte") as u8)
         .collect();
 
-    let stored_formats: Formats = serde_json::from_slice(&stored_bytes)?;
+    let stored_formats: Formats = bcs::from_bytes(&stored_bytes)?;
     let expected_formats = CounterApplication::formats().unwrap();
     assert_eq!(stored_formats, expected_formats);
 
@@ -2137,7 +2137,7 @@ async fn test_publish_module_with_formats_remote_registration(
         .map(|byte| byte.as_u64().expect("byte") as u8)
         .collect();
 
-    let stored_formats: Formats = serde_json::from_slice(&stored_bytes)?;
+    let stored_formats: Formats = bcs::from_bytes(&stored_bytes)?;
     let expected_formats = CounterApplication::formats().unwrap();
     assert_eq!(stored_formats, expected_formats);
 


### PR DESCRIPTION
## Motivation

The formats blob published to the formats-registry was encoded as **JSON** on the publish side (`ClientContext::prepare_bcs_publication`) and decoded as JSON by both consumers (`linera-explorer` and the integration tests), even though the example README describes the blob as *"the BCS serialization of an application's `Formats`"* and the registry's write operation is itself BCS-encoded. This migrates the blob encoding to BCS across every site so it matches the documented intent.

It also adds a small `extract-formats` tool requested for producing a publishable blob file from an app's SNAP snapshot.

## Changes

- **Migrate the formats blob to BCS** at all encode/decode sites:
  - `linera-client/src/client_context.rs` (publish): `serde_json::to_vec` → `bcs::to_bytes`.
  - `linera-explorer/src/formats.rs` (the real downstream consumer): `serde_json::from_slice` → `linera_sdk::bcs::from_bytes`.
  - `linera-service/tests/linera_net_tests.rs` (two sites): `serde_json::from_slice` → `bcs::from_bytes`.
  - The explorer's `serde_json::to_string(&formats)` JS-interop boundary is intentionally left as JSON.
- **New `extract-formats` binary** in the `formats-registry` example. It calls `linera_client::client_context::read_formats_from_snap` (now made `pub`) to parse an app's SNAP snapshot into `Formats`, BCS-serializes it, and writes a file ready for `linera publish-data-blob`.
- README + doc updates.

## Test plan

- `linera-client`, `linera-explorer`, and the `extract-formats` binary compile.
- Ran the tool end-to-end: `counter` → 5 bytes (`00 0c 0c 02 02`, decoding to empty registry + two `U64` + two `Unit`, matching the snap); `fungible` → 808 bytes (real registry).
- The existing `test_publish_module_with_formats_*` integration tests exercise the full publish → store → fetch → `bcs::from_bytes` round-trip.