### PR TITLE
Stop tracking publisher chains after unsubscribing.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -661,11 +661,40 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         })
     }
 
-    fn remove_event_subscriber(&mut self, chain_id: ChainId) {
-        self.event_subscribers.retain(|_, subscribers| {
+    /// Removes `chain_id` as a subscriber from every publisher, and returns the publishers that
+    /// no longer have any subscribers as a result.
+    fn remove_event_subscriber(&mut self, chain_id: ChainId) -> Vec<ChainId> {
+        let mut orphaned = Vec::new();
+        self.event_subscribers.retain(|publisher_id, subscribers| {
             subscribers.remove(&chain_id);
-            !subscribers.is_empty()
+            if subscribers.is_empty() {
+                orphaned.push(*publisher_id);
+                false
+            } else {
+                true
+            }
         });
+        orphaned
+    }
+
+    /// Stops listening to a publisher chain whose last subscriber went away, provided the chain is
+    /// only tracked because of event subscriptions (i.e. its mode is `EventsOnly`). Wallet chains
+    /// (`FullChain`/`FollowChain`) are left untouched, as is any chain we're not listening to.
+    async fn stop_tracking_publisher(&mut self, publisher_id: ChainId) {
+        let mode = self.context.lock().await.client().chain_mode(publisher_id);
+        if !matches!(mode, Some(ListeningMode::EventsOnly(_))) {
+            return;
+        }
+        let Some(listening_client) = self.listening.remove(&publisher_id) else {
+            return;
+        };
+        self.context
+            .lock()
+            .await
+            .client()
+            .remove_chain_mode(publisher_id);
+        listening_client.stop().await;
+        debug!(%publisher_id, "stopped tracking publisher chain after its last subscriber went away");
     }
 
     /// Updates the event subscribers map, and returns all publishing chains we need to listen to.
@@ -710,6 +739,29 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                 .or_default()
                 .insert(chain_id);
         }
+        // Detect publishers this chain no longer subscribes to (e.g. an application called
+        // `unsubscribe_from_events`), and stop tracking any that were only tracked on its behalf.
+        let removed_publishers = self
+            .event_subscribers
+            .iter()
+            .filter(|(publisher_id, subscribers)| {
+                subscribers.contains(&chain_id) && !publishing_chains.contains_key(publisher_id)
+            })
+            .map(|(publisher_id, _)| *publisher_id)
+            .collect::<Vec<_>>();
+        for publisher_id in removed_publishers {
+            let orphaned = {
+                let Some(subscribers) = self.event_subscribers.get_mut(&publisher_id) else {
+                    continue;
+                };
+                subscribers.remove(&chain_id);
+                subscribers.is_empty()
+            };
+            if orphaned {
+                self.event_subscribers.remove(&publisher_id);
+                self.stop_tracking_publisher(publisher_id).await;
+            }
+        }
         Ok(publishing_chains)
     }
 
@@ -749,8 +801,11 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                                     error!(%chain_id, "attempted to drop a non-existent listener");
                                     continue;
                                 };
-                                self.remove_event_subscriber(chain_id);
+                                let orphaned = self.remove_event_subscriber(chain_id);
                                 listening_client.stop().await;
+                                for publisher_id in orphaned {
+                                    self.stop_tracking_publisher(publisher_id).await;
+                                }
                                 if let Err(error) = self.context.lock().await.wallet().remove(chain_id).await {
                                     error!(%error, %chain_id, "error removing a chain from the wallet");
                                 }
@@ -785,8 +840,11 @@ impl<C: ClientContext + 'static> ChainListener<C> {
                             error!(%chain_id, "attempted to drop a non-existent listener");
                             continue;
                         };
-                        self.remove_event_subscriber(chain_id);
+                        let orphaned = self.remove_event_subscriber(chain_id);
                         listening_client.stop().await;
+                        for publisher_id in orphaned {
+                            self.stop_tracking_publisher(publisher_id).await;
+                        }
                         continue;
                     };
                     return Ok(Action::Notification(notification));

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -436,6 +436,168 @@ async fn test_chain_listener_admin_chain() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests that the chain listener stops tracking an event publisher chain once the subscriber
+/// chain unsubscribes from it (#4260).
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case::test_case(linera_execution::WasmRuntime::Wasmer; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case::test_case(linera_execution::WasmRuntime::Wasmtime; "wasmtime"))]
+#[test_log::test(tokio::test)]
+async fn test_chain_listener_untracks_after_unsubscribe(
+    wasm_runtime: linera_execution::WasmRuntime,
+) -> anyhow::Result<()> {
+    use linera_base::{data_types::Bytecode, vm::VmRuntime};
+    use linera_core::test_utils::ClientOutcomeResultExt as _;
+    use linera_execution::{Operation, ResourceControlPolicy};
+
+    let signer = InMemorySigner::new(Some(0));
+    let config = ChainListenerConfig::default();
+    let storage_builder = MemoryStorageBuilder::with_wasm_runtime(wasm_runtime);
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer.clone())
+        .await?
+        .with_policy(ResourceControlPolicy::all_categories());
+    // Root chain 0 is the admin chain (always fully synced); use higher indices for the test
+    // chains so that the publisher is not the admin chain.
+    let _admin = builder.add_root_chain(0, Amount::ONE).await?;
+    let sender = builder.add_root_chain(1, Amount::ONE).await?;
+    let receiver = builder.add_root_chain(2, Amount::ONE).await?;
+    let sender_id = sender.chain_id();
+    let receiver_id = receiver.chain_id();
+
+    let genesis_config = GenesisConfig::new_for_testing(&builder);
+    let admin_chain_id = genesis_config.admin_chain_id();
+
+    // Publish the `social` example (which uses event streams) and create an instance on both
+    // chains.
+    let (contract_path, service_path) =
+        linera_execution::wasm_test::get_example_bytecode_paths("social")?;
+    let contract = Bytecode::load_from_file(contract_path).await?;
+    let service = Bytecode::load_from_file(service_path).await?;
+    let (module_id, _) = receiver
+        .publish_module(contract, service, VmRuntime::Wasm, None)
+        .await
+        .unwrap_ok_committed();
+    let module_id = module_id.with_abi::<social::SocialAbi, (), ()>();
+    let (application_id, _) = receiver
+        .create_application(module_id, &(), &(), vec![])
+        .await
+        .unwrap_ok_committed();
+
+    // The receiver subscribes to the sender's posts, the sender posts, and the receiver records
+    // the event.
+    let subscribe = social::Operation::Subscribe {
+        chain_id: sender_id,
+    };
+    receiver
+        .execute_operation(Operation::user(application_id, &subscribe)?)
+        .await
+        .unwrap_ok_committed();
+    let post = social::Operation::Post {
+        text: "hello".to_string(),
+        image_url: None,
+    };
+    sender
+        .execute_operation(Operation::user(application_id, &post)?)
+        .await
+        .unwrap_ok_committed();
+    receiver.synchronize_from_validators().await?;
+    receiver.process_inbox().await?;
+
+    // Start a chain listener that fully tracks the receiver. Its signer holds no keys, so it only
+    // follows the chains: it observes blocks but never proposes any itself.
+    let storage = builder.make_storage().await?;
+    let receiver_epoch = receiver.chain_info().await?.epoch;
+    let mut context = ClientContext {
+        client: Arc::new(Client::new(
+            environment::Impl {
+                storage: storage.clone(),
+                network: builder.make_node_provider(),
+                signer: InMemorySigner::new(Some(99)),
+                wallet: environment::TestWallet::default(),
+            },
+            admin_chain_id,
+            false,
+            [(receiver_id, ListeningMode::FullChain)],
+            format!("Listener for {receiver_id:.8}"),
+            Some(Duration::from_secs(30)),
+            Some(Duration::from_secs(1)),
+            1000,
+            chain_client::Options::test_default(),
+            DEFAULT_BLOCK_CACHE_SIZE,
+            DEFAULT_EXECUTION_STATE_CACHE_SIZE,
+            &linera_core::client::RequestsSchedulerConfig::default(),
+        )),
+    };
+    context
+        .update_wallet_for_new_chain(
+            receiver_id,
+            receiver.preferred_owner(),
+            clock.current_time(),
+            receiver_epoch,
+        )
+        .await?;
+    let listener_client = context.client.clone();
+
+    let context = Arc::new(Mutex::new(context));
+    let cancellation_token = CancellationToken::new();
+    let chain_listener = ChainListener::new(
+        config,
+        context,
+        storage,
+        cancellation_token.child_token(),
+        tokio::sync::mpsc::unbounded_channel().1,
+        false,
+    )
+    .run()
+    .await
+    .unwrap();
+    let handle = linera_base::Task::spawn(async move { chain_listener.await.unwrap() });
+
+    // Because the receiver is subscribed to the sender, the listener should start tracking the
+    // sender as an event publisher (in `EventsOnly` mode).
+    wait_until(|| {
+        matches!(
+            listener_client.chain_mode(sender_id),
+            Some(ListeningMode::EventsOnly(_))
+        )
+    })
+    .await;
+
+    // The receiver unsubscribes. The listener should react to the new block and stop tracking the
+    // sender, since the subscription was the only reason it was tracked.
+    let unsubscribe = social::Operation::Unsubscribe {
+        chain_id: sender_id,
+    };
+    receiver
+        .execute_operation(Operation::user(application_id, &unsubscribe)?)
+        .await
+        .unwrap_ok_committed();
+
+    wait_until(|| listener_client.chain_mode(sender_id).is_none()).await;
+
+    // The receiver itself is still tracked.
+    assert!(listener_client.chain_mode(receiver_id).is_some());
+
+    cancellation_token.cancel();
+    handle.await;
+
+    Ok(())
+}
+
+/// Polls `condition`, yielding to the background listener task between attempts, until it holds or
+/// the attempt budget is exhausted (in which case it panics). The listener here is notification-
+/// driven, so no test-clock advancement is needed.
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+async fn wait_until(mut condition: impl FnMut() -> bool) {
+    for i in 0.. {
+        if condition() {
+            return;
+        }
+        assert!(i < 200, "condition not met within the attempt budget");
+        linera_base::time::timer::sleep(Duration::from_millis(20)).await;
+    }
+}
+
 /// Tests that the ListenerCommand::Listen actually adds chains to the wallet.
 #[test_log::test(tokio::test)]
 async fn test_chain_listener_listen_command_adds_chains_to_wallet() -> anyhow::Result<()> {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -332,6 +332,16 @@ impl ChainModes {
         }
         result
     }
+
+    /// Stops tracking `chain_id`, removing its entry entirely. Returns the removed mode, if any.
+    /// The tracked-set hash is recomputed only if the removed chain was `FullChain`.
+    pub fn remove_mode(&mut self, chain_id: &ChainId) -> Option<ListeningMode> {
+        let removed = self.modes.remove(chain_id)?;
+        if removed.is_full() {
+            self.full = Self::compute_full(&self.modes);
+        }
+        Some(removed)
+    }
 }
 
 /// A builder that creates [`ChainClient`]s which share the cache and notifiers.
@@ -519,6 +529,15 @@ impl<Env: Environment> Client<Env> {
             .write()
             .expect("Panics should not happen while holding a lock to `chain_modes`")
             .extend_mode(chain_id, mode)
+    }
+
+    /// Stops tracking a chain, removing its listening mode. Returns the removed mode, if any.
+    #[instrument(level = "trace", skip(self))]
+    pub fn remove_chain_mode(&self, chain_id: ChainId) -> Option<ListeningMode> {
+        self.chain_modes
+            .write()
+            .expect("Panics should not happen while holding a lock to `chain_modes`")
+            .remove_mode(&chain_id)
     }
 
     /// Returns the listening mode for a chain, if it is tracked.
@@ -2683,6 +2702,44 @@ pub async fn create_bytecode_blobs(
         blobs.push(blob);
     }
     (blobs, module_id)
+}
+
+#[cfg(test)]
+mod chain_modes_tests {
+    use std::collections::BTreeSet;
+
+    use linera_base::{crypto::CryptoHash, identifiers::ChainId};
+
+    use super::{ChainModes, ListeningMode};
+
+    /// `remove_mode` reports the previous mode (and `None` for an absent chain), and only rehashes
+    /// the memoized fully-tracked set when the removed chain was `FullChain` — removing an
+    /// `EventsOnly` chain leaves that set untouched.
+    #[test]
+    fn remove_mode_updates_full_set_only_for_full_chains() {
+        let mut modes = ChainModes::default();
+        let full = ChainId(CryptoHash::test_hash("full"));
+        let events_only = ChainId(CryptoHash::test_hash("events-only"));
+        modes.extend_mode(full, ListeningMode::FullChain);
+        modes.extend_mode(events_only, ListeningMode::EventsOnly(BTreeSet::new()));
+
+        let full_hash_before = modes.full().hash();
+        // Removing the events-only chain returns its mode but doesn't touch the fully-tracked set.
+        assert!(matches!(
+            modes.remove_mode(&events_only),
+            Some(ListeningMode::EventsOnly(_))
+        ));
+        assert!(modes.get(&events_only).is_none());
+        // Removing it again is a no-op.
+        assert!(modes.remove_mode(&events_only).is_none());
+        assert_eq!(modes.full().hash(), full_hash_before);
+        assert_eq!(modes.full().inner().0, BTreeSet::from([full]));
+
+        // Removing the full chain empties and rehashes the fully-tracked set.
+        assert_eq!(modes.remove_mode(&full), Some(ListeningMode::FullChain));
+        assert_ne!(modes.full().hash(), full_hash_before);
+        assert!(modes.full().inner().0.is_empty());
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

The chain listener currently keeps listening for updates on publisher chains even after the last subscriber was removed.

## Proposal

Stop listening if the only reason for listening to a chain is that it's a publisher, and the last subscriber unsubscribed.

## Test Plan

Tests were added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/4260
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
