### PR TITLE
Encode the application formats blob as BCS instead of JSON

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -886,7 +886,7 @@ Publish module
 * `--vm-runtime <VM_RUNTIME>` — The virtual machine runtime to use
 
   Default value: `wasm`
-* `--formats <FORMATS>` — Optional path to an insta SNAP file containing the YAML serialization of the application's `Formats`. When provided, the formats are JSON-encoded and published as a third blob alongside the contract and service blobs; the resulting `ModuleId` carries the formats blob hash
+* `--formats <FORMATS>` — Optional path to an insta SNAP file containing the YAML serialization of the application's `Formats`. When provided, the formats are BCS-encoded and published as a third blob alongside the contract and service blobs; the resulting `ModuleId` carries the formats blob hash
 
 
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1710,7 +1710,7 @@ impl BlobContent {
         BlobContent::new(BlobType::ApplicationDescription, bytes)
     }
 
-    /// Creates a new application formats [`BlobContent`] from the JSON-encoded
+    /// Creates a new application formats [`BlobContent`] from the BCS-encoded
     /// `Formats` description bytes.
     pub fn new_application_formats(bytes: impl Into<Box<[u8]>>) -> Self {
         BlobContent::new(BlobType::ApplicationFormats, bytes)
@@ -1832,7 +1832,7 @@ impl Blob {
         ))
     }
 
-    /// Creates a new application formats [`Blob`] from the JSON-encoded
+    /// Creates a new application formats [`Blob`] from the BCS-encoded
     /// `Formats` description bytes.
     pub fn new_application_formats(bytes: impl Into<Box<[u8]>>) -> Self {
         Blob::new(BlobContent::new_application_formats(bytes))

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -271,7 +271,7 @@ pub enum BlobType {
     Committee,
     /// A blob containing a chain description.
     ChainDescription,
-    /// A blob containing the JSON-encoded `Formats` description published
+    /// A blob containing the BCS-encoded `Formats` description published
     /// alongside an application's contract and service blobs.
     ApplicationFormats,
     /// A blob containing one ordered chunk of a chain's execution-state dump at a
@@ -527,7 +527,7 @@ pub struct ModuleId<Abi = (), Parameters = (), InstantiationArgument = ()> {
     pub service_blob_hash: CryptoHash,
     /// The virtual machine being used.
     pub vm_runtime: VmRuntime,
-    /// The hash of an optional blob containing the JSON-encoded `Formats`
+    /// The hash of an optional blob containing the BCS-encoded `Formats`
     /// description for this module's application. Published alongside the
     /// contract and service blobs when available.
     pub formats_blob_hash: Option<CryptoHash>,

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -961,8 +961,10 @@ impl<Env: Environment> ClientContext<Env> {
 }
 
 /// Reads an insta SNAP file containing a YAML-encoded `Formats` value, parses
-/// it, and returns the canonical JSON encoding to publish as the application
-/// formats blob.
+/// it, and returns the canonical BCS encoding to publish as the application
+/// formats blob. BCS matches the documented intent (the blob is "the BCS
+/// serialization of an application's `Formats`") and the encoding the explorer
+/// decodes with.
 #[cfg(feature = "fs")]
 fn load_formats_from_snap(path: &std::path::Path) -> Result<Vec<u8>, Error> {
     let content = fs::read_to_string(path).map_err(|e| {
@@ -980,13 +982,7 @@ fn load_formats_from_snap(path: &std::path::Path) -> Result<Vec<u8>, Error> {
             format!("failed to parse SNAP body in {path:?} as Formats: {e}"),
         )
     })?;
-    serde_json::to_vec(&formats).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("failed to serialize Formats as JSON: {e}"),
-        )
-        .into()
-    })
+    Ok(bcs::to_bytes(&formats)?)
 }
 
 #[cfg(feature = "fs")]

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -873,7 +873,7 @@ impl<Env: Environment> ClientContext<Env> {
         })?;
 
         let formats_bytes = match formats {
-            Some(path) => Some(load_formats_from_snap(&path)?),
+            Some(path) => Some(bcs::to_bytes(&load_formats_from_snap(&path)?)?),
             None => None,
         };
 
@@ -960,13 +960,13 @@ impl<Env: Environment> ClientContext<Env> {
     }
 }
 
-/// Reads an insta SNAP file containing a YAML-encoded `Formats` value, parses
-/// it, and returns the canonical BCS encoding to publish as the application
-/// formats blob. BCS matches the documented intent (the blob is "the BCS
+/// Reads an insta SNAP file containing a YAML-encoded `Formats` value and parses
+/// it. The caller BCS-serializes the result to obtain the application formats
+/// blob payload: BCS matches the documented intent (the blob is "the BCS
 /// serialization of an application's `Formats`") and the encoding the explorer
 /// decodes with.
 #[cfg(feature = "fs")]
-fn load_formats_from_snap(path: &std::path::Path) -> Result<Vec<u8>, Error> {
+fn load_formats_from_snap(path: &std::path::Path) -> Result<linera_sdk::formats::Formats, Error> {
     let content = fs::read_to_string(path).map_err(|e| {
         std::io::Error::new(e.kind(), format!("failed to read SNAP file {path:?}: {e}"))
     })?;
@@ -976,13 +976,13 @@ fn load_formats_from_snap(path: &std::path::Path) -> Result<Vec<u8>, Error> {
             format!("SNAP file {path:?} is missing the `---` frontmatter delimiters"),
         )
     })?;
-    let formats: linera_sdk::formats::Formats = serde_yaml_08::from_str(body).map_err(|e| {
+    let formats = serde_yaml_08::from_str(body).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("failed to parse SNAP body in {path:?} as Formats: {e}"),
         )
     })?;
-    Ok(bcs::to_bytes(&formats)?)
+    Ok(formats)
 }
 
 #[cfg(feature = "fs")]

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2611,7 +2611,7 @@ impl<Env: Environment> ChainClient<Env> {
         }
     }
 
-    /// Publishes some module, optionally along with a JSON-encoded `Formats`
+    /// Publishes some module, optionally along with a BCS-encoded `Formats`
     /// description that becomes a third blob alongside contract and service.
     #[cfg(not(target_arch = "wasm32"))]
     #[instrument(level = "trace", skip(contract, service, formats))]

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2563,7 +2563,7 @@ impl CheckCertificateResult {
 }
 
 /// Creates a compressed Contract, Service and bytecode, plus an optional
-/// `ApplicationFormats` blob built from the JSON-encoded `Formats` description
+/// `ApplicationFormats` blob built from the BCS-encoded `Formats` description
 /// bytes.
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn create_bytecode_blobs(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1133,7 +1133,7 @@ pub trait ContractRuntime: BaseRuntime {
     fn create_data_blob(&mut self, bytes: Vec<u8>) -> Result<DataBlobHash, ExecutionError>;
 
     /// Publishes a module with contract and service bytecode and an optional
-    /// JSON-encoded `Formats` description, returning the module ID.
+    /// BCS-encoded `Formats` description, returning the module ID.
     fn publish_module(
         &mut self,
         contract: Bytecode,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1951,7 +1951,7 @@ impl From<&MessageContext> for ExecutingMessage {
 }
 
 /// Creates a compressed contract and service bytecode synchronously, plus an
-/// optional `ApplicationFormats` blob built from the JSON-encoded `Formats`
+/// optional `ApplicationFormats` blob built from the BCS-encoded `Formats`
 /// description bytes.
 pub fn create_bytecode_blobs_sync(
     contract: &Bytecode,

--- a/linera-execution/src/wasm/runtime_api.rs
+++ b/linera-execution/src/wasm/runtime_api.rs
@@ -667,7 +667,7 @@ where
     }
 
     /// Publishes a module with contract and service bytecode and an optional
-    /// JSON-encoded `Formats` description, returning the module ID.
+    /// BCS-encoded `Formats` description, returning the module ID.
     fn publish_module(
         caller: &mut Caller,
         contract: Bytecode,

--- a/linera-explorer/src/formats.rs
+++ b/linera-explorer/src/formats.rs
@@ -55,7 +55,7 @@ pub async fn fetch_formats(
                 .ok_or_else(|| anyhow!("application formats query returned non-u8 byte"))
         })
         .collect::<Result<_>>()?;
-    let formats: Formats = serde_json::from_slice(&bytes)
-        .context("formats blob did not deserialize as Formats JSON")?;
+    let formats: Formats = linera_sdk::bcs::from_bytes(&bytes)
+        .context("formats blob did not deserialize as Formats BCS")?;
     Ok(Some(formats))
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -440,7 +440,7 @@ where
     }
 
     /// Publishes a module with contract and service bytecode and an optional
-    /// JSON-encoded `Formats` description, returning the module ID.
+    /// BCS-encoded `Formats` description, returning the module ID.
     pub fn publish_module(
         &mut self,
         contract: Bytecode,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -1248,7 +1248,7 @@ type MutationRoot {
 		"""
 		vmRuntime: VmRuntime!,
 		"""
-		Optional JSON-encoded `Formats` description bytes
+		Optional BCS-encoded `Formats` description bytes
 		"""
 		formats: [Int!]
 	): ModuleId!
@@ -1496,7 +1496,7 @@ type QueryRoot {
 	"""
 	version: VersionInfo!
 	"""
-	Returns the bytes of an application formats blob (JSON-encoded `Formats`)
+	Returns the bytes of an application formats blob (BCS-encoded `Formats`)
 	stored in the local node, given the formats blob hash carried by a
 	`ModuleId`. Returns `None` if the blob is not present locally.
 	"""

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -901,7 +901,7 @@ pub enum ClientCommand {
 
         /// Optional path to an insta SNAP file containing the YAML serialization
         /// of the application's `Formats`. When provided, the formats are
-        /// JSON-encoded and published as a third blob alongside the contract
+        /// BCS-encoded and published as a third blob alongside the contract
         /// and service blobs; the resulting `ModuleId` carries the formats blob
         /// hash.
         #[arg(long)]

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -716,7 +716,7 @@ and no system operations."
         service: Bytecode,
         #[graphql(desc = "The virtual machine being used (either Wasm or Evm)")]
         vm_runtime: VmRuntime,
-        #[graphql(desc = "Optional JSON-encoded `Formats` description bytes")] formats: Option<
+        #[graphql(desc = "Optional BCS-encoded `Formats` description bytes")] formats: Option<
             Vec<u8>,
         >,
     ) -> Result<ModuleId, Error> {
@@ -921,7 +921,7 @@ where
         linera_version::VersionInfo::default()
     }
 
-    /// Returns the bytes of an application formats blob (JSON-encoded `Formats`)
+    /// Returns the bytes of an application formats blob (BCS-encoded `Formats`)
     /// stored in the local node, given the formats blob hash carried by a
     /// `ModuleId`. Returns `None` if the blob is not present locally.
     async fn application_formats(


### PR DESCRIPTION
## Motivation

On `testnet_conway`, #6555 migrated the formats-registry blob from JSON to BCS so the
encoding matches the documented intent ("the BCS serialization of an application's
`Formats`"). Most of #6555 targets the formats-registry *example application* and its
BCS-publication flow, which do not exist on `main` — `main` instead publishes the
application `Formats` as a plain data blob bundled with the module bytecode, and the
explorer fetches it by hash via the node's `applicationFormats` GraphQL query.

This PR brings #6555's *intent* to `main`'s own design: the formats blob was still being
JSON-encoded on the publish side and JSON-decoded by the explorer, even though it is
described everywhere as a BCS-encoded `Formats`. This makes the encoding match the docs
and the registry's own BCS conventions.

## Proposal

- Encode the formats blob as BCS at the publish site
  (`client_context::load_formats_from_snap`: `serde_json::to_vec` -> `bcs::to_bytes`).
- Decode it as BCS in the explorer
  (`linera-explorer/src/formats.rs`: `serde_json::from_slice` -> `linera_sdk::bcs::from_bytes`).
- Update the now-inaccurate doc comments / CLI help that described the blob as
  "JSON-encoded `Formats`" to "BCS-encoded `Formats`" across `linera-base`,
  `linera-core`, `linera-execution`, `linera-sdk`, `linera-service`, and `CLI.md`.

The GraphQL/JS-interop boundaries that are genuinely JSON (the node query envelope, the
explorer response parsing) are intentionally left as JSON. Only the blob payload changes.

This does **not** port #6555's formats-registry example app, registry ABI, or
`prepare_bcs_publication` flow, none of which exist on `main` (that registry-application
architecture is testnet-only; see the #6547 -> #6549 split for the same dividing line).

## Test Plan

- `cargo check -p linera-client -p linera-explorer` — clean.
- `cargo clippy -p linera-client -p linera-explorer` — clean.
- `cargo +nightly fmt --check` (with the CI's unstable opts) — clean.
- The blob is opaque bytes end-to-end except at the two endpoints changed here
  (encode in `linera-client`, decode in `linera-explorer`); BCS round-trips through the
  same `linera_sdk::formats::Formats` type.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Ports the blob-encoding migration from #6555 (testnet_conway) to `main`.
- Sibling SDK-layer port: #6549 (port of #6547).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
