### PR TITLE
Remove the unused max_stream_queries option from the key-value store traits

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -255,9 +255,6 @@ Client implementation and command-line tool for the Linera blockchain
 * `-w`, `--with-wallet <WITH_WALLET>` — Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet storage config from the environment variables `LINERA_WALLET_{X}` and `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and `LINERA_STORAGE`
 * `--storage <STORAGE_CONFIG>` — Storage configuration for the blockchain history
 * `--storage-max-concurrent-queries <STORAGE_MAX_CONCURRENT_QUERIES>` — The maximal number of simultaneous queries to the database
-* `--storage-max-stream-queries <STORAGE_MAX_STREAM_QUERIES>` — The maximal number of simultaneous stream queries to the database
-
-  Default value: `10`
 * `--storage-max-cache-size <STORAGE_MAX_CACHE_SIZE>` — The maximal memory used in the storage cache
 
   Default value: `10000000`

--- a/linera-bridge/src/relay/mod.rs
+++ b/linera-bridge/src/relay/mod.rs
@@ -248,7 +248,6 @@ async fn create_rocksdb_storage(
         inner_config: RocksDbStoreInternalConfig {
             path_with_guard: PathWithGuard::new(path.to_path_buf()),
             spawn_mode: RocksDbSpawnMode::get_spawn_mode_from_runtime(),
-            max_stream_queries: 10,
             enable_statistics: false,
             statistics_level: Default::default(),
         },

--- a/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
+++ b/linera-bridge/tests/e2e/tests/auto_deposit_scan.rs
@@ -68,7 +68,6 @@ async fn test_auto_deposit_scan() -> anyhow::Result<()> {
     let relay_genesis_config = genesis_config.clone();
 
     let config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
+++ b/linera-bridge/tests/e2e/tests/burn_completion_requires_on_chain_evidence.rs
@@ -63,7 +63,6 @@ async fn relayer_does_not_mark_burn_complete_when_token_was_not_transferred() ->
     let relay_genesis_config = genesis_config.clone();
 
     let store_config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
+++ b/linera-bridge/tests/e2e/tests/burns_per_evm_tx.rs
@@ -92,7 +92,6 @@ async fn burns_per_evm_tx(
     let genesis_config = faucet.genesis_config().await?;
 
     let store_config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/committee_rotation.rs
+++ b/linera-bridge/tests/e2e/tests/committee_rotation.rs
@@ -61,7 +61,6 @@ async fn test_committee_rotation_updates_evm_light_client() -> anyhow::Result<()
     let relay_genesis_config = genesis_config.clone();
 
     let config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/evm_to_linera_bridge.rs
@@ -58,7 +58,6 @@ async fn test_evm_to_linera_bridge() -> anyhow::Result<()> {
     let genesis_config = faucet.genesis_config().await?;
 
     let config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/fungible_bridge.rs
+++ b/linera-bridge/tests/e2e/tests/fungible_bridge.rs
@@ -58,7 +58,6 @@ async fn test_fungible_bridge_transfers_to_evm() -> anyhow::Result<()> {
     let genesis_config = faucet.genesis_config().await?;
 
     let config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
+++ b/linera-bridge/tests/e2e/tests/multi_tx_burn_chunking.rs
@@ -76,7 +76,6 @@ async fn relayer_falls_back_to_chunked_process_burns() -> anyhow::Result<()> {
     let relay_genesis_config = genesis_config.clone();
 
     let store_config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_block.rs
@@ -53,7 +53,6 @@ async fn relayer_processes_every_burn_in_one_block() -> anyhow::Result<()> {
     let relay_genesis_config = genesis_config.clone();
 
     let store_config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
+++ b/linera-bridge/tests/e2e/tests/multiple_burns_same_recipient_across_blocks.rs
@@ -61,7 +61,6 @@ async fn relayer_processes_every_burn_to_same_recipient() -> anyhow::Result<()> 
     let relay_genesis_config = genesis_config.clone();
 
     let store_config = MemoryStoreConfig {
-        max_stream_queries: 10,
         kill_on_drop: true,
     };
     let mut storage = DbStorage::<MemoryDatabase, _>::maybe_create_and_connect(

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -32,10 +32,6 @@ pub struct RocksDbConfig {
     #[arg(long)]
     max_concurrent_queries: Option<usize>,
 
-    /// The maximal number of simultaneous stream queries to the database
-    #[arg(long, default_value = "10")]
-    pub max_stream_queries: usize,
-
     /// The maximal memory used in the storage cache in bytes.
     #[arg(long, default_value = "10000000")]
     pub max_cache_size: usize,
@@ -112,7 +108,6 @@ impl RocksDbRunner {
         let inner_config = RocksDbStoreInternalConfig {
             spawn_mode,
             path_with_guard,
-            max_stream_queries: config.client.max_stream_queries,
             enable_statistics: false,
             statistics_level: Default::default(),
         };

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -26,10 +26,6 @@ pub struct ScyllaDbConfig {
     #[arg(long)]
     max_concurrent_queries: Option<usize>,
 
-    /// The maximal number of simultaneous stream queries to the database
-    #[arg(long, default_value = "10")]
-    pub max_stream_queries: usize,
-
     /// The maximal memory used in the storage cache in bytes.
     #[arg(long, default_value = "10000000")]
     pub max_cache_size: usize,
@@ -104,7 +100,6 @@ impl ScyllaDbRunner {
         };
         let inner_config = ScyllaDbStoreInternalConfig {
             uri: config.client.uri.clone(),
-            max_stream_queries: config.client.max_stream_queries,
             max_concurrent_queries: config.client.max_concurrent_queries,
             replication_factor: config.client.replication_factor,
         };

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -106,10 +106,6 @@ impl ReadableKeyValueStore for KeyValueStore {
     // on the size of its values.
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
 
-    fn max_stream_queries(&self) -> usize {
-        1
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, KeyValueStoreError> {
         Ok(Vec::new())
     }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -953,8 +953,6 @@ impl Runnable for Job {
                                     n,
                                     on_drop,
                                     vec![
-                                        "--storage-max-stream-queries".to_string(),
-                                        "50".to_string(),
                                         "--timings".to_string(),
                                         "--max-new-events-per-block".to_string(),
                                         "10000".to_string(),

--- a/linera-storage-runtime/src/common_options.rs
+++ b/linera-storage-runtime/src/common_options.rs
@@ -14,10 +14,6 @@ pub struct CommonStorageOptions {
     #[arg(long, global = true)]
     pub storage_max_concurrent_queries: Option<usize>,
 
-    /// The maximal number of simultaneous stream queries to the database
-    #[arg(long, default_value = "10", global = true)]
-    pub storage_max_stream_queries: usize,
-
     /// The maximal memory used in the storage cache.
     #[arg(long, default_value = "10000000", global = true)]
     pub storage_max_cache_size: usize,

--- a/linera-storage-runtime/src/storage_config.rs
+++ b/linera-storage-runtime/src/storage_config.rs
@@ -307,7 +307,6 @@ impl StorageConfig {
         match &self.inner_storage_config {
             InnerStorageConfig::Memory { genesis_path } => {
                 let config = linera_views::memory::MemoryStoreConfig {
-                    max_stream_queries: options.storage_max_stream_queries,
                     kill_on_drop: false,
                 };
                 let genesis_path = genesis_path.clone();
@@ -323,7 +322,6 @@ impl StorageConfig {
                     linera_storage_service::common::StorageServiceStoreInternalConfig {
                         endpoint: endpoint.clone(),
                         max_concurrent_queries: options.storage_max_concurrent_queries,
-                        max_stream_queries: options.storage_max_stream_queries,
                     };
                 let config = linera_storage_service::common::StorageServiceStoreConfig {
                     inner_config,
@@ -337,7 +335,6 @@ impl StorageConfig {
                 let inner_config = linera_views::rocks_db::RocksDbStoreInternalConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard,
-                    max_stream_queries: options.storage_max_stream_queries,
                     enable_statistics: options.rocksdb_enable_statistics,
                     statistics_level: options.rocksdb_statistics_level,
                 };
@@ -351,7 +348,6 @@ impl StorageConfig {
             InnerStorageConfig::ScyllaDb { uri } => {
                 let inner_config = linera_views::scylla_db::ScyllaDbStoreInternalConfig {
                     uri: uri.clone(),
-                    max_stream_queries: options.storage_max_stream_queries,
                     max_concurrent_queries: options.storage_max_concurrent_queries,
                     replication_factor: options.storage_replication_factor,
                 };
@@ -370,7 +366,6 @@ impl StorageConfig {
                 let inner_config = linera_views::rocks_db::RocksDbStoreInternalConfig {
                     spawn_mode: *spawn_mode,
                     path_with_guard: path_with_guard.clone(),
-                    max_stream_queries: options.storage_max_stream_queries,
                     enable_statistics: options.rocksdb_enable_statistics,
                     statistics_level: options.rocksdb_statistics_level,
                 };
@@ -381,7 +376,6 @@ impl StorageConfig {
 
                 let inner_config = linera_views::scylla_db::ScyllaDbStoreInternalConfig {
                     uri: uri.clone(),
-                    max_stream_queries: options.storage_max_stream_queries,
                     max_concurrent_queries: options.storage_max_concurrent_queries,
                     replication_factor: options.storage_replication_factor,
                 };

--- a/linera-storage-runtime/src/storage_config.rs
+++ b/linera-storage-runtime/src/storage_config.rs
@@ -301,6 +301,10 @@ impl StorageConfig {
     /// The addition of the common config to get a full configuration
     pub fn add_common_storage_options(
         &self,
+        #[cfg_attr(
+            not(any(feature = "storage-service", feature = "rocksdb", feature = "scylladb")),
+            allow(unused_variables)
+        )]
         options: &CommonStorageOptions,
     ) -> Result<StoreConfig, anyhow::Error> {
         let namespace = self.namespace.clone();

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -49,8 +49,7 @@ const MAX_KEY_SIZE: usize = 1000000;
 // * Interior mutability is required for the client because
 // accessing requires mutability while the KeyValueStore
 // does not allow it.
-// * The semaphore and max_stream_queries work as other
-// stores.
+// * The semaphore works as other stores.
 //
 // The encoding of namespaces is done by taking their
 // serialization. This works because the set of serialization
@@ -69,7 +68,6 @@ const MAX_KEY_SIZE: usize = 1000000;
 pub struct StorageServiceDatabaseInternal {
     channel: Channel,
     semaphore: Option<Arc<Semaphore>>,
-    max_stream_queries: usize,
     namespace: Vec<u8>,
 }
 
@@ -78,7 +76,6 @@ pub struct StorageServiceDatabaseInternal {
 pub struct StorageServiceStoreInternal {
     channel: Channel,
     semaphore: Option<Arc<Semaphore>>,
-    max_stream_queries: usize,
     prefix_len: usize,
     start_key: Vec<u8>,
     root_key_written: Arc<AtomicBool>,
@@ -94,10 +91,6 @@ impl WithError for StorageServiceStoreInternal {
 
 impl ReadableKeyValueStore for StorageServiceStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-
-    fn max_stream_queries(&self) -> usize {
-        self.max_stream_queries
-    }
 
     fn root_key(&self) -> Result<Vec<u8>, StorageServiceStoreError> {
         let root_key = bcs::from_bytes(&self.start_key[self.prefix_len..])?;
@@ -473,14 +466,12 @@ impl KeyValueDatabase for StorageServiceDatabaseInternal {
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
         let namespace = bcs::to_bytes(namespace)?;
-        let max_stream_queries = config.max_stream_queries;
         let endpoint = config.http_address();
         let endpoint = Endpoint::from_shared(endpoint)?;
         let channel = endpoint.connect_lazy();
         Ok(Self {
             channel,
             semaphore,
-            max_stream_queries,
             namespace,
         })
     }
@@ -488,7 +479,6 @@ impl KeyValueDatabase for StorageServiceDatabaseInternal {
     fn open_shared(&self, root_key: &[u8]) -> Result<Self::Store, StorageServiceStoreError> {
         let channel = self.channel.clone();
         let semaphore = self.semaphore.clone();
-        let max_stream_queries = self.max_stream_queries;
         let mut start_key = vec![KeyPrefix::Key as u8];
         start_key.extend(&self.namespace);
         start_key.extend(bcs::to_bytes(root_key)?);
@@ -496,7 +486,6 @@ impl KeyValueDatabase for StorageServiceDatabaseInternal {
         Ok(StorageServiceStoreInternal {
             channel,
             semaphore,
-            max_stream_queries,
             prefix_len,
             start_key,
             root_key_written: Arc::new(AtomicBool::new(false)),
@@ -605,7 +594,6 @@ pub fn service_config_from_endpoint(
     Ok(StorageServiceStoreInternalConfig {
         endpoint: endpoint.to_string(),
         max_concurrent_queries: None,
-        max_stream_queries: 100,
     })
 }
 

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -88,8 +88,6 @@ pub struct StorageServiceStoreInternalConfig {
     pub endpoint: String,
     /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
-    /// Preferred buffer size for async streams.
-    pub max_stream_queries: usize,
 }
 
 /// The config type

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -262,9 +262,6 @@ enum StorageServerOptions {
         /// The storage service address.
         #[arg(long)]
         endpoint: String,
-        /// Preferred buffer size for async streams.
-        #[arg(long, default_value = "10")]
-        max_stream_queries: usize,
     },
 
     #[cfg(with_rocksdb)]
@@ -279,9 +276,6 @@ enum StorageServerOptions {
         /// Path to the rocksdb database.
         #[arg(long)]
         path: String,
-        /// Preferred buffer size for async streams.
-        #[arg(long, default_value = "10")]
-        max_stream_queries: usize,
         /// The maximum size of the cache, in bytes (keys size + value sizes)
         #[arg(long, default_value = "10000000")]
         max_cache_size: usize,
@@ -645,10 +639,8 @@ async fn main() {
         StorageServerOptions::Memory {
             namespace,
             endpoint,
-            max_stream_queries,
         } => {
             let config = MemoryStoreConfig {
-                max_stream_queries,
                 kill_on_drop: false,
             };
             let database = MemoryDatabase::maybe_create_and_connect(&config, &namespace)
@@ -664,7 +656,6 @@ async fn main() {
             namespace,
             endpoint,
             path,
-            max_stream_queries,
             max_cache_size,
             max_value_entry_size,
             max_find_keys_entry_size,
@@ -680,7 +671,6 @@ async fn main() {
             let inner_config = RocksDbStoreInternalConfig {
                 spawn_mode,
                 path_with_guard,
-                max_stream_queries,
                 enable_statistics: false,
                 statistics_level: Default::default(),
             };

--- a/linera-views/src/backends/dual.rs
+++ b/linera-views/src/backends/dual.rs
@@ -88,13 +88,6 @@ where
         S2::MAX_KEY_SIZE
     };
 
-    fn max_stream_queries(&self) -> usize {
-        match self {
-            Self::First(store) => store.max_stream_queries(),
-            Self::Second(store) => store.max_stream_queries(),
-        }
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
         Ok(match self {
             Self::First(store) => store.root_key().map_err(DualStoreError::First)?,

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -24,7 +24,7 @@ use crate::{
 
 /// The initial configuration of the system
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IndexedDbStoreConfig {}
+pub struct IndexedDbStoreConfig;
 
 /// The prefixes being used in the system
 static ROOT_KEY_DOMAIN: [u8; 1] = [0];
@@ -320,7 +320,7 @@ mod testing {
     /// Creates a test IndexedDB store for working.
     #[cfg(with_testing)]
     pub async fn create_indexed_db_test_store() -> IndexedDbStore {
-        let config = IndexedDbStoreConfig {};
+        let config = IndexedDbStoreConfig;
         let namespace = generate_test_namespace();
         let database = IndexedDbDatabase::connect(&config, &namespace)
             .await

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -24,17 +24,11 @@ use crate::{
 
 /// The initial configuration of the system
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IndexedDbStoreConfig {
-    /// Preferred buffer size for async streams.
-    pub max_stream_queries: usize,
-}
+pub struct IndexedDbStoreConfig {}
 
 /// The prefixes being used in the system
 static ROOT_KEY_DOMAIN: [u8; 1] = [0];
 static STORED_ROOT_KEYS_PREFIX: [u8; 1] = [1];
-
-/// The number of streams for the test
-pub const TEST_INDEX_DB_MAX_STREAM_QUERIES: usize = 10;
 
 const OBJECT_STORE_NAME: &str = "linera";
 
@@ -44,8 +38,6 @@ const OBJECT_STORE_NAME: &str = "linera";
 pub struct IndexedDbDatabase {
     /// The database used for storing the data.
     pub database: Rc<indexed_db::Database<Infallible>>,
-    /// The maximum number of queries used for the stream.
-    pub max_stream_queries: usize,
     /// The database name used for storing the data.
     pub namespace: String,
 }
@@ -110,10 +102,6 @@ impl WithError for IndexedDbDatabase {
 
 impl ReadableKeyValueStore for IndexedDbStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
-
-    fn max_stream_queries(&self) -> usize {
-        self.database.max_stream_queries
-    }
 
     fn root_key(&self) -> Result<Vec<u8>> {
         assert!(self.start_key.starts_with(&ROOT_KEY_DOMAIN));
@@ -262,7 +250,7 @@ impl KeyValueDatabase for IndexedDbDatabase {
         "indexed db".to_string()
     }
 
-    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self> {
+    async fn connect(_config: &Self::Config, namespace: &str) -> Result<Self> {
         Ok(Self {
             database: indexed_db::Factory::<Infallible>::get()?
                 .open(
@@ -279,7 +267,6 @@ impl KeyValueDatabase for IndexedDbDatabase {
                 .await?
                 .into(),
             namespace: namespace.to_string(),
-            max_stream_queries: config.max_stream_queries,
         })
     }
 
@@ -330,22 +317,15 @@ mod testing {
     use super::*;
     use crate::random::generate_test_namespace;
 
-    /// Creates a test IndexedDB client for working.
-    pub async fn create_indexed_db_store_stream_queries(
-        max_stream_queries: usize,
-    ) -> IndexedDbStore {
-        let config = IndexedDbStoreConfig { max_stream_queries };
+    /// Creates a test IndexedDB store for working.
+    #[cfg(with_testing)]
+    pub async fn create_indexed_db_test_store() -> IndexedDbStore {
+        let config = IndexedDbStoreConfig {};
         let namespace = generate_test_namespace();
         let database = IndexedDbDatabase::connect(&config, &namespace)
             .await
             .unwrap();
         database.open_shared(&[]).unwrap()
-    }
-
-    /// Creates a test IndexedDB store for working.
-    #[cfg(with_testing)]
-    pub async fn create_indexed_db_test_store() -> IndexedDbStore {
-        create_indexed_db_store_stream_queries(TEST_INDEX_DB_MAX_STREAM_QUERIES).await
     }
 }
 

--- a/linera-views/src/backends/journaling.rs
+++ b/linera-views/src/backends/journaling.rs
@@ -169,10 +169,6 @@ where
 {
     const MAX_KEY_SIZE: usize = S::MAX_KEY_SIZE;
 
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
         Ok(self.store.root_key()?)
     }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -153,10 +153,6 @@ where
     // The LRU cache does not change the underlying store's size limits.
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
 
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
         self.store.root_key()
     }

--- a/linera-views/src/backends/memory.rs
+++ b/linera-views/src/backends/memory.rs
@@ -25,16 +25,10 @@ use crate::{
 /// The initial configuration of the system
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct MemoryStoreConfig {
-    /// Preferred buffer size for async streams.
-    pub max_stream_queries: usize,
     /// Whether a namespace should be immediately cleaned up from memory when the
     /// connection object is dropped.
     pub kill_on_drop: bool,
 }
-
-/// The number of streams for the test
-#[cfg(with_testing)]
-const TEST_MEMORY_MAX_STREAM_QUERIES: usize = 10;
 
 /// The values in a partition.
 type MemoryStoreMap = BTreeMap<Vec<u8>, Vec<u8>>;
@@ -50,8 +44,6 @@ struct MemoryDatabases {
 pub struct MemoryDatabase {
     /// The current namespace.
     namespace: String,
-    /// The maximum number of queries used for a stream.
-    max_stream_queries: usize,
     /// Whether to remove the namespace on drop.
     kill_on_drop: bool,
 }
@@ -60,7 +52,6 @@ impl MemoryDatabases {
     fn sync_open(
         &mut self,
         namespace: &str,
-        max_stream_queries: usize,
         root_key: &[u8],
     ) -> Result<MemoryStore, MemoryStoreError> {
         let Some(stores) = self.databases.get_mut(namespace) else {
@@ -74,7 +65,6 @@ impl MemoryDatabases {
         Ok(MemoryStore {
             map,
             root_key: root_key.to_vec(),
-            max_stream_queries,
         })
     }
 
@@ -114,8 +104,6 @@ pub struct MemoryStore {
     map: Arc<RwLock<MemoryStoreMap>>,
     /// The root key.
     root_key: Vec<u8>,
-    /// The maximum number of queries used for a stream.
-    max_stream_queries: usize,
 }
 
 impl WithError for MemoryDatabase {
@@ -128,10 +116,6 @@ impl WithError for MemoryStore {
 
 impl ReadableKeyValueStore for MemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
-
-    fn max_stream_queries(&self) -> usize {
-        self.max_stream_queries
-    }
 
     fn root_key(&self) -> Result<Vec<u8>, MemoryStoreError> {
         Ok(self.root_key.clone())
@@ -255,7 +239,6 @@ impl MemoryStore {
         Self {
             map: Arc::default(),
             root_key: Vec::new(),
-            max_stream_queries: TEST_MEMORY_MAX_STREAM_QUERIES,
         }
     }
 }
@@ -289,7 +272,6 @@ impl KeyValueDatabase for MemoryDatabase {
         };
         Ok(MemoryDatabase {
             namespace: namespace.to_string(),
-            max_stream_queries: config.max_stream_queries,
             kill_on_drop: config.kill_on_drop,
         })
     }
@@ -298,7 +280,7 @@ impl KeyValueDatabase for MemoryDatabase {
         let mut databases = MEMORY_DATABASES
             .lock()
             .expect("MEMORY_DATABASES lock should not be poisoned");
-        databases.sync_open(&self.namespace, self.max_stream_queries, root_key)
+        databases.sync_open(&self.namespace, root_key)
     }
 
     fn open_exclusive(&self, root_key: &[u8]) -> Result<Self::Store, MemoryStoreError> {
@@ -350,7 +332,6 @@ impl KeyValueDatabase for MemoryDatabase {
 impl TestKeyValueDatabase for MemoryDatabase {
     async fn new_test_config() -> Result<MemoryStoreConfig, MemoryStoreError> {
         Ok(MemoryStoreConfig {
-            max_stream_queries: TEST_MEMORY_MAX_STREAM_QUERIES,
             kill_on_drop: false,
         })
     }

--- a/linera-views/src/backends/metering.rs
+++ b/linera-views/src/backends/metering.rs
@@ -343,10 +343,6 @@ where
 {
     const MAX_KEY_SIZE: usize = S::MAX_KEY_SIZE;
 
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
         self.store.root_key()
     }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -47,10 +47,6 @@ use crate::{
 static ROOT_KEY_DOMAIN: [u8; 1] = [0];
 static STORED_ROOT_KEYS_PREFIX: u8 = 1;
 
-/// The number of streams for the test
-#[cfg(with_testing)]
-const TEST_ROCKS_DB_MAX_STREAM_QUERIES: usize = 10;
-
 // The maximum size of values in RocksDB is 3 GiB
 // For offset reasons we decrease by 400
 const MAX_VALUE_SIZE: usize = 3 * 1024 * 1024 * 1024 - 400;
@@ -292,7 +288,6 @@ impl RocksDbStoreExecutor {
 pub struct RocksDbStoreInternal {
     executor: RocksDbStoreExecutor,
     path_with_guard: PathWithGuard,
-    max_stream_queries: usize,
     spawn_mode: RocksDbSpawnMode,
     root_key_written: Arc<AtomicBool>,
 }
@@ -302,7 +297,6 @@ pub struct RocksDbStoreInternal {
 pub struct RocksDbDatabaseInternal {
     executor: RocksDbStoreExecutor,
     path_with_guard: PathWithGuard,
-    max_stream_queries: usize,
     spawn_mode: RocksDbSpawnMode,
 }
 
@@ -386,8 +380,6 @@ pub struct RocksDbStoreInternalConfig {
     pub path_with_guard: PathWithGuard,
     /// The chosen spawn mode
     pub spawn_mode: RocksDbSpawnMode,
-    /// Preferred buffer size for async streams.
-    pub max_stream_queries: usize,
     /// Whether to enable RocksDB's internal statistics collection and export it as
     /// Prometheus metrics. Disabled by default to avoid overhead in clients that do not
     /// scrape metrics; enabled explicitly for the workers.
@@ -419,7 +411,6 @@ impl RocksDbDatabaseInternal {
         Ok(RocksDbDatabaseInternal {
             executor: temp_store.executor,
             path_with_guard: temp_store.path_with_guard,
-            max_stream_queries: temp_store.max_stream_queries,
             spawn_mode: temp_store.spawn_mode,
         })
     }
@@ -436,7 +427,6 @@ impl RocksDbStoreInternal {
         let mut path_with_guard = config.path_with_guard.clone();
         path_buf.push(namespace);
         path_with_guard.path_buf = path_buf.clone();
-        let max_stream_queries = config.max_stream_queries;
         let spawn_mode = config.spawn_mode;
         if !std::path::Path::exists(&path_buf) {
             std::fs::create_dir_all(path_buf.clone())?;
@@ -527,7 +517,6 @@ impl RocksDbStoreInternal {
         Ok(RocksDbStoreInternal {
             executor,
             path_with_guard,
-            max_stream_queries,
             spawn_mode,
             root_key_written: Arc::new(AtomicBool::new(false)),
         })
@@ -791,10 +780,6 @@ impl WithError for RocksDbStoreInternal {
 impl ReadableKeyValueStore for RocksDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
 
-    fn max_stream_queries(&self) -> usize {
-        self.max_stream_queries
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, RocksDbStoreInternalError> {
         assert!(self.executor.start_key.starts_with(&ROOT_KEY_DOMAIN));
         let root_key = bcs::from_bytes(&self.executor.start_key[ROOT_KEY_DOMAIN.len()..])?;
@@ -926,7 +911,6 @@ impl KeyValueDatabase for RocksDbDatabaseInternal {
         Ok(RocksDbStoreInternal {
             executor,
             path_with_guard: self.path_with_guard.clone(),
-            max_stream_queries: self.max_stream_queries,
             spawn_mode: self.spawn_mode,
             root_key_written: Arc::new(AtomicBool::new(false)),
         })
@@ -1020,11 +1004,9 @@ impl TestKeyValueDatabase for RocksDbDatabaseInternal {
     async fn new_test_config() -> Result<RocksDbStoreInternalConfig, RocksDbStoreInternalError> {
         let path_with_guard = PathWithGuard::new_testing();
         let spawn_mode = RocksDbSpawnMode::get_spawn_mode_from_runtime();
-        let max_stream_queries = TEST_ROCKS_DB_MAX_STREAM_QUERIES;
         Ok(RocksDbStoreInternalConfig {
             path_with_guard,
             spawn_mode,
-            max_stream_queries,
             enable_statistics: false,
             statistics_level: RocksDbStatisticsLevel::default(),
         })

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -722,7 +722,6 @@ impl ScyllaDbClient {
 pub struct ScyllaDbStoreInternal {
     store: Arc<ScyllaDbClient>,
     semaphore: Option<Arc<Semaphore>>,
-    max_stream_queries: usize,
     root_key: Vec<u8>,
     /// Whether this store was opened with `open_exclusive`. When true, `write_batch`
     /// resolves in-batch prefix/insert collisions via per-statement `USING TIMESTAMP`;
@@ -740,7 +739,6 @@ pub struct ScyllaDbStoreInternal {
 pub struct ScyllaDbDatabaseInternal {
     store: Arc<ScyllaDbClient>,
     semaphore: Option<Arc<Semaphore>>,
-    max_stream_queries: usize,
 }
 
 impl WithError for ScyllaDbDatabaseInternal {
@@ -832,10 +830,6 @@ impl WithError for ScyllaDbStoreInternal {
 
 impl ReadableKeyValueStore for ScyllaDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-
-    fn max_stream_queries(&self) -> usize {
-        self.max_stream_queries
-    }
 
     fn root_key(&self) -> Result<Vec<u8>, ScyllaDbStoreInternalError> {
         Ok(self.root_key[1..].to_vec())
@@ -1033,8 +1027,6 @@ pub struct ScyllaDbStoreInternalConfig {
     pub uri: String,
     /// Maximum number of concurrent database queries allowed for this client.
     pub max_concurrent_queries: Option<usize>,
-    /// Preferred buffer size for async streams.
-    pub max_stream_queries: usize,
     /// The replication factor.
     pub replication_factor: u32,
 }
@@ -1058,23 +1050,16 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
         let semaphore = config
             .max_concurrent_queries
             .map(|n| Arc::new(Semaphore::new(n)));
-        let max_stream_queries = config.max_stream_queries;
-        Ok(Self {
-            store,
-            semaphore,
-            max_stream_queries,
-        })
+        Ok(Self { store, semaphore })
     }
 
     fn open_shared(&self, root_key: &[u8]) -> Result<Self::Store, ScyllaDbStoreInternalError> {
         let store = self.store.clone();
         let semaphore = self.semaphore.clone();
-        let max_stream_queries = self.max_stream_queries;
         let root_key = get_big_root_key(root_key);
         Ok(ScyllaDbStoreInternal {
             store,
             semaphore,
-            max_stream_queries,
             root_key,
             is_exclusive: false,
             ts_floor: Arc::new(AtomicI64::new(0)),
@@ -1084,12 +1069,10 @@ impl KeyValueDatabase for ScyllaDbDatabaseInternal {
     fn open_exclusive(&self, root_key: &[u8]) -> Result<Self::Store, ScyllaDbStoreInternalError> {
         let store = self.store.clone();
         let semaphore = self.semaphore.clone();
-        let max_stream_queries = self.max_stream_queries;
         let root_key = get_big_root_key(root_key);
         Ok(ScyllaDbStoreInternal {
             store,
             semaphore,
-            max_stream_queries,
             root_key,
             is_exclusive: true,
             ts_floor: Arc::new(AtomicI64::new(0)),
@@ -1313,7 +1296,6 @@ impl TestKeyValueDatabase for JournalingKeyValueDatabase<ScyllaDbDatabaseInterna
         Ok(ScyllaDbStoreInternalConfig {
             uri,
             max_concurrent_queries: Some(10),
-            max_stream_queries: 10,
             replication_factor: 1,
         })
     }

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -99,10 +99,6 @@ where
 {
     const MAX_KEY_SIZE: usize = S::MAX_KEY_SIZE - 4;
 
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
         Ok(self.store.root_key()?)
     }
@@ -440,10 +436,6 @@ impl WithError for LimitedTestMemoryStore {
 #[cfg(with_testing)]
 impl ReadableKeyValueStore for LimitedTestMemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
-
-    fn max_stream_queries(&self) -> usize {
-        self.inner.max_stream_queries()
-    }
 
     fn root_key(&self) -> Result<Vec<u8>, MemoryStoreError> {
         self.inner.root_key()

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -52,9 +52,6 @@ pub trait ReadableKeyValueStore: WithError {
     /// The maximal size of keys that can be stored.
     const MAX_KEY_SIZE: usize;
 
-    /// Retrieve the number of stream queries.
-    fn max_stream_queries(&self) -> usize;
-
     /// Gets the root key of the store.
     fn root_key(&self) -> Result<Vec<u8>, Self::Error>;
 
@@ -299,10 +296,6 @@ pub mod inactive_store {
 
     impl ReadableKeyValueStore for InactiveStore {
         const MAX_KEY_SIZE: usize = 0;
-
-        fn max_stream_queries(&self) -> usize {
-            0
-        }
 
         fn root_key(&self) -> Result<Vec<u8>, Self::Error> {
             panic!("attempt to read from an inactive store!")

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -1118,10 +1118,6 @@ impl KeyValueStoreError for ViewContainerError {
 impl<C: Context> ReadableKeyValueStore for ViewContainer<C> {
     const MAX_KEY_SIZE: usize = <C::Store as ReadableKeyValueStore>::MAX_KEY_SIZE;
 
-    fn max_stream_queries(&self) -> usize {
-        1
-    }
-
     fn root_key(&self) -> Result<Vec<u8>, ViewContainerError> {
         Ok(Vec::new())
     }

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -14,7 +14,7 @@ pub async fn get_storage(
     namespace: &str,
 ) -> Result<Storage, linera_views::indexed_db::IndexedDbStoreError> {
     Ok(linera_storage::DbStorage::maybe_create_and_connect(
-        &linera_views::indexed_db::IndexedDbStoreConfig {},
+        &linera_views::indexed_db::IndexedDbStoreConfig,
         namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
         linera_storage::StorageCacheConfig {

--- a/web/@linera/client/src/storage.rs
+++ b/web/@linera/client/src/storage.rs
@@ -14,9 +14,7 @@ pub async fn get_storage(
     namespace: &str,
 ) -> Result<Storage, linera_views::indexed_db::IndexedDbStoreError> {
     Ok(linera_storage::DbStorage::maybe_create_and_connect(
-        &linera_views::indexed_db::IndexedDbStoreConfig {
-            max_stream_queries: 1,
-        },
+        &linera_views::indexed_db::IndexedDbStoreConfig {},
         namespace,
         Some(linera_execution::WasmRuntime::Wasmer),
         linera_storage::StorageCacheConfig {


### PR DESCRIPTION
## Motivation

`max_stream_queries` was declared on the `ReadableKeyValueStore` trait and carried through every backend's config and store struct, but nothing ever read it: every `.max_stream_queries()` call site was a wrapper delegating to its inner store, and every field access just copied the value around during store construction. Backends that actually chunk (e.g. ScyllaDB) use their own constants instead. It was dead surface area, plus a user-facing `--storage-max-stream-queries` CLI flag that did nothing.

## Proposal

Remove `max_stream_queries` entirely:

- Delete the `ReadableKeyValueStore::max_stream_queries` trait method and all of its implementations (memory, rocksdb, scylladb, indexeddb, storage-service, the delegating wrappers, and the `InactiveStore`/`ViewContainer`/SDK-Wasm literal impls).
- Drop the config/struct fields and the constructor parameters that only threaded the value through.
- Remove the `--storage-max-stream-queries` CLI flag (`CommonStorageOptions`), the storage-service server args, and the indexer args, plus all the initializers in `linera-bridge`, `linera-service`, and the web client.
- Remove the now-unused `TEST_*_MAX_STREAM_QUERIES` test constants and fold the redundant `create_indexed_db_store_stream_queries` helper into `create_indexed_db_test_store`.
- Regenerate `CLI.md`.

This is a behavioral no-op — the value was never consumed.

## Test Plan

- `cargo check` on `linera-views` (rocksdb+scylladb), `linera-storage`, `linera-storage-service`, `linera-storage-runtime`, `linera-service`, `linera-indexer`, plus the full `linera` binary build.
- `cargo check -p linera-views --features indexeddb --target wasm32-unknown-unknown` for the web path.
- `cargo clippy` on the touched crates — no warnings.
- `cargo fmt -- --check` on the CI-pinned nightly.
- CI.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
