### PR TITLE
bridge-demo: read EVM balances via direct RPC, not the wallet provider

### DIFF
--- a/examples/bridge-demo/index.html
+++ b/examples/bridge-demo/index.html
@@ -410,6 +410,13 @@
       const TOKEN_ADDRESS    = import.meta.env.LINERA_TOKEN_ADDRESS;    // ERC-20 on EVM
       const BRIDGE_CHAIN_ID  = import.meta.env.LINERA_BRIDGE_CHAIN_ID;  // relay's chain
       const EVM_CHAIN_ID     = import.meta.env.LINERA_EVM_CHAIN_ID || '31337';
+      // Browser-reachable EVM RPC for READ-ONLY calls (balances, tx receipts).
+      // These go straight to the node via a JsonRpcProvider rather than through
+      // the wallet: a balanceOf is a public view call and must not depend on
+      // MetaMask's per-site request queue, which can stall and leave the read
+      // hanging forever. The wallet (evmSigner) is still used for signing/sending.
+      const EVM_RPC_URL      = import.meta.env.LINERA_EVM_RPC_URL || 'http://localhost:8545';
+      const readProvider     = new ethers.JsonRpcProvider(EVM_RPC_URL);
 
       // ── Minimal ABIs ──
       const ERC20_ABI = [
@@ -459,9 +466,9 @@
 
       // ── EVM balance ──
       async function updateEvmBalance() {
-        if (!evmProvider || !evmAddress) return;
+        if (!evmAddress) return;
         try {
-          const token = new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, evmProvider);
+          const token = new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, readProvider);
           const balance = await token.balanceOf(evmAddress);
           // ERC-20 uses 18 decimals
           $('#evm-balance').textContent = ethers.formatUnits(balance, 18);
@@ -522,7 +529,7 @@
       async function waitForTx(hash, timeoutMs = 120_000, intervalMs = 3_000) {
         const deadline = Date.now() + timeoutMs;
         while (Date.now() < deadline) {
-          const receipt = await evmProvider.getTransactionReceipt(hash);
+          const receipt = await readProvider.getTransactionReceipt(hash);
           if (receipt) return receipt;
           await new Promise(r => setTimeout(r, intervalMs));
         }
@@ -608,14 +615,14 @@
           setStatus('Step 2/3: Waiting for relay to forward the burn to EVM...');
 
           // Step 3: Poll EVM balance
-          const initialBalance = await new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, evmProvider)
+          const initialBalance = await new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, readProvider)
             .balanceOf(evmAddress);
 
           setStatus('Step 3/3: Polling EVM balance...');
           const deadline = Date.now() + 60_000;
           while (Date.now() < deadline) {
             await new Promise(r => setTimeout(r, 1000));
-            const current = await new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, evmProvider)
+            const current = await new ethers.Contract(TOKEN_ADDRESS, ERC20_ABI, readProvider)
               .balanceOf(evmAddress);
             if (current > initialBalance) {
               setStatus('Withdrawal complete!');

--- a/examples/bridge-demo/setup.sh
+++ b/examples/bridge-demo/setup.sh
@@ -137,6 +137,10 @@ CONTRACTS_DIR="${CONTRACTS_DIR:-/contracts}"
 OUTPUT_FILE="${OUTPUT_FILE:-$SCRIPT_DIR/.env.local}"
 FAUCET_URL="${FAUCET_URL:-http://localhost:8080}"
 RELAY_URL="${RELAY_URL:-http://localhost:3001}"
+# Browser-reachable EVM RPC for the frontend's read-only calls (balances, tx
+# receipts). The relay/forge use EVM_RPC_URL (the in-container `anvil` host),
+# which a browser can't resolve; the frontend reads via this localhost URL.
+BROWSER_EVM_RPC_URL="${BROWSER_EVM_RPC_URL:-http://localhost:8545}"
 # Docker container has its own solc; don't force a version download.
 FORGE_USE_SOLC=()
 
@@ -411,6 +415,7 @@ LINERA_BRIDGE_ADDRESS=$BRIDGE_ADDRESS
 LINERA_TOKEN_ADDRESS=$TOKEN_ADDRESS
 LINERA_BRIDGE_CHAIN_ID=$BRIDGE_CHAIN_ID
 LINERA_EVM_CHAIN_ID=$EVM_CHAIN_ID
+LINERA_EVM_RPC_URL=$BROWSER_EVM_RPC_URL
 EOF
 
 # Write setup-complete marker so the relay knows it's safe to start.


### PR DESCRIPTION
## Motivation

The `bridge-demo` frontend reads the EVM token balance (and transaction
receipts) through MetaMask's injected `BrowserProvider`. That couples a plain
`balanceOf` view call to the wallet's RPC endpoint and its serialized, per-site
request queue. If the wallet's RPC can't be reached or its queue stalls, the
read hangs forever with no error and the balance display is stuck on `—`, even
though the node is reachable and a direct RPC read returns the value instantly.

## Proposal

Read-only EVM calls no longer go through the wallet:

- Add a direct `ethers.JsonRpcProvider` (`readProvider`), built from a new
  `LINERA_EVM_RPC_URL` env var (default `http://localhost:8545`).
- Use it for all view calls: token `balanceOf` (balance display + withdraw
  polling) and `getTransactionReceipt`.
- The wallet (`evmSigner` / `BrowserProvider`) is still used for everything that
  must be signed and broadcast: `approve`, `deposit`, and the withdraw burn.
- `setup.sh` writes `LINERA_EVM_RPC_URL` into `.env.local` (a browser-reachable
  `localhost` host, as opposed to the relay/forge's in-container `anvil` host).

Rationale: `balanceOf` is a public view call and shouldn't depend on the
wallet's RPC configuration or request queue — wallet for signing, direct RPC for
reads.

## Test Plan

Manual testing against the local bridge-demo stack (Anvil + Linera network via
docker-compose):

- **Before:** with the wallet's RPC unreachable/stalled, the balance stays `—`
  indefinitely with no error; confirmed the `balanceOf` call hangs through
  `BrowserProvider` while a direct `JsonRpcProvider` to the *same* node returns
  the correct balance instantly.
- **After:** the balance displays correctly (reads go straight to the node), and
  deposit/withdraw still sign and broadcast through the wallet.

No automated tests — this is a frontend-only HTML/JS change in an example with no
test suite.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Frontend-only change to `examples/bridge-demo` (no protocol, SDK, or storage impact).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)