### PR TITLE
Concurrent, deduplicated sender catch-up in the proposal loop

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2155,33 +2155,41 @@ impl<Env: Environment> Client<Env> {
                         continue;
                     }
                 }
-                // The local node reports *every* missing sender in a single
-                // `MissingCrossChainUpdates`, so we download them all in one pass and retry once;
-                // there is no need to iterate the discovery one sender at a time.
+                // The local node reports every missing sender bundle in a single
+                // `MissingCrossChainUpdates`, so we download them all in one pass and retry once.
                 if let LocalNodeError::WorkerError(WorkerError::ChainError(chain_err)) = &err {
                     if let ChainError::MissingCrossChainUpdates { chain_id, bundles } = &**chain_err
                     {
                         let chain_id = *chain_id;
-                        // Clone to end the borrow of `err` before we reassign it below.
-                        let bundles = bundles.clone();
-                        if !bundles.is_empty() {
-                            for (origin, height) in bundles {
-                                self.download_sender_block_with_sending_ancestors(
-                                    chain_id,
-                                    origin,
-                                    height,
-                                    remote_node,
-                                )
-                                .await?;
-                            }
-                            if let Err(new_err) =
-                                Box::pin(self.local_node.handle_block_proposal(proposal.clone()))
-                                    .await
-                            {
-                                err = new_err;
-                            } else {
-                                continue 'proposal_loop;
-                            }
+                        // `download_sender_block_with_sending_ancestors` walks each origin's
+                        // message-bearing blocks back from the given height, so the highest missing
+                        // height per origin subsumes the lower ones. Deduplicate to that (also
+                        // ending the borrow of `err` so we can reassign it below), then download the
+                        // independent origins concurrently, bounded by `max_joined_tasks`.
+                        let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
+                        for (origin, height) in bundles {
+                            let entry = origin_heights.entry(*origin).or_insert(*height);
+                            *entry = (*entry).max(*height);
+                        }
+                        stream::iter(origin_heights.into_iter().map(|(origin, height)| {
+                            self.download_sender_block_with_sending_ancestors(
+                                chain_id,
+                                origin,
+                                height,
+                                remote_node,
+                            )
+                        }))
+                        .buffer_unordered(self.options.max_joined_tasks)
+                        .collect::<Vec<_>>()
+                        .await
+                        .into_iter()
+                        .collect::<Result<(), _>>()?;
+                        if let Err(new_err) =
+                            Box::pin(self.local_node.handle_block_proposal(proposal.clone())).await
+                        {
+                            err = new_err;
+                        } else {
+                            continue 'proposal_loop;
                         }
                     }
                 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1164,6 +1164,77 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_proposal_catch_up_with_sender_gap<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    // A lagging validator must be caught up on a sender that has a *gap* from the recipient's
+    // perspective: sender block 0 messages the recipient, block 1 does not, block 2 does. The
+    // recipient consumes those two bundles in two separate blocks, so the second proposal only
+    // references sender block 2 — whose bundle can only be scheduled once block 0 is executed.
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let sender_id = sender.chain_id();
+    let recipient_id = recipient.chain_id();
+
+    // Validator 3 is offline while the sender builds a gapped chain and the recipient consumes
+    // the first bundle.
+    builder.set_fault_type([3], FaultType::OfflineWithInfo);
+
+    // Sender block 0 -> recipient.
+    sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    recipient.synchronize_from_validators().await?;
+    recipient.process_inbox().await?; // recipient block 0 consumes sender block 0's bundle
+
+    // Sender block 1 -> itself (no message to the recipient: the gap), block 2 -> recipient.
+    sender
+        .transfer_to_account(AccountOwner::CHAIN, Amount::ONE, Account::chain(sender_id))
+        .await
+        .unwrap_ok_committed();
+    sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(3),
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    recipient.synchronize_from_validators().await?;
+
+    // Validator 3 comes back; validator 2 goes offline so the recipient's next block needs
+    // validator 3's vote — the updater must catch it up on the sender across the gap.
+    builder.set_fault_type([3], FaultType::Honest);
+    builder.set_fault_type([2], FaultType::Offline);
+
+    recipient.process_inbox().await?; // recipient block 1 consumes sender block 2's bundle
+
+    assert_eq!(
+        recipient.local_balance().await.unwrap(),
+        Amount::from_tokens(4),
+    );
+    assert_eq!(
+        recipient.chain_info().await?.next_block_height,
+        BlockHeight::from(2),
+    );
+    builder
+        .check_that_validators_have_certificate(recipient_id, BlockHeight::from(1), 3)
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -581,15 +581,17 @@ where
                         bundles = bundles.len(),
                         "validator reported missing cross-chain updates; syncing them in one batch",
                     );
-                    // Sync each reported origin chain up to the needed height, collapsing any
-                    // duplicate origins to the highest height.
-                    let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
+                    // The reported bundles are exactly the sender blocks this proposal consumes
+                    // that the validator is missing (the recipient's inbox reports each absent
+                    // bundle). Send precisely those blocks, sparsely, rather than back-filling each
+                    // origin's whole prefix. Grouping into a `BTreeSet` per origin delivers them in
+                    // ascending height order, which the inbox requires.
+                    let mut origin_heights: BTreeMap<ChainId, BTreeSet<BlockHeight>> =
+                        BTreeMap::new();
                     for (origin, height) in bundles {
-                        let target = height.try_add_one()?;
-                        let entry = origin_heights.entry(origin).or_insert(target);
-                        *entry = (*entry).max(target);
+                        origin_heights.entry(origin).or_default().insert(height);
                     }
-                    self.send_chain_info_up_to_heights(
+                    self.send_chain_info_at_heights(
                         origin_heights,
                         CrossChainMessageDelivery::Blocking,
                     )
@@ -607,17 +609,15 @@ where
                     tracing::debug!(
                         remote_node = %self.remote_node.address(),
                         chain_id = %origin,
-                        "Missing cross-chain update; sending chain to validator.",
+                        "Missing cross-chain update; sending sender block to validator.",
                     );
                     sent_cross_chain_updates.insert(origin, height);
-                    // Some received certificates may be missing for this validator
-                    // (e.g. to create the chain or make the balance sufficient) so we are going to
-                    // synchronize them now and retry.
-                    self.send_chain_information(
-                        origin,
-                        height.try_add_one()?,
+                    // A validator on the legacy error reports one missing sender bundle at a time.
+                    // Send exactly that sender block, sparsely, and retry; the validator will
+                    // report the next missing one if any.
+                    self.send_chain_info_at_heights(
+                        [(origin, BTreeSet::from([height]))],
                         CrossChainMessageDelivery::Blocking,
-                        None,
                     )
                     .await?;
                 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -732,15 +732,31 @@ where
     /// Sends chain information to bring a validator up to date with a specific chain.
     ///
     /// This method performs a two-phase synchronization:
-    /// 1. **Height synchronization**: Ensures the validator has all blocks up to `target_block_height`.
+    /// 1. **Height synchronization**: sends the certificates we hold locally for the range
+    ///    `[validator_next_height, target_block_height)`, in order.
     /// 2. **Round synchronization**: If heights match, ensures the validator has proposals/certificates
     ///    for the current consensus round.
+    ///
+    /// Only certificates that are actually in our local storage are sent; heights we don't have are
+    /// silently skipped (see [`Self::read_certificates_for_heights`]). This is deliberate and is what
+    /// makes the "leave gaps on the validator side" behavior (#4181) work: a chain we merely *receive*
+    /// from is stored only at its message-bearing heights, so we push exactly those. The validator
+    /// executes the contiguous prefix and preprocesses any block that sits above a gap — enough to
+    /// deliver that block's cross-chain bundles without our ever having to send the intervening
+    /// non-message blocks (which we don't have anyway).
+    ///
+    /// Because our local storage is guaranteed to hold every block we needed to build a proposal (a
+    /// bundle can only be consumed after its ordered message-bearing predecessors were downloaded),
+    /// this is the reliable way to catch a validator up. Deriving the set to send from a
+    /// `MissingCrossChainUpdates` error instead is *not* reliable: that error lists only the bundles
+    /// the current proposal is missing and omits already-consumed ancestors, which the validator
+    /// still needs executed before it can schedule a later gap block's bundle.
     ///
     /// # Height Sync Strategy
     /// - For existing chains (target_block_height > 0):
     ///   * Optimistically sends the last certificate first (often that's all that's missing).
-    ///   * Falls back to full chain query if the validator needs more context.
-    ///   * Sends any additional missing certificates in order.
+    ///   * Falls back to a full chain query if the validator needs more context.
+    ///   * Sends any additional locally-held certificates in order.
     /// - For new chains (target_block_height == 0):
     ///   * Sends the chain description and dependencies first.
     ///   * Then queries the validator's state.
@@ -800,9 +816,13 @@ where
         self.sync_consensus_round(remote_round, &manager).await
     }
 
-    /// Synchronizes a validator to a specific block height by sending missing certificates.
+    /// Synchronizes a validator to a specific block height by sending the certificates we hold.
     ///
-    /// Uses an optimistic approach: sends the last certificate first, then fills in any gaps.
+    /// Uses an optimistic approach: sends the last certificate first, then, based on the
+    /// validator's reported height, sends the earlier certificates in the range. Only the heights
+    /// we actually have in local storage are sent — any we're missing are silently skipped rather
+    /// than treated as an error, which is what leaves genuine gaps on the validator (see
+    /// [`Self::send_chain_information`] for why that is both safe and intended).
     ///
     /// Returns the [`ChainInfo`] from the validator after synchronization.
     async fn sync_chain_height(
@@ -869,7 +889,7 @@ where
         Ok(info)
     }
 
-    /// Reads certificates for the given heights from storage.
+    /// Reads certificates for the given heights from local storage.
     ///
     /// First attempts to use the optimized `read_certificates_by_heights` method.
     /// Falls back to the traditional `get_block_hashes` + `read_certificates` approach
@@ -877,6 +897,11 @@ where
     ///
     /// When using the fallback, writes the discovered height->hash indices back to storage
     /// so subsequent lookups can use the optimized path.
+    ///
+    /// Heights we don't have are silently dropped: the returned vector contains only the
+    /// certificates actually present, so callers naturally skip any block we never downloaded
+    /// (e.g. a sender's non-message-bearing blocks). Callers must not assume the result covers
+    /// every requested height.
     async fn read_certificates_for_heights(
         &self,
         chain_id: ChainId,
@@ -1069,11 +1094,12 @@ where
             .await
     }
 
-    /// Sends chain information for specific heights on multiple chains.
+    /// Sends the blocks at exactly the specified heights on multiple chains.
     ///
-    /// Unlike `send_chain_info_up_to_heights`, this method only sends the blocks at the
-    /// specified heights, not all blocks up to those heights. This is more efficient for
-    /// sparse chains where only specific blocks are needed.
+    /// Unlike [`Self::send_chain_info_up_to_heights`], this sends *only* the blocks at the given
+    /// heights, not the locally-held prefix leading up to them. Use it only when the required
+    /// blocks are fully self-describing to the validator — e.g. bringing over the specific blocks
+    /// that carry a set of blobs.
     async fn send_chain_info_at_heights(
         &self,
         chain_heights: impl IntoIterator<Item = (ChainId, BTreeSet<BlockHeight>)>,
@@ -1108,6 +1134,8 @@ where
         Ok(())
     }
 
+    /// Brings a validator up to each given `(chain, height)` by pushing the locally-held prefix
+    /// of that chain (via [`Self::send_chain_information`]), for all chains concurrently.
     async fn send_chain_info_up_to_heights(
         &self,
         chain_heights: impl IntoIterator<Item = (ChainId, BlockHeight)>,

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -581,17 +581,15 @@ where
                         bundles = bundles.len(),
                         "validator reported missing cross-chain updates; syncing them in one batch",
                     );
-                    // The reported bundles are exactly the sender blocks this proposal consumes
-                    // that the validator is missing (the recipient's inbox reports each absent
-                    // bundle). Send precisely those blocks, sparsely, rather than back-filling each
-                    // origin's whole prefix. Grouping into a `BTreeSet` per origin delivers them in
-                    // ascending height order, which the inbox requires.
-                    let mut origin_heights: BTreeMap<ChainId, BTreeSet<BlockHeight>> =
-                        BTreeMap::new();
+                    // Sync each reported origin chain up to the needed height, collapsing any
+                    // duplicate origins to the highest height.
+                    let mut origin_heights: BTreeMap<ChainId, BlockHeight> = BTreeMap::new();
                     for (origin, height) in bundles {
-                        origin_heights.entry(origin).or_default().insert(height);
+                        let target = height.try_add_one()?;
+                        let entry = origin_heights.entry(origin).or_insert(target);
+                        *entry = (*entry).max(target);
                     }
-                    self.send_chain_info_at_heights(
+                    self.send_chain_info_up_to_heights(
                         origin_heights,
                         CrossChainMessageDelivery::Blocking,
                     )
@@ -609,15 +607,17 @@ where
                     tracing::debug!(
                         remote_node = %self.remote_node.address(),
                         chain_id = %origin,
-                        "Missing cross-chain update; sending sender block to validator.",
+                        "Missing cross-chain update; sending chain to validator.",
                     );
                     sent_cross_chain_updates.insert(origin, height);
-                    // A validator on the legacy error reports one missing sender bundle at a time.
-                    // Send exactly that sender block, sparsely, and retry; the validator will
-                    // report the next missing one if any.
-                    self.send_chain_info_at_heights(
-                        [(origin, BTreeSet::from([height]))],
+                    // Some received certificates may be missing for this validator
+                    // (e.g. to create the chain or make the balance sufficient) so we are going to
+                    // synchronize them now and retry.
+                    self.send_chain_information(
+                        origin,
+                        height.try_add_one()?,
                         CrossChainMessageDelivery::Blocking,
+                        None,
                     )
                     .await?;
                 }


### PR DESCRIPTION
## Motivation

Follow-up to #6556 on `testnet_conway` (which already batches validator catch-up via the aggregated `MissingCrossChainUpdates` error). This tightens the **local-node** side of the proposal catch-up loop, which still downloaded the reported missing sender blocks one origin at a time.

## Proposal

In the proposal loop that brings the local node up to date after a `MissingCrossChainUpdates` (`client/mod.rs`):

- Drop the dead `if !bundles.is_empty()` guard (the error is only produced with a non-empty set).
- Deduplicate the reported bundles to the **highest missing height per origin**. `download_sender_block_with_sending_ancestors` walks each origin's message-bearing blocks back from the given height, so the max subsumes the lower ones.
- Download the independent origins **concurrently**, bounded by `max_joined_tasks`, instead of sequentially.

### What this PR deliberately does *not* do

An earlier revision also tried to make the **validator-push** catch-up "sparse" — replacing `send_chain_info_up_to_heights` with `send_chain_info_at_heights` so it would send only the specifically-reported sender heights. That was **reverted** because it breaks the "leave gaps on the validator side" design (#4181), as caught by `test_update_validator_sender_gaps`:

- `send_chain_info_up_to_heights` sources the blocks to send from the client's **local storage** (all message-bearing blocks up to the target); for a hub that only receives from a sender, that's already exactly the message-bearing blocks and nothing else, so it's already sparse in practice.
- `send_chain_info_at_heights` sourced them from the **error's reported heights**, which — by design — omit any message-bearing **ancestor** whose bundle was consumed by an earlier block. A gap block's bundle can only be scheduled once its `previous_message_block` has been executed on the validator, so dropping the ancestor leaves the bundle undeliverable and the retry fails.

The push path is therefore left on `send_chain_info_up_to_heights`, and a memory-level regression test (`test_proposal_catch_up_with_sender_gap`) is added to lock this in.

## Test Plan

- `test_proposal_catch_up_with_sender_gap` (new): a sender that messages the recipient at heights 0 and 2 but not 1, consumed across two recipient blocks, with a lagging validator that must be caught up across the gap. Fails with the reverted sparse push, passes with `send_chain_info_up_to_heights`.
- `test_proposal_batches_missing_dependency_catch_up` and `test_handle_block_proposal_with_incoming_bundles` (aggregated-error coverage) pass, as does the broader cross-chain/inbox suite.
- `cargo clippy -p linera-core --lib --tests` and `cargo +nightly fmt` are clean.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- Follow-up to #6556. Main counterpart: #6573.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
