### PR TITLE
Allow the proxy public listener protocol to differ from the advertised one (server config)

### DIFF
--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -13,7 +13,7 @@ use linera_execution::{
     committee::{Committee, ValidatorState},
     ResourceControlPolicy,
 };
-use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
+use linera_rpc::config::{TlsConfig, ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
 use serde::{Deserialize, Serialize};
 
 /// The public configuration of a validator.
@@ -36,6 +36,13 @@ pub struct ValidatorServerConfig {
     pub validator_secret: ValidatorSecretKey,
     /// The internal network configuration of the validator.
     pub internal_network: ValidatorInternalNetworkConfig,
+    /// The TLS mode of the proxy's public listener, when it differs from the
+    /// protocol advertised for this validator in the committee (e.g. an ingress
+    /// in front of the proxy terminates TLS, so clients dial `tls` while the
+    /// proxy itself listens in cleartext). `None` = listen with the advertised
+    /// protocol. Only meaningful for gRPC networks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_listen_protocol: Option<TlsConfig>,
 }
 
 /// The (public) configuration for all validators.

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -26,7 +26,7 @@ use linera_core::{node::NodeError, JoinSetExt as _};
 use linera_metrics::monitoring_server;
 use linera_rpc::{
     config::{
-        NetworkProtocol, ShardConfig, TlsConfig, ValidatorInternalNetworkPreConfig,
+        NetworkProtocol, ShardConfig, ValidatorInternalNetworkPreConfig,
         ValidatorPublicNetworkPreConfig,
     },
     simple::{MessageHandler, TransportProtocol},
@@ -90,15 +90,6 @@ pub struct ProxyOptions {
     #[arg(long)]
     id: Option<usize>,
 
-    /// Overrides the TLS mode of the proxy's public listener, independently of the
-    /// protocol advertised for this validator in the committee
-    /// (`validator.network.protocol` in the server configuration). Set to `cleartext`
-    /// when an ingress in front of the proxy (e.g. a gateway) terminates TLS, so
-    /// clients keep dialing the advertised `tls` endpoint while the proxy itself
-    /// listens in plaintext. Only supported for gRPC networks.
-    #[arg(long, env = "LINERA_PROXY_PUBLIC_PROTOCOL", value_parser = parse_tls_config)]
-    public_protocol: Option<TlsConfig>,
-
     /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
     #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
     otlp_exporter_endpoint: Option<String>,
@@ -107,14 +98,6 @@ pub struct ProxyOptions {
     #[cfg(feature = "jemalloc")]
     #[arg(long, env = "LINERA_ENABLE_MEMORY_PROFILING")]
     enable_memory_profiling: bool,
-}
-
-fn parse_tls_config(value: &str) -> Result<TlsConfig, String> {
-    match value.to_lowercase().as_str() {
-        "tls" => Ok(TlsConfig::Tls),
-        "cleartext" => Ok(TlsConfig::ClearText),
-        _ => Err(format!("expected 'tls' or 'cleartext', got '{value}'")),
-    }
 }
 
 impl ProxyOptions {
@@ -147,7 +130,6 @@ struct ProxyContext {
     recv_timeout: Duration,
     id: usize,
     enable_memory_profiling: bool,
-    public_protocol: Option<TlsConfig>,
 }
 
 impl ProxyContext {
@@ -160,7 +142,6 @@ impl ProxyContext {
             recv_timeout: options.recv_timeout,
             id: options.id.unwrap_or(0),
             enable_memory_profiling: options.enable_memory_profiling(),
-            public_protocol: options.public_protocol,
         })
     }
 }
@@ -201,10 +182,11 @@ where
     fn from_context(context: ProxyContext, storage: S) -> Result<Self> {
         let internal_protocol = context.config.internal_network.protocol;
         let external_protocol = context.config.validator.network.protocol;
-        if context.public_protocol.is_some()
+        let public_listen_protocol = context.config.public_listen_protocol;
+        if public_listen_protocol.is_some()
             && !matches!(external_protocol, NetworkProtocol::Grpc(_))
         {
-            bail!("--public-protocol is only supported for gRPC networks");
+            bail!("public_listen_protocol is only supported for gRPC networks");
         }
         let proxy = match (internal_protocol, external_protocol) {
             (NetworkProtocol::Grpc { .. }, NetworkProtocol::Grpc(tls)) => {
@@ -212,7 +194,10 @@ where
                     context.config.internal_network,
                     context.send_timeout,
                     context.recv_timeout,
-                    context.public_protocol.unwrap_or(tls),
+                    // The listener binds with the configured override (e.g. an
+                    // ingress terminates TLS in front of the proxy), while the
+                    // committee keeps advertising the external protocol.
+                    public_listen_protocol.unwrap_or(tls),
                     storage,
                     context.id,
                 ))

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -26,7 +26,7 @@ use linera_core::{node::NodeError, JoinSetExt as _};
 use linera_metrics::monitoring_server;
 use linera_rpc::{
     config::{
-        NetworkProtocol, ShardConfig, ValidatorInternalNetworkPreConfig,
+        NetworkProtocol, ShardConfig, TlsConfig, ValidatorInternalNetworkPreConfig,
         ValidatorPublicNetworkPreConfig,
     },
     simple::{MessageHandler, TransportProtocol},
@@ -90,6 +90,15 @@ pub struct ProxyOptions {
     #[arg(long)]
     id: Option<usize>,
 
+    /// Overrides the TLS mode of the proxy's public listener, independently of the
+    /// protocol advertised for this validator in the committee
+    /// (`validator.network.protocol` in the server configuration). Set to `cleartext`
+    /// when an ingress in front of the proxy (e.g. a gateway) terminates TLS, so
+    /// clients keep dialing the advertised `tls` endpoint while the proxy itself
+    /// listens in plaintext. Only supported for gRPC networks.
+    #[arg(long, env = "LINERA_PROXY_PUBLIC_PROTOCOL", value_parser = parse_tls_config)]
+    public_protocol: Option<TlsConfig>,
+
     /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
     #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
     otlp_exporter_endpoint: Option<String>,
@@ -98,6 +107,14 @@ pub struct ProxyOptions {
     #[cfg(feature = "jemalloc")]
     #[arg(long, env = "LINERA_ENABLE_MEMORY_PROFILING")]
     enable_memory_profiling: bool,
+}
+
+fn parse_tls_config(value: &str) -> Result<TlsConfig, String> {
+    match value.to_lowercase().as_str() {
+        "tls" => Ok(TlsConfig::Tls),
+        "cleartext" => Ok(TlsConfig::ClearText),
+        _ => Err(format!("expected 'tls' or 'cleartext', got '{value}'")),
+    }
 }
 
 impl ProxyOptions {
@@ -130,6 +147,7 @@ struct ProxyContext {
     recv_timeout: Duration,
     id: usize,
     enable_memory_profiling: bool,
+    public_protocol: Option<TlsConfig>,
 }
 
 impl ProxyContext {
@@ -142,6 +160,7 @@ impl ProxyContext {
             recv_timeout: options.recv_timeout,
             id: options.id.unwrap_or(0),
             enable_memory_profiling: options.enable_memory_profiling(),
+            public_protocol: options.public_protocol,
         })
     }
 }
@@ -182,13 +201,18 @@ where
     fn from_context(context: ProxyContext, storage: S) -> Result<Self> {
         let internal_protocol = context.config.internal_network.protocol;
         let external_protocol = context.config.validator.network.protocol;
+        if context.public_protocol.is_some()
+            && !matches!(external_protocol, NetworkProtocol::Grpc(_))
+        {
+            bail!("--public-protocol is only supported for gRPC networks");
+        }
         let proxy = match (internal_protocol, external_protocol) {
             (NetworkProtocol::Grpc { .. }, NetworkProtocol::Grpc(tls)) => {
                 Self::Grpc(GrpcProxy::new(
                     context.config.internal_network,
                     context.send_timeout,
                     context.recv_timeout,
-                    tls,
+                    context.public_protocol.unwrap_or(tls),
                     storage,
                     context.id,
                 ))

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -367,6 +367,12 @@ struct ValidatorOptions {
     /// The network protocol for workers.
     internal_protocol: NetworkProtocol,
 
+    /// The TLS mode the proxy binds its public listener with, when it differs
+    /// from `external_protocol` (the advertised one) — e.g. `"ClearText"` when
+    /// an ingress terminates TLS in front of the proxy. Optional.
+    #[serde(default)]
+    public_listen_protocol: Option<TlsConfig>,
+
     /// The public name and the port of each of the shards
     shards: Vec<ShardConfig>,
 
@@ -405,6 +411,7 @@ fn make_server_config<R: CryptoRng>(
             validator,
             validator_secret: validator_keypair.secret_key,
             internal_network,
+            public_listen_protocol: options.public_listen_protocol,
         },
     )?)
 }
@@ -818,6 +825,7 @@ mod test {
                 internal_protocol: NetworkProtocol::Simple(TransportProtocol::Udp),
                 host: "host".into(),
                 port: 9000,
+                public_listen_protocol: None,
                 proxies: vec![ProxyConfig {
                     host: "proxy".into(),
                     public_port: 20100,


### PR DESCRIPTION
## Motivation

`linera-proxy` binds its public listener from `validator.network.protocol` — the same field the committee advertises to clients. When an ingress in front of the proxy (e.g. an Envoy Gateway with a real certificate) terminates TLS, the two roles diverge: clients must keep dialing `tls`, while the proxy itself must listen in `cleartext` (its only TLS identity is the self-signed `CERT_PEM` baked into the binary, which webpki-validating clients reject anyway). Today the only way to express that is post-editing `server_N.json` after `linera-server generate`.

## Proposal

A config field, not a CLI flag (reviewer feedback): `ValidatorServerConfig` gains an optional `public_listen_protocol` (serde-defaulted and skipped when `None`, so every existing `server.json` parses AND serializes unchanged). `linera-server generate` accepts the same optional field in `validator_N.toml` and writes it through, so deployments express the topology at mint time — no post-editing. The proxy binds its public listener with `public_listen_protocol.unwrap_or(advertised)`; setting it on a non-gRPC network fails explicitly. Absent field = behavior identical to today.

## Test Plan

- `cargo clippy -p linera-client -p linera-service --all-targets -- -D warnings` clean; `cargo +nightly fmt`.
- `test_validator_options` (extended TOML round-trip) passes.
- CI.

## Release Plan

These changes follow the usual release cycle.

## Links

- https://github.com/linera-io/linera-infra/pull/1472 (infra mint currently post-edits `server_N.json`; this field replaces that jq)