### PR TITLE
Deactivate automatic instruction-count benchmark runs

### DIFF
--- a/.github/workflows/instruction-count-benchmarks.yml
+++ b/.github/workflows/instruction-count-benchmarks.yml
@@ -2,17 +2,13 @@
 # If you rename it, update the workflow_run trigger there too.
 name: Instruction Count Benchmarks
 
+# DEACTIVATED: automatic runs are disabled because the PR regression warnings proved
+# unreliable — the baseline selector compares against a commit older than the merge base
+# (author-date vs artifact-creation-date mismatch), the bench harness spawns a
+# multi-threaded tokio runtime so instruction counts vary run to run, and the paths
+# filter misses linera-base, a dependency compiled into the benchmarks. Manual runs via
+# workflow_dispatch still work. Fix the above before restoring push/pull_request triggers.
 on:
-  push:
-    branches: [main, 'devnet_*', 'testnet_*']
-  pull_request:
-    branches:
-      - "**"
-    paths:
-      - 'linera-views/**'
-      - 'linera-views-derive/**'
-      - '.github/workflows/instruction-count-benchmarks.yml'
-      - '.github/scripts/format-bench-results.sh'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Motivation

The instruction-count benchmark bot has been posting regression warnings on every `linera-views` PR since #5487, but an audit of all 69 commented PRs showed the warnings are unreliable in both directions:

- **False positives**: PR #6366 was flagged `+1.34%` even though its bench binary is byte-identical to its merge base. The baseline selector compares artifact `created_at` against the merge base's *author* date (which predates the push for squash merges), so it always selects a baseline older than the merge base — in that case 5 commits older, attributing unrelated main-branch drift to the PR. CI-only PRs (#6026, #6076) with zero Rust changes were also flagged, and running the same binary twice produces instruction counts differing by up to ~1% (the bench harness spawns a multi-threaded tokio runtime per benchmark, so the instruction stream is not reproducible run to run) — on the 5–20k-instruction benchmarks the 1% warning threshold sits inside that jitter band.
- **False negatives**: the `pull_request` paths filter only watches `linera-views/**`, so changes to `linera-base` — a dependency compiled into the benchmark binary — never trigger a run on their own PR.

No warning has ever been acted on (the one genuine large regression, +9.9% in #6277, merged without discussion).

## Proposal

Deactivate automatic runs by removing the `push` and `pull_request` triggers, keeping `workflow_dispatch` for manual runs. The benchmark code, the formatting script, and the comment-posting workflow all remain in-tree so the system can be fixed and re-enabled later; the comment workflow is inert because its job only fires for `pull_request`-event runs.

## Test Plan

- YAML validated; the only remaining trigger is `workflow_dispatch`, and both jobs keep their `github.event_name == 'workflow_dispatch'` guards, so manual runs still work end to end.
- Verified the workflow is not a required status check, so no PR can block on it.
- Reproduction evidence for the audit: rebuilt the bench binary at #6366's head and merge base with the pinned toolchain (identical sha256), diffed the two CI baseline runs' logs (constant ±19-instruction inter-run offset), and ran the same binary twice locally (`front_100_from_1000`: 16,644 → 16,493).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)