### PR TITLE
Cache user-application formats lookups in the explorer

### DIFF
--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -15,7 +15,7 @@ mod graphql;
 mod input_type;
 mod js_utils;
 
-use std::str::FromStr;
+use std::{cell::RefCell, collections::HashMap, str::FromStr};
 
 use anyhow::{anyhow, Context as _, Result};
 use futures::prelude::*;
@@ -52,6 +52,20 @@ use wasm_bindgen_futures::spawn_local;
 use ws_stream_wasm::*;
 
 static WEBSOCKET: OnceCell<WsMeta> = OnceCell::new();
+
+thread_local! {
+    /// Memoizes the `Formats` resolved for each `(chain_id, application_id)` so a
+    /// block with many operations from the same application only pays the two node
+    /// round-trips (blob-hash resolution + formats fetch) once per page session.
+    ///
+    /// Both outcomes are cached: `Some(formats)` (positive) and `None` (negative —
+    /// the app has no formats blob, or the node has none). Formats are immutable, so
+    /// neither can change without a reload. Transient `Err` outcomes are *not*
+    /// cached so they get retried. Wasm runs single-threaded, so a `thread_local`
+    /// `RefCell` is the whole story and reloading the page clears the cache.
+    static FORMATS_CACHE: RefCell<HashMap<(String, String), Option<formats::Formats>>> =
+        RefCell::new(HashMap::new());
+}
 
 pub(crate) fn reqwest_client() -> reqwest::Client {
     // timeouts cannot be enforced when compiling to wasm-js.
@@ -964,6 +978,19 @@ async fn fetch_user_app_formats(
             return None;
         }
     };
+    let cache_key = (data.chain.to_string(), application_id.to_string());
+    if let Some(cached) = FORMATS_CACHE.with(|c| c.borrow().get(&cache_key).cloned()) {
+        log_str(&format!(
+            "{op}: formats cache hit for app {application_id} ({})",
+            if cached.is_some() {
+                "formats"
+            } else {
+                "no formats"
+            }
+        ));
+        return cached;
+    }
+
     let node = url(&data.config, &Protocol::Http, &AddressKind::Node);
     log_str(&format!(
         "{op}: looking up formats blob hash for app {application_id} on chain {} (node={node})",
@@ -976,17 +1003,26 @@ async fn fetch_user_app_formats(
                 hash
             }
             Ok(None) => {
+                // App genuinely has no formats blob hash: a definitive negative, cache it.
                 log_str(&format!(
                     "{op}: application {application_id} has no formats blob hash"
                 ));
+                FORMATS_CACHE.with(|c| c.borrow_mut().insert(cache_key, None));
                 return None;
             }
             Err(e) => {
+                // Transient lookup failure: do not cache, let the next call retry.
                 log_str(&format!("{op}: failed to resolve formats_blob_hash: {e}"));
                 return None;
             }
         };
-    match formats::fetch_formats(&node, &data.chain.to_string(), &formats_blob_hash_hex).await {
+    let result = match formats::fetch_formats(
+        &node,
+        &data.chain.to_string(),
+        &formats_blob_hash_hex,
+    )
+    .await
+    {
         Ok(Some(f)) => {
             log_str(&format!("{op}: node returned formats"));
             Some(f)
@@ -998,10 +1034,13 @@ async fn fetch_user_app_formats(
             None
         }
         Err(e) => {
+            // Transient formats query failure: do not cache, let the next call retry.
             log_str(&format!("{op}: formats query failed: {e}"));
-            None
+            return None;
         }
-    }
+    };
+    FORMATS_CACHE.with(|c| c.borrow_mut().insert(cache_key, result.clone()));
+    result
 }
 
 /// Run a `Formats::decode_*` method against `bytes_hex`, returning a JS value or

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -54,16 +54,18 @@ use ws_stream_wasm::*;
 static WEBSOCKET: OnceCell<WsMeta> = OnceCell::new();
 
 thread_local! {
-    /// Memoizes the `Formats` resolved for each `(chain_id, application_id)` so a
-    /// block with many operations from the same application only pays the two node
-    /// round-trips (blob-hash resolution + formats fetch) once per page session.
+    /// Memoizes the `Formats` resolved for each `application_id` so a block with many
+    /// operations from the same application only pays the two node round-trips
+    /// (blob-hash resolution + formats fetch) once per page session. An
+    /// `application_id` is globally unique and its formats are immutable, so the
+    /// chain it is observed on is irrelevant to the key.
     ///
     /// Both outcomes are cached: `Some(formats)` (positive) and `None` (negative —
     /// the app has no formats blob, or the node has none). Formats are immutable, so
     /// neither can change without a reload. Transient `Err` outcomes are *not*
     /// cached so they get retried. Wasm runs single-threaded, so a `thread_local`
     /// `RefCell` is the whole story and reloading the page clears the cache.
-    static FORMATS_CACHE: RefCell<HashMap<(String, String), Option<formats::Formats>>> =
+    static FORMATS_CACHE: RefCell<HashMap<String, Option<formats::Formats>>> =
         RefCell::new(HashMap::new());
 }
 
@@ -978,7 +980,7 @@ async fn fetch_user_app_formats(
             return None;
         }
     };
-    let cache_key = (data.chain.to_string(), application_id.to_string());
+    let cache_key = application_id.to_string();
     if let Some(cached) = FORMATS_CACHE.with(|c| c.borrow().get(&cache_key).cloned()) {
         log_str(&format!(
             "{op}: formats cache hit for app {application_id} ({})",


### PR DESCRIPTION
## Motivation

`fetch_user_app_formats` in the explorer's `src/lib.rs` performs two node
round-trips on every decode: it resolves the application's `formats_blob_hash`
on the active chain, then fetches the formats blob. A block with many
operations from the same application re-fetches identical, immutable data once
per operation, which is wasteful.

## Proposal

Memoize formats lookups with a `thread_local` cache keyed by `application_id`
→ `Option<formats::Formats>`. The cache is checked before the two lookups and
short-circuits both on a hit. An `application_id` is globally unique and its
formats are immutable, so the chain it is observed on is irrelevant to the key.

- Both outcomes are cached: `Some(formats)` (positive) and `None` (negative —
  the app has no formats blob, or the node has none). Formats are immutable, so
  neither can change without a reload.
- Transient `Err` outcomes are **not** cached, so they retry on the next call.
- Wasm runs single-threaded, so a `thread_local` `RefCell<HashMap>` is
  sufficient; reloading the page clears the cache.

This follows the model added on `testnet_conway` in #6566, adapted to `main`'s
formats resolution (blob hash on the active chain; no formats-registry
chain/app id).

The diff is surgical: the `fetch_user_app_formats` function, the `thread_local!`
block, and two `std` imports.

## Test Plan

From `linera-explorer/`, all pass:
- `cargo check`
- `cargo +nightly fmt` (no diff)
- `npx vue-tsc --noEmit`
- `CI=1 npx vitest run` (26 tests pass)

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Mirrors #6566 on `testnet_conway`.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
