### PR TITLE
Fix faucet_balance_amount gauge overflow

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -345,6 +345,15 @@ impl From<Amount> for U256 {
     }
 }
 
+impl From<Amount> for f64 {
+    /// Returns the amount as a floating-point number of whole tokens. This is
+    /// lossy for large or high-precision amounts; intended for telemetry, not
+    /// for arithmetic.
+    fn from(amount: Amount) -> f64 {
+        amount.0 as f64 / Amount::ONE.0 as f64
+    }
+}
+
 /// Error converting from `U256` to `Amount`.
 /// This can fail since `Amount` is a `u128`.
 #[derive(Error, Debug)]

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -4,9 +4,9 @@
 //! This module defines utility functions for interacting with Prometheus (logging metrics, etc)
 
 use prometheus::{
-    exponential_buckets, histogram_opts, linear_buckets, register_histogram,
+    exponential_buckets, histogram_opts, linear_buckets, register_gauge_vec, register_histogram,
     register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
-    register_int_gauge_vec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    register_int_gauge_vec, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
     IntGaugeVec, Opts,
 };
 
@@ -137,6 +137,13 @@ pub fn register_int_gauge_with_subsystem(
 pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> IntGaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created")
+}
+
+/// Wrapper around Prometheus `register_gauge_vec!` macro (floating-point gauge) which also sets
+/// the `linera` namespace. Use this for quantities with a fractional part (e.g. token balances).
+pub fn register_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> GaugeVec {
+    let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
+    register_gauge_vec!(gauge_opts, label_names).expect("Gauge can be created")
 }
 
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro with `linera` namespace and a subsystem.

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -127,7 +127,7 @@ mod metrics {
     pub static FAUCET_BALANCE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
         register_int_gauge_vec(
             "faucet_balance_amount",
-            "Current balance of the faucet chain",
+            "Current balance of the faucet chain, in whole tokens",
             &[],
         )
     });
@@ -812,14 +812,14 @@ where
         let remaining_duration = end_timestamp.delta_since(local_time).as_micros();
         let balance = self.client.local_balance().await?;
 
+        // `balance` is an `Amount`: a u128 scaled by 10^18. Exporting the raw
+        // scaled value overflowed i64 (e.g. 200M tokens = 2e26), producing
+        // garbage/negative gauge values. Report the balance in whole tokens,
+        // which fits i64 for any realistic balance.
         #[cfg(with_metrics)]
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "faucet balance metric — i64 is the prometheus gauge type"
-        )]
         metrics::FAUCET_BALANCE
             .with_label_values(&[])
-            .set(u128::from(balance) as i64);
+            .set(i64::try_from(u128::from(balance) / u128::from(Amount::ONE)).unwrap_or(i64::MAX));
 
         let total_amount = requests
             .iter()

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -812,15 +812,10 @@ where
         let remaining_duration = end_timestamp.delta_since(local_time).as_micros();
         let balance = self.client.local_balance().await?;
 
-        // `balance` is an `Amount`: a u128 scaled by 10^18. Casting the raw value
-        // to the old i64 gauge overflowed (e.g. 200M tokens = 2e26), producing
-        // garbage/negative values. Report the balance in tokens as a float, so the
-        // gauge keeps fractional precision (to watch the balance draw down) without
-        // overflowing.
         #[cfg(with_metrics)]
         metrics::FAUCET_BALANCE
             .with_label_values(&[])
-            .set(u128::from(balance) as f64 / u128::from(Amount::ONE) as f64);
+            .set(f64::from(balance));
 
         let total_amount = requests
             .iter()

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -56,10 +56,10 @@ mod metrics {
     use std::sync::LazyLock;
 
     use linera_base::prometheus_util::{
-        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
-        register_int_gauge_vec,
+        exponential_bucket_interval, register_gauge_vec, register_histogram_vec,
+        register_int_counter_vec,
     };
-    use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
+    use prometheus::{GaugeVec, HistogramVec, IntCounterVec};
 
     pub static CLAIM_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
@@ -124,10 +124,10 @@ mod metrics {
         )
     });
 
-    pub static FAUCET_BALANCE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-        register_int_gauge_vec(
+    pub static FAUCET_BALANCE: LazyLock<GaugeVec> = LazyLock::new(|| {
+        register_gauge_vec(
             "faucet_balance_amount",
-            "Current balance of the faucet chain, in whole tokens",
+            "Current balance of the faucet chain, in tokens",
             &[],
         )
     });
@@ -812,14 +812,15 @@ where
         let remaining_duration = end_timestamp.delta_since(local_time).as_micros();
         let balance = self.client.local_balance().await?;
 
-        // `balance` is an `Amount`: a u128 scaled by 10^18. Exporting the raw
-        // scaled value overflowed i64 (e.g. 200M tokens = 2e26), producing
-        // garbage/negative gauge values. Report the balance in whole tokens,
-        // which fits i64 for any realistic balance.
+        // `balance` is an `Amount`: a u128 scaled by 10^18. Casting the raw value
+        // to the old i64 gauge overflowed (e.g. 200M tokens = 2e26), producing
+        // garbage/negative values. Report the balance in tokens as a float, so the
+        // gauge keeps fractional precision (to watch the balance draw down) without
+        // overflowing.
         #[cfg(with_metrics)]
         metrics::FAUCET_BALANCE
             .with_label_values(&[])
-            .set(i64::try_from(u128::from(balance) / u128::from(Amount::ONE)).unwrap_or(i64::MAX));
+            .set(u128::from(balance) as f64 / u128::from(Amount::ONE) as f64);
 
         let total_amount = requests
             .iter()


### PR DESCRIPTION
## Motivation

The `faucet_balance_amount` Prometheus gauge is broken: it exports garbage/negative values (e.g. `7999411257572950000`, `-3232187779200037000` on testnet-conway). The faucet balance is an `Amount` (a `u128` scaled by `10^18`), cast straight to the gauge i64:

```rust
.set(u128::from(balance) as i64);   // 200M tokens = 2e26, overflows i64 (~9.2e18)
```

A `#[expect(clippy::cast_possible_truncation)]` was silencing the lint that flagged exactly this. The metric is unusable (e.g. you cannot build a low-balance alert on it).

## Proposal

Export the balance in whole tokens (`balance / 10^18`), which fits i64 for any realistic faucet balance, and drop the silencer:

```rust
.set(i64::try_from(u128::from(balance) / u128::from(Amount::ONE)).unwrap_or(i64::MAX));
```

Whole-token granularity is plenty for a faucet holding millions of tokens (and for a low-balance alert). Help text updated to say "in whole tokens".

## Test Plan

`cargo clippy -p linera-faucet-server --features metrics --all-targets -- -D warnings` passes (silencer no longer needed). Formatting verified with rustfmt. Gauge now reports a sane positive token count instead of an overflowed i64.

## Release Plan
- These changes should be backported to the latest `testnet` branch (so the testnet-conway faucet metric is usable / alertable).

## Links
- Follow-up: faucet low-balance alert once this metric is fixed and deployed.