### PR TITLE
`ConfirmedBlock` vote ledger

### DIFF
--- a/linera-base/src/crypto/secp256k1/mod.rs
+++ b/linera-base/src/crypto/secp256k1/mod.rs
@@ -70,6 +70,12 @@ pub struct Secp256k1KeyPair {
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub struct Secp256k1Signature(pub Signature);
 
+impl std::hash::Hash for Secp256k1Signature {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
+
 impl Allocative for Secp256k1Signature {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         visitor.visit_simple_sized::<Self>();

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -29,7 +29,9 @@ use tracing::instrument;
 #[cfg(with_metrics)]
 use crate::prometheus_util::MeasureLatency as _;
 use crate::{
-    crypto::{BcsHashable, CryptoError, CryptoHash},
+    crypto::{
+        BcsHashable, BcsSignable, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSignature,
+    },
     doc_scalar, hex_debug, http,
     identifiers::{
         ApplicationId, BlobId, BlobType, ChainId, EventId, GenericApplicationId, ModuleId, StreamId,
@@ -2109,6 +2111,39 @@ doc_scalar!(
     "A blob of binary data, with its content-addressed blob ID."
 );
 doc_scalar!(ApplicationDescription, "Description of a user application");
+
+/// Identifies one validator's commitment for one epoch: the hashes of the blobs
+/// holding the commitment's chunks, in order. The chunks list all confirmation
+/// votes the validator signed in the epoch.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Allocative)]
+pub struct CommitmentManifest {
+    /// The revoked epoch the commitment is for.
+    pub epoch: Epoch,
+    /// The committing validator.
+    pub validator: ValidatorPublicKey,
+    /// The hashes of the `EpochCommitment` blobs, in chunk order.
+    pub blob_hashes: Vec<CryptoHash>,
+}
+
+impl BcsSignable<'_> for CommitmentManifest {}
+
+/// A [`CommitmentManifest`] signed by the committing validator.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Allocative)]
+pub struct SignedCommitmentManifest {
+    /// The manifest.
+    pub manifest: CommitmentManifest,
+    /// The signature of the validator named in the manifest.
+    pub signature: ValidatorSignature,
+}
+
+impl SignedCommitmentManifest {
+    /// Verifies that the signature is valid for the manifest, by the validator the
+    /// manifest names.
+    pub fn check(&self) -> Result<(), CryptoError> {
+        self.signature
+            .check(&self.manifest, self.manifest.validator)
+    }
+}
 
 #[cfg(with_metrics)]
 mod metrics {

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1736,6 +1736,12 @@ impl BlobContent {
         BlobContent::new(BlobType::ChainDescription, bytes)
     }
 
+    /// Creates a new epoch commitment [`BlobContent`] from the BCS-encoded
+    /// commitment chunk bytes.
+    pub fn new_epoch_commitment(bytes: impl Into<Box<[u8]>>) -> Self {
+        BlobContent::new(BlobType::EpochCommitment, bytes)
+    }
+
     /// Gets a reference to the blob's bytes.
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
@@ -1854,6 +1860,12 @@ impl Blob {
     /// Creates a new chain description [`Blob`] from a [`ChainDescription`].
     pub fn new_chain_description(chain_description: &ChainDescription) -> Self {
         Blob::new(BlobContent::new_chain_description(chain_description))
+    }
+
+    /// Creates a new epoch commitment [`Blob`] from the BCS-encoded commitment
+    /// chunk bytes.
+    pub fn new_epoch_commitment(bytes: impl Into<Box<[u8]>>) -> Self {
+        Blob::new(BlobContent::new_epoch_commitment(bytes))
     }
 
     /// A content-addressed blob ID i.e. the hash of the `Blob`.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1900,6 +1900,11 @@ impl Blob {
     pub fn is_checkpoint_blob(&self) -> bool {
         self.content().blob_type().is_checkpoint_blob()
     }
+
+    /// Returns whether the blob carries a chunk of a validator's epoch commitment.
+    pub fn is_epoch_commitment_blob(&self) -> bool {
+        self.content().blob_type().is_epoch_commitment_blob()
+    }
 }
 
 impl Serialize for Blob {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -296,6 +296,13 @@ impl BlobType {
     pub fn is_checkpoint_blob(&self) -> bool {
         matches!(self, BlobType::CheckpointExecutionState)
     }
+
+    /// Returns whether the blob carries a chunk of a validator's epoch commitment.
+    /// Such blobs are exempt from per-block published-blob counts and per-blob
+    /// fees.
+    pub fn is_epoch_commitment_blob(&self) -> bool {
+        matches!(self, BlobType::EpochCommitment)
+    }
 }
 
 impl fmt::Display for BlobType {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -279,6 +279,9 @@ pub enum BlobType {
     /// A single checkpoint produces a sequence of such blobs whose content hashes
     /// are listed in `OracleResponse::Checkpoint`.
     CheckpointExecutionState,
+    /// A blob containing one ordered chunk of a validator's commitment to the
+    /// confirmation votes it signed in a revoked epoch.
+    EpochCommitment,
 }
 
 impl BlobType {

--- a/linera-bridge/src/solidity/BridgeTypes.sol
+++ b/linera-bridge/src/solidity/BridgeTypes.sol
@@ -215,7 +215,8 @@ library BridgeTypes {
         Committee,
         ChainDescription,
         ApplicationFormats,
-        CheckpointExecutionState
+        CheckpointExecutionState,
+        EpochCommitment
     }
 
     function bcs_serialize_BlobType(BlobType input) internal pure returns (bytes memory) {
@@ -230,7 +231,7 @@ library BridgeTypes {
         uint256 new_pos;
         uint256 choice;
         (new_pos, choice) = bcs_deserialize_offset_uleb128(pos, input);
-        require(choice < 9, "invalid variant index");
+        require(choice < 10, "invalid variant index");
         return (new_pos, BlobType(uint8(choice)));
     }
 

--- a/linera-bridge/tests/snapshots/format__format.yaml.snap
+++ b/linera-bridge/tests/snapshots/format__format.yaml.snap
@@ -52,6 +52,8 @@ BlobType:
       ApplicationFormats: UNIT
     8:
       CheckpointExecutionState: UNIT
+    9:
+      EpochCommitment: UNIT
 BlockHeader:
   STRUCT:
     - chain_id:

--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -13,11 +13,13 @@ use linera_base::{
 use linera_execution::committee::Committee;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{generic::GenericCertificate, Certificate, Certified, LiteCertificate};
+use super::{
+    generic::GenericCertificate, Certificate, Certified, LiteCertificate, ValidatedBlockCertificate,
+};
 use crate::{
-    block::{Block, ConfirmedBlock, ConversionError},
+    block::{Block, ConfirmedBlock, ConversionError, ValidatedBlock},
     data_types::MessageBundle,
-    justification::JustificationChain,
+    justification::{CommittedQuorum, JustificationChain},
     ChainError,
 };
 
@@ -89,6 +91,49 @@ impl ConfirmedBlockCertificate {
     /// Consumes this certificate, returning the signed quorum and the justification chain.
     pub fn into_parts(self) -> (GenericCertificate<ConfirmedBlock>, JustificationChain) {
         (self.quorum, self.justification)
+    }
+
+    /// Reconstructs the validated-block certificate with the given justification
+    /// commitment from this certificate's justification chain, or `None` if no link
+    /// of the chain has that commitment. This recovers the quorum that a
+    /// confirmation vote for this block cited, from stored data alone: the cited
+    /// quorum is a link of the chain whenever the vote's round is at most the round
+    /// this certificate was formed in.
+    pub fn cited_validated_certificate(
+        &self,
+        justification_commitment: CryptoHash,
+    ) -> Option<ValidatedBlockCertificate> {
+        let value_hash = self.hash();
+        let links = self.justification.links();
+        let mut previous = None;
+        let mut unlocking_round = None;
+        for (index, link) in links.iter().enumerate() {
+            let commitment = CommittedQuorum {
+                value_hash,
+                round: link.round,
+                unlocking_round,
+                previous,
+                signatures: link.signatures.clone(),
+            }
+            .commitment();
+            if commitment == justification_commitment {
+                let quorum = GenericCertificate::new_with_payload(
+                    ValidatedBlock::new(self.block().clone()),
+                    link.round,
+                    unlocking_round,
+                    false,
+                    previous,
+                    link.signatures.clone(),
+                );
+                return Some(ValidatedBlockCertificate::from_parts(
+                    quorum,
+                    JustificationChain::new(links[..index].to_vec()),
+                ));
+            }
+            previous = Some(commitment);
+            unlocking_round = Some(link.round);
+        }
+        None
     }
 
     /// Returns the round in which the value was certified.

--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -465,6 +465,11 @@ impl From<&AdminOperation> for AdminOperationMetadata {
                 epoch: Some(epoch.0 as i32),
                 blob_hash: None,
             },
+            AdminOperation::RegisterCommitment { manifest } => AdminOperationMetadata {
+                admin_operation_type: "RegisterCommitment".to_string(),
+                epoch: Some(manifest.manifest.epoch.0 as i32),
+                blob_hash: None,
+            },
         }
     }
 }

--- a/linera-chain/src/epoch_commitment.rs
+++ b/linera-chain/src/epoch_commitment.rs
@@ -15,13 +15,10 @@
 //! double-signing.
 //!
 //! The entries are chunked into size-bounded blobs of type `EpochCommitment`,
-//! identified by a [`CommitmentManifest`] signed with the validator's key.
+//! identified by a [`CommitmentManifest`](linera_base::data_types::CommitmentManifest)
+//! signed with the validator's key.
 
-use linera_base::{
-    crypto::{BcsSignable, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSignature},
-    data_types::Epoch,
-    identifiers::ChainId,
-};
+use linera_base::identifiers::ChainId;
 use serde::{Deserialize, Serialize};
 
 use crate::vote_ledger::JustifiedVote;
@@ -51,43 +48,12 @@ pub struct CommitmentChunk {
     pub entries: Vec<CommitmentEntry>,
 }
 
-/// Identifies one validator's commitment for one epoch: the hashes of the blobs
-/// holding its [`CommitmentChunk`]s, in order.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CommitmentManifest {
-    /// The revoked epoch the commitment is for.
-    pub epoch: Epoch,
-    /// The committing validator.
-    pub validator: ValidatorPublicKey,
-    /// The hashes of the `EpochCommitment` blobs, in chunk order.
-    pub blob_hashes: Vec<CryptoHash>,
-}
-
-impl BcsSignable<'_> for CommitmentManifest {}
-
-/// A [`CommitmentManifest`] signed by the committing validator.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct SignedCommitmentManifest {
-    /// The manifest.
-    pub manifest: CommitmentManifest,
-    /// The signature of the validator named in the manifest.
-    pub signature: ValidatorSignature,
-}
-
-impl SignedCommitmentManifest {
-    /// Verifies that the signature is valid for the manifest, by the validator the
-    /// manifest names.
-    pub fn check(&self) -> Result<(), CryptoError> {
-        self.signature
-            .check(&self.manifest, self.manifest.validator)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use linera_base::crypto::ValidatorKeypair;
-
-    use super::*;
+    use linera_base::{
+        crypto::{CryptoHash, ValidatorKeypair, ValidatorSignature},
+        data_types::{CommitmentManifest, Epoch, SignedCommitmentManifest},
+    };
 
     #[test]
     fn test_signed_commitment_manifest() {

--- a/linera-chain/src/epoch_commitment.rs
+++ b/linera-chain/src/epoch_commitment.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Epoch commitments
+//!
+//! When an epoch is revoked, each of its validators commits to the confirmation
+//! votes it signed in that epoch, assembled from its
+//! [vote ledger](crate::vote_ledger). Per chain, the commitment holds the last
+//! block the validator confirmation-signed — which *covers* all earlier blocks on
+//! that chain of blocks via the parent-hash links — plus every superseded vote.
+//! Each vote comes with the justification it cited, so that a justified re-vote
+//! cannot be mistaken for double-signing and every entry can be attributed to the
+//! individual validator. Once the commitment is published, any confirmation
+//! signature from the epoch that is neither covered nor listed proves
+//! double-signing.
+//!
+//! The entries are chunked into size-bounded blobs of type `EpochCommitment`,
+//! identified by a [`CommitmentManifest`] signed with the validator's key.
+
+use linera_base::{
+    crypto::{BcsSignable, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSignature},
+    data_types::Epoch,
+    identifiers::ChainId,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::vote_ledger::JustifiedVote;
+
+/// All confirmation votes one validator signed on one chain in one epoch.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct CommitmentEntry {
+    /// The chain the votes were cast on.
+    pub chain_id: ChainId,
+    /// The validator's latest confirmation vote on this chain, with the
+    /// justification it cited. It covers every block up to and including the voted
+    /// one.
+    pub committed: JustifiedVote,
+    /// Votes for blocks that lost out at their height; they lie off the covered
+    /// chain of blocks.
+    pub superseded: Vec<JustifiedVote>,
+}
+
+/// The payload of one `EpochCommitment` blob: a size-bounded chunk of the
+/// commitment's entries. Entries are sorted by chain ID across the whole
+/// commitment, each chunk continuing where the previous one ended.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct CommitmentChunk {
+    /// The commitment entries in this chunk.
+    pub entries: Vec<CommitmentEntry>,
+}
+
+/// Identifies one validator's commitment for one epoch: the hashes of the blobs
+/// holding its [`CommitmentChunk`]s, in order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitmentManifest {
+    /// The revoked epoch the commitment is for.
+    pub epoch: Epoch,
+    /// The committing validator.
+    pub validator: ValidatorPublicKey,
+    /// The hashes of the `EpochCommitment` blobs, in chunk order.
+    pub blob_hashes: Vec<CryptoHash>,
+}
+
+impl BcsSignable<'_> for CommitmentManifest {}
+
+/// A [`CommitmentManifest`] signed by the committing validator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignedCommitmentManifest {
+    /// The manifest.
+    pub manifest: CommitmentManifest,
+    /// The signature of the validator named in the manifest.
+    pub signature: ValidatorSignature,
+}
+
+impl SignedCommitmentManifest {
+    /// Verifies that the signature is valid for the manifest, by the validator the
+    /// manifest names.
+    pub fn check(&self) -> Result<(), CryptoError> {
+        self.signature
+            .check(&self.manifest, self.manifest.validator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::crypto::ValidatorKeypair;
+
+    use super::*;
+
+    #[test]
+    fn test_signed_commitment_manifest() {
+        let keypair = ValidatorKeypair::generate();
+        let manifest = CommitmentManifest {
+            epoch: Epoch::from(2),
+            validator: keypair.public_key,
+            blob_hashes: vec![CryptoHash::test_hash("commitment chunk")],
+        };
+        let signature = ValidatorSignature::new(&manifest, &keypair.secret_key);
+        let signed = SignedCommitmentManifest {
+            manifest,
+            signature,
+        };
+        signed.check().unwrap();
+
+        // A manifest naming a different validator fails verification.
+        let other = ValidatorKeypair::generate();
+        let mut forged = signed.clone();
+        forged.manifest.validator = other.public_key;
+        assert!(forged.check().is_err());
+    }
+}

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -25,6 +25,7 @@ mod outbox;
 mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
+pub mod vote_ledger;
 
 pub use chain::{BlockExecutionPhase, ChainIdSet, ChainStateView, ChainTipState, StreamCounts};
 use data_types::{MessageBundle, PostedMessage};

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -18,6 +18,7 @@ mod block_tracker;
 mod chain;
 /// Data types exchanged while proposing, voting on, and confirming blocks.
 pub mod data_types;
+pub mod epoch_commitment;
 mod inbox;
 pub mod justification;
 pub mod manager;

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -11,6 +11,7 @@ use super::*;
 use crate::{
     block::{Block, BlockBodyField, ConfirmedBlock, ValidatedBlock},
     test::{make_first_block, BlockTestExt},
+    types::{ConfirmedBlockCertificate, GenericCertificate, ValidatedBlockCertificate},
 };
 
 fn dummy_chain_id(index: u32) -> ChainId {
@@ -333,4 +334,45 @@ fn round_ordering() {
     assert!(Round::SingleLeader(1) < Round::SingleLeader(2));
     assert!(Round::SingleLeader(2) < Round::Validator(0));
     assert!(Round::Validator(1) < Round::Validator(2))
+}
+
+#[test]
+fn test_cited_validated_certificate() {
+    let block = sample_block();
+    let validated = ValidatedBlock::new(block.clone());
+    // A lineage of two validated quorums: one in round 1, one in round 2 citing it.
+    let validated1 =
+        ValidatedBlockCertificate::new(validated.clone(), Round::SingleLeader(1), vec![]);
+    let validated2 = ValidatedBlockCertificate::from_parts(
+        GenericCertificate::new_with_payload(
+            validated,
+            Round::SingleLeader(2),
+            Some(Round::SingleLeader(1)),
+            false,
+            Some(validated1.full_justification_commitment()),
+            vec![],
+        ),
+        validated1.full_justification(),
+    );
+    // A certificate confirming the block in round 2, carrying the full chain.
+    let confirmed = ConfirmedBlockCertificate::from_parts(
+        GenericCertificate::new_with_payload(
+            ConfirmedBlock::new(block),
+            Round::SingleLeader(2),
+            None,
+            false,
+            Some(validated2.full_justification_commitment()),
+            vec![],
+        ),
+        validated2.full_justification(),
+    );
+    // Each quorum in the chain is reconstructible by its commitment.
+    for original in [&validated2, &validated1] {
+        let commitment = original.full_justification_commitment();
+        let cited = confirmed.cited_validated_certificate(commitment).unwrap();
+        assert_eq!(cited, *original);
+    }
+    assert!(confirmed
+        .cited_validated_certificate(CryptoHash::test_hash("unrelated"))
+        .is_none());
 }

--- a/linera-chain/src/vote_ledger.rs
+++ b/linera-chain/src/vote_ledger.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Vote ledger
+//!
+//! A validator's durable record of every confirmation vote it signs, kept per epoch
+//! and chain. The chain manager only holds the current height's vote and the
+//! certificate it cites; both are overwritten as the chain advances, so without
+//! this ledger a validator cannot reconstruct what it signed — in particular votes
+//! for blocks that never got a quorum, or votes superseded by a justified re-vote
+//! at the same height.
+//!
+//! When an epoch is revoked, the ledger is what the validator's *commitment* is
+//! assembled from: per chain, the last confirmation-voted block — which covers all
+//! earlier votes on that chain of blocks via the parent-hash links — plus every
+//! superseded vote, each with the justification it cited.
+
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::{BlockHeight, Round},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::types::ValidatedBlockCertificate;
+
+/// A confirmation vote a validator signed: the voted block's height and hash, and
+/// the round the vote was cast in.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoteRecord {
+    /// The height of the voted block.
+    pub height: BlockHeight,
+    /// The round the vote was cast in.
+    pub round: Round,
+    /// The hash of the voted block.
+    pub block_hash: CryptoHash,
+}
+
+/// A confirmation vote for a block that lost out at its height: either the
+/// validator later cast a justified confirmation vote for a different block at the
+/// same height, or a different block was confirmed there without the validator's
+/// vote.
+///
+/// The protocol allows both, so a superseded vote is not by itself evidence of
+/// double-signing — but only as long as it can be shown together with its
+/// justification. It is kept here because the certificate it cited is not
+/// otherwise retained once the chain moves on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct SupersededVote {
+    /// The superseded vote.
+    pub record: VoteRecord,
+    /// The validated-block certificate the vote cited, or `None` for a vote cast in
+    /// a chain's first round, which cites no validated quorum.
+    pub justification: Option<ValidatedBlockCertificate>,
+}
+
+/// All confirmation votes a validator signed on one chain in one epoch: the latest
+/// vote, which covers all earlier votes on the same chain of blocks via the
+/// parent-hash links, and any superseded votes, which lie off that chain.
+///
+/// The latest vote's justification is needed too when the commitment is assembled,
+/// but it is not stored here: it is recoverable at that point in each of the three
+/// states the vote can be in. If the vote is still pending at the chain's tip, the
+/// chain manager's locking certificate is exactly the cited justification. If the
+/// voted block was confirmed, its stored certificate carries the justification. And
+/// if a different block was confirmed at the vote's height, the vote was recorded
+/// as superseded — together with its justification — at that moment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct LedgerEntry {
+    /// The latest confirmation vote on this chain.
+    pub latest: VoteRecord,
+    /// Votes for blocks that lost out at their height.
+    pub superseded: Vec<SupersededVote>,
+}

--- a/linera-chain/src/vote_ledger.rs
+++ b/linera-chain/src/vote_ledger.rs
@@ -23,8 +23,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::ValidatedBlockCertificate;
 
-/// A confirmation vote a validator signed: the voted block's height and hash, and
-/// the round the vote was cast in.
+/// A confirmation vote a validator signed: the voted block's height and hash, the
+/// round the vote was cast in, and the justification commitment it signed.
+///
+/// Together these identify the vote's entire signed payload (see
+/// [`VoteValue`](crate::data_types::VoteValue)): a confirmation vote signs no
+/// unlocking round, and its first-round attestation is `true` exactly when it
+/// cites no quorum.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VoteRecord {
     /// The height of the voted block.
@@ -33,6 +38,10 @@ pub struct VoteRecord {
     pub round: Round,
     /// The hash of the voted block.
     pub block_hash: CryptoHash,
+    /// The justification commitment the vote signed: the hash of the validated
+    /// quorum it cited, or `None` for a vote in the chain's first round (including
+    /// the fast round), which cites none.
+    pub justification_commitment: Option<CryptoHash>,
 }
 
 /// A confirmation vote together with the justification it cited. The

--- a/linera-chain/src/vote_ledger.rs
+++ b/linera-chain/src/vote_ledger.rs
@@ -35,19 +35,20 @@ pub struct VoteRecord {
     pub block_hash: CryptoHash,
 }
 
-/// A confirmation vote for a block that lost out at its height: either the
-/// validator later cast a justified confirmation vote for a different block at the
-/// same height, or a different block was confirmed there without the validator's
-/// vote.
+/// A confirmation vote together with the justification it cited. The
+/// justification is what distinguishes a legitimate re-vote from double-signing,
+/// so a vote must never be shown without it.
 ///
-/// The protocol allows both, so a superseded vote is not by itself evidence of
-/// double-signing — but only as long as it can be shown together with its
-/// justification. It is kept here because the certificate it cited is not
-/// otherwise retained once the chain moves on.
+/// In a [`LedgerEntry`] this is a *superseded* vote — one for a block that lost
+/// out at its height, either because the validator later cast a justified
+/// confirmation vote for a different block there, or because a different block was
+/// confirmed there without the validator's vote. The protocol allows both, and the
+/// certificate the vote cited is not otherwise retained once the chain moves on.
+/// In a commitment entry, the *committed* vote takes this form too.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
-pub struct SupersededVote {
-    /// The superseded vote.
+pub struct JustifiedVote {
+    /// The vote.
     pub record: VoteRecord,
     /// The validated-block certificate the vote cited, or `None` for a vote cast in
     /// a chain's first round, which cites no validated quorum.
@@ -71,5 +72,5 @@ pub struct LedgerEntry {
     /// The latest confirmation vote on this chain.
     pub latest: VoteRecord,
     /// Votes for blocks that lost out at their height.
-    pub superseded: Vec<SupersededVote>,
+    pub superseded: Vec<JustifiedVote>,
 }

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -7,6 +7,7 @@ use std::{collections::HashSet, sync::Arc};
 
 use linera_base::{crypto::ValidatorSecretKey, identifiers::ChainId, time::Duration};
 
+use super::SignatureFreezer;
 use crate::CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES;
 
 /// Configuration parameters for the chain worker and its owning
@@ -56,6 +57,10 @@ pub struct ChainWorkerConfig {
     /// mechanisms. If `None`, every chain is eligible (subject to the
     /// respective feature flag). If `Some`, only chains in the set are.
     pub recovery_whitelist: Option<HashSet<ChainId>>,
+    /// The barrier that stops the validator from signing votes in frozen epochs.
+    /// Cloning the config shares it, so all chain workers of a
+    /// [`WorkerState`][`crate::worker::WorkerState`] see the same frozen epochs.
+    pub freezer: SignatureFreezer,
 }
 
 impl ChainWorkerConfig {
@@ -98,6 +103,7 @@ impl Default for ChainWorkerConfig {
             allow_revert_confirm: false,
             reset_on_corrupted_chain_state: None,
             recovery_whitelist: None,
+            freezer: SignatureFreezer::default(),
         }
     }
 }

--- a/linera-core/src/chain_worker/freezer.rs
+++ b/linera-core/src/chain_worker/freezer.rs
@@ -45,6 +45,14 @@ impl SignatureFreezer {
             *max_frozen = Some(epoch);
         }
     }
+
+    /// Returns whether the given epoch is frozen.
+    pub(crate) async fn is_frozen(&self, epoch: Epoch) -> bool {
+        self.max_frozen
+            .read()
+            .await
+            .is_some_and(|max_frozen| epoch <= max_frozen)
+    }
 }
 
 /// Keeps signing open while alive: a freeze started while a `SigningGuard`

--- a/linera-core/src/chain_worker/freezer.rs
+++ b/linera-core/src/chain_worker/freezer.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A barrier that permanently stops a validator from signing votes in old epochs.
+
+use std::sync::Arc;
+
+use linera_base::data_types::Epoch;
+use tokio::sync::{OwnedRwLockReadGuard, RwLock};
+
+use crate::worker::WorkerError;
+
+/// Tracks the highest epoch whose signatures are frozen on this validator, and
+/// acts as a barrier between vote creation and freezing an epoch: every signing
+/// path holds a [`SigningGuard`] across its whole check-sign-record-save
+/// sequence, and [`SignatureFreezer::freeze`] returns only once all guards taken
+/// out before the freeze have been dropped. So after `freeze` returns, no vote in
+/// the frozen epochs can be created anymore, and every vote created before the
+/// call is fully persisted.
+///
+/// All chain workers of a validator process share one instance, via
+/// [`ChainWorkerConfig`](super::ChainWorkerConfig).
+#[derive(Clone, Debug, Default)]
+pub struct SignatureFreezer {
+    /// The highest frozen epoch; this epoch and all earlier ones are frozen.
+    max_frozen: Arc<RwLock<Option<Epoch>>>,
+}
+
+impl SignatureFreezer {
+    /// Checks that the given epoch is not frozen, and returns a guard that delays
+    /// any freeze until it is dropped.
+    pub(crate) async fn guard_signing(&self, epoch: Epoch) -> Result<SigningGuard, WorkerError> {
+        let guard = self.max_frozen.clone().read_owned().await;
+        match *guard {
+            Some(max_frozen) if epoch <= max_frozen => Err(WorkerError::VoteInFrozenEpoch(epoch)),
+            _ => Ok(SigningGuard { _guard: guard }),
+        }
+    }
+
+    /// Freezes the given epoch and all earlier ones, waiting for signing in
+    /// progress to complete.
+    pub(crate) async fn freeze(&self, epoch: Epoch) {
+        let mut max_frozen = self.max_frozen.write().await;
+        if max_frozen.is_none_or(|max| max < epoch) {
+            *max_frozen = Some(epoch);
+        }
+    }
+}
+
+/// Keeps signing open while alive: a freeze started while a `SigningGuard`
+/// exists completes only after the guard is dropped.
+pub(crate) struct SigningGuard {
+    _guard: OwnedRwLockReadGuard<Option<Epoch>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::future::poll_immediate;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_signature_freezer() {
+        let freezer = SignatureFreezer::default();
+        let epoch = Epoch::from(2);
+        let guard = freezer.guard_signing(epoch).await.unwrap();
+
+        // While a signing guard is alive, the freeze waits for it.
+        let mut freeze = Box::pin(freezer.freeze(epoch));
+        assert!(poll_immediate(&mut freeze).await.is_none());
+        drop(guard);
+        freeze.await;
+
+        // The frozen epoch and earlier ones are refused; later ones are open.
+        for frozen_epoch in [Epoch::ZERO, Epoch::from(1), epoch] {
+            assert!(matches!(
+                freezer.guard_signing(frozen_epoch).await,
+                Err(WorkerError::VoteInFrozenEpoch(_))
+            ));
+        }
+        freezer.guard_signing(Epoch::from(3)).await.unwrap();
+
+        // Freezing an earlier epoch does not lower the frozen boundary.
+        freezer.freeze(Epoch::from(1)).await;
+        assert!(freezer.guard_signing(epoch).await.is_err());
+        freezer.guard_signing(Epoch::from(3)).await.unwrap();
+    }
+}

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -5,9 +5,12 @@
 
 mod config;
 mod delivery_notifier;
+mod freezer;
 pub(crate) mod handle;
 pub(crate) mod state;
 
 pub(super) use self::delivery_notifier::DeliveryNotifier;
 pub(crate) use self::state::{BlockOutcome, CrossChainUpdateResult, EventSubscriptionsResult};
-pub use self::{config::ChainWorkerConfig, state::ProcessConfirmedBlockMode};
+pub use self::{
+    config::ChainWorkerConfig, freezer::SignatureFreezer, state::ProcessConfirmedBlockMode,
+};

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -341,9 +341,13 @@ where
             height: header.height,
             round: vote.round,
             block_hash: vote.value().hash(),
+            justification_commitment: vote.justification_commitment,
         };
         let justification = match self.chain.manager.locking_block.get() {
-            Some(LockingBlock::Regular(certificate)) if certificate.round == vote.round => {
+            Some(LockingBlock::Regular(certificate))
+                if vote.justification_commitment
+                    == Some(certificate.full_justification_commitment()) =>
+            {
                 Some(certificate.clone())
             }
             _ => None,
@@ -369,14 +373,15 @@ where
             (old, Some(new)) if old.as_ref().is_none_or(|old| old.record != new.record) => {
                 // A new confirmation vote was created. The old vote is superseded if
                 // it was for a different block at the same height. (A missing
-                // justification means the pairing was broken earlier and the pair is
-                // already in the ledger — don't overwrite it, unless the vote was a
-                // fast-round one, which never had a justification.)
+                // justification for a vote that cited one means the pairing was
+                // broken earlier and the pair is already in the ledger — don't
+                // overwrite it.)
                 let superseded = old
                     .filter(|old| {
                         old.record.height == new.record.height
                             && old.record.block_hash != new.record.block_hash
-                            && (old.justification.is_some() || old.record.round.is_fast())
+                            && (old.justification.is_some()
+                                || old.record.justification_commitment.is_none())
                     })
                     .map(|old| JustifiedVote {
                         record: old.record,
@@ -410,12 +415,15 @@ where
         Ok(())
     }
 
-    /// If this validator's pending confirmation vote is for a different block than
-    /// the confirmed one about to be executed, persists it in the vote ledger: the
-    /// chain is moving past the vote's height, and the manager state holding the
-    /// vote and its justification is about to be cleared. (As in
-    /// `reconcile_vote_ledger`, a round-based vote without its justification is
-    /// already in the ledger and must not be overwritten.)
+    /// If this validator's pending confirmation vote would become unrecoverable
+    /// once the confirmed block about to be executed clears the manager state,
+    /// persists it in the vote ledger. That is the case when a different block was
+    /// confirmed at the vote's height (the vote was bypassed), and also when the
+    /// vote is for the confirmed block itself but the certificate's justification
+    /// chain does not contain the quorum the vote cited — then the certificate
+    /// cannot reproduce it later. (As in `reconcile_vote_ledger`, a vote whose
+    /// justification pairing was broken earlier is already in the ledger and must
+    /// not be overwritten.)
     async fn record_bypassed_vote(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -423,9 +431,18 @@ where
         let Some(old) = self.pending_confirmed_vote() else {
             return Ok(());
         };
-        if old.record.block_hash == certificate.hash()
-            || (old.justification.is_none() && !old.record.round.is_fast())
-        {
+        if old.record.block_hash == certificate.hash() {
+            let recoverable_from_certificate = match old.record.justification_commitment {
+                None => true, // The vote cited nothing; the latest-vote entry suffices.
+                Some(commitment) => certificate
+                    .cited_validated_certificate(commitment)
+                    .is_some(),
+            };
+            if recoverable_from_certificate {
+                return Ok(());
+            }
+        }
+        if old.justification.is_none() && old.record.justification_commitment.is_some() {
             return Ok(());
         }
         self.storage

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -268,9 +268,10 @@ where
     }
 
     /// Filters bundles destined for this chain to drop ones already received and to refuse
-    /// ones whose epoch has been revoked on the admin chain.
+    /// ones whose epoch has settled on the admin chain (a quorum of the next epoch's
+    /// commitments; revocation alone leaves the committee bonded and its bundles trusted).
     ///
-    /// A revoked-epoch bundle is still accepted if (a) it has already been executed by
+    /// A settled-epoch bundle is still accepted if (a) it has already been executed by
     /// anticipation (`bundle.height <= last_anticipated_block_height`), or (b) a later
     /// bundle in the same batch is in a still-trusted epoch — that bundle's certificate
     /// transitively re-certifies all preceding ones via prev-hash chaining.
@@ -294,9 +295,9 @@ where
             if bundle.height < next_height_to_receive {
                 skipped_len = i + 1;
             }
-            let is_revoked = self
+            let is_settled = self
                 .storage
-                .is_epoch_revoked(*epoch)
+                .is_epoch_settled(*epoch)
                 .await
                 .map_err(|error| {
                     WorkerError::ChainError(Box::new(ChainError::ExecutionError(
@@ -304,7 +305,7 @@ where
                         ChainExecutionContext::Block,
                     )))
                 })?;
-            if !is_revoked || Some(bundle.height) <= last_anticipated_block_height {
+            if !is_settled || Some(bundle.height) <= last_anticipated_block_height {
                 trusted_len = i + 1;
             }
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1024,6 +1024,7 @@ where
             .filter_map(|(blob_id, maybe_blob)| Some((blob_id, maybe_blob?)))
             .collect();
         let old_round = self.chain.manager.current_round();
+        let signing_guard = self.config.freezer.guard_signing(epoch).await?;
         let old_vote = self.pending_confirmed_vote();
         self.chain.manager.create_final_vote(
             certificate,
@@ -1033,6 +1034,7 @@ where
         )?;
         self.reconcile_vote_ledger(old_vote).await?;
         self.save().await?;
+        drop(signing_guard);
         let actions = self.create_network_actions(Some(old_round)).await?;
         Ok((
             self.chain_info_response().await?,
@@ -2215,13 +2217,14 @@ where
                 found_block_height: height
             }
         );
-        let epoch = chain.execution_state.system.epoch.get();
+        let epoch = *chain.execution_state.system.epoch.get();
         let chain_id = chain.chain_id();
         let key_pair = self.config.key_pair();
         let local_time = self.storage.clock().current_time();
+        let _signing_guard = self.config.freezer.guard_signing(epoch).await?;
         if chain
             .manager
-            .create_timeout_vote(chain_id, height, round, *epoch, key_pair, local_time)?
+            .create_timeout_vote(chain_id, height, round, epoch, key_pair, local_time)?
         {
             self.save().await?;
         }
@@ -2264,6 +2267,7 @@ where
             let chain_id = chain.chain_id();
             let height = chain.tip_state.get().next_block_height;
             let key_pair = self.config.key_pair();
+            let _signing_guard = self.config.freezer.guard_signing(epoch).await?;
             if chain
                 .manager
                 .vote_fallback(chain_id, height, epoch, key_pair)
@@ -2681,6 +2685,7 @@ where
         let blobs = self
             .get_required_blobs(proposal.expected_blob_ids(), block.created_blobs())
             .await?;
+        let signing_guard = self.config.freezer.guard_signing(epoch).await?;
         let old_vote = self.pending_confirmed_vote();
         let key_pair = self.config.key_pair();
         let manager = &mut self.chain.manager;
@@ -2698,6 +2703,7 @@ where
         }
         self.reconcile_vote_ledger(old_vote).await?;
         self.save().await?;
+        drop(signing_guard);
         let actions = self.create_network_actions(Some(old_round)).await?;
         Ok((self.chain_info_response().await?, actions))
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -28,6 +28,7 @@ use linera_chain::{
         BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
         OriginalProposal, ProposalContent, ProposedBlock,
     },
+    epoch_commitment::{CommitmentChunk, CommitmentEntry},
     manager::{self, LockingBlock, ManagerSafetySnapshot},
     types::{
         Block, CertificateValue as _, ConfirmedBlock, ConfirmedBlockCertificate,
@@ -38,8 +39,11 @@ use linera_chain::{
     ChainTipState, ExecutionResultExt as _, StreamCounts,
 };
 use linera_execution::{
-    system::{EpochEventData, EventSubscriptions, EPOCH_STREAM_NAME},
-    ExecutionRuntimeContext as _, ExecutionStateView, Query, QueryContext, QueryOutcome,
+    committee::Committee,
+    system::{
+        AdminOperation, EpochEventData, EventSubscriptions, SystemOperation, EPOCH_STREAM_NAME,
+    },
+    ExecutionRuntimeContext as _, ExecutionStateView, Operation, Query, QueryContext, QueryOutcome,
     ResourceTracker, ServiceRuntimeEndpoint,
 };
 use linera_storage::{Clock as _, Storage};
@@ -455,6 +459,114 @@ where
                 },
             )
             .await?;
+        Ok(())
+    }
+
+    /// Verifies the epoch commitments registered by the block's
+    /// `RegisterCommitment` operations, against this worker's own storage: every
+    /// vote must carry exactly the justification it signed, verified against the
+    /// revoked epoch's committee, and the committed block must be grounded in a
+    /// certified parent. Data this worker is missing surfaces as
+    /// `BlocksNotFound`, so the proposing client can push it — validators never
+    /// fetch. Execution itself only checks the manifest (signature, membership,
+    /// blob presence); this is the deep check that runs before this worker signs
+    /// a vote for the block.
+    async fn check_epoch_commitments<'a>(
+        &self,
+        operations: impl Iterator<Item = &'a Operation>,
+        blobs: &BTreeMap<BlobId, &Blob>,
+    ) -> Result<(), WorkerError> {
+        for operation in operations {
+            let Operation::System(operation) = operation else {
+                continue;
+            };
+            let SystemOperation::Admin(AdminOperation::RegisterCommitment { manifest }) =
+                &**operation
+            else {
+                continue;
+            };
+            let epoch = manifest.manifest.epoch;
+            let committee = self.committee_for_epoch(epoch).await?;
+            // Entries must be strictly sorted by serialized chain ID across the
+            // whole commitment: the canonical form, and no chain appears twice.
+            let mut previous_chain = None;
+            for blob_hash in &manifest.manifest.blob_hashes {
+                let blob_id = BlobId::new(*blob_hash, BlobType::EpochCommitment);
+                let chunk = match blobs.get(&blob_id) {
+                    Some(blob) => bcs::from_bytes::<CommitmentChunk>(blob.bytes())?,
+                    None => {
+                        let Some(blob) = self.storage.read_blob(blob_id).await? else {
+                            return Err(WorkerError::BlobsNotFound(vec![blob_id]));
+                        };
+                        bcs::from_bytes::<CommitmentChunk>(blob.bytes())?
+                    }
+                };
+                for entry in &chunk.entries {
+                    let chain_key = bcs::to_bytes(&entry.chain_id)?;
+                    ensure!(
+                        previous_chain.as_ref() < Some(&chain_key),
+                        WorkerError::InvalidEpochCommitment("entries are not sorted by chain ID")
+                    );
+                    previous_chain = Some(chain_key);
+                    self.check_commitment_entry(entry, &committee).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Verifies one commitment entry: the committed and superseded votes with
+    /// their justifications, their mutual consistency, and the committed block's
+    /// grounding in a certified parent block.
+    async fn check_commitment_entry(
+        &self,
+        entry: &CommitmentEntry,
+        committee: &Committee,
+    ) -> Result<(), WorkerError> {
+        let committed = &entry.committed.record;
+        check_justified_vote(&entry.committed, committee)?;
+        if let Some(justification) = &entry.committed.justification {
+            // Grounding: the committed block's parent must be certified. The
+            // justification carries the committed block itself, so the parent
+            // link can be checked. (A first-round vote cites no justification;
+            // grounding it — like verifying the creation edge of a block at
+            // height zero — needs the block or chain description pushed
+            // separately and is not implemented yet.)
+            let header = &justification.block().header;
+            ensure!(
+                header.chain_id == entry.chain_id && header.height == committed.height,
+                WorkerError::InvalidEpochCommitment(
+                    "the justification is for a different chain or height"
+                )
+            );
+            if let Some(parent_hash) = header.previous_block_hash {
+                let Some(parent) = self.storage.read_certificate(parent_hash).await? else {
+                    return Err(WorkerError::BlocksNotFound(vec![parent_hash]));
+                };
+                let parent_header = &parent.block().header;
+                ensure!(
+                    parent_header.chain_id == entry.chain_id
+                        && parent_header.height.try_add_one()? == committed.height,
+                    WorkerError::InvalidEpochCommitment(
+                        "the committed block's parent is not the previous block"
+                    )
+                );
+            }
+        }
+        for superseded in &entry.superseded {
+            check_justified_vote(superseded, committee)?;
+            // A superseded vote lies at or below the committed height; at the
+            // same height, the committed vote must be from a later round — the
+            // justified re-vote that superseded it.
+            let record = &superseded.record;
+            ensure!(
+                record.height < committed.height
+                    || (record.height == committed.height && record.round < committed.round),
+                WorkerError::InvalidEpochCommitment(
+                    "a superseded vote is not below the committed vote"
+                )
+            );
+        }
         Ok(())
     }
 
@@ -1039,7 +1151,10 @@ where
         let blobs = maybe_blobs
             .into_iter()
             .filter_map(|(blob_id, maybe_blob)| Some((blob_id, maybe_blob?)))
-            .collect();
+            .collect::<BTreeMap<_, _>>();
+        let provided_blobs = blobs.iter().map(|(id, blob)| (*id, blob)).collect();
+        self.check_epoch_commitments(block.body.operations(), &provided_blobs)
+            .await?;
         let old_round = self.chain.manager.current_round();
         let signing_guard = self.config.freezer.guard_signing(epoch).await?;
         let old_vote = self.pending_confirmed_vote();
@@ -2659,6 +2774,13 @@ where
             outcome,
         } = content;
 
+        let provided_blobs = published_blobs
+            .iter()
+            .map(|blob| (blob.id(), blob))
+            .collect::<BTreeMap<_, _>>();
+        self.check_epoch_commitments(block.operations(), &provided_blobs)
+            .await?;
+
         if self.config.key_pair().is_some()
             && block.timestamp.duration_since(local_time) > self.config.block_time_grace_period
         {
@@ -3016,6 +3138,37 @@ struct PendingConfirmedVote {
     record: VoteRecord,
     /// The validated-block certificate the vote cited, if any.
     justification: Option<ValidatedBlockCertificate>,
+}
+
+/// Verifies that a committed or superseded vote carries exactly the
+/// justification it signed: the certificate is for the voted block and round,
+/// its commitment is the one the vote's signature covers, and its quorum
+/// verifies against the epoch's committee. A vote that signed no justification
+/// commitment must carry none.
+fn check_justified_vote(vote: &JustifiedVote, committee: &Committee) -> Result<(), WorkerError> {
+    match (&vote.justification, vote.record.justification_commitment) {
+        (Some(certificate), Some(commitment)) => {
+            ensure!(
+                certificate.hash() == vote.record.block_hash
+                    && certificate.round == vote.record.round,
+                WorkerError::InvalidEpochCommitment(
+                    "the justification is not for the voted block and round"
+                )
+            );
+            ensure!(
+                certificate.full_justification_commitment() == commitment,
+                WorkerError::InvalidEpochCommitment(
+                    "the justification is not the quorum the vote signed"
+                )
+            );
+            certificate.check(committee)?;
+            Ok(())
+        }
+        (None, None) => Ok(()),
+        _ => Err(WorkerError::InvalidEpochCommitment(
+            "a vote and its justification do not match",
+        )),
+    }
 }
 
 /// Returns an error if the block is not at the expected epoch.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -28,11 +28,12 @@ use linera_chain::{
         BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
         OriginalProposal, ProposalContent, ProposedBlock,
     },
-    manager::{self, ManagerSafetySnapshot},
+    manager::{self, LockingBlock, ManagerSafetySnapshot},
     types::{
-        Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
-        ValidatedBlockCertificate,
+        Block, CertificateValue as _, ConfirmedBlock, ConfirmedBlockCertificate,
+        TimeoutCertificate, ValidatedBlockCertificate,
     },
+    vote_ledger::{SupersededVote, VoteRecord},
     BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
     ChainTipState, ExecutionResultExt as _, StreamCounts,
 };
@@ -326,6 +327,118 @@ where
         } else {
             vec![]
         })
+    }
+
+    /// Returns this validator's pending confirmation vote, paired with the
+    /// justification it cited: the manager's locking certificate, if the vote was
+    /// based on one. The pairing only holds while the locking certificate is still
+    /// the one the vote cited, which its round tells us; fast-round votes cite no
+    /// certificate.
+    fn pending_confirmed_vote(&self) -> Option<PendingConfirmedVote> {
+        let vote = self.chain.manager.confirmed_vote()?;
+        let header = &vote.value().block().header;
+        let record = VoteRecord {
+            height: header.height,
+            round: vote.round,
+            block_hash: vote.value().hash(),
+        };
+        let justification = match self.chain.manager.locking_block.get() {
+            Some(LockingBlock::Regular(certificate)) if certificate.round == vote.round => {
+                Some(certificate.clone())
+            }
+            _ => None,
+        };
+        Some(PendingConfirmedVote {
+            epoch: header.epoch,
+            record,
+            justification,
+        })
+    }
+
+    /// Brings the vote ledger up to date after a manager operation that may have
+    /// created a confirmation vote, or overwritten the previous vote or the locking
+    /// certificate it cited. `old_vote` must be captured before the operation, and
+    /// this must be called before the chain state is saved, so that no vote can
+    /// leave this worker without being in the ledger.
+    async fn reconcile_vote_ledger(
+        &self,
+        old_vote: Option<PendingConfirmedVote>,
+    ) -> Result<(), WorkerError> {
+        let new_vote = self.pending_confirmed_vote();
+        match (old_vote, new_vote) {
+            (old, Some(new)) if old.as_ref().is_none_or(|old| old.record != new.record) => {
+                // A new confirmation vote was created. The old vote is superseded if
+                // it was for a different block at the same height. (A missing
+                // justification means the pairing was broken earlier and the pair is
+                // already in the ledger — don't overwrite it, unless the vote was a
+                // fast-round one, which never had a justification.)
+                let superseded = old
+                    .filter(|old| {
+                        old.record.height == new.record.height
+                            && old.record.block_hash != new.record.block_hash
+                            && (old.justification.is_some() || old.record.round.is_fast())
+                    })
+                    .map(|old| SupersededVote {
+                        record: old.record,
+                        justification: old.justification,
+                    });
+                self.storage
+                    .record_confirmed_vote(new.epoch, self.chain_id(), new.record, superseded)
+                    .await?;
+            }
+            (Some(old), new) => {
+                // The vote is unchanged, but the manager may have stopped pairing it
+                // with its justification — e.g. the locking certificate was replaced
+                // by a newer one without a new vote being cast. Then the ledger is
+                // the pairing's only remaining home.
+                if old.justification.is_some() && new.is_none_or(|new| new.justification.is_none())
+                {
+                    self.storage
+                        .record_superseded_vote(
+                            old.epoch,
+                            self.chain_id(),
+                            SupersededVote {
+                                record: old.record,
+                                justification: old.justification,
+                            },
+                        )
+                        .await?;
+                }
+            }
+            (None, _) => {}
+        }
+        Ok(())
+    }
+
+    /// If this validator's pending confirmation vote is for a different block than
+    /// the confirmed one about to be executed, persists it in the vote ledger: the
+    /// chain is moving past the vote's height, and the manager state holding the
+    /// vote and its justification is about to be cleared. (As in
+    /// `reconcile_vote_ledger`, a round-based vote without its justification is
+    /// already in the ledger and must not be overwritten.)
+    async fn record_bypassed_vote(
+        &self,
+        certificate: &ConfirmedBlockCertificate,
+    ) -> Result<(), WorkerError> {
+        let Some(old) = self.pending_confirmed_vote() else {
+            return Ok(());
+        };
+        if old.record.block_hash == certificate.hash()
+            || (old.justification.is_none() && !old.record.round.is_fast())
+        {
+            return Ok(());
+        }
+        self.storage
+            .record_superseded_vote(
+                old.epoch,
+                self.chain_id(),
+                SupersededVote {
+                    record: old.record,
+                    justification: old.justification,
+                },
+            )
+            .await?;
+        Ok(())
     }
 
     /// Returns whether this chain is known to be active (initialized).
@@ -911,12 +1024,14 @@ where
             .filter_map(|(blob_id, maybe_blob)| Some((blob_id, maybe_blob?)))
             .collect();
         let old_round = self.chain.manager.current_round();
+        let old_vote = self.pending_confirmed_vote();
         self.chain.manager.create_final_vote(
             certificate,
             self.config.key_pair(),
             self.storage.clock().current_time(),
             blobs,
         )?;
+        self.reconcile_vote_ledger(old_vote).await?;
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
         Ok((
@@ -1128,6 +1243,8 @@ where
                 inbox_cursors.clone(),
             )
         };
+        self.record_bypassed_vote(&certificate).await?;
+
         // Every pre-checkpoint sender block the oracle response names must already
         // be in storage before we touch any chain state. If some aren't, record
         // their hashes as trusted-by-this-checkpoint and error with `BlocksNotFound`
@@ -1266,6 +1383,8 @@ where
         self.initialize_and_save_if_needed().await?;
         let (epoch, _) = self.chain.current_committee().await?;
         check_block_epoch(epoch, chain_id, block.header.epoch)?;
+
+        self.record_bypassed_vote(&certificate).await?;
 
         // The chain is initialized and this block has not executed yet, so the current ownership
         // is the configuration the block was proposed under — even for the chain's first block,
@@ -2562,6 +2681,7 @@ where
         let blobs = self
             .get_required_blobs(proposal.expected_blob_ids(), block.created_blobs())
             .await?;
+        let old_vote = self.pending_confirmed_vote();
         let key_pair = self.config.key_pair();
         let manager = &mut self.chain.manager;
         match manager.create_vote(&proposal, block, key_pair, local_time, blobs)? {
@@ -2576,6 +2696,7 @@ where
             }
             None => (),
         }
+        self.reconcile_vote_ledger(old_vote).await?;
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
         Ok((self.chain_info_response().await?, actions))
@@ -2861,6 +2982,17 @@ fn missing_blob_ids<'a>(
         .filter(|(_, maybe_blob)| maybe_blob.is_none())
         .map(|(blob_id, _)| *blob_id)
         .collect()
+}
+
+/// A pending confirmation vote paired with the justification it cited, captured
+/// from the chain manager before an operation that may overwrite either.
+struct PendingConfirmedVote {
+    /// The epoch of the voted block.
+    epoch: Epoch,
+    /// The vote, as recorded in the vote ledger.
+    record: VoteRecord,
+    /// The validated-block certificate the vote cited, if any.
+    justification: Option<ValidatedBlockCertificate>,
 }
 
 /// Returns an error if the block is not at the expected epoch.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -33,7 +33,7 @@ use linera_chain::{
         Block, CertificateValue as _, ConfirmedBlock, ConfirmedBlockCertificate,
         TimeoutCertificate, ValidatedBlockCertificate,
     },
-    vote_ledger::{SupersededVote, VoteRecord},
+    vote_ledger::{JustifiedVote, VoteRecord},
     BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
     ChainTipState, ExecutionResultExt as _, StreamCounts,
 };
@@ -378,7 +378,7 @@ where
                             && old.record.block_hash != new.record.block_hash
                             && (old.justification.is_some() || old.record.round.is_fast())
                     })
-                    .map(|old| SupersededVote {
+                    .map(|old| JustifiedVote {
                         record: old.record,
                         justification: old.justification,
                     });
@@ -397,7 +397,7 @@ where
                         .record_superseded_vote(
                             old.epoch,
                             self.chain_id(),
-                            SupersededVote {
+                            JustifiedVote {
                                 record: old.record,
                                 justification: old.justification,
                             },
@@ -432,7 +432,7 @@ where
             .record_superseded_vote(
                 old.epoch,
                 self.chain_id(),
-                SupersededVote {
+                JustifiedVote {
                     record: old.record,
                     justification: old.justification,
                 },

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -470,12 +470,16 @@ where
     /// `BlocksNotFound`, so the proposing client can push it — validators never
     /// fetch. Execution itself only checks the manifest (signature, membership,
     /// blob presence); this is the deep check that runs before this worker signs
-    /// a vote for the block.
+    /// a vote for the block — a node without a validator key creates no votes
+    /// and skips it, since it may not hold the other chains' certificates.
     async fn check_epoch_commitments<'a>(
         &self,
         operations: impl Iterator<Item = &'a Operation>,
         blobs: &BTreeMap<BlobId, &Blob>,
     ) -> Result<(), WorkerError> {
+        if self.config.key_pair().is_none() {
+            return Ok(());
+        }
         for operation in operations {
             let Operation::System(operation) = operation else {
                 continue;
@@ -2957,6 +2961,9 @@ where
         }
         if query.request_latest_checkpoint_height {
             info.requested_latest_checkpoint_height = *self.chain.latest_checkpoint_height.get();
+        }
+        if query.request_pending_commitments {
+            info.requested_pending_commitments = self.storage.pending_commitments().await?;
         }
         Ok(ChainInfoResponse::new(info, self.config.key_pair()))
     }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -21,7 +21,8 @@ use linera_base::{
     crypto::{signer, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlobContent,
-        BlockHeight, ChainDescription, Epoch, MessagePolicy, Round, TimeDelta, Timestamp,
+        BlockHeight, ChainDescription, Epoch, MessagePolicy, Round, SignedCommitmentManifest,
+        TimeDelta, Timestamp,
     },
     ensure,
     identifiers::{
@@ -48,8 +49,8 @@ use linera_chain::{
 use linera_execution::{
     committee::Committee,
     system::{
-        AdminOperation, OpenChainConfig, SystemOperation, EPOCH_STREAM_NAME,
-        REMOVED_EPOCH_STREAM_NAME,
+        AdminOperation, OpenChainConfig, SystemOperation, COMMITMENT_STREAM_NAME,
+        EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
     },
     ExecutionError, Operation, Query, QueryOutcome,
 };
@@ -2945,6 +2946,77 @@ impl<Env: Environment> ChainClient<Env> {
         }
         ensure!(!operations.is_empty(), Error::EpochAlreadyRevoked);
         self.execute_operations(operations, vec![]).await
+    }
+
+    /// Registers validators' pending epoch commitments on the admin chain:
+    /// queries every current validator for the signed commitment manifests it
+    /// holds, downloads their blobs, and publishes the ones not registered yet.
+    /// Unreachable validators are skipped — their commitments are picked up by a
+    /// later call. Returns the number of newly registered commitments.
+    #[instrument(level = "trace")]
+    pub async fn register_commitments(&self) -> Result<ClientOutcome<usize>, Error> {
+        self.prepare_chain().await?;
+        let registered = self
+            .events_from_index(StreamId::system(COMMITMENT_STREAM_NAME), 0)
+            .await?
+            .into_iter()
+            .map(|index_and_event| {
+                let manifest: SignedCommitmentManifest = bcs::from_bytes(&index_and_event.event)?;
+                Ok((manifest.manifest.epoch, manifest.manifest.validator))
+            })
+            .collect::<Result<BTreeSet<_>, bcs::Error>>()?;
+        // Collect each validator's pending manifests and their blobs, concurrently.
+        let nodes = self.client.validator_nodes().await?;
+        let query = ChainInfoQuery::new(self.chain_id).with_pending_commitments();
+        let collected = future::join_all(nodes.iter().map(|remote| {
+            let query = query.clone();
+            async move {
+                let response = remote.node.handle_chain_info_query(query).await.ok()?;
+                let mut result = Vec::new();
+                'manifests: for manifest in response.info.requested_pending_commitments {
+                    if manifest.check().is_err() {
+                        continue;
+                    }
+                    let mut blobs = Vec::new();
+                    for blob_hash in &manifest.manifest.blob_hashes {
+                        let blob_id = BlobId::new(*blob_hash, BlobType::EpochCommitment);
+                        let Ok(content) = remote.node.download_blob(blob_id).await else {
+                            continue 'manifests;
+                        };
+                        let blob = Blob::new(content);
+                        if blob.id() != blob_id {
+                            continue 'manifests;
+                        }
+                        blobs.push(blob);
+                    }
+                    result.push((manifest, blobs));
+                }
+                Some(result)
+            }
+        }))
+        .await;
+        let mut operations = Vec::new();
+        let mut blobs = Vec::new();
+        let mut seen = registered;
+        for (manifest, manifest_blobs) in collected.into_iter().flatten().flatten() {
+            if !seen.insert((manifest.manifest.epoch, manifest.manifest.validator)) {
+                continue;
+            }
+            operations.push(Operation::system(SystemOperation::Admin(
+                AdminOperation::RegisterCommitment {
+                    manifest: Box::new(manifest),
+                },
+            )));
+            blobs.extend(manifest_blobs);
+        }
+        if operations.is_empty() {
+            return Ok(ClientOutcome::Committed(0));
+        }
+        let count = operations.len();
+        Ok(self
+            .execute_operations(operations, blobs)
+            .await?
+            .map(|_| count))
     }
 
     /// Sends money to a chain.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2071,7 +2071,10 @@ impl<Env: Environment> Client<Env> {
         let view_err = |error: ExecutionError| NodeError::ViewError {
             error: error.to_string(),
         };
-        if storage.is_epoch_revoked(epoch).await.map_err(view_err)? {
+        // A revoked epoch's certificates stay acceptable until the epoch settles —
+        // a quorum of the next epoch's commitments — because its committee is still
+        // bonded until then. After settlement, only covered blocks are trusted.
+        if storage.is_epoch_settled(epoch).await.map_err(view_err)? {
             return Ok(CheckCertificateResult::OldEpoch);
         }
         let Some(committee) = storage.committee_for_epoch(epoch).await.map_err(view_err)? else {

--- a/linera-core/src/commitment.rs
+++ b/linera-core/src/commitment.rs
@@ -127,7 +127,9 @@ where
     S: Storage,
     C: ShardControl,
 {
-    /// Creates an agent committing in the given validator's name.
+    /// Creates an agent committing in the given validator's name. Commitment
+    /// blobs are capped at `max_chunk_bytes` or the committee policy's maximum
+    /// blob size, whichever is lower.
     pub fn new(
         storage: S,
         shards: C,
@@ -172,13 +174,19 @@ where
         if !committee.validators().contains_key(&self.validator) {
             return Ok(false);
         }
+        // Chunks must satisfy the blob size limit at publication time; the margin
+        // leaves room for the chunk's own length prefix.
+        let policy_chunk_bytes = usize::try_from(committee.policy().maximum_blob_size)
+            .unwrap_or(usize::MAX)
+            .saturating_sub(16);
+        let max_chunk_bytes = self.max_chunk_bytes.min(policy_chunk_bytes);
         self.shards.freeze_epoch(epoch).await?;
         let assembled = assemble_commitment(
             &self.storage,
             &self.shards,
             epoch,
             self.validator,
-            self.max_chunk_bytes,
+            max_chunk_bytes,
         )
         .await?;
         let signature = self

--- a/linera-core/src/commitment.rs
+++ b/linera-core/src/commitment.rs
@@ -6,13 +6,11 @@
 
 use linera_base::{
     crypto::{ValidatorPublicKey, ValidatorSignature},
-    data_types::{ArithmeticError, Blob, Epoch},
+    data_types::{ArithmeticError, Blob, CommitmentManifest, Epoch, SignedCommitmentManifest},
     identifiers::ChainId,
 };
 use linera_chain::{
-    epoch_commitment::{
-        CommitmentChunk, CommitmentEntry, CommitmentManifest, SignedCommitmentManifest,
-    },
+    epoch_commitment::{CommitmentChunk, CommitmentEntry},
     manager::LockingBlock,
     vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
 };

--- a/linera-core/src/commitment.rs
+++ b/linera-core/src/commitment.rs
@@ -1,0 +1,138 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Assembly of a validator's epoch commitment from its vote ledger.
+
+use linera_base::{
+    crypto::ValidatorPublicKey,
+    data_types::{Blob, Epoch},
+    identifiers::ChainId,
+};
+use linera_chain::{
+    epoch_commitment::{CommitmentChunk, CommitmentEntry, CommitmentManifest},
+    manager::LockingBlock,
+    vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
+};
+use linera_storage::Storage;
+
+use crate::worker::WorkerError;
+
+/// A commitment assembled from the vote ledger, ready to be signed.
+pub struct AssembledCommitment {
+    /// The blobs holding the commitment's chunks.
+    pub blobs: Vec<Blob>,
+    /// The manifest listing them.
+    pub manifest: CommitmentManifest,
+}
+
+/// Assembles this validator's commitment for the given epoch from the vote
+/// ledger, chunked into blobs of at most roughly `max_chunk_bytes` each (a single
+/// oversized entry still becomes its own chunk).
+///
+/// This must only run after the epoch has been frozen on every worker sharing the
+/// storage: the freeze is what makes the ledger complete, and it keeps a pending
+/// latest vote from being bypassed unrecorded while we read.
+pub async fn assemble_commitment<S: Storage>(
+    storage: &S,
+    epoch: Epoch,
+    validator: ValidatorPublicKey,
+    max_chunk_bytes: usize,
+) -> Result<AssembledCommitment, WorkerError> {
+    let mut chunks = Vec::new();
+    let mut entries = Vec::new();
+    let mut entries_bytes = 0;
+    // The chain IDs are sorted by their serialized form, so the entries end up
+    // sorted across the whole commitment.
+    for chain_id in storage.vote_ledger_chain_ids(epoch).await? {
+        let ledger_entry = storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .ok_or(WorkerError::MissingVoteJustification(chain_id))?;
+        let entry = commitment_entry(storage, chain_id, ledger_entry).await?;
+        let entry_bytes = bcs::serialized_size(&entry)?;
+        if !entries.is_empty() && entries_bytes + entry_bytes > max_chunk_bytes {
+            chunks.push(CommitmentChunk {
+                entries: std::mem::take(&mut entries),
+            });
+            entries_bytes = 0;
+        }
+        entries_bytes += entry_bytes;
+        entries.push(entry);
+    }
+    if !entries.is_empty() {
+        chunks.push(CommitmentChunk { entries });
+    }
+    let blobs = chunks
+        .iter()
+        .map(|chunk| Ok(Blob::new_epoch_commitment(bcs::to_bytes(chunk)?)))
+        .collect::<Result<Vec<_>, bcs::Error>>()?;
+    let manifest = CommitmentManifest {
+        epoch,
+        validator,
+        blob_hashes: blobs.iter().map(|blob| blob.id().hash).collect(),
+    };
+    Ok(AssembledCommitment { blobs, manifest })
+}
+
+/// Builds the commitment entry for one chain: the ledger entry with the latest
+/// vote's justification recovered.
+async fn commitment_entry<S: Storage>(
+    storage: &S,
+    chain_id: ChainId,
+    ledger_entry: LedgerEntry,
+) -> Result<CommitmentEntry, WorkerError> {
+    let LedgerEntry {
+        latest,
+        mut superseded,
+    } = ledger_entry;
+    let justification = match latest.justification_commitment {
+        None => None, // The vote cited nothing (fast or first round).
+        Some(_) => {
+            // If the vote's height was passed while the certificate could not
+            // reproduce the cited quorum, the pair was recorded alongside the
+            // superseded votes; it is the committed vote, not a superseded one.
+            if let Some(index) = superseded.iter().position(|vote| vote.record == latest) {
+                superseded.remove(index).justification
+            } else {
+                Some(recover_justification(storage, chain_id, &latest).await?)
+            }
+        }
+    };
+    if justification.is_none() && latest.justification_commitment.is_some() {
+        return Err(WorkerError::MissingVoteJustification(chain_id));
+    }
+    Ok(CommitmentEntry {
+        chain_id,
+        committed: JustifiedVote {
+            record: latest,
+            justification,
+        },
+        superseded,
+    })
+}
+
+/// Recovers the validated certificate the latest vote cited: from the chain
+/// manager's locking certificate if the vote is still pending at the tip, or from
+/// the stored confirmed certificate's justification chain if the voted block was
+/// finalized.
+async fn recover_justification<S: Storage>(
+    storage: &S,
+    chain_id: ChainId,
+    latest: &VoteRecord,
+) -> Result<linera_chain::types::ValidatedBlockCertificate, WorkerError> {
+    let commitment = latest
+        .justification_commitment
+        .expect("only called for votes that cited a quorum");
+    let chain = storage.load_chain(chain_id).await?;
+    if let Some(LockingBlock::Regular(certificate)) = chain.manager.locking_block.get() {
+        if certificate.full_justification_commitment() == commitment {
+            return Ok(certificate.clone());
+        }
+    }
+    if let Some(certificate) = storage.read_certificate(latest.block_hash).await? {
+        if let Some(cited) = certificate.cited_validated_certificate(commitment) {
+            return Ok(cited);
+        }
+    }
+    Err(WorkerError::MissingVoteJustification(chain_id))
+}

--- a/linera-core/src/commitment.rs
+++ b/linera-core/src/commitment.rs
@@ -22,7 +22,10 @@ use linera_views::ViewError;
 use thiserror::Error;
 use tracing::info;
 
-use crate::worker::{WorkerError, WorkerState};
+use crate::{
+    data_types::ChainInfoQuery,
+    worker::{WorkerError, WorkerState},
+};
 
 /// An error while assembling or driving an epoch commitment.
 #[derive(Debug, Error)]
@@ -39,6 +42,9 @@ pub enum CommitmentError {
     /// An epoch number overflowed.
     #[error(transparent)]
     Arithmetic(#[from] ArithmeticError),
+    /// A serialization error.
+    #[error(transparent)]
+    Bcs(#[from] bcs::Error),
     /// A shard could not be reached or refused the request.
     #[error("Shard request failed: {0}")]
     Shard(String),
@@ -66,6 +72,14 @@ pub trait ShardControl {
         &self,
         manifest: &CommitmentManifest,
     ) -> Result<ValidatorSignature, CommitmentError>;
+
+    /// Returns the chain manager's current locking block, obtained from the
+    /// chain worker responsible for the chain — only that worker may access the
+    /// chain's state.
+    async fn locking_block(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<Option<LockingBlock>, CommitmentError>;
 }
 
 impl<S> ShardControl for WorkerState<S>
@@ -81,6 +95,15 @@ where
         manifest: &CommitmentManifest,
     ) -> Result<ValidatorSignature, CommitmentError> {
         Ok(WorkerState::sign_commitment_manifest(self, manifest).await?)
+    }
+
+    async fn locking_block(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<Option<LockingBlock>, CommitmentError> {
+        let query = ChainInfoQuery::new(chain_id).with_manager_values();
+        let response = self.handle_chain_info_query(query).await?;
+        Ok(response.info.manager.requested_locking.map(|boxed| *boxed))
     }
 }
 
@@ -150,8 +173,14 @@ where
             return Ok(false);
         }
         self.shards.freeze_epoch(epoch).await?;
-        let assembled =
-            assemble_commitment(&self.storage, epoch, self.validator, self.max_chunk_bytes).await?;
+        let assembled = assemble_commitment(
+            &self.storage,
+            &self.shards,
+            epoch,
+            self.validator,
+            self.max_chunk_bytes,
+        )
+        .await?;
         let signature = self
             .shards
             .sign_commitment_manifest(&assembled.manifest)
@@ -187,13 +216,16 @@ pub struct AssembledCommitment {
 ///
 /// This must only run after the epoch has been frozen on every worker sharing the
 /// storage: the freeze is what makes the ledger complete, and it keeps a pending
-/// latest vote from being bypassed unrecorded while we read.
-pub async fn assemble_commitment<S: Storage>(
+/// latest vote from being bypassed unrecorded while we read. Chain state is never
+/// read from storage directly — a pending vote's locking certificate is obtained
+/// through the chain's worker, via [`ShardControl::locking_block`].
+pub async fn assemble_commitment<S: Storage, C: ShardControl>(
     storage: &S,
+    shards: &C,
     epoch: Epoch,
     validator: ValidatorPublicKey,
     max_chunk_bytes: usize,
-) -> Result<AssembledCommitment, WorkerError> {
+) -> Result<AssembledCommitment, CommitmentError> {
     let mut chunks = Vec::new();
     let mut entries = Vec::new();
     let mut entries_bytes = 0;
@@ -204,7 +236,7 @@ pub async fn assemble_commitment<S: Storage>(
             .read_vote_ledger_entry(epoch, chain_id)
             .await?
             .ok_or(WorkerError::MissingVoteJustification(chain_id))?;
-        let entry = commitment_entry(storage, chain_id, ledger_entry).await?;
+        let entry = commitment_entry(storage, shards, chain_id, ledger_entry).await?;
         let entry_bytes = bcs::serialized_size(&entry)?;
         if !entries.is_empty() && entries_bytes + entry_bytes > max_chunk_bytes {
             chunks.push(CommitmentChunk {
@@ -221,7 +253,7 @@ pub async fn assemble_commitment<S: Storage>(
     let blobs = chunks
         .iter()
         .map(|chunk| Ok(Blob::new_epoch_commitment(bcs::to_bytes(chunk)?)))
-        .collect::<Result<Vec<_>, bcs::Error>>()?;
+        .collect::<Result<Vec<_>, CommitmentError>>()?;
     let manifest = CommitmentManifest {
         epoch,
         validator,
@@ -232,11 +264,12 @@ pub async fn assemble_commitment<S: Storage>(
 
 /// Builds the commitment entry for one chain: the ledger entry with the latest
 /// vote's justification recovered.
-async fn commitment_entry<S: Storage>(
+async fn commitment_entry<S: Storage, C: ShardControl>(
     storage: &S,
+    shards: &C,
     chain_id: ChainId,
     ledger_entry: LedgerEntry,
-) -> Result<CommitmentEntry, WorkerError> {
+) -> Result<CommitmentEntry, CommitmentError> {
     let LedgerEntry {
         latest,
         mut superseded,
@@ -250,12 +283,12 @@ async fn commitment_entry<S: Storage>(
             if let Some(index) = superseded.iter().position(|vote| vote.record == latest) {
                 superseded.remove(index).justification
             } else {
-                Some(recover_justification(storage, chain_id, &latest).await?)
+                Some(recover_justification(storage, shards, chain_id, &latest).await?)
             }
         }
     };
     if justification.is_none() && latest.justification_commitment.is_some() {
-        return Err(WorkerError::MissingVoteJustification(chain_id));
+        return Err(WorkerError::MissingVoteJustification(chain_id).into());
     }
     Ok(CommitmentEntry {
         chain_id,
@@ -271,18 +304,18 @@ async fn commitment_entry<S: Storage>(
 /// manager's locking certificate if the vote is still pending at the tip, or from
 /// the stored confirmed certificate's justification chain if the voted block was
 /// finalized.
-async fn recover_justification<S: Storage>(
+async fn recover_justification<S: Storage, C: ShardControl>(
     storage: &S,
+    shards: &C,
     chain_id: ChainId,
     latest: &VoteRecord,
-) -> Result<linera_chain::types::ValidatedBlockCertificate, WorkerError> {
+) -> Result<linera_chain::types::ValidatedBlockCertificate, CommitmentError> {
     let commitment = latest
         .justification_commitment
         .expect("only called for votes that cited a quorum");
-    let chain = storage.load_chain(chain_id).await?;
-    if let Some(LockingBlock::Regular(certificate)) = chain.manager.locking_block.get() {
+    if let Some(LockingBlock::Regular(certificate)) = shards.locking_block(chain_id).await? {
         if certificate.full_justification_commitment() == commitment {
-            return Ok(certificate.clone());
+            return Ok(certificate);
         }
     }
     if let Some(certificate) = storage.read_certificate(latest.block_hash).await? {
@@ -290,5 +323,5 @@ async fn recover_justification<S: Storage>(
             return Ok(cited);
         }
     }
-    Err(WorkerError::MissingVoteJustification(chain_id))
+    Err(WorkerError::MissingVoteJustification(chain_id).into())
 }

--- a/linera-core/src/commitment.rs
+++ b/linera-core/src/commitment.rs
@@ -1,21 +1,177 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Assembly of a validator's epoch commitment from its vote ledger.
+//! A validator's epoch commitments: assembly from the vote ledger, and the agent
+//! that commits every revoked epoch the validator belonged to.
 
 use linera_base::{
-    crypto::ValidatorPublicKey,
-    data_types::{Blob, Epoch},
+    crypto::{ValidatorPublicKey, ValidatorSignature},
+    data_types::{ArithmeticError, Blob, Epoch},
     identifiers::ChainId,
 };
 use linera_chain::{
-    epoch_commitment::{CommitmentChunk, CommitmentEntry, CommitmentManifest},
+    epoch_commitment::{
+        CommitmentChunk, CommitmentEntry, CommitmentManifest, SignedCommitmentManifest,
+    },
     manager::LockingBlock,
     vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
 };
+use linera_execution::ExecutionError;
 use linera_storage::Storage;
+use linera_views::ViewError;
+use thiserror::Error;
+use tracing::info;
 
-use crate::worker::WorkerError;
+use crate::worker::{WorkerError, WorkerState};
+
+/// An error while assembling or driving an epoch commitment.
+#[derive(Debug, Error)]
+pub enum CommitmentError {
+    /// An error from the worker, e.g. while assembling or signing.
+    #[error(transparent)]
+    Worker(#[from] WorkerError),
+    /// An error reading from or writing to storage.
+    #[error(transparent)]
+    View(#[from] ViewError),
+    /// An error resolving epochs or committees.
+    #[error(transparent)]
+    Execution(#[from] ExecutionError),
+    /// An epoch number overflowed.
+    #[error(transparent)]
+    Arithmetic(#[from] ArithmeticError),
+    /// A shard could not be reached or refused the request.
+    #[error("Shard request failed: {0}")]
+    Shard(String),
+    /// The epoch is revoked, but the admin-chain event naming its committee is not
+    /// in local storage yet.
+    #[error("The committee for revoked epoch {0} is not available locally yet")]
+    MissingCommittee(Epoch),
+}
+
+/// Access to all shards of a validator, for the two operations an epoch
+/// commitment needs from them: freezing signing, and signing the manifest with
+/// the validator key, which lives in the shards.
+///
+/// A [`WorkerState`] implements this directly for single-worker validators and
+/// tests; a multi-shard validator implements it over the internal RPCs.
+pub trait ShardControl {
+    /// Permanently freezes vote signing in the given epoch and all earlier ones,
+    /// on every shard. When this returns, every vote any shard created is durably
+    /// in the ledger, and no more can be added.
+    async fn freeze_epoch(&self, epoch: Epoch) -> Result<(), CommitmentError>;
+
+    /// Signs the manifest with the validator key. The signer refuses unless the
+    /// manifest names its validator and the epoch is frozen.
+    async fn sign_commitment_manifest(
+        &self,
+        manifest: &CommitmentManifest,
+    ) -> Result<ValidatorSignature, CommitmentError>;
+}
+
+impl<S> ShardControl for WorkerState<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    async fn freeze_epoch(&self, epoch: Epoch) -> Result<(), CommitmentError> {
+        Ok(WorkerState::freeze_epoch(self, epoch).await?)
+    }
+
+    async fn sign_commitment_manifest(
+        &self,
+        manifest: &CommitmentManifest,
+    ) -> Result<ValidatorSignature, CommitmentError> {
+        Ok(WorkerState::sign_commitment_manifest(self, manifest).await?)
+    }
+}
+
+/// Drives this validator's epoch commitments: when an epoch the validator
+/// belonged to is revoked, freezes it on all shards, assembles the commitment
+/// from the vote ledger, has a shard sign the manifest, and persists the signed
+/// commitment for publication on the admin chain.
+pub struct CommitmentAgent<S, C> {
+    storage: S,
+    shards: C,
+    validator: ValidatorPublicKey,
+    max_chunk_bytes: usize,
+    /// The first epoch the next pass will look at; every epoch below it is
+    /// already handled. Starts over from zero on restart — handled epochs are
+    /// then skipped by their stored commitment or non-membership.
+    next_epoch: Epoch,
+}
+
+impl<S, C> CommitmentAgent<S, C>
+where
+    S: Storage,
+    C: ShardControl,
+{
+    /// Creates an agent committing in the given validator's name.
+    pub fn new(
+        storage: S,
+        shards: C,
+        validator: ValidatorPublicKey,
+        max_chunk_bytes: usize,
+    ) -> Self {
+        CommitmentAgent {
+            storage,
+            shards,
+            validator,
+            max_chunk_bytes,
+            next_epoch: Epoch::ZERO,
+        }
+    }
+
+    /// Commits every revoked epoch that is not handled yet, in epoch order, and
+    /// returns the newly committed epochs. Call this periodically; it is
+    /// idempotent, and a run interrupted mid-epoch redoes that epoch on the next
+    /// call — the stored signed manifest is what marks an epoch as done.
+    pub async fn process_revoked_epochs(&mut self) -> Result<Vec<Epoch>, CommitmentError> {
+        let mut committed = Vec::new();
+        while self.storage.is_epoch_revoked(self.next_epoch).await? {
+            let epoch = self.next_epoch;
+            if self.storage.read_pending_commitment(epoch).await?.is_none()
+                && self.commit_epoch(epoch).await?
+            {
+                committed.push(epoch);
+            }
+            self.next_epoch = epoch.try_add_one()?;
+        }
+        Ok(committed)
+    }
+
+    /// Commits the given revoked epoch, unless this validator was not in its
+    /// committee. Returns whether a commitment was made.
+    async fn commit_epoch(&self, epoch: Epoch) -> Result<bool, CommitmentError> {
+        let committee = self
+            .storage
+            .committee_for_epoch(epoch)
+            .await?
+            .ok_or(CommitmentError::MissingCommittee(epoch))?;
+        if !committee.validators().contains_key(&self.validator) {
+            return Ok(false);
+        }
+        self.shards.freeze_epoch(epoch).await?;
+        let assembled =
+            assemble_commitment(&self.storage, epoch, self.validator, self.max_chunk_bytes).await?;
+        let signature = self
+            .shards
+            .sign_commitment_manifest(&assembled.manifest)
+            .await?;
+        let signed = SignedCommitmentManifest {
+            manifest: assembled.manifest,
+            signature,
+        };
+        // The blobs go in before the manifest: the stored manifest marks the
+        // epoch as done, so everything it references must already be durable.
+        self.storage.write_blobs(&assembled.blobs).await?;
+        self.storage.write_pending_commitment(&signed).await?;
+        info!(
+            epoch = %epoch,
+            chunks = signed.manifest.blob_hashes.len(),
+            "committed to this validator's votes in the revoked epoch"
+        );
+        Ok(true)
+    }
+}
 
 /// A commitment assembled from the vote ledger, ready to be signed.
 pub struct AssembledCommitment {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -10,7 +10,9 @@ use linera_base::{
         BcsSignable, CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSecretKey,
         ValidatorSignature,
     },
-    data_types::{Amount, BlockHeight, ChainDescription, Epoch, Round, Timestamp},
+    data_types::{
+        Amount, BlockHeight, ChainDescription, Epoch, Round, SignedCommitmentManifest, Timestamp,
+    },
     identifiers::{AccountOwner, ChainId, StreamId},
 };
 use linera_chain::{
@@ -64,6 +66,10 @@ pub struct ChainInfoQuery {
     /// to skip downloading and replaying pre-checkpoint blocks.
     #[debug(skip_if = Not::not)]
     pub request_latest_checkpoint_height: bool,
+    /// Query the validator's own pending epoch commitments, so the admin chain's
+    /// proposer can register them.
+    #[debug(skip_if = Not::not)]
+    pub request_pending_commitments: bool,
 }
 
 impl ChainInfoQuery {
@@ -81,12 +87,19 @@ impl ChainInfoQuery {
             request_sent_certificate_hashes_by_heights: Vec::new(),
             request_previous_event_blocks: Vec::new(),
             request_latest_checkpoint_height: false,
+            request_pending_commitments: false,
         }
     }
 
     /// Also requests the height of the most recent checkpoint block.
     pub fn with_latest_checkpoint_height(mut self) -> Self {
         self.request_latest_checkpoint_height = true;
+        self
+    }
+
+    /// Also requests the validator's own pending epoch commitments.
+    pub fn with_pending_commitments(mut self) -> Self {
+        self.request_pending_commitments = true;
         self
     }
 
@@ -185,6 +198,10 @@ pub struct ChainInfo {
     /// `None` if no such block exists or the field was not requested.
     #[debug(skip_if = Option::is_none)]
     pub requested_latest_checkpoint_height: Option<BlockHeight>,
+    /// The response to `request_pending_commitments`: the queried validator's own
+    /// signed commitment manifests awaiting publication on the admin chain.
+    #[debug(skip_if = Vec::is_empty)]
+    pub requested_pending_commitments: Vec<SignedCommitmentManifest>,
 }
 
 impl ChainInfo {
@@ -303,6 +320,7 @@ impl ChainInfo {
             requested_received_log: Vec::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
+            requested_pending_commitments: Vec::new(),
         })
     }
 }

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -13,6 +13,8 @@ mod chain_worker;
 pub use chain_worker::{ChainWorkerConfig, ProcessConfirmedBlockMode};
 /// The high-level client for interacting with chains and validators.
 pub mod client;
+/// Assembly of a validator's epoch commitment from its vote ledger.
+pub mod commitment;
 pub use client::Client;
 /// Data types exchanged between clients, workers, and validator nodes.
 pub mod data_types;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -59,6 +59,7 @@ use linera_chain::{
         CertificateKind, CertificateValue, Certified, ConfirmedBlock, ConfirmedBlockCertificate,
         Timeout, ValidatedBlock, ValidatedBlockCertificate,
     },
+    vote_ledger::VoteRecord,
     ChainError, ChainExecutionContext, ChainStateView,
 };
 use linera_execution::{
@@ -3659,6 +3660,23 @@ where
     let value = ConfirmedBlock::new(block1.clone());
     assert_eq!(vote.value, LiteValue::new(&value));
 
+    // The confirmation vote is recorded in the vote ledger.
+    let entry = env
+        .executing_worker()
+        .storage_client()
+        .read_vote_ledger_entry(Epoch::ZERO, chain_1)
+        .await?
+        .unwrap();
+    assert_eq!(
+        entry.latest,
+        VoteRecord {
+            height: BlockHeight::from(1),
+            round: Round::SingleLeader(1),
+            block_hash: LiteValue::new(&value).value_hash,
+        }
+    );
+    assert!(entry.superseded.is_empty());
+
     // Instead of submitting the confirmed block certificate, let rounds 2 to 4 time out, too.
     let certificate_timeout =
         env.make_certificate_with_round(value_timeout.clone(), Round::SingleLeader(4));
@@ -3792,6 +3810,57 @@ where
         response.info.manager.pending.unwrap().kind(),
         CertificateKind::Confirmed
     );
+
+    // In round 8, a validated certificate for block2 lets the worker vote to
+    // confirm it, superseding its earlier confirmation vote for block1. The vote
+    // ledger lists the superseded vote together with the justification it cited:
+    // `certificate1` — captured at the moment the locking block moved on from it.
+    let certificate2b = env.make_certificate_with_round(value2.clone(), Round::SingleLeader(8));
+    worker
+        .handle_validated_certificate(certificate2b.clone())
+        .await?;
+    let entry = worker
+        .storage_client()
+        .read_vote_ledger_entry(Epoch::ZERO, chain_1)
+        .await?
+        .unwrap();
+    assert_eq!(
+        entry.latest,
+        VoteRecord {
+            height: BlockHeight::from(1),
+            round: Round::SingleLeader(8),
+            block_hash: LiteValue::new(&ConfirmedBlock::new(block2.clone())).value_hash,
+        }
+    );
+    assert_eq!(entry.superseded.len(), 1);
+    assert_eq!(
+        entry.superseded[0].record,
+        VoteRecord {
+            height: BlockHeight::from(1),
+            round: Round::SingleLeader(1),
+            block_hash: LiteValue::new(&ConfirmedBlock::new(block1.clone())).value_hash,
+        }
+    );
+    assert_eq!(entry.superseded[0].justification, Some(certificate1));
+
+    // Block1 gets confirmed without this validator's vote: the bypassed vote for
+    // block2 is preserved in the ledger too, with its justification, while the
+    // latest-vote entry is untouched.
+    let confirmed1 = env
+        .make_certificate_with_round(ConfirmedBlock::new(block1.clone()), Round::SingleLeader(1));
+    worker
+        .fully_handle_certificate_with_notifications(confirmed1, &())
+        .await?;
+    let entry = worker
+        .storage_client()
+        .read_vote_ledger_entry(Epoch::ZERO, chain_1)
+        .await?
+        .unwrap();
+    assert_eq!(entry.latest.round, Round::SingleLeader(8));
+    assert_eq!(entry.superseded.len(), 2);
+    assert_eq!(entry.superseded[1].record.round, Round::SingleLeader(8));
+    assert_eq!(entry.superseded[1].justification, Some(certificate2b));
+
     Ok(())
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -40,7 +40,7 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::{
         AccountPublicKey, AccountSecretKey, AccountSignature, CryptoHash, InMemorySigner,
-        ValidatorKeypair,
+        ValidatorKeypair, ValidatorSignature,
     },
     data_types::*,
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, EventId, StreamId},
@@ -52,7 +52,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
         PostedMessage, ProposedBlock, Transaction, Vote,
     },
-    epoch_commitment::{CommitmentChunk, CommitmentManifest, SignedCommitmentManifest},
+    epoch_commitment::CommitmentChunk,
     justification::{JustificationChain, JustificationLink},
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -67,7 +67,7 @@ use linera_execution::{
     committee::Committee,
     system::{
         AdminOperation, EpochEventData, OpenChainConfig, SystemMessage, SystemOperation,
-        EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
+        COMMITMENT_STREAM_NAME, EPOCH_STREAM_NAME, REMOVED_EPOCH_STREAM_NAME,
     },
     test_utils::{
         dummy_chain_description, ExpectedCall, MockApplication, RegisterMockApplication,
@@ -3354,6 +3354,61 @@ where
         .await?
         .is_none());
     assert_eq!(non_member.storage_client().max_frozen_epoch().await?, None);
+
+    // The pending commitment can be registered on the admin chain; the signed
+    // manifest is emitted as a commitment event.
+    let proposal4 = make_child_block(&certificate3.into_value())
+        .with_epoch(2)
+        .with_operation(SystemOperation::Admin(AdminOperation::RegisterCommitment {
+            manifest: Box::new(pending.clone()),
+        }));
+    let certificate4 = env.execute_proposal(proposal4.clone(), vec![]).await?;
+    assert_eq!(
+        certificate4.block().body.events,
+        vec![vec![Event {
+            stream_id: StreamId::system(COMMITMENT_STREAM_NAME),
+            index: 0,
+            value: bcs::to_bytes(&pending)?,
+        }]]
+    );
+
+    // Commitments are rejected for epochs that are not revoked, from validators
+    // outside the epoch's committee, and with invalid signatures.
+    let outsider = ValidatorKeypair::generate();
+    let signed_by_outsider = |epoch| {
+        let manifest = CommitmentManifest {
+            epoch,
+            validator: outsider.public_key,
+            blob_hashes: Vec::new(),
+        };
+        let signature = ValidatorSignature::new(&manifest, &outsider.secret_key);
+        SignedCommitmentManifest {
+            manifest,
+            signature,
+        }
+    };
+    let mut forged = pending.clone();
+    forged.manifest.blob_hashes = vec![CryptoHash::test_hash("forged")];
+    for (manifest, expected) in [
+        (signed_by_outsider(Epoch::from(1)), "revoked epochs"),
+        (
+            signed_by_outsider(Epoch::ZERO),
+            "not in the epoch's committee",
+        ),
+        (forged, "signature is invalid"),
+    ] {
+        let proposal = make_child_block(&certificate4.clone().into_value())
+            .with_epoch(2)
+            .with_operation(SystemOperation::Admin(AdminOperation::RegisterCommitment {
+                manifest: Box::new(manifest),
+            }));
+        let result = env
+            .executing_worker()
+            .stage_block_execution(proposal, None, vec![], BundleExecutionPolicy::committed())
+            .await;
+        let error = result.err().unwrap().to_string();
+        assert!(error.contains(expected), "{error:?} vs {expected:?}");
+    }
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -52,6 +52,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
         PostedMessage, ProposedBlock, Transaction, Vote,
     },
+    epoch_commitment::{CommitmentManifest, SignedCommitmentManifest},
     justification::{JustificationChain, JustificationLink},
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -3885,6 +3886,36 @@ where
     worker
         .fully_handle_certificate_with_notifications(confirmed3, &())
         .await?;
+
+    // The worker signs commitment manifests for the frozen epoch — but not for an
+    // unfrozen epoch, and not in another validator's name.
+    let manifest = CommitmentManifest {
+        epoch: Epoch::ZERO,
+        validator: worker.public_key(),
+        blob_hashes: vec![CryptoHash::test_hash("commitment chunk")],
+    };
+    let signature = worker.sign_commitment_manifest(&manifest).await?;
+    let signed = SignedCommitmentManifest {
+        manifest: manifest.clone(),
+        signature,
+    };
+    signed.check()?;
+    let unfrozen_manifest = CommitmentManifest {
+        epoch: Epoch::from(1),
+        ..manifest.clone()
+    };
+    assert_matches!(
+        worker.sign_commitment_manifest(&unfrozen_manifest).await,
+        Err(WorkerError::EpochNotFrozen(_))
+    );
+    let foreign_manifest = CommitmentManifest {
+        validator: ValidatorKeypair::generate().public_key,
+        ..manifest
+    };
+    assert_matches!(
+        worker.sign_commitment_manifest(&foreign_manifest).await,
+        Err(WorkerError::CommitmentValidatorMismatch)
+    );
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -52,7 +52,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
         PostedMessage, ProposedBlock, Transaction, Vote,
     },
-    epoch_commitment::{CommitmentManifest, SignedCommitmentManifest},
+    epoch_commitment::{CommitmentChunk, CommitmentManifest, SignedCommitmentManifest},
     justification::{JustificationChain, JustificationLink},
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -87,6 +87,7 @@ use crate::test_utils::RocksDbStorageBuilder;
 use crate::test_utils::ScyllaDbStorageBuilder;
 use crate::{
     chain_worker::{ChainWorkerConfig, ProcessConfirmedBlockMode},
+    commitment::assemble_commitment,
     data_types::*,
     test_utils::{MemoryStorageBuilder, StorageBuilder},
     worker::{
@@ -3674,6 +3675,7 @@ where
             height: BlockHeight::from(1),
             round: Round::SingleLeader(1),
             block_hash: LiteValue::new(&value).value_hash,
+            justification_commitment: Some(certificate1.full_justification_commitment()),
         }
     );
     assert!(entry.superseded.is_empty());
@@ -3831,6 +3833,7 @@ where
             height: BlockHeight::from(1),
             round: Round::SingleLeader(8),
             block_hash: LiteValue::new(&ConfirmedBlock::new(block2.clone())).value_hash,
+            justification_commitment: Some(certificate2b.full_justification_commitment()),
         }
     );
     assert_eq!(entry.superseded.len(), 1);
@@ -3840,9 +3843,37 @@ where
             height: BlockHeight::from(1),
             round: Round::SingleLeader(1),
             block_hash: LiteValue::new(&ConfirmedBlock::new(block1.clone())).value_hash,
+            justification_commitment: Some(certificate1.full_justification_commitment()),
         }
     );
     assert_eq!(entry.superseded[0].justification, Some(certificate1));
+
+    // Assembling the commitment while the latest vote is pending at the tip
+    // recovers its justification from the manager's locking certificate.
+    let assembled = assemble_commitment(
+        worker.storage_client(),
+        Epoch::ZERO,
+        worker.public_key(),
+        usize::MAX,
+    )
+    .await?;
+    assert_eq!(assembled.manifest.epoch, Epoch::ZERO);
+    assert_eq!(assembled.manifest.validator, worker.public_key());
+    assert_eq!(assembled.blobs.len(), 1);
+    assert_eq!(
+        assembled.manifest.blob_hashes,
+        vec![assembled.blobs[0].id().hash]
+    );
+    let chunk = bcs::from_bytes::<CommitmentChunk>(assembled.blobs[0].bytes())?;
+    assert_eq!(chunk.entries.len(), 1);
+    let commitment_entry = &chunk.entries[0];
+    assert_eq!(commitment_entry.chain_id, chain_1);
+    assert_eq!(commitment_entry.committed.record, entry.latest);
+    assert_eq!(
+        commitment_entry.committed.justification,
+        Some(certificate2b.clone())
+    );
+    assert_eq!(commitment_entry.superseded, entry.superseded);
 
     // Block1 gets confirmed without this validator's vote: the bypassed vote for
     // block2 is preserved in the ledger too, with its justification, while the
@@ -3860,7 +3891,32 @@ where
     assert_eq!(entry.latest.round, Round::SingleLeader(8));
     assert_eq!(entry.superseded.len(), 2);
     assert_eq!(entry.superseded[1].record.round, Round::SingleLeader(8));
-    assert_eq!(entry.superseded[1].justification, Some(certificate2b));
+    assert_eq!(
+        entry.superseded[1].justification,
+        Some(certificate2b.clone())
+    );
+
+    // Assembly now takes the committed vote's justification from the bypass
+    // record instead, and does not list that record as superseded.
+    let assembled = assemble_commitment(
+        worker.storage_client(),
+        Epoch::ZERO,
+        worker.public_key(),
+        usize::MAX,
+    )
+    .await?;
+    let chunk = bcs::from_bytes::<CommitmentChunk>(assembled.blobs[0].bytes())?;
+    let commitment_entry = &chunk.entries[0];
+    assert_eq!(commitment_entry.committed.record, entry.latest);
+    assert_eq!(
+        commitment_entry.committed.justification,
+        Some(certificate2b)
+    );
+    assert_eq!(commitment_entry.superseded.len(), 1);
+    assert_eq!(
+        commitment_entry.superseded[0].record.round,
+        Round::SingleLeader(1)
+    );
 
     // After freezing the epoch, the validator refuses to vote for a validated
     // block at the next height.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3895,6 +3895,7 @@ where
     // recovers its justification from the manager's locking certificate.
     let assembled = assemble_commitment(
         worker.storage_client(),
+        &worker,
         Epoch::ZERO,
         worker.public_key(),
         usize::MAX,
@@ -3943,6 +3944,7 @@ where
     // record instead, and does not list that record as superseded.
     let assembled = assemble_commitment(
         worker.storage_client(),
+        &worker,
         Epoch::ZERO,
         worker.public_key(),
         usize::MAX,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3861,6 +3861,31 @@ where
     assert_eq!(entry.superseded[1].record.round, Round::SingleLeader(8));
     assert_eq!(entry.superseded[1].justification, Some(certificate2b));
 
+    // After freezing the epoch, the validator refuses to vote for a validated
+    // block at the next height.
+    worker.freeze_epoch(Epoch::ZERO).await?;
+    let proposed_block3 = make_child_block(&ConfirmedBlock::new(block1.clone()))
+        .with_simple_transfer(chain_1, small_transfer);
+    let (_, block3, _, _, _) = worker
+        .stage_block_execution(
+            proposed_block3,
+            None,
+            vec![],
+            BundleExecutionPolicy::committed(),
+        )
+        .await?;
+    let certificate3 = env
+        .make_certificate_with_round(ValidatedBlock::new(block3.clone()), Round::SingleLeader(0));
+    let result = worker.handle_validated_certificate(certificate3).await;
+    assert_matches!(result, Err(WorkerError::VoteInFrozenEpoch(Epoch::ZERO)));
+
+    // But confirmed blocks are still processed: only signing is frozen.
+    let confirmed3 =
+        env.make_certificate_with_round(ConfirmedBlock::new(block3), Round::SingleLeader(0));
+    worker
+        .fully_handle_certificate_with_notifications(confirmed3, &())
+        .await?;
+
     Ok(())
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -236,6 +236,63 @@ where
         Ok(())
     }
 
+    /// Makes the given epoch *settled* in both workers' storage: creates the next
+    /// epoch's committee (reusing the genesis committee) and records a quorum of
+    /// its commitments, so `is_epoch_settled(epoch)` returns true. The stored
+    /// manifests are only read for their `(epoch, validator)`, so a throwaway
+    /// signature suffices.
+    async fn settle_epoch(&self, epoch: Epoch) -> Result<(), anyhow::Error> {
+        let next_epoch = epoch.try_add_one()?;
+        let admin_chain_id = self.admin_chain_id();
+        let blob_hash = self
+            .worker
+            .storage_client()
+            .read_network_description()
+            .await?
+            .unwrap()
+            .genesis_committee_blob_hash;
+        let mut events = vec![(
+            EventId {
+                chain_id: admin_chain_id,
+                stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                index: next_epoch.0,
+            },
+            bcs::to_bytes(&EpochEventData {
+                blob_hash,
+                timestamp: Timestamp::from(0),
+            })?,
+        )];
+        let throwaway = ValidatorKeypair::generate();
+        for (index, validator) in (0u32..).zip(self.committee.validators().keys()) {
+            let manifest = CommitmentManifest {
+                epoch: next_epoch,
+                validator: *validator,
+                blob_hashes: Vec::new(),
+            };
+            let signature = ValidatorSignature::new(&manifest, &throwaway.secret_key);
+            events.push((
+                EventId {
+                    chain_id: admin_chain_id,
+                    stream_id: StreamId::system(COMMITMENT_STREAM_NAME),
+                    index,
+                },
+                bcs::to_bytes(&SignedCommitmentManifest {
+                    manifest,
+                    signature,
+                })?,
+            ));
+        }
+        self.worker
+            .storage_client()
+            .write_events(events.clone())
+            .await?;
+        self.executing_worker
+            .storage_client()
+            .write_events(events)
+            .await?;
+        Ok(())
+    }
+
     pub async fn register_mock_application(
         &self,
         chain_id: ChainId,
@@ -3176,6 +3233,10 @@ where
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
 
+    // Settle epoch 0 (a quorum of epoch-1 commitments): only then is it distrusted,
+    // and its cross-chain messages refused. Revocation alone leaves it trusted.
+    env.settle_epoch(Epoch::ZERO).await?;
+
     // Try to execute the transfer from the user chain to the admin chain.
     env.worker()
         .fully_handle_certificate_with_notifications(certificate0.clone(), &())
@@ -3195,7 +3256,7 @@ where
         );
         assert_eq!(*user_chain.execution_state.system.epoch.get(), Epoch::ZERO);
 
-        // .. but the message has been refused: epoch 0 is revoked on the admin chain.
+        // .. but the message has been refused: epoch 0 has settled on the admin chain.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
         assert!(admin_chain.is_active().await?);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
@@ -3539,19 +3600,10 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let chain_1 = env
         .add_root_chain(1, AccountOwner::CHAIN, Amount::ZERO)
         .await;
-    // Mark epoch 0 as revoked so the helper rejects bundles signed by it,
-    // unless they're re-certified by a later trusted-epoch bundle.
-    env.worker()
-        .storage_client()
-        .write_events([(
-            EventId {
-                chain_id: env.admin_chain_id(),
-                stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
-                index: 0,
-            },
-            Vec::new(),
-        )])
-        .await?;
+    // Settle epoch 0 so the helper rejects bundles signed by it, unless they're
+    // re-certified by a later trusted-epoch bundle. (Revocation alone leaves the
+    // committee bonded and its bundles trusted; only settlement distrusts them.)
+    env.settle_epoch(Epoch::ZERO).await?;
 
     let chain_0 = env.admin_description.clone();
     let key_pair0 = AccountSecretKey::generate();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -87,7 +87,7 @@ use crate::test_utils::RocksDbStorageBuilder;
 use crate::test_utils::ScyllaDbStorageBuilder;
 use crate::{
     chain_worker::{ChainWorkerConfig, ProcessConfirmedBlockMode},
-    commitment::assemble_commitment,
+    commitment::{assemble_commitment, CommitmentAgent},
     data_types::*,
     test_utils::{MemoryStorageBuilder, StorageBuilder},
     worker::{
@@ -3311,6 +3311,49 @@ where
         response.info.requested_previous_event_blocks,
         BTreeMap::from([(stream_id, (BlockHeight(2), certificate3.hash()))]),
     );
+
+    // The commitment agent notices the revoked epoch, freezes it, and persists a
+    // signed commitment. A second pass finds nothing new to do.
+    let member = env.executing_worker().clone();
+    let mut agent = CommitmentAgent::new(
+        member.storage_client().clone(),
+        member.clone(),
+        member.public_key(),
+        usize::MAX,
+    );
+    assert_eq!(agent.process_revoked_epochs().await?, vec![Epoch::ZERO]);
+    let pending = member
+        .storage_client()
+        .read_pending_commitment(Epoch::ZERO)
+        .await?
+        .unwrap();
+    pending.check()?;
+    assert_eq!(pending.manifest.epoch, Epoch::ZERO);
+    assert_eq!(pending.manifest.validator, member.public_key());
+    // No confirmation votes were cast in this test, so the commitment is empty.
+    assert!(pending.manifest.blob_hashes.is_empty());
+    assert_eq!(
+        member.storage_client().max_frozen_epoch().await?,
+        Some(Epoch::ZERO)
+    );
+    assert_eq!(agent.process_revoked_epochs().await?, Vec::new());
+
+    // A validator that was not in the revoked epoch's committee neither commits
+    // nor freezes.
+    let non_member = env.worker().clone();
+    let mut agent = CommitmentAgent::new(
+        non_member.storage_client().clone(),
+        non_member.clone(),
+        non_member.public_key(),
+        usize::MAX,
+    );
+    assert_eq!(agent.process_revoked_epochs().await?, Vec::new());
+    assert!(non_member
+        .storage_client()
+        .read_pending_commitment(Epoch::ZERO)
+        .await?
+        .is_none());
+    assert_eq!(non_member.storage_client().max_frozen_epoch().await?, None);
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -52,7 +52,7 @@ use linera_chain::{
         IncomingBundle, LiteValue, LiteVote, MessageAction, MessageBundle, OperationResult,
         PostedMessage, ProposedBlock, Transaction, Vote,
     },
-    epoch_commitment::CommitmentChunk,
+    epoch_commitment::{CommitmentChunk, CommitmentEntry},
     justification::{JustificationChain, JustificationLink},
     manager::LockingBlock,
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
@@ -60,7 +60,7 @@ use linera_chain::{
         CertificateKind, CertificateValue, Certified, ConfirmedBlock, ConfirmedBlockCertificate,
         Timeout, ValidatedBlock, ValidatedBlockCertificate,
     },
-    vote_ledger::VoteRecord,
+    vote_ledger::{JustifiedVote, VoteRecord},
     ChainError, ChainExecutionContext, ChainStateView,
 };
 use linera_execution::{
@@ -3388,7 +3388,7 @@ where
         }
     };
     let mut forged = pending.clone();
-    forged.manifest.blob_hashes = vec![CryptoHash::test_hash("forged")];
+    forged.manifest.validator = outsider.public_key;
     for (manifest, expected) in [
         (signed_by_outsider(Epoch::from(1)), "revoked epochs"),
         (
@@ -3409,6 +3409,125 @@ where
         let error = result.err().unwrap().to_string();
         assert!(error.contains(expected), "{error:?} vs {expected:?}");
     }
+
+    // Before voting on a registration, the worker checks the commitment's
+    // entries in depth. A vote carrying exactly the justification it signed,
+    // for a block grounded in this worker's storage, passes; a vote whose
+    // record does not match its justification is rejected; and a committed
+    // block with an unknown parent surfaces as `BlocksNotFound`, so the
+    // proposer can push it.
+    let make_signed_commitment = |entries: Vec<CommitmentEntry>| {
+        let chunk = CommitmentChunk { entries };
+        let chunk_blob = Blob::new_epoch_commitment(bcs::to_bytes(&chunk).unwrap());
+        let manifest = CommitmentManifest {
+            epoch: Epoch::ZERO,
+            validator: member.public_key(),
+            blob_hashes: vec![chunk_blob.id().hash],
+        };
+        (manifest, chunk_blob)
+    };
+    let justification = env.make_certificate_with_round(
+        ValidatedBlock::new(certificate0.block().clone()),
+        Round::SingleLeader(0),
+    );
+    let valid_entry = CommitmentEntry {
+        chain_id: user_id,
+        committed: JustifiedVote {
+            record: VoteRecord {
+                height: BlockHeight::ZERO,
+                round: Round::SingleLeader(0),
+                block_hash: certificate0.hash(),
+                justification_commitment: Some(justification.full_justification_commitment()),
+            },
+            justification: Some(justification.clone()),
+        },
+        superseded: Vec::new(),
+    };
+    let mut mismatched_entry = valid_entry.clone();
+    mismatched_entry.committed.record.round = Round::SingleLeader(1);
+    let ungrounded_block = BlockExecutionOutcome::default().with(
+        make_child_block(&ConfirmedBlock::new(
+            BlockExecutionOutcome::default().with(make_first_block(user_id)),
+        ))
+        .with_simple_transfer(admin_chain_id, Amount::ONE),
+    );
+    let ungrounded_justification = env.make_certificate_with_round(
+        ValidatedBlock::new(ungrounded_block.clone()),
+        Round::SingleLeader(0),
+    );
+    let ungrounded_entry = CommitmentEntry {
+        chain_id: user_id,
+        committed: JustifiedVote {
+            record: VoteRecord {
+                height: BlockHeight::from(1),
+                round: Round::SingleLeader(0),
+                block_hash: ungrounded_block.hash(),
+                justification_commitment: Some(
+                    ungrounded_justification.full_justification_commitment(),
+                ),
+            },
+            justification: Some(ungrounded_justification),
+        },
+        superseded: Vec::new(),
+    };
+    let mut parent = certificate4;
+    for (entries, expected) in [
+        (vec![valid_entry], None),
+        (
+            vec![mismatched_entry],
+            Some("not for the voted block and round"),
+        ),
+        (vec![ungrounded_entry], Some("Blocks not found")),
+    ] {
+        let (manifest, chunk_blob) = make_signed_commitment(entries);
+        env.write_blobs(std::slice::from_ref(&chunk_blob)).await?;
+        let signature = member.sign_commitment_manifest(&manifest).await?;
+        let proposal = make_child_block(&parent.clone().into_value())
+            .with_epoch(2)
+            .with_operation(SystemOperation::Admin(AdminOperation::RegisterCommitment {
+                manifest: Box::new(SignedCommitmentManifest {
+                    manifest,
+                    signature,
+                }),
+            }));
+        let (_, block, _, _, _) = env
+            .executing_worker()
+            .stage_block_execution(
+                proposal,
+                None,
+                vec![chunk_blob],
+                BundleExecutionPolicy::committed(),
+            )
+            .await?;
+        let validated = env
+            .make_certificate_with_round(ValidatedBlock::new(block.clone()), Round::MultiLeader(0));
+        let result = env
+            .executing_worker()
+            .handle_validated_certificate(validated)
+            .await;
+        match expected {
+            None => {
+                result?;
+                // Advance the tip so the next iteration builds on a fresh height.
+                let confirmed = env
+                    .make_certificate_with_round(ConfirmedBlock::new(block), Round::MultiLeader(0));
+                env.executing_worker()
+                    .fully_handle_certificate_with_notifications(confirmed.clone(), &())
+                    .await?;
+                parent = confirmed;
+            }
+            Some(expected) => {
+                let error = result.err().unwrap().to_string();
+                assert!(error.contains(expected), "{error:?} vs {expected:?}");
+            }
+        }
+    }
+
+    // The single validator holds all the stake and has registered its
+    // commitment for epoch 0, so the epoch is settled; epoch 1 is not.
+    let storage = env.executing_worker().storage_client();
+    assert!(storage.commitment_quorum_reached(Epoch::ZERO).await?);
+    assert!(!storage.commitment_quorum_reached(Epoch::from(1)).await?);
 
     Ok(())
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -17,8 +17,8 @@ use futures::{
 use linera_base::{
     crypto::{CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSignature},
     data_types::{
-        ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round, TimeDelta,
-        Timestamp,
+        ApplicationDescription, ArithmeticError, Blob, BlockHeight, CommitmentManifest, Epoch,
+        Round, TimeDelta, Timestamp,
     },
     doc_scalar, ensure,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
@@ -28,7 +28,6 @@ use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache, DEFAULT_CLEANU
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
     data_types::{BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock},
-    epoch_commitment::CommitmentManifest,
     types::{
         Block, CertificateValue, Certified, ConfirmedBlock, ConfirmedBlockCertificate,
         GenericCertificate, LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -400,6 +400,10 @@ pub enum WorkerError {
     InvalidLiteCertificate,
     #[error("Fast blocks cannot query oracles")]
     FastBlockUsingOracles,
+    /// The validator has permanently stopped signing votes in this epoch, in
+    /// preparation for committing to the votes it made in it.
+    #[error("Cannot vote in epoch {0}: this validator has frozen its signatures for it")]
+    VoteInFrozenEpoch(Epoch),
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     /// Variant raised when the chain references these block hashes via a
@@ -454,6 +458,7 @@ impl WorkerError {
             | WorkerError::MissingCertificateValue
             | WorkerError::InvalidLiteCertificate
             | WorkerError::FastBlockUsingOracles
+            | WorkerError::VoteInFrozenEpoch(_)
             | WorkerError::BlobsNotFound(_)
             | WorkerError::BlocksNotFound(_)
             | WorkerError::InvalidBlockProposal(_)
@@ -935,6 +940,25 @@ where
             chain_batches: Arc::new(papaya::HashMap::new()),
             outbound_cross_chain_sender: None,
         }
+    }
+
+    /// Permanently stops this worker from signing votes in the given epoch and
+    /// all earlier ones, and persists the freeze across restarts. When this
+    /// returns, no more votes in those epochs can be created, and every vote
+    /// created before the call is durably recorded in the vote ledger.
+    pub async fn freeze_epoch(&self, epoch: Epoch) -> Result<(), WorkerError> {
+        self.storage.mark_epoch_frozen(epoch).await?;
+        self.chain_worker_config.freezer.freeze(epoch).await;
+        Ok(())
+    }
+
+    /// Loads the persisted signature freeze into memory. Validators must call
+    /// this on startup, before handling requests.
+    pub async fn load_frozen_epochs(&self) -> Result<(), WorkerError> {
+        if let Some(epoch) = self.storage.max_frozen_epoch().await? {
+            self.chain_worker_config.freezer.freeze(epoch).await;
+        }
+        Ok(())
     }
 
     /// Installs a shard-routing dispatcher used for outbound cross-chain requests

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -413,6 +413,10 @@ pub enum WorkerError {
     EpochNotFrozen(Epoch),
     #[error("The commitment manifest names a different validator")]
     CommitmentValidatorMismatch,
+    /// A `RegisterCommitment` operation's entries failed verification against
+    /// this worker's storage.
+    #[error("Invalid epoch commitment: {0}")]
+    InvalidEpochCommitment(&'static str),
     /// The vote ledger, chain state and stored certificates together no longer
     /// yield the justification this validator's latest vote on the chain cited.
     /// This indicates local storage corruption: the write hooks preserve the
@@ -476,6 +480,7 @@ impl WorkerError {
             | WorkerError::VoteInFrozenEpoch(_)
             | WorkerError::EpochNotFrozen(_)
             | WorkerError::CommitmentValidatorMismatch
+            | WorkerError::InvalidEpochCommitment(_)
             | WorkerError::BlobsNotFound(_)
             | WorkerError::BlocksNotFound(_)
             | WorkerError::InvalidBlockProposal(_)

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -15,12 +15,12 @@ use futures::{
     FutureExt as _,
 };
 use linera_base::{
-    crypto::{CryptoError, CryptoHash, ValidatorPublicKey},
+    crypto::{CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSignature},
     data_types::{
         ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round, TimeDelta,
         Timestamp,
     },
-    doc_scalar,
+    doc_scalar, ensure,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
 };
 use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache, DEFAULT_CLEANUP_INTERVAL_SECS};
@@ -28,6 +28,7 @@ use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache, DEFAULT_CLEANU
 use linera_chain::ChainExecutionContext;
 use linera_chain::{
     data_types::{BlockProposal, BundleExecutionPolicy, MessageBundle, ProposedBlock},
+    epoch_commitment::CommitmentManifest,
     types::{
         Block, CertificateValue, Certified, ConfirmedBlock, ConfirmedBlockCertificate,
         GenericCertificate, LiteCertificate, Timeout, TimeoutCertificate, ValidatedBlock,
@@ -404,6 +405,15 @@ pub enum WorkerError {
     /// preparation for committing to the votes it made in it.
     #[error("Cannot vote in epoch {0}: this validator has frozen its signatures for it")]
     VoteInFrozenEpoch(Epoch),
+    #[error("This worker has no validator key configured")]
+    MissingValidatorKey,
+    /// A commitment manifest can only be signed once the epoch is frozen: before
+    /// that, votes could still be added to the ledger the commitment was built
+    /// from.
+    #[error("Cannot sign a commitment manifest for epoch {0}: it is not frozen")]
+    EpochNotFrozen(Epoch),
+    #[error("The commitment manifest names a different validator")]
+    CommitmentValidatorMismatch,
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     /// Variant raised when the chain references these block hashes via a
@@ -459,6 +469,8 @@ impl WorkerError {
             | WorkerError::InvalidLiteCertificate
             | WorkerError::FastBlockUsingOracles
             | WorkerError::VoteInFrozenEpoch(_)
+            | WorkerError::EpochNotFrozen(_)
+            | WorkerError::CommitmentValidatorMismatch
             | WorkerError::BlobsNotFound(_)
             | WorkerError::BlocksNotFound(_)
             | WorkerError::InvalidBlockProposal(_)
@@ -471,6 +483,7 @@ impl WorkerError {
             | WorkerError::BlockHashNotFound { .. }
             | WorkerError::LocalBlockNotFound { .. }
             | WorkerError::MissingNetworkDescription
+            | WorkerError::MissingValidatorKey
             | WorkerError::Thread(_)
             | WorkerError::ReadCertificatesError(_)
             | WorkerError::PoisonedWorker
@@ -959,6 +972,32 @@ where
             self.chain_worker_config.freezer.freeze(epoch).await;
         }
         Ok(())
+    }
+
+    /// Signs a manifest of this validator's commitment with the validator key.
+    /// Refuses unless the manifest names this validator and its epoch is frozen:
+    /// before the freeze, votes could still be added to the ledger the commitment
+    /// was built from.
+    pub async fn sign_commitment_manifest(
+        &self,
+        manifest: &CommitmentManifest,
+    ) -> Result<ValidatorSignature, WorkerError> {
+        let key_pair = self
+            .chain_worker_config
+            .key_pair()
+            .ok_or(WorkerError::MissingValidatorKey)?;
+        ensure!(
+            manifest.validator == key_pair.public(),
+            WorkerError::CommitmentValidatorMismatch
+        );
+        ensure!(
+            self.chain_worker_config
+                .freezer
+                .is_frozen(manifest.epoch)
+                .await,
+            WorkerError::EpochNotFrozen(manifest.epoch)
+        );
+        Ok(ValidatorSignature::new(manifest, key_pair))
     }
 
     /// Installs a shard-routing dispatcher used for outbound cross-chain requests

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -414,6 +414,12 @@ pub enum WorkerError {
     EpochNotFrozen(Epoch),
     #[error("The commitment manifest names a different validator")]
     CommitmentValidatorMismatch,
+    /// The vote ledger, chain state and stored certificates together no longer
+    /// yield the justification this validator's latest vote on the chain cited.
+    /// This indicates local storage corruption: the write hooks preserve the
+    /// pairing before every state transition that would lose it.
+    #[error("Cannot recover the justification for this validator's vote on chain {0}")]
+    MissingVoteJustification(ChainId),
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     /// Variant raised when the chain references these block hashes via a
@@ -484,6 +490,7 @@ impl WorkerError {
             | WorkerError::LocalBlockNotFound { .. }
             | WorkerError::MissingNetworkDescription
             | WorkerError::MissingValidatorKey
+            | WorkerError::MissingVoteJustification(_)
             | WorkerError::Thread(_)
             | WorkerError::ReadCertificatesError(_)
             | WorkerError::PoisonedWorker

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1566,6 +1566,14 @@ impl Operation {
             Some(SystemOperation::Admin(AdminOperation::PublishCommitteeBlob { blob_hash })) => {
                 vec![BlobId::new(*blob_hash, BlobType::Committee)]
             }
+            Some(SystemOperation::Admin(AdminOperation::RegisterCommitment { manifest })) => {
+                manifest
+                    .manifest
+                    .blob_hashes
+                    .iter()
+                    .map(|hash| BlobId::new(*hash, BlobType::EpochCommitment))
+                    .collect()
+            }
             Some(SystemOperation::PublishModule { module_id }) => module_id.bytecode_blob_ids(),
             _ => vec![],
         }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -36,7 +36,7 @@ use derive_more::Display;
 use js_sys::wasm_bindgen::JsValue;
 use linera_base::{
     abi::Abi,
-    crypto::{BcsHashable, CryptoHash},
+    crypto::{BcsHashable, CryptoError, CryptoHash},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlockHeight,
         Bytecode, DecompressionError, Epoch, NetworkDescription, SendMessageRequest, StreamUpdate,
@@ -367,6 +367,12 @@ pub enum ExecutionError {
     InvalidCommitteeEpoch { expected: Epoch, provided: Epoch },
     #[error("Failed to remove committee")]
     InvalidCommitteeRemoval,
+    #[error("Epoch commitments can only be registered for revoked epochs")]
+    CommitmentEpochNotRevoked,
+    #[error("The committing validator was not in the epoch's committee")]
+    CommitmentValidatorNotInCommittee,
+    #[error("The commitment manifest's signature is invalid: {0}")]
+    InvalidCommitmentSignature(CryptoError),
     #[error("No recorded response for oracle query")]
     MissingOracleResponse,
     #[error("process_streams was not called for all stream updates")]
@@ -429,6 +435,9 @@ impl ExecutionError {
             | ExecutionError::AdminOperationOnNonAdminChain
             | ExecutionError::InvalidCommitteeEpoch { .. }
             | ExecutionError::InvalidCommitteeRemoval
+            | ExecutionError::CommitmentEpochNotRevoked
+            | ExecutionError::CommitmentValidatorNotInCommittee
+            | ExecutionError::InvalidCommitmentSignature(_)
             | ExecutionError::MissingOracleResponse
             | ExecutionError::UnprocessedStreams
             | ExecutionError::OutdatedUpdateStream

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -463,7 +463,8 @@ impl ResourceControlPolicy {
             | BlobType::ApplicationFormats
             | BlobType::Committee
             | BlobType::ChainDescription
-            | BlobType::CheckpointExecutionState => {}
+            | BlobType::CheckpointExecutionState
+            | BlobType::EpochCommitment => {}
         }
         Ok(())
     }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -704,11 +704,15 @@ where
     pub fn track_blob_published(&mut self, blob: &Blob) -> Result<(), ExecutionError> {
         self.policy.check_blob_size(blob.content())?;
         let size = blob.content().bytes().len() as u64;
-        // Committee and checkpoint-execution-state blobs are exempt from fees and the
-        // per-block published-blob limit. Committee blobs are produced by network-level
-        // governance; checkpoint blobs are produced by `SystemOperation::Checkpoint`
-        // and their size is bounded by the policy's `maximum_blob_size` per chunk.
-        if blob.is_committee_blob() || blob.is_checkpoint_blob() {
+        // Committee, checkpoint-execution-state and epoch-commitment blobs are exempt
+        // from fees and the per-block published-blob limit. Committee blobs are
+        // produced by network-level governance; checkpoint and commitment blobs are
+        // size-bounded by the policy's `maximum_blob_size` per chunk, but a checkpoint
+        // or a revoked epoch's commitment can need arbitrarily many chunks, and every
+        // validator of a revoked epoch is protocol-bound to publish its commitment —
+        // capping the count per block would make large commitments unpublishable.
+        if blob.is_committee_blob() || blob.is_checkpoint_blob() || blob.is_epoch_commitment_blob()
+        {
             return Ok(());
         }
         {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -18,7 +18,7 @@ use linera_base::{
     data_types::{
         Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight,
         ChainDescription, ChainOrigin, Cursor, Epoch, InitialChainConfig, OracleResponse,
-        Timestamp,
+        SignedCommitmentManifest, Timestamp,
     },
     ensure, hex_debug,
     identifiers::{
@@ -49,6 +49,8 @@ use crate::{
 pub static EPOCH_STREAM_NAME: &[u8] = &[0];
 /// The event stream name for removed epochs.
 pub static REMOVED_EPOCH_STREAM_NAME: &[u8] = &[1];
+/// The event stream name for validators' epoch commitments.
+pub static COMMITMENT_STREAM_NAME: &[u8] = &[2];
 
 /// The data stored in an epoch creation event.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -340,6 +342,11 @@ pub enum AdminOperation {
     /// Removes a committee. Blocks signed by this committee will only be accepted once they
     /// have been followed (hence re-certified) by a block certified by a recent committee.
     RemoveCommittee { epoch: Epoch },
+    /// Registers a validator's commitment to the confirmation votes it signed in a
+    /// revoked epoch. The commitment's blobs must be published by the same block.
+    RegisterCommitment {
+        manifest: Box<SignedCommitmentManifest>,
+    },
 }
 
 /// A system message meant to be executed on a remote chain.
@@ -546,6 +553,58 @@ where
                         let next_index = epoch.0.checked_add(1).ok_or(ArithmeticError::Overflow)?;
                         self.stream_event_counts.insert(&stream_id, next_index)?;
                         txn_tracker.add_event(stream_id, epoch.0, vec![]);
+                    }
+                    AdminOperation::RegisterCommitment { manifest } => {
+                        let epoch = manifest.manifest.epoch;
+                        // Commitments are only registrable for revoked epochs; before
+                        // the revocation, the validator could still sign votes.
+                        let removed_stream = StreamId::system(REMOVED_EPOCH_STREAM_NAME);
+                        let removed_count = self
+                            .stream_event_counts
+                            .get(&removed_stream)
+                            .await?
+                            .unwrap_or(0);
+                        ensure!(
+                            epoch.0 < removed_count,
+                            ExecutionError::CommitmentEpochNotRevoked
+                        );
+                        manifest
+                            .check()
+                            .map_err(ExecutionError::InvalidCommitmentSignature)?;
+                        // The committing validator must have been in the epoch's
+                        // committee. The committee is resolved from the admin chain's
+                        // own event history, which every executor of this block has.
+                        let committee_hash = self
+                            .context()
+                            .extra()
+                            .get_committee_hashes(epoch..=epoch)
+                            .await?
+                            .remove(&epoch)
+                            .ok_or(ExecutionError::InternalError(
+                                "missing committee for a revoked epoch",
+                            ))?;
+                        let committee = self
+                            .context()
+                            .extra()
+                            .get_or_load_committee_by_hash(committee_hash)
+                            .await?;
+                        ensure!(
+                            committee
+                                .validators()
+                                .contains_key(&manifest.manifest.validator),
+                            ExecutionError::CommitmentValidatorNotInCommittee
+                        );
+                        for blob_hash in &manifest.manifest.blob_hashes {
+                            self.blob_published(
+                                &BlobId::new(*blob_hash, BlobType::EpochCommitment),
+                                txn_tracker,
+                            )?;
+                        }
+                        let stream_id = StreamId::system(COMMITMENT_STREAM_NAME);
+                        let index = self.stream_event_counts.get(&stream_id).await?.unwrap_or(0);
+                        let next_index = index.checked_add(1).ok_or(ArithmeticError::Overflow)?;
+                        self.stream_event_counts.insert(&stream_id, next_index)?;
+                        txn_tracker.add_event(stream_id, index, bcs::to_bytes(&manifest)?);
                     }
                 }
             }

--- a/linera-exporter/src/test_utils.rs
+++ b/linera-exporter/src/test_utils.rs
@@ -229,6 +229,7 @@ impl ValidatorNode for DummyValidator {
             requested_received_log: vec![],
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
+            requested_pending_commitments: Vec::new(),
         };
 
         let response = if missing_blobs.is_empty() {

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -288,6 +288,9 @@ message ChainInfoQuery {
   // Query the height of the most recent block whose certificate records an
   // OracleResponse::Checkpoint, if any.
   bool request_latest_checkpoint_height = 11;
+
+  // Query the validator's own pending epoch commitments.
+  bool request_pending_commitments = 12;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -42,6 +42,10 @@ service ValidatorWorker {
   // Permanently stop signing votes in this epoch and all earlier ones (trusted!).
   // Only returns once every vote created before the call is durably recorded.
   rpc FreezeEpoch(FreezeEpochRequest) returns (google.protobuf.Empty);
+
+  // Sign a manifest of this validator's commitment for a frozen epoch with the
+  // validator key (trusted!).
+  rpc SignCommitmentManifest(SignCommitmentManifestRequest) returns (SignCommitmentManifestResponse);
 }
 
 // How to communicate with a validator or a local node.
@@ -212,6 +216,16 @@ message CrossChainRequest {
 // A request to permanently stop signing votes in this epoch and all earlier ones.
 message FreezeEpochRequest {
   uint32 epoch = 1;
+}
+
+// A request to sign a commitment manifest, as BCS-serialized bytes.
+message SignCommitmentManifestRequest {
+  bytes manifest = 1;
+}
+
+// The validator's signature over a commitment manifest, as BCS-serialized bytes.
+message SignCommitmentManifestResponse {
+  bytes signature = 1;
 }
 
 // Communicate a number of messages from the sender to the recipient.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -38,6 +38,10 @@ service ValidatorWorker {
 
   // Handle a (trusted!) cross-chain request.
   rpc HandleCrossChainRequest(CrossChainRequest) returns (google.protobuf.Empty);
+
+  // Permanently stop signing votes in this epoch and all earlier ones (trusted!).
+  // Only returns once every vote created before the call is durably recorded.
+  rpc FreezeEpoch(FreezeEpochRequest) returns (google.protobuf.Empty);
 }
 
 // How to communicate with a validator or a local node.
@@ -203,6 +207,11 @@ message CrossChainRequest {
     ConfirmUpdatedRecipient confirm_updated_recipient = 2;
     RevertConfirm revert_confirm = 3;
   }
+}
+
+// A request to permanently stop signing votes in this epoch and all earlier ones.
+message FreezeEpochRequest {
+  uint32 epoch = 1;
 }
 
 // Communicate a number of messages from the sender to the recipient.

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -197,6 +197,14 @@ impl GrpcClient {
     fn try_into_chain_info(
         result: api::ChainInfoResult,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        result.try_into()
+    }
+}
+
+impl TryFrom<api::ChainInfoResult> for linera_core::data_types::ChainInfoResponse {
+    type Error = NodeError;
+
+    fn try_from(result: api::ChainInfoResult) -> Result<Self, Self::Error> {
         let inner = result.inner.ok_or_else(|| NodeError::GrpcError {
             error: "missing body from response".to_string(),
         })?;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -707,6 +707,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_sent_certificate_hashes_by_heights,
             request_previous_event_blocks,
             request_latest_checkpoint_height: chain_info_query.request_latest_checkpoint_height,
+            request_pending_commitments: chain_info_query.request_pending_commitments,
         })
     }
 }
@@ -740,6 +741,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_fallback: chain_info_query.request_fallback,
             request_previous_event_blocks: Some(request_previous_event_blocks),
             request_latest_checkpoint_height: chain_info_query.request_latest_checkpoint_height,
+            request_pending_commitments: chain_info_query.request_pending_commitments,
         })
     }
 }
@@ -1252,6 +1254,7 @@ pub mod tests {
             requested_received_log: vec![],
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
+            requested_pending_commitments: Vec::new(),
         });
 
         let chain_info_response_none = ChainInfoResponse {
@@ -1289,6 +1292,7 @@ pub mod tests {
             request_sent_certificate_hashes_by_heights: (3..8).map(BlockHeight::from).collect(),
             request_previous_event_blocks: Vec::new(),
             request_latest_checkpoint_height: true,
+            request_pending_commitments: true,
         };
         round_trip_check::<_, api::ChainInfoQuery>(&chain_info_query_some);
     }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -13,11 +13,10 @@ use futures::{
 #[cfg(with_metrics)]
 use linera_base::time::Instant;
 use linera_base::{
-    data_types::{Blob, Epoch},
+    data_types::{Blob, CommitmentManifest, Epoch},
     identifiers::ChainId,
     time::Duration,
 };
-use linera_chain::epoch_commitment::CommitmentManifest;
 use linera_core::{
     join_set_ext::JoinSet,
     node::NodeError,

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -12,7 +12,11 @@ use futures::{
 };
 #[cfg(with_metrics)]
 use linera_base::time::Instant;
-use linera_base::{data_types::Blob, identifiers::ChainId, time::Duration};
+use linera_base::{
+    data_types::{Blob, Epoch},
+    identifiers::ChainId,
+    time::Duration,
+};
 use linera_core::{
     join_set_ext::JoinSet,
     node::NodeError,
@@ -32,7 +36,7 @@ use super::{
         notifier_service_client::NotifierServiceClient,
         validator_worker_client::ValidatorWorkerClient,
         validator_worker_server::{ValidatorWorker as ValidatorWorkerRpc, ValidatorWorkerServer},
-        BlockProposal, ChainInfoQuery, ChainInfoResult, CrossChainRequest,
+        BlockProposal, ChainInfoQuery, ChainInfoResult, CrossChainRequest, FreezeEpochRequest,
         HandlePendingBlobRequest, LiteCertificate, PendingBlobRequest, PendingBlobResult,
     },
     pool::GrpcConnectionPool,
@@ -1070,6 +1074,34 @@ where
             }
         }
         Ok(Response::new(()))
+    }
+
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(
+            nickname = self.state.nickname(),
+            epoch = ?request.get_ref().epoch
+        )
+    )]
+    async fn freeze_epoch(
+        &self,
+        request: Request<FreezeEpochRequest>,
+    ) -> Result<Response<()>, Status> {
+        let traffic_type = Self::get_traffic_type(&request);
+        let epoch = Epoch(request.into_inner().epoch);
+        match self.state.freeze_epoch(epoch).await {
+            Ok(()) => {
+                Self::log_request_success("freeze_epoch", traffic_type);
+                Ok(Response::new(()))
+            }
+            Err(error) => {
+                Self::log_request_error("freeze_epoch", traffic_type, &error.error_type());
+                self.log_error(&error, "Failed to freeze epoch");
+                Err(Status::internal(error.to_string()))
+            }
+        }
     }
 }
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -17,6 +17,7 @@ use linera_base::{
     identifiers::ChainId,
     time::Duration,
 };
+use linera_chain::epoch_commitment::CommitmentManifest;
 use linera_core::{
     join_set_ext::JoinSet,
     node::NodeError,
@@ -38,6 +39,7 @@ use super::{
         validator_worker_server::{ValidatorWorker as ValidatorWorkerRpc, ValidatorWorkerServer},
         BlockProposal, ChainInfoQuery, ChainInfoResult, CrossChainRequest, FreezeEpochRequest,
         HandlePendingBlobRequest, LiteCertificate, PendingBlobRequest, PendingBlobResult,
+        SignCommitmentManifestRequest, SignCommitmentManifestResponse,
     },
     pool::GrpcConnectionPool,
     GrpcError, GRPC_MAX_MESSAGE_SIZE,
@@ -1099,6 +1101,38 @@ where
             Err(error) => {
                 Self::log_request_error("freeze_epoch", traffic_type, &error.error_type());
                 self.log_error(&error, "Failed to freeze epoch");
+                Err(Status::internal(error.to_string()))
+            }
+        }
+    }
+
+    #[instrument(
+        target = "grpc_server",
+        skip_all,
+        err,
+        fields(nickname = self.state.nickname())
+    )]
+    async fn sign_commitment_manifest(
+        &self,
+        request: Request<SignCommitmentManifestRequest>,
+    ) -> Result<Response<SignCommitmentManifestResponse>, Status> {
+        let traffic_type = Self::get_traffic_type(&request);
+        let manifest = bcs::from_bytes::<CommitmentManifest>(&request.into_inner().manifest)
+            .map_err(|error| Status::invalid_argument(error.to_string()))?;
+        match self.state.sign_commitment_manifest(&manifest).await {
+            Ok(signature) => {
+                Self::log_request_success("sign_commitment_manifest", traffic_type);
+                let signature = bcs::to_bytes(&signature)
+                    .map_err(|error| Status::internal(error.to_string()))?;
+                Ok(Response::new(SignCommitmentManifestResponse { signature }))
+            }
+            Err(error) => {
+                Self::log_request_error(
+                    "sign_commitment_manifest",
+                    traffic_type,
+                    &error.error_type(),
+                );
+                self.log_error(&error, "Failed to sign commitment manifest");
                 Err(Status::internal(error.to_string()))
             }
         }

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -4,7 +4,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlobContent, BlockHeight, NetworkDescription},
+    data_types::{BlobContent, BlockHeight, Epoch, NetworkDescription},
     identifiers::{BlobId, ChainId, EventId},
 };
 use linera_chain::{
@@ -87,6 +87,11 @@ pub enum RpcMessage {
     // Notification subscription
     SubscribeNotifications(Vec<ChainId>),
     Notification(Box<Notification>),
+
+    // Internal to a validator: permanently stop signing votes in this epoch and
+    // all earlier ones. Sent directly to each shard, not routed via the proxy.
+    FreezeEpoch(Epoch),
+    FreezeEpochResponse,
 }
 
 impl RpcMessage {
@@ -136,7 +141,9 @@ impl RpcMessage {
             | ShardInfoResponse(_)
             | DownloadCertificatesResponse(_)
             | SubscribeNotifications(_)
-            | Notification(_) => {
+            | Notification(_)
+            | FreezeEpoch(_)
+            | FreezeEpochResponse => {
                 return None;
             }
         };
@@ -189,7 +196,20 @@ impl RpcMessage {
             | DownloadCertificatesResponse(_)
             | DownloadCertificatesByHeightsResponse(_)
             | SubscribeNotifications(_)
-            | Notification(_) => false,
+            | Notification(_)
+            | FreezeEpoch(_)
+            | FreezeEpochResponse => false,
+        }
+    }
+}
+
+impl TryFrom<RpcMessage> for () {
+    type Error = NodeError;
+    fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
+        match message {
+            RpcMessage::FreezeEpochResponse => Ok(()),
+            RpcMessage::Error(error) => Err(*error),
+            _ => Err(NodeError::UnexpectedMessage),
         }
     }
 }

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    crypto::CryptoHash,
+    crypto::{CryptoHash, ValidatorSignature},
     data_types::{BlobContent, BlockHeight, Epoch, NetworkDescription},
     identifiers::{BlobId, ChainId, EventId},
 };
 use linera_chain::{
     data_types::{BlockProposal, LiteVote},
+    epoch_commitment::CommitmentManifest,
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_core::{
@@ -92,6 +93,11 @@ pub enum RpcMessage {
     // all earlier ones. Sent directly to each shard, not routed via the proxy.
     FreezeEpoch(Epoch),
     FreezeEpochResponse,
+
+    // Internal to a validator: sign a manifest of this validator's commitment
+    // for a frozen epoch. Sent directly to a shard, not routed via the proxy.
+    SignCommitmentManifest(Box<CommitmentManifest>),
+    SignCommitmentManifestResponse(Box<ValidatorSignature>),
 }
 
 impl RpcMessage {
@@ -143,7 +149,9 @@ impl RpcMessage {
             | SubscribeNotifications(_)
             | Notification(_)
             | FreezeEpoch(_)
-            | FreezeEpochResponse => {
+            | FreezeEpochResponse
+            | SignCommitmentManifest(_)
+            | SignCommitmentManifestResponse(_) => {
                 return None;
             }
         };
@@ -198,7 +206,9 @@ impl RpcMessage {
             | SubscribeNotifications(_)
             | Notification(_)
             | FreezeEpoch(_)
-            | FreezeEpochResponse => false,
+            | FreezeEpochResponse
+            | SignCommitmentManifest(_)
+            | SignCommitmentManifestResponse(_) => false,
         }
     }
 }
@@ -208,6 +218,17 @@ impl TryFrom<RpcMessage> for () {
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         match message {
             RpcMessage::FreezeEpochResponse => Ok(()),
+            RpcMessage::Error(error) => Err(*error),
+            _ => Err(NodeError::UnexpectedMessage),
+        }
+    }
+}
+
+impl TryFrom<RpcMessage> for ValidatorSignature {
+    type Error = NodeError;
+    fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
+        match message {
+            RpcMessage::SignCommitmentManifestResponse(signature) => Ok(*signature),
             RpcMessage::Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -4,12 +4,11 @@
 
 use linera_base::{
     crypto::{CryptoHash, ValidatorSignature},
-    data_types::{BlobContent, BlockHeight, Epoch, NetworkDescription},
+    data_types::{BlobContent, BlockHeight, CommitmentManifest, Epoch, NetworkDescription},
     identifiers::{BlobId, ChainId, EventId},
 };
 use linera_chain::{
     data_types::{BlockProposal, LiteVote},
-    epoch_commitment::CommitmentManifest,
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
 };
 use linera_core::{

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -387,6 +387,14 @@ where
                 Ok(Some(RpcMessage::VersionInfoResponse(Box::default())))
             }
 
+            RpcMessage::FreezeEpoch(epoch) => match self.server.state.freeze_epoch(epoch).await {
+                Ok(()) => Ok(Some(RpcMessage::FreezeEpochResponse)),
+                Err(error) => {
+                    self.log_error(&error, "Failed to freeze epoch");
+                    Err(error.into())
+                }
+            },
+
             RpcMessage::SubscribeNotifications(_) | RpcMessage::Notification(_) => {
                 // Subscriptions are handled at the transport level, not here.
                 Err(NodeError::UnexpectedMessage)
@@ -419,9 +427,8 @@ where
             | RpcMessage::UploadBlob(_)
             | RpcMessage::UploadBlobResponse(_)
             | RpcMessage::DownloadCertificatesByHeights(_, _)
-            | RpcMessage::DownloadCertificatesByHeightsResponse(_) => {
-                Err(NodeError::UnexpectedMessage)
-            }
+            | RpcMessage::DownloadCertificatesByHeightsResponse(_)
+            | RpcMessage::FreezeEpochResponse => Err(NodeError::UnexpectedMessage),
         };
 
         self.server.packets_processed += 1;

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -395,6 +395,18 @@ where
                 }
             },
 
+            RpcMessage::SignCommitmentManifest(manifest) => {
+                match self.server.state.sign_commitment_manifest(&manifest).await {
+                    Ok(signature) => Ok(Some(RpcMessage::SignCommitmentManifestResponse(
+                        Box::new(signature),
+                    ))),
+                    Err(error) => {
+                        self.log_error(&error, "Failed to sign commitment manifest");
+                        Err(error.into())
+                    }
+                }
+            }
+
             RpcMessage::SubscribeNotifications(_) | RpcMessage::Notification(_) => {
                 // Subscriptions are handled at the transport level, not here.
                 Err(NodeError::UnexpectedMessage)
@@ -428,7 +440,8 @@ where
             | RpcMessage::UploadBlobResponse(_)
             | RpcMessage::DownloadCertificatesByHeights(_, _)
             | RpcMessage::DownloadCertificatesByHeightsResponse(_)
-            | RpcMessage::FreezeEpochResponse => Err(NodeError::UnexpectedMessage),
+            | RpcMessage::FreezeEpochResponse
+            | RpcMessage::SignCommitmentManifestResponse(_) => Err(NodeError::UnexpectedMessage),
         };
 
         self.server.packets_processed += 1;

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -11,6 +11,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{MessageAction, OriginalProposal, Transaction},
+    epoch_commitment::{CommitmentChunk, SignedCommitmentManifest},
     manager::{ChainManagerInfo, LockingBlock},
     types::{Certificate, CertificateKind, ConfirmedBlock, Timeout, ValidatedBlock},
 };
@@ -83,6 +84,8 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<NodeError>(&samples)?;
     tracer.trace_type::<Reason>(&samples)?;
     tracer.trace_type::<RpcMessage>(&samples)?;
+    tracer.trace_type::<CommitmentChunk>(&samples)?;
+    tracer.trace_type::<SignedCommitmentManifest>(&samples)?;
     tracer.trace_type::<BlobType>(&samples)?;
     tracer.trace_type::<BlobContent>(&samples)?;
     tracer.trace_type::<AccountOwner>(&samples)?;

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -4,14 +4,16 @@
 
 use linera_base::{
     crypto::{AccountPublicKey, AccountSignature, CryptoHash, TestString},
-    data_types::{BlobContent, ChainDescription, ChainOrigin, OracleResponse, Round},
+    data_types::{
+        BlobContent, ChainDescription, ChainOrigin, OracleResponse, Round, SignedCommitmentManifest,
+    },
     identifiers::{Account, AccountOwner, BlobType, GenericApplicationId},
     ownership::ChainOwnership,
     vm::VmRuntime,
 };
 use linera_chain::{
     data_types::{MessageAction, OriginalProposal, Transaction},
-    epoch_commitment::{CommitmentChunk, SignedCommitmentManifest},
+    epoch_commitment::CommitmentChunk,
     manager::{ChainManagerInfo, LockingBlock},
     types::{Certificate, CertificateKind, ConfirmedBlock, Timeout, ValidatedBlock},
 };

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1246,6 +1246,12 @@ RpcMessage:
       Notification:
         NEWTYPE:
           TYPENAME: Notification
+    40:
+      FreezeEpoch:
+        NEWTYPE:
+          TYPENAME: Epoch
+    41:
+      FreezeEpochResponse: UNIT
 Secp256k1PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -138,6 +138,8 @@ BlobType:
       ApplicationFormats: UNIT
     8:
       CheckpointExecutionState: UNIT
+    9:
+      EpochCommitment: UNIT
 Block:
   STRUCT:
     - header:
@@ -444,6 +446,29 @@ ChainOwnership:
     - open_multi_leader_rounds: BOOL
     - timeout_config:
         TYPENAME: TimeoutConfig
+CommitmentChunk:
+  STRUCT:
+    - entries:
+        SEQ:
+          TYPENAME: CommitmentEntry
+CommitmentEntry:
+  STRUCT:
+    - chain_id:
+        TYPENAME: ChainId
+    - committed:
+        TYPENAME: JustifiedVote
+    - superseded:
+        SEQ:
+          TYPENAME: JustifiedVote
+CommitmentManifest:
+  STRUCT:
+    - epoch:
+        TYPENAME: Epoch
+    - validator:
+        TYPENAME: Secp256k1PublicKey
+    - blob_hashes:
+        SEQ:
+          TYPENAME: CryptoHash
 ConfirmedBlockCertificate:
   STRUCT:
     - value:
@@ -608,6 +633,13 @@ JustificationLink:
           TUPLE:
             - TYPENAME: Secp256k1PublicKey
             - TYPENAME: Secp256k1Signature
+JustifiedVote:
+  STRUCT:
+    - record:
+        TYPENAME: VoteRecord
+    - justification:
+        OPTION:
+          TYPENAME: ValidatedBlockCertificate
 LiteCertificate:
   STRUCT:
     - value:
@@ -1252,6 +1284,14 @@ RpcMessage:
           TYPENAME: Epoch
     41:
       FreezeEpochResponse: UNIT
+    42:
+      SignCommitmentManifest:
+        NEWTYPE:
+          TYPENAME: CommitmentManifest
+    43:
+      SignCommitmentManifestResponse:
+        NEWTYPE:
+          TYPENAME: Secp256k1Signature
 Secp256k1PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -1266,6 +1306,12 @@ ShardInfo:
   STRUCT:
     - shard_id: U64
     - total_shards: U64
+SignedCommitmentManifest:
+  STRUCT:
+    - manifest:
+        TYPENAME: CommitmentManifest
+    - signature:
+        TYPENAME: Secp256k1Signature
 StreamId:
   STRUCT:
     - application_id:
@@ -1473,3 +1519,11 @@ VmRuntime:
       Wasm: UNIT
     1:
       Evm: UNIT
+VoteRecord:
+  STRUCT:
+    - height:
+        TYPENAME: BlockHeight
+    - round:
+        TYPENAME: Round
+    - block_hash:
+        TYPENAME: CryptoHash

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -348,6 +348,9 @@ ChainInfo:
     - requested_latest_checkpoint_height:
         OPTION:
           TYPENAME: BlockHeight
+    - requested_pending_commitments:
+        SEQ:
+          TYPENAME: SignedCommitmentManifest
 ChainInfoQuery:
   STRUCT:
     - chain_id:
@@ -374,6 +377,7 @@ ChainInfoQuery:
         SEQ:
           TYPENAME: StreamId
     - request_latest_checkpoint_height: BOOL
+    - request_pending_commitments: BOOL
 ChainInfoResponse:
   STRUCT:
     - info:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -1527,3 +1527,6 @@ VoteRecord:
         TYPENAME: Round
     - block_hash:
         TYPENAME: CryptoHash
+    - justification_commitment:
+        OPTION:
+          TYPENAME: CryptoHash

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -81,6 +81,11 @@ AdminOperation:
         STRUCT:
           - epoch:
               TYPENAME: Epoch
+    3:
+      RegisterCommitment:
+        STRUCT:
+          - manifest:
+              TYPENAME: SignedCommitmentManifest
 Amount:
   NEWTYPESTRUCT: U128
 ApplicationId:

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -545,6 +545,12 @@ pub enum ClientCommand {
         epoch: Epoch,
     },
 
+    /// Registers validators' pending epoch commitments on the admin chain:
+    /// queries every validator for the signed commitment manifests it holds for
+    /// revoked epochs, downloads their blobs, and publishes the ones not
+    /// registered yet.
+    RegisterCommitments,
+
     /// View or update the resource control policy
     ResourceControlPolicy {
         /// Overrides for individual resource control policy parameters.
@@ -1136,6 +1142,7 @@ impl ClientCommand {
             | ClientCommand::QueryShardInfo { .. }
             | ClientCommand::ResourceControlPolicy { .. }
             | ClientCommand::RevokeEpochs { .. }
+            | ClientCommand::RegisterCommitments
             | ClientCommand::CreateGenesisConfig { .. }
             | ClientCommand::PublishModule { .. }
             | ClientCommand::ListEventsFromIndex { .. }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -752,6 +752,25 @@ impl Runnable for Job {
                 );
             }
 
+            RegisterCommitments => {
+                let mut context = options
+                    .create_client_context(storage, wallet, keystore)
+                    .await?;
+                let chain_client = context
+                    .make_chain_client(context.wallet().genesis_admin_chain_id())
+                    .await?;
+                let count = context
+                    .apply_client_command(&chain_client, |chain_client| {
+                        let chain_client = chain_client.clone();
+                        async move { chain_client.register_commitments().await }
+                    })
+                    .await
+                    .context("Failed to register commitments")?;
+                context.wallet().save()?;
+                // Parsed by tooling; keep the format stable.
+                println!("Registered {count} commitment(s)");
+            }
+
             #[cfg_attr(
                 not(feature = "opentelemetry"),
                 allow(unreachable_code, unused_variables)

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1318,6 +1318,27 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera register-commitments` and returns the number of newly
+    /// registered commitments.
+    pub async fn register_commitments(&self) -> Result<usize> {
+        let stdout = self
+            .command()
+            .await?
+            .arg("register-commitments")
+            .spawn_and_wait_for_stdout()
+            .await?;
+        let count = stdout
+            .lines()
+            .find_map(|line| {
+                line.strip_prefix("Registered ")?
+                    .strip_suffix(" commitment(s)")?
+                    .parse()
+                    .ok()
+            })
+            .context("missing commitment count in output")?;
+        Ok(count)
+    }
+
     /// Runs `linera resource-control-policy` with the given overrides.
     pub async fn set_resource_control_policy(
         &self,

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -16,9 +16,13 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
-use linera_base::identifiers::ChainId;
+use linera_base::{crypto::ValidatorSignature, data_types::Epoch, identifiers::ChainId};
+use linera_chain::{epoch_commitment::CommitmentManifest, manager::LockingBlock};
 use linera_core::{
-    data_types::CertificatesByHeightRequest, notifier::ChannelNotifier, JoinSetExt as _,
+    commitment::{CommitmentAgent, CommitmentError, ShardControl},
+    data_types::{CertificatesByHeightRequest, ChainInfoQuery},
+    notifier::ChannelNotifier,
+    JoinSetExt as _,
 };
 #[cfg(with_metrics)]
 use linera_metrics::monitoring_server;
@@ -35,10 +39,10 @@ use linera_rpc::{
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
             BlobContent, BlobId, BlobIds, BlockProposal, Certificate, CertificatesBatchRequest,
-            CertificatesBatchResponse, ChainInfoResult, CryptoHash, HandlePendingBlobRequest,
-            LiteCertificate, NetworkDescription, Notification, NotificationBatch,
-            PendingBlobRequest, PendingBlobResult, RawCertificate, RawCertificatesBatch,
-            SubscriptionRequest, VersionInfo,
+            CertificatesBatchResponse, ChainInfoResult, CryptoHash, FreezeEpochRequest,
+            HandlePendingBlobRequest, LiteCertificate, NetworkDescription, Notification,
+            NotificationBatch, PendingBlobRequest, PendingBlobResult, RawCertificate,
+            RawCertificatesBatch, SignCommitmentManifestRequest, SubscriptionRequest, VersionInfo,
         },
         pool::GrpcConnectionPool,
         GrpcProtoConversionError, GrpcProxyable, GRPC_CHUNKED_MESSAGE_FILL_LIMIT,
@@ -57,7 +61,7 @@ use tonic::{
 };
 use tonic_web::GrpcWebLayer;
 use tower::{builder::ServiceBuilder, Layer, Service};
-use tracing::{debug, info, instrument, Instrument as _, Level};
+use tracing::{debug, info, instrument, warn, Instrument as _, Level};
 
 #[cfg(with_metrics)]
 mod metrics {
@@ -199,6 +203,9 @@ where
     }
 }
 
+/// How often the commitment agent checks for newly revoked epochs.
+const COMMITMENT_CHECK_INTERVAL: Duration = Duration::from_secs(60);
+
 #[derive(Clone)]
 pub struct GrpcProxy<S>(Arc<GrpcProxyInner<S>>);
 
@@ -320,6 +327,11 @@ where
         health_reporter
             .set_serving::<ValidatorNodeServer<GrpcProxy<S>>>()
             .await;
+        let _commitment_agent = join_set.spawn_task(
+            self.clone()
+                .run_commitment_agent(shutdown_signal.clone())
+                .in_current_span(),
+        );
         let internal_server = join_set.spawn_task(
             Server::builder()
                 .add_service(self.as_notifier_service())
@@ -370,6 +382,38 @@ where
             public_res = public_server => public_res??,
         }
         Ok(())
+    }
+
+    /// Periodically commits this validator's votes in newly revoked epochs: for
+    /// each one, the commitment agent freezes signing on all shards, assembles
+    /// the commitment from the vote ledger, has a shard sign the manifest, and
+    /// stores the result for publication on the admin chain. Every proxy runs
+    /// the agent — each step is idempotent, and concurrent runs write the same
+    /// records.
+    async fn run_commitment_agent(self, shutdown_signal: CancellationToken) {
+        let validator = self.0.internal_config.public_key;
+        let storage = self.0.storage.clone();
+        let mut agent = CommitmentAgent::new(storage, self.clone(), validator, usize::MAX);
+        let mut interval = tokio::time::interval(COMMITMENT_CHECK_INTERVAL);
+        loop {
+            select! {
+                _ = shutdown_signal.cancelled() => return,
+                _ = interval.tick() => {}
+            }
+            match agent.process_revoked_epochs().await {
+                Ok(epochs) => {
+                    if !epochs.is_empty() {
+                        info!(
+                            ?epochs,
+                            "committed this validator's votes in revoked epochs"
+                        );
+                    }
+                }
+                Err(error) => {
+                    warn!(%error, "failed to process revoked epochs; will retry");
+                }
+            }
+        }
     }
 
     /// Pre-configures the public server with no services attached.
@@ -442,6 +486,73 @@ where
         };
         status.set_source(Arc::new(err));
         status
+    }
+}
+
+impl<S> ShardControl for GrpcProxy<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    async fn freeze_epoch(&self, epoch: Epoch) -> Result<(), CommitmentError> {
+        let requests = self
+            .0
+            .internal_config
+            .shards
+            .iter()
+            .map(|shard| async move {
+                self.worker_client_for_shard(shard)
+                    .map_err(|error| CommitmentError::Shard(error.to_string()))?
+                    .freeze_epoch(FreezeEpochRequest { epoch: epoch.0 })
+                    .await
+                    .map_err(|status| CommitmentError::Shard(status.to_string()))?;
+                Ok::<_, CommitmentError>(())
+            });
+        futures::future::try_join_all(requests).await?;
+        Ok(())
+    }
+
+    async fn sign_commitment_manifest(
+        &self,
+        manifest: &CommitmentManifest,
+    ) -> Result<ValidatorSignature, CommitmentError> {
+        // The validator key lives in the shards; any of them can sign.
+        let shard = self
+            .0
+            .internal_config
+            .shards
+            .first()
+            .ok_or_else(|| CommitmentError::Shard("no shards configured".to_string()))?;
+        let request = SignCommitmentManifestRequest {
+            manifest: bcs::to_bytes(manifest)?,
+        };
+        let response = self
+            .worker_client_for_shard(shard)
+            .map_err(|error| CommitmentError::Shard(error.to_string()))?
+            .sign_commitment_manifest(request)
+            .await
+            .map_err(|status| CommitmentError::Shard(status.to_string()))?
+            .into_inner();
+        Ok(bcs::from_bytes(&response.signature)?)
+    }
+
+    async fn locking_block(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<Option<LockingBlock>, CommitmentError> {
+        let shard = self.0.internal_config.get_shard_for(chain_id).clone();
+        let query = ChainInfoQuery::new(chain_id).with_manager_values();
+        let request = api::ChainInfoQuery::try_from(query)
+            .map_err(|error| CommitmentError::Shard(error.to_string()))?;
+        let result = self
+            .worker_client_for_shard(&shard)
+            .map_err(|error| CommitmentError::Shard(error.to_string()))?
+            .handle_chain_info_query(request)
+            .await
+            .map_err(|status| CommitmentError::Shard(status.to_string()))?
+            .into_inner();
+        let response = linera_core::data_types::ChainInfoResponse::try_from(result)
+            .map_err(|error| CommitmentError::Shard(error.to_string()))?;
+        Ok(response.info.manager.requested_locking.map(|boxed| *boxed))
     }
 }
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -16,8 +16,12 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
-use linera_base::{crypto::ValidatorSignature, data_types::Epoch, identifiers::ChainId};
-use linera_chain::{epoch_commitment::CommitmentManifest, manager::LockingBlock};
+use linera_base::{
+    crypto::ValidatorSignature,
+    data_types::{CommitmentManifest, Epoch},
+    identifiers::ChainId,
+};
+use linera_chain::manager::LockingBlock;
 use linera_core::{
     commitment::{CommitmentAgent, CommitmentError, ShardControl},
     data_types::{CertificatesByHeightRequest, ChainInfoQuery},

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -582,7 +582,9 @@ where
             | UploadBlobResponse(_)
             | DownloadCertificatesByHeightsResponse(_)
             | SubscribeNotifications(_)
-            | Notification(_) => Err(anyhow::Error::from(NodeError::UnexpectedMessage)),
+            | Notification(_)
+            | FreezeEpoch(_)
+            | FreezeEpochResponse => Err(anyhow::Error::from(NodeError::UnexpectedMessage)),
         }
     }
 }

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -584,7 +584,11 @@ where
             | SubscribeNotifications(_)
             | Notification(_)
             | FreezeEpoch(_)
-            | FreezeEpochResponse => Err(anyhow::Error::from(NodeError::UnexpectedMessage)),
+            | FreezeEpochResponse
+            | SignCommitmentManifest(_)
+            | SignCommitmentManifestResponse(_) => {
+                Err(anyhow::Error::from(NodeError::UnexpectedMessage))
+            }
         }
     }
 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -270,6 +270,10 @@ impl Runnable for ServerContext {
             }
         };
 
+        for (state, _, _) in &states {
+            state.load_frozen_epochs().await?;
+        }
+
         let mut join_set = match self.server_config.internal_network.protocol {
             NetworkProtocol::Simple(protocol) => self.spawn_simple(
                 &listen_address,

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -233,6 +233,26 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         )
         .await?;
 
+    if matches!(network, Network::Grpc) {
+        // Epochs 0–2 are revoked. The last remaining validator belonged to the
+        // epoch-1 and epoch-2 committees, so its proxy's commitment agent (which
+        // ticks every 60 seconds) freezes those epochs and prepares signed
+        // commitments; `register-commitments` collects and publishes them on the
+        // admin chain. (The removed validators' commitments are unreachable and
+        // simply skipped.)
+        let mut registered = 0;
+        for _ in 0..30 {
+            registered += client.register_commitments().await?;
+            if registered >= 2 {
+                break;
+            }
+            linera_base::time::timer::sleep(Duration::from_secs(5)).await;
+        }
+        assert_eq!(registered, 2);
+        // Everything pending is registered now; another run is a no-op.
+        assert_eq!(client.register_commitments().await?, 0);
+    }
+
     if let Some((service, notifications)) = &mut node_service_2 {
         let height = client
             .load_wallet()?

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -18,6 +18,7 @@ use linera_base::{
 };
 use linera_cache::{Arc as CacheArc, ValueCache};
 use linera_chain::{
+    epoch_commitment::SignedCommitmentManifest,
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainStateView,
@@ -472,6 +473,18 @@ impl MultiPartitionBatch {
         self.put_key_value(root_key, key, Vec::new());
     }
 
+    /// Adds a signed commitment manifest awaiting publication on the admin chain.
+    fn add_pending_commitment(
+        &mut self,
+        manifest: &SignedCommitmentManifest,
+    ) -> Result<(), ViewError> {
+        let root_key = RootKey::PendingCommitments.bytes();
+        let key = bcs::to_bytes(&manifest.manifest.epoch)?;
+        let value = bcs::to_bytes(manifest)?;
+        self.put_key_value(root_key, key, value);
+        Ok(())
+    }
+
     /// Adds a superseded confirmation vote to the epoch's vote ledger, without
     /// touching the chain's latest-vote entry.
     fn add_superseded_vote(
@@ -642,6 +655,9 @@ pub enum RootKey {
     /// Markers for the epochs in which this validator has permanently stopped
     /// signing votes, keyed by epoch.
     FrozenEpochs,
+    /// This validator's signed commitment manifests awaiting publication on the
+    /// admin chain, keyed by epoch.
+    PendingCommitments,
 }
 
 const CHAIN_ID_TAG: u8 = 2;
@@ -1749,6 +1765,39 @@ where
             max_epoch = max_epoch.max(Some(epoch));
         }
         Ok(max_epoch)
+    }
+
+    #[instrument(skip_all, fields(epoch = %manifest.manifest.epoch))]
+    async fn write_pending_commitment(
+        &self,
+        manifest: &SignedCommitmentManifest,
+    ) -> Result<(), ViewError> {
+        let mut batch = MultiPartitionBatch::new();
+        batch.add_pending_commitment(manifest)?;
+        self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all, fields(epoch = %epoch))]
+    async fn read_pending_commitment(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<SignedCommitmentManifest>, ViewError> {
+        let root_key = RootKey::PendingCommitments.bytes();
+        let store = self.database.open_shared(&root_key)?;
+        Ok(store.read_value(&bcs::to_bytes(&epoch)?).await?)
+    }
+
+    #[instrument(skip_all)]
+    async fn pending_commitments(&self) -> Result<Vec<SignedCommitmentManifest>, ViewError> {
+        let root_key = RootKey::PendingCommitments.bytes();
+        let store = self.database.open_shared(&root_key)?;
+        let mut manifests = Vec::<SignedCommitmentManifest>::new();
+        for (_, value) in store.find_key_values_by_prefix(&[]).await? {
+            manifests.push(bcs::from_bytes(&value)?);
+        }
+        // BCS-serialized epochs don't sort numerically.
+        manifests.sort_by_key(|manifest| manifest.manifest.epoch);
+        Ok(manifests)
     }
 
     #[instrument(skip_all)]

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -19,7 +19,7 @@ use linera_base::{
 use linera_cache::{Arc as CacheArc, ValueCache};
 use linera_chain::{
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
-    vote_ledger::{LedgerEntry, SupersededVote, VoteRecord},
+    vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainStateView,
 };
 use linera_execution::{
@@ -450,7 +450,7 @@ impl MultiPartitionBatch {
         epoch: Epoch,
         chain_id: &ChainId,
         record: &VoteRecord,
-        superseded: Option<&SupersededVote>,
+        superseded: Option<&JustifiedVote>,
     ) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
         metrics::WRITE_CONFIRMED_VOTE_COUNTER.inc();
@@ -478,7 +478,7 @@ impl MultiPartitionBatch {
         &mut self,
         epoch: Epoch,
         chain_id: &ChainId,
-        superseded: &SupersededVote,
+        superseded: &JustifiedVote,
     ) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
         metrics::WRITE_SUPERSEDED_VOTE_COUNTER.inc();
@@ -1675,7 +1675,7 @@ where
         epoch: Epoch,
         chain_id: ChainId,
         record: VoteRecord,
-        superseded: Option<SupersededVote>,
+        superseded: Option<JustifiedVote>,
     ) -> Result<(), ViewError> {
         let mut batch = MultiPartitionBatch::new();
         batch.add_confirmed_vote(epoch, &chain_id, &record, superseded.as_ref())?;
@@ -1687,7 +1687,7 @@ where
         &self,
         epoch: Epoch,
         chain_id: ChainId,
-        superseded: SupersededVote,
+        superseded: JustifiedVote,
     ) -> Result<(), ViewError> {
         let mut batch = MultiPartitionBatch::new();
         batch.add_superseded_vote(epoch, &chain_id, &superseded)?;

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -12,13 +12,14 @@ use async_trait::async_trait;
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight, NetworkDescription, TimeDelta, Timestamp},
+    data_types::{Blob, BlockHeight, Epoch, NetworkDescription, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
     time::Duration,
 };
 use linera_cache::{Arc as CacheArc, ValueCache};
 use linera_chain::{
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
+    vote_ledger::{LedgerEntry, SupersededVote, VoteRecord},
     ChainStateView,
 };
 use linera_execution::{
@@ -419,6 +420,29 @@ impl MultiPartitionBatch {
         self.put_key_value(root_key, key, value);
     }
 
+    /// Adds a confirmation vote to the epoch's vote ledger: overwrites the chain's
+    /// latest-vote entry, and stores the replaced vote under its own key if the new
+    /// vote superseded one at the same height. Both are blind writes, so recording
+    /// a vote never requires a read.
+    fn add_confirmed_vote(
+        &mut self,
+        epoch: Epoch,
+        chain_id: &ChainId,
+        record: &VoteRecord,
+        superseded: Option<&SupersededVote>,
+    ) -> Result<(), ViewError> {
+        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let key = to_vote_ledger_latest_key(chain_id);
+        let value = bcs::to_bytes(record)?;
+        self.put_key_value(root_key.clone(), key, value);
+        if let Some(superseded) = superseded {
+            let key = to_vote_ledger_superseded_key(chain_id, &superseded.record);
+            let value = bcs::to_bytes(superseded)?;
+            self.put_key_value(root_key, key, value);
+        }
+        Ok(())
+    }
+
     fn add_network_description(
         &mut self,
         information: &NetworkDescription,
@@ -565,6 +589,8 @@ pub enum RootKey {
     BlockByHeight(ChainId),
     /// The event-to-block-height index of a chain.
     EventBlockHeight(ChainId),
+    /// This validator's own confirmation votes in an epoch, keyed by chain.
+    VoteLedger(Epoch),
 }
 
 const CHAIN_ID_TAG: u8 = 2;
@@ -594,6 +620,30 @@ fn to_event_key(event_id: &EventId) -> Vec<u8> {
 
 pub(crate) fn to_height_key(height: BlockHeight) -> Vec<u8> {
     bcs::to_bytes(&height).unwrap()
+}
+
+/// Tag prefix for a chain's latest confirmation vote in a `VoteLedger` partition.
+const VOTE_LEDGER_LATEST_TAG: u8 = 0;
+/// Tag prefix for a chain's superseded confirmation votes in a `VoteLedger`
+/// partition.
+const VOTE_LEDGER_SUPERSEDED_TAG: u8 = 1;
+
+fn to_vote_ledger_latest_key(chain_id: &ChainId) -> Vec<u8> {
+    let mut key = vec![VOTE_LEDGER_LATEST_TAG];
+    key.extend(bcs::to_bytes(chain_id).unwrap());
+    key
+}
+
+fn to_vote_ledger_superseded_prefix(chain_id: &ChainId) -> Vec<u8> {
+    let mut key = vec![VOTE_LEDGER_SUPERSEDED_TAG];
+    key.extend(bcs::to_bytes(chain_id).unwrap());
+    key
+}
+
+fn to_vote_ledger_superseded_key(chain_id: &ChainId, record: &VoteRecord) -> Vec<u8> {
+    let mut key = to_vote_ledger_superseded_prefix(chain_id);
+    key.extend(bcs::to_bytes(&(record.height, record.round)).unwrap());
+    key
 }
 
 fn is_chain_state(root_key: &[u8]) -> bool {
@@ -1558,6 +1608,67 @@ where
             batch.add_event(&event_id, value);
         }
         self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all, fields(chain_id = %chain_id, epoch = %epoch))]
+    async fn record_confirmed_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        record: VoteRecord,
+        superseded: Option<SupersededVote>,
+    ) -> Result<(), ViewError> {
+        let mut batch = MultiPartitionBatch::new();
+        batch.add_confirmed_vote(epoch, &chain_id, &record, superseded.as_ref())?;
+        self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all, fields(chain_id = %chain_id, epoch = %epoch))]
+    async fn record_superseded_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        superseded: SupersededVote,
+    ) -> Result<(), ViewError> {
+        let mut batch = MultiPartitionBatch::new();
+        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let key = to_vote_ledger_superseded_key(&chain_id, &superseded.record);
+        let value = bcs::to_bytes(&superseded)?;
+        batch.put_key_value(root_key, key, value);
+        self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all, fields(chain_id = %chain_id, epoch = %epoch))]
+    async fn read_vote_ledger_entry(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+    ) -> Result<Option<LedgerEntry>, ViewError> {
+        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let store = self.database.open_shared(&root_key)?;
+        let Some(latest) = store
+            .read_value::<VoteRecord>(&to_vote_ledger_latest_key(&chain_id))
+            .await?
+        else {
+            return Ok(None);
+        };
+        let prefix = to_vote_ledger_superseded_prefix(&chain_id);
+        let mut superseded = Vec::new();
+        for (_, value) in store.find_key_values_by_prefix(&prefix).await? {
+            superseded.push(bcs::from_bytes(&value)?);
+        }
+        Ok(Some(LedgerEntry { latest, superseded }))
+    }
+
+    #[instrument(skip_all, fields(epoch = %epoch))]
+    async fn vote_ledger_chain_ids(&self, epoch: Epoch) -> Result<Vec<ChainId>, ViewError> {
+        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let store = self.database.open_shared(&root_key)?;
+        let mut chain_ids = Vec::new();
+        for short_key in store.find_keys_by_prefix(&[VOTE_LEDGER_LATEST_TAG]).await? {
+            chain_ids.push(bcs::from_bytes(&short_key)?);
+        }
+        Ok(chain_ids)
     }
 
     #[instrument(skip_all)]

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -454,7 +454,7 @@ impl MultiPartitionBatch {
     ) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
         metrics::WRITE_CONFIRMED_VOTE_COUNTER.inc();
-        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let root_key = to_vote_ledger_root_key(epoch, chain_id);
         let key = to_vote_ledger_latest_key(chain_id);
         let value = bcs::to_bytes(record)?;
         self.put_key_value(root_key.clone(), key, value);
@@ -474,7 +474,7 @@ impl MultiPartitionBatch {
     ) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
         metrics::WRITE_SUPERSEDED_VOTE_COUNTER.inc();
-        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let root_key = to_vote_ledger_root_key(epoch, chain_id);
         let key = to_vote_ledger_superseded_key(chain_id, &superseded.record);
         let value = bcs::to_bytes(superseded)?;
         self.put_key_value(root_key, key, value);
@@ -627,8 +627,10 @@ pub enum RootKey {
     BlockByHeight(ChainId),
     /// The event-to-block-height index of a chain.
     EventBlockHeight(ChainId),
-    /// This validator's own confirmation votes in an epoch, keyed by chain.
-    VoteLedger(Epoch),
+    /// One bucket of this validator's own confirmation votes in an epoch, keyed
+    /// by chain. Buckets split the ledger by the chain ID's first byte, so that no
+    /// single partition has to hold a whole epoch's votes.
+    VoteLedger(Epoch, u8),
 }
 
 const CHAIN_ID_TAG: u8 = 2;
@@ -665,6 +667,14 @@ const VOTE_LEDGER_LATEST_TAG: u8 = 0;
 /// Tag prefix for a chain's superseded confirmation votes in a `VoteLedger`
 /// partition.
 const VOTE_LEDGER_SUPERSEDED_TAG: u8 = 1;
+
+/// Returns the root key of the vote-ledger bucket holding this chain's entries.
+/// Chain IDs are hashes, so the buckets split an epoch's ledger uniformly into
+/// 256 partitions.
+fn to_vote_ledger_root_key(epoch: Epoch, chain_id: &ChainId) -> Vec<u8> {
+    let bucket = bcs::to_bytes(chain_id).unwrap()[0];
+    RootKey::VoteLedger(epoch, bucket).bytes()
+}
 
 fn to_vote_ledger_latest_key(chain_id: &ChainId) -> Vec<u8> {
     let mut key = vec![VOTE_LEDGER_LATEST_TAG];
@@ -1679,7 +1689,7 @@ where
         epoch: Epoch,
         chain_id: ChainId,
     ) -> Result<Option<LedgerEntry>, ViewError> {
-        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let root_key = to_vote_ledger_root_key(epoch, &chain_id);
         let store = self.database.open_shared(&root_key)?;
         let Some(latest) = store
             .read_value::<VoteRecord>(&to_vote_ledger_latest_key(&chain_id))
@@ -1697,11 +1707,15 @@ where
 
     #[instrument(skip_all, fields(epoch = %epoch))]
     async fn vote_ledger_chain_ids(&self, epoch: Epoch) -> Result<Vec<ChainId>, ViewError> {
-        let root_key = RootKey::VoteLedger(epoch).bytes();
-        let store = self.database.open_shared(&root_key)?;
+        // Ascending buckets, and sorted keys within each, so the result is ordered
+        // by serialized chain ID.
         let mut chain_ids = Vec::new();
-        for short_key in store.find_keys_by_prefix(&[VOTE_LEDGER_LATEST_TAG]).await? {
-            chain_ids.push(bcs::from_bytes(&short_key)?);
+        for bucket in 0..=u8::MAX {
+            let root_key = RootKey::VoteLedger(epoch, bucket).bytes();
+            let store = self.database.open_shared(&root_key)?;
+            for short_key in store.find_keys_by_prefix(&[VOTE_LEDGER_LATEST_TAG]).await? {
+                chain_ids.push(bcs::from_bytes(&short_key)?);
+            }
         }
         Ok(chain_ids)
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -254,6 +254,27 @@ pub mod metrics {
         )
     });
 
+    /// The metric counting how often a confirmation vote is written to the vote
+    /// ledger.
+    #[doc(hidden)]
+    pub(super) static WRITE_CONFIRMED_VOTE_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "write_confirmed_vote",
+            "The metric counting how often a confirmation vote is written to the vote ledger",
+        )
+    });
+
+    /// The metric counting how often a superseded confirmation vote is written to
+    /// the vote ledger.
+    #[doc(hidden)]
+    pub(super) static WRITE_SUPERSEDED_VOTE_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "write_superseded_vote",
+            "The metric counting how often a superseded confirmation vote is written to the \
+            vote ledger",
+        )
+    });
+
     /// The metric counting how often a block hash is read by height from storage.
     #[doc(hidden)]
     pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: LazyLock<IntCounterVec> =
@@ -431,15 +452,32 @@ impl MultiPartitionBatch {
         record: &VoteRecord,
         superseded: Option<&SupersededVote>,
     ) -> Result<(), ViewError> {
+        #[cfg(with_metrics)]
+        metrics::WRITE_CONFIRMED_VOTE_COUNTER.inc();
         let root_key = RootKey::VoteLedger(epoch).bytes();
         let key = to_vote_ledger_latest_key(chain_id);
         let value = bcs::to_bytes(record)?;
         self.put_key_value(root_key.clone(), key, value);
         if let Some(superseded) = superseded {
-            let key = to_vote_ledger_superseded_key(chain_id, &superseded.record);
-            let value = bcs::to_bytes(superseded)?;
-            self.put_key_value(root_key, key, value);
+            self.add_superseded_vote(epoch, chain_id, superseded)?;
         }
+        Ok(())
+    }
+
+    /// Adds a superseded confirmation vote to the epoch's vote ledger, without
+    /// touching the chain's latest-vote entry.
+    fn add_superseded_vote(
+        &mut self,
+        epoch: Epoch,
+        chain_id: &ChainId,
+        superseded: &SupersededVote,
+    ) -> Result<(), ViewError> {
+        #[cfg(with_metrics)]
+        metrics::WRITE_SUPERSEDED_VOTE_COUNTER.inc();
+        let root_key = RootKey::VoteLedger(epoch).bytes();
+        let key = to_vote_ledger_superseded_key(chain_id, &superseded.record);
+        let value = bcs::to_bytes(superseded)?;
+        self.put_key_value(root_key, key, value);
         Ok(())
     }
 
@@ -1631,10 +1669,7 @@ where
         superseded: SupersededVote,
     ) -> Result<(), ViewError> {
         let mut batch = MultiPartitionBatch::new();
-        let root_key = RootKey::VoteLedger(epoch).bytes();
-        let key = to_vote_ledger_superseded_key(&chain_id, &superseded.record);
-        let value = bcs::to_bytes(&superseded)?;
-        batch.put_key_value(root_key, key, value);
+        batch.add_superseded_vote(epoch, &chain_id, &superseded)?;
         self.write_batch(batch).await
     }
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -12,13 +12,15 @@ use async_trait::async_trait;
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight, Epoch, NetworkDescription, TimeDelta, Timestamp},
+    data_types::{
+        Blob, BlockHeight, Epoch, NetworkDescription, SignedCommitmentManifest, TimeDelta,
+        Timestamp,
+    },
     identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
     time::Duration,
 };
 use linera_cache::{Arc as CacheArc, ValueCache};
 use linera_chain::{
-    epoch_commitment::SignedCommitmentManifest,
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
     vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainStateView,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -464,6 +464,14 @@ impl MultiPartitionBatch {
         Ok(())
     }
 
+    /// Adds a marker recording that this validator has permanently stopped
+    /// signing votes in the given epoch.
+    fn add_frozen_epoch(&mut self, epoch: Epoch) {
+        let root_key = RootKey::FrozenEpochs.bytes();
+        let key = bcs::to_bytes(&epoch).unwrap();
+        self.put_key_value(root_key, key, Vec::new());
+    }
+
     /// Adds a superseded confirmation vote to the epoch's vote ledger, without
     /// touching the chain's latest-vote entry.
     fn add_superseded_vote(
@@ -631,6 +639,9 @@ pub enum RootKey {
     /// by chain. Buckets split the ledger by the chain ID's first byte, so that no
     /// single partition has to hold a whole epoch's votes.
     VoteLedger(Epoch, u8),
+    /// Markers for the epochs in which this validator has permanently stopped
+    /// signing votes, keyed by epoch.
+    FrozenEpochs,
 }
 
 const CHAIN_ID_TAG: u8 = 2;
@@ -1718,6 +1729,26 @@ where
             }
         }
         Ok(chain_ids)
+    }
+
+    #[instrument(skip_all, fields(epoch = %epoch))]
+    async fn mark_epoch_frozen(&self, epoch: Epoch) -> Result<(), ViewError> {
+        let mut batch = MultiPartitionBatch::new();
+        batch.add_frozen_epoch(epoch);
+        self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all)]
+    async fn max_frozen_epoch(&self) -> Result<Option<Epoch>, ViewError> {
+        let root_key = RootKey::FrozenEpochs.bytes();
+        let store = self.database.open_shared(&root_key)?;
+        let mut max_epoch = None;
+        // BCS-serialized epochs don't sort numerically, so scan all markers.
+        for key in store.find_keys_by_prefix(&[]).await? {
+            let epoch = bcs::from_bytes::<Epoch>(&key)?;
+            max_epoch = max_epoch.max(Some(epoch));
+        }
+        Ok(max_epoch)
     }
 
     #[instrument(skip_all)]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -15,7 +15,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{
         ApplicationDescription, Blob, BlockHeight, ChainDescription, CompressedBytecode, Epoch,
-        NetworkDescription, TimeDelta, Timestamp,
+        NetworkDescription, SignedCommitmentManifest, TimeDelta, Timestamp,
     },
     identifiers::{ApplicationId, BlobId, BlobType, ChainId, EventId, IndexAndEvent, StreamId},
     time::Duration,
@@ -23,7 +23,6 @@ use linera_base::{
 };
 pub use linera_cache::{Arc, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_chain::{
-    epoch_commitment::SignedCommitmentManifest,
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainError, ChainStateView,
@@ -735,7 +734,7 @@ mod tests {
         crypto::{AccountPublicKey, CryptoHash, ValidatorKeypair, ValidatorSignature},
         data_types::{
             Amount, ApplicationPermissions, Blob, BlockHeight, ChainDescription, ChainOrigin,
-            Epoch, InitialChainConfig, NetworkDescription, Round, Timestamp,
+            CommitmentManifest, Epoch, InitialChainConfig, NetworkDescription, Round, Timestamp,
         },
         identifiers::{BlobId, BlobType, ChainId, EventId, StreamId},
         ownership::ChainOwnership,
@@ -743,7 +742,6 @@ mod tests {
     use linera_chain::{
         block::{Block, ConfirmedBlock},
         data_types::{BlockExecutionOutcome, ProposedBlock},
-        epoch_commitment::CommitmentManifest,
     };
     use linera_execution::{BlobOrigin, BlobState};
     #[cfg(feature = "scylladb")]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -1123,6 +1123,16 @@ mod tests {
             .is_none());
         assert_eq!(storage.vote_ledger_chain_ids(epoch).await?, vec![chain_id]);
 
+        // Chains land in different buckets of the epoch's ledger; the listing spans
+        // all of them and is ordered by serialized chain ID.
+        let chain_id2 = ChainId(CryptoHash::test_hash("vote ledger chain 2"));
+        storage
+            .record_confirmed_vote(epoch, chain_id2, vote3, None)
+            .await?;
+        let mut expected = vec![chain_id, chain_id2];
+        expected.sort_by_key(|id| bcs::to_bytes(id).unwrap());
+        assert_eq!(storage.vote_ledger_chain_ids(epoch).await?, expected);
+
         Ok(())
     }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -555,6 +555,42 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         Ok(Some(self.get_or_load_committee_by_hash(blob_hash).await?))
     }
 
+    /// Returns whether validators holding a quorum of the given epoch's stake
+    /// have registered commitments for it on the admin chain, according to the
+    /// commitment events in local storage. Duplicate registrations by the same
+    /// validator count once.
+    async fn commitment_quorum_reached(&self, epoch: Epoch) -> Result<bool, ExecutionError> {
+        let Some(committee) = self.committee_for_epoch(epoch).await? else {
+            return Ok(false);
+        };
+        let admin_chain_id = self
+            .read_network_description()
+            .await?
+            .ok_or(ExecutionError::NoNetworkDescriptionFound)?
+            .admin_chain_id;
+        let stream_id = StreamId::system(linera_execution::system::COMMITMENT_STREAM_NAME);
+        let mut committed = std::collections::BTreeSet::new();
+        for index in 0.. {
+            let event_id = EventId {
+                chain_id: admin_chain_id,
+                stream_id: stream_id.clone(),
+                index,
+            };
+            let Some(bytes) = self.read_event(event_id).await? else {
+                break;
+            };
+            let manifest: SignedCommitmentManifest = bcs::from_bytes(&bytes)?;
+            if manifest.manifest.epoch == epoch {
+                committed.insert(manifest.manifest.validator);
+            }
+        }
+        let weight = committed
+            .iter()
+            .map(|validator| committee.weight(validator))
+            .sum::<u64>();
+        Ok(weight >= committee.quorum_threshold())
+    }
+
     /// Lists the blob IDs in storage.
     async fn list_blob_ids(&self) -> Result<Vec<BlobId>, ViewError>;
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -24,7 +24,7 @@ use linera_base::{
 pub use linera_cache::{Arc, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
-    vote_ledger::{LedgerEntry, SupersededVote, VoteRecord},
+    vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainError, ChainStateView,
 };
 use linera_execution::{
@@ -255,7 +255,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         epoch: Epoch,
         chain_id: ChainId,
         record: VoteRecord,
-        superseded: Option<SupersededVote>,
+        superseded: Option<JustifiedVote>,
     ) -> Result<(), ViewError>;
 
     /// Records a superseded confirmation vote in the vote ledger for the given
@@ -266,7 +266,7 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         &self,
         epoch: Epoch,
         chain_id: ChainId,
-        superseded: SupersededVote,
+        superseded: JustifiedVote,
     ) -> Result<(), ViewError>;
 
     /// Reads the vote-ledger entry for the given epoch and chain.
@@ -1081,7 +1081,7 @@ mod tests {
             round: Round::MultiLeader(1),
             block_hash: CryptoHash::test_hash("block B"),
         };
-        let superseded = SupersededVote {
+        let superseded = JustifiedVote {
             record: vote1,
             justification: None,
         };
@@ -1109,7 +1109,7 @@ mod tests {
         // A different block gets confirmed at height 1 without this validator's
         // vote: the bypassed vote is recorded as superseded on its own, without
         // touching the latest-vote entry.
-        let bypassed = SupersededVote {
+        let bypassed = JustifiedVote {
             record: vote3.clone(),
             justification: None,
         };

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -1064,6 +1064,7 @@ mod tests {
             height: BlockHeight::ZERO,
             round: Round::MultiLeader(0),
             block_hash: CryptoHash::test_hash("block A"),
+            justification_commitment: None,
         };
         storage
             .record_confirmed_vote(epoch, chain_id, vote1.clone(), None)
@@ -1080,6 +1081,7 @@ mod tests {
             height: BlockHeight::ZERO,
             round: Round::MultiLeader(1),
             block_hash: CryptoHash::test_hash("block B"),
+            justification_commitment: Some(CryptoHash::test_hash("quorum B")),
         };
         let superseded = JustifiedVote {
             record: vote1,
@@ -1095,6 +1097,7 @@ mod tests {
             height: BlockHeight::from(1),
             round: Round::MultiLeader(0),
             block_hash: CryptoHash::test_hash("block C"),
+            justification_commitment: None,
         };
         storage
             .record_confirmed_vote(epoch, chain_id, vote3.clone(), None)

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -23,6 +23,7 @@ use linera_base::{
 };
 pub use linera_cache::{Arc, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_chain::{
+    epoch_commitment::SignedCommitmentManifest,
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
     vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainError, ChainStateView,
@@ -285,6 +286,22 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
 
     /// Returns the highest epoch marked as frozen for signing, if any.
     async fn max_frozen_epoch(&self) -> Result<Option<Epoch>, ViewError>;
+
+    /// Stores a signed commitment manifest of this validator, to be held until the
+    /// commitment is published on the admin chain.
+    async fn write_pending_commitment(
+        &self,
+        manifest: &SignedCommitmentManifest,
+    ) -> Result<(), ViewError>;
+
+    /// Reads this validator's pending commitment manifest for the given epoch.
+    async fn read_pending_commitment(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<SignedCommitmentManifest>, ViewError>;
+
+    /// Lists this validator's pending commitment manifests, in epoch order.
+    async fn pending_commitments(&self) -> Result<Vec<SignedCommitmentManifest>, ViewError>;
 
     /// Reads the network description.
     async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
@@ -715,7 +732,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use linera_base::{
-        crypto::{AccountPublicKey, CryptoHash},
+        crypto::{AccountPublicKey, CryptoHash, ValidatorKeypair, ValidatorSignature},
         data_types::{
             Amount, ApplicationPermissions, Blob, BlockHeight, ChainDescription, ChainOrigin,
             Epoch, InitialChainConfig, NetworkDescription, Round, Timestamp,
@@ -726,6 +743,7 @@ mod tests {
     use linera_chain::{
         block::{Block, ConfirmedBlock},
         data_types::{BlockExecutionOutcome, ProposedBlock},
+        epoch_commitment::CommitmentManifest,
     };
     use linera_execution::{BlobOrigin, BlobState};
     #[cfg(feature = "scylladb")]
@@ -1149,6 +1167,35 @@ mod tests {
         assert_eq!(storage.max_frozen_epoch().await?, Some(Epoch::from(3)));
         storage.mark_epoch_frozen(Epoch::from(1)).await?;
         assert_eq!(storage.max_frozen_epoch().await?, Some(Epoch::from(3)));
+
+        // Pending commitments are stored by epoch and listed in epoch order.
+        assert!(storage.read_pending_commitment(epoch).await?.is_none());
+        assert!(storage.pending_commitments().await?.is_empty());
+        let keypair = ValidatorKeypair::generate();
+        let signed_manifest = |epoch| {
+            let manifest = CommitmentManifest {
+                epoch,
+                validator: keypair.public_key,
+                blob_hashes: Vec::new(),
+            };
+            let signature = ValidatorSignature::new(&manifest, &keypair.secret_key);
+            SignedCommitmentManifest {
+                manifest,
+                signature,
+            }
+        };
+        let commitment3 = signed_manifest(Epoch::from(3));
+        let commitment1 = signed_manifest(Epoch::from(1));
+        storage.write_pending_commitment(&commitment3).await?;
+        storage.write_pending_commitment(&commitment1).await?;
+        assert_eq!(
+            storage.read_pending_commitment(Epoch::from(1)).await?,
+            Some(commitment1.clone())
+        );
+        assert_eq!(
+            storage.pending_commitments().await?,
+            vec![commitment1, commitment3]
+        );
 
         Ok(())
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -24,6 +24,7 @@ use linera_base::{
 pub use linera_cache::{Arc, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
+    vote_ledger::{LedgerEntry, SupersededVote, VoteRecord},
     ChainError, ChainStateView,
 };
 use linera_execution::{
@@ -245,6 +246,38 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         &self,
         events: impl IntoIterator<Item = (EventId, Vec<u8>)> + Send,
     ) -> Result<(), ViewError>;
+
+    /// Records a confirmation vote this validator signed, in the vote ledger for
+    /// the given epoch. If the vote replaced an earlier confirmation vote at the
+    /// same height, the replaced vote must be passed as `superseded`.
+    async fn record_confirmed_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        record: VoteRecord,
+        superseded: Option<SupersededVote>,
+    ) -> Result<(), ViewError>;
+
+    /// Records a superseded confirmation vote in the vote ledger for the given
+    /// epoch, without touching the chain's latest-vote entry. This is used when a
+    /// block other than the voted one is confirmed at the vote's height without
+    /// the validator casting a new vote there.
+    async fn record_superseded_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        superseded: SupersededVote,
+    ) -> Result<(), ViewError>;
+
+    /// Reads the vote-ledger entry for the given epoch and chain.
+    async fn read_vote_ledger_entry(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+    ) -> Result<Option<LedgerEntry>, ViewError>;
+
+    /// Lists the chains with a vote-ledger entry for the given epoch.
+    async fn vote_ledger_chain_ids(&self, epoch: Epoch) -> Result<Vec<ChainId>, ViewError>;
 
     /// Reads the network description.
     async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
@@ -1010,6 +1043,89 @@ mod tests {
         Ok(())
     }
 
+    async fn test_storage_vote_ledger<S: Storage + Sync>(storage: &S) -> Result<(), ViewError> {
+        let epoch = Epoch::from(1);
+        let chain_id = ChainId(CryptoHash::test_hash("vote ledger chain"));
+        assert!(storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .is_none());
+        assert!(storage.vote_ledger_chain_ids(epoch).await?.is_empty());
+
+        // The first vote on the chain.
+        let vote1 = VoteRecord {
+            height: BlockHeight::ZERO,
+            round: Round::MultiLeader(0),
+            block_hash: CryptoHash::test_hash("block A"),
+        };
+        storage
+            .record_confirmed_vote(epoch, chain_id, vote1.clone(), None)
+            .await?;
+        let entry = storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .unwrap();
+        assert_eq!(entry.latest, vote1);
+        assert!(entry.superseded.is_empty());
+
+        // A justified re-vote at the same height supersedes the first vote.
+        let vote2 = VoteRecord {
+            height: BlockHeight::ZERO,
+            round: Round::MultiLeader(1),
+            block_hash: CryptoHash::test_hash("block B"),
+        };
+        let superseded = SupersededVote {
+            record: vote1,
+            justification: None,
+        };
+        storage
+            .record_confirmed_vote(epoch, chain_id, vote2, Some(superseded.clone()))
+            .await?;
+
+        // A vote at the next height overwrites the latest vote and keeps the
+        // superseded one.
+        let vote3 = VoteRecord {
+            height: BlockHeight::from(1),
+            round: Round::MultiLeader(0),
+            block_hash: CryptoHash::test_hash("block C"),
+        };
+        storage
+            .record_confirmed_vote(epoch, chain_id, vote3.clone(), None)
+            .await?;
+        let entry = storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .unwrap();
+        assert_eq!(entry.latest, vote3);
+        assert_eq!(entry.superseded, vec![superseded.clone()]);
+
+        // A different block gets confirmed at height 1 without this validator's
+        // vote: the bypassed vote is recorded as superseded on its own, without
+        // touching the latest-vote entry.
+        let bypassed = SupersededVote {
+            record: vote3.clone(),
+            justification: None,
+        };
+        storage
+            .record_superseded_vote(epoch, chain_id, bypassed.clone())
+            .await?;
+        let entry = storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .unwrap();
+        assert_eq!(entry.latest, vote3);
+        assert_eq!(entry.superseded, vec![superseded, bypassed]);
+
+        // Entries are kept per epoch and per chain.
+        assert!(storage
+            .read_vote_ledger_entry(Epoch::from(2), chain_id)
+            .await?
+            .is_none());
+        assert_eq!(storage.vote_ledger_chain_ids(epoch).await?, vec![chain_id]);
+
+        Ok(())
+    }
+
     /// Generic test function to test Storage trait features
     #[test_case(DbStorage::<MemoryDatabase, _>::make_test_storage(None).await; "memory")]
     #[cfg_attr(feature = "scylladb", test_case(DbStorage::<ScyllaDbDatabase, _>::make_test_storage(None).await; "scylla_db"))]
@@ -1023,6 +1139,7 @@ mod tests {
         test_storage_certificate(&storage).await?;
         test_storage_event(&storage).await?;
         test_storage_network_description(&storage).await?;
+        test_storage_vote_ledger(&storage).await?;
         Ok(())
     }
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -591,6 +591,19 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         Ok(weight >= committee.quorum_threshold())
     }
 
+    /// Returns whether the given epoch is *settled*: a quorum of the next epoch's
+    /// committee has published commitments on the admin chain. Once an epoch is
+    /// settled, its committee may unbond, so its raw signatures are no longer
+    /// trustworthy — only blocks covered by a quorum of its commitments are. Until
+    /// then the committee is still bonded and its signatures remain acceptable,
+    /// even after the epoch has been revoked (see PoS.md).
+    async fn is_epoch_settled(&self, epoch: Epoch) -> Result<bool, ExecutionError> {
+        let Ok(next_epoch) = epoch.try_add_one() else {
+            return Ok(false);
+        };
+        self.commitment_quorum_reached(next_epoch).await
+    }
+
     /// Lists the blob IDs in storage.
     async fn list_blob_ids(&self) -> Result<Vec<BlobId>, ViewError>;
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -279,6 +279,13 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
     /// Lists the chains with a vote-ledger entry for the given epoch.
     async fn vote_ledger_chain_ids(&self, epoch: Epoch) -> Result<Vec<ChainId>, ViewError>;
 
+    /// Durably marks the given epoch, and implicitly all earlier ones, as frozen
+    /// for signing, so that the freeze outlives restarts.
+    async fn mark_epoch_frozen(&self, epoch: Epoch) -> Result<(), ViewError>;
+
+    /// Returns the highest epoch marked as frozen for signing, if any.
+    async fn max_frozen_epoch(&self) -> Result<Option<Epoch>, ViewError>;
+
     /// Reads the network description.
     async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
 
@@ -1132,6 +1139,13 @@ mod tests {
         let mut expected = vec![chain_id, chain_id2];
         expected.sort_by_key(|id| bcs::to_bytes(id).unwrap());
         assert_eq!(storage.vote_ledger_chain_ids(epoch).await?, expected);
+
+        // Freeze markers: the highest marked epoch wins, regardless of order.
+        assert_eq!(storage.max_frozen_epoch().await?, None);
+        storage.mark_epoch_frozen(Epoch::from(3)).await?;
+        assert_eq!(storage.max_frozen_epoch().await?, Some(Epoch::from(3)));
+        storage.mark_epoch_frozen(Epoch::from(1)).await?;
+        assert_eq!(storage.max_frozen_epoch().await?, Some(Epoch::from(3)));
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

To defend against long-range attacks where validators make up chains that were never legitimately created, we need all validators to commit to the set of `ConfirmedBlock` votes they made in each epoch.

As an optimization, we can leave out votes for blocks that got confirmed, if we already made a vote for one of their descendants.

Currently, votes are ephemeral entries in the chain manager that get deleted after each block height.

## Proposal

Store the votes in shared storage.

Use 256 buckets (depending on chain ID); with that, ScyllaDB should support hundreds of millions of chains.

## Test Plan

Tests were added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Preparation for https://github.com/linera-io/linera-protocol/issues/6594.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
