### PR TITLE
Prune `block_hashes` at every checkpoint

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -650,6 +650,20 @@ impl Block {
             .any(|responses| !responses.is_empty())
     }
 
+    /// Returns whether this block consumes any [`CheckpointAck`] message. Such blocks
+    /// are barred from the fast round: an acknowledgement's bundle has no availability
+    /// guarantee, so validators can legitimately disagree on whether they hold it, and
+    /// a fast-round proposal cannot be re-proposed without the bundle once some
+    /// validators have voted to confirm it.
+    ///
+    /// [`CheckpointAck`]: linera_execution::SystemMessage::CheckpointAck
+    pub fn consumes_checkpoint_ack(&self) -> bool {
+        self.body
+            .incoming_bundles()
+            .flat_map(|incoming| &incoming.bundle.messages)
+            .any(|posted| posted.message.is_checkpoint_ack())
+    }
+
     /// Returns whether this block matches the proposal.
     pub fn matches_proposed_block(&self, block: &ProposedBlock) -> bool {
         let ProposedBlock {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -556,8 +556,10 @@ where
     }
 
     /// Inserts `(height, hash)` into `block_hashes` and updates the
-    /// `next_height_to_preprocess` register accordingly. Every write to
+    /// `next_height_to_preprocess` register accordingly. Every insertion into
     /// `block_hashes` must go through this helper so the register stays in sync.
+    /// Removals are confined to `prune_block_hashes`, which only drops heights below the
+    /// highest one and so leaves the register untouched.
     fn insert_block_hash(
         &mut self,
         height: BlockHeight,
@@ -1518,8 +1520,66 @@ where
         self.insert_block_hash(block.header.height, hash)?;
         if block.body.starts_with_checkpoint() {
             self.latest_checkpoint_height.set(Some(block.header.height));
+            self.prune_block_hashes(block).await?;
         }
         Ok(updated_streams)
+    }
+
+    /// Drops the entries of `block_hashes` below the checkpoint block that the chain no
+    /// longer needs, so that the map does not grow without bound as the chain advances.
+    ///
+    /// Two kinds of pre-checkpoint block survive:
+    ///
+    /// * The blocks the checkpoint vouches for in its `outbox_block_hashes`, i.e. the ones
+    ///   that still carry unacknowledged messages. These are the blocks a node bootstrapping
+    ///   from the checkpoint is given, and the only ones a surviving `previous_message_blocks`
+    ///   anchor can point at, since the checkpoint drops the anchor of every fully
+    ///   acknowledged recipient.
+    /// * The blocks still queued in an outbox. Delivery is confirmed by the recipient's
+    ///   validators, which is a separate path from the acknowledgement that empties
+    ///   `unfinalized_message_blocks`, so a queue can outlive the checkpoint's guarantee.
+    ///   Dropping such a block would leave the outbox unable to build a cross-chain request
+    ///   for it, and hence unable to ever drain. Outbox queues are local state, so unlike the
+    ///   vouched-for set this one differs between nodes: what remains is bounded, not
+    ///   identical everywhere.
+    ///
+    /// Only heights below the checkpoint are removed, so `next_height_to_preprocess` — which
+    /// tracks the highest known height — stays accurate.
+    async fn prune_block_hashes(&mut self, block: &Block) -> Result<(), ChainError> {
+        let Some(OracleResponse::Checkpoint {
+            outbox_block_hashes,
+            ..
+        }) = block.body.oracle_responses.first().and_then(|r| r.first())
+        else {
+            return Err(ChainError::InternalError(
+                "checkpoint block is missing its OracleResponse::Checkpoint".into(),
+            ));
+        };
+        let vouched_for = outbox_block_hashes.iter().collect::<HashSet<_>>();
+        // Every outbox, not just the ones in `nonempty_outboxes`: on a client that index only
+        // covers tracked targets, but an untracked target's queue is resurrected by
+        // `reconcile_outbox_index` if the chain is tracked later on. An outbox is removed once
+        // its queue drains, so this loads no more entries than there are pending recipients.
+        let mut queued = BTreeSet::new();
+        for (_, outbox) in self.outboxes.try_load_all_entries().await? {
+            queued.extend(outbox.queue.elements().await?);
+        }
+        let obsolete = self
+            .block_hashes
+            .index_values()
+            .await?
+            .into_iter()
+            .filter(|(height, hash)| {
+                *height < block.header.height
+                    && !vouched_for.contains(hash)
+                    && !queued.contains(height)
+            })
+            .map(|(height, _)| height)
+            .collect::<Vec<_>>();
+        for height in obsolete {
+            self.block_hashes.remove(&height)?;
+        }
+        Ok(())
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.
@@ -1695,13 +1755,14 @@ where
                 if *outbox.next_height_to_schedule.get() > block_height {
                     continue; // We already added this recipient's messages to the outbox.
                 }
+                // A missing entry means a checkpoint pruned the block: the recipient had
+                // acknowledged everything we sent it below the checkpoint, so there is no
+                // predecessor left to chain to. That is the same state a node that
+                // bootstrapped from the checkpoint is in, where the outbox is rebuilt from
+                // scratch and starts out at height zero.
                 let maybe_prev_hash = match outbox.next_height_to_schedule.get().try_sub_one().ok()
                 {
-                    Some(height) => {
-                        Some(self.block_hashes.get(&height).await?.ok_or_else(|| {
-                            ChainError::CorruptedChainState("missing entry in block_hashes".into())
-                        })?)
-                    }
+                    Some(height) => self.block_hashes.get(&height).await?,
                     None => None, // No message to that sender was added yet.
                 };
                 // Only schedule if this block contains the next message for that recipient.
@@ -1715,12 +1776,14 @@ where
                     }
                     (Some(_), None) => {
                         // The outbox already has a previous height for this recipient,
-                        // but this block's body recorded no predecessor — that means
-                        // this is the first non-`CheckpointAck` send to this recipient,
-                        // even though earlier `CheckpointAck`-only blocks have already
-                        // been added to the off-chain outbox. We can still schedule:
-                        // the bundle will carry `previous_height = None`, which the
-                        // receiver accepts as "first ever".
+                        // but this block's body recorded no predecessor. Either earlier
+                        // `CheckpointAck`-only blocks were added to the off-chain outbox
+                        // while being skipped from `body.previous_message_blocks`, or a
+                        // checkpoint dropped the recipient's anchor because it had
+                        // acknowledged everything we sent it. Both mean the recipient has
+                        // no unreceived message from us below this block, so we can
+                        // schedule: the bundle carries `previous_height = None`, which
+                        // only tells the receiver to skip its gap check.
                     }
                     (None, Some((_, prev_msg_block_height))) => {
                         // We have no previously processed block in the outbox, but we are
@@ -1733,8 +1796,8 @@ where
                     }
                     (Some(ref prev_hash), Some((prev_msg_block_hash, _))) => {
                         // Only process the outbox if the hashes match. A mismatch can
-                        // arise legitimately when intermediate `CheckpointAck`-only
-                        // blocks sit in the off-chain outbox but are skipped from
+                        // arise legitimately when intermediate blocks sit in the
+                        // off-chain outbox but are skipped from
                         // `body.previous_message_blocks`; same fallback as the
                         // `(Some, None)` arm above.
                         if prev_hash != prev_msg_block_hash {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1755,11 +1755,12 @@ where
                 if *outbox.next_height_to_schedule.get() > block_height {
                     continue; // We already added this recipient's messages to the outbox.
                 }
-                // A missing entry means a checkpoint pruned the block: the recipient had
-                // acknowledged everything we sent it below the checkpoint, so there is no
-                // predecessor left to chain to. That is the same state a node that
-                // bootstrapped from the checkpoint is in, where the outbox is rebuilt from
-                // scratch and starts out at height zero.
+                // A missing entry means a checkpoint pruned the block: its messages were
+                // acknowledged and its outbox queue had drained, but the outbox survived
+                // the drain by being ahead of the tip at the time, so it still points past
+                // the pruned block. There is no predecessor left to chain to, which
+                // matches the incoming block's body: the checkpoint dropped the
+                // acknowledged recipient's anchor too.
                 let maybe_prev_hash = match outbox.next_height_to_schedule.get().try_sub_one().ok()
                 {
                     Some(height) => self.block_hashes.get(&height).await?,

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -85,6 +85,15 @@ where
     /// validator (e.g. when a sender re-pushes) must be a no-op rather than re-enter
     /// the inbox or the removed-by-anticipation queue.
     pub restored_cursor: RegisterView<C, Cursor>,
+    /// The lowest cursor at which the sender may still push a new bundle. Set when an
+    /// update's first bundle declares no predecessor: the sender's checkpoint settled
+    /// the lane below that bundle, so nothing below is re-pushable — a node that never
+    /// received those bundles can only learn of their consumption through this chain's
+    /// certified blocks. Below this cursor, consumptions that cannot be reconciled with
+    /// `added_bundles` are ignored instead of raising `UnexpectedBundle`, nothing is
+    /// anticipated, and re-deliveries are dropped. Bundles actually present in
+    /// `added_bundles` are unaffected: they still reconcile (or get skipped) normally.
+    pub sender_pruned_cursor: RegisterView<C, Cursor>,
 }
 
 #[derive(Error, Debug)]
@@ -207,6 +216,25 @@ where
         Ok(())
     }
 
+    /// Records that the sender will never push a bundle with a cursor below `cursor`
+    /// again, because an update declared no predecessor for its first bundle — the
+    /// sender's checkpoint settled the lane below it. Anticipated bundles below the
+    /// cursor are dropped: the push each of them is waiting for will never arrive, and
+    /// leaving them in place would fail the reconciliation of every future push.
+    pub async fn note_sender_pruned_below(&mut self, cursor: Cursor) -> Result<(), ViewError> {
+        if cursor <= *self.sender_pruned_cursor.get() {
+            return Ok(());
+        }
+        self.sender_pruned_cursor.set(cursor);
+        while let Some(front) = self.removed_bundles.front().await? {
+            if front.cursor() >= cursor {
+                break;
+            }
+            self.removed_bundles.delete_front();
+        }
+        Ok(())
+    }
+
     /// Consumes a bundle from the inbox.
     ///
     /// Returns `true` if the bundle was already known, i.e. it was present in `added_bundles`.
@@ -245,6 +273,18 @@ where
         }
         // Reconcile the bundle with the next added bundle, or mark it as removed.
         let already_known = match self.added_bundles.front().await? {
+            Some(previous_bundle)
+                if previous_bundle.cursor() > cursor
+                    && cursor < *self.sender_pruned_cursor.get() =>
+            {
+                // The bundle was never added and never will be — but the sender's
+                // checkpoint settled the lane below `sender_pruned_cursor`, so the push
+                // is not missing, it is gone for good. The consumption executes from the
+                // certified block's own copy of the bundle; there is nothing to
+                // reconcile.
+                tracing::trace!("Ignoring consumption of pruned bundle {:?}", bundle);
+                false
+            }
             Some(previous_bundle) => {
                 // Rationale: If the two cursors are equal, then the bundles should match.
                 // Otherwise, at this point we know that `self.next_cursor_to_add >
@@ -261,6 +301,12 @@ where
                 self.added_bundles.delete_front();
                 tracing::trace!("Consuming bundle {:?}", bundle);
                 true
+            }
+            None if cursor < *self.sender_pruned_cursor.get() => {
+                // Nothing to anticipate: the sender's checkpoint settled the lane below
+                // `sender_pruned_cursor`, so this bundle will never be pushed.
+                tracing::trace!("Ignoring consumption of pruned bundle {:?}", bundle);
+                false
             }
             None => {
                 tracing::trace!("Marking bundle as expected: {:?}", bundle);
@@ -286,6 +332,12 @@ where
         if cursor < *self.restored_cursor.get() {
             // The sender is re-delivering a bundle whose effects are already baked
             // into our restored execution state. Silently drop it.
+            return Ok(false);
+        }
+        if cursor < *self.sender_pruned_cursor.get() {
+            // A re-delivery racing the update that declared the lane settled below
+            // `sender_pruned_cursor`. Whatever this bundle's fate — consumed and
+            // acknowledged, or skipped — reconciliation for it is over. Silently drop it.
             return Ok(false);
         }
         ensure!(

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -235,6 +235,26 @@ where
         Ok(())
     }
 
+    /// Removes the added bundle at `cursor` and records the lane as settled up to and
+    /// including it, as if the sender had declared it so. Used for a bundle that can
+    /// never be consumed by this chain's blocks — enough validators cannot hold it that
+    /// no proposal consuming it gets certified. A certified consumption by another
+    /// owner's block still reconciles, as a no-op below `sender_pruned_cursor`.
+    pub async fn settle_unavailable_bundle(&mut self, cursor: Cursor) -> Result<(), ViewError> {
+        let bundles = self.added_bundles.elements().await?;
+        self.added_bundles.clear();
+        for bundle in bundles {
+            if bundle.cursor() != cursor {
+                self.added_bundles.push_back(bundle);
+            }
+        }
+        self.note_sender_pruned_below(Cursor {
+            height: cursor.height,
+            index: cursor.index.saturating_add(1),
+        })
+        .await
+    }
+
     /// Consumes a bundle from the inbox.
     ///
     /// Returns `true` if the bundle was already known, i.e. it was present in `added_bundles`.

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -409,3 +409,88 @@ async fn test_inbox_restore_from_checkpoint() {
         );
     }
 }
+
+/// A push with no predecessor marks the lane as settled below its first bundle:
+/// consuming a settled bundle that was never delivered here reconciles as a no-op — even
+/// past an already-added later bundle, where it used to fail as `UnexpectedBundle` and
+/// wedge the lane for good.
+#[tokio::test]
+async fn test_inbox_settled_lane_add_then_remove() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    // The sender's checkpoint settled the lane below height 8; the height-5 bundle was
+    // never delivered here.
+    view.note_sender_pruned_below(make_bundle(hash, 8, 0, [8]).cursor())
+        .await
+        .unwrap();
+    assert!(view.add_bundle(make_bundle(hash, 8, 0, [8])).await.unwrap());
+    // A certified block consumes the missed height-5 bundle: ignored, and not
+    // anticipated — the sender will never push it.
+    assert!(!view
+        .remove_bundle(&make_bundle(hash, 5, 0, [5]))
+        .await
+        .unwrap());
+    assert_eq!(view.removed_bundles.count(), 0);
+    // The added bundle is untouched and consumes normally.
+    assert!(view
+        .remove_bundle(&make_bundle(hash, 8, 0, [8]))
+        .await
+        .unwrap());
+    assert_eq!(view.added_bundles.count(), 0);
+}
+
+/// The consume-first ordering: a settled bundle was consumed by anticipation before the
+/// no-predecessor push arrived. The push must drop the stale anticipated entry — the
+/// push it awaits will never come — instead of failing to reconcile against it.
+#[tokio::test]
+async fn test_inbox_settled_lane_remove_then_add() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    // A certified block consumes the height-5 bundle before anything was added.
+    assert!(!view
+        .remove_bundle(&make_bundle(hash, 5, 0, [5]))
+        .await
+        .unwrap());
+    assert_eq!(view.removed_bundles.count(), 1);
+    // The no-predecessor push at height 8 arrives: the anticipated entry is dropped and
+    // the new bundle is added.
+    view.note_sender_pruned_below(make_bundle(hash, 8, 0, [8]).cursor())
+        .await
+        .unwrap();
+    assert_eq!(view.removed_bundles.count(), 0);
+    assert!(view.add_bundle(make_bundle(hash, 8, 0, [8])).await.unwrap());
+    // A late re-delivery of a settled bundle is dropped, not an error.
+    assert!(!view.add_bundle(make_bundle(hash, 5, 0, [5])).await.unwrap());
+}
+
+/// Delivered bundles stay live below the settled point: a pending bundle in
+/// `added_bundles` — e.g. a `CheckpointAck` sent by a checkpoint block itself, which no
+/// anchor tracks — must still reconcile normally, and corruption at its cursor is still
+/// caught.
+#[tokio::test]
+async fn test_inbox_settled_lane_keeps_pending_bundles() {
+    let hash = CryptoHash::test_hash("1");
+    let mut view = InboxStateView::new().await;
+    // The height-5 bundle was delivered before the no-predecessor push at height 8.
+    assert!(view.add_bundle(make_bundle(hash, 5, 0, [5])).await.unwrap());
+    view.note_sender_pruned_below(make_bundle(hash, 8, 0, [8]).cursor())
+        .await
+        .unwrap();
+    assert!(view.add_bundle(make_bundle(hash, 8, 0, [8])).await.unwrap());
+    assert_eq!(view.added_bundles.count(), 2);
+    // Consuming a different bundle at the pending bundle's cursor still fails.
+    assert_matches!(
+        view.remove_bundle(&make_bundle(hash, 5, 0, [9])).await,
+        Err(InboxError::UnexpectedBundle { .. })
+    );
+    // The pending bundle itself consumes normally.
+    assert!(view
+        .remove_bundle(&make_bundle(hash, 5, 0, [5]))
+        .await
+        .unwrap());
+    assert!(view
+        .remove_bundle(&make_bundle(hash, 8, 0, [8]))
+        .await
+        .unwrap());
+    assert_eq!(view.added_bundles.count(), 0);
+}

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1686,24 +1686,16 @@ where
         let mut heights_to_re_add = Vec::new();
         let mut current_height = latest_height;
         while current_height >= retransmit_from {
-            // We arrived at current_height via previous_message_blocks links, starting from the
-            // chain state and following the links downwards. So these blocks should all be in
-            // `block_hashes` already.
+            // A height missing from `block_hashes` means a checkpoint pruned the block:
+            // every recipient — in particular this one — had acknowledged its messages.
+            // Acknowledgements cover a prefix of each lane, so everything from here down
+            // is included in the recipient's own latest checkpoint and needs no
+            // retransmission. Stop the walk and resend only what was collected above.
+            let Some(hash) = self.chain.block_hashes.get(&current_height).await? else {
+                break;
+            };
             heights_to_re_add.push(current_height);
             // Load the block at current_height to find the previous message block
-            let hash = match &*self
-                .chain
-                .block_hashes_for_heights([current_height])
-                .await?
-            {
-                [hash] => *hash,
-                _ => {
-                    return Err(WorkerError::BlockHashNotFound {
-                        height: current_height,
-                        chain_id: self.chain_id(),
-                    })
-                }
-            };
             let block = self
                 .read_confirmed_blocks(&[hash])
                 .await?

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1419,6 +1419,16 @@ where
     ) -> Result<CrossChainUpdateResult, WorkerError> {
         // Only process certificates with relevant heights and epochs.
         let mut inbox = self.chain.inboxes.try_load_entry_mut(&origin).await?;
+        // An update whose first bundle declares no predecessor certifies that the sender
+        // will never push anything below that bundle on this lane again: either the lane
+        // is fresh, or the sender's checkpoint settled everything below. Record that in
+        // the inbox, so that consumptions of the settled bundles by this chain's
+        // certified blocks reconcile as no-ops instead of wedging the lane.
+        if sender_previous_height.is_none() {
+            if let Some((_, bundle)) = bundles.first() {
+                inbox.note_sender_pruned_below(bundle.cursor()).await?;
+            }
+        }
         let next_height_to_receive = inbox.next_block_height_to_receive()?;
         let last_anticipated_block_height = inbox
             .removed_bundles

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2556,6 +2556,10 @@ where
             !round.is_fast() || !block.has_oracle_responses(),
             WorkerError::FastBlockUsingOracles
         );
+        ensure!(
+            !round.is_fast() || !block.consumes_checkpoint_ack(),
+            WorkerError::FastBlockConsumingCheckpointAck
+        );
         let chain = &mut self.chain;
         // Don't save the changes since the block is not confirmed yet.
         chain.rollback();

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -15,8 +15,8 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
-        ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, OracleResponse, Round,
-        Timestamp,
+        ApplicationDescription, ArithmeticError, Blob, BlockHeight, Cursor, Epoch, OracleResponse,
+        Round, Timestamp,
     },
     ensure,
     hashed::Hashed,
@@ -1505,6 +1505,22 @@ where
             return Ok(CrossChainUpdateResult::NothingToDo);
         }
         Ok(CrossChainUpdateResult::Updated(last_updated_height))
+    }
+
+    /// Removes an incoming bundle that can never be consumed by this chain's blocks —
+    /// enough validators cannot hold it that no proposal consuming it gets certified —
+    /// and marks the lane as settled up to it, so that a certified consumption by
+    /// another owner's block still reconciles as a no-op.
+    pub(crate) async fn settle_unavailable_bundle(
+        &mut self,
+        origin: ChainId,
+        cursor: Cursor,
+    ) -> Result<(), WorkerError> {
+        let mut inbox = self.chain.inboxes.try_load_entry_mut(&origin).await?;
+        inbox.settle_unavailable_bundle(cursor).await?;
+        drop(inbox);
+        self.save().await?;
+        Ok(())
     }
 
     /// Handles the cross-chain request confirming that the recipient was updated.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -21,7 +21,7 @@ use linera_base::{
     crypto::{signer, CryptoHash, Signer, ValidatorPublicKey},
     data_types::{
         Amount, ApplicationDescription, ApplicationPermissions, ArithmeticError, Blob, BlobContent,
-        BlockHeight, ChainDescription, Epoch, MessagePolicy, Round, TimeDelta, Timestamp,
+        BlockHeight, ChainDescription, Cursor, Epoch, MessagePolicy, Round, TimeDelta, Timestamp,
     },
     ensure,
     identifiers::{
@@ -425,6 +425,22 @@ impl<Env: Environment> ChainClient<Env> {
             .get(&self.chain_id)
             .expect("Chain client constructed for invalid chain")
             .proposal_mutex()
+    }
+
+    /// Settles acknowledgement bundles that a validator rejected as unavailable in the
+    /// local inbox: they are removed from the pending bundles, durably, so future
+    /// proposals leave them out without a failed round-trip.
+    async fn settle_unavailable_acks(
+        &self,
+        acks: BTreeMap<(ChainId, BlockHeight), Cursor>,
+    ) -> Result<(), Error> {
+        for ((origin, _), cursor) in acks {
+            self.client
+                .local_node
+                .settle_unavailable_bundle(self.chain_id, origin, cursor)
+                .await?;
+        }
+        Ok(())
     }
 
     /// Returns the pending proposal, if any.
@@ -1452,22 +1468,41 @@ impl<Env: Environment> ChainClient<Env> {
         // Even if there is no pending proposal, this still calls
         // `request_leader_timeout_if_needed` which ensures the local chain state
         // is synchronized with the current consensus round.
+        let pending_acks = proposal_guard
+            .as_ref()
+            .map(|pending| ack_bundles_in(&pending.block.transactions))
+            .unwrap_or_default();
         match self
             .process_pending_block_without_prepare(&mut proposal_guard)
-            .await?
+            .await
         {
-            ClientOutcome::Committed(Some(certificate)) => {
+            Ok(ClientOutcome::Committed(Some(certificate))) => {
                 return Ok(self.classify_committed(certificate, &operations));
             }
-            ClientOutcome::WaitForTimeout(timeout) => {
+            Ok(ClientOutcome::WaitForTimeout(timeout)) => {
                 return Ok(ClientOutcome::WaitForTimeout(timeout))
             }
-            ClientOutcome::Conflict(certificate) => {
+            Ok(ClientOutcome::Conflict(certificate)) => {
                 return Ok(ClientOutcome::Conflict(certificate))
             }
-            ClientOutcome::Committed(None) => {}
+            Ok(ClientOutcome::Committed(None)) => {}
+            Err(error) => {
+                // The leftover proposal itself may contain an unavailable
+                // acknowledgement bundle; discard it rather than stay wedged. The loop
+                // below rebuilds the block without the bundle.
+                let unavailable = unavailable_ack_bundles(&error, &pending_acks);
+                if unavailable.is_empty() {
+                    return Err(error);
+                }
+                warn!(
+                    chain_id = %self.chain_id,
+                    ?unavailable,
+                    "discarding a pending proposal with unavailable acknowledgement bundles",
+                );
+                self.settle_unavailable_acks(unavailable).await?;
+                *proposal_guard = None;
+            }
         }
-
         loop {
             // Collect pending messages and epoch changes after acquiring the lock to avoid
             // race conditions where messages valid for one block height are proposed at a
@@ -1483,13 +1518,38 @@ impl<Env: Environment> ChainClient<Env> {
                 )));
             }
 
+            let proposed_acks = ack_bundles_in(&transactions);
+
             self.new_pending_block(transactions, blobs.clone(), &mut proposal_guard)
                 .await?;
 
-            match self
+            let outcome = match self
                 .process_pending_block_without_prepare(&mut proposal_guard)
-                .await?
+                .await
             {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    let unavailable = unavailable_ack_bundles(&error, &proposed_acks);
+                    if unavailable.is_empty() {
+                        return Err(error);
+                    }
+                    // A validator rejected an acknowledgement bundle it does not hold —
+                    // e.g. it bootstrapped the sender chain from a checkpoint past the
+                    // acknowledgement, which nothing resends. Settle the bundle in the
+                    // local inbox and retry without it: validators that do hold it
+                    // discard it when the lane's next bundle is consumed.
+                    warn!(
+                        chain_id = %self.chain_id,
+                        ?unavailable,
+                        "retrying the proposal without unavailable acknowledgement bundles",
+                    );
+                    self.settle_unavailable_acks(unavailable).await?;
+                    *proposal_guard = None;
+                    continue;
+                }
+            };
+
+            match outcome {
                 ClientOutcome::Committed(Some(certificate)) => {
                     return Ok(self.classify_committed(certificate, &operations));
                 }
@@ -3527,6 +3587,60 @@ impl<Env: Environment> ChainClient<Env> {
 
         Ok(())
     }
+}
+
+/// Returns the transactions' incoming bundles that consist solely of `CheckpointAck`
+/// messages, keyed by `(origin, height)` — the fields named by
+/// [`NodeError::MissingCrossChainUpdate`] — with their inbox cursors as values.
+fn ack_bundles_in(transactions: &[Transaction]) -> BTreeMap<(ChainId, BlockHeight), Cursor> {
+    transactions
+        .iter()
+        .filter_map(|transaction| match transaction {
+            Transaction::ReceiveMessages(incoming)
+                if incoming
+                    .bundle
+                    .messages
+                    .iter()
+                    .all(|posted| posted.message.is_checkpoint_ack()) =>
+            {
+                Some((
+                    (incoming.origin, incoming.bundle.height),
+                    incoming.bundle.cursor(),
+                ))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Returns the subset of `ack_bundles` — the proposed bundles consisting solely of
+/// `CheckpointAck` messages, keyed by `(origin, height)` — that a validator rejected
+/// with [`NodeError::MissingCrossChainUpdate`]. An acknowledgement's bundle has no
+/// availability guarantee, so a validator that does not hold it never will; a proposal
+/// containing it can only be certified by retrying without it.
+fn unavailable_ack_bundles(
+    error: &Error,
+    ack_bundles: &BTreeMap<(ChainId, BlockHeight), Cursor>,
+) -> BTreeMap<(ChainId, BlockHeight), Cursor> {
+    let Error::CommunicationError(error) = error else {
+        return BTreeMap::new();
+    };
+    let node_errors = match error {
+        CommunicationError::Trusted(error) => vec![error],
+        CommunicationError::Sample(samples) => samples.iter().map(|(error, _)| error).collect(),
+        CommunicationError::NoConsensus(_, _) => Vec::new(),
+    };
+    node_errors
+        .into_iter()
+        .filter_map(|error| match error {
+            NodeError::MissingCrossChainUpdate { origin, height, .. } => {
+                let key = (*origin, *height);
+                let cursor = ack_bundles.get(&key)?;
+                Some((key, *cursor))
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 #[cfg(with_testing)]

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2227,10 +2227,10 @@ impl<Env: Environment> ChainClient<Env> {
             return Ok(ClientOutcome::Committed(None)); // Nothing to do.
         };
 
-        let has_oracle_responses = block.has_oracle_responses();
+        let needs_slow_round = block.has_oracle_responses() || block.consumes_checkpoint_ack();
         let (proposed_block, outcome) = block.into_proposal();
         let round = match self
-            .round_for_new_proposal(&info, &owner, has_oracle_responses)
+            .round_for_new_proposal(&info, &owner, needs_slow_round)
             .await?
         {
             Either::Left(round) => round,
@@ -2398,20 +2398,23 @@ impl<Env: Environment> ChainClient<Env> {
     }
 
     /// Returns a round in which we can propose a new block or the given one, if possible.
+    /// `needs_slow_round` indicates that the block itself is barred from the fast round —
+    /// it uses oracles or consumes a checkpoint acknowledgement.
     async fn round_for_new_proposal(
         &self,
         info: &ChainInfo,
         identity: &AccountOwner,
-        has_oracle_responses: bool,
+        needs_slow_round: bool,
     ) -> Result<Either<Round, RoundTimeout>, Error> {
         let manager = &info.manager;
         let seed = manager.seed;
         // If there is a conflicting proposal in the current round, we can only propose if the
         // next round can be started without a timeout, i.e. if we are in a multi-leader round.
-        // Similarly, we cannot propose a block that uses oracles in the fast round, and also
-        // skip the fast round if fast blocks are not allowed.
+        // Similarly, we cannot propose a block that uses oracles or receives a checkpoint
+        // acknowledgement in the fast round, and also skip the fast round if fast blocks are
+        // not allowed.
         let skip_fast = manager.current_round.is_fast()
-            && (has_oracle_responses || !self.options.allow_fast_blocks);
+            && (needs_slow_round || !self.options.allow_fast_blocks);
         let conflict = manager
             .requested_signed_proposal
             .as_ref()

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -491,6 +491,21 @@ where
         Ok(self.node.state.reset_and_reexecute_chain(chain_id).await?)
     }
 
+    /// Removes an incoming bundle of `chain_id` that can never be consumed by its
+    /// blocks, and marks the lane from `origin` as settled up to it.
+    pub async fn settle_unavailable_bundle(
+        &self,
+        chain_id: ChainId,
+        origin: ChainId,
+        cursor: linera_base::data_types::Cursor,
+    ) -> Result<(), LocalNodeError> {
+        Ok(self
+            .node
+            .state
+            .settle_unavailable_bundle(chain_id, origin, cursor)
+            .await?)
+    }
+
     /// Gets received certificate trackers.
     pub async fn get_received_certificate_trackers(
         &self,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4573,6 +4573,102 @@ where
     Ok(())
 }
 
+/// A proposal consuming a `CheckpointAck` bundle that some validator can never hold
+/// must be retried without it. Validator 0 misses the recipient's ack-sending
+/// checkpoint and is later bootstrapped from the recipient's *next* checkpoint, so the
+/// ack block stays below its tip: pushing certificates cannot heal it, and it rejects
+/// every ack-consuming proposal with `MissingCrossChainUpdate`. With a second validator
+/// offline, such a proposal cannot reach quorum — the client must drop the skippable
+/// ack bundle and move on instead of wedging.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[test_log::test(tokio::test)]
+async fn test_unavailable_checkpoint_ack_is_skipped<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    // Validator 0 sees nothing of what follows: not the transfer, and crucially not the
+    // recipient's checkpoints.
+    builder.set_fault_type([0], FaultType::NoChains);
+    let producer = builder.add_root_chain(1, Amount::from_tokens(7)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let recipient_id = recipient.chain_id();
+
+    // The recipient consumes a transfer and checkpoints, acknowledging it; then burns
+    // and checkpoints again, so its latest checkpoint sits above the ack-sending block.
+    producer
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(2),
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    recipient.synchronize_from_validators().await?;
+    recipient.process_inbox().await?;
+    recipient.checkpoint().await.unwrap().unwrap();
+    recipient
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    recipient.checkpoint().await.unwrap().unwrap();
+
+    // Validator 0 comes back and validator 1 goes offline. The recipient's next block
+    // bootstraps validator 0 from the latest checkpoint — past the ack-sending block,
+    // which nothing can deliver to it anymore.
+    builder.set_fault_type([0], FaultType::Honest);
+    builder.set_fault_type([1], FaultType::Offline);
+    recipient
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+
+    // The producer's inbox holds only the unavailable ack. Consuming it can never be
+    // certified (validator 0 rejects it, validator 1 is offline), so the client skips
+    // the bundle; with nothing else to include, no block is proposed at all.
+    producer.synchronize_from_validators().await?;
+    let (certificates, _) = producer.process_inbox().await?;
+    assert!(
+        certificates.is_empty(),
+        "the unconsumable ack must be skipped, not wedge the client",
+    );
+
+    // The skip is durable: the ack was settled in the local inbox, so a fresh
+    // `process_inbox` — e.g. after a client restart — has nothing to retry.
+    {
+        let chain = producer
+            .client
+            .local_node
+            .chain_state_view(producer.chain_id())
+            .await?;
+        let inbox = chain
+            .inboxes
+            .try_load_entry(&recipient_id)
+            .await?
+            .expect("the producer has an inbox for the recipient");
+        assert_eq!(
+            inbox.added_bundles.count(),
+            0,
+            "the settled ack must be gone from the local inbox",
+        );
+    }
+
+    // The chain stays fully usable: a new transfer commits — without the ack.
+    let certificate = producer
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    assert!(!certificate.block().consumes_checkpoint_ack());
+
+    Ok(())
+}
+
 /// Verifies the push side of the checkpoint flow: a validator that missed the whole
 /// chain is brought up to speed by the proposing client pushing only the latest
 /// checkpoint plus the pre-checkpoint sender blocks it certifies, not every

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -47,6 +47,7 @@ use crate::{
         chain_client::{self, ChainClient},
         ClientOutcome, ListeningMode,
     },
+    data_types::CrossChainRequest,
     local_node::LocalNodeError,
     node::{
         NodeError::{self, ClientIoError},
@@ -4406,6 +4407,115 @@ where
         recipient.local_balance().await?,
         Amount::from_tokens(2),
         "the post-cycle transfer must reach the checkpointed recipient",
+    );
+
+    Ok(())
+}
+
+/// Verifies that a `RevertConfirm` walk survives checkpoint pruning. With a partially
+/// acknowledged lane, the `previous_message_blocks` anchor points at the latest,
+/// unacknowledged message block, but the link in that block's body leads down into the
+/// acknowledged prefix, which a checkpoint prunes from `block_hashes` once delivery is
+/// confirmed — as it is on a validator, which hosts both chains. The walk must stop
+/// there — those bundles are covered by the recipient's own checkpoint — and still
+/// resend the blocks collected above it, so a reset recipient recovers its wiped
+/// in-flight bundles.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[test_log::test(tokio::test)]
+async fn test_revert_confirm_stops_at_pruned_heights<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let producer = builder.add_root_chain(1, Amount::from_tokens(7)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let producer_id = producer.chain_id();
+    let recipient_id = recipient.chain_id();
+
+    // Producer.0: a transfer that the recipient consumes and acknowledges by
+    // checkpointing.
+    producer
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    recipient.synchronize_from_validators().await?;
+    recipient.process_inbox().await?;
+    recipient.checkpoint().await.unwrap().unwrap();
+
+    // Producer.1: consume the ack. Producer.2: a second transfer, which stays
+    // unacknowledged; its body's `previous_message_blocks` link points down at the
+    // acknowledged transfer.
+    producer.synchronize_from_validators().await?;
+    producer.process_inbox().await?;
+    let transfer_2 = producer
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_tokens(2),
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    let transfer_2_height = transfer_2.block().header.height;
+
+    // Producer.3: checkpoint. It vouches only for the unacknowledged second transfer.
+    producer.checkpoint().await.unwrap().unwrap();
+
+    // On a validator the first transfer's block is pruned from `block_hashes`: it is
+    // acknowledged, and the validator hosts the recipient chain too, so it has seen the
+    // delivery confirmation that drains the outbox. The second transfer's block
+    // survives because the checkpoint vouches for it, and the recipient's anchor points
+    // at it.
+    let worker = builder.node(0).worker().await;
+    {
+        let chain = worker.chain_state_view(producer_id).await?;
+        assert!(
+            chain.block_hashes.get(&BlockHeight::ZERO).await?.is_none(),
+            "the acknowledged, delivered transfer should be pruned on the validator",
+        );
+        assert!(chain.block_hashes.get(&transfer_2_height).await?.is_some());
+        assert_eq!(
+            chain
+                .execution_state
+                .previous_message_blocks
+                .get(&recipient_id)
+                .await?,
+            Some(transfer_2_height),
+        );
+    }
+
+    // A recipient that reset to its own checkpoint asks every sender to resend from the
+    // bottom. The walk starts at the anchor, re-adds the second transfer, and then hits
+    // the pruned height: it must stop there and resend what it collected rather than
+    // fail without resending anything.
+    let actions = worker
+        .handle_cross_chain_request(CrossChainRequest::RevertConfirm {
+            sender: producer_id,
+            recipient: recipient_id,
+            retransmit_from: BlockHeight::ZERO,
+        })
+        .await?;
+    let resent_heights = actions
+        .cross_chain_requests
+        .iter()
+        .filter_map(|request| match request {
+            CrossChainRequest::UpdateRecipient {
+                recipient, bundles, ..
+            } if *recipient == recipient_id => Some(bundles),
+            _ => None,
+        })
+        .flatten()
+        .map(|(_, bundle)| bundle.height)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        resent_heights,
+        vec![transfer_2_height],
+        "the revert must resend the unacknowledged transfer",
     );
 
     Ok(())

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4521,6 +4521,58 @@ where
     Ok(())
 }
 
+/// A block that consumes a `CheckpointAck` must not use the fast round: the ack's
+/// bundle has no availability guarantee — no anchor tracks it, no checkpoint vouches
+/// for its block — so validators can legitimately disagree on whether they hold it,
+/// and a fast proposal cannot be re-proposed without it once it has collected confirm
+/// votes. The client proposes such blocks in a slower round instead.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[test_log::test(tokio::test)]
+async fn test_checkpoint_ack_skips_fast_round<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let mut producer = builder.add_root_chain(1, Amount::from_tokens(7)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let recipient_id = recipient.chain_id();
+
+    // The producer is a super owner proposing in the fast round.
+    producer.options_mut().allow_fast_blocks = true;
+    let owner = producer.identity().await?;
+    producer
+        .change_ownership(ChainOwnership::single_super(owner))
+        .await
+        .unwrap();
+    let certificate = producer
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(certificate.round, Round::Fast);
+
+    // The recipient consumes the transfer and checkpoints, acknowledging it.
+    recipient.synchronize_from_validators().await?;
+    recipient.process_inbox().await?;
+    recipient.checkpoint().await.unwrap().unwrap();
+
+    // Consuming the ack lands in the first multi-leader round, not the fast round.
+    producer.synchronize_from_validators().await?;
+    let (certificates, _) = producer.process_inbox().await?;
+    let certificate = certificates
+        .first()
+        .expect("the ack-consuming block is committed");
+    assert!(certificate.block().consumes_checkpoint_ack());
+    assert_eq!(certificate.round, Round::MultiLeader(0));
+
+    Ok(())
+}
+
 /// Verifies the push side of the checkpoint flow: a validator that missed the whole
 /// chain is brought up to speed by the proposing client pushing only the latest
 /// checkpoint plus the pre-checkpoint sender blocks it certifies, not every

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4380,6 +4380,34 @@ where
         );
     }
 
+    // The producer→recipient lane must stay usable after the completed cycle, even for a
+    // node that bootstrapped from checkpoint #2 and therefore holds no pre-checkpoint
+    // blocks. Simulate one by resetting the producer to its latest checkpoint. Checkpoint
+    // #2 dropped the recipient's `previous_message_blocks` anchor (everything sent to it
+    // was acknowledged), so the new block carries no predecessor: the reset producer can
+    // execute it without the height-0 entry of `block_hashes`, and the checkpointed
+    // recipient accepts the bundle.
+    producer
+        .client
+        .local_node
+        .reset_and_reexecute_chain(producer_id)
+        .await?;
+    producer
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(recipient_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    recipient.synchronize_from_validators().await?;
+    recipient.process_inbox().await?;
+    assert_eq!(
+        recipient.local_balance().await?,
+        Amount::from_tokens(2),
+        "the post-cycle transfer must reach the checkpointed recipient",
+    );
+
     Ok(())
 }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4251,6 +4251,22 @@ where
     // Producer.1: checkpoint #1. unfinalized_message_blocks[recipient] = {(0, 0)}.
     producer.checkpoint().await.unwrap().unwrap();
 
+    // The transfer is unacknowledged, so checkpoint #1 vouches for its block and must keep
+    // it in `block_hashes` — that is the block a node bootstrapping from the checkpoint is
+    // handed, and the one the recipient's `previous_message_blocks` anchor points at.
+    {
+        let producer_state = producer
+            .client
+            .local_node
+            .chain_state_view(producer_id)
+            .await?;
+        assert!(producer_state
+            .block_hashes
+            .get(&BlockHeight::ZERO)
+            .await?
+            .is_some());
+    }
+
     // Recipient.0: consume the transfer. Now the inbox's `next_cursor_to_remove[producer]`
     // is past the transfer's cursor and `pending_checkpoint_ack_targets` contains the
     // producer.
@@ -4337,6 +4353,32 @@ where
             .any(|msg| msg.destination == recipient_id),
         "cycle should terminate: producer's next checkpoint must not notify the recipient",
     );
+
+    // Checkpoint #2 vouches for nothing, so it prunes the blocks below it from
+    // `block_hashes` — checkpoint #1 at height 1 and the ack-consuming block at height 2.
+    //
+    // The transfer at height 0 stays, because this client's outbox still queues it: the
+    // recipient's acknowledgement came back as a message, whereas an outbox is only drained
+    // by a delivery confirmation from the recipient's validators, which this client has not
+    // seen. Pruning height 0 would leave the outbox unable to build its cross-chain request,
+    // and hence unable to ever drain.
+    {
+        let producer_state = producer
+            .client
+            .local_node
+            .chain_state_view(producer_id)
+            .await?;
+        let outbox = producer_state
+            .outboxes
+            .try_load_entry(&recipient_id)
+            .await?
+            .expect("the producer has an outbox for the recipient");
+        assert_eq!(outbox.queue.elements().await?, vec![BlockHeight::ZERO]);
+        assert_eq!(
+            producer_state.block_hashes.indices().await?,
+            vec![BlockHeight::ZERO, checkpoint_2.block().header.height],
+        );
+    }
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -356,6 +356,12 @@ where
         self.fault_type
     }
 
+    /// Returns a clone of the validator's worker state, for tests that inspect or drive
+    /// the validator's chain workers directly.
+    pub async fn worker(&self) -> WorkerState<S> {
+        self.client.lock().await.state.clone()
+    }
+
     fn set_fault_type(&mut self, fault_type: FaultType) {
         self.fault_type = fault_type;
     }
@@ -654,43 +660,22 @@ where
         heights: Vec<BlockHeight>,
         sender: oneshot::Sender<Result<Vec<ConfirmedBlockCertificate>, NodeError>>,
     ) -> Result<(), Result<Vec<ConfirmedBlockCertificate>, NodeError>> {
-        // First, use do_handle_chain_info_query to get the certificate hashes
-        let (query_sender, query_receiver) = oneshot::channel();
-        let query = ChainInfoQuery::new(chain_id).with_sent_certificate_hashes_by_heights(heights);
-
-        let self_clone = self.clone();
-        self.do_handle_chain_info_query(query, query_sender)
+        let validator = self.client.lock().await;
+        let certificates = validator
+            .state
+            .storage_client()
+            .read_certificates_by_heights(chain_id, &heights)
             .await
-            .expect("Failed to handle chain info query");
-
-        // Get the response from the chain info query
-        let chain_info_response = query_receiver.await.map_err(|_| {
-            Err(NodeError::ClientIoError {
-                error: "Failed to receive chain info response".to_string(),
+            .map(|certificates| {
+                certificates
+                    .into_iter()
+                    .flatten()
+                    .map(CacheArc::unwrap_or_clone)
+                    .collect()
             })
-        })?;
+            .map_err(Into::into);
 
-        let hashes = match chain_info_response {
-            Ok(response) => response.info.requested_sent_certificate_hashes,
-            Err(e) => {
-                return sender.send(Err(e));
-            }
-        };
-
-        // Now use do_download_certificates to get the actual certificates
-        let (cert_sender, cert_receiver) = oneshot::channel();
-        self_clone
-            .do_download_certificates(hashes, cert_sender)
-            .await?;
-
-        // Forward the result to the original sender
-        let result = cert_receiver.await.map_err(|_| {
-            Err(NodeError::ClientIoError {
-                error: "Failed to receive certificates".to_string(),
-            })
-        })?;
-
-        sender.send(result)
+        sender.send(certificates)
     }
 
     async fn do_blob_last_used_by(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5451,6 +5451,193 @@ where
     Ok(())
 }
 
+/// Preprocessing must tolerate a predecessor height that a checkpoint pruned from
+/// `block_hashes`. An outbox drained while ahead of the tip survives with
+/// `next_height_to_schedule` pointing past its last scheduled block; once that block's
+/// messages are acknowledged, the next checkpoint prunes it. Preprocessing a later
+/// message block on the same lane (with a gap) then finds no hash at the predecessor
+/// height. That is legitimate pruning, not corruption: the checkpoint also dropped the
+/// recipient's `previous_message_blocks` anchor, so the incoming block carries no
+/// predecessor either, and its messages must be scheduled for delivery.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_preprocess_tolerates_pruned_predecessor<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let sender_key_pair = AccountSecretKey::generate();
+    let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
+    let chain_1 = env
+        .add_root_chain(1, sender_key_pair.public().into(), Amount::from_tokens(10))
+        .await
+        .id();
+    let chain_2 = env
+        .add_root_chain(2, AccountPublicKey::test_key(2).into(), Amount::ZERO)
+        .await
+        .id();
+
+    // chain_1.0: a transfer to chain_2.
+    let cert_transfer = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::ONE,
+            Vec::new(),
+            None,
+        )
+        .await;
+
+    // chain_2.0 consumes the transfer, and chain_2.1 checkpoints, acknowledging it.
+    let transfer_bundle = IncomingBundle {
+        origin: chain_1,
+        bundle: cert_transfer
+            .message_bundles_for(chain_2)
+            .next()
+            .expect("the transfer sends a bundle to chain_2")
+            .1,
+        action: MessageAction::Accept,
+    };
+    let cert_consume = env
+        .execute_proposal(
+            make_first_block(chain_2).with_incoming_bundle(transfer_bundle),
+            vec![],
+        )
+        .await?;
+    let cert_checkpoint_2 = env
+        .execute_proposal(
+            make_child_block(cert_consume.value()).with_operation(SystemOperation::Checkpoint),
+            vec![],
+        )
+        .await?;
+
+    // chain_1.1 consumes the ack, and chain_1.2 checkpoints: with the whole lane
+    // acknowledged there is nothing to vouch for, and chain_2's anchor is dropped.
+    let ack_bundle = IncomingBundle {
+        origin: chain_2,
+        bundle: cert_checkpoint_2
+            .message_bundles_for(chain_1)
+            .next()
+            .expect("chain_2's checkpoint sends a CheckpointAck to chain_1")
+            .1,
+        action: MessageAction::Accept,
+    };
+    let cert_ack = env
+        .execute_proposal(
+            make_child_block(cert_transfer.value()).with_incoming_bundle(ack_bundle),
+            vec![],
+        )
+        .await?;
+    let cert_checkpoint_1 = env
+        .execute_proposal(
+            make_child_block(cert_ack.value()).with_operation(SystemOperation::Checkpoint),
+            vec![],
+        )
+        .await?;
+
+    // chain_1.3: a message-free filler, so the next transfer sits above it. chain_1.4:
+    // another transfer to chain_2 — since the checkpoint dropped the lane's anchor, its
+    // body carries no predecessor for chain_2.
+    let cert_filler = env
+        .execute_proposal(
+            make_child_block(cert_checkpoint_1.value())
+                .with_burn(Amount::ONE)
+                .with_authenticated_owner(Some(sender_key_pair.public().into())),
+            vec![],
+        )
+        .await?;
+    let cert_final = env
+        .make_simple_transfer_certificate(
+            chain_1,
+            sender_key_pair.public(),
+            chain_2,
+            Amount::from_tokens(2),
+            Vec::new(),
+            Some(&cert_filler),
+        )
+        .await;
+    assert!(
+        cert_final
+            .inner()
+            .block()
+            .body
+            .previous_message_blocks
+            .is_empty(),
+        "the checkpoint should have dropped the acknowledged lane's anchor",
+    );
+
+    // The worker under test preprocesses the transfer and then receives its delivery
+    // confirmation while still at height zero: the queue drains, but the outbox is
+    // ahead of the tip and therefore survives, remembering the transfer as its
+    // predecessor.
+    env.worker()
+        .process_confirmed_block(
+            cert_transfer.clone(),
+            ProcessConfirmedBlockMode::Preprocess,
+            None,
+        )
+        .await?;
+    env.worker()
+        .handle_cross_chain_request(CrossChainRequest::ConfirmUpdatedRecipient {
+            sender: chain_1,
+            recipient: chain_2,
+            latest_height: BlockHeight::ZERO,
+        })
+        .await?;
+
+    // Execute up to and including chain_1's checkpoint. The checkpoint vouches for
+    // nothing and no outbox queues the transfer, so both pre-checkpoint blocks are
+    // pruned — while the drained outbox lingers, still pointing past the transfer.
+    for cert in [&cert_transfer, &cert_ack, &cert_checkpoint_1] {
+        env.worker()
+            .process_confirmed_block(cert.clone(), ProcessConfirmedBlockMode::Execute, None)
+            .await?;
+    }
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        assert_eq!(
+            chain.block_hashes.indices().await?,
+            vec![cert_checkpoint_1.inner().block().header.height],
+        );
+        let outbox = chain
+            .outboxes
+            .try_load_entry(&chain_2)
+            .await?
+            .expect("the drained outbox survives, being ahead of the tip");
+        assert_eq!(*outbox.next_height_to_schedule.get(), BlockHeight::from(1));
+        assert_eq!(outbox.queue.count(), 0);
+    }
+
+    // Preprocess the post-checkpoint transfer, skipping the filler, so there is a gap.
+    // The outbox's predecessor height has no `block_hashes` entry, but the transfer
+    // must still be scheduled for delivery.
+    env.worker()
+        .process_confirmed_block(
+            cert_final.clone(),
+            ProcessConfirmedBlockMode::Preprocess,
+            None,
+        )
+        .await?;
+    let chain = env.worker().chain_state_view(chain_1).await?;
+    assert_eq!(
+        chain
+            .outboxes
+            .try_load_entry(&chain_2)
+            .await?
+            .expect("the outbox for chain_2 still exists")
+            .queue
+            .elements()
+            .await?,
+        vec![cert_final.inner().block().header.height],
+        "the post-checkpoint transfer must be scheduled despite the pruned predecessor",
+    );
+    Ok(())
+}
+
 /// A confirmation whose first-round attestation is untruthful is rejected when the block is
 /// executed in order, where the chain's ownership — and thus its real first round — is known.
 /// This single-owner chain's first round is `MultiLeader(0)`, but the certificate claims the

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -5451,19 +5451,26 @@ where
     Ok(())
 }
 
-/// Preprocessing must tolerate a predecessor height that a checkpoint pruned from
-/// `block_hashes`. An outbox drained while ahead of the tip survives with
+/// Both ends of a message lane must tolerate blocks that a checkpoint pruned.
+///
+/// Sender side: an outbox drained while ahead of the tip survives with
 /// `next_height_to_schedule` pointing past its last scheduled block; once that block's
 /// messages are acknowledged, the next checkpoint prunes it. Preprocessing a later
 /// message block on the same lane (with a gap) then finds no hash at the predecessor
 /// height. That is legitimate pruning, not corruption: the checkpoint also dropped the
 /// recipient's `previous_message_blocks` anchor, so the incoming block carries no
 /// predecessor either, and its messages must be scheduled for delivery.
+///
+/// Receiver side: a node that never received the pruned block's bundle gets the
+/// post-checkpoint bundle with `previous_height: None`, which marks the lane as settled
+/// below it. When a certified block later consumes the missed bundle, the inbox must
+/// reconcile it as a no-op — its cursor is below an already-added bundle, which without
+/// the settling mark is a fatal `UnexpectedBundle`, wedging the lane for good.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
-async fn test_preprocess_tolerates_pruned_predecessor<B>(
+async fn test_checkpoint_pruned_lane_sender_and_receiver<B>(
     mut storage_builder: B,
 ) -> anyhow::Result<()>
 where
@@ -5622,19 +5629,72 @@ where
             None,
         )
         .await?;
-    let chain = env.worker().chain_state_view(chain_1).await?;
-    assert_eq!(
-        chain
-            .outboxes
-            .try_load_entry(&chain_2)
-            .await?
-            .expect("the outbox for chain_2 still exists")
-            .queue
-            .elements()
-            .await?,
-        vec![cert_final.inner().block().header.height],
-        "the post-checkpoint transfer must be scheduled despite the pruned predecessor",
+    {
+        let chain = env.worker().chain_state_view(chain_1).await?;
+        assert_eq!(
+            chain
+                .outboxes
+                .try_load_entry(&chain_2)
+                .await?
+                .expect("the outbox for chain_2 still exists")
+                .queue
+                .elements()
+                .await?,
+            vec![cert_final.inner().block().header.height],
+            "the post-checkpoint transfer must be scheduled despite the pruned predecessor",
+        );
+    }
+
+    // Receiver side. This worker's chain_2 never received the first transfer's bundle:
+    // it only gets the post-checkpoint transfer, whose update declares no predecessor
+    // and thereby marks the lane as settled below it.
+    let update = update_recipient_direct(chain_2, &cert_final);
+    assert_matches!(
+        &update,
+        CrossChainRequest::UpdateRecipient {
+            previous_height: None,
+            ..
+        }
     );
+    env.worker().handle_cross_chain_request(update).await?;
+
+    // Replaying chain_2's certified blocks consumes the first transfer's bundle — never
+    // added here, and sitting below the added post-checkpoint bundle. The settled mark
+    // makes that a no-op instead of a fatal `UnexpectedBundle`.
+    for cert in [&cert_consume, &cert_checkpoint_2] {
+        env.worker()
+            .process_confirmed_block(cert.clone(), ProcessConfirmedBlockMode::Execute, None)
+            .await?;
+    }
+
+    // The lane stays healthy: the pending post-checkpoint bundle reconciles normally
+    // when chain_2's next block consumes it.
+    let final_bundle = IncomingBundle {
+        origin: chain_1,
+        bundle: cert_final
+            .message_bundles_for(chain_2)
+            .next()
+            .expect("the post-checkpoint transfer sends a bundle to chain_2")
+            .1,
+        action: MessageAction::Accept,
+    };
+    let cert_consume_final = env
+        .execute_proposal(
+            make_child_block(cert_checkpoint_2.value()).with_incoming_bundle(final_bundle),
+            vec![],
+        )
+        .await?;
+    env.worker()
+        .process_confirmed_block(cert_consume_final, ProcessConfirmedBlockMode::Execute, None)
+        .await?;
+    let chain = env.worker().chain_state_view(chain_2).await?;
+    let inbox = chain
+        .inboxes
+        .try_load_entry(&chain_1)
+        .await?
+        .expect("chain_2 has an inbox for chain_1");
+    assert_eq!(inbox.added_bundles.count(), 0);
+    assert_eq!(inbox.removed_bundles.count(), 0);
     Ok(())
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -400,6 +400,8 @@ pub enum WorkerError {
     InvalidLiteCertificate,
     #[error("Fast blocks cannot query oracles")]
     FastBlockUsingOracles,
+    #[error("Fast blocks cannot receive checkpoint acknowledgements")]
+    FastBlockConsumingCheckpointAck,
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     /// Variant raised when the chain references these block hashes via a
@@ -454,6 +456,7 @@ impl WorkerError {
             | WorkerError::MissingCertificateValue
             | WorkerError::InvalidLiteCertificate
             | WorkerError::FastBlockUsingOracles
+            | WorkerError::FastBlockConsumingCheckpointAck
             | WorkerError::BlobsNotFound(_)
             | WorkerError::BlocksNotFound(_)
             | WorkerError::InvalidBlockProposal(_)

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -17,8 +17,8 @@ use futures::{
 use linera_base::{
     crypto::{CryptoError, CryptoHash, ValidatorPublicKey},
     data_types::{
-        ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, Round, TimeDelta,
-        Timestamp,
+        ApplicationDescription, ArithmeticError, Blob, BlockHeight, Cursor, Epoch, Round,
+        TimeDelta, Timestamp,
     },
     doc_scalar,
     identifiers::{AccountOwner, ApplicationId, BlobId, ChainId, EventId, StreamId},
@@ -1575,6 +1575,20 @@ where
                 bundles,
             )
             .await
+    }
+
+    /// Removes an incoming bundle of `chain_id` that can never be consumed by its
+    /// blocks, and marks the lane from `origin` as settled up to it. See
+    /// `ChainWorkerState::settle_unavailable_bundle`.
+    pub async fn settle_unavailable_bundle(
+        &self,
+        chain_id: ChainId,
+        origin: ChainId,
+        cursor: Cursor,
+    ) -> Result<(), WorkerError> {
+        let state = self.get_or_create_chain_worker(chain_id).await?;
+        let mut guard = handle::write_lock(&state).await?;
+        guard.settle_unavailable_bundle(origin, cursor).await
     }
 
     /// Test helper that runs `ChainWorkerState::reset_and_reexecute_chain` for the given

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -54,7 +54,9 @@ pub struct ExecutionStateViewInner<C> {
     pub system: SystemExecutionStateView<C>,
     /// User applications.
     pub users: ReentrantCollectionView<C, ApplicationId, KeyValueStoreView<C>>,
-    /// The heights of previous blocks that sent messages to the same recipients.
+    /// The heights of previous blocks that sent messages to the same recipients. A
+    /// checkpoint drops the entry of every recipient that has acknowledged all of them,
+    /// so an entry never points at a block a checkpoint stopped guaranteeing.
     pub previous_message_blocks: MapView<C, ChainId, BlockHeight>,
     /// The heights of previous blocks that published events to the same streams.
     pub previous_event_blocks: MapView<C, StreamId, BlockHeight>,
@@ -202,6 +204,43 @@ where
         // reset the set so the next own checkpoint only fires for origins that send
         // us a fresh non-`Checkpoint` message in the meantime.
         self.system.pending_checkpoint_ack_targets.clear();
+        self.prune_message_anchors().await?;
+        Ok(())
+    }
+
+    /// Drops the `previous_message_blocks` anchor of every recipient that has acknowledged
+    /// all the messages we sent it, i.e. every recipient absent from
+    /// `unfinalized_message_blocks`.
+    ///
+    /// A checkpoint only guarantees the availability of the blocks listed in the
+    /// checkpoint's `outbox_block_hashes`, which are exactly the ones still referenced by
+    /// `unfinalized_message_blocks`. An anchor pointing below the checkpoint at any other
+    /// block would dangle: a node that bootstrapped from the checkpoint never saw that
+    /// block, so resolving the anchor to a hash would fail.
+    ///
+    /// Only fully acknowledged recipients are dropped. A recipient with unacknowledged
+    /// bundles keeps its anchor, so the chain of `previous_message_blocks` links that lets
+    /// it detect and fetch skipped message blocks stays intact — unlike
+    /// `previous_event_blocks`, which the checkpoint clears outright because the summary
+    /// events supersede the pruned ones. Its anchor is also the highest height in its
+    /// `unfinalized_message_blocks` entry — both are written together for every
+    /// non-`CheckpointAck` bundle, and an acknowledgement only trims a prefix of the
+    /// cursors — so the anchor is covered by `outbox_block_hashes`.
+    async fn prune_message_anchors(&mut self) -> Result<(), ExecutionError> {
+        let mut acknowledged = Vec::new();
+        for recipient in self.previous_message_blocks.indices().await? {
+            if !self
+                .system
+                .unfinalized_message_blocks
+                .contains_key(&recipient)
+                .await?
+            {
+                acknowledged.push(recipient);
+            }
+        }
+        for recipient in acknowledged {
+            self.previous_message_blocks.remove(&recipient)?;
+        }
         Ok(())
     }
 

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -290,7 +290,8 @@ async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyho
     };
 
     // Producer side: apply a checkpoint with non-empty origin_cursors and check that
-    // it queues one `SystemMessage::CheckpointAck` per origin.
+    // it queues one `SystemMessage::CheckpointAck` per origin, and that it prunes the
+    // `previous_message_blocks` anchors of recipients that acknowledged everything.
     use linera_views::{batch::Batch, store::WritableKeyValueStore as _, views::View as _};
     let mut view = SystemExecutionState {
         description: Some(dummy_chain_description(0)),
@@ -298,6 +299,24 @@ async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyho
     }
     .into_view()
     .await;
+    // `recipient_acked` has no `unfinalized_message_blocks` entry, so the checkpoint stops
+    // guaranteeing the availability of its anchor block and must drop the anchor.
+    // `recipient_pending` still owes us an acknowledgement at its anchor height, so its
+    // anchor is covered by `outbox_block_hashes` and must survive.
+    let recipient_acked = dummy_chain_description(4).id();
+    let recipient_pending = dummy_chain_description(5).id();
+    let pending_anchor = BlockHeight::from(6);
+    view.previous_message_blocks
+        .insert(&recipient_acked, BlockHeight::from(4))?;
+    view.previous_message_blocks
+        .insert(&recipient_pending, pending_anchor)?;
+    view.system.unfinalized_message_blocks.insert(
+        &recipient_pending,
+        std::collections::BTreeSet::from([Cursor {
+            height: pending_anchor,
+            index: 0,
+        }]),
+    )?;
     let mut batch = Batch::new();
     view.pre_save(&mut batch)?;
     view.context().store().write_batch(batch).await?;
@@ -328,6 +347,16 @@ async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyho
             })
         );
     }
+    assert!(
+        !view
+            .previous_message_blocks
+            .contains_key(&recipient_acked)
+            .await?
+    );
+    assert_eq!(
+        view.previous_message_blocks.get(&recipient_pending).await?,
+        Some(pending_anchor)
+    );
 
     // Receiver side: pre-populate `unfinalized_message_blocks` with three heights
     // from origin_a (the block-end hook would normally do this), then deliver the

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -785,6 +785,17 @@ type InboxStateView {
 	the inbox or the removed-by-anticipation queue.
 	"""
 	restoredCursor: Cursor!
+	"""
+	The lowest cursor at which the sender may still push a new bundle. Set when an
+	update's first bundle declares no predecessor: the sender's checkpoint settled
+	the lane below that bundle, so nothing below is re-pushable — a node that never
+	received those bundles can only learn of their consumption through this chain's
+	certified blocks. Below this cursor, consumptions that cannot be reconciled with
+	`added_bundles` are ignored instead of raising `UnexpectedBundle`, nothing is
+	anticipated, and re-deliveries are dropped. Bundles actually present in
+	`added_bundles` are unaffected: they still reconcile (or get skipped) normally.
+	"""
+	senderPrunedCursor: Cursor!
 }
 
 """

--- a/linera-service/src/proxy/main.rs
+++ b/linera-service/src/proxy/main.rs
@@ -489,36 +489,14 @@ where
                 Ok(Some(RpcMessage::DownloadCertificatesResponse(certificates)))
             }
             DownloadCertificatesByHeights(chain_id, heights) => {
-                let shard = self.internal_config.get_shard_for(chain_id).clone();
-                let protocol = self.internal_config.protocol;
-
-                let chain_info_query = RpcMessage::ChainInfoQuery(Box::new(
-                    linera_core::data_types::ChainInfoQuery::new(chain_id)
-                        .with_sent_certificate_hashes_by_heights(heights),
-                ));
-
-                let hashes = match Self::try_proxy_message(
-                    chain_info_query,
-                    shard.clone(),
-                    protocol,
-                    self.send_timeout,
-                    self.recv_timeout,
-                )
-                .await
-                {
-                    Ok(Some(RpcMessage::ChainInfoResponse(response))) => {
-                        response.info.requested_sent_certificate_hashes
-                    }
-                    _ => bail!("Failed to retrieve sent certificate hashes"),
-                };
-                let certificates = self.storage.read_certificates(&hashes).await?;
-                let certificates = match ResultReadCertificates::new(certificates, hashes) {
-                    ResultReadCertificates::Certificates(certificates) => certificates,
-                    ResultReadCertificates::InvalidHashes(hashes) => {
-                        bail!("Missing certificates: {hashes:?}")
-                    }
-                };
-
+                let certificates = self
+                    .storage
+                    .read_certificates_by_heights(chain_id, &heights)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .map(CacheArc::unwrap_or_clone)
+                    .collect();
                 Ok(Some(RpcMessage::DownloadCertificatesByHeightsResponse(
                     certificates,
                 )))


### PR DESCRIPTION
## Motivation

A checkpoint only guarantees the availability of the blocks it vouches for in its `outbox_block_hashes`, so a node that bootstraps from it never learns the other pre-checkpoint blocks.

However, a node that just _executes_ a block with a checkpoint, without bootstrapping from it, has its `block_hashes` collection growing indefinitely.

## Proposal

Drop those from `block_hashes` when executing a checkpoint. Retained below the checkpoint are the vouched-for blocks, which still carry unacknowledged messages, and any block still queued in an outbox.

For the vouched-for set to cover every `previous_message_blocks` anchor, the checkpoint also drops the anchor of each recipient that has acknowledged everything we sent it. Such an anchor would otherwise dangle even without any pruning, breaking a bootstrapped node on its next block to that recipient.

The rest of the codebase is made to survive pruned block hashes:

- `process_outgoing_messages` treats a missing `block_hashes` entry for the outbox's previous height as "no predecessor" instead of a corrupted chain state — the same state a bootstrapped node's rebuilt outbox is in.
- `handle_revert_confirm` stops re-adding heights at the first pruned one instead of failing: acknowledgements cover a lane prefix, so everything below the pruned height is already acknowledged in the recipient's own checkpoint.
- The simple-protocol proxy serves `DownloadCertificatesByHeights` directly from storage instead of going through the (now prunable) `block_hashes` map.

**Settled lanes.** When the first bundle of a cross-chain update declares no predecessor, the sender's checkpoint settled the lane below it, and the sender will never push anything below that bundle again. The receiving inbox records this in a new `sender_pruned_cursor`: below it, consumptions that cannot be reconciled with `added_bundles` are ignored instead of raising `UnexpectedBundle`, nothing is anticipated, and late re-deliveries are dropped. Without this, a node that replays the recipient chain without having seen the pre-checkpoint bundles would corrupt its inbox cursor. Bundles actually present in the inbox still reconcile (or get skipped) normally.

**`CheckpointAck` liveness.** Acknowledgements are the one bundle class with no availability story: checkpoints don't vouch for them, they are excluded from `previous_message_blocks` and `unfinalized_message_blocks`, and bootstrapping doesn't restore them to the outbox. A validator that bootstrapped the recipient chain from a later checkpoint can therefore never obtain a pre-checkpoint ack, and no one can make it validate a block consuming that ack. So:

- A block in the fast round must never consume a `CheckpointAck`: the worker rejects such proposals, and the client routes ack-consuming blocks to a non-fast round. Otherwise a fast proposal confirmed by half the validators and unvalidatable by the other half would brick the chain.
- If a proposal fails with `MissingCrossChainUpdate` for an ack bundle even after the updater has sent the validator the sender chain's information, the client retries the proposal without any ack bundles.
- The skip is durable: the client settles the unavailable bundle in its own inbox — removing it from `added_bundles` and advancing `sender_pruned_cursor` past it — so a restart or a later `linera process-inbox` doesn't propose it again, while a certified block from another chain owner that does consume the ack still reconciles as a no-op.

This also fixes the issues found in #6609.

## Test Plan

Tests were extended: inbox unit tests for the settled-lane marker, a two-worker test driving a full sender/receiver checkpoint-ack cycle across pruned lanes, and client tests for revert-confirm on pruned heights, the fast-round exclusion, and skipping an ack a validator cannot hold.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
