### PR TITLE
linera-views: export RocksDB statistics as Prometheus metrics (backport #6511)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -309,6 +309,10 @@ Client implementation and command-line tool for the Linera blockchain
 * `--storage-replication-factor <STORAGE_REPLICATION_FACTOR>` — The replication factor for the keyspace
 
   Default value: `1`
+* `--rocksdb-enable-statistics` — Enable RocksDB's internal statistics collection and export them as Prometheus metrics. Off by default; enable it on nodes whose metrics are scraped
+* `--rocksdb-statistics-level <ROCKSDB_STATISTICS_LEVEL>` — The level of detail collected when `--rocksdb-enable-statistics` is set. Higher levels collect more, and more expensive, data. One of: `disable-all`, `except-histogram-or-timers`, `except-timers`, `except-detailed-timers`, `except-time-for-mutex`, `all`
+
+  Default value: `except-histogram-or-timers`
 * `--wasm-runtime <WASM_RUNTIME>` — The WebAssembly runtime to use
 * `--with-application-logs` — Output log messages from contract execution
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5956,6 +5956,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "test-case",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4366,6 +4366,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.65",

--- a/linera-bridge/contracts/evm-bridge/Cargo.lock
+++ b/linera-bridge/contracts/evm-bridge/Cargo.lock
@@ -3564,6 +3564,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",

--- a/linera-bridge/tests/e2e/Cargo.lock
+++ b/linera-bridge/tests/e2e/Cargo.lock
@@ -4330,6 +4330,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum 0.26.3",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -118,6 +118,8 @@ impl RocksDbRunner {
             spawn_mode,
             path_with_guard,
             max_stream_queries: config.client.max_stream_queries,
+            enable_statistics: false,
+            statistics_level: Default::default(),
         };
         let rocksdb_store_config = RocksDbStoreConfig {
             inner_config,

--- a/linera-sdk/tests/fixtures/Cargo.lock
+++ b/linera-sdk/tests/fixtures/Cargo.lock
@@ -2511,6 +2511,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "strum",
  "sysinfo",
  "tempfile",
  "thiserror 1.0.69",

--- a/linera-storage-runtime/src/lib.rs
+++ b/linera-storage-runtime/src/lib.rs
@@ -22,7 +22,7 @@ use linera_storage_service::{
 };
 #[cfg(feature = "rocksdb")]
 use linera_views::rocks_db::{
-    PathWithGuard, RocksDbDatabase, RocksDbSpawnMode, RocksDbStoreConfig,
+    PathWithGuard, RocksDbDatabase, RocksDbSpawnMode, RocksDbStatisticsLevel, RocksDbStoreConfig,
     RocksDbStoreInternalConfig,
 };
 use linera_views::{
@@ -123,6 +123,25 @@ pub struct CommonStorageOptions {
     /// The replication factor for the keyspace
     #[arg(long, default_value = "1", global = true)]
     pub storage_replication_factor: u32,
+
+    /// Enable RocksDB's internal statistics collection and export them as Prometheus
+    /// metrics. Off by default; enable it on nodes whose metrics are scraped.
+    #[cfg(feature = "rocksdb")]
+    #[arg(long, global = true)]
+    pub rocksdb_enable_statistics: bool,
+
+    /// The level of detail collected when `--rocksdb-enable-statistics` is set. Higher
+    /// levels collect more, and more expensive, data. One of: `disable-all`,
+    /// `except-histogram-or-timers`, `except-timers`, `except-detailed-timers`,
+    /// `except-time-for-mutex`, `all`.
+    #[cfg(feature = "rocksdb")]
+    #[arg(
+        long,
+        default_value = "except-histogram-or-timers",
+        value_parser = RocksDbStatisticsLevel::from_str,
+        global = true
+    )]
+    pub rocksdb_statistics_level: RocksDbStatisticsLevel,
 }
 
 impl CommonStorageOptions {
@@ -522,6 +541,8 @@ impl StorageConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard,
                     max_stream_queries: options.storage_max_stream_queries,
+                    enable_statistics: options.rocksdb_enable_statistics,
+                    statistics_level: options.rocksdb_statistics_level,
                 };
                 let config = RocksDbStoreConfig {
                     inner_config,
@@ -553,6 +574,8 @@ impl StorageConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard: path_with_guard.clone(),
                     max_stream_queries: options.storage_max_stream_queries,
+                    enable_statistics: options.rocksdb_enable_statistics,
+                    statistics_level: options.rocksdb_statistics_level,
                 };
                 let first_config = RocksDbStoreConfig {
                     inner_config,

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -672,6 +672,8 @@ async fn main() {
                 spawn_mode,
                 path_with_guard,
                 max_stream_queries,
+                enable_statistics: false,
+                statistics_level: Default::default(),
             };
             let storage_cache_config = StorageCacheConfig {
                 max_cache_size,

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -55,6 +55,7 @@ scylla = { workspace = true, optional = true }
 serde.workspace = true
 sha3.workspace = true
 static_assertions.workspace = true
+strum.workspace = true
 sysinfo.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -299,6 +299,75 @@ impl WithError for RocksDbDatabaseInternal {
     type Error = RocksDbStoreInternalError;
 }
 
+/// The level of detail collected by RocksDB's internal statistics.
+///
+/// This mirrors [`rocksdb::statistics::StatsLevel`]. The levels are nested: each one
+/// collects a superset of the data collected by the previous one, at increasing cost.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize, Serialize, strum::EnumString)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum RocksDbStatisticsLevel {
+    /// Collect nothing.
+    DisableAll,
+    /// Collect tickers (counters) only; skip all histograms and timers.
+    #[default]
+    ExceptHistogramOrTimers,
+    /// Collect tickers and histograms, but skip timer statistics.
+    ExceptTimers,
+    /// Collect everything except time spent inside the mutex lock and on compression.
+    ExceptDetailedTimers,
+    /// Collect everything except the counters that require taking time inside the mutex lock.
+    ExceptTimeForMutex,
+    /// Collect everything, including the duration of mutex operations.
+    All,
+}
+
+impl RocksDbStatisticsLevel {
+    fn to_rocksdb(self) -> rocksdb::statistics::StatsLevel {
+        use rocksdb::statistics::StatsLevel;
+        match self {
+            Self::DisableAll => StatsLevel::DisableAll,
+            Self::ExceptHistogramOrTimers => StatsLevel::ExceptHistogramOrTimers,
+            Self::ExceptTimers => StatsLevel::ExceptTimers,
+            Self::ExceptDetailedTimers => StatsLevel::ExceptDetailedTimers,
+            Self::ExceptTimeForMutex => StatsLevel::ExceptTimeForMutex,
+            Self::All => StatsLevel::All,
+        }
+    }
+}
+
+#[cfg(test)]
+mod statistics_level_tests {
+    use std::str::FromStr as _;
+
+    use super::RocksDbStatisticsLevel;
+
+    #[test]
+    fn parses_kebab_case_names() {
+        let cases = [
+            ("disable-all", RocksDbStatisticsLevel::DisableAll),
+            (
+                "except-histogram-or-timers",
+                RocksDbStatisticsLevel::ExceptHistogramOrTimers,
+            ),
+            ("except-timers", RocksDbStatisticsLevel::ExceptTimers),
+            (
+                "except-detailed-timers",
+                RocksDbStatisticsLevel::ExceptDetailedTimers,
+            ),
+            (
+                "except-time-for-mutex",
+                RocksDbStatisticsLevel::ExceptTimeForMutex,
+            ),
+            ("all", RocksDbStatisticsLevel::All),
+        ];
+        for (name, expected) in cases {
+            assert_eq!(RocksDbStatisticsLevel::from_str(name), Ok(expected));
+        }
+        assert!(RocksDbStatisticsLevel::from_str("not-a-level").is_err());
+    }
+}
+
 /// The initial configuration of the system
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RocksDbStoreInternalConfig {
@@ -308,6 +377,14 @@ pub struct RocksDbStoreInternalConfig {
     pub spawn_mode: RocksDbSpawnMode,
     /// Preferred buffer size for async streams.
     pub max_stream_queries: usize,
+    /// Whether to enable RocksDB's internal statistics collection and export it as
+    /// Prometheus metrics. Disabled by default to avoid overhead in clients that do not
+    /// scrape metrics; enabled explicitly for the workers.
+    #[serde(default)]
+    pub enable_statistics: bool,
+    /// The level of detail collected when `enable_statistics` is set.
+    #[serde(default)]
+    pub statistics_level: RocksDbStatisticsLevel,
 }
 
 impl RocksDbDatabaseInternal {
@@ -425,11 +502,17 @@ impl RocksDbStoreInternal {
         // Don't use random access pattern since we do prefix scans
         options.set_advise_random_on_open(false);
 
-        let db = DB::open(&options, path_buf)?;
-        let executor = RocksDbStoreExecutor {
-            db: Arc::new(db),
-            start_key,
-        };
+        if config.enable_statistics {
+            options.enable_statistics();
+            options.set_statistics_level(config.statistics_level.to_rocksdb());
+        }
+
+        let db = Arc::new(DB::open(&options, path_buf)?);
+        #[cfg(with_metrics)]
+        if config.enable_statistics {
+            statistics_metrics::register(Arc::new(options), db.clone());
+        }
+        let executor = RocksDbStoreExecutor { db, start_key };
         Ok(RocksDbStoreInternal {
             executor,
             path_with_guard,
@@ -437,6 +520,256 @@ impl RocksDbStoreInternal {
             spawn_mode,
             root_key_written: Arc::new(AtomicBool::new(false)),
         })
+    }
+}
+
+/// Exports RocksDB's internal statistics as Prometheus metrics.
+///
+/// The collector reads the values lazily at scrape time: cumulative tickers via
+/// `get_ticker_count` and instantaneous LSM state via `GetIntProperty`. Neither requires
+/// the (more expensive) histogram/timer statistics levels.
+#[cfg(with_metrics)]
+mod statistics_metrics {
+    use std::sync::{Arc, OnceLock};
+
+    use prometheus::{
+        core::{Collector, Desc},
+        proto::MetricFamily,
+        IntGauge,
+    };
+    use rocksdb::{statistics::Ticker, Options};
+
+    use super::DB;
+
+    enum Source {
+        Ticker(Ticker),
+        Property(&'static str),
+    }
+
+    struct Entry {
+        source: Source,
+        gauge: IntGauge,
+    }
+
+    fn definitions() -> Vec<(&'static str, &'static str, Source)> {
+        vec![
+            (
+                "linera_rocksdb_block_cache_hit",
+                "Cumulative RocksDB block cache hits since open",
+                Source::Ticker(Ticker::BlockCacheHit),
+            ),
+            (
+                "linera_rocksdb_block_cache_miss",
+                "Cumulative RocksDB block cache misses since open",
+                Source::Ticker(Ticker::BlockCacheMiss),
+            ),
+            (
+                "linera_rocksdb_compact_read_bytes",
+                "Cumulative bytes read during compaction since open",
+                Source::Ticker(Ticker::CompactReadBytes),
+            ),
+            (
+                "linera_rocksdb_compact_write_bytes",
+                "Cumulative bytes written during compaction since open",
+                Source::Ticker(Ticker::CompactWriteBytes),
+            ),
+            (
+                "linera_rocksdb_flush_write_bytes",
+                "Cumulative bytes written during flushes since open",
+                Source::Ticker(Ticker::FlushWriteBytes),
+            ),
+            (
+                "linera_rocksdb_stall_micros",
+                "Cumulative write-stall time in microseconds since open",
+                Source::Ticker(Ticker::StallMicros),
+            ),
+            (
+                "linera_rocksdb_bytes_written",
+                "Cumulative user bytes written since open",
+                Source::Ticker(Ticker::BytesWritten),
+            ),
+            (
+                "linera_rocksdb_bytes_read",
+                "Cumulative user bytes read since open",
+                Source::Ticker(Ticker::BytesRead),
+            ),
+            (
+                "linera_rocksdb_wal_bytes",
+                "Cumulative bytes written to the write-ahead log since open",
+                Source::Ticker(Ticker::WalFileBytes),
+            ),
+            (
+                "linera_rocksdb_bloom_filter_useful",
+                "Cumulative count of reads avoided by the bloom filter since open",
+                Source::Ticker(Ticker::BloomFilterUseful),
+            ),
+            (
+                "linera_rocksdb_memtable_hit",
+                "Cumulative memtable hits since open",
+                Source::Ticker(Ticker::MemtableHit),
+            ),
+            (
+                "linera_rocksdb_memtable_miss",
+                "Cumulative memtable misses since open",
+                Source::Ticker(Ticker::MemtableMiss),
+            ),
+            (
+                "linera_rocksdb_number_keys_written",
+                "Cumulative number of keys written since open",
+                Source::Ticker(Ticker::NumberKeysWritten),
+            ),
+            (
+                "linera_rocksdb_num_files_at_level0",
+                "Number of files at level 0",
+                Source::Property("rocksdb.num-files-at-level0"),
+            ),
+            (
+                "linera_rocksdb_estimate_pending_compaction_bytes",
+                "Estimated bytes pending compaction",
+                Source::Property("rocksdb.estimate-pending-compaction-bytes"),
+            ),
+            (
+                "linera_rocksdb_num_running_compactions",
+                "Number of currently running compactions",
+                Source::Property("rocksdb.num-running-compactions"),
+            ),
+            (
+                "linera_rocksdb_num_running_flushes",
+                "Number of currently running flushes",
+                Source::Property("rocksdb.num-running-flushes"),
+            ),
+            (
+                "linera_rocksdb_is_write_stopped",
+                "Whether writes are currently stopped (1) or not (0)",
+                Source::Property("rocksdb.is-write-stopped"),
+            ),
+            (
+                "linera_rocksdb_actual_delayed_write_rate",
+                "Current delayed write rate in bytes/s (0 when not delayed)",
+                Source::Property("rocksdb.actual-delayed-write-rate"),
+            ),
+            (
+                "linera_rocksdb_cur_size_all_mem_tables",
+                "Approximate size in bytes of all active and unflushed memtables",
+                Source::Property("rocksdb.cur-size-all-mem-tables"),
+            ),
+            (
+                "linera_rocksdb_num_immutable_mem_table",
+                "Number of immutable memtables not yet flushed",
+                Source::Property("rocksdb.num-immutable-mem-table"),
+            ),
+            (
+                "linera_rocksdb_live_sst_files_size",
+                "Total size in bytes of all live SST files",
+                Source::Property("rocksdb.live-sst-files-size"),
+            ),
+            (
+                "linera_rocksdb_total_sst_files_size",
+                "Total size in bytes of all SST files including obsolete ones",
+                Source::Property("rocksdb.total-sst-files-size"),
+            ),
+            (
+                "linera_rocksdb_estimate_num_keys",
+                "Estimated number of keys in the database",
+                Source::Property("rocksdb.estimate-num-keys"),
+            ),
+            (
+                "linera_rocksdb_block_cache_usage",
+                "Memory in bytes used by the block cache",
+                Source::Property("rocksdb.block-cache-usage"),
+            ),
+            (
+                "linera_rocksdb_block_cache_capacity",
+                "Capacity in bytes of the block cache",
+                Source::Property("rocksdb.block-cache-capacity"),
+            ),
+        ]
+    }
+
+    struct RocksDbStatisticsCollector {
+        options: Arc<Options>,
+        db: Arc<DB>,
+        entries: Vec<Entry>,
+    }
+
+    impl RocksDbStatisticsCollector {
+        fn new(options: Arc<Options>, db: Arc<DB>) -> Self {
+            let entries = definitions()
+                .into_iter()
+                .map(|(name, help, source)| Entry {
+                    source,
+                    gauge: IntGauge::new(name, help)
+                        .expect("RocksDB statistics metric name is valid"),
+                })
+                .collect();
+            Self {
+                options,
+                db,
+                entries,
+            }
+        }
+    }
+
+    impl Collector for RocksDbStatisticsCollector {
+        fn desc(&self) -> Vec<&Desc> {
+            self.entries
+                .iter()
+                .flat_map(|entry| entry.gauge.desc())
+                .collect()
+        }
+
+        fn collect(&self) -> Vec<MetricFamily> {
+            self.entries
+                .iter()
+                .flat_map(|entry| {
+                    let value = match &entry.source {
+                        Source::Ticker(ticker) => self.options.get_ticker_count(*ticker) as i64,
+                        Source::Property(property) => {
+                            self.db
+                                .property_int_value(*property)
+                                .ok()
+                                .flatten()
+                                .unwrap_or(0) as i64
+                        }
+                    };
+                    entry.gauge.set(value);
+                    entry.gauge.collect()
+                })
+                .collect()
+        }
+    }
+
+    pub(super) fn register(options: Arc<Options>, db: Arc<DB>) {
+        static REGISTERED: OnceLock<()> = OnceLock::new();
+        if REGISTERED.set(()).is_err() {
+            tracing::warn!(
+                "RocksDB statistics collector is already registered; skipping additional store"
+            );
+            return;
+        }
+        let collector = RocksDbStatisticsCollector::new(options, db);
+        if let Err(error) = prometheus::register(Box::new(collector)) {
+            tracing::warn!("failed to register the RocksDB statistics collector: {error}");
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::collections::HashSet;
+
+        use super::{definitions, IntGauge};
+
+        #[test]
+        fn definitions_build_unique_valid_gauges() {
+            let definitions = definitions();
+            assert!(!definitions.is_empty());
+            let mut names = HashSet::new();
+            for (name, help, _source) in &definitions {
+                assert!(!help.is_empty(), "metric {name} has empty help text");
+                assert!(names.insert(*name), "duplicate metric name: {name}");
+                IntGauge::new(*name, *help).expect("metric definition should be valid");
+            }
+        }
     }
 }
 
@@ -675,6 +1008,8 @@ impl TestKeyValueDatabase for RocksDbDatabaseInternal {
             path_with_guard,
             spawn_mode,
             max_stream_queries,
+            enable_statistics: false,
+            statistics_level: RocksDbStatisticsLevel::default(),
         })
     }
 }


### PR DESCRIPTION
## Motivation

Backport of #6511 to `testnet_conway`. The PM workers run on conway and need RocksDB engine observability (block cache, compaction / write-amplification, write stalls, LSM structure).

## Proposal

Hand-port of #6511 onto conway's layout (conway keeps the storage options + construction + parsing in a single `linera-storage-runtime/src/lib.rs`, vs main's split into `common_options.rs` / `storage_config.rs`):

- `linera-views`: `RocksDbStatisticsLevel` (serde + `strum::EnumString` `FromStr` -> `rocksdb::StatsLevel`), two `#[serde(default)]` config fields, `build()` wiring (`enable_statistics()` + level), and a lazy `with_metrics` Prometheus `Collector` exporting `linera_rocksdb_*` (cumulative tickers via `get_ticker_count` + LSM state via `GetIntProperty`).
- `--rocksdb-enable-statistics` (default off) + `--rocksdb-statistics-level` (default `except-histogram-or-timers`), both gated `#[cfg(feature = "rocksdb")]`.

Off by default; enabled explicitly on the workers. No on-disk format impact.

## Test Plan

- All four `linera-storage-runtime` feature combos compile (incl. no-rocksdb); `clippy --no-default-features -D warnings` clean; views clippy (rocksdb+metrics) clean; unit tests pass (level parse/map + collector definitions).
- All 6 workspace lockfiles refreshed (`cargo metadata`); `--locked` verified in each.
- `cargo fmt`, `cargo machete`, `cargo doc` (strict), `CLI.md` regenerated.

## Release Plan
- Nothing to do / These changes follow the usual deployment cycle (conway backport of merged #6511).

## Links
- Main PR: #6511 (merged)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)