### PR TITLE
linera-*: satisfy mismatched_lifetime_syntaxes under newer toolchains

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -448,7 +448,7 @@ where
         key_pair: Option<&ValidatorSecretKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
-    ) -> Result<Option<ValidatedOrConfirmedVote>, ChainError> {
+    ) -> Result<Option<ValidatedOrConfirmedVote<'_>>, ChainError> {
         let round = proposal.content.round;
 
         match &proposal.original_proposal {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -1220,7 +1220,7 @@ impl TestClock {
         self.lock().sleep_callback = None;
     }
 
-    fn lock(&self) -> std::sync::MutexGuard<TestClockInner> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, TestClockInner> {
         self.0.lock().expect("poisoned TestClock mutex")
     }
 }

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -180,7 +180,10 @@ impl RocksDbStoreExecutor {
         Ok(entries.into_iter().collect::<Result<_, _>>()?)
     }
 
-    fn get_find_prefix_iterator(&self, prefix: &[u8]) -> rocksdb::DBRawIteratorWithThreadMode<DB> {
+    fn get_find_prefix_iterator(
+        &self,
+        prefix: &[u8],
+    ) -> rocksdb::DBRawIteratorWithThreadMode<'_, DB> {
         // Configure ReadOptions optimized for SSDs and iterator performance
         let mut read_opts = rocksdb::ReadOptions::default();
         // Enable async I/O for better concurrency

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -313,7 +313,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
     pub async fn try_load_entry(
         &self,
         short_key: &[u8],
-    ) -> Result<Option<ReadGuardedView<W>>, ViewError> {
+    ) -> Result<Option<ReadGuardedView<'_, W>>, ViewError> {
         let updates = self.updates.read().await;
         match updates.get(short_key) {
             Some(update) => match update {
@@ -371,7 +371,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
     pub async fn try_load_entries(
         &self,
         short_keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<ReadGuardedView<W>>>, ViewError> {
+    ) -> Result<Vec<Option<ReadGuardedView<'_, W>>>, ViewError> {
         let mut results = Vec::with_capacity(short_keys.len());
         let mut keys_to_check = Vec::new();
         let mut keys_to_check_metadata = Vec::new();
@@ -461,7 +461,7 @@ impl<W: View> ByteCollectionView<W::Context, W> {
     /// ```
     pub async fn try_load_all_entries(
         &self,
-    ) -> Result<Vec<(Vec<u8>, ReadGuardedView<W>)>, ViewError> {
+    ) -> Result<Vec<(Vec<u8>, ReadGuardedView<'_, W>)>, ViewError> {
         let updates = self.updates.read().await; // Acquire the read lock to prevent writes.
         let short_keys = self.keys().await?;
         let mut results = Vec::with_capacity(short_keys.len());
@@ -1033,7 +1033,7 @@ impl<I: Serialize, W: View> CollectionView<W::Context, I, W> {
     pub async fn try_load_entry<Q>(
         &self,
         index: &Q,
-    ) -> Result<Option<ReadGuardedView<W>>, ViewError>
+    ) -> Result<Option<ReadGuardedView<'_, W>>, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + ?Sized,
@@ -1065,7 +1065,7 @@ impl<I: Serialize, W: View> CollectionView<W::Context, I, W> {
     pub async fn try_load_entries<'a, Q>(
         &self,
         indices: impl IntoIterator<Item = &'a Q>,
-    ) -> Result<Vec<Option<ReadGuardedView<W>>>, ViewError>
+    ) -> Result<Vec<Option<ReadGuardedView<'_, W>>>, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + 'a,
@@ -1094,7 +1094,7 @@ impl<I: Serialize, W: View> CollectionView<W::Context, I, W> {
     /// assert_eq!(subviews.len(), 1);
     /// # })
     /// ```
-    pub async fn try_load_all_entries(&self) -> Result<Vec<(I, ReadGuardedView<W>)>, ViewError>
+    pub async fn try_load_all_entries(&self) -> Result<Vec<(I, ReadGuardedView<'_, W>)>, ViewError>
     where
         I: DeserializeOwned,
     {
@@ -1451,7 +1451,7 @@ impl<I: CustomSerialize, W: View> CustomCollectionView<W::Context, I, W> {
     pub async fn try_load_entry<Q>(
         &self,
         index: &Q,
-    ) -> Result<Option<ReadGuardedView<W>>, ViewError>
+    ) -> Result<Option<ReadGuardedView<'_, W>>, ViewError>
     where
         I: Borrow<Q>,
         Q: CustomSerialize,
@@ -1482,7 +1482,7 @@ impl<I: CustomSerialize, W: View> CustomCollectionView<W::Context, I, W> {
     pub async fn try_load_entries<'a, Q>(
         &self,
         indices: impl IntoIterator<Item = &'a Q>,
-    ) -> Result<Vec<Option<ReadGuardedView<W>>>, ViewError>
+    ) -> Result<Vec<Option<ReadGuardedView<'_, W>>>, ViewError>
     where
         I: Borrow<Q>,
         Q: CustomSerialize + 'a,
@@ -1511,7 +1511,7 @@ impl<I: CustomSerialize, W: View> CustomCollectionView<W::Context, I, W> {
     /// assert_eq!(subviews.len(), 1);
     /// # })
     /// ```
-    pub async fn try_load_all_entries(&self) -> Result<Vec<(I, ReadGuardedView<W>)>, ViewError>
+    pub async fn try_load_all_entries(&self) -> Result<Vec<(I, ReadGuardedView<'_, W>)>, ViewError>
     where
         I: CustomSerialize,
     {
@@ -1815,7 +1815,7 @@ mod graphql {
         async fn entry(
             &self,
             key: K,
-        ) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
+        ) -> Result<Entry<K, ReadGuardedView<'_, V>>, async_graphql::Error> {
             let value = self
                 .try_load_entry(&key)
                 .await?
@@ -1826,7 +1826,7 @@ mod graphql {
         async fn entries(
             &self,
             input: Option<MapInput<K>>,
-        ) -> Result<Vec<Entry<K, ReadGuardedView<V>>>, async_graphql::Error> {
+        ) -> Result<Vec<Entry<K, ReadGuardedView<'_, V>>>, async_graphql::Error> {
             let keys = if let Some(keys) = input
                 .and_then(|input| input.filters)
                 .and_then(|filters| filters.keys)
@@ -1880,7 +1880,7 @@ mod graphql {
         async fn entry(
             &self,
             key: K,
-        ) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
+        ) -> Result<Entry<K, ReadGuardedView<'_, V>>, async_graphql::Error> {
             let value = self
                 .try_load_entry(&key)
                 .await?
@@ -1891,7 +1891,7 @@ mod graphql {
         async fn entries(
             &self,
             input: Option<MapInput<K>>,
-        ) -> Result<Vec<Entry<K, ReadGuardedView<V>>>, async_graphql::Error> {
+        ) -> Result<Vec<Entry<K, ReadGuardedView<'_, V>>>, async_graphql::Error> {
             let keys = if let Some(keys) = input
                 .and_then(|input| input.filters)
                 .and_then(|filters| filters.keys)

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -123,7 +123,7 @@ impl<UserData> AsStoreMut for EntrypointInstance<UserData> {
 impl<UserData> EntrypointInstance<UserData> {
     /// Returns mutable references to the [`Store`] and the [`wasmer::Instance`] stored inside this
     /// [`EntrypointInstance`].
-    pub fn as_store_and_instance_mut(&mut self) -> (StoreMut, &mut wasmer::Instance) {
+    pub fn as_store_and_instance_mut(&mut self) -> (StoreMut<'_>, &mut wasmer::Instance) {
         (self.store.as_store_mut(), &mut self.instance)
     }
 }


### PR DESCRIPTION
## Motivation

Newer Rust toolchains (e.g. the linera-bridge nightly) enable the `mismatched_lifetime_syntaxes` lint, which fires when an input lifetime flows to an output path type written without an explicit `<'_>`.

## Proposal

 Add the anonymous lifetime to the 16 affected return types across linera-views (13), linera-witty, linera-chain and linera-storage. No behavior change; these are green under the crate's own pinned toolchain where the lint is inactive.

## Test Plan

CI

## Release Plan

These changes should be ported to `main` branch


- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
