### PR TITLE
Batch validator catch-up via an aggregated MissingCrossChainUpdates error

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -699,6 +699,10 @@ where
         }
         let origins = bundles_by_origin.keys().copied().collect::<Vec<_>>();
         let inboxes = self.inboxes.try_load_entries_mut(&origins).await?;
+        // When the bundles must already be present (block proposals), collect *every* missing
+        // `(origin, height)` rather than bailing on the first, so the caller can be told the
+        // full set of cross-chain updates to fetch in a single round-trip.
+        let mut missing_bundles = Vec::new();
         for ((origin, bundles), mut inbox) in bundles_by_origin.into_iter().zip(inboxes) {
             tracing::trace!(
                 "Removing [{}] from inbox for {origin}",
@@ -714,15 +718,8 @@ where
                     .remove_bundle(bundle)
                     .await
                     .map_err(|error| (chain_id, origin, error))?;
-                if must_be_present {
-                    ensure!(
-                        was_present,
-                        ChainError::MissingCrossChainUpdate {
-                            chain_id,
-                            origin,
-                            height: bundle.height,
-                        }
-                    );
+                if must_be_present && !was_present {
+                    missing_bundles.push((origin, bundle.height));
                 }
             }
             inbox.observe_size_metric();
@@ -732,6 +729,15 @@ where
                 }
             }
         }
+        ensure!(
+            missing_bundles.is_empty(),
+            ChainError::MissingDependencies {
+                chain_id,
+                bundles: missing_bundles,
+                events: Vec::new(),
+                blobs: Vec::new(),
+            }
+        );
         Ok(())
     }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -731,11 +731,9 @@ where
         }
         ensure!(
             missing_bundles.is_empty(),
-            ChainError::MissingDependencies {
+            ChainError::MissingCrossChainUpdates {
                 chain_id,
                 bundles: missing_bundles,
-                events: Vec::new(),
-                blobs: Vec::new(),
             }
         );
         Ok(())

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -53,15 +53,6 @@ pub enum ChainError {
     #[error("The chain being queried is not active {0}")]
     InactiveChain(ChainId),
     #[error(
-        "Cannot vote for block proposal of chain {chain_id} because a message \
-         from chain {origin} at height {height} has not been received yet"
-    )]
-    MissingCrossChainUpdate {
-        chain_id: ChainId,
-        origin: ChainId,
-        height: BlockHeight,
-    },
-    #[error(
         "Message in block proposed to {chain_id} does not match the previously received messages from \
         origin {origin:?}: was {bundle:?} instead of {previous_bundle:?}"
     )]
@@ -229,7 +220,6 @@ impl ChainError {
             | ChainError::MissingOracleResponseList
             | ChainError::RoundDoesNotTimeOut
             | ChainError::NotTimedOutYet(_)
-            | ChainError::MissingCrossChainUpdate { .. }
             | ChainError::MissingDependencies { .. } => false,
             ChainError::ViewError(_)
             | ChainError::UnexpectedMessage { .. }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -31,7 +31,7 @@ use linera_base::{
     bcs,
     crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
-    identifiers::{ApplicationId, BlobId, ChainId, EventId},
+    identifiers::{ApplicationId, ChainId},
 };
 use linera_execution::ExecutionError;
 use linera_views::ViewError;
@@ -168,20 +168,17 @@ pub enum ChainError {
     #[error("Not signing timeout certificate; current round times out at time {0}")]
     NotTimedOutYet(Timestamp),
     #[error(
-        "Cannot process the block for chain {chain_id}: missing prerequisites \
-         ({} cross-chain bundle(s), {} event(s), {} blob(s)) that have not been received yet",
-        bundles.len(), events.len(), blobs.len()
+        "Cannot vote for block proposal of chain {chain_id} because {} cross-chain message \
+         bundle(s) have not been received yet",
+        bundles.len()
     )]
-    MissingDependencies {
+    MissingCrossChainUpdates {
         chain_id: ChainId,
-        /// Missing incoming message bundles, as `(origin chain, height)` pairs that must be
-        /// received before this block can be validated (as a proposal) or applied (when
-        /// already confirmed).
+        /// The missing incoming message bundles, as `(origin chain, height)` pairs that must
+        /// all be received before this block can be validated. The validator reports every
+        /// missing bundle at once so the client can fetch them in a single round, instead of
+        /// the legacy one-rejection-per-missing-sender behavior.
         bundles: Vec<(ChainId, BlockHeight)>,
-        /// Missing events required to execute this block.
-        events: Vec<EventId>,
-        /// Missing blobs required to execute this block.
-        blobs: Vec<BlobId>,
     },
 }
 
@@ -220,7 +217,7 @@ impl ChainError {
             | ChainError::MissingOracleResponseList
             | ChainError::RoundDoesNotTimeOut
             | ChainError::NotTimedOutYet(_)
-            | ChainError::MissingDependencies { .. } => false,
+            | ChainError::MissingCrossChainUpdates { .. } => false,
             ChainError::ViewError(_)
             | ChainError::UnexpectedMessage { .. }
             | ChainError::InboxGapDetected { .. }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -31,7 +31,7 @@ use linera_base::{
     bcs,
     crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
-    identifiers::{ApplicationId, ChainId},
+    identifiers::{ApplicationId, BlobId, ChainId, EventId},
 };
 use linera_execution::ExecutionError;
 use linera_views::ViewError;
@@ -176,6 +176,21 @@ pub enum ChainError {
     RoundDoesNotTimeOut,
     #[error("Not signing timeout certificate; current round times out at time {0}")]
     NotTimedOutYet(Timestamp),
+    #[error(
+        "Cannot vote for block proposal of chain {chain_id}: missing prerequisites \
+         ({} cross-chain bundle(s), {} event(s), {} blob(s)) that have not been received yet",
+        bundles.len(), events.len(), blobs.len()
+    )]
+    MissingDependencies {
+        chain_id: ChainId,
+        /// Missing incoming message bundles, as `(origin chain, height)` pairs that must
+        /// be received before this block can be validated.
+        bundles: Vec<(ChainId, BlockHeight)>,
+        /// Missing events required to execute this block.
+        events: Vec<EventId>,
+        /// Missing blobs required to execute this block.
+        blobs: Vec<BlobId>,
+    },
 }
 
 impl ChainError {
@@ -213,7 +228,8 @@ impl ChainError {
             | ChainError::MissingOracleResponseList
             | ChainError::RoundDoesNotTimeOut
             | ChainError::NotTimedOutYet(_)
-            | ChainError::MissingCrossChainUpdate { .. } => false,
+            | ChainError::MissingCrossChainUpdate { .. }
+            | ChainError::MissingDependencies { .. } => false,
             ChainError::ViewError(_)
             | ChainError::UnexpectedMessage { .. }
             | ChainError::InboxGapDetected { .. }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -177,14 +177,15 @@ pub enum ChainError {
     #[error("Not signing timeout certificate; current round times out at time {0}")]
     NotTimedOutYet(Timestamp),
     #[error(
-        "Cannot vote for block proposal of chain {chain_id}: missing prerequisites \
+        "Cannot process the block for chain {chain_id}: missing prerequisites \
          ({} cross-chain bundle(s), {} event(s), {} blob(s)) that have not been received yet",
         bundles.len(), events.len(), blobs.len()
     )]
     MissingDependencies {
         chain_id: ChainId,
-        /// Missing incoming message bundles, as `(origin chain, height)` pairs that must
-        /// be received before this block can be validated.
+        /// Missing incoming message bundles, as `(origin chain, height)` pairs that must be
+        /// received before this block can be validated (as a proposal) or applied (when
+        /// already confirmed).
         bundles: Vec<(ChainId, BlockHeight)>,
         /// Missing events required to execute this block.
         events: Vec<EventId>,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2082,20 +2082,27 @@ impl<Env: Environment> Client<Env> {
                     }
                 }
                 while let LocalNodeError::WorkerError(WorkerError::ChainError(chain_err)) = &err {
-                    if let ChainError::MissingCrossChainUpdate {
-                        chain_id,
-                        origin,
-                        height,
+                    if let ChainError::MissingDependencies {
+                        chain_id, bundles, ..
                     } = &**chain_err
                     {
-                        self.download_sender_block_with_sending_ancestors(
-                            *chain_id,
-                            *origin,
-                            *height,
-                            remote_node,
-                        )
-                        .await?;
-                        // Retry
+                        let chain_id = *chain_id;
+                        // Clone to end the borrow of `err` before we reassign it below.
+                        let bundles = bundles.clone();
+                        if bundles.is_empty() {
+                            break;
+                        }
+                        // Download every missing sender block the validator reported, in one
+                        // pass, then retry once.
+                        for (origin, height) in bundles {
+                            self.download_sender_block_with_sending_ancestors(
+                                chain_id,
+                                origin,
+                                height,
+                                remote_node,
+                            )
+                            .await?;
+                        }
                         if let Err(new_err) =
                             Box::pin(self.local_node.handle_block_proposal(proposal.clone())).await
                         {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2081,35 +2081,34 @@ impl<Env: Environment> Client<Env> {
                         continue;
                     }
                 }
-                while let LocalNodeError::WorkerError(WorkerError::ChainError(chain_err)) = &err {
+                // The local node reports *every* missing sender in a single
+                // `MissingCrossChainUpdates`, so we download them all in one pass and retry once;
+                // there is no need to iterate the discovery one sender at a time.
+                if let LocalNodeError::WorkerError(WorkerError::ChainError(chain_err)) = &err {
                     if let ChainError::MissingCrossChainUpdates { chain_id, bundles } = &**chain_err
                     {
                         let chain_id = *chain_id;
                         // Clone to end the borrow of `err` before we reassign it below.
                         let bundles = bundles.clone();
-                        if bundles.is_empty() {
-                            break;
+                        if !bundles.is_empty() {
+                            for (origin, height) in bundles {
+                                self.download_sender_block_with_sending_ancestors(
+                                    chain_id,
+                                    origin,
+                                    height,
+                                    remote_node,
+                                )
+                                .await?;
+                            }
+                            if let Err(new_err) =
+                                Box::pin(self.local_node.handle_block_proposal(proposal.clone()))
+                                    .await
+                            {
+                                err = new_err;
+                            } else {
+                                continue 'proposal_loop;
+                            }
                         }
-                        // Download every missing sender block the validator reported, in one
-                        // pass, then retry once.
-                        for (origin, height) in bundles {
-                            self.download_sender_block_with_sending_ancestors(
-                                chain_id,
-                                origin,
-                                height,
-                                remote_node,
-                            )
-                            .await?;
-                        }
-                        if let Err(new_err) =
-                            Box::pin(self.local_node.handle_block_proposal(proposal.clone())).await
-                        {
-                            err = new_err;
-                        } else {
-                            continue 'proposal_loop;
-                        }
-                    } else {
-                        break;
                     }
                 }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2082,9 +2082,7 @@ impl<Env: Environment> Client<Env> {
                     }
                 }
                 while let LocalNodeError::WorkerError(WorkerError::ChainError(chain_err)) = &err {
-                    if let ChainError::MissingDependencies {
-                        chain_id, bundles, ..
-                    } = &**chain_err
+                    if let ChainError::MissingCrossChainUpdates { chain_id, bundles } = &**chain_err
                     {
                         let chain_id = *chain_id;
                         // Clone to end the borrow of `err` before we reassign it below.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -346,15 +346,13 @@ pub enum NodeError {
     },
 
     #[error(
-        "Validator is missing prerequisites to validate or apply the block for chain \
-         {chain_id}: {} cross-chain bundle(s), {} event(s), {} blob(s)",
-        bundles.len(), events.len(), blobs.len()
+        "Validator is missing {} cross-chain message bundle(s) to validate the block for \
+         chain {chain_id}",
+        bundles.len()
     )]
-    MissingDependencies {
+    MissingCrossChainUpdates {
         chain_id: ChainId,
         bundles: Vec<(ChainId, BlockHeight)>,
-        events: Vec<EventId>,
-        blobs: Vec<BlobId>,
     },
 }
 
@@ -406,7 +404,7 @@ impl NodeError {
             NodeError::BlobsNotFound(_)
             | NodeError::EventsNotFound(_)
             | NodeError::MissingCrossChainUpdate { .. }
-            | NodeError::MissingDependencies { .. }
+            | NodeError::MissingCrossChainUpdates { .. }
             | NodeError::WrongRound(_)
             | NodeError::UnexpectedBlockHeight { .. }
             | NodeError::InactiveChain(_)
@@ -495,17 +493,9 @@ impl From<CryptoError> for NodeError {
 impl From<ChainError> for NodeError {
     fn from(error: ChainError) -> Self {
         match error {
-            ChainError::MissingDependencies {
-                chain_id,
-                bundles,
-                events,
-                blobs,
-            } => Self::MissingDependencies {
-                chain_id,
-                bundles,
-                events,
-                blobs,
-            },
+            ChainError::MissingCrossChainUpdates { chain_id, bundles } => {
+                Self::MissingCrossChainUpdates { chain_id, bundles }
+            }
             ChainError::InactiveChain(chain_id) => Self::InactiveChain(chain_id),
             ChainError::ExecutionError(execution_error, context) => match *execution_error {
                 ExecutionError::BlobsNotFound(blob_ids) => Self::BlobsNotFound(blob_ids),

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -346,8 +346,8 @@ pub enum NodeError {
     },
 
     #[error(
-        "Validator is missing prerequisites to validate the block for chain {chain_id}: \
-         {} cross-chain bundle(s), {} event(s), {} blob(s)",
+        "Validator is missing prerequisites to validate or apply the block for chain \
+         {chain_id}: {} cross-chain bundle(s), {} event(s), {} blob(s)",
         bundles.len(), events.len(), blobs.len()
     )]
     MissingDependencies {

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -495,15 +495,6 @@ impl From<CryptoError> for NodeError {
 impl From<ChainError> for NodeError {
     fn from(error: ChainError) -> Self {
         match error {
-            ChainError::MissingCrossChainUpdate {
-                chain_id,
-                origin,
-                height,
-            } => Self::MissingCrossChainUpdate {
-                chain_id,
-                origin,
-                height,
-            },
             ChainError::MissingDependencies {
                 chain_id,
                 bundles,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -344,6 +344,18 @@ pub enum NodeError {
         chain_id: ChainId,
         remote_node: Box<ValidatorPublicKey>,
     },
+
+    #[error(
+        "Validator is missing prerequisites to validate the block for chain {chain_id}: \
+         {} cross-chain bundle(s), {} event(s), {} blob(s)",
+        bundles.len(), events.len(), blobs.len()
+    )]
+    MissingDependencies {
+        chain_id: ChainId,
+        bundles: Vec<(ChainId, BlockHeight)>,
+        events: Vec<EventId>,
+        blobs: Vec<BlobId>,
+    },
 }
 
 /// Parsed data from an `InvalidTimestamp` error.
@@ -394,6 +406,7 @@ impl NodeError {
             NodeError::BlobsNotFound(_)
             | NodeError::EventsNotFound(_)
             | NodeError::MissingCrossChainUpdate { .. }
+            | NodeError::MissingDependencies { .. }
             | NodeError::WrongRound(_)
             | NodeError::UnexpectedBlockHeight { .. }
             | NodeError::InactiveChain(_)
@@ -490,6 +503,17 @@ impl From<ChainError> for NodeError {
                 chain_id,
                 origin,
                 height,
+            },
+            ChainError::MissingDependencies {
+                chain_id,
+                bundles,
+                events,
+                blobs,
+            } => Self::MissingDependencies {
+                chain_id,
+                bundles,
+                events,
+                blobs,
             },
             ChainError::InactiveChain(chain_id) => Self::InactiveChain(chain_id),
             ChainError::ExecutionError(execution_error, context) => match *execution_error {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1082,6 +1082,91 @@ where
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
+async fn test_proposal_batches_missing_dependency_catch_up<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    // Regression test for the hub-chain freeze fixed by the aggregated `MissingDependencies`
+    // error. A block that consumes incoming bundles from several sender chains is proposed to a
+    // validator that is behind on *all* of those senders. The validator must report every
+    // missing sender at once and the client must catch them up in a single batch, instead of
+    // the legacy one-rejection-and-round-trip-per-sender loop that serialized into multi-minute
+    // stalls. The test exercises the client-side batching/termination logic in `updater.rs`,
+    // which the worker- and gRPC-level unit tests in this PR do not cover.
+    let signer = InMemorySigner::new(None);
+    // Zero default-faulty validators so the only unavailable validators are the ones this test
+    // deliberately takes offline below; the quorum is still three out of four.
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+
+    // Three independent sender chains and one recipient ("hub") chain. The committee has four
+    // validators with a quorum of three.
+    let sender1 = builder.add_root_chain(1, Amount::from_tokens(2)).await?;
+    let sender2 = builder.add_root_chain(2, Amount::from_tokens(2)).await?;
+    let sender3 = builder.add_root_chain(3, Amount::from_tokens(2)).await?;
+    let recipient = builder.add_root_chain(4, Amount::ZERO).await?;
+    let recipient_id = recipient.chain_id();
+
+    // Phase A: validator 3 is unavailable while the senders transfer to the recipient. In the
+    // single-process harness a validator only delivers a cross-chain message to the recipient's
+    // inbox when it handles the sender's certificate, so validator 3 ends up missing both the
+    // sender blocks and the resulting bundles in the recipient's inbox. The transfers still
+    // reach the quorum {0, 1, 2}.
+    builder.set_fault_type([3], FaultType::OfflineWithInfo);
+    for sender in [&sender1, &sender2, &sender3] {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::ONE,
+                Account::chain(recipient_id),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+
+    // The recipient learns about all three incoming bundles (and preprocesses the sender blocks
+    // into its local storage) from the honest quorum.
+    recipient.synchronize_from_validators().await?;
+
+    // Phase B: validator 3 comes back, but validator 2 — one of the validators that *does* have
+    // the sender blocks — goes offline. The recipient's block now needs validator 3's vote to
+    // reach a quorum {0, 1, 3}, so the updater cannot route around validator 3: it must catch it
+    // up on every missing sender before validator 3 can accept the proposal.
+    builder.set_fault_type([3], FaultType::Honest);
+    builder.set_fault_type([2], FaultType::Offline);
+
+    // Consume all three bundles in a single block. Validator 3 rejects the proposal with an
+    // aggregated `MissingDependencies` listing all three senders; the client syncs them in one
+    // batch and the block is confirmed.
+    recipient.process_inbox().await?;
+
+    assert_eq!(
+        recipient.local_balance().await.unwrap(),
+        Amount::from_tokens(3),
+    );
+    // A single block consumed all three bundles (height 1, not 3).
+    assert_eq!(
+        recipient.chain_info().await?.next_block_height,
+        BlockHeight::from(1),
+    );
+    assert!(recipient.pending_proposal().await.is_none());
+
+    // The previously-lagging validator 3 was caught up and voted: the block reached the quorum
+    // {0, 1, 3} (validator 2 is offline and is skipped by the check).
+    builder
+        .check_that_validators_have_certificate(recipient_id, BlockHeight::ZERO, 3)
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
 async fn test_receiving_unconfirmed_transfer_with_lagging_sender_balances<B>(
     storage_builder: B,
 ) -> anyhow::Result<()>

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1088,10 +1088,11 @@ async fn test_proposal_batches_missing_dependency_catch_up<B>(
 where
     B: StorageBuilder,
 {
-    // Regression test for the hub-chain freeze fixed by the aggregated `MissingDependencies`
-    // error. A block that consumes incoming bundles from several sender chains is proposed to a
-    // validator that is behind on *all* of those senders. The validator must report every
-    // missing sender at once and the client must catch them up in a single batch, instead of
+    // Regression test for the hub-chain freeze fixed by the aggregated
+    // `MissingCrossChainUpdates` error. A block that consumes incoming bundles from several
+    // sender chains is proposed to a validator that is behind on *all* of those senders. The
+    // validator must report every missing sender at once and the client must catch them up in
+    // a single batch, instead of
     // the legacy one-rejection-and-round-trip-per-sender loop that serialized into multi-minute
     // stalls. The test exercises the client-side batching/termination logic in `updater.rs`,
     // which the worker- and gRPC-level unit tests in this PR do not cover.
@@ -1137,8 +1138,8 @@ where
     builder.set_fault_type([2], FaultType::Offline);
 
     // Consume all three bundles in a single block. Validator 3 rejects the proposal with an
-    // aggregated `MissingDependencies` listing all three senders; the client syncs them in one
-    // batch and the block is confirmed.
+    // aggregated `MissingCrossChainUpdates` listing all three senders; the client syncs them in
+    // one batch and the block is confirmed.
     recipient.process_inbox().await?;
 
     assert_eq!(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1548,8 +1548,8 @@ where
     }
     {
         // A proposal on a chain whose inbox is empty consumes two cross-chain bundles that
-        // were never received. The validator must report *both* missing dependencies at
-        // once (rather than bailing on the first) so the client can fetch them in a single
+        // were never received. The validator must report *both* missing cross-chain updates
+        // at once (rather than bailing on the first) so the client can fetch them in a single
         // round-trip.
         let block_proposal = make_first_block(chain_3)
             .with_incoming_bundle(IncomingBundle {
@@ -1591,14 +1591,14 @@ where
             panic!("unexpected error: {error}");
         };
         match *chain_error {
-            ChainError::MissingDependencies { bundles, .. } => assert_eq!(
+            ChainError::MissingCrossChainUpdates { bundles, .. } => assert_eq!(
                 bundles,
                 vec![
                     (chain_1, BlockHeight::ZERO),
                     (chain_1, BlockHeight::from(1))
                 ],
             ),
-            other => panic!("expected MissingDependencies, got {other}"),
+            other => panic!("expected MissingCrossChainUpdates, got {other}"),
         }
     }
     Ok(())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1546,6 +1546,61 @@ where
             .await
             .0?;
     }
+    {
+        // A proposal on a chain whose inbox is empty consumes two cross-chain bundles that
+        // were never received. The validator must report *both* missing dependencies at
+        // once (rather than bailing on the first) so the client can fetch them in a single
+        // round-trip.
+        let block_proposal = make_first_block(chain_3)
+            .with_incoming_bundle(IncomingBundle {
+                origin: chain_1,
+                bundle: MessageBundle {
+                    certificate_hash: certificate0.hash(),
+                    height: BlockHeight::ZERO,
+                    timestamp: Timestamp::from(0),
+                    transaction_index: 0,
+                    messages: vec![
+                        system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
+                    ],
+                },
+                action: MessageAction::Accept,
+            })
+            .with_incoming_bundle(IncomingBundle {
+                origin: chain_1,
+                bundle: MessageBundle {
+                    certificate_hash: certificate1.hash(),
+                    height: BlockHeight::from(1),
+                    timestamp: Timestamp::from(0),
+                    transaction_index: 0,
+                    messages: vec![system_credit_message(Amount::from_tokens(3))
+                        .to_posted(0, MessageKind::Tracked)],
+                },
+                action: MessageAction::Accept,
+            })
+            .with_authenticated_signer(Some(recipient_owner))
+            .into_first_proposal(recipient_owner, &signer)
+            .await
+            .unwrap();
+        let error = env
+            .worker()
+            .handle_block_proposal(block_proposal)
+            .await
+            .0
+            .unwrap_err();
+        let WorkerError::ChainError(chain_error) = error else {
+            panic!("unexpected error: {error}");
+        };
+        match *chain_error {
+            ChainError::MissingDependencies { bundles, .. } => assert_eq!(
+                bundles,
+                vec![
+                    (chain_1, BlockHeight::ZERO),
+                    (chain_1, BlockHeight::from(1))
+                ],
+            ),
+            other => panic!("expected MissingDependencies, got {other}"),
+        }
+    }
     Ok(())
 }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -272,51 +272,60 @@ where
 
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
-        let mut handled_dependencies = false;
+        let mut sent_event_publishers = BTreeSet::new();
+        let mut sent_bundle_origins = BTreeSet::new();
         loop {
             match result {
-                // A validator that understands aggregated dependency errors declares
-                // everything it needs to apply this confirmed certificate at once. Supply it
-                // all in one batch. (Confirmed blocks tolerate not-yet-received bundles, so
-                // `bundles` is usually empty here, but we sync any the validator reports for
-                // uniformity with the proposal path.)
+                // A validator that understands aggregated dependency errors declares what it
+                // is missing to apply this confirmed certificate as `MissingDependencies`.
+                // Supply each category, tracking what we have already sent so that catch-ups
+                // that take several rounds (e.g. the committee first, then blobs) make
+                // progress on every iteration and terminate once we have nothing new to send.
+                // (Confirmed blocks tolerate not-yet-received bundles, so `bundles` is usually
+                // empty here, but we sync any the validator reports for uniformity.)
                 Err(NodeError::MissingDependencies {
-                    chain_id: _,
+                    chain_id: dependencies_chain_id,
                     bundles,
                     events,
                     blobs,
-                }) if !handled_dependencies => {
-                    handled_dependencies = true;
+                }) => {
+                    let mut made_progress = false;
                     // Missing blobs: the certificate is confirmed, so the blobs are in our
                     // storage and we upload them directly.
-                    if !blobs.is_empty() {
+                    if !blobs.is_empty() && !sent_blobs {
                         self.remote_node
                             .check_blobs_not_found(certificate, &blobs)?;
-                        let maybe_blobs = self
+                        let downloaded = self
                             .client
                             .local_node
                             .read_blobs_from_storage(&blobs)
-                            .await?;
-                        let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blobs))?;
+                            .await?
+                            .ok_or_else(|| NodeError::BlobsNotFound(blobs.clone()))?;
                         self.remote_node
                             .node
-                            .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
+                            .upload_blobs(downloaded.into_iter().map(|b| b.into_std()).collect())
                             .await?;
+                        sent_blobs = true;
+                        made_progress = true;
                     }
                     // Missing events: the admin chain's epoch stream carries the committee
                     // that signed the certificate, so it gets the dedicated update; any other
                     // publisher chains are synced up to the height we would next preprocess.
                     if !events.is_empty() {
-                        if events.iter().any(|event_id| {
-                            event_id.chain_id == self.admin_chain_id
-                                && event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
-                        }) {
+                        if !sent_admin_chain
+                            && events.iter().any(|event_id| {
+                                event_id.chain_id == self.admin_chain_id
+                                    && event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
+                            })
+                        {
                             self.update_admin_chain().await?;
+                            sent_admin_chain = true;
+                            made_progress = true;
                         }
                         let mut publisher_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
                         for event_id in &events {
                             if event_id.chain_id == self.admin_chain_id
-                                || publisher_heights.contains_key(&event_id.chain_id)
+                                || !sent_event_publishers.insert(event_id.chain_id)
                             {
                                 continue;
                             }
@@ -333,21 +342,37 @@ where
                                 CrossChainMessageDelivery::NonBlocking,
                             )
                             .await?;
+                            made_progress = true;
                         }
                     }
                     // Missing bundles: sync each origin chain up to the needed height.
                     if !bundles.is_empty() {
                         let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
-                        for (origin, height) in bundles {
-                            let target = height.try_add_one()?;
-                            let entry = origin_heights.entry(origin).or_insert(target);
-                            *entry = (*entry).max(target);
+                        for &(origin, height) in &bundles {
+                            if !sent_bundle_origins.insert(origin) {
+                                continue;
+                            }
+                            origin_heights.insert(origin, height.try_add_one()?);
                         }
-                        self.send_chain_info_up_to_heights(
-                            origin_heights,
-                            CrossChainMessageDelivery::Blocking,
-                        )
-                        .await?;
+                        if !origin_heights.is_empty() {
+                            self.send_chain_info_up_to_heights(
+                                origin_heights,
+                                CrossChainMessageDelivery::Blocking,
+                            )
+                            .await?;
+                            made_progress = true;
+                        }
+                    }
+                    // Nothing left that we know how to supply: surface the error instead of
+                    // retrying forever.
+                    if !made_progress {
+                        return Err(NodeError::MissingDependencies {
+                            chain_id: dependencies_chain_id,
+                            bundles,
+                            events,
+                            blobs,
+                        }
+                        .into());
                     }
                 }
                 Err(NodeError::EventsNotFound(event_ids))

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -272,109 +272,8 @@ where
 
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
-        let mut sent_event_publishers = BTreeSet::new();
-        let mut sent_bundle_origins = BTreeSet::new();
         loop {
             match result {
-                // A validator that understands aggregated dependency errors declares what it
-                // is missing to apply this confirmed certificate as `MissingDependencies`.
-                // Supply each category, tracking what we have already sent so that catch-ups
-                // that take several rounds (e.g. the committee first, then blobs) make
-                // progress on every iteration and terminate once we have nothing new to send.
-                // (Confirmed blocks tolerate not-yet-received bundles, so `bundles` is usually
-                // empty here, but we sync any the validator reports for uniformity.)
-                Err(NodeError::MissingDependencies {
-                    chain_id: dependencies_chain_id,
-                    bundles,
-                    events,
-                    blobs,
-                }) => {
-                    let mut made_progress = false;
-                    // Missing blobs: the certificate is confirmed, so the blobs are in our
-                    // storage and we upload them directly.
-                    if !blobs.is_empty() && !sent_blobs {
-                        self.remote_node
-                            .check_blobs_not_found(certificate, &blobs)?;
-                        let downloaded = self
-                            .client
-                            .local_node
-                            .read_blobs_from_storage(&blobs)
-                            .await?
-                            .ok_or_else(|| NodeError::BlobsNotFound(blobs.clone()))?;
-                        self.remote_node
-                            .node
-                            .upload_blobs(downloaded.into_iter().map(|b| b.into_std()).collect())
-                            .await?;
-                        sent_blobs = true;
-                        made_progress = true;
-                    }
-                    // Missing events: the admin chain's epoch stream carries the committee
-                    // that signed the certificate, so it gets the dedicated update; any other
-                    // publisher chains are synced up to the height we would next preprocess.
-                    if !events.is_empty() {
-                        if !sent_admin_chain
-                            && events.iter().any(|event_id| {
-                                event_id.chain_id == self.admin_chain_id
-                                    && event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
-                            })
-                        {
-                            self.update_admin_chain().await?;
-                            sent_admin_chain = true;
-                            made_progress = true;
-                        }
-                        let mut publisher_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
-                        for event_id in &events {
-                            if event_id.chain_id == self.admin_chain_id
-                                || !sent_event_publishers.insert(event_id.chain_id)
-                            {
-                                continue;
-                            }
-                            let height = self
-                                .client
-                                .local_node
-                                .get_next_height_to_preprocess(event_id.chain_id)
-                                .await?;
-                            publisher_heights.insert(event_id.chain_id, height);
-                        }
-                        if !publisher_heights.is_empty() {
-                            self.send_chain_info_up_to_heights(
-                                publisher_heights,
-                                CrossChainMessageDelivery::NonBlocking,
-                            )
-                            .await?;
-                            made_progress = true;
-                        }
-                    }
-                    // Missing bundles: sync each origin chain up to the needed height.
-                    if !bundles.is_empty() {
-                        let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
-                        for &(origin, height) in &bundles {
-                            if !sent_bundle_origins.insert(origin) {
-                                continue;
-                            }
-                            origin_heights.insert(origin, height.try_add_one()?);
-                        }
-                        if !origin_heights.is_empty() {
-                            self.send_chain_info_up_to_heights(
-                                origin_heights,
-                                CrossChainMessageDelivery::Blocking,
-                            )
-                            .await?;
-                            made_progress = true;
-                        }
-                    }
-                    // Nothing left that we know how to supply: surface the error instead of
-                    // retrying forever.
-                    if !made_progress {
-                        return Err(NodeError::MissingDependencies {
-                            chain_id: dependencies_chain_id,
-                            bundles,
-                            events,
-                            blobs,
-                        }
-                        .into());
-                    }
-                }
                 Err(NodeError::EventsNotFound(event_ids))
                     if !sent_admin_chain
                         && certificate.inner().chain_id() != self.admin_chain_id
@@ -580,7 +479,6 @@ where
         let chain_id = proposal.content.block.chain_id;
         let mut sent_cross_chain_updates = BTreeMap::new();
         let mut publisher_chain_ids_sent = BTreeSet::new();
-        let mut sent_blob_ids = BTreeSet::new();
         let storage = self.client.local_node.storage_client();
         loop {
             let local_time = storage.clock().current_time();
@@ -654,26 +552,22 @@ where
                     )
                     .await?;
                 }
-                // A validator that understands aggregated dependency errors declares
-                // everything it is missing to validate this proposal in one error. Sync it
-                // all in a single batch (origins concurrently) instead of discovering each
-                // missing item through a separate rejection and round-trip.
-                Err(NodeError::MissingDependencies {
+                // A validator that understands the aggregated error reports every missing
+                // cross-chain bundle in a single `MissingCrossChainUpdates`. Sync all the origin
+                // chains in one batch instead of discovering each one through a separate
+                // rejection and round-trip.
+                Err(NodeError::MissingCrossChainUpdates {
                     chain_id: dependencies_chain_id,
                     bundles,
-                    events,
-                    blobs,
                 }) if dependencies_chain_id == proposal.content.block.chain_id => {
                     tracing::debug!(
                         remote_node = %self.remote_node.address(),
                         %chain_id,
                         bundles = bundles.len(),
-                        events = events.len(),
-                        blobs = blobs.len(),
-                        "validator reported missing dependencies; syncing them in one batch",
+                        "validator reported missing cross-chain updates; syncing them in one batch",
                     );
-                    // 1. Missing incoming bundles: sync each origin chain up to the needed
-                    //    height. The `sent_cross_chain_updates` guard prevents re-sync loops.
+                    // Sync each origin chain up to the needed height. The
+                    // `sent_cross_chain_updates` guard prevents re-sync loops.
                     let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
                     for (origin, height) in bundles {
                         if sent_cross_chain_updates
@@ -687,90 +581,22 @@ where
                         let entry = origin_heights.entry(origin).or_insert(target);
                         *entry = (*entry).max(target);
                     }
-                    // 2. Missing events: sync each publisher chain up to the height our local
-                    //    node would next preprocess.
-                    let mut publisher_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
-                    for event_id in events {
-                        if !publisher_chain_ids_sent.insert(event_id.chain_id) {
-                            continue;
-                        }
-                        let height = self
-                            .client
-                            .local_node
-                            .get_next_height_to_preprocess(event_id.chain_id)
-                            .await?;
-                        publisher_heights.insert(event_id.chain_id, height);
-                    }
-                    // 3. Missing blobs: send the ones this proposal publishes, then sync the
-                    //    chains that last used any remaining ones. `sent_blob_ids` dedups both
-                    //    across loop iterations so the guard below can detect lack of progress.
-                    let published_blob_ids =
-                        BTreeSet::from_iter(proposal.content.block.published_blob_ids());
-                    let blobs_to_publish = published_blob_ids
-                        .iter()
-                        .copied()
-                        .filter(|blob_id| sent_blob_ids.insert(*blob_id))
-                        .collect::<Vec<_>>();
-                    let missing_blob_ids = blobs
-                        .into_iter()
-                        .filter(|blob_id| {
-                            !published_blob_ids.contains(blob_id) && sent_blob_ids.insert(*blob_id)
-                        })
-                        .collect::<Vec<_>>();
-
-                    // Guard against an infinite loop if the validator keeps reporting
-                    // dependencies we have already synced.
+                    // Guard against an infinite loop if the validator keeps reporting bundles
+                    // we have already synced.
                     ensure!(
-                        !origin_heights.is_empty()
-                            || !publisher_heights.is_empty()
-                            || !blobs_to_publish.is_empty()
-                            || !missing_blob_ids.is_empty(),
+                        !origin_heights.is_empty(),
                         NodeError::ResponseHandlingError {
                             error: format!(
-                                "validator repeatedly reported already-synced dependencies \
-                                 for chain {dependencies_chain_id}"
+                                "validator repeatedly reported already-synced cross-chain \
+                                 updates for chain {dependencies_chain_id}"
                             ),
                         }
                     );
-
-                    if !blobs_to_publish.is_empty() {
-                        let published_blobs = self
-                            .client
-                            .local_node
-                            .get_proposed_blobs(chain_id, blobs_to_publish)
-                            .await?;
-                        if !published_blobs.is_empty() {
-                            self.remote_node
-                                .send_pending_blobs(chain_id, published_blobs)
-                                .await?;
-                        }
-                    }
-                    if !origin_heights.is_empty() {
-                        self.send_chain_info_up_to_heights(
-                            origin_heights,
-                            CrossChainMessageDelivery::Blocking,
-                        )
-                        .await?;
-                    }
-                    if !publisher_heights.is_empty() {
-                        self.send_chain_info_up_to_heights(
-                            publisher_heights,
-                            CrossChainMessageDelivery::NonBlocking,
-                        )
-                        .await?;
-                    }
-                    if !missing_blob_ids.is_empty() {
-                        let missing_blob_ids = self
-                            .remote_node
-                            .node
-                            .missing_blob_ids(missing_blob_ids)
-                            .await?;
-                        self.send_chain_info_for_blobs(
-                            &missing_blob_ids,
-                            CrossChainMessageDelivery::NonBlocking,
-                        )
-                        .await?;
-                    }
+                    self.send_chain_info_up_to_heights(
+                        origin_heights,
+                        CrossChainMessageDelivery::Blocking,
+                    )
+                    .await?;
                 }
                 Err(NodeError::MissingCrossChainUpdate {
                     chain_id,

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -477,7 +477,11 @@ where
         clock_skew_sender: mpsc::UnboundedSender<ClockSkewReport>,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let chain_id = proposal.content.block.chain_id;
+        // `sent_cross_chain_updates` tracks per-origin progress for the legacy per-sender
+        // `MissingCrossChainUpdate` path (a non-upgraded validator); `synced_cross_chain_updates`
+        // is the one-shot guard for the aggregated `MissingCrossChainUpdates` path.
         let mut sent_cross_chain_updates = BTreeMap::new();
+        let mut synced_cross_chain_updates = false;
         let mut publisher_chain_ids_sent = BTreeSet::new();
         let storage = self.client.local_node.storage_client();
         loop {
@@ -552,46 +556,39 @@ where
                     )
                     .await?;
                 }
-                // A validator that understands the aggregated error reports every missing
-                // cross-chain bundle in a single `MissingCrossChainUpdates`. Sync all the origin
-                // chains in one batch instead of discovering each one through a separate
-                // rejection and round-trip.
+                // A validator that understands the aggregated error reports *every* missing
+                // cross-chain bundle in a single `MissingCrossChainUpdates`, so we sync all of
+                // them at once and retry. If it still reports missing bundles after we synced the
+                // whole set, retrying would not make progress, so we surface the error instead of
+                // looping.
                 Err(NodeError::MissingCrossChainUpdates {
                     chain_id: dependencies_chain_id,
                     bundles,
                 }) if dependencies_chain_id == proposal.content.block.chain_id => {
+                    ensure!(
+                        !synced_cross_chain_updates,
+                        NodeError::ResponseHandlingError {
+                            error: format!(
+                                "validator still reports missing cross-chain updates for chain \
+                                 {dependencies_chain_id} after they were all synced"
+                            ),
+                        }
+                    );
+                    synced_cross_chain_updates = true;
                     tracing::debug!(
                         remote_node = %self.remote_node.address(),
                         %chain_id,
                         bundles = bundles.len(),
                         "validator reported missing cross-chain updates; syncing them in one batch",
                     );
-                    // Sync each origin chain up to the needed height. The
-                    // `sent_cross_chain_updates` guard prevents re-sync loops.
+                    // Sync each reported origin chain up to the needed height, collapsing any
+                    // duplicate origins to the highest height.
                     let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
                     for (origin, height) in bundles {
-                        if sent_cross_chain_updates
-                            .get(&origin)
-                            .is_some_and(|sent| *sent >= height)
-                        {
-                            continue;
-                        }
-                        sent_cross_chain_updates.insert(origin, height);
                         let target = height.try_add_one()?;
                         let entry = origin_heights.entry(origin).or_insert(target);
                         *entry = (*entry).max(target);
                     }
-                    // Guard against an infinite loop if the validator keeps reporting bundles
-                    // we have already synced.
-                    ensure!(
-                        !origin_heights.is_empty(),
-                        NodeError::ResponseHandlingError {
-                            error: format!(
-                                "validator repeatedly reported already-synced cross-chain \
-                                 updates for chain {dependencies_chain_id}"
-                            ),
-                        }
-                    );
                     self.send_chain_info_up_to_heights(
                         origin_heights,
                         CrossChainMessageDelivery::Blocking,

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -272,8 +272,84 @@ where
 
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
+        let mut handled_dependencies = false;
         loop {
             match result {
+                // A validator that understands aggregated dependency errors declares
+                // everything it needs to apply this confirmed certificate at once. Supply it
+                // all in one batch. (Confirmed blocks tolerate not-yet-received bundles, so
+                // `bundles` is usually empty here, but we sync any the validator reports for
+                // uniformity with the proposal path.)
+                Err(NodeError::MissingDependencies {
+                    chain_id: _,
+                    bundles,
+                    events,
+                    blobs,
+                }) if !handled_dependencies => {
+                    handled_dependencies = true;
+                    // Missing blobs: the certificate is confirmed, so the blobs are in our
+                    // storage and we upload them directly.
+                    if !blobs.is_empty() {
+                        self.remote_node
+                            .check_blobs_not_found(certificate, &blobs)?;
+                        let maybe_blobs = self
+                            .client
+                            .local_node
+                            .read_blobs_from_storage(&blobs)
+                            .await?;
+                        let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blobs))?;
+                        self.remote_node
+                            .node
+                            .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
+                            .await?;
+                    }
+                    // Missing events: the admin chain's epoch stream carries the committee
+                    // that signed the certificate, so it gets the dedicated update; any other
+                    // publisher chains are synced up to the height we would next preprocess.
+                    if !events.is_empty() {
+                        if events.iter().any(|event_id| {
+                            event_id.chain_id == self.admin_chain_id
+                                && event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
+                        }) {
+                            self.update_admin_chain().await?;
+                        }
+                        let mut publisher_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
+                        for event_id in &events {
+                            if event_id.chain_id == self.admin_chain_id
+                                || publisher_heights.contains_key(&event_id.chain_id)
+                            {
+                                continue;
+                            }
+                            let height = self
+                                .client
+                                .local_node
+                                .get_next_height_to_preprocess(event_id.chain_id)
+                                .await?;
+                            publisher_heights.insert(event_id.chain_id, height);
+                        }
+                        if !publisher_heights.is_empty() {
+                            self.send_chain_info_up_to_heights(
+                                publisher_heights,
+                                CrossChainMessageDelivery::NonBlocking,
+                            )
+                            .await?;
+                        }
+                    }
+                    // Missing bundles: sync each origin chain up to the needed height.
+                    if !bundles.is_empty() {
+                        let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
+                        for (origin, height) in bundles {
+                            let target = height.try_add_one()?;
+                            let entry = origin_heights.entry(origin).or_insert(target);
+                            *entry = (*entry).max(target);
+                        }
+                        self.send_chain_info_up_to_heights(
+                            origin_heights,
+                            CrossChainMessageDelivery::Blocking,
+                        )
+                        .await?;
+                    }
+                }
                 Err(NodeError::EventsNotFound(event_ids))
                     if !sent_admin_chain
                         && certificate.inner().chain_id() != self.admin_chain_id

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -479,6 +479,7 @@ where
         let chain_id = proposal.content.block.chain_id;
         let mut sent_cross_chain_updates = BTreeMap::new();
         let mut publisher_chain_ids_sent = BTreeSet::new();
+        let mut sent_blob_ids = BTreeSet::new();
         let storage = self.client.local_node.storage_client();
         loop {
             let local_time = storage.clock().current_time();
@@ -551,6 +552,124 @@ where
                         None,
                     )
                     .await?;
+                }
+                // A validator that understands aggregated dependency errors declares
+                // everything it is missing to validate this proposal in one error. Sync it
+                // all in a single batch (origins concurrently) instead of discovering each
+                // missing item through a separate rejection and round-trip.
+                Err(NodeError::MissingDependencies {
+                    chain_id: dependencies_chain_id,
+                    bundles,
+                    events,
+                    blobs,
+                }) if dependencies_chain_id == proposal.content.block.chain_id => {
+                    tracing::debug!(
+                        remote_node = %self.remote_node.address(),
+                        %chain_id,
+                        bundles = bundles.len(),
+                        events = events.len(),
+                        blobs = blobs.len(),
+                        "validator reported missing dependencies; syncing them in one batch",
+                    );
+                    // 1. Missing incoming bundles: sync each origin chain up to the needed
+                    //    height. The `sent_cross_chain_updates` guard prevents re-sync loops.
+                    let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
+                    for (origin, height) in bundles {
+                        if sent_cross_chain_updates
+                            .get(&origin)
+                            .is_some_and(|sent| *sent >= height)
+                        {
+                            continue;
+                        }
+                        sent_cross_chain_updates.insert(origin, height);
+                        let target = height.try_add_one()?;
+                        let entry = origin_heights.entry(origin).or_insert(target);
+                        *entry = (*entry).max(target);
+                    }
+                    // 2. Missing events: sync each publisher chain up to the height our local
+                    //    node would next preprocess.
+                    let mut publisher_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
+                    for event_id in events {
+                        if !publisher_chain_ids_sent.insert(event_id.chain_id) {
+                            continue;
+                        }
+                        let height = self
+                            .client
+                            .local_node
+                            .get_next_height_to_preprocess(event_id.chain_id)
+                            .await?;
+                        publisher_heights.insert(event_id.chain_id, height);
+                    }
+                    // 3. Missing blobs: send the ones this proposal publishes, then sync the
+                    //    chains that last used any remaining ones. `sent_blob_ids` dedups both
+                    //    across loop iterations so the guard below can detect lack of progress.
+                    let published_blob_ids =
+                        BTreeSet::from_iter(proposal.content.block.published_blob_ids());
+                    let blobs_to_publish = published_blob_ids
+                        .iter()
+                        .copied()
+                        .filter(|blob_id| sent_blob_ids.insert(*blob_id))
+                        .collect::<Vec<_>>();
+                    let missing_blob_ids = blobs
+                        .into_iter()
+                        .filter(|blob_id| {
+                            !published_blob_ids.contains(blob_id) && sent_blob_ids.insert(*blob_id)
+                        })
+                        .collect::<Vec<_>>();
+
+                    // Guard against an infinite loop if the validator keeps reporting
+                    // dependencies we have already synced.
+                    ensure!(
+                        !origin_heights.is_empty()
+                            || !publisher_heights.is_empty()
+                            || !blobs_to_publish.is_empty()
+                            || !missing_blob_ids.is_empty(),
+                        NodeError::ResponseHandlingError {
+                            error: format!(
+                                "validator repeatedly reported already-synced dependencies \
+                                 for chain {dependencies_chain_id}"
+                            ),
+                        }
+                    );
+
+                    if !blobs_to_publish.is_empty() {
+                        let published_blobs = self
+                            .client
+                            .local_node
+                            .get_proposed_blobs(chain_id, blobs_to_publish)
+                            .await?;
+                        if !published_blobs.is_empty() {
+                            self.remote_node
+                                .send_pending_blobs(chain_id, published_blobs)
+                                .await?;
+                        }
+                    }
+                    if !origin_heights.is_empty() {
+                        self.send_chain_info_up_to_heights(
+                            origin_heights,
+                            CrossChainMessageDelivery::Blocking,
+                        )
+                        .await?;
+                    }
+                    if !publisher_heights.is_empty() {
+                        self.send_chain_info_up_to_heights(
+                            publisher_heights,
+                            CrossChainMessageDelivery::NonBlocking,
+                        )
+                        .await?;
+                    }
+                    if !missing_blob_ids.is_empty() {
+                        let missing_blob_ids = self
+                            .remote_node
+                            .node
+                            .missing_blob_ids(missing_blob_ids)
+                            .await?;
+                        self.send_chain_info_for_blobs(
+                            &missing_blob_ids,
+                            CrossChainMessageDelivery::NonBlocking,
+                        )
+                        .await?;
+                    }
                 }
                 Err(NodeError::MissingCrossChainUpdate {
                     chain_id,

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -278,6 +278,11 @@ message BlockProposal {
   // A lite certificate for a validated block, or a fast block proposal, that
   // justifies the proposal in this round.
   optional bytes original_proposal = 6;
+
+  // Whether the sender understands the aggregated `MissingDependencies` error. When
+  // false (e.g. an older client that predates it), the validator downgrades that error
+  // to the legacy per-item errors before replying, for backward compatibility.
+  bool supports_aggregated_missing = 7;
 }
 
 // A certified statement from the committee, without the value.
@@ -333,6 +338,9 @@ message HandleConfirmedCertificateRequest {
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
   bool wait_for_outgoing_messages = 3;
+
+  // Whether the sender understands the aggregated `MissingDependencies` error.
+  bool supports_aggregated_missing = 4;
 }
 
 // A request for a pending blob.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -279,9 +279,10 @@ message BlockProposal {
   // justifies the proposal in this round.
   optional bytes original_proposal = 6;
 
-  // Whether the sender understands the aggregated `MissingDependencies` error. When
+  // Whether the sender understands the aggregated `MissingCrossChainUpdates` error. When
   // false (e.g. an older client that predates it), the validator downgrades that error
-  // to the legacy per-item errors before replying, for backward compatibility.
+  // to the legacy per-sender `MissingCrossChainUpdate` before replying, for backward
+  // compatibility.
   bool supports_aggregated_missing = 7;
 }
 
@@ -339,7 +340,7 @@ message HandleConfirmedCertificateRequest {
   // been received by the target chains.
   bool wait_for_outgoing_messages = 3;
 
-  // Whether the sender understands the aggregated `MissingDependencies` error.
+  // Whether the sender understands the aggregated `MissingCrossChainUpdates` error.
   bool supports_aggregated_missing = 4;
 }
 

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -255,7 +255,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
                 .original_proposal
                 .map(|cert| bincode::serialize(&cert))
                 .transpose()?,
-            // This binary understands the aggregated `MissingDependencies` error.
+            // This binary understands the aggregated `MissingCrossChainUpdates` error.
             supports_aggregated_missing: true,
         })
     }
@@ -490,7 +490,7 @@ impl TryFrom<HandleConfirmedCertificateRequest> for api::HandleConfirmedCertific
             chain_id: Some(request.certificate.inner().chain_id().into()),
             certificate: Some(request.certificate.try_into()?),
             wait_for_outgoing_messages: request.wait_for_outgoing_messages,
-            // This binary understands the aggregated `MissingDependencies` error.
+            // This binary understands the aggregated `MissingCrossChainUpdates` error.
             supports_aggregated_missing: true,
         })
     }
@@ -1262,56 +1262,38 @@ pub mod tests {
 
     /// `NodeError` is bincode-encoded into the gRPC error field (see `TryFrom<NodeError> for
     /// api::ChainInfoResult`), so an upgraded peer must be able to decode the aggregated
-    /// `MissingDependencies` variant. This also guards against accidentally reordering the
+    /// `MissingCrossChainUpdates` variant. This also guards against accidentally reordering the
     /// enum (the variant must stay appended for wire compatibility with older peers).
     #[test]
-    fn test_node_error_missing_dependencies_round_trip() {
-        use linera_base::identifiers::{BlobType, EventId};
-        let error = NodeError::MissingDependencies {
+    fn test_node_error_missing_cross_chain_updates_round_trip() {
+        let error = NodeError::MissingCrossChainUpdates {
             chain_id: dummy_chain_id(0),
             bundles: vec![
                 (dummy_chain_id(1), BlockHeight::from(7)),
                 (dummy_chain_id(2), BlockHeight::from(0)),
             ],
-            events: vec![EventId {
-                chain_id: dummy_chain_id(3),
-                stream_id: StreamId::system(b"test".to_vec()),
-                index: 5,
-            }],
-            blobs: vec![BlobId::new(CryptoHash::test_hash("blob"), BlobType::Data)],
         };
         let encoded = bincode::serialize(&error).unwrap();
         let decoded: NodeError = bincode::deserialize(&encoded).unwrap();
         assert_eq!(error, decoded);
     }
 
-    /// The chain-level error must map to the node-level error preserving every field, so the
-    /// client receives the full missing set.
+    /// The chain-level error must map to the node-level error preserving every reported sender,
+    /// so the client receives the full missing set.
     #[test]
-    fn test_chain_error_missing_dependencies_maps_to_node_error() {
-        use linera_base::identifiers::{BlobType, EventId};
+    fn test_chain_error_missing_cross_chain_updates_maps_to_node_error() {
         let chain_id = dummy_chain_id(0);
-        let bundles = vec![(dummy_chain_id(1), BlockHeight::from(3))];
-        let events = vec![EventId {
-            chain_id: dummy_chain_id(2),
-            stream_id: StreamId::system(b"s".to_vec()),
-            index: 1,
-        }];
-        let blobs = vec![BlobId::new(CryptoHash::test_hash("b"), BlobType::Data)];
-        let node_error = NodeError::from(linera_chain::ChainError::MissingDependencies {
+        let bundles = vec![
+            (dummy_chain_id(1), BlockHeight::from(3)),
+            (dummy_chain_id(2), BlockHeight::from(8)),
+        ];
+        let node_error = NodeError::from(linera_chain::ChainError::MissingCrossChainUpdates {
             chain_id,
             bundles: bundles.clone(),
-            events: events.clone(),
-            blobs: blobs.clone(),
         });
         assert_eq!(
             node_error,
-            NodeError::MissingDependencies {
-                chain_id,
-                bundles,
-                events,
-                blobs,
-            }
+            NodeError::MissingCrossChainUpdates { chain_id, bundles }
         );
     }
 

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -1256,6 +1256,61 @@ pub mod tests {
         round_trip_check::<_, api::ChainId>(&chain_id);
     }
 
+    /// `NodeError` is bincode-encoded into the gRPC error field (see `TryFrom<NodeError> for
+    /// api::ChainInfoResult`), so an upgraded peer must be able to decode the aggregated
+    /// `MissingDependencies` variant. This also guards against accidentally reordering the
+    /// enum (the variant must stay appended for wire compatibility with older peers).
+    #[test]
+    fn test_node_error_missing_dependencies_round_trip() {
+        use linera_base::identifiers::{BlobType, EventId};
+        let error = NodeError::MissingDependencies {
+            chain_id: dummy_chain_id(0),
+            bundles: vec![
+                (dummy_chain_id(1), BlockHeight::from(7)),
+                (dummy_chain_id(2), BlockHeight::from(0)),
+            ],
+            events: vec![EventId {
+                chain_id: dummy_chain_id(3),
+                stream_id: StreamId::system(b"test".to_vec()),
+                index: 5,
+            }],
+            blobs: vec![BlobId::new(CryptoHash::test_hash("blob"), BlobType::Data)],
+        };
+        let encoded = bincode::serialize(&error).unwrap();
+        let decoded: NodeError = bincode::deserialize(&encoded).unwrap();
+        assert_eq!(error, decoded);
+    }
+
+    /// The chain-level error must map to the node-level error preserving every field, so the
+    /// client receives the full missing set.
+    #[test]
+    fn test_chain_error_missing_dependencies_maps_to_node_error() {
+        use linera_base::identifiers::{BlobType, EventId};
+        let chain_id = dummy_chain_id(0);
+        let bundles = vec![(dummy_chain_id(1), BlockHeight::from(3))];
+        let events = vec![EventId {
+            chain_id: dummy_chain_id(2),
+            stream_id: StreamId::system(b"s".to_vec()),
+            index: 1,
+        }];
+        let blobs = vec![BlobId::new(CryptoHash::test_hash("b"), BlobType::Data)];
+        let node_error = NodeError::from(linera_chain::ChainError::MissingDependencies {
+            chain_id,
+            bundles: bundles.clone(),
+            events: events.clone(),
+            blobs: blobs.clone(),
+        });
+        assert_eq!(
+            node_error,
+            NodeError::MissingDependencies {
+                chain_id,
+                bundles,
+                events,
+                blobs,
+            }
+        );
+    }
+
     #[test]
     pub fn test_chain_info_response() {
         let chain_info = Box::new(ChainInfo {

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -255,6 +255,8 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
                 .original_proposal
                 .map(|cert| bincode::serialize(&cert))
                 .transpose()?,
+            // This binary understands the aggregated `MissingDependencies` error.
+            supports_aggregated_missing: true,
         })
     }
 }
@@ -488,6 +490,8 @@ impl TryFrom<HandleConfirmedCertificateRequest> for api::HandleConfirmedCertific
             chain_id: Some(request.certificate.inner().chain_id().into()),
             certificate: Some(request.certificate.try_into()?),
             wait_for_outgoing_messages: request.wait_for_outgoing_messages,
+            // This binary understands the aggregated `MissingDependencies` error.
+            supports_aggregated_missing: true,
         })
     }
 }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -49,61 +49,42 @@ use crate::{
 type CrossChainSender = mpsc::Sender<(linera_core::data_types::CrossChainRequest, ShardId)>;
 type NotificationSender = tokio::sync::broadcast::Sender<Notification>;
 
-/// Adapts a "missing prerequisite" error to the capabilities the requesting client
-/// advertised, keeping the wire protocol backward compatible.
+/// Downgrades the aggregated [`NodeError::MissingDependencies`] back to a legacy per-item
+/// error for clients that did not advertise that they understand it, keeping the wire
+/// protocol backward compatible. Capable clients (and all other errors) pass through
+/// unchanged.
 ///
-/// Clients that understand the aggregated [`NodeError::MissingDependencies`] receive every
-/// missing-prerequisite condition in that single shape (so they can fetch everything in one
-/// batch). Older clients that predate it only understand the legacy per-item errors, so the
-/// aggregated error is downgraded back to one of them. Errors unrelated to missing
-/// prerequisites pass through unchanged.
-fn adapt_dependency_error(
-    error: NodeError,
-    chain_id: ChainId,
-    supports_aggregated: bool,
-) -> NodeError {
+/// Note that only the missing cross-chain *bundles* are aggregated; missing events and blobs
+/// keep their existing `EventsNotFound` / `BlobsNotFound` errors, which all clients already
+/// understand.
+fn adapt_dependency_error(error: NodeError, supports_aggregated: bool) -> NodeError {
     if supports_aggregated {
-        match error {
-            NodeError::EventsNotFound(events) => NodeError::MissingDependencies {
-                chain_id,
-                bundles: Vec::new(),
-                events,
-                blobs: Vec::new(),
-            },
-            NodeError::BlobsNotFound(blobs) => NodeError::MissingDependencies {
-                chain_id,
-                bundles: Vec::new(),
-                events: Vec::new(),
-                blobs,
-            },
-            other => other,
-        }
-    } else {
-        match error {
-            NodeError::MissingDependencies {
-                chain_id,
-                bundles,
-                events,
-                blobs,
-            } => {
-                if let Some((origin, height)) = bundles.into_iter().next() {
-                    NodeError::MissingCrossChainUpdate {
-                        chain_id,
-                        origin,
-                        height,
-                    }
-                } else if !events.is_empty() {
-                    NodeError::EventsNotFound(events)
-                } else if !blobs.is_empty() {
-                    NodeError::BlobsNotFound(blobs)
-                } else {
-                    NodeError::ChainError {
-                        error: "missing dependencies".to_string(),
-                    }
+        return error;
+    }
+    match error {
+        NodeError::MissingDependencies {
+            chain_id,
+            bundles,
+            events,
+            blobs,
+        } => {
+            if let Some((origin, height)) = bundles.into_iter().next() {
+                NodeError::MissingCrossChainUpdate {
+                    chain_id,
+                    origin,
+                    height,
+                }
+            } else if !events.is_empty() {
+                NodeError::EventsNotFound(events)
+            } else if !blobs.is_empty() {
+                NodeError::BlobsNotFound(blobs)
+            } else {
+                NodeError::ChainError {
+                    error: "missing dependencies".to_string(),
                 }
             }
-            other => other,
         }
+        other => other,
     }
 }
 
@@ -802,8 +783,7 @@ where
         let traffic_type = Self::get_traffic_type(&request);
         let proto = request.into_inner();
         let supports_aggregated = proto.supports_aggregated_missing;
-        let proposal: linera_chain::data_types::BlockProposal = proto.try_into()?;
-        let chain_id = proposal.content.block.chain_id;
+        let proposal = proto.try_into()?;
         trace!(?proposal, "Handling block proposal");
         let (result, actions) = self.state.clone().handle_block_proposal(proposal).await;
         // Dispatch actions whether or not the proposal was accepted: a rejected
@@ -819,8 +799,7 @@ where
             Err(error) => {
                 Self::log_request_error("handle_block_proposal", traffic_type, &error.error_type());
                 self.log_error(&error, "Failed to handle block proposal");
-                adapt_dependency_error(NodeError::from(error), chain_id, supports_aggregated)
-                    .try_into()?
+                adapt_dependency_error(NodeError::from(error), supports_aggregated).try_into()?
             }
         }))
     }
@@ -894,7 +873,6 @@ where
             certificate,
             wait_for_outgoing_messages,
         } = proto.try_into()?;
-        let chain_id = certificate.inner().chain_id();
         trace!(?certificate, "Handling certificate");
         let (sender, receiver) = wait_for_outgoing_messages.then(oneshot::channel).unzip();
         match self
@@ -921,7 +899,7 @@ where
                 );
                 self.log_error(&error, "Failed to handle confirmed certificate");
                 Ok(Response::new(
-                    adapt_dependency_error(NodeError::from(error), chain_id, supports_aggregated)
+                    adapt_dependency_error(NodeError::from(error), supports_aggregated)
                         .try_into()?,
                 ))
             }
@@ -1279,28 +1257,20 @@ mod dependency_error_tests {
     }
 
     #[test]
-    fn capable_client_gets_aggregated_errors() {
-        let cid = chain("target");
-        // Legacy per-item errors are lifted into the aggregated shape.
-        assert!(matches!(
-            adapt_dependency_error(NodeError::EventsNotFound(vec![event()]), cid, true),
-            NodeError::MissingDependencies { events, .. } if events == vec![event()]
-        ));
-        assert!(matches!(
-            adapt_dependency_error(NodeError::BlobsNotFound(vec![blob()]), cid, true),
-            NodeError::MissingDependencies { blobs, .. } if blobs == vec![blob()]
-        ));
-        // An already-aggregated error passes through unchanged.
+    fn capable_client_gets_errors_unchanged() {
+        // A client that understands the aggregated error receives every error as-is, both
+        // the legacy per-item ones and `MissingDependencies` itself.
+        let events = NodeError::EventsNotFound(vec![event()]);
+        assert_eq!(adapt_dependency_error(events.clone(), true), events);
+        let blobs = NodeError::BlobsNotFound(vec![blob()]);
+        assert_eq!(adapt_dependency_error(blobs.clone(), true), blobs);
         let aggregated = NodeError::MissingDependencies {
-            chain_id: cid,
-            bundles: vec![],
-            events: vec![event()],
+            chain_id: chain("target"),
+            bundles: vec![(chain("origin"), BlockHeight::from(7))],
+            events: vec![],
             blobs: vec![],
         };
-        assert_eq!(
-            adapt_dependency_error(aggregated.clone(), cid, true),
-            aggregated
-        );
+        assert_eq!(adapt_dependency_error(aggregated.clone(), true), aggregated);
     }
 
     #[test]
@@ -1316,7 +1286,7 @@ mod dependency_error_tests {
             blobs: vec![blob()],
         };
         assert!(matches!(
-            adapt_dependency_error(with_bundles, cid, false),
+            adapt_dependency_error(with_bundles, false),
             NodeError::MissingCrossChainUpdate { origin: o, height: h, .. }
                 if o == origin && h == height
         ));
@@ -1328,7 +1298,7 @@ mod dependency_error_tests {
             blobs: vec![],
         };
         assert!(matches!(
-            adapt_dependency_error(events_only, cid, false),
+            adapt_dependency_error(events_only, false),
             NodeError::EventsNotFound(events) if events == vec![event()]
         ));
         let blobs_only = NodeError::MissingDependencies {
@@ -1338,7 +1308,7 @@ mod dependency_error_tests {
             blobs: vec![blob()],
         };
         assert!(matches!(
-            adapt_dependency_error(blobs_only, cid, false),
+            adapt_dependency_error(blobs_only, false),
             NodeError::BlobsNotFound(blobs) if blobs == vec![blob()]
         ));
     }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -49,38 +49,26 @@ use crate::{
 type CrossChainSender = mpsc::Sender<(linera_core::data_types::CrossChainRequest, ShardId)>;
 type NotificationSender = tokio::sync::broadcast::Sender<Notification>;
 
-/// Downgrades the aggregated [`NodeError::MissingDependencies`] back to a legacy per-item
-/// error for clients that did not advertise that they understand it, keeping the wire
-/// protocol backward compatible. Capable clients (and all other errors) pass through
-/// unchanged.
-///
-/// Note that only the missing cross-chain *bundles* are aggregated; missing events and blobs
-/// keep their existing `EventsNotFound` / `BlobsNotFound` errors, which all clients already
-/// understand.
+/// Downgrades the aggregated [`NodeError::MissingCrossChainUpdates`] back to the legacy
+/// per-sender [`NodeError::MissingCrossChainUpdate`] for clients that did not advertise that
+/// they understand the aggregated form, keeping the wire protocol backward compatible. Such a
+/// client only learns about the first missing sender and recovers one rejection at a time, as
+/// before. Capable clients (and all other errors) pass through unchanged.
 fn adapt_dependency_error(error: NodeError, supports_aggregated: bool) -> NodeError {
     if supports_aggregated {
         return error;
     }
     match error {
-        NodeError::MissingDependencies {
-            chain_id,
-            bundles,
-            events,
-            blobs,
-        } => {
+        NodeError::MissingCrossChainUpdates { chain_id, bundles } => {
             if let Some((origin, height)) = bundles.into_iter().next() {
                 NodeError::MissingCrossChainUpdate {
                     chain_id,
                     origin,
                     height,
                 }
-            } else if !events.is_empty() {
-                NodeError::EventsNotFound(events)
-            } else if !blobs.is_empty() {
-                NodeError::BlobsNotFound(blobs)
             } else {
                 NodeError::ChainError {
-                    error: "missing dependencies".to_string(),
+                    error: "missing cross-chain updates".to_string(),
                 }
             }
         }
@@ -1231,11 +1219,7 @@ impl GrpcProxyable for CrossChainRequest {
 
 #[cfg(test)]
 mod dependency_error_tests {
-    use linera_base::{
-        crypto::CryptoHash,
-        data_types::BlockHeight,
-        identifiers::{BlobId, BlobType, ChainId, EventId, StreamId},
-    };
+    use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
     use linera_core::node::NodeError;
 
     use super::adapt_dependency_error;
@@ -1244,72 +1228,35 @@ mod dependency_error_tests {
         ChainId(CryptoHash::test_hash(name))
     }
 
-    fn event() -> EventId {
-        EventId {
-            chain_id: chain("publisher"),
-            stream_id: StreamId::system(b"s".to_vec()),
-            index: 0,
-        }
-    }
-
-    fn blob() -> BlobId {
-        BlobId::new(CryptoHash::test_hash("blob"), BlobType::Data)
-    }
-
     #[test]
     fn capable_client_gets_errors_unchanged() {
-        // A client that understands the aggregated error receives every error as-is, both
-        // the legacy per-item ones and `MissingDependencies` itself.
-        let events = NodeError::EventsNotFound(vec![event()]);
-        assert_eq!(adapt_dependency_error(events.clone(), true), events);
-        let blobs = NodeError::BlobsNotFound(vec![blob()]);
-        assert_eq!(adapt_dependency_error(blobs.clone(), true), blobs);
-        let aggregated = NodeError::MissingDependencies {
+        // A client that understands the aggregated error receives `MissingCrossChainUpdates`
+        // as-is, with every reported sender preserved.
+        let aggregated = NodeError::MissingCrossChainUpdates {
             chain_id: chain("target"),
-            bundles: vec![(chain("origin"), BlockHeight::from(7))],
-            events: vec![],
-            blobs: vec![],
+            bundles: vec![
+                (chain("origin1"), BlockHeight::from(7)),
+                (chain("origin2"), BlockHeight::from(0)),
+            ],
         };
         assert_eq!(adapt_dependency_error(aggregated.clone(), true), aggregated);
     }
 
     #[test]
-    fn legacy_client_gets_downgraded_errors() {
+    fn legacy_client_gets_downgraded_error() {
         let cid = chain("target");
         let origin = chain("origin");
         let height = BlockHeight::from(7);
-        // Bundles take priority and downgrade to the per-origin legacy error.
-        let with_bundles = NodeError::MissingDependencies {
+        // For a client that does not understand the aggregated error, it downgrades to the
+        // legacy per-sender error reporting just the first missing sender.
+        let aggregated = NodeError::MissingCrossChainUpdates {
             chain_id: cid,
-            bundles: vec![(origin, height)],
-            events: vec![event()],
-            blobs: vec![blob()],
+            bundles: vec![(origin, height), (chain("other"), BlockHeight::from(1))],
         };
         assert!(matches!(
-            adapt_dependency_error(with_bundles, false),
-            NodeError::MissingCrossChainUpdate { origin: o, height: h, .. }
-                if o == origin && h == height
-        ));
-        // Events-only and blobs-only downgrade to their respective legacy errors.
-        let events_only = NodeError::MissingDependencies {
-            chain_id: cid,
-            bundles: vec![],
-            events: vec![event()],
-            blobs: vec![],
-        };
-        assert!(matches!(
-            adapt_dependency_error(events_only, false),
-            NodeError::EventsNotFound(events) if events == vec![event()]
-        ));
-        let blobs_only = NodeError::MissingDependencies {
-            chain_id: cid,
-            bundles: vec![],
-            events: vec![],
-            blobs: vec![blob()],
-        };
-        assert!(matches!(
-            adapt_dependency_error(blobs_only, false),
-            NodeError::BlobsNotFound(blobs) if blobs == vec![blob()]
+            adapt_dependency_error(aggregated, false),
+            NodeError::MissingCrossChainUpdate { chain_id, origin: o, height: h }
+                if chain_id == cid && o == origin && h == height
         ));
     }
 }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -49,6 +49,64 @@ use crate::{
 type CrossChainSender = mpsc::Sender<(linera_core::data_types::CrossChainRequest, ShardId)>;
 type NotificationSender = tokio::sync::broadcast::Sender<Notification>;
 
+/// Adapts a "missing prerequisite" error to the capabilities the requesting client
+/// advertised, keeping the wire protocol backward compatible.
+///
+/// Clients that understand the aggregated [`NodeError::MissingDependencies`] receive every
+/// missing-prerequisite condition in that single shape (so they can fetch everything in one
+/// batch). Older clients that predate it only understand the legacy per-item errors, so the
+/// aggregated error is downgraded back to one of them. Errors unrelated to missing
+/// prerequisites pass through unchanged.
+fn adapt_dependency_error(
+    error: NodeError,
+    chain_id: ChainId,
+    supports_aggregated: bool,
+) -> NodeError {
+    if supports_aggregated {
+        match error {
+            NodeError::EventsNotFound(events) => NodeError::MissingDependencies {
+                chain_id,
+                bundles: Vec::new(),
+                events,
+                blobs: Vec::new(),
+            },
+            NodeError::BlobsNotFound(blobs) => NodeError::MissingDependencies {
+                chain_id,
+                bundles: Vec::new(),
+                events: Vec::new(),
+                blobs,
+            },
+            other => other,
+        }
+    } else {
+        match error {
+            NodeError::MissingDependencies {
+                chain_id,
+                bundles,
+                events,
+                blobs,
+            } => {
+                if let Some((origin, height)) = bundles.into_iter().next() {
+                    NodeError::MissingCrossChainUpdate {
+                        chain_id,
+                        origin,
+                        height,
+                    }
+                } else if !events.is_empty() {
+                    NodeError::EventsNotFound(events)
+                } else if !blobs.is_empty() {
+                    NodeError::BlobsNotFound(blobs)
+                } else {
+                    NodeError::ChainError {
+                        error: "missing dependencies".to_string(),
+                    }
+                }
+            }
+            other => other,
+        }
+    }
+}
+
 #[cfg(with_metrics)]
 mod metrics {
     use std::sync::LazyLock;
@@ -742,7 +800,10 @@ where
         request: Request<BlockProposal>,
     ) -> Result<Response<ChainInfoResult>, Status> {
         let traffic_type = Self::get_traffic_type(&request);
-        let proposal = request.into_inner().try_into()?;
+        let proto = request.into_inner();
+        let supports_aggregated = proto.supports_aggregated_missing;
+        let proposal: linera_chain::data_types::BlockProposal = proto.try_into()?;
+        let chain_id = proposal.content.block.chain_id;
         trace!(?proposal, "Handling block proposal");
         let (result, actions) = self.state.clone().handle_block_proposal(proposal).await;
         // Dispatch actions whether or not the proposal was accepted: a rejected
@@ -758,7 +819,8 @@ where
             Err(error) => {
                 Self::log_request_error("handle_block_proposal", traffic_type, &error.error_type());
                 self.log_error(&error, "Failed to handle block proposal");
-                NodeError::from(error).try_into()?
+                adapt_dependency_error(NodeError::from(error), chain_id, supports_aggregated)
+                    .try_into()?
             }
         }))
     }
@@ -826,10 +888,13 @@ where
         request: Request<api::HandleConfirmedCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
         let traffic_type = Self::get_traffic_type(&request);
+        let proto = request.into_inner();
+        let supports_aggregated = proto.supports_aggregated_missing;
         let HandleConfirmedCertificateRequest {
             certificate,
             wait_for_outgoing_messages,
-        } = request.into_inner().try_into()?;
+        } = proto.try_into()?;
+        let chain_id = certificate.inner().chain_id();
         trace!(?certificate, "Handling certificate");
         let (sender, receiver) = wait_for_outgoing_messages.then(oneshot::channel).unzip();
         match self
@@ -855,7 +920,10 @@ where
                     &error.error_type(),
                 );
                 self.log_error(&error, "Failed to handle confirmed certificate");
-                Ok(Response::new(NodeError::from(error).try_into()?))
+                Ok(Response::new(
+                    adapt_dependency_error(NodeError::from(error), chain_id, supports_aggregated)
+                        .try_into()?,
+                ))
             }
         }
     }
@@ -1180,5 +1248,98 @@ impl GrpcProxyable for CrossChainRequest {
                 recipient.clone()?.try_into().ok()
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod dependency_error_tests {
+    use linera_base::{
+        crypto::CryptoHash,
+        data_types::BlockHeight,
+        identifiers::{BlobId, BlobType, ChainId, EventId, StreamId},
+    };
+    use linera_core::node::NodeError;
+
+    use super::adapt_dependency_error;
+
+    fn chain(name: &str) -> ChainId {
+        ChainId(CryptoHash::test_hash(name))
+    }
+
+    fn event() -> EventId {
+        EventId {
+            chain_id: chain("publisher"),
+            stream_id: StreamId::system(b"s".to_vec()),
+            index: 0,
+        }
+    }
+
+    fn blob() -> BlobId {
+        BlobId::new(CryptoHash::test_hash("blob"), BlobType::Data)
+    }
+
+    #[test]
+    fn capable_client_gets_aggregated_errors() {
+        let cid = chain("target");
+        // Legacy per-item errors are lifted into the aggregated shape.
+        assert!(matches!(
+            adapt_dependency_error(NodeError::EventsNotFound(vec![event()]), cid, true),
+            NodeError::MissingDependencies { events, .. } if events == vec![event()]
+        ));
+        assert!(matches!(
+            adapt_dependency_error(NodeError::BlobsNotFound(vec![blob()]), cid, true),
+            NodeError::MissingDependencies { blobs, .. } if blobs == vec![blob()]
+        ));
+        // An already-aggregated error passes through unchanged.
+        let aggregated = NodeError::MissingDependencies {
+            chain_id: cid,
+            bundles: vec![],
+            events: vec![event()],
+            blobs: vec![],
+        };
+        assert_eq!(
+            adapt_dependency_error(aggregated.clone(), cid, true),
+            aggregated
+        );
+    }
+
+    #[test]
+    fn legacy_client_gets_downgraded_errors() {
+        let cid = chain("target");
+        let origin = chain("origin");
+        let height = BlockHeight::from(7);
+        // Bundles take priority and downgrade to the per-origin legacy error.
+        let with_bundles = NodeError::MissingDependencies {
+            chain_id: cid,
+            bundles: vec![(origin, height)],
+            events: vec![event()],
+            blobs: vec![blob()],
+        };
+        assert!(matches!(
+            adapt_dependency_error(with_bundles, cid, false),
+            NodeError::MissingCrossChainUpdate { origin: o, height: h, .. }
+                if o == origin && h == height
+        ));
+        // Events-only and blobs-only downgrade to their respective legacy errors.
+        let events_only = NodeError::MissingDependencies {
+            chain_id: cid,
+            bundles: vec![],
+            events: vec![event()],
+            blobs: vec![],
+        };
+        assert!(matches!(
+            adapt_dependency_error(events_only, cid, false),
+            NodeError::EventsNotFound(events) if events == vec![event()]
+        ));
+        let blobs_only = NodeError::MissingDependencies {
+            chain_id: cid,
+            bundles: vec![],
+            events: vec![],
+            blobs: vec![blob()],
+        };
+        assert!(matches!(
+            adapt_dependency_error(blobs_only, cid, false),
+            NodeError::BlobsNotFound(blobs) if blobs == vec![blob()]
+        ));
     }
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -821,7 +821,7 @@ NodeError:
           - remote_node:
               TYPENAME: Secp256k1PublicKey
     31:
-      MissingDependencies:
+      MissingCrossChainUpdates:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
@@ -830,12 +830,6 @@ NodeError:
                 TUPLE:
                   - TYPENAME: ChainId
                   - TYPENAME: BlockHeight
-          - events:
-              SEQ:
-                TYPENAME: EventId
-          - blobs:
-              SEQ:
-                TYPENAME: BlobId
 OpenChainConfig:
   STRUCT:
     - ownership:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -820,6 +820,22 @@ NodeError:
               TYPENAME: ChainId
           - remote_node:
               TYPENAME: Secp256k1PublicKey
+    31:
+      MissingDependencies:
+        STRUCT:
+          - chain_id:
+              TYPENAME: ChainId
+          - bundles:
+              SEQ:
+                TUPLE:
+                  - TYPENAME: ChainId
+                  - TYPENAME: BlockHeight
+          - events:
+              SEQ:
+                TYPENAME: EventId
+          - blobs:
+              SEQ:
+                TYPENAME: BlobId
 OpenChainConfig:
   STRUCT:
     - ownership:


### PR DESCRIPTION
## Motivation

A client that owns a busy hub chain (one receiving cross-chain messages from many sender chains) periodically froze for minutes and tripped the chain-idle liveness probe, restarting the process.

(Likely) Root cause: when a validator is behind on the sender chains a block consumes, it rejects the proposal **one missing sender at a time** (`MissingCrossChainUpdate`), and the client brings it up to date with **one blocking round-trip per sender**. Accepting a single high-fan-out block therefore takes ~N sequential `propose → sync-one-sender → retry` round-trips per validator, and because per-chain block production is a single task gated on a quorum, this serializes into multi-minute stalls (observed `process_inbox` p99 ≈ 8.7 min during a freeze). An operational mitigation (`maxPendingMessageBundles=1`) is already deployed; this is the protocol-level fix.

## Proposal

Add an aggregated error, `MissingCrossChainUpdates { chain_id, bundles }` — the batched form of `MissingCrossChainUpdate` — that lets a validator declare **every** missing incoming bundle it needs to validate a block proposal in a single response, and have the client fetch them all in one batch before retrying.

Concretely:
- When validating a proposal, the validator now **collects all** missing cross-chain bundles instead of bailing on the first, and returns them together as `(origin, height)` pairs.
- The client handles `MissingCrossChainUpdates` on the block-proposal path, syncing every reported origin chain in a single batch (via `send_chain_info_up_to_heights`) and retrying once. The local node's "download missing sender blocks from a validator" path is batched the same way: all reported senders are fetched, then the proposal is retried once.

This deliberately targets **proposals only**. Confirmed certificates don't have the same pathology: missing incoming bundles are tolerated (`must_be_present=false`), missing blobs are already discovered up front from `required_blob_ids` and returned as a single `BlobsNotFound`, and the only relevant missing events (the committee/epoch stream) are already batched into one `EventsNotFound`. So there is no O(N)-round-trip problem to fix there, and the confirmed-certificate path is left on its existing batched errors.

Because clients and validators are upgraded independently, the change is **backward compatible**. The wire error is appended without disturbing existing ones, and a new `supports_aggregated_missing` field on the proposal / confirmed-certificate requests lets a client advertise that it understands the aggregated error. The validator adapts its reply accordingly at the gRPC boundary: capable clients receive every missing sender as `MissingCrossChainUpdates`; older clients are downgraded to the legacy per-sender `MissingCrossChainUpdate` (the first missing sender) and recover one round-trip at a time, exactly as before. All four old/new client/validator combinations interoperate.

A separate follow-up will retire the legacy one-at-a-time path once every deployed node understands the aggregated error.

## Test Plan

- A worker-level test asserts that a proposal consuming several not-yet-received bundles is rejected with a single `MissingCrossChainUpdates` listing **all** of them (rather than bailing on the first).
- A client-level integration test (`test_proposal_batches_missing_dependency_catch_up`) drives the full path end to end: a block consuming bundles from three sender chains is proposed to a validator that is behind on **all** of them; the validator reports one aggregated error, the client catches every sender up in a single batch, and the block is confirmed. The test also confirms the loop terminates.
- Unit tests cover the gRPC error adaptation in both directions: capable clients get `MissingCrossChainUpdates` unchanged; older clients get it downgraded to the legacy per-sender `MissingCrossChainUpdate`.
- Unit tests cover the wire round-trip of the new error (bincode-in-protobuf) and the chain-to-node error mapping.
- `cargo clippy --all-targets` (incl. `--features server`), `cargo +nightly fmt`, and the affected crates' test suites pass.

## Release Plan

Targets `testnet_conway` for now. The new error variant is additive and inert until validators are upgraded; the capability handshake keeps the rollout safe for any mix of upgraded and non-upgraded clients and validators. Changing the wire error set requires a coordinated validator/client deployment.
