### PR TITLE
[testnet] Make RequestScheduler's tracker cancel safe

### DIFF
--- a/linera-core/src/client/requests_scheduler/in_flight_tracker.rs
+++ b/linera-core/src/client/requests_scheduler/in_flight_tracker.rs
@@ -27,7 +27,9 @@ use crate::node::NodeError;
 ///
 /// The entries map is guarded by a synchronous [`Mutex`] (never held across an `.await`)
 /// so that an owner's [`InFlightGuard`] can remove its entry from `Drop`, which is what
-/// makes deduplication cancel-safe — see [`InFlightTracker::insert_new`].
+/// makes deduplication cancel-safe — see [`InFlightTracker::insert_new`]. A `Mutex` is
+/// preferred over an `RwLock` because every critical section is only a few map
+/// operations: too short for reader parallelism to pay for the more expensive lock.
 #[derive(Debug, Clone)]
 pub(super) struct InFlightTracker<N> {
     /// Maps request keys to in-flight entries containing broadcast senders and metadata
@@ -105,24 +107,37 @@ impl<N: Clone> InFlightTracker<N> {
     /// dropping the broadcast sender so subscribers wake with `RecvError::Closed`
     /// and execute the request themselves rather than waiting forever.
     ///
+    /// If an entry already exists for this key (its owner went stale or lost an
+    /// insertion race), the new entry adopts its broadcast sender: the existing
+    /// subscribers are waiting for exactly this data, so they receive the new
+    /// owner's result instead of being disconnected. The previous owner's guard
+    /// is invalidated by the generation bump.
+    ///
     /// # Arguments
     /// - `key`: The request key to insert
     /// - `now`: The current time, recorded as the entry's start time
     pub(super) fn insert_new(&self, key: RequestKey, now: Timestamp) -> InFlightGuard<N> {
-        let (sender, _receiver) = broadcast::channel(1);
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        self.entries
+        let mut in_flight = self
+            .entries
             .lock()
-            .expect("in-flight tracker mutex poisoned")
-            .insert(
-                key.clone(),
-                InFlightEntry {
-                    sender,
-                    started_at: now,
-                    generation,
-                    alternative_peers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
-                },
-            );
+            .expect("in-flight tracker mutex poisoned");
+        // The owner never listens on this channel — it produces the result itself.
+        // Subscribers create their receivers later via `Sender::subscribe`.
+        let sender = match in_flight.remove(&key) {
+            Some(previous) => previous.sender,
+            None => broadcast::channel(1).0,
+        };
+        in_flight.insert(
+            key.clone(),
+            InFlightEntry {
+                sender,
+                started_at: now,
+                generation,
+                alternative_peers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+            },
+        );
+        drop(in_flight);
         InFlightGuard {
             entries: self.entries.clone(),
             key,

--- a/linera-core/src/client/requests_scheduler/in_flight_tracker.rs
+++ b/linera-core/src/client/requests_scheduler/in_flight_tracker.rs
@@ -1,7 +1,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, fmt::Debug, sync::Arc};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+};
 
 use linera_base::{data_types::Timestamp, time::Duration};
 use tokio::sync::broadcast;
@@ -17,10 +24,17 @@ use crate::node::NodeError;
 /// This structure manages a map of request keys to in-flight entries, each containing
 /// broadcast senders for notifying waiters when a request completes, as well as timing
 /// information and alternative data sources.
+///
+/// The entries map is guarded by a synchronous [`Mutex`] (never held across an `.await`)
+/// so that an owner's [`InFlightGuard`] can remove its entry from `Drop`, which is what
+/// makes deduplication cancel-safe — see [`InFlightTracker::insert_new`].
 #[derive(Debug, Clone)]
 pub(super) struct InFlightTracker<N> {
     /// Maps request keys to in-flight entries containing broadcast senders and metadata
-    entries: Arc<tokio::sync::RwLock<HashMap<RequestKey, InFlightEntry<N>>>>,
+    entries: Arc<Mutex<HashMap<RequestKey, InFlightEntry<N>>>>,
+    /// Source of per-entry generation numbers, so an owner only removes the entry it
+    /// created and not a later owner that reused the same key.
+    next_generation: Arc<AtomicU64>,
     /// Maximum duration before an in-flight request is considered stale and deduplication is skipped
     timeout: Duration,
 }
@@ -32,7 +46,8 @@ impl<N: Clone> InFlightTracker<N> {
     /// - `timeout`: Maximum duration before an in-flight request is considered too old to deduplicate against
     pub(super) fn new(timeout: Duration) -> Self {
         Self {
-            entries: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            entries: Arc::new(Mutex::new(HashMap::new())),
+            next_generation: Arc::new(AtomicU64::new(0)),
             timeout,
         }
     }
@@ -49,12 +64,11 @@ impl<N: Clone> InFlightTracker<N> {
     /// # Returns
     /// - `None`: No matching in-flight request found. Also returned if the found request is stale (exceeds timeout).
     /// - `Some(InFlightMatch::Subsuming { key, outcome })`: Subsuming request found
-    pub(super) async fn try_subscribe(
-        &self,
-        key: &RequestKey,
-        now: Timestamp,
-    ) -> Option<InFlightMatch> {
-        let in_flight = self.entries.read().await;
+    pub(super) fn try_subscribe(&self, key: &RequestKey, now: Timestamp) -> Option<InFlightMatch> {
+        let in_flight = self
+            .entries
+            .lock()
+            .expect("in-flight tracker mutex poisoned");
 
         if let Some(entry) = in_flight.get(key) {
             let elapsed = now.duration_since(entry.started_at);
@@ -81,61 +95,39 @@ impl<N: Clone> InFlightTracker<N> {
         None
     }
 
-    /// Inserts a new in-flight request entry.
+    /// Inserts a new in-flight request entry and returns the owner guard.
     ///
-    /// Creates a new broadcast channel and in-flight entry for the given key,
-    /// marking the start time as now.
+    /// The returned [`InFlightGuard`] owns the entry. Completing the request via
+    /// [`InFlightGuard::complete_and_broadcast`] broadcasts the result to all
+    /// subscribers and removes the entry. If the guard is instead dropped without
+    /// completing — for example because the owning task was cancelled, such as a
+    /// losing branch of `communicate_with_quorum` — its `Drop` removes the entry,
+    /// dropping the broadcast sender so subscribers wake with `RecvError::Closed`
+    /// and execute the request themselves rather than waiting forever.
     ///
     /// # Arguments
     /// - `key`: The request key to insert
-    pub(super) async fn insert_new(&self, key: RequestKey, now: Timestamp) {
+    /// - `now`: The current time, recorded as the entry's start time
+    pub(super) fn insert_new(&self, key: RequestKey, now: Timestamp) -> InFlightGuard<N> {
         let (sender, _receiver) = broadcast::channel(1);
-        let mut in_flight = self.entries.write().await;
-
-        in_flight.insert(
-            key,
-            InFlightEntry {
-                sender,
-                started_at: now,
-                alternative_peers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
-            },
-        );
-    }
-
-    /// Completes an in-flight request by removing it and broadcasting the result.
-    ///
-    /// Removes the entry for the given key and broadcasts the result to all waiting
-    /// subscribers. Logs the number of waiters that received the notification.
-    ///
-    /// # Arguments
-    /// - `key`: The request key to complete
-    /// - `result`: The result to broadcast to waiters
-    pub(super) async fn complete_and_broadcast(
-        &self,
-        key: &RequestKey,
-        result: Arc<Result<RequestResult, NodeError>>,
-    ) -> usize {
-        let mut in_flight = self.entries.write().await;
-
-        if let Some(entry) = in_flight.remove(key) {
-            let waiter_count = entry.sender.receiver_count();
-            tracing::trace!(
-                key = ?key,
-                waiters = waiter_count,
-                "request completed; broadcasting result to waiters",
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        self.entries
+            .lock()
+            .expect("in-flight tracker mutex poisoned")
+            .insert(
+                key.clone(),
+                InFlightEntry {
+                    sender,
+                    started_at: now,
+                    generation,
+                    alternative_peers: Arc::new(tokio::sync::RwLock::new(Vec::new())),
+                },
             );
-            if waiter_count != 0 {
-                if let Err(err) = entry.sender.send(result) {
-                    tracing::warn!(
-                        key = ?key,
-                        error = ?err,
-                        "failed to broadcast result to waiters"
-                    );
-                }
-            }
-            return waiter_count;
+        InFlightGuard {
+            entries: self.entries.clone(),
+            key,
+            generation,
         }
-        0
     }
 
     /// Registers an alternative peer for an in-flight request.
@@ -150,14 +142,12 @@ impl<N: Clone> InFlightTracker<N> {
     where
         N: PartialEq + Eq,
     {
-        if let Some(entry) = self.entries.read().await.get(key) {
-            // Register this peer as an alternative source if not already present
-            {
-                let mut alt_peers = entry.alternative_peers.write().await;
-                if !alt_peers.contains(&peer) {
-                    alt_peers.push(peer);
-                }
-            }
+        let Some(alternative_peers) = self.alternative_peers(key) else {
+            return;
+        };
+        let mut alt_peers = alternative_peers.write().await;
+        if !alt_peers.contains(&peer) {
+            alt_peers.push(peer);
         }
     }
 
@@ -171,10 +161,8 @@ impl<N: Clone> InFlightTracker<N> {
     /// # Returns
     /// - `Vec<N>`: List of alternative peers (empty if no entry exists)
     pub(super) async fn get_alternative_peers(&self, key: &RequestKey) -> Option<Vec<N>> {
-        let in_flight = self.entries.read().await;
-
-        let entry = in_flight.get(key)?;
-        let peers = entry.alternative_peers.read().await;
+        let alternative_peers = self.alternative_peers(key)?;
+        let peers = alternative_peers.read().await;
         Some(peers.clone())
     }
 
@@ -187,10 +175,10 @@ impl<N: Clone> InFlightTracker<N> {
     where
         N: PartialEq + Eq,
     {
-        if let Some(entry) = self.entries.read().await.get(key) {
-            let mut alt_peers = entry.alternative_peers.write().await;
-            alt_peers.retain(|p| p != peer);
-        }
+        let Some(alternative_peers) = self.alternative_peers(key) else {
+            return;
+        };
+        alternative_peers.write().await.retain(|p| p != peer);
     }
 
     /// Pops and returns the newest alternative peer from the list.
@@ -205,12 +193,19 @@ impl<N: Clone> InFlightTracker<N> {
     /// - `Some(N)`: The newest alternative peer
     /// - `None`: No entry exists or alternatives list is empty
     pub(super) async fn pop_alternative_peer(&self, key: &RequestKey) -> Option<N> {
-        if let Some(entry) = self.entries.read().await.get(key) {
-            let mut alt_peers = entry.alternative_peers.write().await;
-            alt_peers.pop()
-        } else {
-            None
-        }
+        self.alternative_peers(key)?.write().await.pop()
+    }
+
+    /// Returns the shared alternative-peers list for an entry, if it exists.
+    ///
+    /// The entries lock is released before the caller awaits the returned lock, so the
+    /// synchronous [`Mutex`] is never held across an `.await`.
+    fn alternative_peers(&self, key: &RequestKey) -> Option<Arc<tokio::sync::RwLock<Vec<N>>>> {
+        self.entries
+            .lock()
+            .expect("in-flight tracker mutex poisoned")
+            .get(key)
+            .map(|entry| entry.alternative_peers.clone())
     }
 }
 
@@ -233,6 +228,75 @@ pub(super) enum InFlightMatch {
 #[derive(Debug)]
 pub(super) struct Subscribed(pub(super) broadcast::Receiver<Arc<Result<RequestResult, NodeError>>>);
 
+/// Owns an in-flight entry for the lifetime of the request that created it.
+///
+/// Completing via [`InFlightGuard::complete_and_broadcast`] is the success path. If the
+/// guard is dropped first (the owning task was cancelled), `Drop` removes the entry so
+/// subscribers stop waiting. Both paths are generation-checked, so a guard never touches
+/// an entry a later owner created after this one went stale and was replaced.
+pub(super) struct InFlightGuard<N> {
+    entries: Arc<Mutex<HashMap<RequestKey, InFlightEntry<N>>>>,
+    key: RequestKey,
+    generation: u64,
+}
+
+impl<N> InFlightGuard<N> {
+    /// Removes the owned entry and broadcasts the result to all waiting subscribers.
+    ///
+    /// Returns the number of subscribers that were notified. Does nothing (returns `0`)
+    /// if a later owner has already replaced this entry, in which case this result is
+    /// stale and must not be broadcast. After this call the guard's `Drop` is a no-op.
+    pub(super) fn complete_and_broadcast(
+        &self,
+        result: Arc<Result<RequestResult, NodeError>>,
+    ) -> usize {
+        let mut in_flight = self
+            .entries
+            .lock()
+            .expect("in-flight tracker mutex poisoned");
+        if in_flight
+            .get(&self.key)
+            .is_none_or(|entry| entry.generation != self.generation)
+        {
+            return 0;
+        }
+        let entry = in_flight.remove(&self.key).expect("checked above");
+        let waiter_count = entry.sender.receiver_count();
+        tracing::trace!(
+            key = ?self.key,
+            waiters = waiter_count,
+            "request completed; broadcasting result to waiters",
+        );
+        if waiter_count != 0 {
+            if let Err(err) = entry.sender.send(result) {
+                tracing::warn!(
+                    key = ?self.key,
+                    error = ?err,
+                    "failed to broadcast result to waiters"
+                );
+            }
+        }
+        waiter_count
+    }
+}
+
+impl<N> Drop for InFlightGuard<N> {
+    fn drop(&mut self) {
+        let Ok(mut in_flight) = self.entries.lock() else {
+            return; // Poisoned mutex: nothing safe to do from `Drop`.
+        };
+        // Remove only if our entry is still the current one for this key. Dropping it
+        // drops the broadcast sender, waking subscribers with `Closed` so they execute
+        // the request themselves instead of waiting for a result that will never arrive.
+        if in_flight
+            .get(&self.key)
+            .is_some_and(|entry| entry.generation == self.generation)
+        {
+            in_flight.remove(&self.key);
+        }
+    }
+}
+
 /// In-flight request entry that tracks when the request was initiated.
 #[derive(Debug)]
 pub(super) struct InFlightEntry<N> {
@@ -240,6 +304,8 @@ pub(super) struct InFlightEntry<N> {
     sender: broadcast::Sender<Arc<Result<RequestResult, NodeError>>>,
     /// Time when this request was initiated
     started_at: Timestamp,
+    /// Generation of this entry, used by the owner guard to remove only its own entry.
+    generation: u64,
     /// Alternative peers that can provide this data if the primary request fails
     alternative_peers: Arc<tokio::sync::RwLock<Vec<N>>>,
 }

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -597,7 +597,6 @@ impl<Env: Environment> RequestsScheduler<Env> {
         if let Some(in_flight_match) = self
             .in_flight_tracker
             .try_subscribe(&key, self.clock.current_time())
-            .await
         {
             match in_flight_match {
                 InFlightMatch::Exact(Subscribed(mut receiver)) => {
@@ -698,10 +697,13 @@ impl<Env: Environment> RequestsScheduler<Env> {
             }
         };
 
-        // Create new in-flight entry for this request
-        self.in_flight_tracker
-            .insert_new(key.clone(), self.clock.current_time())
-            .await;
+        // Create a new in-flight entry for this request. The returned guard owns the
+        // entry: if this task is cancelled before completing (e.g. a losing branch of
+        // `communicate_with_quorum`), dropping it removes the entry so subscribers wake
+        // up and execute the request themselves instead of waiting forever.
+        let in_flight_guard = self
+            .in_flight_tracker
+            .insert_new(key.clone(), self.clock.current_time());
 
         // Remove the peer we're about to use from alternatives (it shouldn't retry with itself)
         self.in_flight_tracker
@@ -718,10 +720,8 @@ impl<Env: Environment> RequestsScheduler<Env> {
         let result_for_broadcast: Result<RequestResult, NodeError> = result.clone().map(Into::into);
         let shared_result = Arc::new(result_for_broadcast);
 
-        // Broadcast result and clean up
-        self.in_flight_tracker
-            .complete_and_broadcast(&key, shared_result.clone())
-            .await;
+        // Broadcast result and clean up.
+        in_flight_guard.complete_and_broadcast(shared_result.clone());
 
         if let Ok(success) = shared_result.as_ref() {
             self.cache
@@ -1226,7 +1226,7 @@ mod tests {
         let now = manager.clock.current_time();
 
         // A request is in flight, and two other peers register as alternative sources for it.
-        manager.in_flight_tracker.insert_new(key.clone(), now).await;
+        let guard = manager.in_flight_tracker.insert_new(key.clone(), now);
         manager
             .in_flight_tracker
             .add_alternative_peer(&key, nodes[1].clone())
@@ -1244,14 +1244,46 @@ mod tests {
         );
 
         // Completing the request removes the in-flight entry along with its alternatives.
-        manager
-            .in_flight_tracker
-            .complete_and_broadcast(&key, Arc::new(Ok(RequestResult::Blob(None))))
-            .await;
+        guard.complete_and_broadcast(Arc::new(Ok(RequestResult::Blob(None))));
         assert!(
             manager.get_alternative_peers(&key).await.is_none(),
             "Expected the in-flight entry to be removed after completion",
         );
+    }
+
+    /// Dropping the owner guard without completing must wake subscribers — they fall back to
+    /// executing the request themselves — rather than leaving them blocked forever. Regression
+    /// test for the cold-sync hang where a cancelled `communicate_with_quorum` branch leaked the
+    /// in-flight entry, so its subscribers' `recv().await` never returned.
+    #[tokio::test]
+    async fn test_owner_drop_wakes_subscribers() {
+        use linera_base::identifiers::BlobType;
+
+        let manager = create_test_manager(Duration::from_secs(60), Duration::from_secs(60));
+        let key = RequestKey::Blob(BlobId::new(
+            CryptoHash::test_hash("test_blob"),
+            BlobType::Data,
+        ));
+        let now = manager.clock.current_time();
+
+        // An owner registers an in-flight request; a second caller subscribes to it.
+        let guard = manager.in_flight_tracker.insert_new(key.clone(), now);
+        let Some(InFlightMatch::Exact(Subscribed(mut receiver))) =
+            manager.in_flight_tracker.try_subscribe(&key, now)
+        else {
+            panic!("expected to subscribe to the in-flight request");
+        };
+
+        // The owner is cancelled before completing the request.
+        drop(guard);
+
+        // The subscriber observes the channel closing instead of hanging, and the entry is gone
+        // so a later caller starts its own request.
+        assert!(matches!(
+            receiver.recv().await,
+            Err(tokio::sync::broadcast::error::RecvError::Closed),
+        ));
+        assert!(manager.in_flight_tracker.try_subscribe(&key, now).is_none());
     }
 
     #[tokio::test]
@@ -1323,11 +1355,11 @@ mod tests {
             }
         };
 
-        // Setup: Insert in-flight entry and register alternative peers
-        manager
+        // Setup: Insert in-flight entry and register alternative peers. The guard is
+        // held for the rest of the test so the entry is not dropped before the request runs.
+        let _guard = manager
             .in_flight_tracker
-            .insert_new(key.clone(), manager.clock.current_time())
-            .await;
+            .insert_new(key.clone(), manager.clock.current_time());
         // Register nodes 3, 2, 1 as alternatives (will be popped in reverse: 1, 2, 3)
         for node in nodes.iter().skip(1).rev() {
             manager

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -1286,6 +1286,44 @@ mod tests {
         assert!(manager.in_flight_tracker.try_subscribe(&key, now).is_none());
     }
 
+    /// A new owner for a key adopts the previous entry's broadcast sender, so waiters
+    /// subscribed to the replaced entry receive the new owner's result instead of being
+    /// disconnected — and the stale owner can neither broadcast nor remove the new entry.
+    #[tokio::test]
+    async fn test_new_owner_adopts_existing_waiters() {
+        use linera_base::identifiers::BlobType;
+
+        let manager = create_test_manager(Duration::from_secs(60), Duration::from_secs(60));
+        let key = RequestKey::Blob(BlobId::new(
+            CryptoHash::test_hash("test_blob"),
+            BlobType::Data,
+        ));
+        let now = manager.clock.current_time();
+
+        let first_owner = manager.in_flight_tracker.insert_new(key.clone(), now);
+        let Some(InFlightMatch::Exact(Subscribed(mut receiver))) =
+            manager.in_flight_tracker.try_subscribe(&key, now)
+        else {
+            panic!("expected to subscribe to the in-flight request");
+        };
+
+        // A second owner takes over the same key (e.g. the first went stale).
+        let second_owner = manager.in_flight_tracker.insert_new(key.clone(), now);
+
+        // The stale owner completing late neither broadcasts nor removes the new entry.
+        assert_eq!(
+            first_owner.complete_and_broadcast(Arc::new(Ok(RequestResult::Blob(None)))),
+            0
+        );
+
+        // The waiter subscribed before the takeover receives the new owner's result.
+        assert_eq!(
+            second_owner.complete_and_broadcast(Arc::new(Ok(RequestResult::Blob(None)))),
+            1
+        );
+        assert!(receiver.recv().await.is_ok());
+    }
+
     #[tokio::test]
     async fn test_staggered_parallel_retry_on_failure() {
         use crate::test_utils::{MemoryStorageBuilder, TestBuilder};


### PR DESCRIPTION
## Motivation

Backport of #6577 to `testnet_conway`.

The client's request scheduler deduplicates concurrent requests for the same
data (`RequestsScheduler::deduplicated_request`): the first caller becomes the
*owner* and executes the request, while later callers *subscribe* and wait on a
broadcast channel. `InFlightTracker` holds the in-flight entries; only
`complete_and_broadcast` ever removed one.

This is not cancel-safe. If the owning task is dropped **before** completing —
which happens routinely: `synchronize_up_to` runs `download_certificates_from`
against every validator under `communicate_with_quorum`, and once a quorum
responds the losing futures are dropped mid-flight — the entry leaks. Its
broadcast sender stays alive, so every subscriber blocks **forever** on
`receiver.recv().await` (no timeout). A subscriber in a different task tree then
starves the whole sync: the chain never advances, the client sits at 0% CPU, and
only a process restart recovers it.

Latent under today's request timing (the subscription join window is
`max_request_ttl`, 200 ms), but reliably reproducible under workloads that line
the cert-download tasks up in lockstep.

## Proposal

Make the tracker cancel-safe with an ownership guard (identical to #6577; cherry-pick):

- `insert_new` returns an `InFlightGuard` that owns the entry, held across the
  cancellation-prone `try_staggered_parallel().await`.
- `InFlightGuard::complete_and_broadcast` broadcasts + removes (success path).
- Dropping the guard without completing removes the entry, dropping the sender so
  subscribers wake with `RecvError::Closed` and execute the request themselves —
  a fall-through path that already existed but could never be reached while the
  entry leaked.
- A per-entry `generation` (`AtomicU64`) means a guard only removes *its own*
  entry, never a newer owner's after this one went stale. Both completion and
  `Drop` are generation-checked (idempotent, race-safe).
- When a new owner takes over a key that still has an entry (stale owner or
  insertion race), it adopts that entry's broadcast sender, so existing waiters
  receive the new owner's result instead of being disconnected and retrying.
- Entries map moves to `std::sync::Mutex` so `Drop` can clean synchronously;
  never held across an `.await`.

Client-side only; no protocol, storage, or validator change.

## Test Plan

- New unit regression tests `test_owner_drop_wakes_subscribers` and
  `test_new_owner_adopts_existing_waiters`; `cargo test -p linera-core --lib
  requests_scheduler` → 29 passed; `cargo clippy --all-targets` and
  `cargo fmt --check` clean.
- End-to-end, real workload (measured on a testnet_conway client build): a
  fresh-wallet/empty-DB cold sync of a blob-heavy market chain, interleaved with
  vs. without this fix under identical network conditions:

  | Build | Cold syncs | Hung |
  |-------|-----------|------|
  | without this fix | 12 | **5 (~42%)** |
  | with this fix | 12 | **0** |

  Every unfixed hang was immediately followed by a clean ~12 s fixed run on the
  same conditions.

## Release Plan

- These changes follow the usual `testnet_conway` release cycle. Client-side
  only — no validator hotfix.

## Links

- Main PR: #6577
- Exposed by, and a prerequisite for, the streaming `DownloadBlobs` caller
  backport #6476.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
