### PR TITLE
explorer: env-only formats registry + formats caching

### DIFF
--- a/linera-explorer/src/components/App.vue
+++ b/linera-explorer/src/components/App.vue
@@ -13,18 +13,41 @@ import Transfer from './Transfer.vue'
 export default {
   data() { return data() },
   created() {
-    // The formats-registry chain/app id come exclusively from Vite env vars
-    // (e.g. a `.env.local`). They are runtime-only values on the Vue root — never
-    // persisted to localStorage and not editable in the navbar — so the explorer
-    // always decodes against the registry for the wallet it was launched with,
-    // with no stale stored value to shadow it.
-    const envChain = import.meta.env.VITE_FORMATS_REGISTRY_CHAIN as string | undefined
-    const envApp = import.meta.env.VITE_FORMATS_REGISTRY_APP_ID as string | undefined
-    this.formats_registry_chain = envChain || null
-    this.formats_registry_app_id = envApp || null
+    this.resolve_formats_registry()
+  },
+  computed: {
+    // True when both formats-registry values are pinned via Vite env vars (e.g.
+    // a `.env.local`). In that case the env values are authoritative and the
+    // navbar inputs are hidden; otherwise the inputs are shown and the values are
+    // entered manually and persisted to localStorage.
+    formats_registry_from_env(): boolean {
+      return Boolean(import.meta.env.VITE_FORMATS_REGISTRY_CHAIN && import.meta.env.VITE_FORMATS_REGISTRY_APP_ID)
+    }
   },
   methods: {
     save_config() { save_config(this) },
+    // Compute the effective formats-registry values used for decoding: the Vite
+    // env vars when set, otherwise the manual values persisted in `config`. The
+    // env vars win, so a stale stored value can never shadow the registry for the
+    // wallet the explorer was launched with. The result lives in runtime-only
+    // root fields (never persisted), which is what the wasm decoders read.
+    resolve_formats_registry() {
+      const envChain = import.meta.env.VITE_FORMATS_REGISTRY_CHAIN as string | undefined
+      const envApp = import.meta.env.VITE_FORMATS_REGISTRY_APP_ID as string | undefined
+      this.formats_registry_chain = (envChain || this.config.formats_registry_chain) || null
+      this.formats_registry_app_id = (envApp || this.config.formats_registry_app_id) || null
+    },
+    on_formats_registry_change() {
+      // Treat empty/whitespace as "unset" so the optional fields round-trip to
+      // None instead of failing to parse, then persist and re-resolve.
+      for (const k of ['formats_registry_chain', 'formats_registry_app_id']) {
+        if (typeof this.config[k] === 'string' && this.config[k].trim() === '') {
+          this.config[k] = null
+        }
+      }
+      save_config(this)
+      this.resolve_formats_registry()
+    },
     route(name?: string, args?: [string, string][]) { route(this, name, args) },
     decode_user_operation(application_id: string, bytes_hex: string) {
       return decode_user_operation(this, application_id, bytes_hex)
@@ -99,6 +122,13 @@ export default {
                 <input v-model="config.node" class="form-control" @change="save_config" style="width:190px">
                 <span class="input-group-text">indexer</span>
                 <input v-model="config.indexer" class="form-control" @change="save_config" style="width:190px">
+              </div>
+            </li>
+            <li class="nav-item mx-2" v-if="!formats_registry_from_env">
+              <div class="input-group">
+                <span class="input-group-text">formats registry</span>
+                <input v-model="config.formats_registry_chain" class="form-control font-monospace" placeholder="chain id" @change="on_formats_registry_change" style="width:200px">
+                <input v-model="config.formats_registry_app_id" class="form-control font-monospace" placeholder="application id" @change="on_formats_registry_change" style="width:200px">
               </div>
             </li>
             <li class="nav-item mx-2">

--- a/linera-explorer/src/components/App.vue
+++ b/linera-explorer/src/components/App.vue
@@ -13,34 +13,18 @@ import Transfer from './Transfer.vue'
 export default {
   data() { return data() },
   created() {
-    // Fill in formats-registry defaults from Vite env vars when they were not
-    // previously set in localStorage. Lets developers wire up dev-net values in
-    // a `.env.local` once instead of re-typing them after every restart.
+    // The formats-registry chain/app id come exclusively from Vite env vars
+    // (a `.env.local` written by scripts/explore-chain.sh). They are runtime-only
+    // values on the Vue root — never persisted to localStorage and not editable
+    // in the navbar — so the explorer always decodes against the registry for the
+    // wallet it was launched with, with no stale stored value to shadow it.
     const envChain = import.meta.env.VITE_FORMATS_REGISTRY_CHAIN as string | undefined
     const envApp = import.meta.env.VITE_FORMATS_REGISTRY_APP_ID as string | undefined
-    let dirty = false
-    if (envChain && !this.config.formats_registry_chain) {
-      this.config.formats_registry_chain = envChain
-      dirty = true
-    }
-    if (envApp && !this.config.formats_registry_app_id) {
-      this.config.formats_registry_app_id = envApp
-      dirty = true
-    }
-    if (dirty) save_config(this)
+    this.formats_registry_chain = envChain || null
+    this.formats_registry_app_id = envApp || null
   },
   methods: {
     save_config() { save_config(this) },
-    on_formats_registry_change() {
-      // Treat empty/whitespace as "unset" so the optional fields round-trip to
-      // None instead of failing to parse.
-      for (const k of ['formats_registry_chain', 'formats_registry_app_id']) {
-        if (typeof this.config[k] === 'string' && this.config[k].trim() === '') {
-          this.config[k] = null
-        }
-      }
-      save_config(this)
-    },
     route(name?: string, args?: [string, string][]) { route(this, name, args) },
     decode_user_operation(application_id: string, bytes_hex: string) {
       return decode_user_operation(this, application_id, bytes_hex)
@@ -115,13 +99,6 @@ export default {
                 <input v-model="config.node" class="form-control" @change="save_config" style="width:190px">
                 <span class="input-group-text">indexer</span>
                 <input v-model="config.indexer" class="form-control" @change="save_config" style="width:190px">
-              </div>
-            </li>
-            <li class="nav-item mx-2">
-              <div class="input-group">
-                <span class="input-group-text">formats registry</span>
-                <input v-model="config.formats_registry_chain" class="form-control font-monospace" placeholder="chain id" @change="on_formats_registry_change" style="width:200px">
-                <input v-model="config.formats_registry_app_id" class="form-control font-monospace" placeholder="application id" @change="on_formats_registry_change" style="width:200px">
               </div>
             </li>
             <li class="nav-item mx-2">

--- a/linera-explorer/src/components/App.vue
+++ b/linera-explorer/src/components/App.vue
@@ -14,10 +14,10 @@ export default {
   data() { return data() },
   created() {
     // The formats-registry chain/app id come exclusively from Vite env vars
-    // (a `.env.local` written by scripts/explore-chain.sh). They are runtime-only
-    // values on the Vue root — never persisted to localStorage and not editable
-    // in the navbar — so the explorer always decodes against the registry for the
-    // wallet it was launched with, with no stale stored value to shadow it.
+    // (e.g. a `.env.local`). They are runtime-only values on the Vue root — never
+    // persisted to localStorage and not editable in the navbar — so the explorer
+    // always decodes against the registry for the wallet it was launched with,
+    // with no stale stored value to shadow it.
     const envChain = import.meta.env.VITE_FORMATS_REGISTRY_CHAIN as string | undefined
     const envApp = import.meta.env.VITE_FORMATS_REGISTRY_APP_ID as string | undefined
     this.formats_registry_chain = envChain || null

--- a/linera-explorer/src/components/Applications.vue
+++ b/linera-explorer/src/components/Applications.vue
@@ -18,7 +18,7 @@ const formatsState = ref<Record<string, any | false | null>>({})
 async function refreshFormats() {
   const root: any = getCurrentInstance()?.proxy?.$root
   if (!root || typeof root.fetch_user_app_formats !== 'function') return
-  if (!root.config?.formats_registry_chain || !root.config?.formats_registry_app_id) {
+  if (!root.formats_registry_chain || !root.formats_registry_app_id) {
     // Mark all entries as "not available" (formats registry not configured).
     const next: Record<string, any | false | null> = {}
     for (const a of props.apps) next[a.id] = false
@@ -103,7 +103,7 @@ watch(() => props.apps.map(a => a.id).join('|'), refreshFormats, { immediate: tr
               <span class="spinner-border spinner-border-sm text-muted"></span>
             </template>
             <template v-else-if="formatsState[a.id] === false">
-              <button class="btn btn-link btn-sm text-muted" disabled :title="(($root as any).config?.formats_registry_chain && ($root as any).config?.formats_registry_app_id) ? 'No formats registered for this module' : 'Set the formats registry chain and app id in the navbar'">
+              <button class="btn btn-link btn-sm text-muted" disabled :title="(($root as any).formats_registry_chain && ($root as any).formats_registry_app_id) ? 'No formats registered for this module' : 'Set VITE_FORMATS_REGISTRY_CHAIN and VITE_FORMATS_REGISTRY_APP_ID in .env.local'">
                 <i class="bi bi-x-circle"></i>
               </button>
             </template>

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -57,10 +57,8 @@ function mountBlockWithRoot(block: any, opts: {
     global: {
       config: {
         globalProperties: {
-          config: {
-            formats_registry_chain: opts.formats_registry ? 'fake-chain-id' : null,
-            formats_registry_app_id: opts.formats_registry ?? null,
-          },
+          formats_registry_chain: opts.formats_registry ? 'fake-chain-id' : null,
+          formats_registry_app_id: opts.formats_registry ?? null,
           decode_user_event_value: (application_id: string, bytes_hex: string) =>
             opts.decode_user_event_value ? opts.decode_user_event_value(application_id, bytes_hex) : null,
           decode_user_response: (application_id: string, bytes_hex: string) =>

--- a/linera-explorer/src/components/DecodedBytes.vue
+++ b/linera-explorer/src/components/DecodedBytes.vue
@@ -38,7 +38,7 @@ async function tryDecode() {
   decoded.value = null
   if (!props.applicationId || !props.bytesHex) return
   const root: any = getCurrentInstance()?.proxy?.$root
-  if (!root?.config?.formats_registry_chain || !root?.config?.formats_registry_app_id) return
+  if (!root?.formats_registry_chain || !root?.formats_registry_app_id) return
   const fn = root[methodName()]
   if (typeof fn !== 'function') return
   decoding.value = true

--- a/linera-explorer/src/components/Op.test.ts
+++ b/linera-explorer/src/components/Op.test.ts
@@ -13,10 +13,8 @@ function mountWithRoot(op: any, opts: { formats_registry?: string | null, decode
     global: {
       config: {
         globalProperties: {
-          config: {
-            formats_registry_chain: opts.formats_registry ? 'fake-chain-id' : null,
-            formats_registry_app_id: opts.formats_registry ?? null,
-          },
+          formats_registry_chain: opts.formats_registry ? 'fake-chain-id' : null,
+          formats_registry_app_id: opts.formats_registry ?? null,
           decode_user_operation: (application_id: string, bytes_hex: string) =>
             opts.decode ? opts.decode(application_id, bytes_hex) : null
         } as any

--- a/linera-explorer/src/components/Transaction.test.ts
+++ b/linera-explorer/src/components/Transaction.test.ts
@@ -48,10 +48,8 @@ function mountReceiveUserMessage(opts: {
     global: {
       config: {
         globalProperties: {
-          config: {
-            formats_registry_chain: opts.formats_registry ? 'fake-chain-id' : null,
-            formats_registry_app_id: opts.formats_registry ?? null,
-          },
+          formats_registry_chain: opts.formats_registry ? 'fake-chain-id' : null,
+          formats_registry_app_id: opts.formats_registry ?? null,
           decode_user_message: (application_id: string, bytes_hex: string) =>
             opts.decode ? opts.decode(application_id, bytes_hex) : null
         } as any

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -12,9 +12,7 @@ mod graphql;
 mod input_type;
 mod js_utils;
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::str::FromStr;
+use std::{cell::RefCell, collections::HashMap, str::FromStr};
 
 use anyhow::{anyhow, Context as _, Result};
 use futures::prelude::*;
@@ -969,7 +967,9 @@ async fn fetch_user_app_formats(
         .as_deref()
         .filter(|s| !s.is_empty())
     else {
-        log_str(&format!("{op}: no formats_registry_chain set (VITE_FORMATS_REGISTRY_CHAIN)"));
+        log_str(&format!(
+            "{op}: no formats_registry_chain set (VITE_FORMATS_REGISTRY_CHAIN)"
+        ));
         return None;
     };
     let Some(registry_app_id) = data
@@ -977,7 +977,9 @@ async fn fetch_user_app_formats(
         .as_deref()
         .filter(|s| !s.is_empty())
     else {
-        log_str(&format!("{op}: no formats_registry_app_id set (VITE_FORMATS_REGISTRY_APP_ID)"));
+        log_str(&format!(
+            "{op}: no formats_registry_app_id set (VITE_FORMATS_REGISTRY_APP_ID)"
+        ));
         return None;
     };
     let cache_key = (
@@ -988,7 +990,11 @@ async fn fetch_user_app_formats(
     if let Some(cached) = FORMATS_CACHE.with(|c| c.borrow().get(&cache_key).cloned()) {
         log_str(&format!(
             "{op}: formats cache hit for app {application_id} ({})",
-            if cached.is_some() { "formats" } else { "no formats" }
+            if cached.is_some() {
+                "formats"
+            } else {
+                "no formats"
+            }
         ));
         return cached;
     }
@@ -1021,8 +1027,13 @@ async fn fetch_user_app_formats(
     log_str(&format!(
         "{op}: querying registry chain={registry_chain} app={registry_app_id} module={module_id_hex}"
     ));
-    let result = match formats::fetch_formats(&node, registry_chain, registry_app_id, &module_id_hex)
-        .await
+    let result = match formats::fetch_formats(
+        &node,
+        registry_chain,
+        registry_app_id,
+        &module_id_hex,
+    )
+    .await
     {
         Ok(Some(f)) => {
             log_str(&format!("{op}: registry returned formats"));

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -97,17 +97,6 @@ pub struct Config {
     indexer: String,
     node: String,
     tls: bool,
-    /// Hex-encoded chain id where the formats registry application is deployed.
-    /// Must be set together with [`Self::formats_registry_app_id`]. Stored as a
-    /// raw string so the JS-side `v-model` round-trips cleanly through
-    /// `serde_wasm_bindgen`; we validate the format only when actually using
-    /// the value.
-    #[serde(default)]
-    formats_registry_chain: Option<String>,
-    /// Hex-encoded application id of the formats registry. Same string-storage
-    /// rationale as [`Self::formats_registry_chain`].
-    #[serde(default)]
-    formats_registry_app_id: Option<String>,
 }
 
 impl Config {
@@ -117,8 +106,6 @@ impl Config {
             indexer: "localhost:8081".to_string(),
             node: "localhost:8080".to_string(),
             tls: false,
-            formats_registry_chain: None,
-            formats_registry_app_id: None,
         };
         // Return default if window doesn't exist (e.g., in test environment).
         let Some(window) = web_sys::window() else {
@@ -142,6 +129,18 @@ pub struct Data {
     chains: Vec<ChainId>,
     chain: ChainId,
     plugins: Vec<String>,
+    /// Hex-encoded chain id where the formats registry application is deployed.
+    /// Sourced exclusively from the `VITE_FORMATS_REGISTRY_CHAIN` env var (see
+    /// `App.vue`), so it is a runtime-only field on `Data` rather than part of
+    /// the localStorage-persisted [`Config`]. Must be set together with
+    /// [`Self::formats_registry_app_id`]; we validate the format only when
+    /// actually using the value.
+    #[serde(default)]
+    formats_registry_chain: Option<String>,
+    /// Hex-encoded application id of the formats registry. Same env-only
+    /// rationale as [`Self::formats_registry_chain`].
+    #[serde(default)]
+    formats_registry_app_id: Option<String>,
 }
 
 /// Initializes Vue data.
@@ -156,6 +155,8 @@ pub fn data() -> JsValue {
         )
         .unwrap(),
         plugins: Vec::new(),
+        formats_registry_chain: None,
+        formats_registry_app_id: None,
     };
     data.serialize(&SER).unwrap()
 }
@@ -946,21 +947,19 @@ async fn fetch_user_app_formats(
         }
     };
     let Some(registry_chain) = data
-        .config
         .formats_registry_chain
         .as_deref()
         .filter(|s| !s.is_empty())
     else {
-        log_str(&format!("{op}: no formats_registry_chain set in config"));
+        log_str(&format!("{op}: no formats_registry_chain set (VITE_FORMATS_REGISTRY_CHAIN)"));
         return None;
     };
     let Some(registry_app_id) = data
-        .config
         .formats_registry_app_id
         .as_deref()
         .filter(|s| !s.is_empty())
     else {
-        log_str(&format!("{op}: no formats_registry_app_id set in config"));
+        log_str(&format!("{op}: no formats_registry_app_id set (VITE_FORMATS_REGISTRY_APP_ID)"));
         return None;
     };
     let node = url(&data.config, &Protocol::Http, &AddressKind::Node);

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -12,6 +12,8 @@ mod graphql;
 mod input_type;
 mod js_utils;
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context as _, Result};
@@ -49,6 +51,22 @@ use wasm_bindgen_futures::spawn_local;
 use ws_stream_wasm::*;
 
 static WEBSOCKET: OnceCell<WsMeta> = OnceCell::new();
+
+thread_local! {
+    /// Caches the formats resolved for an application so repeated decodes within
+    /// (and across) blocks don't re-issue the module-id lookup and registry query
+    /// for the same app. Keyed by `(registry_chain, registry_app_id,
+    /// application_id)` — the registry pair keeps entries valid if the configured
+    /// registry ever changes.
+    ///
+    /// Both outcomes are cached: `Some(formats)` (positive) and `None` (negative —
+    /// the app has no registered formats), since module formats are immutable.
+    /// Only definitive results are stored; transient lookup/query errors are not
+    /// cached so they get retried. Wasm runs single-threaded, so a `thread_local`
+    /// `RefCell` is the whole story and reloading the page clears the cache.
+    static FORMATS_CACHE: RefCell<HashMap<(String, String, String), Option<formats::Formats>>> =
+        RefCell::new(HashMap::new());
+}
 
 pub(crate) fn reqwest_client() -> reqwest::Client {
     // timeouts cannot be enforced when compiling to wasm-js.
@@ -962,6 +980,19 @@ async fn fetch_user_app_formats(
         log_str(&format!("{op}: no formats_registry_app_id set (VITE_FORMATS_REGISTRY_APP_ID)"));
         return None;
     };
+    let cache_key = (
+        registry_chain.to_string(),
+        registry_app_id.to_string(),
+        application_id.to_string(),
+    );
+    if let Some(cached) = FORMATS_CACHE.with(|c| c.borrow().get(&cache_key).cloned()) {
+        log_str(&format!(
+            "{op}: formats cache hit for app {application_id} ({})",
+            if cached.is_some() { "formats" } else { "no formats" }
+        ));
+        return cached;
+    }
+
     let node = url(&data.config, &Protocol::Http, &AddressKind::Node);
     log_str(&format!(
         "{op}: looking up module for app {application_id} on active chain {} (node={node})",
@@ -973,13 +1004,16 @@ async fn fetch_user_app_formats(
             m
         }
         Ok(None) => {
+            // App genuinely absent on this chain: a definitive negative, cache it.
             log_str(&format!(
                 "{op}: application {application_id} not found on chain {}",
                 data.chain
             ));
+            FORMATS_CACHE.with(|c| c.borrow_mut().insert(cache_key, None));
             return None;
         }
         Err(e) => {
+            // Transient lookup failure: do not cache, let the next call retry.
             log_str(&format!("{op}: failed to look up module id: {e}"));
             return None;
         }
@@ -987,7 +1021,9 @@ async fn fetch_user_app_formats(
     log_str(&format!(
         "{op}: querying registry chain={registry_chain} app={registry_app_id} module={module_id_hex}"
     ));
-    match formats::fetch_formats(&node, registry_chain, registry_app_id, &module_id_hex).await {
+    let result = match formats::fetch_formats(&node, registry_chain, registry_app_id, &module_id_hex)
+        .await
+    {
         Ok(Some(f)) => {
             log_str(&format!("{op}: registry returned formats"));
             Some(f)
@@ -999,10 +1035,13 @@ async fn fetch_user_app_formats(
             None
         }
         Err(e) => {
+            // Transient registry query failure: do not cache, let the next call retry.
             log_str(&format!("{op}: registry query failed: {e}"));
-            None
+            return None;
         }
-    }
+    };
+    FORMATS_CACHE.with(|c| c.borrow_mut().insert(cache_key, result.clone()));
+    result
 }
 
 /// Run a `Formats::decode_*` method against `bytes_hex`, returning a JS value or

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -113,6 +113,19 @@ pub struct Config {
     indexer: String,
     node: String,
     tls: bool,
+    /// Hex-encoded chain id of the formats-registry application, used as the
+    /// manual fallback when the `VITE_FORMATS_REGISTRY_CHAIN` env var is unset.
+    /// Editable in the navbar and persisted to localStorage; the env var, when
+    /// set, takes precedence (resolution happens in `App.vue`). Stored as a raw
+    /// string so the JS-side `v-model` round-trips cleanly through
+    /// `serde_wasm_bindgen`; we validate the format only when using the value.
+    #[serde(default)]
+    formats_registry_chain: Option<String>,
+    /// Hex-encoded formats-registry app id; manual fallback for the
+    /// `VITE_FORMATS_REGISTRY_APP_ID` env var. Same rationale as
+    /// [`Self::formats_registry_chain`].
+    #[serde(default)]
+    formats_registry_app_id: Option<String>,
 }
 
 impl Config {
@@ -122,6 +135,8 @@ impl Config {
             indexer: "localhost:8081".to_string(),
             node: "localhost:8080".to_string(),
             tls: false,
+            formats_registry_chain: None,
+            formats_registry_app_id: None,
         };
         // Return default if window doesn't exist (e.g., in test environment).
         let Some(window) = web_sys::window() else {
@@ -145,16 +160,16 @@ pub struct Data {
     chains: Vec<ChainId>,
     chain: ChainId,
     plugins: Vec<String>,
-    /// Hex-encoded chain id where the formats registry application is deployed.
-    /// Sourced exclusively from the `VITE_FORMATS_REGISTRY_CHAIN` env var (see
-    /// `App.vue`), so it is a runtime-only field on `Data` rather than part of
-    /// the localStorage-persisted [`Config`]. Must be set together with
-    /// [`Self::formats_registry_app_id`]; we validate the format only when
-    /// actually using the value.
+    /// Effective hex-encoded chain id of the formats-registry application used
+    /// for decoding: the `VITE_FORMATS_REGISTRY_CHAIN` env var when set, else the
+    /// persisted [`Config::formats_registry_chain`]. Resolved in `App.vue` and
+    /// kept here as a runtime-only field (never persisted), which is what the
+    /// wasm decoders read. Must be set together with
+    /// [`Self::formats_registry_app_id`]; we validate the format only when using it.
     #[serde(default)]
     formats_registry_chain: Option<String>,
-    /// Hex-encoded application id of the formats registry. Same env-only
-    /// rationale as [`Self::formats_registry_chain`].
+    /// Effective hex-encoded formats-registry app id. Same env-or-config
+    /// resolution as [`Self::formats_registry_chain`].
     #[serde(default)]
     formats_registry_app_id: Option<String>,
 }


### PR DESCRIPTION
## Summary

Two related changes to `linera-explorer`'s formats-registry handling:

### 1. Prefer env vars for the formats registry, with a manual fallback
The formats-registry chain id and app id were stored in the localStorage-persisted `Config` and only ever taken from a stored value if one was present. A value stored by an earlier run could then shadow the registry for the wallet the explorer was actually launched with, so the explorer decoded against a stale registry.

Now the **effective** values are resolved as `env ?? persisted config`:

- When `VITE_FORMATS_REGISTRY_CHAIN` / `VITE_FORMATS_REGISTRY_APP_ID` are set (e.g. via a `.env.local`), they are **authoritative** and the navbar inputs are hidden. The env values are runtime-only and never persisted, so no stored value can shadow them.
- When the env vars are unset, the navbar inputs are shown and the values are entered manually and persisted to localStorage, as before.

The effective values live in runtime-only fields on `Data` (what the wasm decoders read); `Config` keeps the manual/persisted copies alongside `node`, `indexer`, and `tls`.

### 2. Cache resolved application formats (positive and negative)
`fetch_user_app_formats` re-ran the module-id lookup **and** the registry query on every decode, so a block with many operations of the same application repeatedly fetched identical, immutable formats.

Added a `thread_local` cache keyed by `(registry_chain, registry_app_id, application_id)`. Both outcomes are cached — `Some(formats)` and `None` (the app has no registered formats, or is absent on the chain) — since module formats are immutable. Transient module-id lookup / registry-query errors are **not** cached, so they retry. The cache lives for the page session; reloading clears it.

## Test plan
- `cargo check` passes.
- `vue-tsc --noEmit` passes.
- `vitest run` — 23 component tests pass (Op / Block / Transaction fixtures expose the registry fields at the `$root` level).