### PR TITLE
ci: build docker images on main pushes

### DIFF
--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -2,7 +2,7 @@ name: Docker Image
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*', 'bridge-main' ]
+    branches: [ main, 'devnet_*', 'testnet_*', 'bridge-main' ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Motivation

We are standing up a new devnet that **tracks main**: its ArgoCD validator config pins a `linera` image digest built from main and moves it forward on deploys (the same mechanism `testnet_conway` uses from its branch). For that to work, pushes to `main` need to build and push the images.

## Proposal

Add `main` to the `push` trigger of `.github/workflows/docker_image.yml` (which already builds on `devnet_*` / `testnet_*` / `bridge-main`). On a push to `main`, each image (`linera`, `linera-tests`, `indexer`, `explorer`, `exporter`, `bridge`, `playground`) is built and pushed to `us-docker.pkg.dev/linera-io-dev/linera-public-registry` tagged with the branch name (`main`) plus the short and long commit SHAs — exactly as for the existing branches.

Note: this builds on every merge to `main`, which is busy — that is the intended cost of tracking main for the devnet.

## Test Plan

Trigger check: the workflow already runs successfully on `testnet_*`/`devnet_*` pushes; `main` reuses the identical job (for `main`, `BRANCH_TAG=main`; no branch-specific logic). Merging this makes the next push to `main` produce `linera:main` + `:<short-sha>` + `:<long-sha>`.

## Release Plan
- Nothing to do / These changes follow the usual deployment cycle.

## Links
- New declarative devnet work (linera-infra).