### PR TITLE
Re-certify revoked-epoch blocks via their descendants

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -375,6 +375,36 @@ where
         })
     }
 
+    /// Ensures that this worker may still create signatures for blocks in the given
+    /// epoch: once an epoch has been revoked on the admin chain, its committee must
+    /// not sign anything new. A chain that failed to migrate to a newer epoch before
+    /// the revocation is frozen.
+    async fn ensure_epoch_signable(
+        &self,
+        epoch: Epoch,
+        height: BlockHeight,
+    ) -> Result<(), WorkerError> {
+        let is_revoked = self
+            .storage
+            .is_epoch_revoked(epoch)
+            .await
+            .map_err(|error| {
+                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                    Box::new(error),
+                    ChainExecutionContext::Block,
+                )))
+            })?;
+        ensure!(
+            !is_revoked,
+            WorkerError::VoteInRevokedEpoch {
+                chain_id: self.chain_id(),
+                epoch,
+                height,
+            }
+        );
+        Ok(())
+    }
+
     /// Returns whether this chain is known to be active (initialized).
     pub(crate) fn knows_chain_is_active(&self) -> bool {
         self.knows_chain_is_active
@@ -938,6 +968,7 @@ where
                 BlockOutcome::Skipped,
             ));
         }
+        self.ensure_epoch_signable(epoch, height).await?;
 
         self.block_values
             .insert_hashed(Cow::Borrowed(certificate.inner().inner()));
@@ -2143,21 +2174,22 @@ where
         height: BlockHeight,
         round: Round,
     ) -> Result<(), WorkerError> {
-        let chain = &mut self.chain;
         ensure!(
-            height == chain.tip_state.get().next_block_height,
+            height == self.chain.tip_state.get().next_block_height,
             WorkerError::UnexpectedBlockHeight {
-                expected_block_height: chain.tip_state.get().next_block_height,
+                expected_block_height: self.chain.tip_state.get().next_block_height,
                 found_block_height: height
             }
         );
-        let epoch = chain.execution_state.system.epoch.get();
-        let chain_id = chain.chain_id();
+        let epoch = *self.chain.execution_state.system.epoch.get();
+        self.ensure_epoch_signable(epoch, height).await?;
+        let chain_id = self.chain.chain_id();
         let key_pair = self.config.key_pair();
         let local_time = self.storage.clock().current_time();
-        if chain
+        if self
+            .chain
             .manager
-            .create_timeout_vote(chain_id, height, round, *epoch, key_pair, local_time)?
+            .create_timeout_vote(chain_id, height, round, epoch, key_pair, local_time)?
         {
             self.save().await?;
         }
@@ -2172,7 +2204,7 @@ where
         chain_id = %self.chain_id()
     ))]
     async fn vote_for_fallback(&mut self) -> Result<(), WorkerError> {
-        let chain = &mut self.chain;
+        let chain = &self.chain;
         let epoch = *chain.execution_state.system.epoch.get();
         let Some(admin_chain_id) = chain.execution_state.system.admin_chain_id.get() else {
             return Ok(());
@@ -2196,11 +2228,20 @@ where
             .clock()
             .current_time()
             .delta_since(event_data.timestamp);
-        if elapsed >= chain.ownership().await?.timeout_config.fallback_duration {
-            let chain_id = chain.chain_id();
-            let height = chain.tip_state.get().next_block_height;
+        if elapsed
+            >= self
+                .chain
+                .ownership()
+                .await?
+                .timeout_config
+                .fallback_duration
+        {
+            let chain_id = self.chain.chain_id();
+            let height = self.chain.tip_state.get().next_block_height;
+            self.ensure_epoch_signable(epoch, height).await?;
             let key_pair = self.config.key_pair();
-            if chain
+            if self
+                .chain
                 .manager
                 .vote_fallback(chain_id, height, epoch, key_pair)
             {
@@ -2484,6 +2525,7 @@ where
         // Check the epoch.
         let (epoch, committee) = chain.current_committee().await?;
         check_block_epoch(epoch, block.chain_id, block.epoch)?;
+        self.ensure_epoch_signable(epoch, block.height).await?;
         let policy = committee.policy().clone();
         block.check_proposal_size(policy.maximum_block_proposal_size)?;
         // Check the authentication of the block.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -328,6 +328,53 @@ where
         })
     }
 
+    /// Ensures that the certificate's epoch is still a sufficient basis for trusting
+    /// its block.
+    ///
+    /// A certificate from a revoked epoch no longer proves anything by itself: the
+    /// committee that signed it is not trusted any more. Such a block is only
+    /// accepted if it is transitively re-certified by a block we accepted while its
+    /// epoch was still trusted — either the block itself is already in
+    /// `block_hashes`, or an accepted child block commits to it via its
+    /// `previous_block_hash`.
+    async fn ensure_epoch_trusted(
+        &self,
+        certificate: &ConfirmedBlockCertificate,
+    ) -> Result<(), WorkerError> {
+        let header = &certificate.block().header;
+        let is_revoked = self
+            .storage
+            .is_epoch_revoked(header.epoch)
+            .await
+            .map_err(|error| {
+                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                    Box::new(error),
+                    ChainExecutionContext::Block,
+                )))
+            })?;
+        if !is_revoked {
+            return Ok(());
+        }
+        let block_hash = certificate.hash();
+        if self.chain.block_hashes.get(&header.height).await? == Some(block_hash) {
+            return Ok(());
+        }
+        let child_height = header.height.try_add_one()?;
+        if let Some(child_hash) = self.chain.block_hashes.get(&child_height).await? {
+            let child = self.storage.read_confirmed_block(child_hash).await?;
+            if child
+                .is_some_and(|child| child.block().header.previous_block_hash == Some(block_hash))
+            {
+                return Ok(());
+            }
+        }
+        Err(WorkerError::EpochRevoked {
+            chain_id: header.chain_id,
+            epoch: header.epoch,
+            height: header.height,
+        })
+    }
+
     /// Returns whether this chain is known to be active (initialized).
     pub(crate) fn knows_chain_is_active(&self) -> bool {
         self.knows_chain_is_active
@@ -975,6 +1022,14 @@ where
         // We haven't processed the block - verify the certificate first.
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
+        // If the epoch has been revoked, the quorum signature alone is no longer a
+        // sufficient basis for trust: the block must also be vouched for by a block
+        // this worker already trusts — a checkpoint trust mark, an earlier
+        // acceptance of the same block, or an accepted child block that commits to
+        // it via `previous_block_hash`.
+        if !in_trust_set {
+            self.ensure_epoch_trusted(&certificate).await?;
+        }
 
         // Certificate check passed - which means the blobs the block requires are legitimate and
         // we can take note of it, so that if any are missing, we will accept them when the client

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -3491,37 +3491,73 @@ impl<Env: Environment> ChainClient<Env> {
             .read_certificates_by_heights(self.chain_id, &heights)
             .await?
             .into_iter()
-            .flatten();
+            .flatten()
+            .collect::<Vec<_>>();
 
-        for certificate in certificates {
-            let missing_blob_ids = match remote_node
-                .handle_confirmed_certificate(
-                    certificate.clone(),
-                    CrossChainMessageDelivery::NonBlocking,
-                )
+        let mut index = 0;
+        while let Some(certificate) = certificates.get(index) {
+            match self
+                .push_certificate_to_validator(&remote_node, certificate)
                 .await
             {
-                Ok(_) => continue,
-                Err(NodeError::BlobsNotFound(missing_blob_ids)) => missing_blob_ids,
-                Err(err) => return Err(err.into()),
-            };
-            // The validator is missing blobs the certificate depends on
-            // (including possibly the chain description). Upload and retry.
-            let missing_blobs = self
-                .client
-                .storage_client()
-                .read_blobs(&missing_blob_ids)
-                .await?
-                .into_iter()
-                .flatten()
-                .map(|b| b.into_std())
-                .collect();
-            remote_node.upload_blobs(missing_blobs).await?;
-            remote_node
-                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
-                .await?;
+                Ok(()) => index += 1,
+                Err(Error::RemoteNodeError(NodeError::EpochRevoked { .. })) => {
+                    // The validator no longer trusts the epoch that signed this
+                    // certificate. Push the remaining blocks in decreasing height
+                    // order instead: the newest block's epoch is still trusted (if
+                    // it isn't, its push fails and there is no way to re-certify
+                    // the chain), and each accepted child re-certifies its parent
+                    // via `previous_block_hash`. Then resume the ascending pass,
+                    // which executes the now-preprocessed blocks in order.
+                    for descendant in certificates[index + 1..].iter().rev() {
+                        self.push_certificate_to_validator(&remote_node, descendant)
+                            .await?;
+                    }
+                    self.push_certificate_to_validator(&remote_node, certificate)
+                        .await?;
+                    index += 1;
+                }
+                Err(err) => return Err(err),
+            }
         }
 
+        Ok(())
+    }
+
+    /// Sends a single confirmed certificate to the validator, uploading any blobs it
+    /// reports as missing (including possibly the chain description) and retrying.
+    async fn push_certificate_to_validator(
+        &self,
+        remote_node: &Env::ValidatorNode,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+    ) -> Result<(), Error> {
+        let missing_blob_ids = match remote_node
+            .handle_confirmed_certificate(
+                certificate.clone(),
+                CrossChainMessageDelivery::NonBlocking,
+            )
+            .await
+        {
+            Ok(_) => return Ok(()),
+            Err(NodeError::BlobsNotFound(missing_blob_ids)) => missing_blob_ids,
+            Err(err) => return Err(err.into()),
+        };
+        let missing_blobs = self
+            .client
+            .storage_client()
+            .read_blobs(&missing_blob_ids)
+            .await?
+            .into_iter()
+            .flatten()
+            .map(|b| b.into_std())
+            .collect();
+        remote_node.upload_blobs(missing_blobs).await?;
+        remote_node
+            .handle_confirmed_certificate(
+                certificate.clone(),
+                CrossChainMessageDelivery::NonBlocking,
+            )
+            .await?;
         Ok(())
     }
 }

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -3497,18 +3497,17 @@ impl<Env: Environment> ChainClient<Env> {
                 Ok(()) => index += 1,
                 Err(Error::RemoteNodeError(NodeError::EpochRevoked { .. })) => {
                     // The validator no longer trusts the epoch that signed this
-                    // certificate. Push the remaining blocks in decreasing height
-                    // order instead: the newest block's epoch is still trusted (if
-                    // it isn't, its push fails and there is no way to re-certify
-                    // the chain), and each accepted child re-certifies its parent
-                    // via `previous_block_hash`. Then resume the ascending pass,
-                    // which executes the now-preprocessed blocks in order.
-                    for descendant in certificates[index + 1..].iter().rev() {
+                    // certificate. Push this and the remaining blocks in decreasing
+                    // height order instead: the newest block's epoch is still
+                    // trusted (if it isn't, its push fails and there is no way to
+                    // re-certify the chain), and each accepted child re-certifies
+                    // its parent via `previous_block_hash`. Then resume the
+                    // ascending pass, which executes the now-preprocessed blocks
+                    // in order.
+                    for descendant in certificates[index..].iter().rev() {
                         self.push_certificate_to_validator(&remote_node, descendant)
                             .await?;
                     }
-                    self.push_certificate_to_validator(&remote_node, certificate)
-                        .await?;
                     index += 1;
                 }
                 Err(err) => return Err(err),

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -284,12 +284,6 @@ pub enum Error {
     #[error("The state of the client is incompatible with the proposed block: {0}")]
     BlockProposalError(&'static str),
 
-    #[error(
-        "Cannot accept a certificate from a committee that was retired. \
-         Try a newer certificate from the same origin"
-    )]
-    CommitteeDeprecationError,
-
     #[error("Protocol error within chain client: {0}")]
     ProtocolError(&'static str),
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1783,7 +1783,7 @@ impl<Env: Environment> Client<Env> {
             }
 
             let remote_heights_ref = &remote_heights;
-            let certificates = match communicate_concurrently(
+            let (certificates, unknown_epoch_heights) = match communicate_concurrently(
                 &nodes,
                 async move |remote_node| {
                     let mut remote_heights = remote_heights_ref.clone();
@@ -1801,7 +1801,7 @@ impl<Env: Environment> Client<Env> {
                         // anything from the validator - let the function try the other validators
                         return Err(NodeError::MissingCertificateValue);
                     }
-                    let certificates = self
+                    let downloaded = self
                         .requests_scheduler
                         .download_certificates_by_heights(
                             &remote_node,
@@ -1809,28 +1809,34 @@ impl<Env: Environment> Client<Env> {
                             remote_heights,
                         )
                         .await?;
-                    let mut certificates_with_check_results = vec![];
-                    for cert in certificates {
-                        let committee_known = match self.check_certificate(&cert).await {
-                            Ok(()) => true,
-                            Err(chain_client::Error::CommitteeSynchronizationError) => false,
+                    // Set aside the certificates whose epochs we don't know yet:
+                    // they are not received - and not re-downloaded either, until a
+                    // future sync cycle after our view of the admin chain has
+                    // caught up.
+                    let mut certificates = Vec::new();
+                    let mut unknown_epoch_heights = Vec::new();
+                    for cert in downloaded {
+                        match self.check_certificate(&cert).await {
+                            Ok(()) => certificates.push(cert),
+                            Err(chain_client::Error::CommitteeSynchronizationError) => {
+                                unknown_epoch_heights.push(cert.block().header.height);
+                            }
                             Err(chain_client::Error::RemoteNodeError(error)) => return Err(error),
                             Err(error) => {
                                 return Err(NodeError::ResponseHandlingError {
                                     error: error.to_string(),
                                 })
                             }
-                        };
-                        certificates_with_check_results.push((cert, committee_known));
+                        }
                     }
-                    Ok(certificates_with_check_results)
+                    Ok((certificates, unknown_epoch_heights))
                 },
                 self.options.certificate_batch_download_hedge_delay,
                 self.storage_client().clock(),
             )
             .await
             {
-                Ok(certificates_with_check_results) => certificates_with_check_results,
+                Ok(result) => result,
                 Err(errors) => {
                     let faulty_validators = errors
                         .into_iter()
@@ -1862,19 +1868,12 @@ impl<Env: Environment> Client<Env> {
                 "received certificates",
             );
 
-            let mut to_remove_from_queue = BTreeSet::new();
+            let mut to_remove_from_queue = BTreeSet::from_iter(unknown_epoch_heights);
 
-            for (certificate, committee_known) in certificates {
+            for certificate in certificates {
                 let hash = certificate.hash();
                 let chain_id = certificate.block().header.chain_id;
                 let height = certificate.block().header.height;
-                if !committee_known {
-                    // The committee for the certificate's epoch is not known locally
-                    // yet - do not receive the certificate, but also do not attempt
-                    // to re-download it.
-                    to_remove_from_queue.insert(height);
-                    continue;
-                }
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1205,23 +1205,35 @@ impl<Env: Environment> Client<Env> {
                 .map_while(|maybe_certificate| maybe_certificate)
                 .collect::<Vec<_>>();
             if batch.is_empty() {
-                for node in nodes {
-                    match self
-                        .requests_scheduler
-                        .download_certificates_by_heights(node, chain_id, heights.clone())
-                        .await
-                    {
-                        Ok(downloaded) if !downloaded.is_empty() => {
-                            batch = downloaded
-                                .into_iter()
-                                .map(|certificate| {
-                                    self.storage_client().cache_certificate(certificate)
-                                })
-                                .collect();
-                            break;
+                // Race the validators instead of trying them one by one: a slow or
+                // faulty validator must not stall the walk. A validator that
+                // returns nothing counts as a failure so the others take over.
+                let heights = &heights;
+                let downloaded = communicate_concurrently(
+                    nodes,
+                    async move |remote_node| {
+                        let downloaded = self
+                            .requests_scheduler
+                            .download_certificates_by_heights(
+                                &remote_node,
+                                chain_id,
+                                heights.clone(),
+                            )
+                            .await?;
+                        if downloaded.is_empty() {
+                            return Err(NodeError::MissingCertificateValue);
                         }
-                        Ok(_) | Err(_) => continue,
-                    }
+                        Ok(downloaded)
+                    },
+                    self.options.certificate_batch_download_hedge_delay,
+                    self.storage_client().clock(),
+                )
+                .await;
+                if let Ok(downloaded) = downloaded {
+                    batch = downloaded
+                        .into_iter()
+                        .map(|certificate| self.storage_client().cache_certificate(certificate))
+                        .collect();
                 }
             }
             if batch.is_empty() {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -916,7 +916,8 @@ impl<Env: Environment> Client<Env> {
                                 }
                             }
                             for cert in certificates {
-                                self.check_certificate(&cert)
+                                let check_result = self
+                                    .check_certificate(&cert)
                                     .await
                                     .map_err(|error| {
                                         tracing::debug!(
@@ -924,15 +925,19 @@ impl<Env: Environment> Client<Env> {
                                             "invalid certificate"
                                         );
                                         error
-                                    })?
-                                    .into_result()
-                                    .map_err(|error| {
+                                    })?;
+                                // Revoked-epoch certificates are passed through: the
+                                // local worker accepts them only if a trusted
+                                // descendant vouches for them.
+                                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                                    check_result.into_result().map_err(|error| {
                                         tracing::debug!(
                                             %validator_address, %error,
                                             "could not check certificate"
                                         );
                                         error
                                     })?;
+                                }
                                 checked_certificates.push(cert);
                             }
                         }
@@ -1081,8 +1086,10 @@ impl<Env: Environment> Client<Env> {
     }
 
     /// Calls `handle_confirmed_certificate`, retrying with any missing blobs (downloaded
-    /// from `nodes`) and any missing events (downloaded from the publisher
-    /// chains via the current validators).
+    /// from `nodes`), any missing events (downloaded from the publisher
+    /// chains via the current validators), and — if the certificate's epoch is
+    /// revoked — the block's descendants (processed in decreasing height order so
+    /// they transitively re-certify the block).
     async fn handle_certificate_with_retry(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -1091,11 +1098,31 @@ impl<Env: Environment> Client<Env> {
     ) -> Result<ChainInfoResponse, chain_client::Error> {
         let mut downloaded_blobs = HashSet::<BlobId>::new();
         let mut downloaded_blocks = HashSet::<CryptoHash>::new();
+        let mut walked_descendants = false;
         let mut events = EventSetDownloader::new(self);
         loop {
             let result = self
                 .handle_confirmed_certificate(certificate.clone(), mode)
                 .await;
+            if let Err(LocalNodeError::WorkerError(WorkerError::EpochRevoked {
+                chain_id,
+                height,
+                ..
+            })) = &result
+            {
+                // The local worker doesn't trust the certificate's revoked epoch on
+                // its own. Try to establish trust by processing the block's
+                // descendants first.
+                if !walked_descendants {
+                    walked_descendants = true;
+                    if self
+                        .preprocess_descendants(*chain_id, *height, nodes)
+                        .await?
+                    {
+                        continue;
+                    }
+                }
+            }
             if let Err(LocalNodeError::BlobsNotFound(blob_ids)) = &result {
                 let new_blobs = filter_new(blob_ids, &downloaded_blobs);
                 if !new_blobs.is_empty() {
@@ -1155,6 +1182,95 @@ impl<Env: Environment> Client<Env> {
             }
         }
         Ok(())
+    }
+
+    /// Recovers a revoked-epoch block rejected by the local worker by processing the
+    /// block's descendants first, in decreasing height order.
+    ///
+    /// Collects the chain's certificates from `height + 1` up to and including the
+    /// first one whose epoch is not revoked (the anchor) — from local storage where
+    /// possible, otherwise from `nodes` — and feeds them through the local worker
+    /// newest-first: the anchor is trusted based on its own epoch, and each accepted
+    /// child then vouches for its parent via `previous_block_hash`. Returns `false`
+    /// if no anchor was found, e.g. because the chain's tip is itself in a revoked
+    /// epoch.
+    async fn preprocess_descendants(
+        &self,
+        chain_id: ChainId,
+        height: BlockHeight,
+        nodes: &[RemoteNode<Env::ValidatorNode>],
+    ) -> Result<bool, chain_client::Error> {
+        let batch_size = self.options.certificate_download_batch_size;
+        let mut certificates = Vec::new();
+        let mut next_height = height.try_add_one()?;
+        'anchor: loop {
+            let heights = (0..batch_size)
+                .map(|offset| {
+                    u64::from(next_height)
+                        .checked_add(offset)
+                        .map(BlockHeight)
+                        .ok_or(ArithmeticError::Overflow)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let mut batch = self
+                .storage_client()
+                .read_certificates_by_heights(chain_id, &heights)
+                .await?
+                .into_iter()
+                .map_while(|maybe_certificate| maybe_certificate)
+                .collect::<Vec<_>>();
+            if batch.is_empty() {
+                for node in nodes {
+                    match self
+                        .requests_scheduler
+                        .download_certificates_by_heights(node, chain_id, heights.clone())
+                        .await
+                    {
+                        Ok(downloaded) if !downloaded.is_empty() => {
+                            batch = downloaded
+                                .into_iter()
+                                .map(|certificate| {
+                                    self.storage_client().cache_certificate(certificate)
+                                })
+                                .collect();
+                            break;
+                        }
+                        Ok(_) | Err(_) => continue,
+                    }
+                }
+            }
+            if batch.is_empty() {
+                return Ok(false);
+            }
+            for certificate in batch {
+                if certificate.block().header.height != next_height {
+                    // A gap in the returned heights breaks the vouching chain.
+                    return Ok(false);
+                }
+                let epoch = certificate.block().header.epoch;
+                let is_revoked = self
+                    .storage_client()
+                    .is_epoch_revoked(epoch)
+                    .await
+                    .map_err(LocalNodeError::from)?;
+                certificates.push(certificate);
+                if !is_revoked {
+                    break 'anchor;
+                }
+                next_height = next_height.try_add_one()?;
+            }
+        }
+        // Process the descendants newest-first, so that each block is vouched for
+        // by the one processed just before it.
+        for certificate in certificates.iter().rev() {
+            Box::pin(self.handle_certificate_with_retry(
+                certificate,
+                nodes,
+                ProcessConfirmedBlockMode::Preprocess,
+            ))
+            .await?;
+        }
+        Ok(true)
     }
 
     async fn handle_certificate<T: ProcessableCertificate>(
@@ -1618,7 +1734,13 @@ impl<Env: Environment> Client<Env> {
                         check_result = self.check_certificate(&certificate).await?;
                     }
                 }
-                check_result.into_result()?;
+                // A certificate from a revoked epoch is not rejected here: the local
+                // worker accepts it if an already-trusted descendant vouches for it,
+                // and `handle_certificate_with_retry` below downloads and processes
+                // the descendants on demand.
+                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                    check_result.into_result()?;
+                }
             }
             // Recover history from the network.
             let nodes = if let Some(nodes) = nodes {
@@ -1710,8 +1832,7 @@ impl<Env: Environment> Client<Env> {
                     let mut certificates_with_check_results = vec![];
                     for cert in certificates {
                         let check_result = self.check_certificate(&cert).await?;
-                        certificates_with_check_results
-                            .push((cert, check_result.into_result().is_ok()));
+                        certificates_with_check_results.push((cert, check_result));
                     }
                     Ok(certificates_with_check_results)
                 },
@@ -1758,13 +1879,16 @@ impl<Env: Environment> Client<Env> {
                 let hash = certificate.hash();
                 let chain_id = certificate.block().header.chain_id;
                 let height = certificate.block().header.height;
-                if !check_result {
+                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
                     // The certificate was correctly signed, but we were missing a committee to
                     // validate it properly - do not receive it, but also do not attempt to
                     // re-download it.
                     to_remove_from_queue.insert(height);
                     continue;
                 }
+                // A revoked-epoch certificate is still received: the local worker
+                // accepts it if a trusted descendant vouches for it.
+                let old_epoch = matches!(check_result, CheckCertificateResult::OldEpoch);
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self
@@ -1776,6 +1900,12 @@ impl<Env: Environment> Client<Env> {
                     .await
                 {
                     warn!(%error, %hash, "Received invalid certificate");
+                    if old_epoch {
+                        // The block could not be re-certified via descendants
+                        // either; drop it from the queue instead of re-downloading
+                        // it indefinitely.
+                        to_remove_from_queue.insert(height);
+                    }
                 } else {
                     to_remove_from_queue.insert(height);
                     if let Err(error) = sender.send(ChainAndHeight { chain_id, height }) {
@@ -1888,8 +2018,14 @@ impl<Env: Environment> Client<Env> {
                 self.storage_client().cache_certificate(certificate)
             };
 
-            // Validate the certificate.
-            self.check_certificate(&certificate).await?.into_result()?;
+            // Validate the certificate. Revoked-epoch certificates are passed
+            // through: they are processed via `receive_sender_certificate` below,
+            // and the local worker only accepts them if a trusted descendant
+            // vouches for them.
+            let check_result = self.check_certificate(&certificate).await?;
+            if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                check_result.into_result()?;
+            }
 
             // Check if there's a previous message block to our chain.
             let block = certificate.block();
@@ -1982,7 +2118,12 @@ impl<Env: Environment> Client<Env> {
                     continue;
                 };
 
-                self.check_certificate(&certificate).await?.into_result()?;
+                // Revoked-epoch certificates are passed through: the local worker
+                // only accepts them if a trusted descendant vouches for them.
+                let check_result = self.check_certificate(&certificate).await?;
+                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
+                    check_result.into_result()?;
+                }
 
                 self.storage_client().cache_certificate(certificate)
             };

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -42,7 +42,7 @@ use linera_chain::{
     },
     ChainError, ChainIdSet,
 };
-use linera_execution::{committee::Committee, ExecutionError};
+use linera_execution::committee::Committee;
 use linera_storage::{Arc as CacheArc, Clock as _, ResultReadCertificates, Storage as _};
 use rand::seq::SliceRandom;
 use received_log::ReceivedLogs;
@@ -916,28 +916,13 @@ impl<Env: Environment> Client<Env> {
                                 }
                             }
                             for cert in certificates {
-                                let check_result = self
-                                    .check_certificate(&cert)
-                                    .await
-                                    .map_err(|error| {
-                                        tracing::debug!(
-                                            %validator_address, %error,
-                                            "invalid certificate"
-                                        );
-                                        error
-                                    })?;
-                                // Revoked-epoch certificates are passed through: the
-                                // local worker accepts them only if a trusted
-                                // descendant vouches for them.
-                                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                                    check_result.into_result().map_err(|error| {
-                                        tracing::debug!(
-                                            %validator_address, %error,
-                                            "could not check certificate"
-                                        );
-                                        error
-                                    })?;
-                                }
+                                self.check_certificate(&cert).await.map_err(|error| {
+                                    tracing::debug!(
+                                        %validator_address, %error,
+                                        "invalid certificate"
+                                    );
+                                    error
+                                })?;
                                 checked_certificates.push(cert);
                             }
                         }
@@ -1687,8 +1672,11 @@ impl<Env: Environment> Client<Env> {
         Box::pin(async move {
             // Verify the certificate before doing any expensive networking.
             if let ReceiveCertificateMode::NeedsCheck = mode {
-                let mut check_result = self.check_certificate(&certificate).await?;
-                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                let mut check_result = self.check_certificate(&certificate).await;
+                if matches!(
+                    check_result,
+                    Err(chain_client::Error::CommitteeSynchronizationError)
+                ) {
                     // The certificate is from an epoch our local view of the admin chain
                     // hasn't caught up to yet. Catch up and check again instead of failing.
                     // Prefer the nodes that gave us the certificate: they evidently know
@@ -1710,12 +1698,7 @@ impl<Env: Environment> Client<Env> {
                                 Box::pin(async move {
                                     self.synchronize_chain_state_from(&node, admin_chain_id)
                                         .await?;
-                                    match self.check_certificate(certificate).await? {
-                                        CheckCertificateResult::FutureEpoch => {
-                                            Err(chain_client::Error::CommitteeSynchronizationError)
-                                        }
-                                        _ => Ok(()),
-                                    }
+                                    self.check_certificate(certificate).await
                                 })
                             },
                             self.options.blob_download_hedge_delay,
@@ -1727,20 +1710,17 @@ impl<Env: Environment> Client<Env> {
                         false
                     };
                     if synced_from_serving_node {
-                        check_result = self.check_certificate(&certificate).await?;
+                        check_result = self.check_certificate(&certificate).await;
                     }
-                    if matches!(check_result, CheckCertificateResult::FutureEpoch) {
+                    if matches!(
+                        check_result,
+                        Err(chain_client::Error::CommitteeSynchronizationError)
+                    ) {
                         Box::pin(self.synchronize_chain_state(admin_chain_id)).await?;
-                        check_result = self.check_certificate(&certificate).await?;
+                        check_result = self.check_certificate(&certificate).await;
                     }
                 }
-                // A certificate from a revoked epoch is not rejected here: the local
-                // worker accepts it if an already-trusted descendant vouches for it,
-                // and `handle_certificate_with_retry` below downloads and processes
-                // the descendants on demand.
-                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                    check_result.into_result()?;
-                }
+                check_result?;
             }
             // Recover history from the network.
             let nodes = if let Some(nodes) = nodes {
@@ -1831,8 +1811,17 @@ impl<Env: Environment> Client<Env> {
                         .await?;
                     let mut certificates_with_check_results = vec![];
                     for cert in certificates {
-                        let check_result = self.check_certificate(&cert).await?;
-                        certificates_with_check_results.push((cert, check_result));
+                        let committee_known = match self.check_certificate(&cert).await {
+                            Ok(()) => true,
+                            Err(chain_client::Error::CommitteeSynchronizationError) => false,
+                            Err(chain_client::Error::RemoteNodeError(error)) => return Err(error),
+                            Err(error) => {
+                                return Err(NodeError::ResponseHandlingError {
+                                    error: error.to_string(),
+                                })
+                            }
+                        };
+                        certificates_with_check_results.push((cert, committee_known));
                     }
                     Ok(certificates_with_check_results)
                 },
@@ -1875,20 +1864,17 @@ impl<Env: Environment> Client<Env> {
 
             let mut to_remove_from_queue = BTreeSet::new();
 
-            for (certificate, check_result) in certificates {
+            for (certificate, committee_known) in certificates {
                 let hash = certificate.hash();
                 let chain_id = certificate.block().header.chain_id;
                 let height = certificate.block().header.height;
-                if matches!(check_result, CheckCertificateResult::FutureEpoch) {
-                    // The certificate was correctly signed, but we were missing a committee to
-                    // validate it properly - do not receive it, but also do not attempt to
-                    // re-download it.
+                if !committee_known {
+                    // The committee for the certificate's epoch is not known locally
+                    // yet - do not receive the certificate, but also do not attempt
+                    // to re-download it.
                     to_remove_from_queue.insert(height);
                     continue;
                 }
-                // A revoked-epoch certificate is still received: the local worker
-                // accepts it if a trusted descendant vouches for it.
-                let old_epoch = matches!(check_result, CheckCertificateResult::OldEpoch);
                 // We checked the certificates right after downloading them.
                 let mode = ReceiveCertificateMode::AlreadyChecked;
                 if let Err(error) = self
@@ -1900,10 +1886,15 @@ impl<Env: Environment> Client<Env> {
                     .await
                 {
                     warn!(%error, %hash, "Received invalid certificate");
-                    if old_epoch {
-                        // The block could not be re-certified via descendants
-                        // either; drop it from the queue instead of re-downloading
-                        // it indefinitely.
+                    if matches!(
+                        &error,
+                        chain_client::Error::LocalNodeError(LocalNodeError::WorkerError(
+                            WorkerError::EpochRevoked { .. }
+                        ))
+                    ) {
+                        // The block's epoch is revoked and it could not be
+                        // re-certified via descendants; drop it from the queue
+                        // instead of re-downloading it indefinitely.
                         to_remove_from_queue.insert(height);
                     }
                 } else {
@@ -2018,14 +2009,8 @@ impl<Env: Environment> Client<Env> {
                 self.storage_client().cache_certificate(certificate)
             };
 
-            // Validate the certificate. Revoked-epoch certificates are passed
-            // through: they are processed via `receive_sender_certificate` below,
-            // and the local worker only accepts them if a trusted descendant
-            // vouches for them.
-            let check_result = self.check_certificate(&certificate).await?;
-            if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                check_result.into_result()?;
-            }
+            // Validate the certificate.
+            self.check_certificate(&certificate).await?;
 
             // Check if there's a previous message block to our chain.
             let block = certificate.block();
@@ -2118,12 +2103,7 @@ impl<Env: Environment> Client<Env> {
                     continue;
                 };
 
-                // Revoked-epoch certificates are passed through: the local worker
-                // only accepts them if a trusted descendant vouches for them.
-                let check_result = self.check_certificate(&certificate).await?;
-                if !matches!(check_result, CheckCertificateResult::OldEpoch) {
-                    check_result.into_result()?;
-                }
+                self.check_certificate(&certificate).await?;
 
                 self.storage_client().cache_certificate(certificate)
             };
@@ -2199,6 +2179,17 @@ impl<Env: Environment> Client<Env> {
         .await
     }
 
+    /// Verifies the certificate's signatures against the committee of its own epoch.
+    ///
+    /// The committee is resolved from the admin chain's epoch event stream, which
+    /// works even if the epoch has been revoked since. Whether a valid certificate
+    /// from a revoked epoch is still a sufficient basis for trusting its block is
+    /// not decided here: the worker only accepts such a block if an already-trusted
+    /// block vouches for it.
+    ///
+    /// Returns [`chain_client::Error::CommitteeSynchronizationError`] if the epoch
+    /// is not known locally yet, e.g. because our local view of the admin chain is
+    /// behind; synchronizing the admin chain and retrying may resolve this.
     #[instrument(
         level = "trace", skip_all,
         fields(certificate_hash = ?incoming_certificate.hash()),
@@ -2206,20 +2197,18 @@ impl<Env: Environment> Client<Env> {
     async fn check_certificate(
         &self,
         incoming_certificate: &ConfirmedBlockCertificate,
-    ) -> Result<CheckCertificateResult, NodeError> {
+    ) -> Result<(), chain_client::Error> {
         let epoch = incoming_certificate.block().header.epoch;
-        let storage = self.storage_client();
-        let view_err = |error: ExecutionError| NodeError::ViewError {
-            error: error.to_string(),
-        };
-        if storage.is_epoch_revoked(epoch).await.map_err(view_err)? {
-            return Ok(CheckCertificateResult::OldEpoch);
-        }
-        let Some(committee) = storage.committee_for_epoch(epoch).await.map_err(view_err)? else {
-            return Ok(CheckCertificateResult::FutureEpoch);
-        };
-        incoming_certificate.check(&committee)?;
-        Ok(CheckCertificateResult::New)
+        let committee = self
+            .storage_client()
+            .committee_for_epoch(epoch)
+            .await
+            .map_err(LocalNodeError::from)?
+            .ok_or(chain_client::Error::CommitteeSynchronizationError)?;
+        incoming_certificate
+            .check(&committee)
+            .map_err(NodeError::from)?;
+        Ok(())
     }
 
     /// Downloads and processes any certificates we are missing for the given chain.
@@ -2851,25 +2840,6 @@ pub struct PendingProposal {
 enum ReceiveCertificateMode {
     NeedsCheck,
     AlreadyChecked,
-}
-
-enum CheckCertificateResult {
-    /// The certificate's epoch has been revoked on the admin chain.
-    OldEpoch,
-    /// The committee for the certificate's epoch is unknown to us yet, e.g. because
-    /// our local view of the admin chain is behind.
-    FutureEpoch,
-    New,
-}
-
-impl CheckCertificateResult {
-    fn into_result(self) -> Result<(), chain_client::Error> {
-        match self {
-            Self::OldEpoch => Err(chain_client::Error::CommitteeDeprecationError),
-            Self::FutureEpoch => Err(chain_client::Error::CommitteeSynchronizationError),
-            Self::New => Ok(()),
-        }
-    }
 }
 
 /// Creates a compressed Contract, Service and bytecode, plus an optional

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -1253,9 +1253,8 @@ mod tests {
     }
 
     /// Dropping the owner guard without completing must wake subscribers — they fall back to
-    /// executing the request themselves — rather than leaving them blocked forever. Regression
-    /// test for the cold-sync hang where a cancelled `communicate_with_quorum` branch leaked the
-    /// in-flight entry, so its subscribers' `recv().await` never returned.
+    /// executing the request themselves — rather than leaving them blocked forever, since a
+    /// dropped owner leaves the in-flight entry that the subscribers' `recv().await` waits on.
     #[tokio::test]
     async fn test_owner_drop_wakes_subscribers() {
         use linera_base::identifiers::BlobType;

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -12,7 +12,8 @@ use futures::stream::Stream;
 use linera_base::{
     crypto::{CryptoError, CryptoHash, ValidatorPublicKey},
     data_types::{
-        ArithmeticError, Blob, BlobContent, BlockHeight, NetworkDescription, Round, Timestamp,
+        ArithmeticError, Blob, BlobContent, BlockHeight, Epoch, NetworkDescription, Round,
+        Timestamp,
     },
     identifiers::{BlobId, ChainId, EventId},
     task::{MaybeSend, MaybeSync},
@@ -366,6 +367,16 @@ pub enum NodeError {
 
     #[error("No validators available to handle the request")]
     NoValidators,
+
+    #[error(
+        "Cannot trust the certificate for block at height {height} on chain {chain_id}: \
+        epoch {epoch} has been revoked and no trusted block vouches for the block"
+    )]
+    EpochRevoked {
+        chain_id: ChainId,
+        epoch: Epoch,
+        height: BlockHeight,
+    },
 }
 
 impl NodeError {
@@ -387,6 +398,7 @@ impl NodeError {
             | NodeError::UnexpectedBlockHeight { .. }
             | NodeError::InactiveChain(_)
             | NodeError::InvalidTimestamp { .. }
+            | NodeError::EpochRevoked { .. }
             | NodeError::MissingCertificateValue => true,
 
             // Unexpected: network issues, validator misbehavior, or internal problems.
@@ -519,6 +531,15 @@ impl From<WorkerError> for NodeError {
             } => NodeError::UnexpectedBlockHeight {
                 expected_block_height,
                 found_block_height,
+            },
+            WorkerError::EpochRevoked {
+                chain_id,
+                epoch,
+                height,
+            } => Self::EpochRevoked {
+                chain_id,
+                epoch,
+                height,
             },
             WorkerError::InvalidTimestamp {
                 block_timestamp,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1528,7 +1528,7 @@ where
 /// not heard of yet.
 ///
 /// The blob-recovery path downloads the publishing certificate from a validator, but
-/// validating it locally yields `CheckCertificateResult::FutureEpoch`. The client must
+/// validating it locally yields `CommitteeSynchronizationError`. The client must
 /// react by catching up on the admin chain and retrying, so the blob read succeeds.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1413,6 +1413,113 @@ where
     assert_eq!(certificates.len(), 3);
     assert_eq!(user.chain_info().await?.epoch, Epoch::from(6));
 
+    // A fresh client, starting from genesis storage only, can still synchronize the
+    // user chain even though its first two blocks are signed by the revoked epochs
+    // 0 and 1: the local worker rejects them at first, and the client recovers by
+    // processing their descendants in decreasing height order.
+    let info = user.chain_info().await?;
+    let user2 = builder
+        .make_client(user.chain_id(), None, BlockHeight::ZERO)
+        .await?;
+    user2.synchronize_from_validators().await?;
+    let info2 = user2.chain_info().await?;
+    assert_eq!(info2.next_block_height, info.next_block_height);
+    assert_eq!(info2.epoch, Epoch::from(6));
+
+    Ok(())
+}
+
+/// Tests that a client can bring a lagging validator up to date across an epoch
+/// revocation: certificates signed by a revoked epoch are rejected by the validator
+/// at first, and the client recovers by uploading their descendants in decreasing
+/// height order, so that each accepted child re-certifies its parent.
+///
+/// Exercises both upload paths: the updater's certificate push (triggered by a block
+/// proposal that needs the lagging validator's vote) and the explicit
+/// `sync_validator` API.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_sync_lagging_validator_across_revoked_epoch<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let user = builder.add_root_chain(1, Amount::from_tokens(6)).await?;
+    let validators = builder.initial_committee.validators().clone();
+
+    // Validator 0 misses the user chain's early history; the remaining three
+    // validators still form a quorum.
+    builder.set_fault_type([0], FaultType::Offline);
+
+    // Height 0, signed by epoch 0.
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+
+    // Create epoch 1 and migrate the user chain to it. The migration block at
+    // height 1 still carries epoch 0 in its header; only the block at height 2 is
+    // signed by epoch 1.
+    let committee = Committee::new(validators, ResourceControlPolicy::default())?;
+    admin.stage_new_committee(committee.clone()).await?;
+    user.synchronize_from_validators().await?;
+    user.process_inbox().await?;
+    assert_eq!(user.chain_info().await?.epoch, Epoch::from(1));
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+
+    // Validator 0 comes back online and learns that epoch 0 is revoked — but it
+    // still has none of the user chain's blocks.
+    builder.set_fault_type([0], FaultType::Honest);
+    admin.revoke_epochs(Epoch::ZERO).await?;
+    admin.sync_validator(builder.node(0)).await?;
+
+    // With validator 1 offline, the next block needs validator 0's vote, so the
+    // updater must bring it up to date — past the revoked-epoch blocks at heights
+    // 0 and 1.
+    builder.set_fault_type([1], FaultType::Offline);
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    // Validator 1 is offline, so a count of 3 requires validator 0 to have the
+    // certificates.
+    builder
+        .check_that_validators_have_certificate(user.chain_id(), BlockHeight::ZERO, 3)
+        .await;
+    builder
+        .check_that_validators_have_certificate(user.chain_id(), BlockHeight::from(3), 3)
+        .await;
+
+    // Now validator 1 misses the epoch-1 blocks: the user chain migrates to epoch 2
+    // and epoch 1 gets revoked while validator 1 is offline.
+    admin.stage_new_committee(committee).await?;
+    user.synchronize_from_validators().await?;
+    user.process_inbox().await?;
+    assert_eq!(user.chain_info().await?.epoch, Epoch::from(2));
+    user.burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    builder.set_fault_type([1], FaultType::Honest);
+    admin.revoke_epochs(Epoch::from(1)).await?;
+    admin.sync_validator(builder.node(1)).await?;
+
+    // Validator 1 is at height 3; the blocks at heights 3 and 4 are signed by the
+    // now-revoked epoch 1. `sync_validator` recovers by pushing the epoch-2 block
+    // at height 5 first.
+    user.sync_validator(builder.node(1)).await?;
+    let response = builder
+        .node(1)
+        .handle_chain_info_query(crate::data_types::ChainInfoQuery::new(user.chain_id()))
+        .await?;
+    assert_eq!(response.info.next_block_height, BlockHeight::from(6));
+
     Ok(())
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3125,81 +3125,121 @@ where
         &[OperationResult::default()]
     );
 
-    // Have the admin chain create a new epoch and retire the old one immediately.
+    // Have the admin chain create a new epoch.
     let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
     let blob_hash = committee_blob.id().hash;
     env.write_blobs(std::slice::from_ref(&committee_blob))
         .await?;
 
-    let proposal1 = make_first_block(admin_chain_id)
-        .with_operation(SystemOperation::Admin(AdminOperation::CreateCommittee {
+    let proposal1 = make_first_block(admin_chain_id).with_operation(SystemOperation::Admin(
+        AdminOperation::CreateCommittee {
             epoch: Epoch::from(1),
             blob_hash,
-        }))
-        .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
-            epoch: Epoch::ZERO,
-        }));
+        },
+    ));
 
     let certificate1 = env.execute_proposal(proposal1.clone(), vec![]).await?;
 
     assert!(certificate1.value().matches_proposed_block(&proposal1));
     assert_outcome_matches!(
         certificate1.block(),
-        &[vec![], vec![]],
+        &[vec![]],
         &BTreeMap::new(),
         &BTreeMap::new(),
-        &[vec![OracleResponse::Blob(committee_blob.id())], vec![]],
-        &[
-            vec![Event {
-                stream_id: StreamId::system(EPOCH_STREAM_NAME),
-                index: 1,
-                value: bcs::to_bytes(&EpochEventData {
-                    blob_hash: committee_blob.id().hash,
-                    timestamp: Timestamp::from(0),
-                })
-                .unwrap(),
-            }],
-            vec![Event {
-                stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
-                index: 0,
-                value: Vec::new(),
-            }],
-        ],
-        &[vec![], vec![]],
-        &[OperationResult::default(), OperationResult::default()],
+        &[vec![OracleResponse::Blob(committee_blob.id())]],
+        &[vec![Event {
+            stream_id: StreamId::system(EPOCH_STREAM_NAME),
+            index: 1,
+            value: bcs::to_bytes(&EpochEventData {
+                blob_hash: committee_blob.id().hash,
+                timestamp: Timestamp::from(0),
+            })
+            .unwrap(),
+        }]],
+        &[vec![]],
+        &[OperationResult::default()],
+    );
+
+    // Extend the user chain with two blocks while epoch 0 is still trusted: the
+    // block at height 1 advances the chain to epoch 1, but its header still
+    // carries epoch 0 — only the block at height 2 is signed by epoch 1.
+    let proposal_height1 = make_child_block(&certificate0.clone().into_value())
+        .with_operation(SystemOperation::ProcessNewEpoch(Epoch::from(1)))
+        .with_authenticated_owner(Some(owner1));
+    let certificate_height1 = env.execute_proposal(proposal_height1, vec![]).await?;
+    let proposal_height2 = make_child_block(&certificate_height1.clone().into_value())
+        .with_epoch(1)
+        .with_simple_transfer(user_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let certificate_height2 = env.execute_proposal(proposal_height2, vec![]).await?;
+
+    // Now retire epoch 0.
+    let proposal_revoke = make_child_block(&certificate1.clone().into_value())
+        .with_epoch(1)
+        .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
+            epoch: Epoch::ZERO,
+        }));
+    let certificate_revoke = env
+        .execute_proposal(proposal_revoke.clone(), vec![])
+        .await?;
+
+    assert!(certificate_revoke
+        .value()
+        .matches_proposed_block(&proposal_revoke));
+    assert_outcome_matches!(
+        certificate_revoke.block(),
+        &[vec![]],
+        &BTreeMap::new(),
+        &BTreeMap::new(),
+        &[vec![]],
+        &[vec![Event {
+            stream_id: StreamId::system(REMOVED_EPOCH_STREAM_NAME),
+            index: 0,
+            value: Vec::new(),
+        }]],
+        &[vec![]],
+        &[OperationResult::default()],
     );
 
     env.worker()
         .fully_handle_certificate_with_notifications(certificate1.clone(), &())
         .await?;
-
-    // Try to execute the transfer from the user chain to the admin chain.
     env.worker()
-        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
+        .fully_handle_certificate_with_notifications(certificate_revoke.clone(), &())
         .await?;
 
+    // Try to execute the transfer from the user chain to the admin chain. The
+    // certificate is rejected: epoch 0 is revoked on the admin chain, and no
+    // trusted block vouches for the user chain's block yet.
+    let error = env
+        .worker()
+        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
+        .await
+        .unwrap_err();
+    assert_matches!(
+        error,
+        WorkerError::EpochRevoked {
+            epoch: Epoch::ZERO,
+            ..
+        }
+    );
+
     {
-        // The transfer was started..
+        // The transfer was not executed ..
         let user_chain = env.worker().chain_state_view(user_id).await?;
-        assert!(user_chain.is_active().await?);
         assert_eq!(
-            BlockHeight::from(1),
+            BlockHeight::ZERO,
             user_chain.tip_state.get().next_block_height
         );
-        assert_eq!(
-            *user_chain.execution_state.system.balance.get(),
-            Amount::from_tokens(2)
-        );
-        assert_eq!(*user_chain.execution_state.system.epoch.get(), Epoch::ZERO);
 
-        // .. but the message has been refused: epoch 0 is revoked on the admin chain.
+        // .. and no message has reached the admin chain.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
         assert!(admin_chain.is_active().await?);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
 
     // Force the admin chain to receive the money nonetheless by anticipation.
-    let proposal2 = make_child_block(&certificate1.clone().into_value())
+    let proposal2 = make_child_block(&certificate_revoke.clone().into_value())
         .with_epoch(1)
         .with_incoming_bundle(IncomingBundle {
             origin: user_id,
@@ -3246,14 +3286,44 @@ where
             .is_some());
     }
 
-    // Try again to execute the transfer from the user chain to the admin chain.
-    // This time, normal delivery is allowed because the bundle's height is at most
-    // `last_anticipated_block_height` (it was already executed by anticipation).
-    env.worker()
-        .fully_handle_certificate_with_notifications(certificate0.clone(), &())
-        .await?;
+    // The block at height 1 is from the revoked epoch and nothing vouches for it
+    // yet, so it is rejected.
+    let error = env
+        .worker()
+        .fully_handle_certificate_with_notifications(certificate_height1.clone(), &())
+        .await
+        .unwrap_err();
+    assert_matches!(
+        error,
+        WorkerError::EpochRevoked {
+            epoch: Epoch::ZERO,
+            ..
+        }
+    );
+
+    // In decreasing height order, each block is accepted: the block at height 2 by
+    // its trusted epoch, and each revoked-epoch block by the child accepted just
+    // before it, which commits to it via `previous_block_hash`. The blocks at
+    // heights 2 and 1 are preprocessed (they have no parent yet); the block at
+    // height 0 executes, and its message is delivered too: the bundle's height is
+    // at most `last_anticipated_block_height` (it was already executed by
+    // anticipation).
+    for certificate in [
+        certificate_height2.clone(),
+        certificate_height1.clone(),
+        certificate0.clone(),
+    ] {
+        env.worker()
+            .fully_handle_certificate_with_notifications(certificate, &())
+            .await?;
+    }
 
     {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(1),
+            user_chain.tip_state.get().next_block_height
+        );
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
         assert!(admin_chain.is_active().await?);
         assert_no_removed_bundles(&admin_chain).await;
@@ -3306,7 +3376,7 @@ where
         .await?;
     assert_eq!(
         response.info.requested_previous_event_blocks,
-        BTreeMap::from([(stream_id, (BlockHeight(2), certificate3.hash()))]),
+        BTreeMap::from([(stream_id, (BlockHeight(3), certificate3.hash()))]),
     );
 
     Ok(())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3099,7 +3099,8 @@ where
 {
     let mut env =
         TestEnvironment::new_with_amount(&mut storage_builder, false, false, Amount::ZERO).await?;
-    let owner1 = AccountSecretKey::generate().public().into();
+    let mut signer = InMemorySigner::new(None);
+    let owner1 = signer.generate_new().into();
     let chain_1_desc = env.add_root_chain(1, owner1, Amount::from_tokens(3)).await;
     let mut committees = BTreeMap::new();
     let committee = env.committee().clone();
@@ -3237,6 +3238,19 @@ where
         assert!(admin_chain.is_active().await?);
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
+
+    // The user chain is stuck in the revoked epoch 0, so it is frozen: the committee
+    // must not sign anything new for that epoch, and a block proposal is rejected.
+    let proposal_frozen = make_first_block(user_id)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .into_first_proposal(owner1, &signer)
+        .await
+        .unwrap();
+    let (result, _actions) = env.worker().handle_block_proposal(proposal_frozen).await;
+    assert_matches!(
+        result,
+        Err(WorkerError::VoteInRevokedEpoch { epoch, .. }) if epoch == Epoch::ZERO
+    );
 
     // Force the admin chain to receive the money nonetheless by anticipation.
     let proposal2 = make_child_block(&certificate_revoke.clone().into_value())

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{future, Future, StreamExt};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{ArithmeticError, BlockHeight, Round, TimeDelta},
+    data_types::{ArithmeticError, BlockHeight, Epoch, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, BlobType, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
@@ -295,12 +295,14 @@ where
                 }) if !sent_descendants => {
                     // The validator no longer trusts the epoch that signed the
                     // certificate. Push the block's descendants from local storage
-                    // in decreasing height order: the newest one is in a
-                    // still-trusted epoch, and each accepted child then
-                    // re-certifies its parent via `previous_block_hash`.
+                    // in decreasing height order, up to the first one from a later
+                    // epoch: each accepted child re-certifies its parent via
+                    // `previous_block_hash`. If the validator revoked the later
+                    // epoch as well, pushing that descendant recursively triggers
+                    // the same recovery one epoch further up.
                     sent_descendants = true;
                     let Some(descendants) = self
-                        .read_descendants_up_to_trusted_epoch(chain_id, height)
+                        .read_descendants_up_to_next_epoch(chain_id, height, epoch)
                         .await?
                     else {
                         // We hold no descendant in a trusted epoch, so we cannot
@@ -865,13 +867,14 @@ where
     }
 
     /// Reads this chain's certificates from local storage, from `height + 1` up to
-    /// and including the first one whose epoch is not revoked. Returns `None` if
-    /// storage runs out of blocks before a trusted-epoch one is found — then the
+    /// and including the first one from an epoch later than `epoch`. Returns `None`
+    /// if storage runs out of blocks before a later-epoch one is found — then the
     /// vouching chain cannot be completed.
-    async fn read_descendants_up_to_trusted_epoch(
+    async fn read_descendants_up_to_next_epoch(
         &self,
         chain_id: ChainId,
         height: BlockHeight,
+        epoch: Epoch,
     ) -> Result<Option<Vec<CacheArc<ConfirmedBlockCertificate>>>, chain_client::Error> {
         let storage = self.client.local_node.storage_client();
         let batch_size = self.client.options().certificate_upload_batch_size as u64;
@@ -896,13 +899,9 @@ where
                 return Ok(None);
             }
             for certificate in batch {
-                let epoch = certificate.block().header.epoch;
-                let is_revoked = storage
-                    .is_epoch_revoked(epoch)
-                    .await
-                    .map_err(LocalNodeError::from)?;
+                let is_later_epoch = certificate.block().header.epoch > epoch;
                 certificates.push(certificate);
-                if !is_revoked {
+                if is_later_epoch {
                     return Ok(Some(certificates));
                 }
                 next_height = next_height.try_add_one()?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{future, Future, StreamExt};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{BlockHeight, Round, TimeDelta},
+    data_types::{ArithmeticError, BlockHeight, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, BlobType, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
@@ -256,6 +256,7 @@ where
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
         let mut sent_blocks = false;
+        let mut sent_descendants = false;
         loop {
             match result {
                 Err(NodeError::EventsNotFound(event_ids))
@@ -286,6 +287,34 @@ where
                         .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
                         .await?;
                     sent_blobs = true;
+                }
+                Err(NodeError::EpochRevoked {
+                    chain_id,
+                    epoch,
+                    height,
+                }) if !sent_descendants => {
+                    // The validator no longer trusts the epoch that signed the
+                    // certificate. Push the block's descendants from local storage
+                    // in decreasing height order: the newest one is in a
+                    // still-trusted epoch, and each accepted child then
+                    // re-certifies its parent via `previous_block_hash`.
+                    sent_descendants = true;
+                    let Some(descendants) = self
+                        .read_descendants_up_to_trusted_epoch(chain_id, height)
+                        .await?
+                    else {
+                        // We hold no descendant in a trusted epoch, so we cannot
+                        // re-certify the block for the validator.
+                        return Err(NodeError::EpochRevoked {
+                            chain_id,
+                            epoch,
+                            height,
+                        }
+                        .into());
+                    };
+                    for descendant in descendants.iter().rev() {
+                        Box::pin(self.send_confirmed_certificate(descendant, delivery)).await?;
+                    }
                 }
                 Err(NodeError::BlocksNotFound(hashes)) if !sent_blocks => {
                     // The validator has recorded these hashes as trusted by a
@@ -833,6 +862,52 @@ where
         }
 
         Ok(info)
+    }
+
+    /// Reads this chain's certificates from local storage, from `height + 1` up to
+    /// and including the first one whose epoch is not revoked. Returns `None` if
+    /// storage runs out of blocks before a trusted-epoch one is found — then the
+    /// vouching chain cannot be completed.
+    async fn read_descendants_up_to_trusted_epoch(
+        &self,
+        chain_id: ChainId,
+        height: BlockHeight,
+    ) -> Result<Option<Vec<CacheArc<ConfirmedBlockCertificate>>>, chain_client::Error> {
+        let storage = self.client.local_node.storage_client();
+        let batch_size = self.client.options().certificate_upload_batch_size as u64;
+        let mut certificates = Vec::new();
+        let mut next_height = height.try_add_one()?;
+        loop {
+            let heights = (0..batch_size)
+                .map(|offset| {
+                    u64::from(next_height)
+                        .checked_add(offset)
+                        .map(BlockHeight)
+                        .ok_or(ArithmeticError::Overflow)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            let batch = storage
+                .read_certificates_by_heights(chain_id, &heights)
+                .await?
+                .into_iter()
+                .map_while(|maybe_certificate| maybe_certificate)
+                .collect::<Vec<_>>();
+            if batch.is_empty() {
+                return Ok(None);
+            }
+            for certificate in batch {
+                let epoch = certificate.block().header.epoch;
+                let is_revoked = storage
+                    .is_epoch_revoked(epoch)
+                    .await
+                    .map_err(LocalNodeError::from)?;
+                certificates.push(certificate);
+                if !is_revoked {
+                    return Ok(Some(certificates));
+                }
+                next_height = next_height.try_add_one()?;
+            }
+        }
     }
 
     /// Reads certificates for the given heights from storage.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt,
     hash::Hash,
     mem,
@@ -248,6 +248,63 @@ where
         certificate: &CacheArc<ConfirmedBlockCertificate>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
+        // Certificates still to be sent, in reverse sending order: when the validator
+        // rejects the top entry because its epoch is revoked, the descendants that
+        // re-certify it are stacked on top of it, so every rejected block is preceded
+        // by the child vouching for it via `previous_block_hash`.
+        let mut stack = vec![certificate.clone()];
+        let mut expanded = HashSet::new();
+        loop {
+            let certificate = stack.last().expect("stack is never empty").clone();
+            match self
+                .send_single_confirmed_certificate(&certificate, delivery)
+                .await
+            {
+                Err(chain_client::Error::RemoteNodeError(NodeError::EpochRevoked {
+                    chain_id,
+                    epoch,
+                    height,
+                })) if !expanded.contains(&certificate.hash()) => {
+                    // The validator no longer trusts the epoch that signed the
+                    // certificate. Send the block's descendants from local storage
+                    // first, in decreasing height order, up to the first one from a
+                    // later epoch. If the validator revoked the later epoch as well,
+                    // sending its first block fails in the same way and extends the
+                    // stack one epoch further.
+                    expanded.insert(certificate.hash());
+                    let Some(descendants) = self
+                        .read_descendants_up_to_next_epoch(chain_id, height, epoch)
+                        .await?
+                    else {
+                        // We hold no descendant from a later epoch, so we cannot
+                        // re-certify the block for the validator.
+                        return Err(NodeError::EpochRevoked {
+                            chain_id,
+                            epoch,
+                            height,
+                        }
+                        .into());
+                    };
+                    stack.extend(descendants);
+                }
+                Err(err) => return Err(err),
+                Ok(info) => {
+                    stack.pop();
+                    if stack.is_empty() {
+                        return Ok(info);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Sends one confirmed certificate to the validator, catching up the admin chain
+    /// and uploading any blobs or blocks the validator reports as missing.
+    async fn send_single_confirmed_certificate(
+        &mut self,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self
             .remote_node
             .handle_optimized_confirmed_certificate(certificate, delivery)
@@ -256,7 +313,6 @@ where
         let mut sent_admin_chain = false;
         let mut sent_blobs = false;
         let mut sent_blocks = false;
-        let mut sent_descendants = false;
         loop {
             match result {
                 Err(NodeError::EventsNotFound(event_ids))
@@ -287,36 +343,6 @@ where
                         .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
                         .await?;
                     sent_blobs = true;
-                }
-                Err(NodeError::EpochRevoked {
-                    chain_id,
-                    epoch,
-                    height,
-                }) if !sent_descendants => {
-                    // The validator no longer trusts the epoch that signed the
-                    // certificate. Push the block's descendants from local storage
-                    // in decreasing height order, up to the first one from a later
-                    // epoch: each accepted child re-certifies its parent via
-                    // `previous_block_hash`. If the validator revoked the later
-                    // epoch as well, pushing that descendant recursively triggers
-                    // the same recovery one epoch further up.
-                    sent_descendants = true;
-                    let Some(descendants) = self
-                        .read_descendants_up_to_next_epoch(chain_id, height, epoch)
-                        .await?
-                    else {
-                        // We hold no descendant in a trusted epoch, so we cannot
-                        // re-certify the block for the validator.
-                        return Err(NodeError::EpochRevoked {
-                            chain_id,
-                            epoch,
-                            height,
-                        }
-                        .into());
-                    };
-                    for descendant in descendants.iter().rev() {
-                        Box::pin(self.send_confirmed_certificate(descendant, delivery)).await?;
-                    }
                 }
                 Err(NodeError::BlocksNotFound(hashes)) if !sent_blocks => {
                     // The validator has recorded these hashes as trusted by a

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -376,6 +376,20 @@ pub enum WorkerError {
         chain_epoch: Epoch,
         epoch: Epoch,
     },
+    /// The certificate's epoch has been revoked on the admin chain, so its
+    /// signatures alone no longer prove anything, and no block this worker already
+    /// trusts vouches for the block. The client can recover by uploading the
+    /// block's descendants in decreasing height order: each accepted descendant
+    /// re-certifies its parent via `previous_block_hash`.
+    #[error(
+        "Cannot trust the certificate for block at height {height} on chain {chain_id}: \
+        epoch {epoch} has been revoked and no trusted block vouches for the block"
+    )]
+    EpochRevoked {
+        chain_id: ChainId,
+        epoch: Epoch,
+        height: BlockHeight,
+    },
 
     #[error("Events not found: {0:?}")]
     EventsNotFound(Vec<EventId>),
@@ -448,6 +462,7 @@ impl WorkerError {
             | WorkerError::InvalidSigner(_)
             | WorkerError::UnexpectedBlockHeight { .. }
             | WorkerError::InvalidEpoch { .. }
+            | WorkerError::EpochRevoked { .. }
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
             | WorkerError::InvalidTimestamp { .. }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -390,6 +390,18 @@ pub enum WorkerError {
         epoch: Epoch,
         height: BlockHeight,
     },
+    /// The epoch has been revoked on the admin chain, so its committee must not
+    /// create any new signatures. A chain that failed to migrate to a newer epoch
+    /// before the revocation is frozen.
+    #[error(
+        "Cannot vote for the block at height {height} on chain {chain_id}: \
+        epoch {epoch} has been revoked"
+    )]
+    VoteInRevokedEpoch {
+        chain_id: ChainId,
+        epoch: Epoch,
+        height: BlockHeight,
+    },
 
     #[error("Events not found: {0:?}")]
     EventsNotFound(Vec<EventId>),
@@ -463,6 +475,7 @@ impl WorkerError {
             | WorkerError::UnexpectedBlockHeight { .. }
             | WorkerError::InvalidEpoch { .. }
             | WorkerError::EpochRevoked { .. }
+            | WorkerError::VoteInRevokedEpoch { .. }
             | WorkerError::EventsNotFound(_)
             | WorkerError::InvalidBlockChaining
             | WorkerError::InvalidTimestamp { .. }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -870,6 +870,15 @@ NodeError:
           - block_time_grace_period_ms: U64
     33:
       NoValidators: UNIT
+    34:
+      EpochRevoked:
+        STRUCT:
+          - chain_id:
+              TYPENAME: ChainId
+          - epoch:
+              TYPENAME: Epoch
+          - height:
+              TYPENAME: BlockHeight
 Notification:
   STRUCT:
     - chain_id:


### PR DESCRIPTION
## Motivation
  
Once an epoch is revoked, its committee's signatures are no longer trustworthy: a certificate from a revoked epoch can't be verified on its own anymore. But nodes still need to accept old blocks — a sender's block with an undelivered message, for example — long after the epoch that certified it is gone. That is why epoch revocation is currently not usable.

## Proposal

Accept a confirmed block from a revoked epoch only if something the node already trusts vouches for it. A block certified in a live epoch commits to its parent's hash, so its descendants re-certify it: the worker records the hash of a block it trusts but hasn't seen yet, and accepts a certificate for that hash regardless of its epoch.

Clients re-certify accordingly: when a validator rejects a block as belonging to a revoked epoch, the client downloads that block's descendants (racing validators, so a single faulty one can't stall the sync) and submits them first. Validators also refuse to sign new blocks in a revoked epoch.

## Test Plan

CI, plus new unit tests in `linera-core` covering worker rejection and acceptance of revoked-epoch blocks and the client's descendant-based recovery.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

  - First of three stacked PRs. Followed by "Vouch for the blocks a block refers to" and
    "Keep the received log per sender epoch".
  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
