### PR TITLE
Recertify ancestor blocks; re-enable epoch revocation.

### DIFF
--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -17,7 +17,7 @@ use super::{generic::GenericCertificate, Certificate, Certified, LiteCertificate
 use crate::{
     block::{Block, ConfirmedBlock, ConversionError},
     data_types::MessageBundle,
-    justification::JustificationChain,
+    justification::{JustificationChain, JustifiedConfirmation},
     ChainError,
 };
 
@@ -84,6 +84,18 @@ impl ConfirmedBlockCertificate {
     /// Returns the full chain of validated quorums for the block.
     pub fn justification(&self) -> &JustificationChain {
         &self.justification
+    }
+
+    /// Returns this confirmation in the form used for fault attribution and
+    /// justification audits.
+    pub fn justified_confirmation(&self) -> JustifiedConfirmation {
+        JustifiedConfirmation {
+            header: self.block().header.clone(),
+            round: self.round(),
+            first_round: self.quorum.first_round(),
+            confirmed_signatures: self.quorum.signatures().clone(),
+            justification: self.justification.clone(),
+        }
     }
 
     /// Consumes this certificate, returning the signed quorum and the justification chain.

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -17,7 +17,7 @@ use super::{generic::GenericCertificate, Certificate, Certified, LiteCertificate
 use crate::{
     block::{Block, ConfirmedBlock, ConversionError},
     data_types::MessageBundle,
-    justification::{JustificationChain, JustifiedConfirmation},
+    justification::JustificationChain,
     ChainError,
 };
 
@@ -84,18 +84,6 @@ impl ConfirmedBlockCertificate {
     /// Returns the full chain of validated quorums for the block.
     pub fn justification(&self) -> &JustificationChain {
         &self.justification
-    }
-
-    /// Returns this confirmation in the form used for fault attribution and
-    /// justification audits.
-    pub fn justified_confirmation(&self) -> JustifiedConfirmation {
-        JustifiedConfirmation {
-            header: self.block().header.clone(),
-            round: self.round(),
-            first_round: self.quorum.first_round(),
-            confirmed_signatures: self.quorum.signatures().clone(),
-            justification: self.justification.clone(),
-        }
     }
 
     /// Consumes this certificate, returning the signed quorum and the justification chain.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -352,8 +352,9 @@ where
     /// Hashes of blocks that are vouched for by data this chain already trusts, but
     /// have not been processed here yet. A hash is inserted when a trusted source
     /// commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
-    /// block's `previous_block_hash` or `previous_message_blocks` links (unless the
-    /// referenced block is already in `block_hashes`). The worker accepts a cert
+    /// block's `previous_block_hash`, `previous_message_blocks` or
+    /// `previous_event_blocks` links (unless the referenced block is already in
+    /// `block_hashes`). The worker accepts a cert
     /// whose hash is in this set regardless of its epoch — the epoch may be revoked,
     /// but the hash commitment makes the block trustworthy — and removes the entry
     /// upon acceptance.
@@ -1538,8 +1539,9 @@ where
     }
 
     /// Records the block references an accepted block commits to — its parent via
-    /// `previous_block_hash` and the latest message block per recipient via
-    /// `previous_message_blocks` — in `vouched_blocks`, unless the referenced block
+    /// `previous_block_hash`, the latest message block per recipient via
+    /// `previous_message_blocks` and the latest event block per stream via
+    /// `previous_event_blocks` — in `vouched_blocks`, unless the referenced block
     /// is already in `block_hashes`. The accepted block is trusted, so these hash
     /// commitments remain a sufficient basis for accepting the referenced blocks
     /// even after the epochs that certified them are revoked.
@@ -1556,7 +1558,12 @@ where
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
         }
-        for (hash, height) in block.body.previous_message_blocks.values() {
+        for (hash, height) in block
+            .body
+            .previous_message_blocks
+            .values()
+            .chain(block.body.previous_event_blocks.values())
+        {
             references.push((*height, *hash));
         }
         let known_hashes = self

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -48,7 +48,8 @@ use crate::{
     manager::ChainManager,
     outbox::OutboxStateView,
     pending_blobs::PendingBlobsView,
-    ChainError, ChainExecutionContext, ExecutionError, ExecutionResultExt,
+    ChainError, ChainExecutionContext, ConflictingCertifiedBlocks, ExecutionError,
+    ExecutionResultExt,
 };
 
 #[cfg(test)]
@@ -1519,7 +1520,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
-        self.vouch_for_block_references(block).await?;
+        self.vouch_for_block_references(block, hash).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1542,7 +1543,18 @@ where
     /// is already in `block_hashes`. The accepted block is trusted, so these hash
     /// commitments remain a sufficient basis for accepting the referenced blocks
     /// even after the epochs that certified them are revoked.
-    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+    ///
+    /// A chain has one certified block per height, so a block committing to a
+    /// different hash than the one already accepted at that height is evidence of
+    /// equivocation — two conflicting certificates signed by that height's
+    /// committee. In that case the block is rejected with
+    /// [`ChainError::ConflictingCertifiedBlocks`], which names the certificate
+    /// pair that proves the fault.
+    async fn vouch_for_block_references(
+        &mut self,
+        block: &Block,
+        block_hash: CryptoHash,
+    ) -> Result<(), ChainError> {
         let mut references = Vec::new();
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
@@ -1559,25 +1571,38 @@ where
                 Some(known_hash) if known_hash == hash => {}
                 None => self.vouched_blocks.insert(&hash)?,
                 Some(known_hash) => {
-                    // A chain has one certified block per height, so a trusted
-                    // block committing to a different hash than the one already
-                    // accepted is evidence of equivocation — two conflicting
-                    // certificates signed by that height's committee. Follow the
-                    // newly accepted block's commitment (it is the one backed by
-                    // a currently trusted certificate), but flag the conflict.
-                    warn!(
-                        chain_id = %self.chain_id(),
-                        %height,
-                        %known_hash,
-                        vouched_hash = %hash,
-                        "conflicting certified blocks at the same height: \
-                         the committee for this height equivocated",
-                    );
-                    self.vouched_blocks.insert(&hash)?;
+                    return Err(self.conflicting_blocks_error(height, known_hash, hash, block_hash));
                 }
             }
         }
         Ok(())
+    }
+
+    /// Builds a [`ChainError::ConflictingCertifiedBlocks`] error and logs the
+    /// conflict: a certified block asserting a different block at `height` than
+    /// the one already accepted is proof that a committee equivocated.
+    fn conflicting_blocks_error(
+        &self,
+        height: BlockHeight,
+        existing_block: CryptoHash,
+        conflicting_block: CryptoHash,
+        witness_block: CryptoHash,
+    ) -> ChainError {
+        tracing::error!(
+            chain_id = %self.chain_id(),
+            %height,
+            %existing_block,
+            %conflicting_block,
+            %witness_block,
+            "conflicting certified blocks at the same height: a committee equivocated",
+        );
+        ChainError::ConflictingCertifiedBlocks(Box::new(ConflictingCertifiedBlocks {
+            chain_id: self.chain_id(),
+            height,
+            existing_block,
+            conflicting_block,
+            witness_block,
+        }))
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.
@@ -1599,7 +1624,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
-        self.vouch_for_block_references(block).await?;
+        self.vouch_for_block_references(block, hash).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
 };
 
@@ -25,7 +25,7 @@ use linera_execution::{
     ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
-    collection_view::CollectionView,
+    collection_view::CustomCollectionView,
     context::Context,
     log_view::LogView,
     map_view::{CustomMapView, MapView},
@@ -303,11 +303,12 @@ where
     /// cannot verify those certificates on their own anymore, and blocks that still
     /// matter are re-certified via `previous_block_hash` /
     /// `previous_message_blocks` links instead.
-    pub received_log: CollectionView<C, Epoch, LogView<C, ChainAndHeight>>,
+    pub received_log: CustomCollectionView<C, Epoch, LogView<C, ChainAndHeight>>,
     /// The number of `received_log` entries we have synchronized, per validator and
-    /// per sender epoch.
-    pub received_certificate_trackers:
-        RegisterView<C, HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>>,
+    /// per sender epoch. Node-local synchronization bookkeeping, not exposed via
+    /// GraphQL.
+    #[cfg_attr(with_graphql, graphql(skip))]
+    pub received_certificate_trackers: MapView<C, (ValidatorPublicKey, Epoch), u64>,
 
     /// Mailboxes used to receive messages indexed by their origin.
     pub inboxes: ReentrantCollectionView<C, ChainId, InboxStateView<C>>,
@@ -650,29 +651,22 @@ where
     }
 
     /// Updates the `received_log` trackers.
-    pub fn update_received_certificate_trackers(
+    pub async fn update_received_certificate_trackers(
         &mut self,
         new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
-    ) {
+    ) -> Result<(), ChainError> {
         for (name, epoch_trackers) in new_trackers {
-            let trackers = self
-                .received_certificate_trackers
-                .get_mut()
-                .entry(name)
-                .or_default();
             for (epoch, tracker) in epoch_trackers {
-                trackers
-                    .entry(epoch)
-                    .and_modify(|t| {
-                        // Because several synchronizations could happen in parallel, we need to
-                        // make sure to never go backward.
-                        if tracker > *t {
-                            *t = tracker;
-                        }
-                    })
-                    .or_insert(tracker);
+                let key = (name, epoch);
+                // Because several synchronizations could happen in parallel, we need to
+                // make sure to never go backward.
+                let current = self.received_certificate_trackers.get(&key).await?;
+                if current.is_none_or(|current| tracker > current) {
+                    self.received_certificate_trackers.insert(&key, tracker)?;
+                }
             }
         }
+        Ok(())
     }
 
     /// Returns the current epoch and committee of this chain.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -339,14 +339,15 @@ where
     /// `SystemOperation::Checkpoint` is executed.
     pub latest_checkpoint_height: RegisterView<C, Option<BlockHeight>>,
 
-    /// Hashes of pre-checkpoint sender blocks the chain has seen a checkpoint cert
-    /// vouch for via `outbox_block_hashes`, but whose actual cert bytes are not yet
-    /// in storage. The worker errors a checkpoint push with
-    /// `BlocksNotFound` when this set is non-empty, then accepts each
-    /// referenced cert (regardless of its own — possibly revoked — epoch) and
-    /// removes the entry. Once the set is empty, the checkpoint restoration can run
-    /// end-to-end.
-    pub pre_checkpoint_block_trust: SetView<C, CryptoHash>,
+    /// Hashes of blocks that are vouched for by data this chain already trusts, but
+    /// have not been processed here yet. A hash is inserted when a trusted source
+    /// commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
+    /// block's `previous_block_hash` or `previous_message_blocks` links (unless the
+    /// referenced block is already in `block_hashes`). The worker accepts a cert
+    /// whose hash is in this set regardless of its epoch — the epoch may be revoked,
+    /// but the hash commitment makes the block trustworthy — and removes the entry
+    /// upon acceptance.
+    pub vouched_blocks: SetView<C, CryptoHash>,
 
     /// The hash of the set of fully-tracked chains that `nonempty_outboxes` and
     /// `outbox_counters` were last reconciled against. On a client these two indices only hold
@@ -1506,6 +1507,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
+        self.vouch_for_block_references(block).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1520,6 +1522,50 @@ where
             self.latest_checkpoint_height.set(Some(block.header.height));
         }
         Ok(updated_streams)
+    }
+
+    /// Records the block references an accepted block commits to — its parent via
+    /// `previous_block_hash` and the latest message block per recipient via
+    /// `previous_message_blocks` — in `vouched_blocks`, unless the referenced block
+    /// is already in `block_hashes`. The accepted block is trusted, so these hash
+    /// commitments remain a sufficient basis for accepting the referenced blocks
+    /// even after the epochs that certified them are revoked.
+    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+        let mut references = Vec::new();
+        if let Some(parent_hash) = block.header.previous_block_hash {
+            references.push((block.header.height.try_sub_one()?, parent_hash));
+        }
+        for (hash, height) in block.body.previous_message_blocks.values() {
+            references.push((*height, *hash));
+        }
+        let known_hashes = self
+            .block_hashes
+            .multi_get(references.iter().map(|(height, _)| height))
+            .await?;
+        for (known, (height, hash)) in known_hashes.into_iter().zip(references) {
+            match known {
+                Some(known_hash) if known_hash == hash => {}
+                None => self.vouched_blocks.insert(&hash)?,
+                Some(known_hash) => {
+                    // A chain has one certified block per height, so a trusted
+                    // block committing to a different hash than the one already
+                    // accepted is evidence of equivocation — two conflicting
+                    // certificates signed by that height's committee. Follow the
+                    // newly accepted block's commitment (it is the one backed by
+                    // a currently trusted certificate), but flag the conflict.
+                    warn!(
+                        chain_id = %self.chain_id(),
+                        %height,
+                        %known_hash,
+                        vouched_hash = %hash,
+                        "conflicting certified blocks at the same height: \
+                         the committee for this height equivocated",
+                    );
+                    self.vouched_blocks.insert(&hash)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.
@@ -1541,6 +1587,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
+        self.vouch_for_block_references(block).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -25,6 +25,7 @@ use linera_execution::{
     ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
+    collection_view::CollectionView,
     context::Context,
     log_view::LogView,
     map_view::{CustomMapView, MapView},
@@ -296,10 +297,17 @@ where
     /// `height < next_block_height` is executed; a block at `height >= next_block_height`
     /// is preprocessed (verified but not yet executed) and may not be contiguous.
     pub block_hashes: CustomMapView<C, BlockHeight, CryptoHash>,
-    /// Sender chain and height of all certified blocks known as a receiver (local ordering).
-    pub received_log: LogView<C, ChainAndHeight>,
-    /// The number of `received_log` entries we have synchronized, for each validator.
-    pub received_certificate_trackers: RegisterView<C, HashMap<ValidatorPublicKey, u64>>,
+    /// Sender chain and height of all certified blocks known as a receiver (local
+    /// ordering), keyed by the epoch of the sender block's certificate. Partitioned
+    /// by epoch so that a revoked epoch's log can be dropped wholesale: clients
+    /// cannot verify those certificates on their own anymore, and blocks that still
+    /// matter are re-certified via `previous_block_hash` /
+    /// `previous_message_blocks` links instead.
+    pub received_log: CollectionView<C, Epoch, LogView<C, ChainAndHeight>>,
+    /// The number of `received_log` entries we have synchronized, per validator and
+    /// per sender epoch.
+    pub received_certificate_trackers:
+        RegisterView<C, HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>>,
 
     /// Mailboxes used to receive messages indexed by their origin.
     pub inboxes: ReentrantCollectionView<C, ChainId, InboxStateView<C>>,
@@ -587,6 +595,7 @@ where
         &mut self,
         inbox: &mut InboxStateView<C>,
         origin: &ChainId,
+        epoch: Epoch,
         bundle: MessageBundle,
         local_time: Timestamp,
         add_to_received_log: bool,
@@ -632,7 +641,10 @@ where
 
         // Remember the certificate for future validator/client synchronizations.
         if add_to_received_log {
-            self.received_log.push(chain_and_height);
+            self.received_log
+                .load_entry_mut(&epoch)
+                .await?
+                .push(chain_and_height);
         }
         Ok(())
     }
@@ -640,20 +652,26 @@ where
     /// Updates the `received_log` trackers.
     pub fn update_received_certificate_trackers(
         &mut self,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) {
-        for (name, tracker) in new_trackers {
-            self.received_certificate_trackers
+        for (name, epoch_trackers) in new_trackers {
+            let trackers = self
+                .received_certificate_trackers
                 .get_mut()
                 .entry(name)
-                .and_modify(|t| {
-                    // Because several synchronizations could happen in parallel, we need to make
-                    // sure to never go backward.
-                    if tracker > *t {
-                        *t = tracker;
-                    }
-                })
-                .or_insert(tracker);
+                .or_default();
+            for (epoch, tracker) in epoch_trackers {
+                trackers
+                    .entry(epoch)
+                    .and_modify(|t| {
+                        // Because several synchronizations could happen in parallel, we need to
+                        // make sure to never go backward.
+                        if tracker > *t {
+                            *t = tracker;
+                        }
+                    })
+                    .or_insert(tracker);
+            }
         }
     }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1520,7 +1520,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
-        self.vouch_for_block_references(block, hash).await?;
+        self.vouch_for_block_references(block).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1550,11 +1550,8 @@ where
     /// committee. In that case the block is rejected with
     /// [`ChainError::ConflictingCertifiedBlocks`], which names the certificate
     /// pair that proves the fault.
-    async fn vouch_for_block_references(
-        &mut self,
-        block: &Block,
-        block_hash: CryptoHash,
-    ) -> Result<(), ChainError> {
+    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+        let block_hash = block.hash();
         let mut references = Vec::new();
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
@@ -1624,7 +1621,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
-        self.vouch_for_block_references(block, hash).await?;
+        self.vouch_for_block_references(block).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -30,7 +30,7 @@ pub use chain::{BlockExecutionPhase, ChainIdSet, ChainStateView, ChainTipState, 
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,
-    crypto::CryptoError,
+    crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, BlockHeight, Epoch, Round, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
@@ -207,6 +207,34 @@ pub enum ChainError {
     NotTimedOutYet(Timestamp),
     #[error("Checkpoint precondition failed: {0}")]
     CheckpointPreconditionFailed(&'static str),
+    #[error(transparent)]
+    ConflictingCertifiedBlocks(Box<ConflictingCertifiedBlocks>),
+}
+
+/// The payload of [`ChainError::ConflictingCertifiedBlocks`]: a certified block
+/// asserts a different block at some height than the one already accepted there.
+/// Since a chain has one certified block per height, the two certificates
+/// together prove that a committee equivocated.
+#[derive(Error, Debug)]
+#[error(
+    "conflicting certified blocks at height {height} on chain {chain_id}: the certificate \
+     of block {witness_block} asserts {conflicting_block} at that height, but \
+     {existing_block} was already accepted — a committee equivocated"
+)]
+pub struct ConflictingCertifiedBlocks {
+    /// The chain with two conflicting certified blocks.
+    pub chain_id: ChainId,
+    /// The height at which the two blocks conflict.
+    pub height: BlockHeight,
+    /// The hash of the block already accepted at `height`.
+    pub existing_block: CryptoHash,
+    /// The conflicting hash asserted at `height` by `witness_block`'s certificate.
+    pub conflicting_block: CryptoHash,
+    /// The hash of the block whose certificate asserts `conflicting_block` at
+    /// `height`: the conflicting block itself, or an accepted block that commits
+    /// to it via `previous_block_hash` or `previous_message_blocks`. Its
+    /// certificate, together with `existing_block`'s, proves the fault.
+    pub witness_block: CryptoHash,
 }
 
 impl ChainError {
@@ -256,6 +284,7 @@ impl ChainError {
             | ChainError::RoundDoesNotTimeOut
             | ChainError::NotTimedOutYet(_)
             | ChainError::CheckpointPreconditionFailed(_)
+            | ChainError::ConflictingCertifiedBlocks(_)
             | ChainError::MissingCrossChainUpdate { .. } => false,
             ChainError::ViewError(_)
             | ChainError::UnexpectedMessage { .. }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -375,6 +375,36 @@ where
         })
     }
 
+    /// Ensures that this worker may still create signatures for blocks in the given
+    /// epoch: once an epoch has been revoked on the admin chain, its committee must
+    /// not sign anything new. A chain that failed to migrate to a newer epoch before
+    /// the revocation is frozen.
+    async fn ensure_epoch_signable(
+        &self,
+        epoch: Epoch,
+        height: BlockHeight,
+    ) -> Result<(), WorkerError> {
+        let is_revoked = self
+            .storage
+            .is_epoch_revoked(epoch)
+            .await
+            .map_err(|error| {
+                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                    Box::new(error),
+                    ChainExecutionContext::Block,
+                )))
+            })?;
+        ensure!(
+            !is_revoked,
+            WorkerError::VoteInRevokedEpoch {
+                chain_id: self.chain_id(),
+                epoch,
+                height,
+            }
+        );
+        Ok(())
+    }
+
     /// Returns whether this chain is known to be active (initialized).
     pub(crate) fn knows_chain_is_active(&self) -> bool {
         self.knows_chain_is_active
@@ -938,6 +968,7 @@ where
                 BlockOutcome::Skipped,
             ));
         }
+        self.ensure_epoch_signable(epoch, height).await?;
 
         self.block_values
             .insert_hashed(Cow::Borrowed(certificate.inner().inner()));
@@ -2143,21 +2174,22 @@ where
         height: BlockHeight,
         round: Round,
     ) -> Result<(), WorkerError> {
-        let chain = &mut self.chain;
         ensure!(
-            height == chain.tip_state.get().next_block_height,
+            height == self.chain.tip_state.get().next_block_height,
             WorkerError::UnexpectedBlockHeight {
-                expected_block_height: chain.tip_state.get().next_block_height,
+                expected_block_height: self.chain.tip_state.get().next_block_height,
                 found_block_height: height
             }
         );
-        let epoch = chain.execution_state.system.epoch.get();
-        let chain_id = chain.chain_id();
+        let epoch = *self.chain.execution_state.system.epoch.get();
+        self.ensure_epoch_signable(epoch, height).await?;
+        let chain_id = self.chain.chain_id();
         let key_pair = self.config.key_pair();
         let local_time = self.storage.clock().current_time();
-        if chain
+        if self
+            .chain
             .manager
-            .create_timeout_vote(chain_id, height, round, *epoch, key_pair, local_time)?
+            .create_timeout_vote(chain_id, height, round, epoch, key_pair, local_time)?
         {
             self.save().await?;
         }
@@ -2172,7 +2204,7 @@ where
         chain_id = %self.chain_id()
     ))]
     async fn vote_for_fallback(&mut self) -> Result<(), WorkerError> {
-        let chain = &mut self.chain;
+        let chain = &self.chain;
         let epoch = *chain.execution_state.system.epoch.get();
         let Some(admin_chain_id) = chain.execution_state.system.admin_chain_id.get() else {
             return Ok(());
@@ -2196,11 +2228,20 @@ where
             .clock()
             .current_time()
             .delta_since(event_data.timestamp);
-        if elapsed >= chain.ownership().await?.timeout_config.fallback_duration {
-            let chain_id = chain.chain_id();
-            let height = chain.tip_state.get().next_block_height;
+        if elapsed
+            >= self
+                .chain
+                .ownership()
+                .await?
+                .timeout_config
+                .fallback_duration
+        {
+            let chain_id = self.chain.chain_id();
+            let height = self.chain.tip_state.get().next_block_height;
+            self.ensure_epoch_signable(epoch, height).await?;
             let key_pair = self.config.key_pair();
-            if chain
+            if self
+                .chain
                 .manager
                 .vote_fallback(chain_id, height, epoch, key_pair)
             {
@@ -2484,6 +2525,7 @@ where
         // Check the epoch.
         let (epoch, committee) = chain.current_committee().await?;
         check_block_epoch(epoch, block.chain_id, block.epoch)?;
+        self.ensure_epoch_signable(epoch, block.height).await?;
         let policy = committee.policy().clone();
         block.check_proposal_size(policy.maximum_block_proposal_size)?;
         // Check the authentication of the block.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -289,16 +289,7 @@ where
             if bundle.height < next_height_to_receive {
                 skipped_len = i + 1;
             }
-            let is_revoked = self
-                .storage
-                .is_epoch_revoked(*epoch)
-                .await
-                .map_err(|error| {
-                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                        Box::new(error),
-                        ChainExecutionContext::Block,
-                    )))
-                })?;
+            let is_revoked = self.is_epoch_revoked(*epoch).await?;
             if !is_revoked || Some(bundle.height) <= last_anticipated_block_height {
                 trusted_len = i + 1;
             }
@@ -325,6 +316,17 @@ where
         })
     }
 
+    /// Returns whether the given epoch has been revoked on the admin chain,
+    /// mapping any storage error to a [`WorkerError`].
+    async fn is_epoch_revoked(&self, epoch: Epoch) -> Result<bool, WorkerError> {
+        self.storage.is_epoch_revoked(epoch).await.map_err(|error| {
+            WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                Box::new(error),
+                ChainExecutionContext::Block,
+            )))
+        })
+    }
+
     /// Ensures that the certificate's epoch is still a sufficient basis for trusting
     /// its block.
     ///
@@ -337,16 +339,7 @@ where
         certificate: &ConfirmedBlockCertificate,
     ) -> Result<(), WorkerError> {
         let header = &certificate.block().header;
-        let is_revoked = self
-            .storage
-            .is_epoch_revoked(header.epoch)
-            .await
-            .map_err(|error| {
-                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                    Box::new(error),
-                    ChainExecutionContext::Block,
-                )))
-            })?;
+        let is_revoked = self.is_epoch_revoked(header.epoch).await?;
         if is_revoked {
             return Err(WorkerError::EpochRevoked {
                 chain_id: header.chain_id,
@@ -366,16 +359,7 @@ where
         epoch: Epoch,
         height: BlockHeight,
     ) -> Result<(), WorkerError> {
-        let is_revoked = self
-            .storage
-            .is_epoch_revoked(epoch)
-            .await
-            .map_err(|error| {
-                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                    Box::new(error),
-                    ChainExecutionContext::Block,
-                )))
-            })?;
+        let is_revoked = self.is_epoch_revoked(epoch).await?;
         ensure!(
             !is_revoked,
             WorkerError::VoteInRevokedEpoch {
@@ -483,36 +467,29 @@ where
     /// matter are re-certified via `previous_block_hash` /
     /// `previous_message_blocks` links instead.
     async fn prune_revoked_received_logs(&mut self, up_to: Epoch) -> Result<(), WorkerError> {
-        // `indices` returns the stored epochs in ascending order. Walk the ones
-        // below `up_to` from newest to oldest: revocation is monotone, so the
-        // first revoked epoch found — and everything below it — can be pruned
-        // without further checks.
-        let mut stored = self.chain.received_log.indices().await?;
-        stored.retain(|epoch| *epoch < up_to);
-        let mut prunable = None;
-        for (position, epoch) in stored.iter().enumerate().rev() {
-            let is_revoked = self
-                .storage
-                .is_epoch_revoked(*epoch)
-                .await
-                .map_err(|error| {
-                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                        Box::new(error),
-                        ChainExecutionContext::Block,
-                    )))
-                })?;
-            if is_revoked {
-                prunable = Some(position);
+        // Find the highest revoked epoch below `up_to`. Since revocation is
+        // monotone, every stored epoch at or below it is revoked and prunable.
+        // Walk the stored epochs below `up_to` from highest to lowest and stop at
+        // the first revoked one.
+        let stored = self.chain.received_log.indices().await?;
+        let mut highest_revoked = None;
+        for epoch in stored.iter().rev().filter(|epoch| **epoch < up_to) {
+            if self.is_epoch_revoked(*epoch).await? {
+                highest_revoked = Some(*epoch);
                 break;
             }
         }
-        let Some(position) = prunable else {
+        let Some(highest_revoked) = highest_revoked else {
             return Ok(());
         };
-        for epoch in &stored[..=position] {
+        let mut pruned = false;
+        for epoch in stored.iter().filter(|epoch| **epoch <= highest_revoked) {
             self.chain.received_log.remove_entry(epoch)?;
+            pruned = true;
         }
-        self.save().await?;
+        if pruned {
+            self.save().await?;
+        }
         Ok(())
     }
 
@@ -2057,16 +2034,7 @@ where
             .collect::<BTreeSet<_>>();
         let mut revoked_epochs = BTreeSet::new();
         for epoch in epochs {
-            let is_revoked = self
-                .storage
-                .is_epoch_revoked(epoch)
-                .await
-                .map_err(|error| {
-                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                        Box::new(error),
-                        ChainExecutionContext::Block,
-                    )))
-                })?;
+            let is_revoked = self.is_epoch_revoked(epoch).await?;
             if !is_revoked {
                 break;
             }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -333,10 +333,10 @@ where
     ///
     /// A certificate from a revoked epoch no longer proves anything by itself: the
     /// committee that signed it is not trusted any more. Such a block is only
-    /// accepted if it is transitively re-certified by a block we accepted while its
-    /// epoch was still trusted — either the block itself is already in
-    /// `block_hashes`, or an accepted child block commits to it via its
-    /// `previous_block_hash`.
+    /// accepted if it was already accepted while its epoch was still trusted, i.e.
+    /// it is in `block_hashes`. (Blocks vouched for by an accepted block's
+    /// `previous_block_hash` or `previous_message_blocks` links, or by a checkpoint
+    /// cert, carry a `vouched_blocks` trust mark and bypass this check.)
     async fn ensure_epoch_trusted(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -355,18 +355,8 @@ where
         if !is_revoked {
             return Ok(());
         }
-        let block_hash = certificate.hash();
-        if self.chain.block_hashes.get(&header.height).await? == Some(block_hash) {
+        if self.chain.block_hashes.get(&header.height).await? == Some(certificate.hash()) {
             return Ok(());
-        }
-        let child_height = header.height.try_add_one()?;
-        if let Some(child_hash) = self.chain.block_hashes.get(&child_height).await? {
-            let child = self.storage.read_confirmed_block(child_hash).await?;
-            if child
-                .is_some_and(|child| child.block().header.previous_block_hash == Some(block_hash))
-            {
-                return Ok(());
-            }
         }
         Err(WorkerError::EpochRevoked {
             chain_id: header.chain_id,
@@ -1021,20 +1011,17 @@ where
         let height = block.header.height;
         let chain_id = block.header.chain_id;
 
-        // Trust-mark accept path: an earlier checkpoint cert recorded this block's
-        // hash in `pre_checkpoint_block_trust`. Removing the trust mark here is
+        // Trust-mark accept path: a checkpoint cert or an accepted block's
+        // `previous_block_hash` / `previous_message_blocks` links recorded this
+        // block's hash in `vouched_blocks`. Removing the trust mark here is
         // only an in-memory change; if anything below fails before `save`, the
         // mark survives on the next reload. The dispatch's `gap` definition
         // (`!=` rather than `<`) routes both above-tip and below-tip trust
         // uploads to `preprocess_certified_block` so the chain can write the
         // cert without advancing the tip.
-        let in_trust_set = self
-            .chain
-            .pre_checkpoint_block_trust
-            .contains(&block_hash)
-            .await?;
+        let in_trust_set = self.chain.vouched_blocks.contains(&block_hash).await?;
         if in_trust_set {
-            self.chain.pre_checkpoint_block_trust.remove(&block_hash)?;
+            self.chain.vouched_blocks.remove(&block_hash)?;
         }
 
         // Check if we already processed this block.
@@ -1054,10 +1041,11 @@ where
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
         // If the epoch has been revoked, the quorum signature alone is no longer a
-        // sufficient basis for trust: the block must also be vouched for by a block
-        // this worker already trusts — a checkpoint trust mark, an earlier
-        // acceptance of the same block, or an accepted child block that commits to
-        // it via `previous_block_hash`.
+        // sufficient basis for trust: the block must also be vouched for by data
+        // this worker already trusts — a `vouched_blocks` trust mark (written by a
+        // checkpoint cert or by an accepted block that commits to this one via
+        // `previous_block_hash` or `previous_message_blocks`) or an earlier
+        // acceptance of the same block.
         if !in_trust_set {
             self.ensure_epoch_trusted(&certificate).await?;
         }
@@ -1229,7 +1217,7 @@ where
         }
         if !missing_blocks.is_empty() {
             for hash in &missing_blocks {
-                self.chain.pre_checkpoint_block_trust.insert(hash)?;
+                self.chain.vouched_blocks.insert(hash)?;
             }
             self.save().await?;
             return Err(WorkerError::BlocksNotFound(missing_blocks));

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -34,7 +34,7 @@ use linera_chain::{
         ValidatedBlockCertificate,
     },
     BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
-    ChainTipState, ExecutionResultExt as _, StreamCounts,
+    ChainTipState, ConflictingCertifiedBlocks, ExecutionResultExt as _, StreamCounts,
 };
 use linera_execution::{
     system::{EpochEventData, EventSubscriptions, EPOCH_STREAM_NAME},
@@ -55,7 +55,9 @@ use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
-    worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
+    worker::{
+        BatchRequest, EquivocationEvidence, NetworkActions, Notification, Reason, WorkerError,
+    },
 };
 
 /// Type alias for event subscriptions result.
@@ -1090,6 +1092,18 @@ where
             self.ensure_epoch_trusted(&certificate).await?;
         }
 
+        // A different certified block already accepted at this height means a
+        // committee equivocated. Detect this before the certificate is written
+        // anywhere: the conflicting certificate is only carried inside the
+        // returned evidence, never persisted.
+        if let Some(existing_hash) = self.chain.block_hashes.get(&height).await? {
+            if existing_hash != block_hash {
+                return Err(self
+                    .same_height_equivocation(existing_hash, certificate)
+                    .await);
+            }
+        }
+
         // Certificate check passed - which means the blobs the block requires are legitimate and
         // we can take note of it, so that if any are missing, we will accept them when the client
         // sends them.
@@ -1134,7 +1148,7 @@ where
         use ProcessConfirmedBlockMode::{Auto, Execute, Preprocess};
         let gap = tip.next_block_height != height;
         let starts_with_checkpoint = block.starts_with_checkpoint();
-        match (mode, gap, starts_with_checkpoint) {
+        let result = match (mode, gap, starts_with_checkpoint) {
             (Preprocess, _, _) | (Auto, true, false) => {
                 self.preprocess_certified_block(certificate, notify_when_messages_are_delivered)
                     .await
@@ -1157,6 +1171,78 @@ where
                 )
                 .await
             }
+        };
+        match result {
+            Err(WorkerError::ChainError(chain_error)) => Err(match *chain_error {
+                ChainError::ConflictingCertifiedBlocks(conflict) => {
+                    self.attach_equivocation_evidence(*conflict).await
+                }
+                chain_error => WorkerError::ChainError(Box::new(chain_error)),
+            }),
+            result => result,
+        }
+    }
+
+    /// Builds the [`WorkerError::Equivocation`] error for a certificate of a
+    /// different block at a height where one is already accepted. The rejected
+    /// certificate goes into the returned evidence as its own witness, without
+    /// ever being written to storage.
+    async fn same_height_equivocation(
+        &self,
+        existing_block: CryptoHash,
+        certificate: ConfirmedBlockCertificate,
+    ) -> WorkerError {
+        let header = &certificate.block().header;
+        let conflict = ConflictingCertifiedBlocks {
+            chain_id: header.chain_id,
+            height: header.height,
+            existing_block,
+            conflicting_block: certificate.hash(),
+            witness_block: certificate.hash(),
+        };
+        tracing::error!(
+            chain_id = %conflict.chain_id,
+            height = %conflict.height,
+            %existing_block,
+            conflicting_block = %conflict.conflicting_block,
+            "conflicting certified blocks at the same height: a committee equivocated",
+        );
+        match self.storage.read_certificate(existing_block).await {
+            Ok(Some(existing)) => WorkerError::Equivocation(Box::new(EquivocationEvidence::new(
+                conflict,
+                CacheArc::unwrap_or_clone(existing),
+                certificate,
+            ))),
+            _ => WorkerError::ChainError(Box::new(ChainError::ConflictingCertifiedBlocks(
+                Box::new(conflict),
+            ))),
+        }
+    }
+
+    /// Upgrades a [`ChainError::ConflictingCertifiedBlocks`] error from the
+    /// vouching step into [`WorkerError::Equivocation`] by attaching the two
+    /// certificates that prove the fault: the certificate of the block already
+    /// accepted at the conflicting height, and the certificate of the witness
+    /// block that commits to a different block there. Both are legitimately in
+    /// storage — the witness is a block of the chain in its own right, not the
+    /// conflicting block itself. Falls back to the plain chain error if either
+    /// certificate cannot be read.
+    async fn attach_equivocation_evidence(
+        &self,
+        conflict: ConflictingCertifiedBlocks,
+    ) -> WorkerError {
+        let existing = self.storage.read_certificate(conflict.existing_block).await;
+        let witness = self.storage.read_certificate(conflict.witness_block).await;
+        if let (Ok(Some(existing)), Ok(Some(witness))) = (existing, witness) {
+            WorkerError::Equivocation(Box::new(EquivocationEvidence::new(
+                conflict,
+                CacheArc::unwrap_or_clone(existing),
+                CacheArc::unwrap_or_clone(witness),
+            )))
+        } else {
+            WorkerError::ChainError(Box::new(ChainError::ConflictingCertifiedBlocks(Box::new(
+                conflict,
+            ))))
         }
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -55,9 +55,7 @@ use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
-    worker::{
-        BatchRequest, EquivocationEvidence, NetworkActions, Notification, Reason, WorkerError,
-    },
+    worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
 
 /// Type alias for event subscriptions result.
@@ -331,11 +329,9 @@ where
     /// its block.
     ///
     /// A certificate from a revoked epoch no longer proves anything by itself: the
-    /// committee that signed it is not trusted any more. Such a block is only
-    /// accepted if it was already accepted while its epoch was still trusted, i.e.
-    /// it is in `block_hashes`. (Blocks vouched for by an accepted block's
-    /// `previous_block_hash` or `previous_message_blocks` links, or by a checkpoint
-    /// cert, carry a `vouched_blocks` trust mark and bypass this check.)
+    /// committee that signed it is not trusted any more. The caller must in that
+    /// case additionally have a trust mark for the block, or a prior acceptance of
+    /// it, to accept it.
     async fn ensure_epoch_trusted(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -351,17 +347,14 @@ where
                     ChainExecutionContext::Block,
                 )))
             })?;
-        if !is_revoked {
-            return Ok(());
+        if is_revoked {
+            return Err(WorkerError::EpochRevoked {
+                chain_id: header.chain_id,
+                epoch: header.epoch,
+                height: header.height,
+            });
         }
-        if self.chain.block_hashes.get(&header.height).await? == Some(certificate.hash()) {
-            return Ok(());
-        }
-        Err(WorkerError::EpochRevoked {
-            chain_id: header.chain_id,
-            epoch: header.epoch,
-            height: header.height,
-        })
+        Ok(())
     }
 
     /// Ensures that this worker may still create signatures for blocks in the given
@@ -1082,26 +1075,41 @@ where
         // We haven't processed the block - verify the certificate first.
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
+
+        // A chain has one certified block per height. Read the accepted hash at
+        // this height once: a *different* hash is proof that a committee
+        // equivocated — reject it before the certificate is written anywhere, so
+        // the conflicting certificate is never persisted; the *same* hash means we
+        // already accepted this block, which also satisfies the revoked-epoch
+        // trust requirement below.
+        let accepted_at_height = self.chain.block_hashes.get(&height).await?;
+        if let Some(existing_hash) = accepted_at_height {
+            if existing_hash != block_hash {
+                tracing::error!(
+                    %chain_id, %height, %existing_hash, conflicting_block = %block_hash,
+                    "conflicting certified blocks at the same height: a committee equivocated",
+                );
+                return Err(ChainError::ConflictingCertifiedBlocks(Box::new(
+                    ConflictingCertifiedBlocks {
+                        chain_id,
+                        height,
+                        existing_block: existing_hash,
+                        conflicting_block: block_hash,
+                        witness_block: block_hash,
+                    },
+                ))
+                .into());
+            }
+        }
+
         // If the epoch has been revoked, the quorum signature alone is no longer a
         // sufficient basis for trust: the block must also be vouched for by data
         // this worker already trusts — a `vouched_blocks` trust mark (written by a
         // checkpoint cert or by an accepted block that commits to this one via
         // `previous_block_hash` or `previous_message_blocks`) or an earlier
         // acceptance of the same block.
-        if !in_trust_set {
+        if !in_trust_set && accepted_at_height != Some(block_hash) {
             self.ensure_epoch_trusted(&certificate).await?;
-        }
-
-        // A different certified block already accepted at this height means a
-        // committee equivocated. Detect this before the certificate is written
-        // anywhere: the conflicting certificate is only carried inside the
-        // returned evidence, never persisted.
-        if let Some(existing_hash) = self.chain.block_hashes.get(&height).await? {
-            if existing_hash != block_hash {
-                return Err(self
-                    .same_height_equivocation(existing_hash, certificate)
-                    .await);
-            }
         }
 
         // Certificate check passed - which means the blobs the block requires are legitimate and
@@ -1148,7 +1156,7 @@ where
         use ProcessConfirmedBlockMode::{Auto, Execute, Preprocess};
         let gap = tip.next_block_height != height;
         let starts_with_checkpoint = block.starts_with_checkpoint();
-        let result = match (mode, gap, starts_with_checkpoint) {
+        match (mode, gap, starts_with_checkpoint) {
             (Preprocess, _, _) | (Auto, true, false) => {
                 self.preprocess_certified_block(certificate, notify_when_messages_are_delivered)
                     .await
@@ -1171,78 +1179,6 @@ where
                 )
                 .await
             }
-        };
-        match result {
-            Err(WorkerError::ChainError(chain_error)) => Err(match *chain_error {
-                ChainError::ConflictingCertifiedBlocks(conflict) => {
-                    self.attach_equivocation_evidence(*conflict).await
-                }
-                chain_error => WorkerError::ChainError(Box::new(chain_error)),
-            }),
-            result => result,
-        }
-    }
-
-    /// Builds the [`WorkerError::Equivocation`] error for a certificate of a
-    /// different block at a height where one is already accepted. The rejected
-    /// certificate goes into the returned evidence as its own witness, without
-    /// ever being written to storage.
-    async fn same_height_equivocation(
-        &self,
-        existing_block: CryptoHash,
-        certificate: ConfirmedBlockCertificate,
-    ) -> WorkerError {
-        let header = &certificate.block().header;
-        let conflict = ConflictingCertifiedBlocks {
-            chain_id: header.chain_id,
-            height: header.height,
-            existing_block,
-            conflicting_block: certificate.hash(),
-            witness_block: certificate.hash(),
-        };
-        tracing::error!(
-            chain_id = %conflict.chain_id,
-            height = %conflict.height,
-            %existing_block,
-            conflicting_block = %conflict.conflicting_block,
-            "conflicting certified blocks at the same height: a committee equivocated",
-        );
-        match self.storage.read_certificate(existing_block).await {
-            Ok(Some(existing)) => WorkerError::Equivocation(Box::new(EquivocationEvidence::new(
-                conflict,
-                CacheArc::unwrap_or_clone(existing),
-                certificate,
-            ))),
-            _ => WorkerError::ChainError(Box::new(ChainError::ConflictingCertifiedBlocks(
-                Box::new(conflict),
-            ))),
-        }
-    }
-
-    /// Upgrades a [`ChainError::ConflictingCertifiedBlocks`] error from the
-    /// vouching step into [`WorkerError::Equivocation`] by attaching the two
-    /// certificates that prove the fault: the certificate of the block already
-    /// accepted at the conflicting height, and the certificate of the witness
-    /// block that commits to a different block there. Both are legitimately in
-    /// storage — the witness is a block of the chain in its own right, not the
-    /// conflicting block itself. Falls back to the plain chain error if either
-    /// certificate cannot be read.
-    async fn attach_equivocation_evidence(
-        &self,
-        conflict: ConflictingCertifiedBlocks,
-    ) -> WorkerError {
-        let existing = self.storage.read_certificate(conflict.existing_block).await;
-        let witness = self.storage.read_certificate(conflict.witness_block).await;
-        if let (Ok(Some(existing)), Ok(Some(witness))) = (existing, witness) {
-            WorkerError::Equivocation(Box::new(EquivocationEvidence::new(
-                conflict,
-                CacheArc::unwrap_or_clone(existing),
-                CacheArc::unwrap_or_clone(witness),
-            )))
-        } else {
-            WorkerError::ChainError(Box::new(ChainError::ConflictingCertifiedBlocks(Box::new(
-                conflict,
-            ))))
         }
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1083,8 +1083,8 @@ where
         // sufficient basis for trust: the block must also be vouched for by data
         // this worker already trusts — a `vouched_blocks` trust mark (written by a
         // checkpoint cert or by an accepted block that commits to this one via
-        // `previous_block_hash` or `previous_message_blocks`) or an earlier
-        // acceptance of the same block.
+        // `previous_block_hash`, `previous_message_blocks` or
+        // `previous_event_blocks`) or an earlier acceptance of the same block.
         if !in_trust_set && accepted_at_height != Some(block_hash) {
             self.ensure_epoch_trusted(&certificate).await?;
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -54,7 +54,9 @@ use tracing::{debug, info, instrument, trace, warn};
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
     client::{ChainModes, ListeningMode},
-    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    data_types::{
+        ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest, ReceivedLogQuery,
+    },
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
 
@@ -275,7 +277,7 @@ where
         next_height_to_receive: BlockHeight,
         last_anticipated_block_height: Option<BlockHeight>,
         mut bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Vec<MessageBundle>, WorkerError> {
+    ) -> Result<Vec<(Epoch, MessageBundle)>, WorkerError> {
         let recipient = self.chain_id();
         let mut latest_height = None;
         let mut skipped_len = 0;
@@ -319,10 +321,7 @@ where
             );
         }
         Ok(if skipped_len < trusted_len {
-            bundles
-                .drain(skipped_len..trusted_len)
-                .map(|(_, bundle)| bundle)
-                .collect()
+            bundles.drain(skipped_len..trusted_len).collect()
         } else {
             vec![]
         })
@@ -478,7 +477,42 @@ where
         if query.request_fallback {
             self.vote_for_fallback().await?;
         }
+        if let Some(ReceivedLogQuery { epoch, .. }) = query.request_received_log {
+            self.prune_revoked_received_logs(epoch).await?;
+        }
         self.prepare_chain_info_response(query).await
+    }
+
+    /// Removes the received logs of revoked epochs below `up_to`. Run whenever a
+    /// client asks for a received log: entries of revoked epochs are useless to
+    /// clients — the certificates they point to can no longer be verified on their
+    /// own, and blocks that still matter are re-certified via
+    /// `previous_block_hash` / `previous_message_blocks` links instead.
+    async fn prune_revoked_received_logs(&mut self, up_to: Epoch) -> Result<(), WorkerError> {
+        let mut pruned = false;
+        for stored_epoch in self.chain.received_log.indices().await? {
+            if stored_epoch >= up_to {
+                continue;
+            }
+            let is_revoked =
+                self.storage
+                    .is_epoch_revoked(stored_epoch)
+                    .await
+                    .map_err(|error| {
+                        WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                            Box::new(error),
+                            ChainExecutionContext::Block,
+                        )))
+                    })?;
+            if is_revoked {
+                self.chain.received_log.remove_entry(&stored_epoch)?;
+                pruned = true;
+            }
+        }
+        if pruned {
+            self.save().await?;
+        }
+        Ok(())
     }
 
     /// Returns the requested blob, if it belongs to the current locking block or pending proposal.
@@ -1535,13 +1569,13 @@ where
                 bundles,
             )
             .await?;
-        let Some(last_updated_height) = bundles.last().map(|bundle| bundle.height) else {
+        let Some(last_updated_height) = bundles.last().map(|(_, bundle)| bundle.height) else {
             return Ok(CrossChainUpdateResult::NothingToDo);
         };
         // Process the received messages in certificates.
         let local_time = self.storage.clock().current_time();
         let mut previous_height = None;
-        for bundle in bundles {
+        for (epoch, bundle) in bundles {
             let add_to_received_log = previous_height != Some(bundle.height);
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
@@ -1549,6 +1583,7 @@ where
                 .receive_message_bundle_with_inbox(
                     &mut inbox,
                     &origin,
+                    epoch,
                     bundle,
                     local_time,
                     add_to_received_log,
@@ -1979,7 +2014,7 @@ where
     ))]
     pub(crate) async fn update_received_certificate_trackers(
         &mut self,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), WorkerError> {
         self.chain
             .update_received_certificate_trackers(new_trackers);
@@ -2127,7 +2162,7 @@ where
     /// Gets received certificate trackers.
     pub(crate) async fn get_received_certificate_trackers(
         &self,
-    ) -> Result<HashMap<ValidatorPublicKey, u64>, WorkerError> {
+    ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, WorkerError> {
         Ok(self.chain.received_certificate_trackers.get().clone())
     }
 
@@ -2737,13 +2772,17 @@ where
             .block_hashes_for_heights(query.request_sent_certificate_hashes_by_heights)
             .await?;
         info.requested_sent_certificate_hashes = hashes;
-        if let Some(start) = query.request_received_log_excluding_first_n {
-            let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
+        if let Some(ReceivedLogQuery { epoch, skip }) = query.request_received_log {
+            let skip = usize::try_from(skip).map_err(|_| ArithmeticError::Overflow)?;
             let max_received_log_entries = self.config.chain_info_max_received_log_entries;
-            let end = start
-                .saturating_add(max_received_log_entries)
-                .min(chain.received_log.count());
-            info.requested_received_log = chain.received_log.read(start..end).await?;
+            if let Some(log) = chain.received_log.try_load_entry(&epoch).await? {
+                let end = skip
+                    .saturating_add(max_received_log_entries)
+                    .min(log.count());
+                if skip < end {
+                    info.requested_received_log = log.read(skip..end).await?;
+                }
+            }
         }
         if query.request_manager_values {
             info.manager.add_values(&chain.manager);

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -54,9 +54,7 @@ use tracing::{debug, info, instrument, trace, warn};
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
     client::{ChainModes, ListeningMode},
-    data_types::{
-        ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest, ReceivedLogQuery,
-    },
+    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
 
@@ -477,41 +475,49 @@ where
         if query.request_fallback {
             self.vote_for_fallback().await?;
         }
-        if let Some(ReceivedLogQuery { epoch, .. }) = query.request_received_log {
-            self.prune_revoked_received_logs(epoch).await?;
+        if let Some(up_to) = query.request_received_log.keys().next().copied() {
+            self.prune_revoked_received_logs(up_to).await?;
         }
         self.prepare_chain_info_response(query).await
     }
 
     /// Removes the received logs of revoked epochs below `up_to`. Run whenever a
-    /// client asks for a received log: entries of revoked epochs are useless to
-    /// clients — the certificates they point to can no longer be verified on their
-    /// own, and blocks that still matter are re-certified via
-    /// `previous_block_hash` / `previous_message_blocks` links instead.
+    /// client asks for received logs, with `up_to` the lowest requested epoch:
+    /// entries of revoked epochs are useless to clients — the certificates they
+    /// point to can no longer be verified on their own, and blocks that still
+    /// matter are re-certified via `previous_block_hash` /
+    /// `previous_message_blocks` links instead.
     async fn prune_revoked_received_logs(&mut self, up_to: Epoch) -> Result<(), WorkerError> {
-        let mut pruned = false;
-        for stored_epoch in self.chain.received_log.indices().await? {
-            if stored_epoch >= up_to {
-                continue;
-            }
-            let is_revoked =
-                self.storage
-                    .is_epoch_revoked(stored_epoch)
-                    .await
-                    .map_err(|error| {
-                        WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                            Box::new(error),
-                            ChainExecutionContext::Block,
-                        )))
-                    })?;
+        // `indices` returns the stored epochs in ascending order. Walk the ones
+        // below `up_to` from newest to oldest: revocation is monotone, so the
+        // first revoked epoch found — and everything below it — can be pruned
+        // without further checks.
+        let mut stored = self.chain.received_log.indices().await?;
+        stored.retain(|epoch| *epoch < up_to);
+        let mut prunable = None;
+        for (position, epoch) in stored.iter().enumerate().rev() {
+            let is_revoked = self
+                .storage
+                .is_epoch_revoked(*epoch)
+                .await
+                .map_err(|error| {
+                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                        Box::new(error),
+                        ChainExecutionContext::Block,
+                    )))
+                })?;
             if is_revoked {
-                self.chain.received_log.remove_entry(&stored_epoch)?;
-                pruned = true;
+                prunable = Some(position);
+                break;
             }
         }
-        if pruned {
-            self.save().await?;
+        let Some(position) = prunable else {
+            return Ok(());
+        };
+        for epoch in &stored[..=position] {
+            self.chain.received_log.remove_entry(epoch)?;
         }
+        self.save().await?;
         Ok(())
     }
 
@@ -2017,7 +2023,38 @@ where
         new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), WorkerError> {
         self.chain
-            .update_received_certificate_trackers(new_trackers);
+            .update_received_certificate_trackers(new_trackers)
+            .await?;
+        // Drop tracker entries for revoked epochs: those epochs' received logs are
+        // pruned by validators and never queried again. Revocation is monotone, so
+        // the walk over the ascending epoch set can stop at the first live one.
+        let keys = self.chain.received_certificate_trackers.indices().await?;
+        let epochs = keys
+            .iter()
+            .map(|(_, epoch)| *epoch)
+            .collect::<BTreeSet<_>>();
+        let mut revoked_epochs = BTreeSet::new();
+        for epoch in epochs {
+            let is_revoked = self
+                .storage
+                .is_epoch_revoked(epoch)
+                .await
+                .map_err(|error| {
+                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                        Box::new(error),
+                        ChainExecutionContext::Block,
+                    )))
+                })?;
+            if !is_revoked {
+                break;
+            }
+            revoked_epochs.insert(epoch);
+        }
+        for key in keys {
+            if revoked_epochs.contains(&key.1) {
+                self.chain.received_certificate_trackers.remove(&key)?;
+            }
+        }
         self.save().await?;
         Ok(())
     }
@@ -2163,7 +2200,19 @@ where
     pub(crate) async fn get_received_certificate_trackers(
         &self,
     ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, WorkerError> {
-        Ok(self.chain.received_certificate_trackers.get().clone())
+        let mut trackers = HashMap::<_, BTreeMap<Epoch, u64>>::new();
+        for ((validator, epoch), tracker) in self
+            .chain
+            .received_certificate_trackers
+            .index_values()
+            .await?
+        {
+            trackers
+                .entry(validator)
+                .or_default()
+                .insert(epoch, tracker);
+        }
+        Ok(trackers)
     }
 
     /// Gets tip state and outbox info for next_outbox_heights calculation.
@@ -2772,15 +2821,24 @@ where
             .block_hashes_for_heights(query.request_sent_certificate_hashes_by_heights)
             .await?;
         info.requested_sent_certificate_hashes = hashes;
-        if let Some(ReceivedLogQuery { epoch, skip }) = query.request_received_log {
-            let skip = usize::try_from(skip).map_err(|_| ArithmeticError::Overflow)?;
-            let max_received_log_entries = self.config.chain_info_max_received_log_entries;
-            if let Some(log) = chain.received_log.try_load_entry(&epoch).await? {
-                let end = skip
-                    .saturating_add(max_received_log_entries)
-                    .min(log.count());
+        if !query.request_received_log.is_empty() {
+            // Serve the requested epochs in ascending order, bounding the total
+            // number of entries in the response: if the bound cuts an epoch's log
+            // short, the client repeats the request with advanced offsets.
+            let mut remaining = self.config.chain_info_max_received_log_entries;
+            for (epoch, skip) in query.request_received_log {
+                if remaining == 0 {
+                    break;
+                }
+                let skip = usize::try_from(skip).map_err(|_| ArithmeticError::Overflow)?;
+                let Some(log) = chain.received_log.try_load_entry(&epoch).await? else {
+                    continue;
+                };
+                let end = skip.saturating_add(remaining).min(log.count());
                 if skip < end {
-                    info.requested_received_log = log.read(skip..end).await?;
+                    let entries = log.read(skip..end).await?;
+                    remaining -= entries.len();
+                    info.requested_received_log.insert(epoch, entries);
                 }
             }
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -328,6 +328,53 @@ where
         })
     }
 
+    /// Ensures that the certificate's epoch is still a sufficient basis for trusting
+    /// its block.
+    ///
+    /// A certificate from a revoked epoch no longer proves anything by itself: the
+    /// committee that signed it is not trusted any more. Such a block is only
+    /// accepted if it is transitively re-certified by a block we accepted while its
+    /// epoch was still trusted — either the block itself is already in
+    /// `block_hashes`, or an accepted child block commits to it via its
+    /// `previous_block_hash`.
+    async fn ensure_epoch_trusted(
+        &self,
+        certificate: &ConfirmedBlockCertificate,
+    ) -> Result<(), WorkerError> {
+        let header = &certificate.block().header;
+        let is_revoked = self
+            .storage
+            .is_epoch_revoked(header.epoch)
+            .await
+            .map_err(|error| {
+                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                    Box::new(error),
+                    ChainExecutionContext::Block,
+                )))
+            })?;
+        if !is_revoked {
+            return Ok(());
+        }
+        let block_hash = certificate.hash();
+        if self.chain.block_hashes.get(&header.height).await? == Some(block_hash) {
+            return Ok(());
+        }
+        let child_height = header.height.try_add_one()?;
+        if let Some(child_hash) = self.chain.block_hashes.get(&child_height).await? {
+            let child = self.storage.read_confirmed_block(child_hash).await?;
+            if child
+                .is_some_and(|child| child.block().header.previous_block_hash == Some(block_hash))
+            {
+                return Ok(());
+            }
+        }
+        Err(WorkerError::EpochRevoked {
+            chain_id: header.chain_id,
+            epoch: header.epoch,
+            height: header.height,
+        })
+    }
+
     /// Returns whether this chain is known to be active (initialized).
     pub(crate) fn knows_chain_is_active(&self) -> bool {
         self.knows_chain_is_active
@@ -975,6 +1022,14 @@ where
         // We haven't processed the block - verify the certificate first.
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
+        // If the epoch has been revoked, the quorum signature alone is no longer a
+        // sufficient basis for trust: the block must also be vouched for by a block
+        // this worker already trusts — a checkpoint trust mark, an earlier
+        // acceptance of the same block, or an accepted child block that commits to
+        // it via `previous_block_hash`.
+        if !in_trust_set {
+            self.ensure_epoch_trusted(&certificate).await?;
+        }
 
         // Certificate check passed - which means the blobs the block requires are legitimate and
         // we can take note of it, so that if any are missing, we will accept them when the client

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1190,6 +1190,7 @@ impl<Env: Environment> ChainClient<Env> {
                 Some(async move {
                     client
                         .download_and_process_sender_chain(
+                            self.chain_id,
                             sender_chain_id,
                             &nodes,
                             received_logs,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1046,22 +1046,23 @@ impl<Env: Environment> ChainClient<Env> {
                 let trackers = &trackers;
                 let received_log_batches = Arc::clone(&received_log_batches);
                 Box::pin(async move {
-                    for epoch in live_epochs {
-                        let tracker = trackers
-                            .get(&remote_node.public_key)
-                            .and_then(|trackers| trackers.get(epoch))
-                            .copied()
-                            .unwrap_or(0);
-                        let batch = client
-                            .get_received_log_from_validator(
-                                chain_id,
-                                &remote_node,
-                                *epoch,
-                                tracker,
-                            )
-                            .await?;
-                        let mut batches = received_log_batches.lock().unwrap();
-                        batches.push((remote_node.public_key, *epoch, batch));
+                    let offsets = live_epochs
+                        .iter()
+                        .map(|epoch| {
+                            let tracker = trackers
+                                .get(&remote_node.public_key)
+                                .and_then(|trackers| trackers.get(epoch))
+                                .copied()
+                                .unwrap_or(0);
+                            (*epoch, tracker)
+                        })
+                        .collect();
+                    let remote_logs = client
+                        .get_received_log_from_validator(chain_id, &remote_node, offsets)
+                        .await?;
+                    let mut batches = received_log_batches.lock().unwrap();
+                    for (epoch, batch) in remote_logs {
+                        batches.push((remote_node.public_key, epoch, batch));
                     }
                     Ok(())
                 })

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -3491,37 +3491,73 @@ impl<Env: Environment> ChainClient<Env> {
             .read_certificates_by_heights(self.chain_id, &heights)
             .await?
             .into_iter()
-            .flatten();
+            .flatten()
+            .collect::<Vec<_>>();
 
-        for certificate in certificates {
-            let missing_blob_ids = match remote_node
-                .handle_confirmed_certificate(
-                    certificate.clone(),
-                    CrossChainMessageDelivery::NonBlocking,
-                )
+        let mut index = 0;
+        while let Some(certificate) = certificates.get(index) {
+            match self
+                .push_certificate_to_validator(&remote_node, certificate)
                 .await
             {
-                Ok(_) => continue,
-                Err(NodeError::BlobsNotFound(missing_blob_ids)) => missing_blob_ids,
-                Err(err) => return Err(err.into()),
-            };
-            // The validator is missing blobs the certificate depends on
-            // (including possibly the chain description). Upload and retry.
-            let missing_blobs = self
-                .client
-                .storage_client()
-                .read_blobs(&missing_blob_ids)
-                .await?
-                .into_iter()
-                .flatten()
-                .map(|b| b.into_std())
-                .collect();
-            remote_node.upload_blobs(missing_blobs).await?;
-            remote_node
-                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
-                .await?;
+                Ok(()) => index += 1,
+                Err(Error::RemoteNodeError(NodeError::EpochRevoked { .. })) => {
+                    // The validator no longer trusts the epoch that signed this
+                    // certificate. Push the remaining blocks in decreasing height
+                    // order instead: the newest block's epoch is still trusted (if
+                    // it isn't, its push fails and there is no way to re-certify
+                    // the chain), and each accepted child re-certifies its parent
+                    // via `previous_block_hash`. Then resume the ascending pass,
+                    // which executes the now-preprocessed blocks in order.
+                    for descendant in certificates[index + 1..].iter().rev() {
+                        self.push_certificate_to_validator(&remote_node, descendant)
+                            .await?;
+                    }
+                    self.push_certificate_to_validator(&remote_node, certificate)
+                        .await?;
+                    index += 1;
+                }
+                Err(err) => return Err(err),
+            }
         }
 
+        Ok(())
+    }
+
+    /// Sends a single confirmed certificate to the validator, uploading any blobs it
+    /// reports as missing (including possibly the chain description) and retrying.
+    async fn push_certificate_to_validator(
+        &self,
+        remote_node: &Env::ValidatorNode,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+    ) -> Result<(), Error> {
+        let missing_blob_ids = match remote_node
+            .handle_confirmed_certificate(
+                certificate.clone(),
+                CrossChainMessageDelivery::NonBlocking,
+            )
+            .await
+        {
+            Ok(_) => return Ok(()),
+            Err(NodeError::BlobsNotFound(missing_blob_ids)) => missing_blob_ids,
+            Err(err) => return Err(err.into()),
+        };
+        let missing_blobs = self
+            .client
+            .storage_client()
+            .read_blobs(&missing_blob_ids)
+            .await?
+            .into_iter()
+            .flatten()
+            .map(|b| b.into_std())
+            .collect();
+        remote_node.upload_blobs(missing_blobs).await?;
+        remote_node
+            .handle_confirmed_certificate(
+                certificate.clone(),
+                CrossChainMessageDelivery::NonBlocking,
+            )
+            .await?;
         Ok(())
     }
 }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -3497,18 +3497,17 @@ impl<Env: Environment> ChainClient<Env> {
                 Ok(()) => index += 1,
                 Err(Error::RemoteNodeError(NodeError::EpochRevoked { .. })) => {
                     // The validator no longer trusts the epoch that signed this
-                    // certificate. Push the remaining blocks in decreasing height
-                    // order instead: the newest block's epoch is still trusted (if
-                    // it isn't, its push fails and there is no way to re-certify
-                    // the chain), and each accepted child re-certifies its parent
-                    // via `previous_block_hash`. Then resume the ascending pass,
-                    // which executes the now-preprocessed blocks in order.
-                    for descendant in certificates[index + 1..].iter().rev() {
+                    // certificate. Push this and the remaining blocks in decreasing
+                    // height order instead: the newest block's epoch is still
+                    // trusted (if it isn't, its push fails and there is no way to
+                    // re-certify the chain), and each accepted child re-certifies
+                    // its parent via `previous_block_hash`. Then resume the
+                    // ascending pass, which executes the now-preprocessed blocks
+                    // in order.
+                    for descendant in certificates[index..].iter().rev() {
                         self.push_certificate_to_validator(&remote_node, descendant)
                             .await?;
                     }
-                    self.push_certificate_to_validator(&remote_node, certificate)
-                        .await?;
                     index += 1;
                 }
                 Err(err) => return Err(err),

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -284,12 +284,6 @@ pub enum Error {
     #[error("The state of the client is incompatible with the proposed block: {0}")]
     BlockProposalError(&'static str),
 
-    #[error(
-        "Cannot accept a certificate from a committee that was retired. \
-         Try a newer certificate from the same origin"
-    )]
-    CommitteeDeprecationError,
-
     #[error("Protocol error within chain client: {0}")]
     ProtocolError(&'static str),
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1001,7 +1001,7 @@ impl<Env: Environment> ChainClient<Env> {
         let _latency = super::metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
         // Use network information from the local chain.
         let chain_id = self.chain_id;
-        let (_, committee) = self.admin_committee().await?;
+        let (current_epoch, committee) = self.admin_committee().await?;
         let nodes = self.client.make_nodes(&committee)?;
 
         let trackers = self
@@ -1012,6 +1012,28 @@ impl<Env: Environment> ChainClient<Env> {
 
         trace!("find_received_certificates: read trackers");
 
+        // The received log is kept per sender epoch, and validators may prune the
+        // logs of revoked epochs, so only the live epochs are queried. Revocation
+        // is monotone, so these are exactly the epochs from the lowest live one up
+        // to the current one.
+        let mut live_epochs = Vec::new();
+        let mut epoch = current_epoch;
+        loop {
+            let is_revoked = self
+                .storage_client()
+                .is_epoch_revoked(epoch)
+                .await
+                .map_err(LocalNodeError::from)?;
+            if is_revoked {
+                break;
+            }
+            live_epochs.push(epoch);
+            let Some(previous_epoch) = epoch.0.checked_sub(1) else {
+                break;
+            };
+            epoch = Epoch(previous_epoch);
+        }
+
         let received_log_batches = Arc::new(std::sync::Mutex::new(Vec::new()));
         // Proceed to downloading received logs.
         let result = communicate_with_quorum(
@@ -1020,14 +1042,27 @@ impl<Env: Environment> ChainClient<Env> {
             |_| (),
             |remote_node| {
                 let client = &self.client;
-                let tracker = trackers.get(&remote_node.public_key).copied().unwrap_or(0);
+                let live_epochs = &live_epochs;
+                let trackers = &trackers;
                 let received_log_batches = Arc::clone(&received_log_batches);
                 Box::pin(async move {
-                    let batch = client
-                        .get_received_log_from_validator(chain_id, &remote_node, tracker)
-                        .await?;
-                    let mut batches = received_log_batches.lock().unwrap();
-                    batches.push((remote_node.public_key, batch));
+                    for epoch in live_epochs {
+                        let tracker = trackers
+                            .get(&remote_node.public_key)
+                            .and_then(|trackers| trackers.get(epoch))
+                            .copied()
+                            .unwrap_or(0);
+                        let batch = client
+                            .get_received_log_from_validator(
+                                chain_id,
+                                &remote_node,
+                                *epoch,
+                                tracker,
+                            )
+                            .await?;
+                        let mut batches = received_log_batches.lock().unwrap();
+                        batches.push((remote_node.public_key, *epoch, batch));
+                    }
                     Ok(())
                 })
             },
@@ -1049,7 +1084,7 @@ impl<Env: Environment> ChainClient<Env> {
 
         debug!(
             received_logs_len = %received_logs.len(),
-            received_logs_total = %received_logs.iter().map(|x| x.1.len()).sum::<usize>(),
+            received_logs_total = %received_logs.iter().map(|x| x.2.len()).sum::<usize>(),
             "collected received logs"
         );
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1783,7 +1783,7 @@ impl<Env: Environment> Client<Env> {
             }
 
             let remote_heights_ref = &remote_heights;
-            let certificates = match communicate_concurrently(
+            let (certificates, unknown_epoch_heights) = match communicate_concurrently(
                 &nodes,
                 async move |remote_node| {
                     let mut remote_heights = remote_heights_ref.clone();
@@ -1801,7 +1801,7 @@ impl<Env: Environment> Client<Env> {
                         // anything from the validator - let the function try the other validators
                         return Err(NodeError::MissingCertificateValue);
                     }
-                    let certificates = self
+                    let downloaded = self
                         .requests_scheduler
                         .download_certificates_by_heights(
                             &remote_node,
@@ -1809,28 +1809,34 @@ impl<Env: Environment> Client<Env> {
                             remote_heights,
                         )
                         .await?;
-                    let mut certificates_with_check_results = vec![];
-                    for cert in certificates {
-                        let committee_known = match self.check_certificate(&cert).await {
-                            Ok(()) => true,
-                            Err(chain_client::Error::CommitteeSynchronizationError) => false,
+                    // Set aside the certificates whose epochs we don't know yet:
+                    // they are not received - and not re-downloaded either, until a
+                    // future sync cycle after our view of the admin chain has
+                    // caught up.
+                    let mut certificates = Vec::new();
+                    let mut unknown_epoch_heights = Vec::new();
+                    for cert in downloaded {
+                        match self.check_certificate(&cert).await {
+                            Ok(()) => certificates.push(cert),
+                            Err(chain_client::Error::CommitteeSynchronizationError) => {
+                                unknown_epoch_heights.push(cert.block().header.height);
+                            }
                             Err(chain_client::Error::RemoteNodeError(error)) => return Err(error),
                             Err(error) => {
                                 return Err(NodeError::ResponseHandlingError {
                                     error: error.to_string(),
                                 })
                             }
-                        };
-                        certificates_with_check_results.push((cert, committee_known));
+                        }
                     }
-                    Ok(certificates_with_check_results)
+                    Ok((certificates, unknown_epoch_heights))
                 },
                 self.options.certificate_batch_download_hedge_delay,
                 self.storage_client().clock(),
             )
             .await
             {
-                Ok(certificates_with_check_results) => certificates_with_check_results,
+                Ok(result) => result,
                 Err(errors) => {
                     let faulty_validators = errors
                         .into_iter()
@@ -1862,19 +1868,12 @@ impl<Env: Environment> Client<Env> {
                 "received certificates",
             );
 
-            let mut to_remove_from_queue = BTreeSet::new();
+            let mut to_remove_from_queue = BTreeSet::from_iter(unknown_epoch_heights);
 
-            for (certificate, committee_known) in certificates {
+            for certificate in certificates {
                 let hash = certificate.hash();
                 let chain_id = certificate.block().header.chain_id;
                 let height = certificate.block().header.height;
-                if !committee_known {
-                    // The committee for the certificate's epoch is not known locally
-                    // yet - do not receive the certificate, but also do not attempt
-                    // to re-download it.
-                    to_remove_from_queue.insert(height);
-                    continue;
-                }
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1205,23 +1205,35 @@ impl<Env: Environment> Client<Env> {
                 .map_while(|maybe_certificate| maybe_certificate)
                 .collect::<Vec<_>>();
             if batch.is_empty() {
-                for node in nodes {
-                    match self
-                        .requests_scheduler
-                        .download_certificates_by_heights(node, chain_id, heights.clone())
-                        .await
-                    {
-                        Ok(downloaded) if !downloaded.is_empty() => {
-                            batch = downloaded
-                                .into_iter()
-                                .map(|certificate| {
-                                    self.storage_client().cache_certificate(certificate)
-                                })
-                                .collect();
-                            break;
+                // Race the validators instead of trying them one by one: a slow or
+                // faulty validator must not stall the walk. A validator that
+                // returns nothing counts as a failure so the others take over.
+                let heights = &heights;
+                let downloaded = communicate_concurrently(
+                    nodes,
+                    async move |remote_node| {
+                        let downloaded = self
+                            .requests_scheduler
+                            .download_certificates_by_heights(
+                                &remote_node,
+                                chain_id,
+                                heights.clone(),
+                            )
+                            .await?;
+                        if downloaded.is_empty() {
+                            return Err(NodeError::MissingCertificateValue);
                         }
-                        Ok(_) | Err(_) => continue,
-                    }
+                        Ok(downloaded)
+                    },
+                    self.options.certificate_batch_download_hedge_delay,
+                    self.storage_client().clock(),
+                )
+                .await;
+                if let Ok(downloaded) = downloaded {
+                    batch = downloaded
+                        .into_iter()
+                        .map(|certificate| self.storage_client().cache_certificate(certificate))
+                        .collect();
                 }
             }
             if batch.is_empty() {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2037,6 +2037,34 @@ impl<Env: Environment> Client<Env> {
                 .await?;
         }
 
+        // If the oldest collected block's epoch has been revoked, its certificate
+        // alone won't convince the local worker. Preprocess the collected chain
+        // newest-first: accepting each block marks the `previous_message_blocks`
+        // hash it commits to as vouched, so the next-older block is accepted
+        // despite its revoked epoch — without downloading any of the intermediate
+        // blocks that sent no message to our chain. (Epoch revocation is monotone,
+        // so only the oldest block needs checking; if even the newest block's
+        // epoch is revoked, its retry logic falls back to walking contiguous
+        // descendants.)
+        if let Some(certificate) = certificates.values().next() {
+            let epoch = certificate.block().header.epoch;
+            if self
+                .storage_client()
+                .is_epoch_revoked(epoch)
+                .await
+                .map_err(LocalNodeError::from)?
+            {
+                for certificate in certificates.values().rev() {
+                    Box::pin(self.handle_certificate_with_retry(
+                        certificate,
+                        std::slice::from_ref(remote_node),
+                        ProcessConfirmedBlockMode::Preprocess,
+                    ))
+                    .await?;
+                }
+            }
+        }
+
         // Process certificates in ascending block height order (BTreeMap keeps them sorted).
         for certificate in certificates.into_values() {
             self.receive_sender_certificate(

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1914,32 +1914,37 @@ impl<Env: Environment> Client<Env> {
         trace!("find_received_certificates: finished processing chain");
     }
 
-    /// Downloads the log of messages received from senders in the given epoch for a
-    /// chain from a validator.
-    #[instrument(level = "trace", skip(self))]
+    /// Downloads the per-epoch logs of messages received from senders in the given
+    /// epochs for a chain from a validator, starting at the given per-epoch
+    /// offsets. All epochs are requested in a single query; the validator bounds
+    /// the total number of entries per response, so the request is repeated with
+    /// advanced offsets until nothing is cut short anymore.
+    #[instrument(level = "trace", skip(self, offsets))]
     async fn get_received_log_from_validator(
         &self,
         chain_id: ChainId,
         remote_node: &RemoteNode<Env::ValidatorNode>,
-        epoch: Epoch,
-        tracker: u64,
-    ) -> Result<Vec<ChainAndHeight>, chain_client::Error> {
-        let mut offset = tracker;
-
+        mut offsets: BTreeMap<Epoch, u64>,
+    ) -> Result<BTreeMap<Epoch, Vec<ChainAndHeight>>, chain_client::Error> {
         // Retrieve the list of newly received certificates from this validator.
-        let mut remote_log = Vec::new();
+        let mut remote_logs = BTreeMap::<Epoch, Vec<ChainAndHeight>>::new();
         loop {
             trace!("get_received_log_from_validator: looping");
-            let query = ChainInfoQuery::new(chain_id).with_received_log(epoch, offset);
+            let query = ChainInfoQuery::new(chain_id).with_received_logs(offsets.clone());
             let info = remote_node.handle_chain_info_query(query).await?;
-            let received_entries = info.requested_received_log.len();
-            offset += received_entries as u64;
-            remote_log.extend(info.requested_received_log);
+            let received_entries: usize = info.requested_received_log.values().map(Vec::len).sum();
+            for (epoch, entries) in info.requested_received_log {
+                if let Some(offset) = offsets.get_mut(&epoch) {
+                    *offset += entries.len() as u64;
+                    remote_logs.entry(epoch).or_default().extend(entries);
+                }
+            }
             trace!(
                 remote_node = remote_node.address(),
                 %received_entries,
                 "get_received_log_from_validator: received log batch",
             );
+            // A response below the total bound means no epoch's log was cut short.
             if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
                 break;
             }
@@ -1947,11 +1952,11 @@ impl<Env: Environment> Client<Env> {
 
         trace!(
             remote_node = remote_node.address(),
-            num_entries = remote_log.len(),
+            num_entries = remote_logs.values().map(Vec::len).sum::<usize>(),
             "get_received_log_from_validator: returning downloaded log",
         );
 
-        Ok(remote_log)
+        Ok(remote_logs)
     }
 
     /// Downloads a specific sender block and recursively downloads any earlier blocks

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2106,33 +2106,8 @@ impl<Env: Environment> Client<Env> {
                 .await?;
         }
 
-        // If the oldest collected block's epoch has been revoked, its certificate
-        // alone won't convince the local worker. Preprocess the collected chain
-        // newest-first: accepting each block marks the `previous_message_blocks`
-        // hash it commits to as vouched, so the next-older block is accepted
-        // despite its revoked epoch — without downloading any of the intermediate
-        // blocks that sent no message to our chain. (Epoch revocation is monotone,
-        // so only the oldest block needs checking; if even the newest block's
-        // epoch is revoked, its retry logic falls back to walking contiguous
-        // descendants.)
-        if let Some(certificate) = certificates.values().next() {
-            let epoch = certificate.block().header.epoch;
-            if self
-                .storage_client()
-                .is_epoch_revoked(epoch)
-                .await
-                .map_err(LocalNodeError::from)?
-            {
-                for certificate in certificates.values().rev() {
-                    Box::pin(self.handle_certificate_with_retry(
-                        certificate,
-                        std::slice::from_ref(remote_node),
-                        ProcessConfirmedBlockMode::Preprocess,
-                    ))
-                    .await?;
-                }
-            }
-        }
+        self.recertify_if_epoch_revoked(&certificates, remote_node)
+            .await?;
 
         // Process certificates in ascending block height order (BTreeMap keeps them sorted).
         for certificate in certificates.into_values() {
@@ -2144,6 +2119,43 @@ impl<Env: Environment> Client<Env> {
             .await?;
         }
 
+        Ok(())
+    }
+
+    /// Preprocesses a sparsely collected run of blocks newest-first if the oldest one's
+    /// epoch has been revoked, so that the newer blocks vouch for the older ones.
+    ///
+    /// A revoked epoch's certificate alone doesn't convince the local worker. But
+    /// accepting a block marks the hashes it commits to in `previous_message_blocks` and
+    /// `previous_event_blocks` as vouched, so the block the oldest one was reached
+    /// through makes it acceptable despite its revoked epoch — without downloading the
+    /// intermediate blocks that sent no message and published no event. Epoch revocation
+    /// is monotone, so only the oldest block needs checking; if even the newest block's
+    /// epoch is revoked, the retry logic falls back to walking contiguous descendants.
+    async fn recertify_if_epoch_revoked(
+        &self,
+        certificates: &BTreeMap<BlockHeight, CacheArc<ConfirmedBlockCertificate>>,
+        remote_node: &RemoteNode<Env::ValidatorNode>,
+    ) -> Result<(), chain_client::Error> {
+        let Some(oldest) = certificates.values().next() else {
+            return Ok(());
+        };
+        if !self
+            .storage_client()
+            .is_epoch_revoked(oldest.block().header.epoch)
+            .await
+            .map_err(LocalNodeError::from)?
+        {
+            return Ok(());
+        }
+        for certificate in certificates.values().rev() {
+            Box::pin(self.handle_certificate_with_retry(
+                certificate,
+                std::slice::from_ref(remote_node),
+                ProcessConfirmedBlockMode::Preprocess,
+            ))
+            .await?;
+        }
         Ok(())
     }
 
@@ -2229,6 +2241,9 @@ impl<Env: Environment> Client<Env> {
 
             certificates.insert(current_height, certificate);
         }
+
+        self.recertify_if_epoch_revoked(&certificates, remote_node)
+            .await?;
 
         // Process in ascending height order.
         for certificate in certificates.into_values() {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1747,6 +1747,7 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "debug", skip_all, fields(chain_id = %sender_chain_id))]
     async fn download_and_process_sender_chain(
         &self,
+        receiver_chain_id: ChainId,
         sender_chain_id: ChainId,
         nodes: &[RemoteNode<Env::ValidatorNode>],
         received_log: &ReceivedLogs,
@@ -1754,6 +1755,55 @@ impl<Env: Environment> Client<Env> {
         sender: mpsc::UnboundedSender<ChainAndHeight>,
     ) {
         let mut nodes = nodes.to_vec();
+        // Process the lowest block together with its earlier message blocks first:
+        // its `previous_message_blocks` chain may reach into revoked epochs, whose
+        // received-log entries are pruned by validators and therefore missing from
+        // `remote_heights`. The ancestor walk downloads exactly the message-bearing
+        // predecessors (re-certifying revoked-epoch ones via the blocks that
+        // commit to them), so that the newer blocks' messages can actually be
+        // scheduled in the outbox. The downloaded certificates land in storage,
+        // where the loop below picks them up.
+        if let Some(lowest_height) = remote_heights.first().copied() {
+            let received_log = &received_log;
+            let result = communicate_concurrently(
+                &nodes,
+                async move |remote_node| {
+                    if !received_log.validator_has_block(
+                        &remote_node.public_key,
+                        sender_chain_id,
+                        lowest_height,
+                    ) {
+                        // The validator's log didn't contain the block; let the
+                        // others handle it.
+                        return Err(chain_client::Error::RemoteNodeError(
+                            NodeError::MissingCertificateValue,
+                        ));
+                    }
+                    self.download_sender_block_with_sending_ancestors(
+                        receiver_chain_id,
+                        sender_chain_id,
+                        lowest_height,
+                        &remote_node,
+                    )
+                    .await
+                },
+                self.options.certificate_batch_download_hedge_delay,
+                self.storage_client().clock(),
+            )
+            .await;
+            if let Err(errors) = result {
+                for (validator, error) in errors {
+                    warn!(
+                        %validator,
+                        %sender_chain_id,
+                        %lowest_height,
+                        %error,
+                        "failed to process the lowest sender block with its \
+                         sending ancestors",
+                    );
+                }
+            }
+        }
         while !remote_heights.is_empty() {
             // Check local storage first — certificates may already be available from
             // a prior sync cycle, another receiver chain, or a concurrent notification.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1914,12 +1914,14 @@ impl<Env: Environment> Client<Env> {
         trace!("find_received_certificates: finished processing chain");
     }
 
-    /// Downloads the log of received messages for a chain from a validator.
+    /// Downloads the log of messages received from senders in the given epoch for a
+    /// chain from a validator.
     #[instrument(level = "trace", skip(self))]
     async fn get_received_log_from_validator(
         &self,
         chain_id: ChainId,
         remote_node: &RemoteNode<Env::ValidatorNode>,
+        epoch: Epoch,
         tracker: u64,
     ) -> Result<Vec<ChainAndHeight>, chain_client::Error> {
         let mut offset = tracker;
@@ -1928,7 +1930,7 @@ impl<Env: Environment> Client<Env> {
         let mut remote_log = Vec::new();
         loop {
             trace!("get_received_log_from_validator: looping");
-            let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
+            let query = ChainInfoQuery::new(chain_id).with_received_log(epoch, offset);
             let info = remote_node.handle_chain_info_query(query).await?;
             let received_entries = info.requested_received_log.len();
             offset += received_entries as u64;

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -916,7 +916,8 @@ impl<Env: Environment> Client<Env> {
                                 }
                             }
                             for cert in certificates {
-                                self.check_certificate(&cert)
+                                let check_result = self
+                                    .check_certificate(&cert)
                                     .await
                                     .map_err(|error| {
                                         tracing::debug!(
@@ -924,15 +925,19 @@ impl<Env: Environment> Client<Env> {
                                             "invalid certificate"
                                         );
                                         error
-                                    })?
-                                    .into_result()
-                                    .map_err(|error| {
+                                    })?;
+                                // Revoked-epoch certificates are passed through: the
+                                // local worker accepts them only if a trusted
+                                // descendant vouches for them.
+                                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                                    check_result.into_result().map_err(|error| {
                                         tracing::debug!(
                                             %validator_address, %error,
                                             "could not check certificate"
                                         );
                                         error
                                     })?;
+                                }
                                 checked_certificates.push(cert);
                             }
                         }
@@ -1081,8 +1086,10 @@ impl<Env: Environment> Client<Env> {
     }
 
     /// Calls `handle_confirmed_certificate`, retrying with any missing blobs (downloaded
-    /// from `nodes`) and any missing events (downloaded from the publisher
-    /// chains via the current validators).
+    /// from `nodes`), any missing events (downloaded from the publisher
+    /// chains via the current validators), and — if the certificate's epoch is
+    /// revoked — the block's descendants (processed in decreasing height order so
+    /// they transitively re-certify the block).
     async fn handle_certificate_with_retry(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -1091,11 +1098,31 @@ impl<Env: Environment> Client<Env> {
     ) -> Result<ChainInfoResponse, chain_client::Error> {
         let mut downloaded_blobs = HashSet::<BlobId>::new();
         let mut downloaded_blocks = HashSet::<CryptoHash>::new();
+        let mut walked_descendants = false;
         let mut events = EventSetDownloader::new(self);
         loop {
             let result = self
                 .handle_confirmed_certificate(certificate.clone(), mode)
                 .await;
+            if let Err(LocalNodeError::WorkerError(WorkerError::EpochRevoked {
+                chain_id,
+                height,
+                ..
+            })) = &result
+            {
+                // The local worker doesn't trust the certificate's revoked epoch on
+                // its own. Try to establish trust by processing the block's
+                // descendants first.
+                if !walked_descendants {
+                    walked_descendants = true;
+                    if self
+                        .preprocess_descendants(*chain_id, *height, nodes)
+                        .await?
+                    {
+                        continue;
+                    }
+                }
+            }
             if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
                 let new_blobs = filter_new(blob_ids, &downloaded_blobs);
                 if !new_blobs.is_empty() {
@@ -1155,6 +1182,95 @@ impl<Env: Environment> Client<Env> {
             }
         }
         Ok(())
+    }
+
+    /// Recovers a revoked-epoch block rejected by the local worker by processing the
+    /// block's descendants first, in decreasing height order.
+    ///
+    /// Collects the chain's certificates from `height + 1` up to and including the
+    /// first one whose epoch is not revoked (the anchor) — from local storage where
+    /// possible, otherwise from `nodes` — and feeds them through the local worker
+    /// newest-first: the anchor is trusted based on its own epoch, and each accepted
+    /// child then vouches for its parent via `previous_block_hash`. Returns `false`
+    /// if no anchor was found, e.g. because the chain's tip is itself in a revoked
+    /// epoch.
+    async fn preprocess_descendants(
+        &self,
+        chain_id: ChainId,
+        height: BlockHeight,
+        nodes: &[RemoteNode<Env::ValidatorNode>],
+    ) -> Result<bool, chain_client::Error> {
+        let batch_size = self.options.certificate_download_batch_size;
+        let mut certificates = Vec::new();
+        let mut next_height = height.try_add_one()?;
+        'anchor: loop {
+            let heights = (0..batch_size)
+                .map(|offset| {
+                    u64::from(next_height)
+                        .checked_add(offset)
+                        .map(BlockHeight)
+                        .ok_or(ArithmeticError::Overflow)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let mut batch = self
+                .storage_client()
+                .read_certificates_by_heights(chain_id, &heights)
+                .await?
+                .into_iter()
+                .map_while(|maybe_certificate| maybe_certificate)
+                .collect::<Vec<_>>();
+            if batch.is_empty() {
+                for node in nodes {
+                    match self
+                        .requests_scheduler
+                        .download_certificates_by_heights(node, chain_id, heights.clone())
+                        .await
+                    {
+                        Ok(downloaded) if !downloaded.is_empty() => {
+                            batch = downloaded
+                                .into_iter()
+                                .map(|certificate| {
+                                    self.storage_client().cache_certificate(certificate)
+                                })
+                                .collect();
+                            break;
+                        }
+                        Ok(_) | Err(_) => continue,
+                    }
+                }
+            }
+            if batch.is_empty() {
+                return Ok(false);
+            }
+            for certificate in batch {
+                if certificate.block().header.height != next_height {
+                    // A gap in the returned heights breaks the vouching chain.
+                    return Ok(false);
+                }
+                let epoch = certificate.block().header.epoch;
+                let is_revoked = self
+                    .storage_client()
+                    .is_epoch_revoked(epoch)
+                    .await
+                    .map_err(LocalNodeError::from)?;
+                certificates.push(certificate);
+                if !is_revoked {
+                    break 'anchor;
+                }
+                next_height = next_height.try_add_one()?;
+            }
+        }
+        // Process the descendants newest-first, so that each block is vouched for
+        // by the one processed just before it.
+        for certificate in certificates.iter().rev() {
+            Box::pin(self.handle_certificate_with_retry(
+                certificate,
+                nodes,
+                ProcessConfirmedBlockMode::Preprocess,
+            ))
+            .await?;
+        }
+        Ok(true)
     }
 
     async fn handle_certificate<T: ProcessableCertificate>(
@@ -1618,7 +1734,13 @@ impl<Env: Environment> Client<Env> {
                         check_result = self.check_certificate(&certificate).await?;
                     }
                 }
-                check_result.into_result()?;
+                // A certificate from a revoked epoch is not rejected here: the local
+                // worker accepts it if an already-trusted descendant vouches for it,
+                // and `handle_certificate_with_retry` below downloads and processes
+                // the descendants on demand.
+                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                    check_result.into_result()?;
+                }
             }
             // Recover history from the network.
             let nodes = if let Some(nodes) = nodes {
@@ -1710,8 +1832,7 @@ impl<Env: Environment> Client<Env> {
                     let mut certificates_with_check_results = vec![];
                     for cert in certificates {
                         let check_result = self.check_certificate(&cert).await?;
-                        certificates_with_check_results
-                            .push((cert, check_result.into_result().is_ok()));
+                        certificates_with_check_results.push((cert, check_result));
                     }
                     Ok(certificates_with_check_results)
                 },
@@ -1758,13 +1879,16 @@ impl<Env: Environment> Client<Env> {
                 let hash = certificate.hash();
                 let chain_id = certificate.block().header.chain_id;
                 let height = certificate.block().header.height;
-                if !check_result {
+                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
                     // The certificate was correctly signed, but we were missing a committee to
                     // validate it properly - do not receive it, but also do not attempt to
                     // re-download it.
                     to_remove_from_queue.insert(height);
                     continue;
                 }
+                // A revoked-epoch certificate is still received: the local worker
+                // accepts it if a trusted descendant vouches for it.
+                let old_epoch = matches!(check_result, CheckCertificateResult::OldEpoch);
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self
@@ -1776,6 +1900,12 @@ impl<Env: Environment> Client<Env> {
                     .await
                 {
                     warn!(%error, %hash, "Received invalid certificate");
+                    if old_epoch {
+                        // The block could not be re-certified via descendants
+                        // either; drop it from the queue instead of re-downloading
+                        // it indefinitely.
+                        to_remove_from_queue.insert(height);
+                    }
                 } else {
                     to_remove_from_queue.insert(height);
                     if let Err(error) = sender.send(ChainAndHeight { chain_id, height }) {
@@ -1888,8 +2018,14 @@ impl<Env: Environment> Client<Env> {
                 self.storage_client().cache_certificate(certificate)
             };
 
-            // Validate the certificate.
-            self.check_certificate(&certificate).await?.into_result()?;
+            // Validate the certificate. Revoked-epoch certificates are passed
+            // through: they are processed via `receive_sender_certificate` below,
+            // and the local worker only accepts them if a trusted descendant
+            // vouches for them.
+            let check_result = self.check_certificate(&certificate).await?;
+            if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                check_result.into_result()?;
+            }
 
             // Check if there's a previous message block to our chain.
             let block = certificate.block();
@@ -1982,7 +2118,12 @@ impl<Env: Environment> Client<Env> {
                     continue;
                 };
 
-                self.check_certificate(&certificate).await?.into_result()?;
+                // Revoked-epoch certificates are passed through: the local worker
+                // only accepts them if a trusted descendant vouches for them.
+                let check_result = self.check_certificate(&certificate).await?;
+                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                    check_result.into_result()?;
+                }
 
                 self.storage_client().cache_certificate(certificate)
             };

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -42,7 +42,7 @@ use linera_chain::{
     },
     ChainError, ChainIdSet,
 };
-use linera_execution::{committee::Committee, ExecutionError};
+use linera_execution::committee::Committee;
 use linera_storage::{Arc as CacheArc, Clock as _, ResultReadCertificates, Storage as _};
 use rand::seq::SliceRandom;
 use received_log::ReceivedLogs;
@@ -916,28 +916,13 @@ impl<Env: Environment> Client<Env> {
                                 }
                             }
                             for cert in certificates {
-                                let check_result = self
-                                    .check_certificate(&cert)
-                                    .await
-                                    .map_err(|error| {
-                                        tracing::debug!(
-                                            %validator_address, %error,
-                                            "invalid certificate"
-                                        );
-                                        error
-                                    })?;
-                                // Revoked-epoch certificates are passed through: the
-                                // local worker accepts them only if a trusted
-                                // descendant vouches for them.
-                                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                                    check_result.into_result().map_err(|error| {
-                                        tracing::debug!(
-                                            %validator_address, %error,
-                                            "could not check certificate"
-                                        );
-                                        error
-                                    })?;
-                                }
+                                self.check_certificate(&cert).await.map_err(|error| {
+                                    tracing::debug!(
+                                        %validator_address, %error,
+                                        "invalid certificate"
+                                    );
+                                    error
+                                })?;
                                 checked_certificates.push(cert);
                             }
                         }
@@ -1687,8 +1672,11 @@ impl<Env: Environment> Client<Env> {
         Box::pin(async move {
             // Verify the certificate before doing any expensive networking.
             if let ReceiveCertificateMode::NeedsCheck = mode {
-                let mut check_result = self.check_certificate(&certificate).await?;
-                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                let mut check_result = self.check_certificate(&certificate).await;
+                if matches!(
+                    check_result,
+                    Err(chain_client::Error::CommitteeSynchronizationError)
+                ) {
                     // The certificate is from an epoch our local view of the admin chain
                     // hasn't caught up to yet. Catch up and check again instead of failing.
                     // Prefer the nodes that gave us the certificate: they evidently know
@@ -1710,12 +1698,7 @@ impl<Env: Environment> Client<Env> {
                                 Box::pin(async move {
                                     self.synchronize_chain_state_from(&node, admin_chain_id)
                                         .await?;
-                                    match self.check_certificate(certificate).await? {
-                                        CheckCertificateResult::FutureEpoch => {
-                                            Err(chain_client::Error::CommitteeSynchronizationError)
-                                        }
-                                        _ => Ok(()),
-                                    }
+                                    self.check_certificate(certificate).await
                                 })
                             },
                             self.options.blob_download_hedge_delay,
@@ -1727,20 +1710,17 @@ impl<Env: Environment> Client<Env> {
                         false
                     };
                     if synced_from_serving_node {
-                        check_result = self.check_certificate(&certificate).await?;
+                        check_result = self.check_certificate(&certificate).await;
                     }
-                    if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                    if matches!(
+                        check_result,
+                        Err(chain_client::Error::CommitteeSynchronizationError)
+                    ) {
                         Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
-                        check_result = self.check_certificate(&certificate).await?;
+                        check_result = self.check_certificate(&certificate).await;
                     }
                 }
-                // A certificate from a revoked epoch is not rejected here: the local
-                // worker accepts it if an already-trusted descendant vouches for it,
-                // and `handle_certificate_with_retry` below downloads and processes
-                // the descendants on demand.
-                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                    check_result.into_result()?;
-                }
+                check_result?;
             }
             // Recover history from the network.
             let nodes = if let Some(nodes) = nodes {
@@ -1831,8 +1811,17 @@ impl<Env: Environment> Client<Env> {
                         .await?;
                     let mut certificates_with_check_results = vec![];
                     for cert in certificates {
-                        let check_result = self.check_certificate(&cert).await?;
-                        certificates_with_check_results.push((cert, check_result));
+                        let committee_known = match self.check_certificate(&cert).await {
+                            Ok(()) => true,
+                            Err(chain_client::Error::CommitteeSynchronizationError) => false,
+                            Err(chain_client::Error::RemoteNodeError(error)) => return Err(error),
+                            Err(error) => {
+                                return Err(NodeError::ResponseHandlingError {
+                                    error: error.to_string(),
+                                })
+                            }
+                        };
+                        certificates_with_check_results.push((cert, committee_known));
                     }
                     Ok(certificates_with_check_results)
                 },
@@ -1875,20 +1864,17 @@ impl<Env: Environment> Client<Env> {
 
             let mut to_remove_from_queue = BTreeSet::new();
 
-            for (certificate, check_result) in certificates {
+            for (certificate, committee_known) in certificates {
                 let hash = certificate.hash();
                 let chain_id = certificate.block().header.chain_id;
                 let height = certificate.block().header.height;
-                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
-                    // The certificate was correctly signed, but we were missing a committee to
-                    // validate it properly - do not receive it, but also do not attempt to
-                    // re-download it.
+                if !committee_known {
+                    // The committee for the certificate's epoch is not known locally
+                    // yet - do not receive the certificate, but also do not attempt
+                    // to re-download it.
                     to_remove_from_queue.insert(height);
                     continue;
                 }
-                // A revoked-epoch certificate is still received: the local worker
-                // accepts it if a trusted descendant vouches for it.
-                let old_epoch = matches!(check_result, CheckCertificateResult::OldEpoch);
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self
@@ -1900,10 +1886,15 @@ impl<Env: Environment> Client<Env> {
                     .await
                 {
                     warn!(%error, %hash, "Received invalid certificate");
-                    if old_epoch {
-                        // The block could not be re-certified via descendants
-                        // either; drop it from the queue instead of re-downloading
-                        // it indefinitely.
+                    if matches!(
+                        &error,
+                        chain_client::Error::LocalNodeError(LocalNodeError::WorkerError(
+                            WorkerError::EpochRevoked { .. }
+                        ))
+                    ) {
+                        // The block's epoch is revoked and it could not be
+                        // re-certified via descendants; drop it from the queue
+                        // instead of re-downloading it indefinitely.
                         to_remove_from_queue.insert(height);
                     }
                 } else {
@@ -2018,14 +2009,8 @@ impl<Env: Environment> Client<Env> {
                 self.storage_client().cache_certificate(certificate)
             };
 
-            // Validate the certificate. Revoked-epoch certificates are passed
-            // through: they are processed via `receive_sender_certificate` below,
-            // and the local worker only accepts them if a trusted descendant
-            // vouches for them.
-            let check_result = self.check_certificate(&certificate).await?;
-            if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                check_result.into_result()?;
-            }
+            // Validate the certificate.
+            self.check_certificate(&certificate).await?;
 
             // Check if there's a previous message block to our chain.
             let block = certificate.block();
@@ -2118,12 +2103,7 @@ impl<Env: Environment> Client<Env> {
                     continue;
                 };
 
-                // Revoked-epoch certificates are passed through: the local worker
-                // only accepts them if a trusted descendant vouches for them.
-                let check_result = self.check_certificate(&certificate).await?;
-                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                    check_result.into_result()?;
-                }
+                self.check_certificate(&certificate).await?;
 
                 self.storage_client().cache_certificate(certificate)
             };
@@ -2199,6 +2179,17 @@ impl<Env: Environment> Client<Env> {
         .await
     }
 
+    /// Verifies the certificate's signatures against the committee of its own epoch.
+    ///
+    /// The committee is resolved from the admin chain's epoch event stream, which
+    /// works even if the epoch has been revoked since. Whether a valid certificate
+    /// from a revoked epoch is still a sufficient basis for trusting its block is
+    /// not decided here: the worker only accepts such a block if an already-trusted
+    /// block vouches for it.
+    ///
+    /// Returns [`chain_client::Error::CommitteeSynchronizationError`] if the epoch
+    /// is not known locally yet, e.g. because our local view of the admin chain is
+    /// behind; synchronizing the admin chain and retrying may resolve this.
     #[instrument(
         level = "trace", skip_all,
         fields(certificate_hash = ?incoming_certificate.hash()),
@@ -2206,20 +2197,18 @@ impl<Env: Environment> Client<Env> {
     async fn check_certificate(
         &self,
         incoming_certificate: &ConfirmedBlockCertificate,
-    ) -> Result<CheckCertificateResult, NodeError> {
+    ) -> Result<(), chain_client::Error> {
         let epoch = incoming_certificate.block().header.epoch;
-        let storage = self.storage_client();
-        let view_err = |error: ExecutionError| NodeError::ViewError {
-            error: error.to_string(),
-        };
-        if storage.is_epoch_revoked(epoch).await.map_err(view_err)? {
-            return Ok(CheckCertificateResult::OldEpoch);
-        }
-        let Some(committee) = storage.committee_for_epoch(epoch).await.map_err(view_err)? else {
-            return Ok(CheckCertificateResult::FutureEpoch);
-        };
-        incoming_certificate.check(&committee)?;
-        Ok(CheckCertificateResult::New)
+        let committee = self
+            .storage_client()
+            .committee_for_epoch(epoch)
+            .await
+            .map_err(LocalNodeError::from)?
+            .ok_or(chain_client::Error::CommitteeSynchronizationError)?;
+        incoming_certificate
+            .check(&committee)
+            .map_err(NodeError::from)?;
+        Ok(())
     }
 
     /// Downloads and processes any certificates we are missing for the given chain.
@@ -2851,25 +2840,6 @@ pub struct PendingProposal {
 enum ReceiveCertificateMode {
     NeedsCheck,
     AlreadyChecked,
-}
-
-enum CheckCertificateResult {
-    /// The certificate's epoch has been revoked on the admin chain.
-    OldEpoch,
-    /// The committee for the certificate's epoch is unknown to us yet, e.g. because
-    /// our local view of the admin chain is behind.
-    FutureEpoch,
-    New,
-}
-
-impl CheckCertificateResult {
-    fn into_result(self) -> Result<(), chain_client::Error> {
-        match self {
-            Self::OldEpoch => Err(chain_client::Error::CommitteeDeprecationError),
-            Self::FutureEpoch => Err(chain_client::Error::CommitteeSynchronizationError),
-            Self::New => Ok(()),
-        }
-    }
 }
 
 /// Creates a compressed Contract, Service and bytecode, plus an optional

--- a/linera-core/src/client/received_log.rs
+++ b/linera-core/src/client/received_log.rs
@@ -3,7 +3,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use linera_base::{crypto::ValidatorPublicKey, data_types::BlockHeight, identifiers::ChainId};
+use linera_base::{
+    crypto::ValidatorPublicKey,
+    data_types::{BlockHeight, Epoch},
+    identifiers::ChainId,
+};
 use linera_chain::data_types::ChainAndHeight;
 
 /// Struct keeping track of the blocks sending messages to some chain, from chains identified by
@@ -14,15 +18,19 @@ pub(super) struct ReceivedLogs(
 );
 
 impl ReceivedLogs {
-    /// Converts a set of logs received from validators into a single log.
+    /// Converts a set of per-epoch logs received from validators into a single log.
     pub(super) fn from_received_result(
-        result: Vec<(ValidatorPublicKey, Vec<ChainAndHeight>)>,
+        result: Vec<(ValidatorPublicKey, Epoch, Vec<ChainAndHeight>)>,
     ) -> Self {
-        Self::from_iterator(result.into_iter().flat_map(|(validator, received_log)| {
-            received_log
+        Self::from_iterator(
+            result
                 .into_iter()
-                .map(move |chain_and_height| (chain_and_height, validator))
-        }))
+                .flat_map(|(validator, _epoch, received_log)| {
+                    received_log
+                        .into_iter()
+                        .map(move |chain_and_height| (chain_and_height, validator))
+                }),
+        )
     }
 
     /// Returns a map that assigns to each chain ID the set of heights. The returned map contains
@@ -203,6 +211,7 @@ impl Iterator for BatchingHelper {
 mod tests {
     use linera_base::{
         crypto::{CryptoHash, ValidatorKeypair},
+        data_types::Epoch,
         identifiers::ChainId,
     };
     use linera_chain::data_types::ChainAndHeight;
@@ -224,6 +233,7 @@ mod tests {
         let validator = ValidatorKeypair::generate().public_key;
         let test_log = ReceivedLogs::from_received_result(vec![(
             validator,
+            Epoch::ZERO,
             vec![
                 (chain1, 1),
                 (chain1, 2),
@@ -330,6 +340,7 @@ mod tests {
         let validator = ValidatorKeypair::generate().public_key;
         let test_log = ReceivedLogs::from_received_result(vec![(
             validator,
+            Epoch::ZERO,
             vec![
                 (chain1, 1),
                 (chain1, 2),
@@ -436,6 +447,7 @@ mod tests {
         let test_log = ReceivedLogs::from_received_result(vec![
             (
                 validator1,
+                Epoch::ZERO,
                 vec![
                     (chain1, 1),
                     (chain1, 2),
@@ -456,6 +468,7 @@ mod tests {
             ),
             (
                 validator2,
+                Epoch::ZERO,
                 vec![
                     (chain1, 1),
                     (chain1, 2),

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -1253,9 +1253,8 @@ mod tests {
     }
 
     /// Dropping the owner guard without completing must wake subscribers — they fall back to
-    /// executing the request themselves — rather than leaving them blocked forever. Regression
-    /// test for the cold-sync hang where a cancelled `communicate_with_quorum` branch leaked the
-    /// in-flight entry, so its subscribers' `recv().await` never returned.
+    /// executing the request themselves — rather than leaving them blocked forever, since a
+    /// dropped owner leaves the in-flight entry that the subscribers' `recv().await` waits on.
     #[tokio::test]
     async fn test_owner_drop_wakes_subscribers() {
         use linera_base::identifiers::BlobType;

--- a/linera-core/src/client/validator_trackers.rs
+++ b/linera-core/src/client/validator_trackers.rs
@@ -3,28 +3,34 @@
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
-use linera_base::{crypto::ValidatorPublicKey, data_types::BlockHeight, identifiers::ChainId};
+use linera_base::{
+    crypto::ValidatorPublicKey,
+    data_types::{BlockHeight, Epoch},
+    identifiers::ChainId,
+};
 use linera_chain::data_types::ChainAndHeight;
 
 use super::received_log::ReceivedLogs;
 
-/// Keeps multiple `ValidatorTracker`s for multiple validators.
-pub(super) struct ValidatorTrackers(BTreeMap<ValidatorPublicKey, ValidatorTracker>);
+/// Keeps a `ValidatorTracker` per validator and sender epoch.
+pub(super) struct ValidatorTrackers(BTreeMap<(ValidatorPublicKey, Epoch), ValidatorTracker>);
 
 impl ValidatorTrackers {
     /// Creates a new `ValidatorTrackers`.
     pub(super) fn new(
-        received_logs: Vec<(ValidatorPublicKey, Vec<ChainAndHeight>)>,
-        trackers: &HashMap<ValidatorPublicKey, u64>,
+        received_logs: Vec<(ValidatorPublicKey, Epoch, Vec<ChainAndHeight>)>,
+        trackers: &HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Self {
         Self(
             received_logs
                 .into_iter()
-                .map(|(validator, log)| {
-                    (
-                        validator,
-                        ValidatorTracker::new(*trackers.get(&validator).unwrap_or(&0), log),
-                    )
+                .map(|(validator, epoch, log)| {
+                    let tracker = trackers
+                        .get(&validator)
+                        .and_then(|trackers| trackers.get(&epoch))
+                        .copied()
+                        .unwrap_or(0);
+                    ((validator, epoch), ValidatorTracker::new(tracker, log))
                 })
                 .collect(),
         )
@@ -38,13 +44,16 @@ impl ValidatorTrackers {
         }
     }
 
-    /// Converts the `ValidatorTrackers` into a map of per-validator tracker values
-    /// (indices into the validators' received logs).
-    pub(super) fn to_map(&self) -> BTreeMap<ValidatorPublicKey, u64> {
-        self.0
-            .iter()
-            .map(|(validator, tracker)| (*validator, tracker.current_tracker_value))
-            .collect()
+    /// Converts the `ValidatorTrackers` into a map of per-validator and per-epoch
+    /// tracker values (indices into the validators' per-epoch received logs).
+    pub(super) fn to_map(&self) -> BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>> {
+        let mut map = BTreeMap::<ValidatorPublicKey, BTreeMap<Epoch, u64>>::new();
+        for ((validator, epoch), tracker) in &self.0 {
+            map.entry(*validator)
+                .or_default()
+                .insert(*epoch, tracker.current_tracker_value);
+        }
+        map
     }
 
     /// Compares validators' received logs of sender chains with local node information and returns
@@ -127,9 +136,11 @@ impl ValidatorTracker {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use linera_base::{
         crypto::{CryptoHash, ValidatorKeypair},
-        data_types::BlockHeight,
+        data_types::{BlockHeight, Epoch},
         identifiers::ChainId,
     };
     use linera_chain::data_types::ChainAndHeight;
@@ -193,14 +204,17 @@ mod test {
         })
         .collect();
 
-        let mut received_log = ReceivedLogs::from_received_result(vec![(validator, log.clone())]);
+        let mut received_log =
+            ReceivedLogs::from_received_result(vec![(validator, Epoch::ZERO, log.clone())]);
 
         assert_eq!(received_log.num_chains(), 2);
         assert_eq!(received_log.num_certs(), 7);
 
         let mut tracker = ValidatorTrackers::new(
-            vec![(validator, log)],
-            &vec![(validator, 0)].into_iter().collect(),
+            vec![(validator, Epoch::ZERO, log)],
+            &vec![(validator, BTreeMap::from([(Epoch::ZERO, 0)]))]
+                .into_iter()
+                .collect(),
         );
 
         let local_heights = vec![(chain1, BlockHeight(3)), (chain2, BlockHeight(3))]
@@ -213,6 +227,9 @@ mod test {
         assert_eq!(received_log.num_certs(), 1);
 
         // tracker should have shifted to point to (chain1, 3)
-        assert_eq!(tracker.0[&validator].current_tracker_value, 5);
+        assert_eq!(
+            tracker.0[&(validator, Epoch::ZERO)].current_tracker_value,
+            5
+        );
     }
 }

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -41,11 +41,11 @@ pub struct ChainInfoQuery {
     #[debug(skip_if = Not::not)]
     pub request_pending_message_bundles: bool,
     /// Query new certificate sender chain IDs and block heights received from the
-    /// chain: the entries of the given sender epoch's received log, excluding the
-    /// first `skip`.
-    #[debug(skip_if = Option::is_none)]
-    #[cfg_attr(with_testing, strategy(proptest::strategy::Just(None)))]
-    pub request_received_log: Option<ReceivedLogQuery>,
+    /// chain: for each requested sender epoch, the entries of that epoch's received
+    /// log, excluding the first `skip`.
+    #[debug(skip_if = BTreeMap::is_empty)]
+    #[cfg_attr(with_testing, strategy(proptest::strategy::Just(BTreeMap::new())))]
+    pub request_received_log: BTreeMap<Epoch, u64>,
     /// Query values from the chain manager, not just votes.
     #[debug(skip_if = Not::not)]
     pub request_manager_values: bool,
@@ -77,7 +77,7 @@ impl ChainInfoQuery {
             test_next_block_height: None,
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log: None,
+            request_received_log: BTreeMap::new(),
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: false,
@@ -111,10 +111,17 @@ impl ChainInfoQuery {
         self
     }
 
-    /// Also requests the given sender epoch's received log entries, excluding the
-    /// first `skip`.
+    /// Also requests one sender epoch's received log entries, excluding the first
+    /// `skip`. Can be called repeatedly to request several epochs' logs at once.
     pub fn with_received_log(mut self, epoch: Epoch, skip: u64) -> Self {
-        self.request_received_log = Some(ReceivedLogQuery { epoch, skip });
+        self.request_received_log.insert(epoch, skip);
+        self
+    }
+
+    /// Also requests the given sender epochs' received log entries, each excluding
+    /// the given number of entries at the front of that epoch's log.
+    pub fn with_received_logs(mut self, queries: impl IntoIterator<Item = (Epoch, u64)>) -> Self {
+        self.request_received_log.extend(queries);
         self
     }
 
@@ -136,16 +143,6 @@ impl ChainInfoQuery {
         self.request_fallback = true;
         self
     }
-}
-
-/// A request for entries of one sender epoch's received log.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-#[cfg_attr(with_testing, derive(Eq, PartialEq))]
-pub struct ReceivedLogQuery {
-    /// The sender epoch whose received log to read.
-    pub epoch: Epoch,
-    /// The number of entries at the front of that epoch's log to skip.
-    pub skip: u64,
 }
 
 /// Information about a chain, returned in response to a [`ChainInfoQuery`].
@@ -186,10 +183,12 @@ pub struct ChainInfo {
     /// The response to `request_sent_certificate_hashes_by_heights`.
     #[debug(skip_if = Vec::is_empty)]
     pub requested_sent_certificate_hashes: Vec<CryptoHash>,
-    /// The response to `request_received_log`: the entries of the requested sender
-    /// epoch's received log, after the requested offset.
-    #[debug(skip_if = Vec::is_empty)]
-    pub requested_received_log: Vec<ChainAndHeight>,
+    /// The response to `request_received_log`: per requested sender epoch, the
+    /// entries of that epoch's received log after the requested offset. The total
+    /// number of entries is bounded, so epochs may be missing or cut short; the
+    /// client continues with adjusted offsets.
+    #[debug(skip_if = BTreeMap::is_empty)]
+    pub requested_received_log: BTreeMap<Epoch, Vec<ChainAndHeight>>,
     /// The response to `request_previous_event_blocks`.
     #[debug(skip_if = BTreeMap::is_empty)]
     pub requested_previous_event_blocks: BTreeMap<StreamId, (BlockHeight, CryptoHash)>,
@@ -312,7 +311,7 @@ impl ChainInfo {
             requested_owner_balance: None,
             requested_pending_message_bundles: Vec::new(),
             requested_sent_certificate_hashes: Vec::new(),
-            requested_received_log: Vec::new(),
+            requested_received_log: BTreeMap::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
         })

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -111,13 +111,6 @@ impl ChainInfoQuery {
         self
     }
 
-    /// Also requests one sender epoch's received log entries, excluding the first
-    /// `skip`. Can be called repeatedly to request several epochs' logs at once.
-    pub fn with_received_log(mut self, epoch: Epoch, skip: u64) -> Self {
-        self.request_received_log.insert(epoch, skip);
-        self
-    }
-
     /// Also requests the given sender epochs' received log entries, each excluding
     /// the given number of entries at the front of that epoch's log.
     pub fn with_received_logs(mut self, queries: impl IntoIterator<Item = (Epoch, u64)>) -> Self {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -40,9 +40,12 @@ pub struct ChainInfoQuery {
     /// Query the received messages that are waiting to be picked in the next block.
     #[debug(skip_if = Not::not)]
     pub request_pending_message_bundles: bool,
-    /// Query new certificate sender chain IDs and block heights received from the chain.
+    /// Query new certificate sender chain IDs and block heights received from the
+    /// chain: the entries of the given sender epoch's received log, excluding the
+    /// first `skip`.
     #[debug(skip_if = Option::is_none)]
-    pub request_received_log_excluding_first_n: Option<u64>,
+    #[cfg_attr(with_testing, strategy(proptest::strategy::Just(None)))]
+    pub request_received_log: Option<ReceivedLogQuery>,
     /// Query values from the chain manager, not just votes.
     #[debug(skip_if = Not::not)]
     pub request_manager_values: bool,
@@ -74,7 +77,7 @@ impl ChainInfoQuery {
             test_next_block_height: None,
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log_excluding_first_n: None,
+            request_received_log: None,
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: false,
@@ -108,9 +111,10 @@ impl ChainInfoQuery {
         self
     }
 
-    /// Also requests the received log entries, excluding the first `n`.
-    pub fn with_received_log_excluding_first_n(mut self, n: u64) -> Self {
-        self.request_received_log_excluding_first_n = Some(n);
+    /// Also requests the given sender epoch's received log entries, excluding the
+    /// first `skip`.
+    pub fn with_received_log(mut self, epoch: Epoch, skip: u64) -> Self {
+        self.request_received_log = Some(ReceivedLogQuery { epoch, skip });
         self
     }
 
@@ -132,6 +136,16 @@ impl ChainInfoQuery {
         self.request_fallback = true;
         self
     }
+}
+
+/// A request for entries of one sender epoch's received log.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct ReceivedLogQuery {
+    /// The sender epoch whose received log to read.
+    pub epoch: Epoch,
+    /// The number of entries at the front of that epoch's log to skip.
+    pub skip: u64,
 }
 
 /// Information about a chain, returned in response to a [`ChainInfoQuery`].
@@ -172,9 +186,8 @@ pub struct ChainInfo {
     /// The response to `request_sent_certificate_hashes_by_heights`.
     #[debug(skip_if = Vec::is_empty)]
     pub requested_sent_certificate_hashes: Vec<CryptoHash>,
-    /// The current number of received certificates (useful for `request_received_log_excluding_first_n`)
-    pub count_received_log: usize,
-    /// The response to `request_received_certificates_excluding_first_n`
+    /// The response to `request_received_log`: the entries of the requested sender
+    /// epoch's received log, after the requested offset.
     #[debug(skip_if = Vec::is_empty)]
     pub requested_received_log: Vec<ChainAndHeight>,
     /// The response to `request_previous_event_blocks`.
@@ -299,7 +312,6 @@ impl ChainInfo {
             requested_owner_balance: None,
             requested_pending_message_bundles: Vec::new(),
             requested_sent_certificate_hashes: Vec::new(),
-            count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -10,7 +10,7 @@ use std::{
 use futures::{stream::FuturesUnordered, TryStreamExt as _};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{ArithmeticError, Blob, BlockHeight},
+    data_types::{ArithmeticError, Blob, BlockHeight, Epoch},
     identifiers::{BlobId, ChainId, EventId, StreamId},
 };
 use linera_chain::{
@@ -391,7 +391,7 @@ where
     pub async fn update_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), LocalNodeError> {
         self.node
             .state
@@ -495,7 +495,7 @@ where
     pub async fn get_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-    ) -> Result<HashMap<ValidatorPublicKey, u64>, LocalNodeError> {
+    ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, LocalNodeError> {
         Ok(self
             .node
             .state

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -12,7 +12,8 @@ use futures::stream::Stream;
 use linera_base::{
     crypto::{CryptoError, CryptoHash, ValidatorPublicKey},
     data_types::{
-        ArithmeticError, Blob, BlobContent, BlockHeight, NetworkDescription, Round, Timestamp,
+        ArithmeticError, Blob, BlobContent, BlockHeight, Epoch, NetworkDescription, Round,
+        Timestamp,
     },
     identifiers::{BlobId, ChainId, EventId},
     task::{MaybeSend, MaybeSync},
@@ -366,6 +367,16 @@ pub enum NodeError {
 
     #[error("No validators available to handle the request")]
     NoValidators,
+
+    #[error(
+        "Cannot trust the certificate for block at height {height} on chain {chain_id}: \
+        epoch {epoch} has been revoked and no trusted block vouches for the block"
+    )]
+    EpochRevoked {
+        chain_id: ChainId,
+        epoch: Epoch,
+        height: BlockHeight,
+    },
 }
 
 impl NodeError {
@@ -387,6 +398,7 @@ impl NodeError {
             | NodeError::UnexpectedBlockHeight { .. }
             | NodeError::InactiveChain(_)
             | NodeError::InvalidTimestamp { .. }
+            | NodeError::EpochRevoked { .. }
             | NodeError::MissingCertificateValue => true,
 
             // Unexpected: network issues, validator misbehavior, or internal problems.
@@ -519,6 +531,15 @@ impl From<WorkerError> for NodeError {
             } => NodeError::UnexpectedBlockHeight {
                 expected_block_height,
                 found_block_height,
+            },
+            WorkerError::EpochRevoked {
+                chain_id,
+                epoch,
+                height,
+            } => Self::EpochRevoked {
+                chain_id,
+                epoch,
+                height,
             },
             WorkerError::InvalidTimestamp {
                 block_timestamp,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1528,7 +1528,7 @@ where
 /// not heard of yet.
 ///
 /// The blob-recovery path downloads the publishing certificate from a validator, but
-/// validating it locally yields `CheckCertificateResult::FutureEpoch`. The client must
+/// validating it locally yields `CommitteeSynchronizationError`. The client must
 /// react by catching up on the admin chain and retrying, so the blob read succeeds.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1871,6 +1871,118 @@ where
     Ok(())
 }
 
+/// A receiver syncing via the received log only sees live epochs' entries, but a
+/// sender block from a revoked epoch may still be undelivered. The sync must
+/// process the lowest listed block together with its sending ancestors, so that
+/// the pruned-epoch message is re-certified and delivered — otherwise the newer
+/// messages could never be scheduled behind the missing one.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_bulk_sync_across_revoked_epoch<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
+    let receiver_id = receiver.chain_id();
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
+
+    // Height 0 (epoch 0): send to the receiver.
+    let cert0 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // Create epoch 1. The receiver learns about it from an admin-chain `NewBlock`
+    // notification — not via `synchronize_from_validators`, which would deliver
+    // the height-0 transfer before the epoch is revoked — and migrates to epoch 1.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
+        .await
+        .unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: create_cert.block().header.height,
+                    hash: create_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    // Height 1 migrates the sender to epoch 1 without sending anything; height 2
+    // (epoch 1) sends to the receiver again.
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let cert1 = migration_certs.last().expect("migration block").clone();
+    let cert2 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // Revoke epoch 0, and let the receiver learn about the revocation the same way.
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: revoke_cert.block().header.height,
+                    hash: revoke_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
+
+    // Sync via the received log: only epoch 1's log is queried, listing only the
+    // height-2 block. Its `previous_message_blocks` walk must fetch and
+    // re-certify the height-0 block, so both transfers get delivered.
+    receiver.synchronize_from_validators().await?;
+    receiver.process_inbox().await?;
+    assert_eq!(
+        receiver.local_balance().await?,
+        Amount::from_tokens(2),
+        "both transfers should have been received",
+    );
+
+    // The sender blocks were downloaded, but not the migration block in between.
+    let storage = receiver.storage_client();
+    assert!(storage.contains_certificate(cert0.hash()).await?);
+    assert!(!storage.contains_certificate(cert1.hash()).await?);
+    assert!(storage.contains_certificate(cert2.hash()).await?);
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1413,6 +1413,113 @@ where
     assert_eq!(certificates.len(), 3);
     assert_eq!(user.chain_info().await?.epoch, Epoch::from(6));
 
+    // A fresh client, starting from genesis storage only, can still synchronize the
+    // user chain even though its first two blocks are signed by the revoked epochs
+    // 0 and 1: the local worker rejects them at first, and the client recovers by
+    // processing their descendants in decreasing height order.
+    let info = user.chain_info().await?;
+    let user2 = builder
+        .make_client(user.chain_id(), None, BlockHeight::ZERO)
+        .await?;
+    user2.synchronize_from_validators().await?;
+    let info2 = user2.chain_info().await?;
+    assert_eq!(info2.next_block_height, info.next_block_height);
+    assert_eq!(info2.epoch, Epoch::from(6));
+
+    Ok(())
+}
+
+/// Tests that a client can bring a lagging validator up to date across an epoch
+/// revocation: certificates signed by a revoked epoch are rejected by the validator
+/// at first, and the client recovers by uploading their descendants in decreasing
+/// height order, so that each accepted child re-certifies its parent.
+///
+/// Exercises both upload paths: the updater's certificate push (triggered by a block
+/// proposal that needs the lagging validator's vote) and the explicit
+/// `sync_validator` API.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_sync_lagging_validator_across_revoked_epoch<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let user = builder.add_root_chain(1, Amount::from_tokens(6)).await?;
+    let validators = builder.initial_committee.validators().clone();
+
+    // Validator 0 misses the user chain's early history; the remaining three
+    // validators still form a quorum.
+    builder.set_fault_type([0], FaultType::Offline);
+
+    // Height 0, signed by epoch 0.
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+
+    // Create epoch 1 and migrate the user chain to it. The migration block at
+    // height 1 still carries epoch 0 in its header; only the block at height 2 is
+    // signed by epoch 1.
+    let committee = Committee::new(validators, ResourceControlPolicy::default())?;
+    admin.stage_new_committee(committee.clone()).await?;
+    user.synchronize_from_validators().await?;
+    user.process_inbox().await?;
+    assert_eq!(user.chain_info().await?.epoch, Epoch::from(1));
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+
+    // Validator 0 comes back online and learns that epoch 0 is revoked — but it
+    // still has none of the user chain's blocks.
+    builder.set_fault_type([0], FaultType::Honest);
+    admin.revoke_epochs(Epoch::ZERO).await?;
+    admin.sync_validator(builder.node(0)).await?;
+
+    // With validator 1 offline, the next block needs validator 0's vote, so the
+    // updater must bring it up to date — past the revoked-epoch blocks at heights
+    // 0 and 1.
+    builder.set_fault_type([1], FaultType::Offline);
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    // Validator 1 is offline, so a count of 3 requires validator 0 to have the
+    // certificates.
+    builder
+        .check_that_validators_have_certificate(user.chain_id(), BlockHeight::ZERO, 3)
+        .await;
+    builder
+        .check_that_validators_have_certificate(user.chain_id(), BlockHeight::from(3), 3)
+        .await;
+
+    // Now validator 1 misses the epoch-1 blocks: the user chain migrates to epoch 2
+    // and epoch 1 gets revoked while validator 1 is offline.
+    admin.stage_new_committee(committee).await?;
+    user.synchronize_from_validators().await?;
+    user.process_inbox().await?;
+    assert_eq!(user.chain_info().await?.epoch, Epoch::from(2));
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    builder.set_fault_type([1], FaultType::Honest);
+    admin.revoke_epochs(Epoch::from(1)).await?;
+    admin.sync_validator(builder.node(1)).await?;
+
+    // Validator 1 is at height 3; the blocks at heights 3 and 4 are signed by the
+    // now-revoked epoch 1. `sync_validator` recovers by pushing the epoch-2 block
+    // at height 5 first.
+    user.sync_validator(builder.node(1)).await?;
+    let response = builder
+        .node(1)
+        .handle_chain_info_query(crate::data_types::ChainInfoQuery::new(user.chain_id()))
+        .await?;
+    assert_eq!(response.info.next_block_height, BlockHeight::from(6));
+
     Ok(())
 }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -19,7 +19,9 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
-    data_types::{IncomingBundle, MessageAction, MessageBundle, PostedMessage, Transaction},
+    data_types::{
+        ChainAndHeight, IncomingBundle, MessageAction, MessageBundle, PostedMessage, Transaction,
+    },
     manager::LockingBlock,
     types::Timeout,
     ChainError, ChainExecutionContext,
@@ -1819,9 +1821,10 @@ where
 
     // `process_notification_from` does not advance the client's
     // `received_certificate_trackers`, so a subsequent `synchronize_from_validators`
-    // still sees (sender, 1) and (sender, 3) in the received log. But the sender's
-    // outbox has those heights scheduled locally now, so `find_received_certificates`
-    // filters them out and routes the sender through
+    // still sees (sender, 3) in epoch 1's received log (epoch 0's log is not even
+    // queried: the epoch is revoked). But the sender's outbox has that height
+    // scheduled locally now, so `find_received_certificates` filters it out and
+    // routes the sender through
     // `retry_pending_cross_chain_requests_from_sender_chains`. Before the fix this
     // initialized the sender's chain worker inside the receiver's node and, on
     // failing to find the `ChainDescription` blob in storage, triggered a download.
@@ -1830,6 +1833,37 @@ where
         !storage.contains_blob(sender_chain_desc_blob_id).await?,
         "retry_pending_cross_chain_requests must not download the ChainDescription",
     );
+
+    // Serving a live epoch's received log prunes the revoked epochs' logs: after
+    // the query below, validator 0 holds only epoch 1's log for the receiver.
+    let response = builder
+        .node(0)
+        .handle_chain_info_query(
+            crate::data_types::ChainInfoQuery::new(receiver_id)
+                .with_received_log(Epoch::from(1), 0),
+        )
+        .await?;
+    assert_eq!(
+        response.info.requested_received_log,
+        vec![ChainAndHeight {
+            chain_id: sender_id,
+            height: cert3.block().header.height,
+        }],
+    );
+    {
+        let validator_0_key = builder.node(0).name();
+        let validator_0_storage = builder
+            .validator_storages
+            .get(&validator_0_key)
+            .expect("validator 0 storage")
+            .clone();
+        let chain_view = validator_0_storage.load_chain(receiver_id).await?;
+        assert_eq!(
+            chain_view.received_log.indices().await?,
+            vec![Epoch::from(1)],
+            "the revoked epoch's received log should have been pruned",
+        );
+    }
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1657,6 +1657,12 @@ where
 /// the `ChainDescription` itself should never be downloaded either — not during
 /// the initial message processing, and not during a later re-sync that routes the
 /// sender through `retry_pending_cross_chain_requests_from_sender_chains`.
+///
+/// The first message block's epoch is revoked before the receiver processes
+/// anything, so the walk must also re-certify it: the epoch-1 message block is
+/// preprocessed first and vouches for the epoch-0 one via
+/// `previous_message_blocks`. Sparseness proves the recovery did not fall back to
+/// downloading contiguous descendants.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]
@@ -1666,7 +1672,7 @@ where
 {
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
     let owner = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();
@@ -1694,8 +1700,13 @@ where
         .await?;
     sender.set_preferred_owner(sender_public_key.into());
     sender.synchronize_from_validators().await?;
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
 
-    // Heights 0 and 2 are burns; heights 1 and 3 send to the receiver.
+    // Height 0 is a burn; height 1 sends to the receiver. Both are epoch-0 blocks.
     let cert0 = sender
         .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
@@ -1708,10 +1719,37 @@ where
         )
         .await
         .unwrap_ok_committed();
-    let cert2 = sender
-        .burn(AccountOwner::CHAIN, Amount::ONE)
+
+    // Create epoch 1. The receiver learns about it from an admin-chain `NewBlock`
+    // notification — not via `synchronize_from_validators`, which would consume
+    // the received log and deliver the height-1 transfer prematurely — and
+    // migrates to epoch 1 so it can keep proposing after epoch 0 is revoked.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
         .await
         .unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: create_cert.block().header.height,
+                    hash: create_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    // Height 2 migrates the sender to epoch 1 without sending anything; height 3
+    // sends to the receiver again, committing to the height-1 block via
+    // `previous_message_blocks`.
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let cert2 = migration_certs.last().expect("migration block").clone();
+    assert_eq!(sender.chain_info().await?.epoch, Epoch::from(1));
     let cert3 = sender
         .transfer_to_account(
             AccountOwner::CHAIN,
@@ -1720,10 +1758,37 @@ where
         )
         .await
         .unwrap_ok_committed();
+    assert_eq!(
+        cert3.block().body.previous_message_blocks,
+        BTreeMap::from([(receiver_id, (cert1.hash(), cert1.block().header.height))]),
+    );
+
+    // Revoke epoch 0, and let the receiver learn about the revocation the same way.
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: revoke_cert.block().header.height,
+                    hash: revoke_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
 
     // Process the notification about the most recent incoming message. This walks
     // back along `previous_message_blocks` and preprocesses only the sender blocks
-    // that sent to us (heights 1 and 3).
+    // that sent to us (heights 1 and 3) — height 3 first, so that it vouches for
+    // the revoked-epoch block at height 1.
     let notification = Notification {
         chain_id: receiver_id,
         reason: Reason::NewIncomingBundle {
@@ -1731,19 +1796,17 @@ where
             height: cert3.block().header.height,
         },
     };
-    let validator = builder
-        .initial_committee
-        .validator_addresses()
-        .next()
-        .unwrap();
     receiver
         .process_notification_from(notification, validator)
         .await;
     receiver.process_inbox().await?;
 
     // Only the blocks that sent something to the receiver should be in local
-    // storage. The burn blocks in between — and the sender's `ChainDescription`
-    // blob itself — should never have been downloaded.
+    // storage. The burn and migration blocks in between — and the sender's
+    // `ChainDescription` blob itself — should never have been downloaded. In
+    // particular, the revoked-epoch block at height 1 was accepted through the
+    // `previous_message_blocks` vouching, not by walking contiguous descendants
+    // (which would have downloaded the migration block at height 2).
     let storage = receiver.storage_client();
     assert!(!storage.contains_certificate(cert0.hash()).await?);
     assert!(storage.contains_certificate(cert1.hash()).await?);
@@ -4614,16 +4677,20 @@ where
         "validator 0 must not have received the pre-checkpoint non-sender block",
     );
 
-    // The trust-mark flow consumed every entry: the validator's first attempt at
-    // the checkpoint errored with `BlocksNotFound`, the client uploaded the missing
-    // sender block (entering the trust-mark accept path on the worker, which
-    // removed the entry), and the second attempt restored the chain cleanly.
+    // The trust-mark flow consumed the checkpoint's `outbox_block_hashes` entry:
+    // the validator's first attempt at the checkpoint errored with
+    // `BlocksNotFound`, the client uploaded the missing sender block (entering the
+    // trust-mark accept path on the worker, which removed the entry), and the
+    // second attempt restored the chain cleanly. What remains is the mark for the
+    // checkpoint block's own parent (`burn_1`, which was never pushed): accepting
+    // the checkpoint vouched for it via `previous_block_hash`.
     {
         let chain_view = validator_0_storage.load_chain(chain_id).await?;
-        let trusted = chain_view.pre_checkpoint_block_trust.indices().await?;
-        assert!(
-            trusted.is_empty(),
-            "validator 0's trust set should be empty after the flow, was {trusted:?}",
+        let trusted = chain_view.vouched_blocks.indices().await?;
+        assert_eq!(
+            trusted,
+            vec![burn_1.hash()],
+            "validator 0's trust set should hold exactly the checkpoint's parent",
         );
         // The checkpoint restored the producer's epoch-1 execution state, which
         // includes the epoch migration. Validator 0's chain is now at epoch 1 —

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1845,10 +1845,13 @@ where
         .await?;
     assert_eq!(
         response.info.requested_received_log,
-        vec![ChainAndHeight {
-            chain_id: sender_id,
-            height: cert3.block().header.height,
-        }],
+        BTreeMap::from([(
+            Epoch::from(1),
+            vec![ChainAndHeight {
+                chain_id: sender_id,
+                height: cert3.block().header.height,
+            }],
+        )]),
     );
     {
         let validator_0_key = builder.node(0).name();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1840,7 +1840,7 @@ where
         .node(0)
         .handle_chain_info_query(
             crate::data_types::ChainInfoQuery::new(receiver_id)
-                .with_received_log(Epoch::from(1), 0),
+                .with_received_logs([(Epoch::from(1), 0)]),
         )
         .await?;
     assert_eq!(

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -34,7 +34,9 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
-use linera_chain::{data_types::MessageAction, ChainError, ChainExecutionContext};
+use linera_chain::{
+    data_types::MessageAction, types::ConfirmedBlockCertificate, ChainError, ChainExecutionContext,
+};
 use linera_execution::{
     wasm_test, ExecutionError, Message, MessageKind, Operation, QueryOutcome,
     ResourceControlPolicy, SystemMessage, SystemOperation, WasmRuntime,
@@ -57,7 +59,7 @@ use crate::{
     },
     local_node::LocalNodeError,
     test_utils::{ClientOutcomeResultExt as _, FaultType},
-    worker::WorkerError,
+    worker::{Notification, Reason, WorkerError},
     Environment,
 };
 
@@ -2128,6 +2130,13 @@ async fn test_memory_read_event_downloads_publisher_chain(
 /// Tests that when a block execution needs events from a publisher chain that isn't
 /// locally available, the client automatically downloads the publisher chain certificates
 /// using the event block height index and retries.
+///
+/// The publisher chain is stored sparsely: only the blocks that emitted events are
+/// downloaded, not the ones in between. The first post's epoch is revoked before the
+/// receiver reads it, so the walk must also re-certify it: the epoch-1 post block is
+/// preprocessed first and vouches for the epoch-0 one via `previous_event_blocks`.
+/// Sparseness proves the recovery did not fall back to downloading contiguous
+/// descendants.
 async fn run_test_read_event_downloads_publisher_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
@@ -2137,8 +2146,14 @@ where
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
 
-    let sender = builder.add_root_chain(0, Amount::ONE).await?;
-    let receiver = builder.add_root_chain(1, Amount::ONE).await?;
+    let admin = builder.add_root_chain(0, Amount::ONE).await?;
+    let sender = builder.add_root_chain(1, Amount::ONE).await?;
+    let receiver = builder.add_root_chain(2, Amount::ONE).await?;
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
 
     // Deploy the social app on the receiver chain.
     let module_id = receiver.publish_wasm_example("social").await?;
@@ -2162,20 +2177,79 @@ where
         text: "Hello from sender!".to_string(),
         image_url: None,
     };
-    sender
+    let post_cert0 = sender
         .execute_operation(Operation::user(application_id, &post)?)
         .await
         .unwrap_ok_committed();
 
-    // Do NOT call receiver.synchronize_from_validators().
-    // Instead, directly execute an UpdateStreams operation that references the
-    // sender's event. The receiver doesn't have the sender's chain locally, so
-    // this will fail with EventsNotFound. The retry logic should use the event
-    // block height index to download only the needed certificates and succeed.
+    // Create epoch 1 and migrate the sender to it. The migration block emits no event,
+    // so the sender's second post commits to the first post's block directly, via
+    // `previous_event_blocks`.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
+        .await
+        .unwrap_ok_committed();
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let migration_cert = migration_certs.last().expect("migration block").clone();
+    assert_eq!(sender.chain_info().await?.epoch, Epoch::from(1));
+
+    let post = social::Operation::Post {
+        text: "Hello again!".to_string(),
+        image_url: None,
+    };
+    let post_cert1 = sender
+        .execute_operation(Operation::user(application_id, &post)?)
+        .await
+        .unwrap_ok_committed();
     let stream_id = StreamId {
         application_id: application_id.forget_abi().into(),
         stream_name: b"posts".into(),
     };
+    assert_eq!(
+        post_cert1.block().body.previous_event_blocks,
+        BTreeMap::from([(
+            stream_id.clone(),
+            (post_cert0.hash(), post_cert0.block().header.height)
+        )]),
+    );
+
+    // Migrate the receiver to epoch 1 as well, and revoke epoch 0. The receiver learns
+    // about both from admin-chain notifications, not from
+    // `synchronize_from_validators`: that would download the sender's event blocks
+    // eagerly, while epoch 0 is still live.
+    let notify_receiver = async |cert: &ConfirmedBlockCertificate| {
+        receiver
+            .process_notification_from(
+                Notification {
+                    chain_id: admin.chain_id(),
+                    reason: Reason::NewBlock {
+                        height: cert.block().header.height,
+                        hash: cert.hash(),
+                    },
+                },
+                validator,
+            )
+            .await
+    };
+    notify_receiver(&create_cert).await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    notify_receiver(&revoke_cert).await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
+
+    // Execute an UpdateStreams operation that references both of the sender's events.
+    // The receiver doesn't have the sender's chain locally, so this will fail with
+    // EventsNotFound. The retry logic should use the event block height index to
+    // download only the needed certificates and succeed.
     receiver
         .execute_operations(
             vec![SystemOperation::UpdateStream {
@@ -2183,7 +2257,7 @@ where
                 chain_id: sender.chain_id(),
                 stream_id,
                 first_index: 0,
-                next_index: 1,
+                next_index: 2,
             }
             .into()],
             vec![],
@@ -2191,7 +2265,7 @@ where
         .await
         .unwrap_ok_committed();
 
-    // Verify that the event was processed: query the received posts.
+    // Verify that the events were processed: query the received posts.
     let query = Request::new("{ receivedPosts { keys { author, index } } }");
     let outcome = receiver
         .query_user_application(application_id, &query)
@@ -2201,6 +2275,7 @@ where
             async_graphql::Value::from_json(json!({
                 "receivedPosts": {
                     "keys": [
+                        { "author": sender.chain_id(), "index": 1 },
                         { "author": sender.chain_id(), "index": 0 }
                     ]
                 }
@@ -2210,6 +2285,15 @@ where
         operations: vec![],
     };
     assert_eq!(outcome, expected);
+
+    // Only the sender's event-bearing blocks should be in the receiver's storage. In
+    // particular, the revoked-epoch post at height 0 was accepted through the
+    // `previous_event_blocks` vouching, not by walking contiguous descendants — which
+    // would have downloaded the migration block in between.
+    let storage = receiver.storage_client();
+    assert!(storage.contains_certificate(post_cert0.hash()).await?);
+    assert!(storage.contains_certificate(post_cert1.hash()).await?);
+    assert!(!storage.contains_certificate(migration_cert.hash()).await?);
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3396,6 +3396,156 @@ where
     Ok(())
 }
 
+/// Tests that a revoked-epoch sender block is accepted when a later accepted block
+/// commits to it via `previous_message_blocks` — without the worker ever seeing the
+/// non-sender block in between. This is what lets a receiver's client re-certify a
+/// sender's old messages by downloading only the message-bearing blocks.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_revoked_epoch_block_vouched_via_previous_message_blocks<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut env =
+        TestEnvironment::new_with_amount(&mut storage_builder, false, false, Amount::ZERO).await?;
+    let mut signer = InMemorySigner::new(None);
+    let owner1 = signer.generate_new().into();
+    let chain_1_desc = env.add_root_chain(1, owner1, Amount::from_tokens(3)).await;
+    let committee = env.committee().clone();
+    let admin_chain_id = env.admin_chain_id();
+    let user_id = chain_1_desc.id();
+
+    // Height 0 (epoch 0): a transfer to the admin chain — the sender block that
+    // will later need re-certification.
+    let proposal_msg0 = make_first_block(user_id)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let cert_msg0 = env.execute_proposal(proposal_msg0, vec![]).await?;
+
+    // Have the admin chain create epoch 1.
+    let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
+    let blob_hash = committee_blob.id().hash;
+    env.write_blobs(std::slice::from_ref(&committee_blob))
+        .await?;
+    let proposal_create = make_first_block(admin_chain_id).with_operation(SystemOperation::Admin(
+        AdminOperation::CreateCommittee {
+            epoch: Epoch::from(1),
+            blob_hash,
+        },
+    ));
+    let cert_create = env.execute_proposal(proposal_create, vec![]).await?;
+
+    // Height 1 (epoch 0): the user chain migrates to epoch 1 without sending any
+    // message. Height 2 (epoch 1): another transfer to the admin chain, which
+    // commits to the height-0 block via `previous_message_blocks`.
+    let proposal_mid = make_child_block(&cert_msg0.clone().into_value())
+        .with_operation(SystemOperation::ProcessNewEpoch(Epoch::from(1)))
+        .with_authenticated_owner(Some(owner1));
+    let cert_mid = env.execute_proposal(proposal_mid, vec![]).await?;
+    let proposal_msg1 = make_child_block(&cert_mid.clone().into_value())
+        .with_epoch(1)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let cert_msg1 = env.execute_proposal(proposal_msg1, vec![]).await?;
+    assert_eq!(
+        cert_msg1.block().body.previous_message_blocks,
+        BTreeMap::from([(admin_chain_id, (cert_msg0.hash(), BlockHeight::ZERO))]),
+    );
+
+    // Retire epoch 0.
+    let proposal_revoke = make_child_block(&cert_create.clone().into_value())
+        .with_epoch(1)
+        .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
+            epoch: Epoch::ZERO,
+        }));
+    let cert_revoke = env.execute_proposal(proposal_revoke, vec![]).await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_create.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_revoke.clone(), &())
+        .await?;
+
+    // The height-0 block is rejected: its epoch is revoked and nothing vouches for
+    // it yet.
+    let error = env
+        .worker()
+        .fully_handle_certificate_with_notifications(cert_msg0.clone(), &())
+        .await
+        .unwrap_err();
+    assert_matches!(
+        error,
+        WorkerError::EpochRevoked {
+            epoch: Epoch::ZERO,
+            ..
+        }
+    );
+
+    // Preprocessing the epoch-1 sender block at height 2 vouches for the height-0
+    // block via `previous_message_blocks` (and for its parent at height 1 via
+    // `previous_block_hash`). The height-0 block is then accepted and executes —
+    // the worker never saw the non-sender block at height 1.
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg1.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg0.clone(), &())
+        .await?;
+
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(1),
+            user_chain.tip_state.get().next_block_height
+        );
+        // The height-0 message has not reached the admin chain yet:
+        // `select_message_bundles` refuses a revoked-epoch bundle that arrives on
+        // its own. It is only accepted once a later bundle from a trusted epoch is
+        // in the same batch.
+        let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
+        assert!(admin_chain.inboxes.indices().await?.is_empty());
+    }
+
+    // The migration block at height 1 is also vouched for (as the height-2 block's
+    // parent), so it is accepted despite its revoked epoch. With the chain tip then
+    // at height 2, re-sending the height-2 block executes it, which schedules its
+    // message: the outbox batch now pairs the revoked-epoch bundle with the epoch-1
+    // bundle behind it, and the admin chain accepts both.
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_mid.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg1.clone(), &())
+        .await?;
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(3),
+            user_chain.tip_state.get().next_block_height
+        );
+        // All trust marks have been consumed.
+        assert!(user_chain.vouched_blocks.indices().await?.is_empty());
+        let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
+        let inbox = admin_chain
+            .inboxes
+            .try_load_entry(&user_id)
+            .await?
+            .expect("admin chain should have an inbox for the user chain");
+        let first_bundle = inbox.added_bundles.front().await?;
+        assert_eq!(
+            first_bundle.map(|bundle| bundle.height),
+            Some(BlockHeight::ZERO),
+            "the re-certified height-0 message should have been delivered",
+        );
+    }
+
+    Ok(())
+}
+
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let mut storage_builder = MemoryStorageBuilder::default();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2507,7 +2507,7 @@ where
             .expect("no received log for epoch 0");
         assert_eq!(received_log.count(), 1);
     }
-    let query = ChainInfoQuery::new(chain_2).with_received_log(Epoch::ZERO, 0);
+    let query = ChainInfoQuery::new(chain_2).with_received_logs([(Epoch::ZERO, 0)]);
     let response = env
         .executing_worker()
         .handle_chain_info_query(query)

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -52,7 +52,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
         PostedMessage, ProposedBlock, Transaction, Vote,
     },
-    justification::{JustificationChain, JustificationLink},
+    justification::{EquivocationProof, JustificationChain, JustificationLink},
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
@@ -3554,6 +3554,161 @@ where
             "the re-certified height-0 message should have been delivered",
         );
     }
+
+    Ok(())
+}
+
+/// Tests that a block committing to a different hash than the one already accepted
+/// at that height is rejected: two certified blocks at the same height prove that
+/// the height's committee equivocated, and neither the conflicting block nor the
+/// block vouching for it must be accepted.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_conflicting_certified_blocks_are_rejected<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let owner_pubkey = signer.generate_new();
+    let owner = AccountOwner::from(owner_pubkey);
+    let balance = Amount::from_tokens(5);
+    let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
+    let chain_1_desc = env.add_root_chain(1, owner, balance).await;
+    let chain_2_desc = env.add_root_chain(2, owner, Amount::ZERO).await;
+    let user_id = chain_1_desc.id();
+    let target = Account::chain(chain_2_desc.id());
+
+    // Two conflicting certified blocks at height 0, and a child of the second one.
+    let cert_a = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::ONE,
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![],
+        )
+        .await;
+    let cert_b = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::from_tokens(2),
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![],
+        )
+        .await;
+    assert_ne!(cert_a.hash(), cert_b.hash());
+    let cert_child = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::ONE,
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![&cert_b],
+        )
+        .await;
+
+    // Preprocess the first block at height 0, then a child of the *conflicting*
+    // block: the child's `previous_block_hash` commitment exposes the equivocation
+    // and the child is rejected instead of vouching for the conflicting block.
+    env.worker()
+        .handle_confirmed_certificate(cert_a.clone(), ProcessConfirmedBlockMode::Preprocess, None)
+        .await?;
+    let error = env
+        .worker()
+        .handle_confirmed_certificate(
+            cert_child.clone(),
+            ProcessConfirmedBlockMode::Preprocess,
+            None,
+        )
+        .await
+        .unwrap_err();
+    let WorkerError::Equivocation(evidence) = &error else {
+        panic!("expected an equivocation error, got {error}");
+    };
+    assert_eq!(evidence.conflict.existing_block, cert_a.hash());
+    assert_eq!(evidence.conflict.conflicting_block, cert_b.hash());
+    assert_eq!(evidence.conflict.witness_block, cert_child.hash());
+    assert_eq!(evidence.conflict.height, BlockHeight::ZERO);
+    // The evidence carries the two signed certificates themselves.
+    assert_eq!(evidence.existing.hash(), cert_a.hash());
+    assert_eq!(evidence.witness.hash(), cert_child.hash());
+    assert!(!evidence.existing.signatures().is_empty());
+    assert!(!evidence.witness.signatures().is_empty());
+    // The witness only commits to the conflicting block via its parent link; the
+    // certificates are at different heights, so no individual signature pair is
+    // contradictory. Per-validator proofs require the conflicting block's own
+    // certificate.
+    assert!(evidence.proofs.is_empty());
+
+    // Nothing was vouched for, and the child was not accepted. (The view holds a
+    // read lock on the chain worker, so drop it before the next request.)
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert!(user_chain.vouched_blocks.indices().await?.is_empty());
+        assert_eq!(
+            user_chain.block_hashes.get(&BlockHeight::from(1)).await?,
+            None
+        );
+    }
+
+    // Pushing the conflicting height-0 block itself is rejected the same way —
+    // and this time the two certificates confirm different blocks at the same
+    // height, so per-validator equivocation proofs can be extracted.
+    let error = env
+        .worker()
+        .handle_confirmed_certificate(cert_b.clone(), ProcessConfirmedBlockMode::Preprocess, None)
+        .await
+        .unwrap_err();
+    let WorkerError::Equivocation(evidence) = &error else {
+        panic!("expected an equivocation error, got {error}");
+    };
+    assert_eq!(evidence.conflict.existing_block, cert_a.hash());
+    assert_eq!(evidence.conflict.conflicting_block, cert_b.hash());
+    assert_eq!(evidence.conflict.witness_block, cert_b.hash());
+    assert_eq!(evidence.witness.hash(), cert_b.hash());
+    // The conflicting certificate is carried only in the evidence — it was never
+    // written to storage.
+    assert!(
+        !env.worker()
+            .storage
+            .contains_certificate(cert_b.hash())
+            .await?,
+        "the rejected conflicting certificate must not be persisted",
+    );
+    assert_eq!(
+        evidence.proofs.len(),
+        1,
+        "expected one proof per double-signing validator"
+    );
+    let proof = &evidence.proofs[0];
+    assert_matches!(proof, EquivocationProof::DoubleVote { .. });
+    assert_eq!(proof.validator(), env.executing_worker().public_key());
+    proof
+        .check(env.committee())
+        .expect("the extracted proof should be self-contained and valid");
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -52,7 +52,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
         PostedMessage, ProposedBlock, Transaction, Vote,
     },
-    justification::{EquivocationProof, JustificationChain, JustificationLink},
+    justification::{JustificationChain, JustificationLink},
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
@@ -3645,23 +3645,19 @@ where
         )
         .await
         .unwrap_err();
-    let WorkerError::Equivocation(evidence) = &error else {
-        panic!("expected an equivocation error, got {error}");
+    let conflict = match &error {
+        WorkerError::ChainError(chain_error) => match &**chain_error {
+            ChainError::ConflictingCertifiedBlocks(conflict) => conflict,
+            other => panic!("expected a conflicting-blocks error, got {other}"),
+        },
+        other => panic!("expected a conflicting-blocks error, got {other}"),
     };
-    assert_eq!(evidence.conflict.existing_block, cert_a.hash());
-    assert_eq!(evidence.conflict.conflicting_block, cert_b.hash());
-    assert_eq!(evidence.conflict.witness_block, cert_child.hash());
-    assert_eq!(evidence.conflict.height, BlockHeight::ZERO);
-    // The evidence carries the two signed certificates themselves.
-    assert_eq!(evidence.existing.hash(), cert_a.hash());
-    assert_eq!(evidence.witness.hash(), cert_child.hash());
-    assert!(!evidence.existing.signatures().is_empty());
-    assert!(!evidence.witness.signatures().is_empty());
-    // The witness only commits to the conflicting block via its parent link; the
-    // certificates are at different heights, so no individual signature pair is
-    // contradictory. Per-validator proofs require the conflicting block's own
-    // certificate.
-    assert!(evidence.proofs.is_empty());
+    // The child commits to the conflicting height-0 block via its parent link, so
+    // it is the witness; the existing block is the one accepted at that height.
+    assert_eq!(conflict.existing_block, cert_a.hash());
+    assert_eq!(conflict.conflicting_block, cert_b.hash());
+    assert_eq!(conflict.witness_block, cert_child.hash());
+    assert_eq!(conflict.height, BlockHeight::ZERO);
 
     // Nothing was vouched for, and the child was not accepted. (The view holds a
     // read lock on the chain worker, so drop it before the next request.)
@@ -3674,23 +3670,23 @@ where
         );
     }
 
-    // Pushing the conflicting height-0 block itself is rejected the same way —
-    // and this time the two certificates confirm different blocks at the same
-    // height, so per-validator equivocation proofs can be extracted.
+    // Pushing the conflicting height-0 block itself is rejected the same way, with
+    // the block as its own witness — and rejected before it is written anywhere.
     let error = env
         .worker()
         .handle_confirmed_certificate(cert_b.clone(), ProcessConfirmedBlockMode::Preprocess, None)
         .await
         .unwrap_err();
-    let WorkerError::Equivocation(evidence) = &error else {
-        panic!("expected an equivocation error, got {error}");
+    let conflict = match &error {
+        WorkerError::ChainError(chain_error) => match &**chain_error {
+            ChainError::ConflictingCertifiedBlocks(conflict) => conflict,
+            other => panic!("expected a conflicting-blocks error, got {other}"),
+        },
+        other => panic!("expected a conflicting-blocks error, got {other}"),
     };
-    assert_eq!(evidence.conflict.existing_block, cert_a.hash());
-    assert_eq!(evidence.conflict.conflicting_block, cert_b.hash());
-    assert_eq!(evidence.conflict.witness_block, cert_b.hash());
-    assert_eq!(evidence.witness.hash(), cert_b.hash());
-    // The conflicting certificate is carried only in the evidence — it was never
-    // written to storage.
+    assert_eq!(conflict.existing_block, cert_a.hash());
+    assert_eq!(conflict.conflicting_block, cert_b.hash());
+    assert_eq!(conflict.witness_block, cert_b.hash());
     assert!(
         !env.worker()
             .storage
@@ -3698,17 +3694,6 @@ where
             .await?,
         "the rejected conflicting certificate must not be persisted",
     );
-    assert_eq!(
-        evidence.proofs.len(),
-        1,
-        "expected one proof per double-signing validator"
-    );
-    let proof = &evidence.proofs[0];
-    assert_matches!(proof, EquivocationProof::DoubleVote { .. });
-    assert_eq!(proof.validator(), env.executing_worker().public_key());
-    proof
-        .check(env.committee())
-        .expect("the extracted proof should be self-contained and valid");
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2252,7 +2252,12 @@ where
     );
     assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(0));
     assert_eq!(None, chain.tip_state.get().block_hash);
-    assert_eq!(chain.received_log.count(), 1);
+    let received_log = chain
+        .received_log
+        .try_load_entry(&Epoch::ZERO)
+        .await?
+        .expect("no received log for epoch 0");
+    assert_eq!(received_log.count(), 1);
     Ok(())
 }
 
@@ -2495,9 +2500,14 @@ where
             recipient_chain.tip_state.get().block_hash,
             Some(certificate.hash())
         );
-        assert_eq!(recipient_chain.received_log.count(), 1);
+        let received_log = recipient_chain
+            .received_log
+            .try_load_entry(&Epoch::ZERO)
+            .await?
+            .expect("no received log for epoch 0");
+        assert_eq!(received_log.count(), 1);
     }
-    let query = ChainInfoQuery::new(chain_2).with_received_log_excluding_first_n(0);
+    let query = ChainInfoQuery::new(chain_2).with_received_log(Epoch::ZERO, 0);
     let response = env
         .executing_worker()
         .handle_chain_info_query(query)
@@ -3653,15 +3663,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         .chain(bundles3.iter().cloned())
         .collect::<Vec<_>>();
 
-    fn without_epochs<'a>(
-        bundles: impl IntoIterator<Item = &'a (Epoch, MessageBundle)>,
-    ) -> Vec<MessageBundle> {
-        bundles
-            .into_iter()
-            .map(|(_, bundle)| bundle.clone())
-            .collect()
-    }
-
     let worker = env.worker();
     // Bundles from a revoked epoch are rejected.
     assert_eq!(
@@ -3702,14 +3703,18 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         worker
             .select_message_bundles(id1, &id0, BlockHeight::ZERO, None, bundles0123.clone())
             .await?,
-        without_epochs(&bundles012)
+        bundles012
     );
     // Skipping bundle 0 still works with re-certification across epochs.
     assert_eq!(
         worker
             .select_message_bundles(id1, &id0, BlockHeight::from(1), None, bundles012.clone())
             .await?,
-        without_epochs(bundles1.iter().chain(&bundles2))
+        bundles1
+            .iter()
+            .cloned()
+            .chain(bundles2.iter().cloned())
+            .collect::<Vec<_>>()
     );
     // Anticipation: bundles up to `last_anticipated_block_height` are accepted even
     // from a revoked epoch.
@@ -3723,7 +3728,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
                 bundles01.clone()
             )
             .await?,
-        without_epochs(&bundles1)
+        bundles1
     );
     assert_eq!(
         worker
@@ -3735,7 +3740,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
                 bundles01.clone()
             )
             .await?,
-        without_epochs(&bundles01)
+        bundles01
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3097,81 +3097,121 @@ where
         &[OperationResult::default()]
     );
 
-    // Have the admin chain create a new epoch and retire the old one immediately.
+    // Have the admin chain create a new epoch.
     let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
     let blob_hash = committee_blob.id().hash;
     env.write_blobs(std::slice::from_ref(&committee_blob))
         .await?;
 
-    let proposal1 = make_first_block(admin_chain_id)
-        .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
+    let proposal1 = make_first_block(admin_chain_id).with_operation(SystemOperation::Admin(
+        AdminOperation::CreateCommittee {
             epoch: Epoch::from(1),
             blob_hash,
-        }))
-        .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
-            epoch: Epoch::ZERO,
-        }));
+        },
+    ));
 
     let certificate1 = env.execute_proposal(proposal1.clone(), vec![]).await?;
 
     assert!(certificate1.value().matches_proposed_block(&proposal1));
     assert_outcome_matches!(
         certificate1.block(),
-        &[vec![], vec![]],
+        &[vec![]],
         &BTreeMap::new(),
         &BTreeMap::new(),
-        &[vec![OracleResponse::Blob(committee_blob.id())], vec![]],
-        &[
-            vec![Event {
-                stream_id: StreamId::system(EPOCH_STREAM_NAME),
-                index: 1,
-                value: bcs::to_bytes(&EpochEventData {
-                    blob_hash: committee_blob.id().hash,
-                    timestamp: Timestamp::from(0),
-                })
-                .unwrap(),
-            }],
-            vec![Event {
-                stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
-                index: 0,
-                value: Vec::new(),
-            }],
-        ],
-        &[vec![], vec![]],
-        &[OperationResult::default(), OperationResult::default()],
+        &[vec![OracleResponse::Blob(committee_blob.id())]],
+        &[vec![Event {
+            stream_id: StreamId::system(EPOCH_STREAM_NAME),
+            index: 1,
+            value: bcs::to_bytes(&EpochEventData {
+                blob_hash: committee_blob.id().hash,
+                timestamp: Timestamp::from(0),
+            })
+            .unwrap(),
+        }]],
+        &[vec![]],
+        &[OperationResult::default()],
+    );
+
+    // Extend the user chain with two blocks while epoch 0 is still trusted: the
+    // block at height 1 advances the chain to epoch 1, but its header still
+    // carries epoch 0 — only the block at height 2 is signed by epoch 1.
+    let proposal_height1 = make_child_block(&certificate0.clone().into_value())
+        .with_operation(SystemOperation::ProcessNewEpoch(Epoch::from(1)))
+        .with_authenticated_owner(Some(owner1));
+    let certificate_height1 = env.execute_proposal(proposal_height1, vec![]).await?;
+    let proposal_height2 = make_child_block(&certificate_height1.clone().into_value())
+        .with_epoch(1)
+        .with_simple_transfer(user_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let certificate_height2 = env.execute_proposal(proposal_height2, vec![]).await?;
+
+    // Now retire epoch 0.
+    let proposal_revoke = make_child_block(&certificate1.clone().into_value())
+        .with_epoch(1)
+        .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
+            epoch: Epoch::ZERO,
+        }));
+    let certificate_revoke = env
+        .execute_proposal(proposal_revoke.clone(), vec![])
+        .await?;
+
+    assert!(certificate_revoke
+        .value()
+        .matches_proposed_block(&proposal_revoke));
+    assert_outcome_matches!(
+        certificate_revoke.block(),
+        &[vec![]],
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+        &[vec![]],
+        &[vec![Event {
+            stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
+            index: 0,
+            value: Vec::new(),
+        }]],
+        &[vec![]],
+        &[OperationResult::default()],
     );
 
     env.worker()
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
-
-    // Try to execute the transfer from the user chain to the admin chain.
     env.worker()
-        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
+        .fully_handle_certificate_with_notifications(certificate_revoke.clone(), &())
         .await?;
 
+    // Try to execute the transfer from the user chain to the admin chain. The
+    // certificate is rejected: epoch 0 is revoked on the admin chain, and no
+    // trusted block vouches for the user chain's block yet.
+    let error = env
+        .worker()
+        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
+        .await
+        .unwrap_err();
+    assert_matches!(
+        error,
+        WorkerError::EpochRevoked {
+            epoch: Epoch::ZERO,
+            ..
+        }
+    );
+
     {
-        // The transfer was started..
+        // The transfer was not executed ..
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active().await?);
         assert_eq!(
-            BlockHeight::from(1),
+            BlockHeight::ZERO,
             user_chain.tip_state.get().next_block_height
         );
-        assert_eq!(
-            *user_chain.execution_state.system.balance.get(),
-            Amount::from_tokens(2)
-        );
-        assert_eq!(*user_chain.execution_state.system.epoch.get(), Epoch::ZERO);
 
-        // .. but the message has been refused: epoch 0 is revoked on the admin chain.
+        // .. and no message has reached the admin chain.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
         assert!(admin_chain.is_active().await?);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
 
     // Force the admin chain to receive the money nonetheless by anticipation.
-    let proposal2 = make_child_block(&certificate1.clone().into_value())
+    let proposal2 = make_child_block(&certificate_revoke.clone().into_value())
         .with_epoch(1)
         .with_incoming_bundle(IncomingBundle {
             origin: user_id,
@@ -3218,14 +3258,44 @@ where
             .is_some());
     }
 
-    // Try again to execute the transfer from the user chain to the admin chain.
-    // This time, normal delivery is allowed because the bundle's height is at most
-    // `last_anticipated_block_height` (it was already executed by anticipation).
-    env.worker()
-        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
-        .await?;
+    // The block at height 1 is from the revoked epoch and nothing vouches for it
+    // yet, so it is rejected.
+    let error = env
+        .worker()
+        .fully_handle_certificate_with_notifications(certificate_height1.clone(), &())
+        .await
+        .unwrap_err();
+    assert_matches!(
+        error,
+        WorkerError::EpochRevoked {
+            epoch: Epoch::ZERO,
+            ..
+        }
+    );
+
+    // In decreasing height order, each block is accepted: the block at height 2 by
+    // its trusted epoch, and each revoked-epoch block by the child accepted just
+    // before it, which commits to it via `previous_block_hash`. The blocks at
+    // heights 2 and 1 are preprocessed (they have no parent yet); the block at
+    // height 0 executes, and its message is delivered too: the bundle's height is
+    // at most `last_anticipated_block_height` (it was already executed by
+    // anticipation).
+    for certificate in [
+        certificate_height2.clone(),
+        certificate_height1.clone(),
+        certificate0.clone(),
+    ] {
+        env.worker()
+            .fully_handle_certificate_with_notifications(certificate, &())
+            .await?;
+    }
 
     {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(1),
+            user_chain.tip_state.get().next_block_height
+        );
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
         assert!(admin_chain.is_active().await?);
         assert_no_removed_bundles(&admin_chain).await;
@@ -3278,7 +3348,7 @@ where
         .await?;
     assert_eq!(
         response.info.requested_previous_event_blocks,
-        BTreeMap::from([(stream_id, (BlockHeight(2), certificate3.hash()))]),
+        BTreeMap::from([(stream_id, (BlockHeight(3), certificate3.hash()))]),
     );
 
     Ok(())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2512,13 +2512,15 @@ where
         .executing_worker()
         .handle_chain_info_query(query)
         .await?;
-    assert_eq!(response.info.requested_received_log.len(), 1);
     assert_eq!(
-        response.info.requested_received_log[0],
-        ChainAndHeight {
-            chain_id: chain_1,
-            height: BlockHeight::ZERO
-        }
+        response.info.requested_received_log,
+        BTreeMap::from([(
+            Epoch::ZERO,
+            vec![ChainAndHeight {
+                chain_id: chain_1,
+                height: BlockHeight::ZERO,
+            }],
+        )])
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3099,7 +3099,8 @@ where
 {
     let mut env =
         TestEnvironment::new_with_amount(&mut storage_builder, false, false, Amount::ZERO).await?;
-    let owner1 = AccountSecretKey::generate().public().into();
+    let mut signer = InMemorySigner::new(None);
+    let owner1 = signer.generate_new().into();
     let chain_1_desc = env.add_root_chain(1, owner1, Amount::from_tokens(3)).await;
     let mut committees = BTreeMap::new();
     let committee = env.committee().clone();
@@ -3237,6 +3238,19 @@ where
         assert!(admin_chain.is_active().await?);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
+
+    // The user chain is stuck in the revoked epoch 0, so it is frozen: the committee
+    // must not sign anything new for that epoch, and a block proposal is rejected.
+    let proposal_frozen = make_first_block(user_id)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .into_first_proposal(owner1, &signer)
+        .await
+        .unwrap();
+    let (result, _actions) = env.worker().handle_block_proposal(proposal_frozen).await;
+    assert_matches!(
+        result,
+        Err(WorkerError::VoteInRevokedEpoch { epoch, .. }) if epoch == Epoch::ZERO
+    );
 
     // Force the admin chain to receive the money nonetheless by anticipation.
     let proposal2 = make_child_block(&certificate_revoke.clone().into_value())

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{future, Future, StreamExt};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{ArithmeticError, BlockHeight, Round, TimeDelta},
+    data_types::{ArithmeticError, BlockHeight, Epoch, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, BlobType, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
@@ -295,12 +295,14 @@ where
                 }) if !sent_descendants => {
                     // The validator no longer trusts the epoch that signed the
                     // certificate. Push the block's descendants from local storage
-                    // in decreasing height order: the newest one is in a
-                    // still-trusted epoch, and each accepted child then
-                    // re-certifies its parent via `previous_block_hash`.
+                    // in decreasing height order, up to the first one from a later
+                    // epoch: each accepted child re-certifies its parent via
+                    // `previous_block_hash`. If the validator revoked the later
+                    // epoch as well, pushing that descendant recursively triggers
+                    // the same recovery one epoch further up.
                     sent_descendants = true;
                     let Some(descendants) = self
-                        .read_descendants_up_to_trusted_epoch(chain_id, height)
+                        .read_descendants_up_to_next_epoch(chain_id, height, epoch)
                         .await?
                     else {
                         // We hold no descendant in a trusted epoch, so we cannot
@@ -865,13 +867,14 @@ where
     }
 
     /// Reads this chain's certificates from local storage, from `height + 1` up to
-    /// and including the first one whose epoch is not revoked. Returns `None` if
-    /// storage runs out of blocks before a trusted-epoch one is found — then the
+    /// and including the first one from an epoch later than `epoch`. Returns `None`
+    /// if storage runs out of blocks before a later-epoch one is found — then the
     /// vouching chain cannot be completed.
-    async fn read_descendants_up_to_trusted_epoch(
+    async fn read_descendants_up_to_next_epoch(
         &self,
         chain_id: ChainId,
         height: BlockHeight,
+        epoch: Epoch,
     ) -> Result<Option<Vec<CacheArc<ConfirmedBlockCertificate>>>, chain_client::Error> {
         let storage = self.client.local_node.storage_client();
         let batch_size = self.client.options().certificate_upload_batch_size as u64;
@@ -896,13 +899,9 @@ where
                 return Ok(None);
             }
             for certificate in batch {
-                let epoch = certificate.block().header.epoch;
-                let is_revoked = storage
-                    .is_epoch_revoked(epoch)
-                    .await
-                    .map_err(LocalNodeError::from)?;
+                let is_later_epoch = certificate.block().header.epoch > epoch;
                 certificates.push(certificate);
-                if !is_revoked {
+                if is_later_epoch {
                     return Ok(Some(certificates));
                 }
                 next_height = next_height.try_add_one()?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{future, Future, StreamExt};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{BlockHeight, Round, TimeDelta},
+    data_types::{ArithmeticError, BlockHeight, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, BlobType, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
@@ -256,6 +256,7 @@ where
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
         let mut sent_blocks = false;
+        let mut sent_descendants = false;
         loop {
             match result {
                 Err(NodeError::EventsNotFound(event_ids))
@@ -286,6 +287,34 @@ where
                         .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
                         .await?;
                     sent_blobs = true;
+                }
+                Err(NodeError::EpochRevoked {
+                    chain_id,
+                    epoch,
+                    height,
+                }) if !sent_descendants => {
+                    // The validator no longer trusts the epoch that signed the
+                    // certificate. Push the block's descendants from local storage
+                    // in decreasing height order: the newest one is in a
+                    // still-trusted epoch, and each accepted child then
+                    // re-certifies its parent via `previous_block_hash`.
+                    sent_descendants = true;
+                    let Some(descendants) = self
+                        .read_descendants_up_to_trusted_epoch(chain_id, height)
+                        .await?
+                    else {
+                        // We hold no descendant in a trusted epoch, so we cannot
+                        // re-certify the block for the validator.
+                        return Err(NodeError::EpochRevoked {
+                            chain_id,
+                            epoch,
+                            height,
+                        }
+                        .into());
+                    };
+                    for descendant in descendants.iter().rev() {
+                        Box::pin(self.send_confirmed_certificate(descendant, delivery)).await?;
+                    }
                 }
                 Err(NodeError::BlocksNotFound(hashes)) if !sent_blocks => {
                     // The validator has recorded these hashes as trusted by a
@@ -833,6 +862,52 @@ where
         }
 
         Ok(info)
+    }
+
+    /// Reads this chain's certificates from local storage, from `height + 1` up to
+    /// and including the first one whose epoch is not revoked. Returns `None` if
+    /// storage runs out of blocks before a trusted-epoch one is found — then the
+    /// vouching chain cannot be completed.
+    async fn read_descendants_up_to_trusted_epoch(
+        &self,
+        chain_id: ChainId,
+        height: BlockHeight,
+    ) -> Result<Option<Vec<CacheArc<ConfirmedBlockCertificate>>>, chain_client::Error> {
+        let storage = self.client.local_node.storage_client();
+        let batch_size = self.client.options().certificate_upload_batch_size as u64;
+        let mut certificates = Vec::new();
+        let mut next_height = height.try_add_one()?;
+        loop {
+            let heights = (0..batch_size)
+                .map(|offset| {
+                    u64::from(next_height)
+                        .checked_add(offset)
+                        .map(BlockHeight)
+                        .ok_or(ArithmeticError::Overflow)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let batch = storage
+                .read_certificates_by_heights(chain_id, &heights)
+                .await?
+                .into_iter()
+                .map_while(|maybe_certificate| maybe_certificate)
+                .collect::<Vec<_>>();
+            if batch.is_empty() {
+                return Ok(None);
+            }
+            for certificate in batch {
+                let epoch = certificate.block().header.epoch;
+                let is_revoked = storage
+                    .is_epoch_revoked(epoch)
+                    .await
+                    .map_err(LocalNodeError::from)?;
+                certificates.push(certificate);
+                if !is_revoked {
+                    return Ok(Some(certificates));
+                }
+                next_height = next_height.try_add_one()?;
+            }
+        }
     }
 
     /// Reads certificates for the given heights from storage.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt,
     hash::Hash,
     mem,
@@ -248,6 +248,63 @@ where
         certificate: &CacheArc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
+        // Certificates still to be sent, in reverse sending order: when the validator
+        // rejects the top entry because its epoch is revoked, the descendants that
+        // re-certify it are stacked on top of it, so every rejected block is preceded
+        // by the child vouching for it via `previous_block_hash`.
+        let mut stack = vec![certificate.clone()];
+        let mut expanded = HashSet::new();
+        loop {
+            let certificate = stack.last().expect("stack is never empty").clone();
+            match self
+                .send_single_confirmed_certificate(&certificate, delivery)
+                .await
+            {
+                Err(chain_client::Error::RemoteNodeError(NodeError::EpochRevoked {
+                    chain_id,
+                    epoch,
+                    height,
+                })) if !expanded.contains(&certificate.hash()) => {
+                    // The validator no longer trusts the epoch that signed the
+                    // certificate. Send the block's descendants from local storage
+                    // first, in decreasing height order, up to the first one from a
+                    // later epoch. If the validator revoked the later epoch as well,
+                    // sending its first block fails in the same way and extends the
+                    // stack one epoch further.
+                    expanded.insert(certificate.hash());
+                    let Some(descendants) = self
+                        .read_descendants_up_to_next_epoch(chain_id, height, epoch)
+                        .await?
+                    else {
+                        // We hold no descendant from a later epoch, so we cannot
+                        // re-certify the block for the validator.
+                        return Err(NodeError::EpochRevoked {
+                            chain_id,
+                            epoch,
+                            height,
+                        }
+                        .into());
+                    };
+                    stack.extend(descendants);
+                }
+                Err(err) => return Err(err),
+                Ok(info) => {
+                    stack.pop();
+                    if stack.is_empty() {
+                        return Ok(info);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Sends one confirmed certificate to the validator, catching up the admin chain
+    /// and uploading any blobs or blocks the validator reports as missing.
+    async fn send_single_confirmed_certificate(
+        &mut self,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self
             .remote_node
             .handle_optimized_confirmed_certificate(certificate, delivery)
@@ -256,7 +313,6 @@ where
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
         let mut sent_blocks = false;
-        let mut sent_descendants = false;
         loop {
             match result {
                 Err(NodeError::EventsNotFound(event_ids))
@@ -287,36 +343,6 @@ where
                         .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
                         .await?;
                     sent_blobs = true;
-                }
-                Err(NodeError::EpochRevoked {
-                    chain_id,
-                    epoch,
-                    height,
-                }) if !sent_descendants => {
-                    // The validator no longer trusts the epoch that signed the
-                    // certificate. Push the block's descendants from local storage
-                    // in decreasing height order, up to the first one from a later
-                    // epoch: each accepted child re-certifies its parent via
-                    // `previous_block_hash`. If the validator revoked the later
-                    // epoch as well, pushing that descendant recursively triggers
-                    // the same recovery one epoch further up.
-                    sent_descendants = true;
-                    let Some(descendants) = self
-                        .read_descendants_up_to_next_epoch(chain_id, height, epoch)
-                        .await?
-                    else {
-                        // We hold no descendant in a trusted epoch, so we cannot
-                        // re-certify the block for the validator.
-                        return Err(NodeError::EpochRevoked {
-                            chain_id,
-                            epoch,
-                            height,
-                        }
-                        .into());
-                    };
-                    for descendant in descendants.iter().rev() {
-                        Box::pin(self.send_confirmed_certificate(descendant, delivery)).await?;
-                    }
                 }
                 Err(NodeError::BlocksNotFound(hashes)) if !sent_blocks => {
                     // The validator has recorded these hashes as trusted by a

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1590,7 +1590,7 @@ where
         next_height_to_receive: BlockHeight,
         last_anticipated_block_height: Option<BlockHeight>,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Vec<MessageBundle>, WorkerError> {
+    ) -> Result<Vec<(Epoch, MessageBundle)>, WorkerError> {
         let state = self.get_or_create_chain_worker(recipient).await?;
         let guard = handle::read_lock(&state).await?;
         guard
@@ -1945,7 +1945,7 @@ where
     pub async fn update_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), WorkerError> {
         self.chain_write(chain_id, move |mut guard| async move {
             guard
@@ -2073,7 +2073,7 @@ where
     pub async fn get_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-    ) -> Result<HashMap<ValidatorPublicKey, u64>, WorkerError> {
+    ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, WorkerError> {
         self.chain_read(chain_id, |guard| async move {
             guard.get_received_certificate_trackers().await
         })

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -28,13 +28,12 @@ use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache, DEFAULT_CLEANU
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
     data_types::{BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock},
-    justification::{extract_equivocations, EquivocationProof},
     types::{
         Block, CertificateValue, Certified, ConfirmedBlock, ConfirmedBlockCertificate,
         GenericCertificate, LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock,
         ValidatedBlockCertificate,
     },
-    ChainError, ChainStateView, ConflictingCertifiedBlocks, StreamCounts,
+    ChainError, ChainStateView, StreamCounts,
 };
 use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome, ResourceTracker};
 use linera_storage::{Clock as _, Storage};
@@ -392,11 +391,6 @@ pub enum WorkerError {
         epoch: Epoch,
         height: BlockHeight,
     },
-    /// Two certificates jointly certify conflicting blocks at the same height of
-    /// the same chain: proof that a committee equivocated. Neither block is
-    /// accepted.
-    #[error("{}", .0.conflict)]
-    Equivocation(Box<EquivocationEvidence>),
     /// The epoch has been revoked on the admin chain, so its committee must not
     /// create any new signatures. A chain that failed to migrate to a newer epoch
     /// before the revocation is frozen.
@@ -469,54 +463,6 @@ pub enum WorkerError {
     BatchRolledBack,
 }
 
-/// The evidence for [`WorkerError::Equivocation`]: two certificates that jointly
-/// assert conflicting blocks at the same height of the same chain. `existing`
-/// certifies the block already accepted there; `witness` asserts a different one
-/// — it is either the conflicting block's own certificate, or the certificate of
-/// an accepted block that commits to the conflicting block via
-/// `previous_block_hash` or `previous_message_blocks`. Either way, at least one
-/// of the two signing quorums violated the protocol.
-#[derive(Debug)]
-pub struct EquivocationEvidence {
-    /// The conflict, naming the chain, the height and the block hashes involved.
-    pub conflict: ConflictingCertifiedBlocks,
-    /// The certificate of the block already accepted at the conflicting height.
-    pub existing: ConfirmedBlockCertificate,
-    /// The certificate asserting a conflicting block at that height.
-    pub witness: ConfirmedBlockCertificate,
-    /// Per-validator [`EquivocationProof`]s extracted from the two certificates:
-    /// one for every validator whose own signatures on them contradict each
-    /// other. When the witness is the conflicting block's own certificate and the
-    /// two blocks were confirmed by the same committee, the proven validators
-    /// hold at least a third of the committee's weight. The list is empty when
-    /// the witness only commits to the conflicting block via its parent or
-    /// previous-message-block links (no vote of its quorum is at the conflicting
-    /// height), or when the two certificates' committees do not intersect; the
-    /// certificate pair itself remains the evidence then.
-    pub proofs: Vec<EquivocationProof>,
-}
-
-impl EquivocationEvidence {
-    /// Assembles the evidence for a conflict from the two certificates involved,
-    /// extracting whatever per-validator proofs they support.
-    pub fn new(
-        conflict: ConflictingCertifiedBlocks,
-        existing: ConfirmedBlockCertificate,
-        witness: ConfirmedBlockCertificate,
-    ) -> Self {
-        let proofs = extract_equivocations(
-            &existing.justified_confirmation(),
-            &witness.justified_confirmation(),
-        );
-        Self {
-            conflict,
-            existing,
-            witness,
-            proofs,
-        }
-    }
-}
-
 impl WorkerError {
     /// Returns whether this error is caused by an issue in the local node.
     ///
@@ -531,7 +477,6 @@ impl WorkerError {
             | WorkerError::InvalidEpoch { .. }
             | WorkerError::EpochRevoked { .. }
             | WorkerError::VoteInRevokedEpoch { .. }
-            | WorkerError::Equivocation(_)
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
             | WorkerError::InvalidTimestamp { .. }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -28,12 +28,13 @@ use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache, DEFAULT_CLEANU
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
     data_types::{BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock},
+    justification::{extract_equivocations, EquivocationProof},
     types::{
         Block, CertificateValue, Certified, ConfirmedBlock, ConfirmedBlockCertificate,
         GenericCertificate, LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock,
         ValidatedBlockCertificate,
     },
-    ChainError, ChainStateView, StreamCounts,
+    ChainError, ChainStateView, ConflictingCertifiedBlocks, StreamCounts,
 };
 use linera_execution::{ExecutionError, ExecutionStateView, Query, QueryOutcome, ResourceTracker};
 use linera_storage::{Clock as _, Storage};
@@ -391,6 +392,11 @@ pub enum WorkerError {
         epoch: Epoch,
         height: BlockHeight,
     },
+    /// Two certificates jointly certify conflicting blocks at the same height of
+    /// the same chain: proof that a committee equivocated. Neither block is
+    /// accepted.
+    #[error("{}", .0.conflict)]
+    Equivocation(Box<EquivocationEvidence>),
     /// The epoch has been revoked on the admin chain, so its committee must not
     /// create any new signatures. A chain that failed to migrate to a newer epoch
     /// before the revocation is frozen.
@@ -463,6 +469,54 @@ pub enum WorkerError {
     BatchRolledBack,
 }
 
+/// The evidence for [`WorkerError::Equivocation`]: two certificates that jointly
+/// assert conflicting blocks at the same height of the same chain. `existing`
+/// certifies the block already accepted there; `witness` asserts a different one
+/// — it is either the conflicting block's own certificate, or the certificate of
+/// an accepted block that commits to the conflicting block via
+/// `previous_block_hash` or `previous_message_blocks`. Either way, at least one
+/// of the two signing quorums violated the protocol.
+#[derive(Debug)]
+pub struct EquivocationEvidence {
+    /// The conflict, naming the chain, the height and the block hashes involved.
+    pub conflict: ConflictingCertifiedBlocks,
+    /// The certificate of the block already accepted at the conflicting height.
+    pub existing: ConfirmedBlockCertificate,
+    /// The certificate asserting a conflicting block at that height.
+    pub witness: ConfirmedBlockCertificate,
+    /// Per-validator [`EquivocationProof`]s extracted from the two certificates:
+    /// one for every validator whose own signatures on them contradict each
+    /// other. When the witness is the conflicting block's own certificate and the
+    /// two blocks were confirmed by the same committee, the proven validators
+    /// hold at least a third of the committee's weight. The list is empty when
+    /// the witness only commits to the conflicting block via its parent or
+    /// previous-message-block links (no vote of its quorum is at the conflicting
+    /// height), or when the two certificates' committees do not intersect; the
+    /// certificate pair itself remains the evidence then.
+    pub proofs: Vec<EquivocationProof>,
+}
+
+impl EquivocationEvidence {
+    /// Assembles the evidence for a conflict from the two certificates involved,
+    /// extracting whatever per-validator proofs they support.
+    pub fn new(
+        conflict: ConflictingCertifiedBlocks,
+        existing: ConfirmedBlockCertificate,
+        witness: ConfirmedBlockCertificate,
+    ) -> Self {
+        let proofs = extract_equivocations(
+            &existing.justified_confirmation(),
+            &witness.justified_confirmation(),
+        );
+        Self {
+            conflict,
+            existing,
+            witness,
+            proofs,
+        }
+    }
+}
+
 impl WorkerError {
     /// Returns whether this error is caused by an issue in the local node.
     ///
@@ -477,6 +531,7 @@ impl WorkerError {
             | WorkerError::InvalidEpoch { .. }
             | WorkerError::EpochRevoked { .. }
             | WorkerError::VoteInRevokedEpoch { .. }
+            | WorkerError::Equivocation(_)
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
             | WorkerError::InvalidTimestamp { .. }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -390,6 +390,18 @@ pub enum WorkerError {
         epoch: Epoch,
         height: BlockHeight,
     },
+    /// The epoch has been revoked on the admin chain, so its committee must not
+    /// create any new signatures. A chain that failed to migrate to a newer epoch
+    /// before the revocation is frozen.
+    #[error(
+        "Cannot vote for the block at height {height} on chain {chain_id}: \
+        epoch {epoch} has been revoked"
+    )]
+    VoteInRevokedEpoch {
+        chain_id: ChainId,
+        epoch: Epoch,
+        height: BlockHeight,
+    },
 
     #[error("Events not found: {0:?}")]
     EventsNotFound(Vec<EventId>),
@@ -463,6 +475,7 @@ impl WorkerError {
             | WorkerError::UnexpectedBlockHeight { .. }
             | WorkerError::InvalidEpoch { .. }
             | WorkerError::EpochRevoked { .. }
+            | WorkerError::VoteInRevokedEpoch { .. }
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
             | WorkerError::InvalidTimestamp { .. }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -378,9 +378,10 @@ pub enum WorkerError {
     },
     /// The certificate's epoch has been revoked on the admin chain, so its
     /// signatures alone no longer prove anything, and no block this worker already
-    /// trusts vouches for the block. The client can recover by uploading the
-    /// block's descendants in decreasing height order: each accepted descendant
-    /// re-certifies its parent via `previous_block_hash`.
+    /// trusts vouches for the block. The client can recover by uploading blocks
+    /// that transitively commit to this one in decreasing height order: each
+    /// accepted block vouches for the blocks it references via
+    /// `previous_block_hash` and `previous_message_blocks`.
     #[error(
         "Cannot trust the certificate for block at height {height} on chain {chain_id}: \
         epoch {epoch} has been revoked and no trusted block vouches for the block"
@@ -429,11 +430,11 @@ pub enum WorkerError {
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     /// Variant raised when the chain references these block hashes via a
-    /// verified-checkpoint trust mark (`pre_checkpoint_block_trust`) but the
-    /// actual content isn't in storage yet. The caller is expected to upload
-    /// each missing block via `handle_confirmed_certificate`; the trust-mark
-    /// accept path verifies the cert against its own (possibly revoked)
-    /// epoch's committee and writes it through.
+    /// trust mark (`vouched_blocks`) but the actual content isn't in storage
+    /// yet. The caller is expected to upload each missing block via
+    /// `handle_confirmed_certificate`; the trust-mark accept path verifies the
+    /// cert against its own (possibly revoked) epoch's committee and writes it
+    /// through.
     #[error("Blocks not found: {0:?}")]
     BlocksNotFound(Vec<CryptoHash>),
     #[error("Block hash at height {height} for chain {chain_id} not found")]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -375,6 +375,20 @@ pub enum WorkerError {
         chain_epoch: Epoch,
         epoch: Epoch,
     },
+    /// The certificate's epoch has been revoked on the admin chain, so its
+    /// signatures alone no longer prove anything, and no block this worker already
+    /// trusts vouches for the block. The client can recover by uploading the
+    /// block's descendants in decreasing height order: each accepted descendant
+    /// re-certifies its parent via `previous_block_hash`.
+    #[error(
+        "Cannot trust the certificate for block at height {height} on chain {chain_id}: \
+        epoch {epoch} has been revoked and no trusted block vouches for the block"
+    )]
+    EpochRevoked {
+        chain_id: ChainId,
+        epoch: Epoch,
+        height: BlockHeight,
+    },
 
     #[error("Events not found: {0:?}")]
     EventsNotFound(Vec<EventId>),
@@ -447,6 +461,7 @@ impl WorkerError {
             | WorkerError::InvalidSigner(_)
             | WorkerError::UnexpectedBlockHeight { .. }
             | WorkerError::InvalidEpoch { .. }
+            | WorkerError::EpochRevoked { .. }
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
             | WorkerError::InvalidTimestamp { .. }

--- a/linera-explorer/src/components/Chain.vue
+++ b/linera-explorer/src/components/Chain.vue
@@ -24,6 +24,14 @@ function pendingBundleCount(): number {
   }
   return count
 }
+
+function receivedLogCount(): number {
+  let count = 0
+  for (const entry of props.chain.receivedLog?.entries || []) {
+    count += entry.value?.entries?.length || 0
+  }
+  return count
+}
 </script>
 
 <template>
@@ -374,16 +382,19 @@ function pendingBundleCount(): number {
         </div>
 
         <!-- Received Log -->
-        <li v-if="chain.receivedLog?.entries?.length" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#chain-'+chain.chainId+'-receivedlog-collapse'">
-          <span><strong>Received Log</strong> ({{ chain.receivedLog.entries.length }})</span>
+        <li v-if="receivedLogCount()" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#chain-'+chain.chainId+'-receivedlog-collapse'">
+          <span><strong>Received Log</strong> ({{ receivedLogCount() }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
-        <div v-if="chain.receivedLog?.entries?.length" class="collapse" :id="'chain-'+chain.chainId+'-receivedlog-collapse'">
+        <div v-if="receivedLogCount()" class="collapse" :id="'chain-'+chain.chainId+'-receivedlog-collapse'">
           <div class="list-group small">
-            <div v-for="(entry, i) in chain.receivedLog.entries" :key="i" class="list-group-item p-1 ps-3">
-              <a @click="$root.route(undefined, [['chain', entry.chainId]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(entry.chainId) }}</a>
-              <span class="ms-1">height {{ displayValue(entry.height) }}</span>
-            </div>
+            <template v-for="epochLog in chain.receivedLog.entries" :key="epochLog.key">
+              <div v-for="(entry, i) in epochLog.value?.entries || []" :key="epochLog.key + '-' + i" class="list-group-item p-1 ps-3">
+                <a @click="$root.route(undefined, [['chain', entry.chainId]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(entry.chainId) }}</a>
+                <span class="ms-1">height {{ displayValue(entry.height) }}</span>
+                <span class="ms-1 text-body-secondary">epoch {{ displayValue(epochLog.key) }}</span>
+              </div>
+            </template>
           </div>
         </div>
 

--- a/linera-exporter/src/test_utils.rs
+++ b/linera-exporter/src/test_utils.rs
@@ -225,7 +225,7 @@ impl ValidatorNode for DummyValidator {
             committee_hash: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            requested_received_log: vec![],
+            requested_received_log: BTreeMap::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
         };

--- a/linera-exporter/src/test_utils.rs
+++ b/linera-exporter/src/test_utils.rs
@@ -225,7 +225,6 @@ impl ValidatorNode for DummyValidator {
             committee_hash: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            count_received_log: 0,
             requested_received_log: vec![],
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -230,15 +230,6 @@ message RevertConfirm {
   BlockHeight retransmit_from = 3;
 }
 
-// A request for entries of one sender epoch's received log.
-message ReceivedLogQuery {
-  // The sender epoch whose received log to read.
-  uint32 epoch = 1;
-
-  // The number of entries at the front of that epoch's log to skip.
-  uint64 skip = 2;
-}
-
 // Request information on a chain.
 message ChainInfoQuery {
   // The chain ID
@@ -250,9 +241,9 @@ message ChainInfoQuery {
   // Query the received messages that are waiting to be picked in the next block.
   bool request_pending_message_bundles = 3;
 
-  // Query the entries of one sender epoch's received log, skipping the first
-  // `skip` entries.
-  optional ReceivedLogQuery request_received_log = 4;
+  // Query the entries of the given sender epochs' received logs, skipping the
+  // given number of entries at the front of each epoch's log.
+  map<uint32, uint64> request_received_log = 4;
 
   // Query values from the chain manager, not just votes.
   bool request_manager_values = 5;

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -230,6 +230,15 @@ message RevertConfirm {
   BlockHeight retransmit_from = 3;
 }
 
+// A request for entries of one sender epoch's received log.
+message ReceivedLogQuery {
+  // The sender epoch whose received log to read.
+  uint32 epoch = 1;
+
+  // The number of entries at the front of that epoch's log to skip.
+  uint64 skip = 2;
+}
+
 // Request information on a chain.
 message ChainInfoQuery {
   // The chain ID
@@ -241,8 +250,9 @@ message ChainInfoQuery {
   // Query the received messages that are waiting to be picked in the next block.
   bool request_pending_message_bundles = 3;
 
-  // Query new certificate removed from the chain.
-  optional uint64 request_received_log_excluding_first_n = 4;
+  // Query the entries of one sender epoch's received log, skipping the first
+  // `skip` entries.
+  optional ReceivedLogQuery request_received_log = 4;
 
   // Query values from the chain manager, not just votes.
   bool request_manager_values = 5;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -22,7 +22,6 @@ use linera_chain::{
 use linera_core::{
     data_types::{
         CertificatesByHeightRequest, ChainInfoQuery, ChainInfoResponse, CrossChainRequest,
-        ReceivedLogQuery,
     },
     node::NodeError,
     worker::Notification,
@@ -699,12 +698,11 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_owner_balance: try_proto_convert(chain_info_query.request_owner_balance)?,
             request_pending_message_bundles: chain_info_query.request_pending_message_bundles,
             chain_id: try_proto_convert(chain_info_query.chain_id)?,
-            request_received_log: chain_info_query.request_received_log.map(|query| {
-                ReceivedLogQuery {
-                    epoch: Epoch(query.epoch),
-                    skip: query.skip,
-                }
-            }),
+            request_received_log: chain_info_query
+                .request_received_log
+                .into_iter()
+                .map(|(epoch, skip)| (Epoch(epoch), skip))
+                .collect(),
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
@@ -738,12 +736,11 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_sent_certificate_hashes_by_heights: Some(
                 request_sent_certificate_hashes_by_heights,
             ),
-            request_received_log: chain_info_query.request_received_log.map(|query| {
-                api::ReceivedLogQuery {
-                    epoch: query.epoch.0,
-                    skip: query.skip,
-                }
-            }),
+            request_received_log: chain_info_query
+                .request_received_log
+                .into_iter()
+                .map(|(epoch, skip)| (epoch.0, skip))
+                .collect(),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
@@ -1257,7 +1254,7 @@ pub mod tests {
             requested_owner_balance: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            requested_received_log: vec![],
+            requested_received_log: BTreeMap::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
         });
@@ -1290,7 +1287,7 @@ pub mod tests {
             test_next_block_height: Some(BlockHeight::from(10)),
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log: None,
+            request_received_log: BTreeMap::from([(Epoch(3), 7)]),
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: true,

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -6,7 +6,7 @@ use linera_base::{
         AccountPublicKey, AccountSignature, CryptoError, CryptoHash, ValidatorPublicKey,
         ValidatorSignature,
     },
-    data_types::{BlobContent, BlockHeight, NetworkDescription},
+    data_types::{BlobContent, BlockHeight, Epoch, NetworkDescription},
     ensure,
     identifiers::{AccountOwner, BlobId, ChainId, EventId},
 };
@@ -22,6 +22,7 @@ use linera_chain::{
 use linera_core::{
     data_types::{
         CertificatesByHeightRequest, ChainInfoQuery, ChainInfoResponse, CrossChainRequest,
+        ReceivedLogQuery,
     },
     node::NodeError,
     worker::Notification,
@@ -698,8 +699,12 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_owner_balance: try_proto_convert(chain_info_query.request_owner_balance)?,
             request_pending_message_bundles: chain_info_query.request_pending_message_bundles,
             chain_id: try_proto_convert(chain_info_query.chain_id)?,
-            request_received_log_excluding_first_n: chain_info_query
-                .request_received_log_excluding_first_n,
+            request_received_log: chain_info_query.request_received_log.map(|query| {
+                ReceivedLogQuery {
+                    epoch: Epoch(query.epoch),
+                    skip: query.skip,
+                }
+            }),
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
@@ -733,8 +738,12 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_sent_certificate_hashes_by_heights: Some(
                 request_sent_certificate_hashes_by_heights,
             ),
-            request_received_log_excluding_first_n: chain_info_query
-                .request_received_log_excluding_first_n,
+            request_received_log: chain_info_query.request_received_log.map(|query| {
+                api::ReceivedLogQuery {
+                    epoch: query.epoch.0,
+                    skip: query.skip,
+                }
+            }),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
@@ -1248,7 +1257,6 @@ pub mod tests {
             requested_owner_balance: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            count_received_log: 0,
             requested_received_log: vec![],
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
@@ -1282,7 +1290,7 @@ pub mod tests {
             test_next_block_height: Some(BlockHeight::from(10)),
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log_excluding_first_n: None,
+            request_received_log: None,
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: true,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -326,7 +326,6 @@ ChainInfo:
     - requested_sent_certificate_hashes:
         SEQ:
           TYPENAME: CryptoHash
-    - count_received_log: U64
     - requested_received_log:
         SEQ:
           TYPENAME: ChainAndHeight
@@ -351,8 +350,9 @@ ChainInfoQuery:
     - request_owner_balance:
         TYPENAME: AccountOwner
     - request_pending_message_bundles: BOOL
-    - request_received_log_excluding_first_n:
-        OPTION: U64
+    - request_received_log:
+        OPTION:
+          TYPENAME: ReceivedLogQuery
     - request_manager_values: BOOL
     - request_leader_timeout:
         OPTION:
@@ -1061,6 +1061,11 @@ Reason:
               TYPENAME: BlockHeight
           - hash:
               TYPENAME: CryptoHash
+ReceivedLogQuery:
+  STRUCT:
+    - epoch:
+        TYPENAME: Epoch
+    - skip: U64
 Response:
   STRUCT:
     - status: U16

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -327,8 +327,12 @@ ChainInfo:
         SEQ:
           TYPENAME: CryptoHash
     - requested_received_log:
-        SEQ:
-          TYPENAME: ChainAndHeight
+        MAP:
+          KEY:
+            TYPENAME: Epoch
+          VALUE:
+            SEQ:
+              TYPENAME: ChainAndHeight
     - requested_previous_event_blocks:
         MAP:
           KEY:
@@ -351,8 +355,10 @@ ChainInfoQuery:
         TYPENAME: AccountOwner
     - request_pending_message_bundles: BOOL
     - request_received_log:
-        OPTION:
-          TYPENAME: ReceivedLogQuery
+        MAP:
+          KEY:
+            TYPENAME: Epoch
+          VALUE: U64
     - request_manager_values: BOOL
     - request_leader_timeout:
         OPTION:
@@ -1061,11 +1067,6 @@ Reason:
               TYPENAME: BlockHeight
           - hash:
               TYPENAME: CryptoHash
-ReceivedLogQuery:
-  STRUCT:
-    - epoch:
-        TYPENAME: Epoch
-    - skip: U64
 Response:
   STRUCT:
     - status: U16

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -834,6 +834,15 @@ NodeError:
           - block_time_grace_period_ms: U64
     33:
       NoValidators: UNIT
+    34:
+      EpochRevoked:
+        STRUCT:
+          - chain_id:
+              TYPENAME: ChainId
+          - epoch:
+              TYPENAME: Epoch
+          - height:
+              TYPENAME: BlockHeight
 Notification:
   STRUCT:
     - chain_id:

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -157,9 +157,15 @@ query Chain(
       }
     }
     receivedLog {
+      keys
       entries {
-        chainId
-        height
+        key
+        value {
+          entries {
+            chainId
+            height
+          }
+        }
       }
     }
     inboxes {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -432,8 +432,9 @@ type ChainStateExtendedView {
 	Hashes of blocks that are vouched for by data this chain already trusts, but
 	have not been processed here yet. A hash is inserted when a trusted source
 	commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
-	block's `previous_block_hash` or `previous_message_blocks` links (unless the
-	referenced block is already in `block_hashes`). The worker accepts a cert
+	block's `previous_block_hash`, `previous_message_blocks` or
+	`previous_event_blocks` links (unless the referenced block is already in
+	`block_hashes`). The worker accepts a cert
 	whose hash is in this set regardless of its epoch — the epoch may be revoked,
 	but the hash commitment makes the block trustworthy — and removes the entry
 	upon acceptance.

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -369,11 +369,17 @@ type ChainStateExtendedView {
 	"""
 	blockHashes: CustomMapView_BlockHeight_CryptoHash_1bae6d76!
 	"""
-	Sender chain and height of all certified blocks known as a receiver (local ordering).
+	Sender chain and height of all certified blocks known as a receiver (local
+	ordering), keyed by the epoch of the sender block's certificate. Partitioned
+	by epoch so that a revoked epoch's log can be dropped wholesale: clients
+	cannot verify those certificates on their own anymore, and blocks that still
+	matter are re-certified via `previous_block_hash` /
+	`previous_message_blocks` links instead.
 	"""
-	receivedLog: LogView_ChainAndHeight_7af83576!
+	receivedLog: CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2!
 	"""
-	The number of `received_log` entries we have synchronized, for each validator.
+	The number of `received_log` entries we have synchronized, per validator and
+	per sender epoch.
 	"""
 	receivedCertificateTrackers: JSONObject!
 	"""
@@ -549,6 +555,13 @@ type ClaimOperationMetadata {
 	amount: Amount!
 }
 
+type CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2 {
+	keys: [Epoch!]!
+	count: Int!
+	entry(key: Epoch!): Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!
+	entries(input: MapInput_Epoch_530caf4b): [Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!]!
+}
+
 """
 A set of validators (identified by their public keys) and their voting rights.
 """
@@ -708,6 +721,14 @@ type Entry_ChainId_OutboxStateView_855dcf53 {
 """
 A GraphQL-visible map item, complete with key.
 """
+type Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a {
+	key: Epoch!
+	value: LogView_ChainAndHeight_7af83576!
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
 type Entry_StreamId_StreamCounts_d5e24a40 {
 	key: StreamId!
 	value: StreamCounts
@@ -851,6 +872,10 @@ input MapFilters_ChainId_37f83aa9 {
 	keys: [ChainId!]
 }
 
+input MapFilters_Epoch_530caf4b {
+	keys: [Epoch!]
+}
+
 input MapFilters_StreamIdInput_b7c3909d {
 	keys: [StreamIdInput!]
 }
@@ -869,6 +894,10 @@ input MapInput_BlockHeight_e824a938 {
 
 input MapInput_ChainId_37f83aa9 {
 	filters: MapFilters_ChainId_37f83aa9
+}
+
+input MapInput_Epoch_530caf4b {
+	filters: MapFilters_Epoch_530caf4b
 }
 
 input MapInput_StreamIdInput_b7c3909d {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -428,15 +428,16 @@ type ChainStateExtendedView {
 	"""
 	latestCheckpointHeight: BlockHeight
 	"""
-	Hashes of pre-checkpoint sender blocks the chain has seen a checkpoint cert
-	vouch for via `outbox_block_hashes`, but whose actual cert bytes are not yet
-	in storage. The worker errors a checkpoint push with
-	`BlocksNotFound` when this set is non-empty, then accepts each
-	referenced cert (regardless of its own — possibly revoked — epoch) and
-	removes the entry. Once the set is empty, the checkpoint restoration can run
-	end-to-end.
+	Hashes of blocks that are vouched for by data this chain already trusts, but
+	have not been processed here yet. A hash is inserted when a trusted source
+	commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
+	block's `previous_block_hash` or `previous_message_blocks` links (unless the
+	referenced block is already in `block_hashes`). The worker accepts a cert
+	whose hash is in this set regardless of its epoch — the epoch may be revoked,
+	but the hash commitment makes the block trustworthy — and removes the entry
+	upon acceptance.
 	"""
-	preCheckpointBlockTrust: SetView_CryptoHash_87fbb60c!
+	vouchedBlocks: SetView_CryptoHash_87fbb60c!
 	"""
 	The hash of the set of fully-tracked chains that `nonempty_outboxes` and
 	`outbox_counters` were last reconciled against. On a client these two indices only hold

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -376,12 +376,7 @@ type ChainStateExtendedView {
 	matter are re-certified via `previous_block_hash` /
 	`previous_message_blocks` links instead.
 	"""
-	receivedLog: CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2!
-	"""
-	The number of `received_log` entries we have synchronized, per validator and
-	per sender epoch.
-	"""
-	receivedCertificateTrackers: JSONObject!
+	receivedLog: CustomCollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2!
 	"""
 	Mailboxes used to receive messages indexed by their origin.
 	"""
@@ -555,13 +550,6 @@ type ClaimOperationMetadata {
 	amount: Amount!
 }
 
-type CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2 {
-	keys: [Epoch!]!
-	count: Int!
-	entry(key: Epoch!): Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!
-	entries(input: MapInput_Epoch_530caf4b): [Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!]!
-}
-
 """
 A set of validators (identified by their public keys) and their voting rights.
 """
@@ -654,6 +642,13 @@ type Cursor {
 	The transaction index within the block.
 	"""
 	index: Int!
+}
+
+type CustomCollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2 {
+	keys: [Epoch!]!
+	count: Int!
+	entry(key: Epoch!): Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!
+	entries(input: MapInput_Epoch_530caf4b): [Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!]!
 }
 
 type CustomMapView_BlockHeight_CryptoHash_1bae6d76 {

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -316,6 +316,19 @@ impl CustomSerialize for linera_base::data_types::BlockHeight {
     }
 }
 
+impl CustomSerialize for linera_base::data_types::Epoch {
+    fn to_custom_bytes(&self) -> Result<Vec<u8>, ViewError> {
+        Ok(self.0.to_be_bytes().to_vec())
+    }
+
+    fn from_custom_bytes(bytes: &[u8]) -> Result<Self, ViewError> {
+        let array: [u8; 4] = bytes
+            .try_into()
+            .map_err(|_| ViewError::PostLoadValuesError)?;
+        Ok(Self(u32::from_be_bytes(array)))
+    }
+}
+
 /// This computes the offset of the BCS serialization of a vector.
 /// The formula that should be satisfied is
 /// `serialized_size(vec![v_1, ...., v_n]) = get_uleb128_size(n)`


### PR DESCRIPTION
 ## Motivation

  We need to allow revoking old epochs. Otherwise validators are required to be
  trusted and keep their keys safe forever, without any time limit.

  Revocation also makes parts of the received log dead weight: entries pointing
  at revoked-epoch certificates are useless to clients, since those certificates
  can no longer be verified on their own. Without pruning, the log grows without
  bound.

  ## Proposal

  In the chain worker, don't trust certificates from revoked epochs unless
  something we already trust vouches for them. Vouching is tracked in a
  `vouched_blocks` set (generalizing the checkpoint trust marks): whenever a
  block is accepted, the blocks it commits to via `previous_block_hash` and
  `previous_message_blocks` are recorded as vouched, unless they are already
  known. Accepting a vouched block consumes the mark and vouches for *its*
  references in turn, so trust propagates backwards transitively. If a trusted
  block commits to a different hash than one already accepted at the same
  height, this is evidence of equivocation and gets logged.

  Also, stop signing on chains in revoked epochs.

  In the client, re-establish trust in a rejected revoked-epoch block by
  processing newer blocks first, in decreasing height order. For sender chains
  this follows the `previous_message_blocks` links, so only the message-bearing
  blocks are downloaded; walking all contiguous descendants remains the fallback
  when the sender never sent to us again from a live epoch.

  Finally, keep the received log partitioned by the epoch of the sender block's
  certificate, ordered numerically in storage:

  - Clients request all live epochs' logs in a single query (a map from epoch to
    tracker offset), and validators serve them under one total entry bound per
    response.
  - Received-certificate trackers are kept per validator *and* epoch, in a map
    view instead of one ever-growing register blob.
  - Validators drop a revoked epoch's log wholesale the next time a client asks
    for a live epoch's log on that chain, and tracker entries for revoked epochs
    are removed whenever trackers are updated. Since revocation is monotone,
    both prunings need only a single revocation check.

  ## Test Plan

  Tests were added, including: re-certification of a revoked-epoch sender block
  via `previous_message_blocks` without the worker ever seeing the intermediate
  non-sender block; and the sparse-sender-chain client test now crosses a
  revoked epoch and asserts that recovery does not fall back to contiguous
  downloads and that validators prune the revoked epoch's log.

  ## Release Plan

  - These changes are protocol-breaking (chain-state layout, RPC query format)
    and must not be backported to the current testnet; they follow the usual
    release cycle for the next network.

  ## Links

  - Part of #6237.
  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)