### PR TITLE
[backport] Race serving nodes concurrently when syncing the admin chain for an unknown epoch

### DIFF
--- a/linera-bridge/src/main.rs
+++ b/linera-bridge/src/main.rs
@@ -3,6 +3,11 @@
 
 //! CLI tool for Linera EVM bridge operations.
 
+// The binary's crate root needs its own limit (the library's does not apply here);
+// monomorphizing the deeply recursive client futures with the bridge's storage stack
+// otherwise overflows the default of 128.
+#![recursion_limit = "512"]
+
 use std::path::PathBuf;
 
 use anyhow::Result;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -344,6 +344,16 @@ pub struct Client<Env: Environment> {
     options: chain_client::Options,
 }
 
+/// Boxed future returned by `receive_sender_certificate`. It is `Send` off the `web`
+/// target (where futures must be `Send`) and `?Send` on `web` (single-threaded, where
+/// the validator node is not `Sync`).
+#[cfg(not(web))]
+type ReceiveSenderCertificateFuture<'a> =
+    std::pin::Pin<Box<dyn Future<Output = Result<(), chain_client::Error>> + Send + 'a>>;
+#[cfg(web)]
+type ReceiveSenderCertificateFuture<'a> =
+    std::pin::Pin<Box<dyn Future<Output = Result<(), chain_client::Error>> + 'a>>;
+
 impl<Env: Environment> Client<Env> {
     /// Creates a new `Client` with a new cache and notifiers.
     #[instrument(level = "trace", skip_all)]
@@ -1393,72 +1403,98 @@ impl<Env: Environment> Client<Env> {
     /// chains we follow get executed, untracked or events-only chains are only
     /// preprocessed.
     #[instrument(level = "trace", skip_all)]
-    async fn receive_sender_certificate(
+    fn receive_sender_certificate(
         &self,
         certificate: CacheArc<ConfirmedBlockCertificate>,
         mode: ReceiveCertificateMode,
         nodes: Option<Vec<RemoteNode<Env::ValidatorNode>>>,
-    ) -> Result<(), chain_client::Error> {
-        // Verify the certificate before doing any expensive networking.
-        let (mut max_epoch, mut committees) = self.admin_committees().await?;
-        if let ReceiveCertificateMode::NeedsCheck = mode {
-            let mut check_result = Self::check_certificate(max_epoch, &committees, &certificate)?;
-            if matches!(check_result, CheckCertificateResult::FutureEpoch) {
-                // The certificate is from an epoch our local view of the admin chain
-                // hasn't caught up to yet. Catch up and check again instead of failing.
-                // Prefer the nodes that gave us the certificate: they evidently know
-                // the newer epoch even if our own committee view is stale or its
-                // members are unreachable. A sync only counts if it actually made the
-                // epoch known; otherwise fall back to the known committee.
-                let admin_chain_id = self.admin_chain_id;
-                let epoch = certificate.block().header.epoch;
-                info!(
-                    %epoch,
-                    "certificate is from an unknown epoch; synchronizing the admin chain"
-                );
-                for node in nodes.iter().flatten() {
-                    match Box::pin(self.synchronize_chain_state_from(node, admin_chain_id)).await {
-                        Ok(()) => {
-                            (max_epoch, committees) = self.admin_committees().await?;
-                            check_result =
-                                Self::check_certificate(max_epoch, &committees, &certificate)?;
-                            if !matches!(check_result, CheckCertificateResult::FutureEpoch) {
-                                break;
-                            }
-                        }
-                        Err(error) => warn!(
-                            %error,
-                            validator = %node.public_key,
-                            "failed to synchronize the admin chain from validator",
-                        ),
+    ) -> ReceiveSenderCertificateFuture<'_> {
+        Box::pin(async move {
+            // Verify the certificate before doing any expensive networking.
+            let (mut max_epoch, mut committees) = self.admin_committees().await?;
+            if let ReceiveCertificateMode::NeedsCheck = mode {
+                let mut check_result =
+                    Self::check_certificate(max_epoch, &committees, &certificate)?;
+                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                    // The certificate is from an epoch our local view of the admin chain
+                    // hasn't caught up to yet. Catch up and check again instead of failing.
+                    // Prefer the nodes that gave us the certificate: they evidently know
+                    // the newer epoch even if our own committee view is stale or its
+                    // members are unreachable. A sync only counts if it actually made the
+                    // epoch known; otherwise fall back to the known committee.
+                    let admin_chain_id = self.admin_chain_id;
+                    let epoch = certificate.block().header.epoch;
+                    info!(
+                        %epoch,
+                        "certificate is from an unknown epoch; synchronizing the admin chain"
+                    );
+                    let synced_from_serving_node = if let Some(nodes) = &nodes {
+                        let certificate = &certificate;
+                        communicate_concurrently(
+                            nodes,
+                            async move |node| {
+                                self.synchronize_chain_state_from(&node, admin_chain_id)
+                                    .await?;
+                                let (max_epoch, committees) = self.admin_committees().await?;
+                                match Self::check_certificate(max_epoch, &committees, certificate)?
+                                {
+                                    CheckCertificateResult::FutureEpoch => {
+                                        Err(chain_client::Error::CommitteeSynchronizationError)
+                                    }
+                                    _ => Ok(()),
+                                }
+                            },
+                            |errors| {
+                                for (validator, error) in &errors {
+                                    warn!(
+                                        %validator,
+                                        %error,
+                                        "failed to synchronize the admin chain from validator",
+                                    );
+                                }
+                                chain_client::Error::CommitteeSynchronizationError
+                            },
+                            self.options.blob_download_hedge_delay,
+                            self.storage_client().clock(),
+                        )
+                        .await
+                        .is_ok()
+                    } else {
+                        false
+                    };
+                    if synced_from_serving_node {
+                        (max_epoch, committees) = self.admin_committees().await?;
+                        check_result =
+                            Self::check_certificate(max_epoch, &committees, &certificate)?;
+                    }
+                    if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                        Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
+                        (max_epoch, committees) = self.admin_committees().await?;
+                        check_result =
+                            Self::check_certificate(max_epoch, &committees, &certificate)?;
                     }
                 }
-                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
-                    Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
-                    (max_epoch, committees) = self.admin_committees().await?;
-                    check_result = Self::check_certificate(max_epoch, &committees, &certificate)?;
-                }
+                check_result.into_result()?;
             }
-            check_result.into_result()?;
-        }
-        // Recover history from the network.
-        let nodes = if let Some(nodes) = nodes {
-            nodes
-        } else {
-            self.validator_nodes().await?
-        };
-        let processing_mode = if self
-            .chain_mode(certificate.value().chain_id())
-            .is_some_and(|m| m.should_sync_chain_state())
-        {
-            ProcessConfirmedBlockMode::Auto
-        } else {
-            ProcessConfirmedBlockMode::Preprocess
-        };
-        self.handle_certificate_with_retry(&certificate, &nodes, processing_mode)
-            .await?;
+            // Recover history from the network.
+            let nodes = if let Some(nodes) = nodes {
+                nodes
+            } else {
+                self.validator_nodes().await?
+            };
+            let processing_mode = if self
+                .chain_mode(certificate.value().chain_id())
+                .is_some_and(|m| m.should_sync_chain_state())
+            {
+                ProcessConfirmedBlockMode::Auto
+            } else {
+                ProcessConfirmedBlockMode::Preprocess
+            };
+            self.handle_certificate_with_retry(&certificate, &nodes, processing_mode)
+                .await?;
 
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Downloads and processes certificates for sender chain blocks.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1354,6 +1354,57 @@ where
     Ok(())
 }
 
+/// Like `test_stale_client_reads_blob_published_in_future_epoch`, but one validator is
+/// offline while the stale client catches up. The admin-chain self-heal races the
+/// reachable validators, so a single unresponsive one must not prevent recovery.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_stale_client_reads_future_epoch_blob_with_offline_validator<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let publisher = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let stale = builder.add_root_chain(2, Amount::from_tokens(3)).await?;
+    let validators = builder.initial_committee.validators().clone();
+
+    // Move the network to epoch 1 (the three remaining validators still form a quorum).
+    // The publisher catches up; `stale` does not.
+    let committee = Committee::new(validators, ResourceControlPolicy::default());
+    admin.stage_new_committee(committee).await?;
+    publisher.synchronize_from_validators().await?;
+    publisher.process_inbox().await?;
+    assert_eq!(publisher.chain_info().await?.epoch, Epoch::from(1));
+    assert_eq!(stale.chain_info().await?.epoch, Epoch::ZERO);
+
+    // Publish a data blob under the epoch-1 committee.
+    let blob_bytes = b"future-epoch blob".to_vec();
+    let blob_id = Blob::new(BlobContent::new_data(blob_bytes.clone())).id();
+    let certificate = publisher
+        .publish_data_blob(blob_bytes)
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(certificate.block().header.epoch, Epoch::from(1));
+
+    // Take one validator offline. The stale client's admin-chain catch-up still succeeds
+    // against the reachable ones.
+    builder.set_fault_type([3], FaultType::Offline);
+
+    stale
+        .read_data_blob(blob_id.hash)
+        .await
+        .unwrap_ok_committed();
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## Motivation

Backport of #6552 to `testnet_conway`. When a client with a stale view of the admin
chain hits a `FutureEpoch` certificate, `receive_sender_certificate` catches up by
syncing the admin chain from the node(s) that served the certificate. The self-heal
loop (added by the #6486 backport) walked those nodes sequentially; every other place
that takes a list of nodes (`download_blobs`, blob recovery) races them with
`communicate_concurrently`, so a slow or unresponsive node does not block the others.

## Proposal

Port of #6552, adapted to `testnet_conway`:

- Replace the sequential per-node loop in `receive_sender_certificate` with
  `communicate_concurrently` over the serving nodes (first node that actually advances
  the epoch wins; the rest are aborted), keeping the known-committee
  `synchronize_chain_state` fallback unchanged. Uses conway's 5-arg
  `communicate_concurrently` signature (with the error-mapping closure).
- Convert `receive_sender_certificate` from an `async fn` to a function returning
  `Pin<Box<dyn Future + Send>>` (cfg-gated `?Send` on `web`). This is required, not
  cosmetic: the admin-chain sync recurses back into `receive_sender_certificate`, and
  without boxing the future at this boundary the `Send` bound needed by the concurrent
  self-heal overflows the trait solver (`E0275`).
- Raise the `linera-bridge` binary's `recursion_limit` to 512 (its crate root had none
  → default 128; the deeper client recursion overflows it in the release build).

Note on scope: today the only `NeedsCheck` caller passes a single serving node, so the
concurrency is latent — behavior is unchanged for the current callers. The change makes
the function honor a multi-node list correctly (and matches the rest of the file).

## Test Plan

- Existing `test_stale_client_reads_blob_published_in_future_epoch` still passes.
- New `test_stale_client_reads_future_epoch_blob_with_offline_validator`: a stale client
  catches up and reads a future-epoch blob while one validator is offline, exercising
  recovery against a partially-unreachable committee.
- `cargo test -p linera-core client_tests`, `cargo clippy --all-targets --all-features
  --workspace --exclude linera-web`, web-default wasm clippy, and
  `cargo build --release --bin linera-bridge --features relay` all pass.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Backport of #6552 (main); follow-up to #6486 / #6481.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)