### PR TITLE
Enforce that a block advances the epoch at most once

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -884,6 +884,8 @@ where
 
         chain.system.progress.get_mut().timestamp = block.timestamp;
 
+        let start_epoch = *chain.system.epoch.get();
+
         let mut resource_controller = ResourceController::new(
             Arc::new(committee_policy),
             ResourceTracker::default(),
@@ -1093,6 +1095,17 @@ where
         // This can only happen if all transactions were incoming bundles that all got discarded
         // due to resource limit errors. This is unlikely in practice but theoretically possible.
         ensure!(!block.transactions.is_empty(), ChainError::EmptyBlock);
+
+        // A block may advance the epoch at most once, so that consecutive blocks never skip
+        // an epoch: the child of a block in epoch `e` is at most in epoch `e + 1`.
+        let end_epoch = *chain.system.epoch.get();
+        ensure!(
+            end_epoch.0 <= start_epoch.0.saturating_add(1),
+            ChainError::MultipleEpochAdvances {
+                start_epoch,
+                end_epoch,
+            }
+        );
 
         let recipients = block_execution_tracker.recipients();
         let non_ack_tx_indices = block_execution_tracker.non_checkpoint_ack_tx_indices();

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -30,7 +30,7 @@ use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,
     crypto::CryptoError,
-    data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
+    data_types::{ArithmeticError, BlockHeight, Epoch, Round, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
 use linera_execution::ExecutionError;
@@ -162,6 +162,14 @@ pub enum ChainError {
     BlockProposalTooLarge(usize),
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
+    #[error(
+        "Block advances the chain's epoch from {start_epoch} to {end_epoch}; \
+         a block may advance the epoch at most once"
+    )]
+    MultipleEpochAdvances {
+        start_epoch: Epoch,
+        end_epoch: Epoch,
+    },
     #[error("Closed chains cannot have operations, accepted messages or empty blocks")]
     ClosedChain,
     #[error("Empty blocks are not allowed")]
@@ -208,6 +216,7 @@ impl ChainError {
             | ChainError::CertificateValidatorReuse
             | ChainError::CertificateRequiresQuorum
             | ChainError::BlockProposalTooLarge(_)
+            | ChainError::MultipleEpochAdvances { .. }
             | ChainError::ClosedChain
             | ChainError::EmptyBlock
             | ChainError::AuthorizedApplications(_)

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1561,8 +1561,8 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     /// Creates a vector of transactions which, in addition to the provided operations,
-    /// also contains epoch changes, receiving message bundles and event stream updates
-    /// (if there are any to be processed).
+    /// also contains the next pending epoch change, receiving message bundles and event
+    /// stream updates (if there are any to be processed).
     /// This should be called when executing a block, in order to make sure that any pending
     /// messages or events are included in it.
     #[instrument(level = "trace", skip(operations))]
@@ -1573,7 +1573,7 @@ impl<Env: Environment> ChainClient<Env> {
         let incoming_bundles = self.pending_message_bundles().await?;
         let stream_updates = self.collect_stream_updates().await?;
         Ok(self
-            .collect_epoch_changes()
+            .next_epoch_change()
             .await?
             .into_iter()
             .map(Transaction::ExecuteOperation)
@@ -2868,20 +2868,21 @@ impl<Env: Environment> ChainClient<Env> {
         }
     }
 
-    /// Returns operations to process all pending new epochs, in order.
-    async fn collect_epoch_changes(&self) -> Result<Vec<Operation>, Error> {
-        let mut next_epoch = self.chain_info().await?.epoch.try_add_one()?;
-        let mut epoch_change_ops = Vec::new();
-        while self
+    /// Returns an operation to process the next pending new epoch, if there is one.
+    ///
+    /// Later epochs are not included, since a block may advance the epoch at most once;
+    /// they are processed by subsequent blocks.
+    async fn next_epoch_change(&self) -> Result<Option<Operation>, Error> {
+        let next_epoch = self.chain_info().await?.epoch.try_add_one()?;
+        if !self
             .has_admin_event(EPOCH_STREAM_NAME, next_epoch.0)
             .await?
         {
-            epoch_change_ops.push(Operation::system(SystemOperation::ProcessNewEpoch(
-                next_epoch,
-            )));
-            next_epoch.try_add_assign_one()?;
+            return Ok(None);
         }
-        Ok(epoch_change_ops)
+        Ok(Some(Operation::system(SystemOperation::ProcessNewEpoch(
+            next_epoch,
+        ))))
     }
 
     /// Returns whether the system event on the admin chain with the given stream name and key

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1381,20 +1381,37 @@ where
     // Transfer goes through and the previous one as well thanks to block chaining.
     assert_eq!(admin.local_balance().await.unwrap(), Amount::from_tokens(3));
 
+    // The user chain is now two epochs behind. A block may advance the epoch at most
+    // once, so executing an operation only processes the first pending epoch change;
+    // the chain is not fully caught up yet.
+    let committee = Committee::new(validators.clone(), ResourceControlPolicy::only_fuel())?;
+    admin.stage_new_committee(committee.clone()).await.unwrap();
+    admin.stage_new_committee(committee).await.unwrap();
+    assert_eq!(admin.chain_info().await?.epoch, Epoch::from(4));
+    user.synchronize_from_validators().await?;
+    let info = user.chain_info().await?;
+    assert_eq!(info.epoch, Epoch::from(2));
+    let next_height = info.next_block_height;
     user.change_application_permissions(ApplicationPermissions::new_single(ApplicationId::new(
         CryptoHash::test_hash("foo"),
     )))
     .await?;
+    let info = user.chain_info().await?;
+    assert_eq!(info.epoch, Epoch::from(3));
+    assert_eq!(info.next_block_height, BlockHeight(next_height.0 + 1));
 
     let committee = Committee::new(validators, ResourceControlPolicy::default())?;
+    admin.stage_new_committee(committee.clone()).await.unwrap();
     admin.stage_new_committee(committee).await.unwrap();
-    assert_eq!(admin.chain_info().await?.epoch, Epoch::from(3));
+    assert_eq!(admin.chain_info().await?.epoch, Epoch::from(6));
 
     // Despite the restrictive application permissions, some system operations are still allowed,
-    // and the user chain can migrate to the new epoch.
+    // and the user chain can migrate to the new epochs — processing the inbox produces one
+    // block per epoch.
     user.synchronize_from_validators().await?;
-    user.process_inbox().await?;
-    assert_eq!(user.chain_info().await?.epoch, Epoch::from(3));
+    let (certificates, _) = user.process_inbox().await?;
+    assert_eq!(certificates.len(), 3);
+    assert_eq!(user.chain_info().await?.epoch, Epoch::from(6));
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3000,6 +3000,28 @@ where
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
+    // A block may advance the epoch at most once: creating two committees in the same
+    // block must fail.
+    let proposal2 = make_child_block(&certificate1.clone().into_value())
+        .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
+            epoch: Epoch::from(2),
+            blob_hash,
+        }))
+        .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
+            epoch: Epoch::from(3),
+            blob_hash,
+        }));
+    let error = env
+        .execute_proposal(proposal2, vec![])
+        .await
+        .expect_err("blocks must not advance the epoch twice")
+        .downcast::<WorkerError>()?;
+    assert_matches!(
+        error,
+        WorkerError::ChainError(chain_error)
+            if matches!(*chain_error, ChainError::MultipleEpochAdvances { .. })
+    );
+
     // Try to execute the transfer.
     env.worker()
         .fully_handle_certificate_with_notifications(certificate0.clone(), &())


### PR DESCRIPTION
## Motivation

For secure revocation handling we will introduce validator commitments on the admin chain in the future, where each validator attests to which certificates they signed. A quorum of such commitments proves that no chain that is not mentioned in those commitments can have been created in that epoch. This is to defend against a second kind of long-range attack in multi-chain system, where validators invent chains that have not legitimately been created.

This defense is only effective, however, if chains cannot skip epochs: Then chain not mentioned in epoch 5's commitments certainly does not exist in epoch 6.

## Proposal

A child of a block in epoch `e` may at most be in epoch `e+1`, so that epochs can never be skipped between consecutive blocks. Since `check_next_epoch` already restricts every epoch change to a +1 step, `execute_block_inner` now only needs to reject blocks whose end epoch exceeds the start epoch by more than one.

The client accordingly includes at most the next pending epoch change in a block, as a best-effort attempt analogous to incoming message bundles; a chain that is several epochs behind catches up fully by processing its inbox, one epoch per block.

## Test Plan

Tests have been updated to reflect the new behavior.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Preparation for #6237 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
