### PR TITLE
Add a `describe-application` CLI command

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -33,6 +33,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera list-events-from-index`↴](#linera-list-events-from-index)
 * [`linera publish-data-blob`↴](#linera-publish-data-blob)
 * [`linera read-data-blob`↴](#linera-read-data-blob)
+* [`linera describe-application`↴](#linera-describe-application)
 * [`linera create-application`↴](#linera-create-application)
 * [`linera publish-and-create`↴](#linera-publish-and-create)
 * [`linera keygen`↴](#linera-keygen)
@@ -112,6 +113,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `list-events-from-index` — Print events from a specific chain and stream from a specified index
 * `publish-data-blob` — Publish a data blob of binary data
 * `read-data-blob` — Verify that a data blob is readable
+* `describe-application` — Describe an existing application: print its `ApplicationDescription` (module ID, creator chain, parameters and required dependencies) as JSON. The description is content-addressed and fetched from the validators, so the application need not be registered on the wallet's default chain
 * `create-application` — Create an application
 * `publish-and-create` — Create an application, and publish the required module
 * `keygen` — Create an unassigned key pair
@@ -926,6 +928,18 @@ Verify that a data blob is readable
 
 * `<HASH>` — The hash of the content
 * `<READER>` — An optional chain ID to verify the blob. The default chain of the wallet is used otherwise
+
+
+
+## `linera describe-application`
+
+Describe an existing application: print its `ApplicationDescription` (module ID, creator chain, parameters and required dependencies) as JSON. The description is content-addressed and fetched from the validators, so the application need not be registered on the wallet's default chain
+
+**Usage:** `linera describe-application <APPLICATION_ID>`
+
+###### **Arguments:**
+
+* `<APPLICATION_ID>` — The ID of the application to describe
 
 
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -20,8 +20,8 @@ use linera_base::{
     abi::Abi,
     crypto::{signer, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
-        ChainDescription, Epoch, MessagePolicy, Round, TimeDelta, Timestamp,
+        Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlobContent,
+        BlockHeight, ChainDescription, Epoch, MessagePolicy, Round, TimeDelta, Timestamp,
     },
     ensure,
     identifiers::{
@@ -583,6 +583,18 @@ impl<Env: Environment> ChainClient<Env> {
     /// Returns the chain's description. Fetches it from the validators if necessary.
     pub async fn get_chain_description(&self) -> Result<ChainDescription, Error> {
         self.client.get_chain_description(self.chain_id).await
+    }
+
+    /// Returns the description of the given application. Fetches the description blob
+    /// from the validators if necessary; the application need not be registered on
+    /// this client's chain.
+    pub async fn get_application_description(
+        &self,
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, Error> {
+        self.client
+            .get_application_description(application_id)
+            .await
     }
 
     /// Obtains up to `self.options.max_pending_message_bundles` pending message bundles for the

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -19,11 +19,12 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::{CryptoHash, Signer as _, ValidatorPublicKey},
     data_types::{
-        ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, Round, TimeDelta, Timestamp,
+        ApplicationDescription, ArithmeticError, Blob, BlockHeight, ChainDescription, Epoch, Round,
+        TimeDelta, Timestamp,
     },
     ensure,
     hashed::Hashed,
-    identifiers::{AccountOwner, BlobId, BlobType, ChainId, EventId, StreamId},
+    identifiers::{AccountOwner, ApplicationId, BlobId, BlobType, ChainId, EventId, StreamId},
     time::Duration,
 };
 #[cfg(not(target_arch = "wasm32"))]
@@ -1144,6 +1145,43 @@ impl<Env: Environment> Client<Env> {
         chain_id: ChainId,
     ) -> Result<ChainDescription, chain_client::Error> {
         let blob = self.get_chain_description_blob(chain_id).await?;
+        Ok(bcs::from_bytes(blob.bytes())?)
+    }
+
+    /// Ensures that the client has the `ApplicationDescription` blob for the given
+    /// application ID, fetching it from the current validators if it is not available
+    /// locally, and returns the blob. The application need not be registered on this
+    /// client's chain: the description is content-addressed and downloaded by blob ID.
+    pub async fn get_application_description_blob(
+        &self,
+        application_id: ApplicationId,
+    ) -> Result<Arc<Blob>, chain_client::Error> {
+        let blob_id = application_id.description_blob_id();
+        let blob = self.local_node.storage_client().read_blob(blob_id).await?;
+        if let Some(blob) = blob {
+            // We have the blob - return it.
+            return Ok(blob.into_std());
+        }
+        // Recover the blob from the current validators, according to the admin chain.
+        Box::pin(self.synchronize_chain_state(self.admin_chain_id)).await?;
+        let nodes = self.validator_nodes().await?;
+        Ok(self
+            .update_local_node_with_blobs_from(vec![blob_id], &nodes)
+            .await?
+            .pop()
+            .unwrap() // Returns exactly as many blobs as passed-in IDs.
+            .into_std())
+    }
+
+    /// Returns the `ApplicationDescription` of the given application, fetching its
+    /// description blob from the validators if it is not available locally.
+    pub async fn get_application_description(
+        &self,
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, chain_client::Error> {
+        let blob = self
+            .get_application_description_blob(application_id)
+            .await?;
         Ok(bcs::from_bytes(blob.bytes())?)
     }
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -963,6 +963,15 @@ pub enum ClientCommand {
         reader: Option<ChainId>,
     },
 
+    /// Describe an existing application: print its `ApplicationDescription` (module
+    /// ID, creator chain, parameters and required dependencies) as JSON. The
+    /// description is content-addressed and fetched from the validators, so the
+    /// application need not be registered on the wallet's default chain.
+    DescribeApplication {
+        /// The ID of the application to describe.
+        application_id: ApplicationId,
+    },
+
     /// Create an application.
     CreateApplication {
         /// The module ID of the application to create.
@@ -1150,6 +1159,7 @@ impl ClientCommand {
             | ClientCommand::ListEventsFromIndex { .. }
             | ClientCommand::PublishDataBlob { .. }
             | ClientCommand::ReadDataBlob { .. }
+            | ClientCommand::DescribeApplication { .. }
             | ClientCommand::CreateApplication { .. }
             | ClientCommand::PublishAndCreate { .. }
             | ClientCommand::Keygen

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1467,6 +1467,25 @@ impl Runnable for Job {
                 info!("Data blob read in {} ms", start_time.elapsed().as_millis());
             }
 
+            DescribeApplication { application_id } => {
+                let context = options
+                    .create_client_context(storage, wallet, keystore)
+                    .await?;
+
+                let start_time = Instant::now();
+                let reader = context.default_chain();
+                info!("Describing application {application_id} via chain {reader}");
+                let chain_client = context.make_chain_client(reader).await?;
+                let description = chain_client
+                    .get_application_description(application_id)
+                    .await?;
+                println!("{}", serde_json::to_string_pretty(&description)?);
+                info!(
+                    "Application described in {} ms",
+                    start_time.elapsed().as_millis()
+                );
+            }
+
             CreateApplication {
                 module_id,
                 creator,


### PR DESCRIPTION
## Motivation

Tooling around the `formats-registry` (and the explorer) needs to map an
application ID to its `ModuleId` — e.g. to register an existing application's
formats after the fact. Today there is no way to fetch an application's
description from the CLI; `applications(chainId:)` in the node service only lists
applications already registered on a *specific* chain, so an arbitrary
application can't be looked up from another chain.

## What this does

Adds `linera describe-application <application-id> [reader]`, which prints the
application's `ApplicationDescription` (module ID, creator chain, parameters and
required dependencies) as JSON:

```console
$ linera describe-application <APP_ID> | jq -r .module_id
<MODULE_ID>
```

The description blob is content-addressed and fetched from the validators by
blob ID, so the **reader chain need not host the application** — the wallet's
default chain works.

## Implementation

- `Client::get_application_description_blob` / `get_application_description`
  (linera-core) — read the description blob, downloading it from the validators
  if it is not available locally, mirroring the existing
  `get_chain_description{,_blob}` helpers.
- `ChainClient::get_application_description` — thin delegating wrapper.
- `DescribeApplication` CLI command + dispatch.