### PR TITLE
Fix faucet_balance_amount gauge overflow (backport #6560)

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -346,6 +346,15 @@ impl From<Amount> for U256 {
     }
 }
 
+impl From<Amount> for f64 {
+    /// Returns the amount as a floating-point number of whole tokens. This is
+    /// lossy for large or high-precision amounts; intended for telemetry, not
+    /// for arithmetic.
+    fn from(amount: Amount) -> f64 {
+        amount.0 as f64 / Amount::ONE.0 as f64
+    }
+}
+
 impl TryFrom<U256> for Amount {
     type Error = ArithmeticError;
 

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -4,9 +4,9 @@
 //! This module defines utility functions for interacting with Prometheus (logging metrics, etc)
 
 use prometheus::{
-    exponential_buckets, histogram_opts, linear_buckets, register_histogram,
+    exponential_buckets, histogram_opts, linear_buckets, register_gauge_vec, register_histogram,
     register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
-    register_int_gauge_vec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    register_int_gauge_vec, GaugeVec, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge,
     IntGaugeVec, Opts,
 };
 
@@ -150,6 +150,13 @@ pub fn register_int_gauge_with_subsystem(
 pub fn register_int_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> IntGaugeVec {
     let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
     register_int_gauge_vec!(gauge_opts, label_names).expect("IntGauge can be created")
+}
+
+/// Wrapper around Prometheus `register_gauge_vec!` macro (floating-point gauge) which also sets
+/// the `linera` namespace. Use this for quantities with a fractional part (e.g. token balances).
+pub fn register_gauge_vec(name: &str, description: &str, label_names: &[&str]) -> GaugeVec {
+    let gauge_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
+    register_gauge_vec!(gauge_opts, label_names).expect("Gauge can be created")
 }
 
 /// Wrapper around Prometheus `register_int_gauge_vec!` macro with `linera` namespace and a subsystem.

--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -59,10 +59,10 @@ mod metrics {
     use std::sync::LazyLock;
 
     use linera_base::prometheus_util::{
-        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
-        register_int_gauge_vec,
+        exponential_bucket_interval, register_gauge_vec, register_histogram_vec,
+        register_int_counter_vec,
     };
-    use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
+    use prometheus::{GaugeVec, HistogramVec, IntCounterVec};
 
     pub static CLAIM_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
@@ -127,10 +127,10 @@ mod metrics {
         )
     });
 
-    pub static FAUCET_BALANCE: LazyLock<IntGaugeVec> = LazyLock::new(|| {
-        register_int_gauge_vec(
+    pub static FAUCET_BALANCE: LazyLock<GaugeVec> = LazyLock::new(|| {
+        register_gauge_vec(
             "faucet_balance_amount",
-            "Current balance of the faucet chain",
+            "Current balance of the faucet chain, in tokens",
             &[],
         )
     });
@@ -821,7 +821,7 @@ where
         #[cfg(with_metrics)]
         metrics::FAUCET_BALANCE
             .with_label_values(&[])
-            .set(u128::from(balance) as i64);
+            .set(f64::from(balance));
 
         let total_amount = requests
             .iter()


### PR DESCRIPTION
## Motivation

Backport of #6560 to `testnet_conway`. The `faucet_balance_amount` gauge exported garbage/negative values — the faucet balance is an `Amount` (u128 scaled by 10^18) cast straight to the old `IntGauge` i64, which overflows (200M tokens = 2e26). The metric is unusable on the live conway faucet (e.g. no low-balance alert possible) until this lands and the faucet image is rebuilt.

## Proposal

Same as #6560:
- Add a float-gauge wrapper `register_gauge_vec` to `linera-base::prometheus_util`.
- Add `From<Amount> for f64` (documented as lossy / telemetry-only) in `linera-base`.
- Switch `FAUCET_BALANCE` from `IntGaugeVec` to `GaugeVec`, set to `f64::from(balance)` — tokens with fractional precision, so the draw-down is visible.

Conway had diverged around `AmountConversionError`/`TryFrom<U256>` (uses `ArithmeticError`); resolved by inserting only the `From<Amount> for f64` impl after `From<Amount> for U256`, preserving conway’s structure.

## Test Plan

`cargo clippy -p linera-base -p linera-faucet-server --features linera-faucet-server/metrics --all-targets -- -D warnings` passes on the conway tree; nightly rustfmt clean. Pure telemetry change, numerically identical conversion.

## Release Plan
- This is the testnet backport of #6560 (already merged to `main`). The conway faucet image needs rebuilding at a commit including this before the metric is live.

## Links
- main PR: #6560