### PR TITLE
Add missing recursion_limit to the evm_to_linera_bridge e2e test crate root

### DIFF
--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![recursion_limit = "256"]
+
 //! End-to-end test: deposit ERC-20 tokens on EVM (Anvil), generate an MPT proof,
 //! submit a `ProcessDeposit` operation to the evm-bridge app on Linera, and verify
 //! that the wrapped-fungible tokens are minted.


### PR DESCRIPTION
## Motivation

`bridge-e2e` on `testnet_conway` is red since #6576 merged: the `evm_to_linera_bridge` test target fails with `E0275` (trait-solver overflow proving `Send` on nested client futures).

#6576 raised `recursion_limit` in the `linera-bridge` binary crate root, but every file under `tests/` is its own crate root, and `evm_to_linera_bridge.rs` is the only e2e test on this branch without a `#![recursion_limit]` attribute (`main` has carried `#![recursion_limit = "256"]` in this file since #5670; the other eight conway tests have their own). The deeper future nesting pushed this crate root past the default limit of 128.

The error is post-monomorphization: `cargo check`/clippy pass (bridge-check was green on #6576), and `bridge-e2e` has no `pull_request` trigger, so it only surfaced on the post-merge push run.

## Proposal

Add `#![recursion_limit = "256"]` to `evm_to_linera_bridge.rs`, matching `main` and the sibling tests.

## Test Plan

Without the fix, `cargo test --no-run` in `linera-bridge/tests/e2e` reproduces the exact CI failure; with it, all test targets build and link. `RUSTFLAGS="-D warnings" cargo check --locked --all-targets` (the bridge-check gate) also passes. Note `bridge-e2e` will not run on this PR — the confirming run is the post-merge push.