### PR TITLE
Vouch for the blocks a block refers to

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -47,7 +47,8 @@ use crate::{
     manager::ChainManager,
     outbox::OutboxStateView,
     pending_blobs::PendingBlobsView,
-    ChainError, ChainExecutionContext, ExecutionError, ExecutionResultExt,
+    ChainError, ChainExecutionContext, ConflictingCertifiedBlocks, ExecutionError,
+    ExecutionResultExt,
 };
 
 #[cfg(test)]
@@ -1507,7 +1508,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
-        self.vouch_for_block_references(block).await?;
+        self.vouch_for_block_references(block, hash).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1530,7 +1531,18 @@ where
     /// is already in `block_hashes`. The accepted block is trusted, so these hash
     /// commitments remain a sufficient basis for accepting the referenced blocks
     /// even after the epochs that certified them are revoked.
-    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+    ///
+    /// A chain has one certified block per height, so a block committing to a
+    /// different hash than the one already accepted at that height is evidence of
+    /// equivocation — two conflicting certificates signed by that height's
+    /// committee. In that case the block is rejected with
+    /// [`ChainError::ConflictingCertifiedBlocks`], which names the certificate
+    /// pair that proves the fault.
+    async fn vouch_for_block_references(
+        &mut self,
+        block: &Block,
+        block_hash: CryptoHash,
+    ) -> Result<(), ChainError> {
         let mut references = Vec::new();
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
@@ -1547,25 +1559,38 @@ where
                 Some(known_hash) if known_hash == hash => {}
                 None => self.vouched_blocks.insert(&hash)?,
                 Some(known_hash) => {
-                    // A chain has one certified block per height, so a trusted
-                    // block committing to a different hash than the one already
-                    // accepted is evidence of equivocation — two conflicting
-                    // certificates signed by that height's committee. Follow the
-                    // newly accepted block's commitment (it is the one backed by
-                    // a currently trusted certificate), but flag the conflict.
-                    warn!(
-                        chain_id = %self.chain_id(),
-                        %height,
-                        %known_hash,
-                        vouched_hash = %hash,
-                        "conflicting certified blocks at the same height: \
-                         the committee for this height equivocated",
-                    );
-                    self.vouched_blocks.insert(&hash)?;
+                    return Err(self.conflicting_blocks_error(height, known_hash, hash, block_hash));
                 }
             }
         }
         Ok(())
+    }
+
+    /// Builds a [`ChainError::ConflictingCertifiedBlocks`] error and logs the
+    /// conflict: a certified block asserting a different block at `height` than
+    /// the one already accepted is proof that a committee equivocated.
+    fn conflicting_blocks_error(
+        &self,
+        height: BlockHeight,
+        existing_block: CryptoHash,
+        conflicting_block: CryptoHash,
+        witness_block: CryptoHash,
+    ) -> ChainError {
+        tracing::error!(
+            chain_id = %self.chain_id(),
+            %height,
+            %existing_block,
+            %conflicting_block,
+            %witness_block,
+            "conflicting certified blocks at the same height: a committee equivocated",
+        );
+        ChainError::ConflictingCertifiedBlocks(Box::new(ConflictingCertifiedBlocks {
+            chain_id: self.chain_id(),
+            height,
+            existing_block,
+            conflicting_block,
+            witness_block,
+        }))
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.
@@ -1587,7 +1612,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
-        self.vouch_for_block_references(block).await?;
+        self.vouch_for_block_references(block, hash).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -343,8 +343,9 @@ where
     /// Hashes of blocks that are vouched for by data this chain already trusts, but
     /// have not been processed here yet. A hash is inserted when a trusted source
     /// commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
-    /// block's `previous_block_hash` or `previous_message_blocks` links (unless the
-    /// referenced block is already in `block_hashes`). The worker accepts a cert
+    /// block's `previous_block_hash`, `previous_message_blocks` or
+    /// `previous_event_blocks` links (unless the referenced block is already in
+    /// `block_hashes`). The worker accepts a cert
     /// whose hash is in this set regardless of its epoch — the epoch may be revoked,
     /// but the hash commitment makes the block trustworthy — and removes the entry
     /// upon acceptance.
@@ -1526,8 +1527,9 @@ where
     }
 
     /// Records the block references an accepted block commits to — its parent via
-    /// `previous_block_hash` and the latest message block per recipient via
-    /// `previous_message_blocks` — in `vouched_blocks`, unless the referenced block
+    /// `previous_block_hash`, the latest message block per recipient via
+    /// `previous_message_blocks` and the latest event block per stream via
+    /// `previous_event_blocks` — in `vouched_blocks`, unless the referenced block
     /// is already in `block_hashes`. The accepted block is trusted, so these hash
     /// commitments remain a sufficient basis for accepting the referenced blocks
     /// even after the epochs that certified them are revoked.
@@ -1547,7 +1549,12 @@ where
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
         }
-        for (hash, height) in block.body.previous_message_blocks.values() {
+        for (hash, height) in block
+            .body
+            .previous_message_blocks
+            .values()
+            .chain(block.body.previous_event_blocks.values())
+        {
             references.push((*height, *hash));
         }
         let known_hashes = self

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1509,7 +1509,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
-        self.vouch_for_block_references(block, hash).await?;
+        self.vouch_for_block_references(block).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1540,11 +1540,8 @@ where
     /// committee. In that case the block is rejected with
     /// [`ChainError::ConflictingCertifiedBlocks`], which names the certificate
     /// pair that proves the fault.
-    async fn vouch_for_block_references(
-        &mut self,
-        block: &Block,
-        block_hash: CryptoHash,
-    ) -> Result<(), ChainError> {
+    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+        let block_hash = block.hash();
         let mut references = Vec::new();
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
@@ -1619,7 +1616,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
-        self.vouch_for_block_references(block, hash).await?;
+        self.vouch_for_block_references(block).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -339,14 +339,15 @@ where
     /// `SystemOperation::Checkpoint` is executed.
     pub latest_checkpoint_height: RegisterView<C, Option<BlockHeight>>,
 
-    /// Hashes of pre-checkpoint sender blocks the chain has seen a checkpoint cert
-    /// vouch for via `outbox_block_hashes`, but whose actual cert bytes are not yet
-    /// in storage. The worker errors a checkpoint push with
-    /// `BlocksNotFound` when this set is non-empty, then accepts each
-    /// referenced cert (regardless of its own — possibly revoked — epoch) and
-    /// removes the entry. Once the set is empty, the checkpoint restoration can run
-    /// end-to-end.
-    pub pre_checkpoint_block_trust: SetView<C, CryptoHash>,
+    /// Hashes of blocks that are vouched for by data this chain already trusts, but
+    /// have not been processed here yet. A hash is inserted when a trusted source
+    /// commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
+    /// block's `previous_block_hash` or `previous_message_blocks` links (unless the
+    /// referenced block is already in `block_hashes`). The worker accepts a cert
+    /// whose hash is in this set regardless of its epoch — the epoch may be revoked,
+    /// but the hash commitment makes the block trustworthy — and removes the entry
+    /// upon acceptance.
+    pub vouched_blocks: SetView<C, CryptoHash>,
 
     /// The hash of the set of fully-tracked chains that `nonempty_outboxes` and
     /// `outbox_counters` were last reconciled against. On a client these two indices only hold
@@ -1506,6 +1507,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
+        self.vouch_for_block_references(block).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1520,6 +1522,50 @@ where
             self.latest_checkpoint_height.set(Some(block.header.height));
         }
         Ok(updated_streams)
+    }
+
+    /// Records the block references an accepted block commits to — its parent via
+    /// `previous_block_hash` and the latest message block per recipient via
+    /// `previous_message_blocks` — in `vouched_blocks`, unless the referenced block
+    /// is already in `block_hashes`. The accepted block is trusted, so these hash
+    /// commitments remain a sufficient basis for accepting the referenced blocks
+    /// even after the epochs that certified them are revoked.
+    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+        let mut references = Vec::new();
+        if let Some(parent_hash) = block.header.previous_block_hash {
+            references.push((block.header.height.try_sub_one()?, parent_hash));
+        }
+        for (hash, height) in block.body.previous_message_blocks.values() {
+            references.push((*height, *hash));
+        }
+        let known_hashes = self
+            .block_hashes
+            .multi_get(references.iter().map(|(height, _)| height))
+            .await?;
+        for (known, (height, hash)) in known_hashes.into_iter().zip(references) {
+            match known {
+                Some(known_hash) if known_hash == hash => {}
+                None => self.vouched_blocks.insert(&hash)?,
+                Some(known_hash) => {
+                    // A chain has one certified block per height, so a trusted
+                    // block committing to a different hash than the one already
+                    // accepted is evidence of equivocation — two conflicting
+                    // certificates signed by that height's committee. Follow the
+                    // newly accepted block's commitment (it is the one backed by
+                    // a currently trusted certificate), but flag the conflict.
+                    warn!(
+                        chain_id = %self.chain_id(),
+                        %height,
+                        %known_hash,
+                        vouched_hash = %hash,
+                        "conflicting certified blocks at the same height: \
+                         the committee for this height equivocated",
+                    );
+                    self.vouched_blocks.insert(&hash)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.
@@ -1541,6 +1587,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
+        self.vouch_for_block_references(block).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -30,7 +30,7 @@ pub use chain::{BlockExecutionPhase, ChainIdSet, ChainStateView, ChainTipState, 
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,
-    crypto::CryptoError,
+    crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, BlockHeight, Epoch, Round, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
@@ -207,6 +207,34 @@ pub enum ChainError {
     NotTimedOutYet(Timestamp),
     #[error("Checkpoint precondition failed: {0}")]
     CheckpointPreconditionFailed(&'static str),
+    #[error(transparent)]
+    ConflictingCertifiedBlocks(Box<ConflictingCertifiedBlocks>),
+}
+
+/// The payload of [`ChainError::ConflictingCertifiedBlocks`]: a certified block
+/// asserts a different block at some height than the one already accepted there.
+/// Since a chain has one certified block per height, the two certificates
+/// together prove that a committee equivocated.
+#[derive(Error, Debug)]
+#[error(
+    "conflicting certified blocks at height {height} on chain {chain_id}: the certificate \
+     of block {witness_block} asserts {conflicting_block} at that height, but \
+     {existing_block} was already accepted — a committee equivocated"
+)]
+pub struct ConflictingCertifiedBlocks {
+    /// The chain with two conflicting certified blocks.
+    pub chain_id: ChainId,
+    /// The height at which the two blocks conflict.
+    pub height: BlockHeight,
+    /// The hash of the block already accepted at `height`.
+    pub existing_block: CryptoHash,
+    /// The conflicting hash asserted at `height` by `witness_block`'s certificate.
+    pub conflicting_block: CryptoHash,
+    /// The hash of the block whose certificate asserts `conflicting_block` at
+    /// `height`: the conflicting block itself, or an accepted block that commits
+    /// to it via `previous_block_hash` or `previous_message_blocks`. Its
+    /// certificate, together with `existing_block`'s, proves the fault.
+    pub witness_block: CryptoHash,
 }
 
 impl ChainError {
@@ -256,6 +284,7 @@ impl ChainError {
             | ChainError::RoundDoesNotTimeOut
             | ChainError::NotTimedOutYet(_)
             | ChainError::CheckpointPreconditionFailed(_)
+            | ChainError::ConflictingCertifiedBlocks(_)
             | ChainError::MissingCrossChainUpdate { .. } => false,
             ChainError::ViewError(_)
             | ChainError::UnexpectedMessage { .. }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -34,7 +34,7 @@ use linera_chain::{
         ValidatedBlockCertificate,
     },
     BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
-    ChainTipState, ExecutionResultExt as _, StreamCounts,
+    ChainTipState, ConflictingCertifiedBlocks, ExecutionResultExt as _, StreamCounts,
 };
 use linera_execution::{
     system::{EpochEventData, EventSubscriptions, EPOCH_STREAM_NAME},
@@ -332,11 +332,9 @@ where
     /// its block.
     ///
     /// A certificate from a revoked epoch no longer proves anything by itself: the
-    /// committee that signed it is not trusted any more. Such a block is only
-    /// accepted if it was already accepted while its epoch was still trusted, i.e.
-    /// it is in `block_hashes`. (Blocks vouched for by an accepted block's
-    /// `previous_block_hash` or `previous_message_blocks` links, or by a checkpoint
-    /// cert, carry a `vouched_blocks` trust mark and bypass this check.)
+    /// committee that signed it is not trusted any more. The caller must in that
+    /// case additionally have a trust mark for the block, or a prior acceptance of
+    /// it, to accept it.
     async fn ensure_epoch_trusted(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -352,17 +350,14 @@ where
                     ChainExecutionContext::Block,
                 )))
             })?;
-        if !is_revoked {
-            return Ok(());
+        if is_revoked {
+            return Err(WorkerError::EpochRevoked {
+                chain_id: header.chain_id,
+                epoch: header.epoch,
+                height: header.height,
+            });
         }
-        if self.chain.block_hashes.get(&header.height).await? == Some(certificate.hash()) {
-            return Ok(());
-        }
-        Err(WorkerError::EpochRevoked {
-            chain_id: header.chain_id,
-            epoch: header.epoch,
-            height: header.height,
-        })
+        Ok(())
     }
 
     /// Ensures that this worker may still create signatures for blocks in the given
@@ -1040,13 +1035,40 @@ where
         // We haven't processed the block - verify the certificate first.
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
+
+        // A chain has one certified block per height. Read the accepted hash at
+        // this height once: a *different* hash is proof that a committee
+        // equivocated — reject it before the certificate is written anywhere, so
+        // the conflicting certificate is never persisted; the *same* hash means we
+        // already accepted this block, which also satisfies the revoked-epoch
+        // trust requirement below.
+        let accepted_at_height = self.chain.block_hashes.get(&height).await?;
+        if let Some(existing_hash) = accepted_at_height {
+            if existing_hash != block_hash {
+                tracing::error!(
+                    %chain_id, %height, %existing_hash, conflicting_block = %block_hash,
+                    "conflicting certified blocks at the same height: a committee equivocated",
+                );
+                return Err(ChainError::ConflictingCertifiedBlocks(Box::new(
+                    ConflictingCertifiedBlocks {
+                        chain_id,
+                        height,
+                        existing_block: existing_hash,
+                        conflicting_block: block_hash,
+                        witness_block: block_hash,
+                    },
+                ))
+                .into());
+            }
+        }
+
         // If the epoch has been revoked, the quorum signature alone is no longer a
         // sufficient basis for trust: the block must also be vouched for by data
         // this worker already trusts — a `vouched_blocks` trust mark (written by a
         // checkpoint cert or by an accepted block that commits to this one via
         // `previous_block_hash` or `previous_message_blocks`) or an earlier
         // acceptance of the same block.
-        if !in_trust_set {
+        if !in_trust_set && accepted_at_height != Some(block_hash) {
             self.ensure_epoch_trusted(&certificate).await?;
         }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -333,10 +333,10 @@ where
     ///
     /// A certificate from a revoked epoch no longer proves anything by itself: the
     /// committee that signed it is not trusted any more. Such a block is only
-    /// accepted if it is transitively re-certified by a block we accepted while its
-    /// epoch was still trusted — either the block itself is already in
-    /// `block_hashes`, or an accepted child block commits to it via its
-    /// `previous_block_hash`.
+    /// accepted if it was already accepted while its epoch was still trusted, i.e.
+    /// it is in `block_hashes`. (Blocks vouched for by an accepted block's
+    /// `previous_block_hash` or `previous_message_blocks` links, or by a checkpoint
+    /// cert, carry a `vouched_blocks` trust mark and bypass this check.)
     async fn ensure_epoch_trusted(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -355,18 +355,8 @@ where
         if !is_revoked {
             return Ok(());
         }
-        let block_hash = certificate.hash();
-        if self.chain.block_hashes.get(&header.height).await? == Some(block_hash) {
+        if self.chain.block_hashes.get(&header.height).await? == Some(certificate.hash()) {
             return Ok(());
-        }
-        let child_height = header.height.try_add_one()?;
-        if let Some(child_hash) = self.chain.block_hashes.get(&child_height).await? {
-            let child = self.storage.read_confirmed_block(child_hash).await?;
-            if child
-                .is_some_and(|child| child.block().header.previous_block_hash == Some(block_hash))
-            {
-                return Ok(());
-            }
         }
         Err(WorkerError::EpochRevoked {
             chain_id: header.chain_id,
@@ -1021,20 +1011,17 @@ where
         let height = block.header.height;
         let chain_id = block.header.chain_id;
 
-        // Trust-mark accept path: an earlier checkpoint cert recorded this block's
-        // hash in `pre_checkpoint_block_trust`. Removing the trust mark here is
+        // Trust-mark accept path: a checkpoint cert or an accepted block's
+        // `previous_block_hash` / `previous_message_blocks` links recorded this
+        // block's hash in `vouched_blocks`. Removing the trust mark here is
         // only an in-memory change; if anything below fails before `save`, the
         // mark survives on the next reload. The dispatch's `gap` definition
         // (`!=` rather than `<`) routes both above-tip and below-tip trust
         // uploads to `preprocess_certified_block` so the chain can write the
         // cert without advancing the tip.
-        let in_trust_set = self
-            .chain
-            .pre_checkpoint_block_trust
-            .contains(&block_hash)
-            .await?;
+        let in_trust_set = self.chain.vouched_blocks.contains(&block_hash).await?;
         if in_trust_set {
-            self.chain.pre_checkpoint_block_trust.remove(&block_hash)?;
+            self.chain.vouched_blocks.remove(&block_hash)?;
         }
 
         // Check if we already processed this block.
@@ -1054,10 +1041,11 @@ where
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
         // If the epoch has been revoked, the quorum signature alone is no longer a
-        // sufficient basis for trust: the block must also be vouched for by a block
-        // this worker already trusts — a checkpoint trust mark, an earlier
-        // acceptance of the same block, or an accepted child block that commits to
-        // it via `previous_block_hash`.
+        // sufficient basis for trust: the block must also be vouched for by data
+        // this worker already trusts — a `vouched_blocks` trust mark (written by a
+        // checkpoint cert or by an accepted block that commits to this one via
+        // `previous_block_hash` or `previous_message_blocks`) or an earlier
+        // acceptance of the same block.
         if !in_trust_set {
             self.ensure_epoch_trusted(&certificate).await?;
         }
@@ -1229,7 +1217,7 @@ where
         }
         if !missing_blocks.is_empty() {
             for hash in &missing_blocks {
-                self.chain.pre_checkpoint_block_trust.insert(hash)?;
+                self.chain.vouched_blocks.insert(hash)?;
             }
             self.save().await?;
             return Err(WorkerError::BlocksNotFound(missing_blocks));

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1066,8 +1066,8 @@ where
         // sufficient basis for trust: the block must also be vouched for by data
         // this worker already trusts — a `vouched_blocks` trust mark (written by a
         // checkpoint cert or by an accepted block that commits to this one via
-        // `previous_block_hash` or `previous_message_blocks`) or an earlier
-        // acceptance of the same block.
+        // `previous_block_hash`, `previous_message_blocks` or
+        // `previous_event_blocks`) or an earlier acceptance of the same block.
         if !in_trust_set && accepted_at_height != Some(block_hash) {
             self.ensure_epoch_trusted(&certificate).await?;
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -289,16 +289,7 @@ where
             if bundle.height < next_height_to_receive {
                 skipped_len = i + 1;
             }
-            let is_revoked = self
-                .storage
-                .is_epoch_revoked(*epoch)
-                .await
-                .map_err(|error| {
-                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                        Box::new(error),
-                        ChainExecutionContext::Block,
-                    )))
-                })?;
+            let is_revoked = self.is_epoch_revoked(*epoch).await?;
             if !is_revoked || Some(bundle.height) <= last_anticipated_block_height {
                 trusted_len = i + 1;
             }
@@ -328,6 +319,17 @@ where
         })
     }
 
+    /// Returns whether the given epoch has been revoked on the admin chain,
+    /// mapping any storage error to a [`WorkerError`].
+    async fn is_epoch_revoked(&self, epoch: Epoch) -> Result<bool, WorkerError> {
+        self.storage.is_epoch_revoked(epoch).await.map_err(|error| {
+            WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                Box::new(error),
+                ChainExecutionContext::Block,
+            )))
+        })
+    }
+
     /// Ensures that the certificate's epoch is still a sufficient basis for trusting
     /// its block.
     ///
@@ -340,16 +342,7 @@ where
         certificate: &ConfirmedBlockCertificate,
     ) -> Result<(), WorkerError> {
         let header = &certificate.block().header;
-        let is_revoked = self
-            .storage
-            .is_epoch_revoked(header.epoch)
-            .await
-            .map_err(|error| {
-                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                    Box::new(error),
-                    ChainExecutionContext::Block,
-                )))
-            })?;
+        let is_revoked = self.is_epoch_revoked(header.epoch).await?;
         if is_revoked {
             return Err(WorkerError::EpochRevoked {
                 chain_id: header.chain_id,
@@ -369,16 +362,7 @@ where
         epoch: Epoch,
         height: BlockHeight,
     ) -> Result<(), WorkerError> {
-        let is_revoked = self
-            .storage
-            .is_epoch_revoked(epoch)
-            .await
-            .map_err(|error| {
-                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                    Box::new(error),
-                    ChainExecutionContext::Block,
-                )))
-            })?;
+        let is_revoked = self.is_epoch_revoked(epoch).await?;
         ensure!(
             !is_revoked,
             WorkerError::VoteInRevokedEpoch {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2049,33 +2049,8 @@ impl<Env: Environment> Client<Env> {
                 .await?;
         }
 
-        // If the oldest collected block's epoch has been revoked, its certificate
-        // alone won't convince the local worker. Preprocess the collected chain
-        // newest-first: accepting each block marks the `previous_message_blocks`
-        // hash it commits to as vouched, so the next-older block is accepted
-        // despite its revoked epoch — without downloading any of the intermediate
-        // blocks that sent no message to our chain. (Epoch revocation is monotone,
-        // so only the oldest block needs checking; if even the newest block's
-        // epoch is revoked, its retry logic falls back to walking contiguous
-        // descendants.)
-        if let Some(certificate) = certificates.values().next() {
-            let epoch = certificate.block().header.epoch;
-            if self
-                .storage_client()
-                .is_epoch_revoked(epoch)
-                .await
-                .map_err(LocalNodeError::from)?
-            {
-                for certificate in certificates.values().rev() {
-                    Box::pin(self.handle_certificate_with_retry(
-                        certificate,
-                        std::slice::from_ref(remote_node),
-                        ProcessConfirmedBlockMode::Preprocess,
-                    ))
-                    .await?;
-                }
-            }
-        }
+        self.recertify_if_epoch_revoked(&certificates, remote_node)
+            .await?;
 
         // Process certificates in ascending block height order (BTreeMap keeps them sorted).
         for certificate in certificates.into_values() {
@@ -2087,6 +2062,43 @@ impl<Env: Environment> Client<Env> {
             .await?;
         }
 
+        Ok(())
+    }
+
+    /// Preprocesses a sparsely collected run of blocks newest-first if the oldest one's
+    /// epoch has been revoked, so that the newer blocks vouch for the older ones.
+    ///
+    /// A revoked epoch's certificate alone doesn't convince the local worker. But
+    /// accepting a block marks the hashes it commits to in `previous_message_blocks` and
+    /// `previous_event_blocks` as vouched, so the block the oldest one was reached
+    /// through makes it acceptable despite its revoked epoch — without downloading the
+    /// intermediate blocks that sent no message and published no event. Epoch revocation
+    /// is monotone, so only the oldest block needs checking; if even the newest block's
+    /// epoch is revoked, the retry logic falls back to walking contiguous descendants.
+    async fn recertify_if_epoch_revoked(
+        &self,
+        certificates: &BTreeMap<BlockHeight, CacheArc<ConfirmedBlockCertificate>>,
+        remote_node: &RemoteNode<Env::ValidatorNode>,
+    ) -> Result<(), chain_client::Error> {
+        let Some(oldest) = certificates.values().next() else {
+            return Ok(());
+        };
+        if !self
+            .storage_client()
+            .is_epoch_revoked(oldest.block().header.epoch)
+            .await
+            .map_err(LocalNodeError::from)?
+        {
+            return Ok(());
+        }
+        for certificate in certificates.values().rev() {
+            Box::pin(self.handle_certificate_with_retry(
+                certificate,
+                std::slice::from_ref(remote_node),
+                ProcessConfirmedBlockMode::Preprocess,
+            ))
+            .await?;
+        }
         Ok(())
     }
 
@@ -2172,6 +2184,9 @@ impl<Env: Environment> Client<Env> {
 
             certificates.insert(current_height, certificate);
         }
+
+        self.recertify_if_epoch_revoked(&certificates, remote_node)
+            .await?;
 
         // Process in ascending height order.
         for certificate in certificates.into_values() {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2049,6 +2049,34 @@ impl<Env: Environment> Client<Env> {
                 .await?;
         }
 
+        // If the oldest collected block's epoch has been revoked, its certificate
+        // alone won't convince the local worker. Preprocess the collected chain
+        // newest-first: accepting each block marks the `previous_message_blocks`
+        // hash it commits to as vouched, so the next-older block is accepted
+        // despite its revoked epoch — without downloading any of the intermediate
+        // blocks that sent no message to our chain. (Epoch revocation is monotone,
+        // so only the oldest block needs checking; if even the newest block's
+        // epoch is revoked, its retry logic falls back to walking contiguous
+        // descendants.)
+        if let Some(certificate) = certificates.values().next() {
+            let epoch = certificate.block().header.epoch;
+            if self
+                .storage_client()
+                .is_epoch_revoked(epoch)
+                .await
+                .map_err(LocalNodeError::from)?
+            {
+                for certificate in certificates.values().rev() {
+                    Box::pin(self.handle_certificate_with_retry(
+                        certificate,
+                        std::slice::from_ref(remote_node),
+                        ProcessConfirmedBlockMode::Preprocess,
+                    ))
+                    .await?;
+                }
+            }
+        }
+
         // Process certificates in ascending block height order (BTreeMap keeps them sorted).
         for certificate in certificates.into_values() {
             self.receive_sender_certificate(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1657,6 +1657,12 @@ where
 /// the `ChainDescription` itself should never be downloaded either — not during
 /// the initial message processing, and not during a later re-sync that routes the
 /// sender through `retry_pending_cross_chain_requests_from_sender_chains`.
+///
+/// The first message block's epoch is revoked before the receiver processes
+/// anything, so the walk must also re-certify it: the epoch-1 message block is
+/// preprocessed first and vouches for the epoch-0 one via
+/// `previous_message_blocks`. Sparseness proves the recovery did not fall back to
+/// downloading contiguous descendants.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]
@@ -1666,7 +1672,7 @@ where
 {
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
     let owner = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();
@@ -1694,8 +1700,13 @@ where
         .await?;
     sender.set_preferred_owner(sender_public_key.into());
     sender.synchronize_from_validators().await?;
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
 
-    // Heights 0 and 2 are burns; heights 1 and 3 send to the receiver.
+    // Height 0 is a burn; height 1 sends to the receiver. Both are epoch-0 blocks.
     let cert0 = sender
         .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
@@ -1708,10 +1719,37 @@ where
         )
         .await
         .unwrap_ok_committed();
-    let cert2 = sender
-        .burn(AccountOwner::CHAIN, Amount::ONE)
+
+    // Create epoch 1. The receiver learns about it from an admin-chain `NewBlock`
+    // notification — not via `synchronize_from_validators`, which would consume
+    // the received log and deliver the height-1 transfer prematurely — and
+    // migrates to epoch 1 so it can keep proposing after epoch 0 is revoked.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
         .await
         .unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: create_cert.block().header.height,
+                    hash: create_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    // Height 2 migrates the sender to epoch 1 without sending anything; height 3
+    // sends to the receiver again, committing to the height-1 block via
+    // `previous_message_blocks`.
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let cert2 = migration_certs.last().expect("migration block").clone();
+    assert_eq!(sender.chain_info().await?.epoch, Epoch::from(1));
     let cert3 = sender
         .transfer_to_account(
             AccountOwner::CHAIN,
@@ -1720,10 +1758,37 @@ where
         )
         .await
         .unwrap_ok_committed();
+    assert_eq!(
+        cert3.block().body.previous_message_blocks,
+        BTreeMap::from([(receiver_id, (cert1.hash(), cert1.block().header.height))]),
+    );
+
+    // Revoke epoch 0, and let the receiver learn about the revocation the same way.
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: revoke_cert.block().header.height,
+                    hash: revoke_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
 
     // Process the notification about the most recent incoming message. This walks
     // back along `previous_message_blocks` and preprocesses only the sender blocks
-    // that sent to us (heights 1 and 3).
+    // that sent to us (heights 1 and 3) — height 3 first, so that it vouches for
+    // the revoked-epoch block at height 1.
     let notification = Notification {
         chain_id: receiver_id,
         reason: Reason::NewIncomingBundle {
@@ -1731,19 +1796,17 @@ where
             height: cert3.block().header.height,
         },
     };
-    let validator = builder
-        .initial_committee
-        .validator_addresses()
-        .next()
-        .unwrap();
     receiver
         .process_notification_from(notification, validator)
         .await;
     receiver.process_inbox().await?;
 
     // Only the blocks that sent something to the receiver should be in local
-    // storage. The burn blocks in between — and the sender's `ChainDescription`
-    // blob itself — should never have been downloaded.
+    // storage. The burn and migration blocks in between — and the sender's
+    // `ChainDescription` blob itself — should never have been downloaded. In
+    // particular, the revoked-epoch block at height 1 was accepted through the
+    // `previous_message_blocks` vouching, not by walking contiguous descendants
+    // (which would have downloaded the migration block at height 2).
     let storage = receiver.storage_client();
     assert!(!storage.contains_certificate(cert0.hash()).await?);
     assert!(storage.contains_certificate(cert1.hash()).await?);
@@ -4614,16 +4677,20 @@ where
         "validator 0 must not have received the pre-checkpoint non-sender block",
     );
 
-    // The trust-mark flow consumed every entry: the validator's first attempt at
-    // the checkpoint errored with `BlocksNotFound`, the client uploaded the missing
-    // sender block (entering the trust-mark accept path on the worker, which
-    // removed the entry), and the second attempt restored the chain cleanly.
+    // The trust-mark flow consumed the checkpoint's `outbox_block_hashes` entry:
+    // the validator's first attempt at the checkpoint errored with
+    // `BlocksNotFound`, the client uploaded the missing sender block (entering the
+    // trust-mark accept path on the worker, which removed the entry), and the
+    // second attempt restored the chain cleanly. What remains is the mark for the
+    // checkpoint block's own parent (`burn_1`, which was never pushed): accepting
+    // the checkpoint vouched for it via `previous_block_hash`.
     {
         let chain_view = validator_0_storage.load_chain(chain_id).await?;
-        let trusted = chain_view.pre_checkpoint_block_trust.indices().await?;
-        assert!(
-            trusted.is_empty(),
-            "validator 0's trust set should be empty after the flow, was {trusted:?}",
+        let trusted = chain_view.vouched_blocks.indices().await?;
+        assert_eq!(
+            trusted,
+            vec![burn_1.hash()],
+            "validator 0's trust set should hold exactly the checkpoint's parent",
         );
         // The checkpoint restored the producer's epoch-1 execution state, which
         // includes the epoch migration. Validator 0's chain is now at epoch 1 —

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -34,7 +34,9 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
-use linera_chain::{data_types::MessageAction, ChainError, ChainExecutionContext};
+use linera_chain::{
+    data_types::MessageAction, types::ConfirmedBlockCertificate, ChainError, ChainExecutionContext,
+};
 use linera_execution::{
     wasm_test, ExecutionError, Message, MessageKind, Operation, QueryOutcome,
     ResourceControlPolicy, SystemMessage, SystemOperation, WasmRuntime,
@@ -57,7 +59,7 @@ use crate::{
     },
     local_node::LocalNodeError,
     test_utils::{ClientOutcomeResultExt as _, FaultType},
-    worker::WorkerError,
+    worker::{Notification, Reason, WorkerError},
     Environment,
 };
 
@@ -2128,6 +2130,13 @@ async fn test_memory_read_event_downloads_publisher_chain(
 /// Tests that when a block execution needs events from a publisher chain that isn't
 /// locally available, the client automatically downloads the publisher chain certificates
 /// using the event block height index and retries.
+///
+/// The publisher chain is stored sparsely: only the blocks that emitted events are
+/// downloaded, not the ones in between. The first post's epoch is revoked before the
+/// receiver reads it, so the walk must also re-certify it: the epoch-1 post block is
+/// preprocessed first and vouches for the epoch-0 one via `previous_event_blocks`.
+/// Sparseness proves the recovery did not fall back to downloading contiguous
+/// descendants.
 async fn run_test_read_event_downloads_publisher_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
@@ -2137,8 +2146,14 @@ where
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
 
-    let sender = builder.add_root_chain(0, Amount::ONE).await?;
-    let receiver = builder.add_root_chain(1, Amount::ONE).await?;
+    let admin = builder.add_root_chain(0, Amount::ONE).await?;
+    let sender = builder.add_root_chain(1, Amount::ONE).await?;
+    let receiver = builder.add_root_chain(2, Amount::ONE).await?;
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
 
     // Deploy the social app on the receiver chain.
     let module_id = receiver.publish_wasm_example("social").await?;
@@ -2162,20 +2177,79 @@ where
         text: "Hello from sender!".to_string(),
         image_url: None,
     };
-    sender
+    let post_cert0 = sender
         .execute_operation(Operation::user(application_id, &post)?)
         .await
         .unwrap_ok_committed();
 
-    // Do NOT call receiver.synchronize_from_validators().
-    // Instead, directly execute an UpdateStreams operation that references the
-    // sender's event. The receiver doesn't have the sender's chain locally, so
-    // this will fail with EventsNotFound. The retry logic should use the event
-    // block height index to download only the needed certificates and succeed.
+    // Create epoch 1 and migrate the sender to it. The migration block emits no event,
+    // so the sender's second post commits to the first post's block directly, via
+    // `previous_event_blocks`.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
+        .await
+        .unwrap_ok_committed();
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let migration_cert = migration_certs.last().expect("migration block").clone();
+    assert_eq!(sender.chain_info().await?.epoch, Epoch::from(1));
+
+    let post = social::Operation::Post {
+        text: "Hello again!".to_string(),
+        image_url: None,
+    };
+    let post_cert1 = sender
+        .execute_operation(Operation::user(application_id, &post)?)
+        .await
+        .unwrap_ok_committed();
     let stream_id = StreamId {
         application_id: application_id.forget_abi().into(),
         stream_name: b"posts".into(),
     };
+    assert_eq!(
+        post_cert1.block().body.previous_event_blocks,
+        BTreeMap::from([(
+            stream_id.clone(),
+            (post_cert0.hash(), post_cert0.block().header.height)
+        )]),
+    );
+
+    // Migrate the receiver to epoch 1 as well, and revoke epoch 0. The receiver learns
+    // about both from admin-chain notifications, not from
+    // `synchronize_from_validators`: that would download the sender's event blocks
+    // eagerly, while epoch 0 is still live.
+    let notify_receiver = async |cert: &ConfirmedBlockCertificate| {
+        receiver
+            .process_notification_from(
+                Notification {
+                    chain_id: admin.chain_id(),
+                    reason: Reason::NewBlock {
+                        height: cert.block().header.height,
+                        hash: cert.hash(),
+                    },
+                },
+                validator,
+            )
+            .await
+    };
+    notify_receiver(&create_cert).await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    notify_receiver(&revoke_cert).await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
+
+    // Execute an UpdateStreams operation that references both of the sender's events.
+    // The receiver doesn't have the sender's chain locally, so this will fail with
+    // EventsNotFound. The retry logic should use the event block height index to
+    // download only the needed certificates and succeed.
     receiver
         .execute_operations(
             vec![SystemOperation::UpdateStream {
@@ -2183,7 +2257,7 @@ where
                 chain_id: sender.chain_id(),
                 stream_id,
                 first_index: 0,
-                next_index: 1,
+                next_index: 2,
             }
             .into()],
             vec![],
@@ -2191,7 +2265,7 @@ where
         .await
         .unwrap_ok_committed();
 
-    // Verify that the event was processed: query the received posts.
+    // Verify that the events were processed: query the received posts.
     let query = Request::new("{ receivedPosts { keys { author, index } } }");
     let outcome = receiver
         .query_user_application(application_id, &query)
@@ -2201,6 +2275,7 @@ where
             async_graphql::Value::from_json(json!({
                 "receivedPosts": {
                     "keys": [
+                        { "author": sender.chain_id(), "index": 1 },
                         { "author": sender.chain_id(), "index": 0 }
                     ]
                 }
@@ -2210,6 +2285,15 @@ where
         operations: vec![],
     };
     assert_eq!(outcome, expected);
+
+    // Only the sender's event-bearing blocks should be in the receiver's storage. In
+    // particular, the revoked-epoch post at height 0 was accepted through the
+    // `previous_event_blocks` vouching, not by walking contiguous descendants — which
+    // would have downloaded the migration block in between.
+    let storage = receiver.storage_client();
+    assert!(storage.contains_certificate(post_cert0.hash()).await?);
+    assert!(storage.contains_certificate(post_cert1.hash()).await?);
+    assert!(!storage.contains_certificate(migration_cert.hash()).await?);
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3396,6 +3396,156 @@ where
     Ok(())
 }
 
+/// Tests that a revoked-epoch sender block is accepted when a later accepted block
+/// commits to it via `previous_message_blocks` — without the worker ever seeing the
+/// non-sender block in between. This is what lets a receiver's client re-certify a
+/// sender's old messages by downloading only the message-bearing blocks.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_revoked_epoch_block_vouched_via_previous_message_blocks<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut env =
+        TestEnvironment::new_with_amount(&mut storage_builder, false, false, Amount::ZERO).await?;
+    let mut signer = InMemorySigner::new(None);
+    let owner1 = signer.generate_new().into();
+    let chain_1_desc = env.add_root_chain(1, owner1, Amount::from_tokens(3)).await;
+    let committee = env.committee().clone();
+    let admin_chain_id = env.admin_chain_id();
+    let user_id = chain_1_desc.id();
+
+    // Height 0 (epoch 0): a transfer to the admin chain — the sender block that
+    // will later need re-certification.
+    let proposal_msg0 = make_first_block(user_id)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let cert_msg0 = env.execute_proposal(proposal_msg0, vec![]).await?;
+
+    // Have the admin chain create epoch 1.
+    let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
+    let blob_hash = committee_blob.id().hash;
+    env.write_blobs(std::slice::from_ref(&committee_blob))
+        .await?;
+    let proposal_create = make_first_block(admin_chain_id).with_operation(SystemOperation::Admin(
+        AdminOperation::CreateCommittee {
+            epoch: Epoch::from(1),
+            blob_hash,
+        },
+    ));
+    let cert_create = env.execute_proposal(proposal_create, vec![]).await?;
+
+    // Height 1 (epoch 0): the user chain migrates to epoch 1 without sending any
+    // message. Height 2 (epoch 1): another transfer to the admin chain, which
+    // commits to the height-0 block via `previous_message_blocks`.
+    let proposal_mid = make_child_block(&cert_msg0.clone().into_value())
+        .with_operation(SystemOperation::ProcessNewEpoch(Epoch::from(1)))
+        .with_authenticated_owner(Some(owner1));
+    let cert_mid = env.execute_proposal(proposal_mid, vec![]).await?;
+    let proposal_msg1 = make_child_block(&cert_mid.clone().into_value())
+        .with_epoch(1)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let cert_msg1 = env.execute_proposal(proposal_msg1, vec![]).await?;
+    assert_eq!(
+        cert_msg1.block().body.previous_message_blocks,
+        BTreeMap::from([(admin_chain_id, (cert_msg0.hash(), BlockHeight::ZERO))]),
+    );
+
+    // Retire epoch 0.
+    let proposal_revoke = make_child_block(&cert_create.clone().into_value())
+        .with_epoch(1)
+        .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
+            epoch: Epoch::ZERO,
+        }));
+    let cert_revoke = env.execute_proposal(proposal_revoke, vec![]).await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_create.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_revoke.clone(), &())
+        .await?;
+
+    // The height-0 block is rejected: its epoch is revoked and nothing vouches for
+    // it yet.
+    let error = env
+        .worker()
+        .fully_handle_certificate_with_notifications(cert_msg0.clone(), &())
+        .await
+        .unwrap_err();
+    assert_matches!(
+        error,
+        WorkerError::EpochRevoked {
+            epoch: Epoch::ZERO,
+            ..
+        }
+    );
+
+    // Preprocessing the epoch-1 sender block at height 2 vouches for the height-0
+    // block via `previous_message_blocks` (and for its parent at height 1 via
+    // `previous_block_hash`). The height-0 block is then accepted and executes —
+    // the worker never saw the non-sender block at height 1.
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg1.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg0.clone(), &())
+        .await?;
+
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(1),
+            user_chain.tip_state.get().next_block_height
+        );
+        // The height-0 message has not reached the admin chain yet:
+        // `select_message_bundles` refuses a revoked-epoch bundle that arrives on
+        // its own. It is only accepted once a later bundle from a trusted epoch is
+        // in the same batch.
+        let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
+        assert!(admin_chain.inboxes.indices().await?.is_empty());
+    }
+
+    // The migration block at height 1 is also vouched for (as the height-2 block's
+    // parent), so it is accepted despite its revoked epoch. With the chain tip then
+    // at height 2, re-sending the height-2 block executes it, which schedules its
+    // message: the outbox batch now pairs the revoked-epoch bundle with the epoch-1
+    // bundle behind it, and the admin chain accepts both.
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_mid.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg1.clone(), &())
+        .await?;
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(3),
+            user_chain.tip_state.get().next_block_height
+        );
+        // All trust marks have been consumed.
+        assert!(user_chain.vouched_blocks.indices().await?.is_empty());
+        let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
+        let inbox = admin_chain
+            .inboxes
+            .try_load_entry(&user_id)
+            .await?
+            .expect("admin chain should have an inbox for the user chain");
+        let first_bundle = inbox.added_bundles.front().await?;
+        assert_eq!(
+            first_bundle.map(|bundle| bundle.height),
+            Some(BlockHeight::ZERO),
+            "the re-certified height-0 message should have been delivered",
+        );
+    }
+
+    Ok(())
+}
+
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let mut storage_builder = MemoryStorageBuilder::default();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3546,6 +3546,146 @@ where
     Ok(())
 }
 
+/// Tests that a block committing to a different hash than the one already accepted
+/// at that height is rejected: two certified blocks at the same height prove that
+/// the height's committee equivocated, and neither the conflicting block nor the
+/// block vouching for it must be accepted.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_conflicting_certified_blocks_are_rejected<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let owner_pubkey = signer.generate_new();
+    let owner = AccountOwner::from(owner_pubkey);
+    let balance = Amount::from_tokens(5);
+    let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
+    let chain_1_desc = env.add_root_chain(1, owner, balance).await;
+    let chain_2_desc = env.add_root_chain(2, owner, Amount::ZERO).await;
+    let user_id = chain_1_desc.id();
+    let target = Account::chain(chain_2_desc.id());
+
+    // Two conflicting certified blocks at height 0, and a child of the second one.
+    let cert_a = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::ONE,
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![],
+        )
+        .await;
+    let cert_b = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::from_tokens(2),
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![],
+        )
+        .await;
+    assert_ne!(cert_a.hash(), cert_b.hash());
+    let cert_child = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::ONE,
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![&cert_b],
+        )
+        .await;
+
+    // Preprocess the first block at height 0, then a child of the *conflicting*
+    // block: the child's `previous_block_hash` commitment exposes the equivocation
+    // and the child is rejected instead of vouching for the conflicting block.
+    env.worker()
+        .handle_confirmed_certificate(cert_a.clone(), ProcessConfirmedBlockMode::Preprocess, None)
+        .await?;
+    let error = env
+        .worker()
+        .handle_confirmed_certificate(
+            cert_child.clone(),
+            ProcessConfirmedBlockMode::Preprocess,
+            None,
+        )
+        .await
+        .unwrap_err();
+    let conflict = match &error {
+        WorkerError::ChainError(chain_error) => match &**chain_error {
+            ChainError::ConflictingCertifiedBlocks(conflict) => conflict,
+            other => panic!("expected a conflicting-blocks error, got {other}"),
+        },
+        other => panic!("expected a conflicting-blocks error, got {other}"),
+    };
+    // The child commits to the conflicting height-0 block via its parent link, so
+    // it is the witness; the existing block is the one accepted at that height.
+    assert_eq!(conflict.existing_block, cert_a.hash());
+    assert_eq!(conflict.conflicting_block, cert_b.hash());
+    assert_eq!(conflict.witness_block, cert_child.hash());
+    assert_eq!(conflict.height, BlockHeight::ZERO);
+
+    // Nothing was vouched for, and the child was not accepted. (The view holds a
+    // read lock on the chain worker, so drop it before the next request.)
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert!(user_chain.vouched_blocks.indices().await?.is_empty());
+        assert_eq!(
+            user_chain.block_hashes.get(&BlockHeight::from(1)).await?,
+            None
+        );
+    }
+
+    // Pushing the conflicting height-0 block itself is rejected the same way, with
+    // the block as its own witness — and rejected before it is written anywhere.
+    let error = env
+        .worker()
+        .handle_confirmed_certificate(cert_b.clone(), ProcessConfirmedBlockMode::Preprocess, None)
+        .await
+        .unwrap_err();
+    let conflict = match &error {
+        WorkerError::ChainError(chain_error) => match &**chain_error {
+            ChainError::ConflictingCertifiedBlocks(conflict) => conflict,
+            other => panic!("expected a conflicting-blocks error, got {other}"),
+        },
+        other => panic!("expected a conflicting-blocks error, got {other}"),
+    };
+    assert_eq!(conflict.existing_block, cert_a.hash());
+    assert_eq!(conflict.conflicting_block, cert_b.hash());
+    assert_eq!(conflict.witness_block, cert_b.hash());
+    assert!(
+        !env.worker()
+            .storage
+            .contains_certificate(cert_b.hash())
+            .await?,
+        "the rejected conflicting certificate must not be persisted",
+    );
+
+    Ok(())
+}
+
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let mut storage_builder = MemoryStorageBuilder::default();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -378,9 +378,10 @@ pub enum WorkerError {
     },
     /// The certificate's epoch has been revoked on the admin chain, so its
     /// signatures alone no longer prove anything, and no block this worker already
-    /// trusts vouches for the block. The client can recover by uploading the
-    /// block's descendants in decreasing height order: each accepted descendant
-    /// re-certifies its parent via `previous_block_hash`.
+    /// trusts vouches for the block. The client can recover by uploading blocks
+    /// that transitively commit to this one in decreasing height order: each
+    /// accepted block vouches for the blocks it references via
+    /// `previous_block_hash` and `previous_message_blocks`.
     #[error(
         "Cannot trust the certificate for block at height {height} on chain {chain_id}: \
         epoch {epoch} has been revoked and no trusted block vouches for the block"
@@ -429,11 +430,11 @@ pub enum WorkerError {
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     /// Variant raised when the chain references these block hashes via a
-    /// verified-checkpoint trust mark (`pre_checkpoint_block_trust`) but the
-    /// actual content isn't in storage yet. The caller is expected to upload
-    /// each missing block via `handle_confirmed_certificate`; the trust-mark
-    /// accept path verifies the cert against its own (possibly revoked)
-    /// epoch's committee and writes it through.
+    /// trust mark (`vouched_blocks`) but the actual content isn't in storage
+    /// yet. The caller is expected to upload each missing block via
+    /// `handle_confirmed_certificate`; the trust-mark accept path verifies the
+    /// cert against its own (possibly revoked) epoch's committee and writes it
+    /// through.
     #[error("Blocks not found: {0:?}")]
     BlocksNotFound(Vec<CryptoHash>),
     #[error("Block hash at height {height} for chain {chain_id} not found")]

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -428,15 +428,16 @@ type ChainStateExtendedView {
 	"""
 	latestCheckpointHeight: BlockHeight
 	"""
-	Hashes of pre-checkpoint sender blocks the chain has seen a checkpoint cert
-	vouch for via `outbox_block_hashes`, but whose actual cert bytes are not yet
-	in storage. The worker errors a checkpoint push with
-	`BlocksNotFound` when this set is non-empty, then accepts each
-	referenced cert (regardless of its own — possibly revoked — epoch) and
-	removes the entry. Once the set is empty, the checkpoint restoration can run
-	end-to-end.
+	Hashes of blocks that are vouched for by data this chain already trusts, but
+	have not been processed here yet. A hash is inserted when a trusted source
+	commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
+	block's `previous_block_hash` or `previous_message_blocks` links (unless the
+	referenced block is already in `block_hashes`). The worker accepts a cert
+	whose hash is in this set regardless of its epoch — the epoch may be revoked,
+	but the hash commitment makes the block trustworthy — and removes the entry
+	upon acceptance.
 	"""
-	preCheckpointBlockTrust: SetView_CryptoHash_87fbb60c!
+	vouchedBlocks: SetView_CryptoHash_87fbb60c!
 	"""
 	The hash of the set of fully-tracked chains that `nonempty_outboxes` and
 	`outbox_counters` were last reconciled against. On a client these two indices only hold


### PR DESCRIPTION
## Motivation

Re-certifying a revoked-epoch block by walking its descendants means downloading every block in between, even though almost none of them are needed: on a sparse chain, a receiver may care about two message blocks a thousand heights apart.

## Proposal

Blocks already commit to the hashes of the blocks they refer to: `previous_message_blocks` points at the last block that sent a message to a given recipient, `previous_event_blocks` at the last block that emitted an event on a given stream. Treat those the same way as the parent hash: when a block is accepted, vouch for everything it commits to. A receiver can then re-certify an old sender block by downloading only the message-bearing blocks, and a subscriber only the event-bearing ones — preprocessing them newest-first, so each block vouches for the next-older one.

A block that commits to a different hash than the one already accepted at that height is proof that a committee equivocated. Reject it before it is written to storage, and log the conflict at ERROR level.

## Test Plan

CI, plus unit tests that re-certify a revoked-epoch block through a `previous_message_blocks` link and through a `previous_event_blocks` link, asserting in both cases that the blocks in between are never downloaded. Conflicting certified blocks are covered by a worker test.

## Release Plan

  - Nothing to do / These changes follow the usual release cycle.

## Links

  - Stacked on #6601.
  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)