### PR TITLE
Give U128 the wrapped-number API

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -381,8 +381,6 @@ impl TryFrom<U256> for Amount {
     PartialOrd,
     Hash,
     derive_more::Display,
-    derive_more::From,
-    derive_more::Into,
     derive_more::Deref,
     derive_more::DerefMut,
     derive_more::FromStr,
@@ -851,6 +849,7 @@ impl TryFrom<BlockHeight> for usize {
 }
 
 impl_wrapped_number!(Amount, u128);
+impl_wrapped_number!(U128, u128);
 impl_wrapped_number!(BlockHeight, u64);
 impl_wrapped_number!(TimeDelta, u64);
 


### PR DESCRIPTION
## Motivation

`U128` consumers (e.g. token applications migrating balances off `Amount`) currently spell every arithmetic step as `U128(a.0 op b.0)`, losing the checked/saturating helpers `Amount` enjoys. 


## Proposal

Derive `impl_wrapped_number!` for `U128` like the other numeric wrappers: `ZERO/MAX`, `try_add`/`try_sub` + `_assign`/`_one` variants, `saturating_{add,sub,mul,div}`,` abs_diff`, `midpoint`, and `Add`/`Sub`/`Mul` operators. The macro also provides `From` in both directions, so the equivalent `derive_more::From`/`Into` derives are dropped; `U128`'s hand-written `serde` (decimal string when human-readable, bare `u128` in binary) is unaffected -- the macro adds no serde impls.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
