### PR TITLE
Vouch for the blocks a block refers to

### DIFF
--- a/linera-chain/src/block.rs
+++ b/linera-chain/src/block.rs
@@ -514,6 +514,24 @@ impl Block {
         CryptoHash::new(&self.header)
     }
 
+    /// Returns the heights and hashes of the blocks on the same chain that this block
+    /// commits to: its parent via `previous_block_hash`, the latest message block per
+    /// recipient via `previous_message_blocks` and the latest event block per stream
+    /// via `previous_event_blocks`. Accepting this block vouches for those blocks.
+    pub fn vouches_for(&self) -> impl Iterator<Item = (BlockHeight, CryptoHash)> + '_ {
+        let parent = self
+            .header
+            .previous_block_hash
+            .and_then(|hash| Some((self.header.height.try_sub_one().ok()?, hash)));
+        let referenced = self
+            .body
+            .previous_message_blocks
+            .values()
+            .chain(self.body.previous_event_blocks.values())
+            .map(|(hash, height)| (*height, *hash));
+        parent.into_iter().chain(referenced)
+    }
+
     /// Returns the bundles of messages sent via the given medium to the specified
     /// recipient. Messages originating from different transactions of the original block
     /// are kept in separate bundles. If the medium is a channel, does not verify that the

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -93,10 +93,11 @@ pub(crate) mod metrics {
     use std::sync::LazyLock;
 
     use linera_base::prometheus_util::{
-        exponential_bucket_interval, register_histogram_vec, register_int_counter_vec,
+        exponential_bucket_interval, register_histogram_vec, register_int_counter,
+        register_int_counter_vec,
     };
     use linera_execution::ResourceTracker;
-    use prometheus::{HistogramVec, IntCounterVec};
+    use prometheus::{HistogramVec, IntCounter, IntCounterVec};
 
     pub static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
@@ -203,6 +204,14 @@ pub(crate) mod metrics {
             "Number of entries in the outbox_counters map (in-flight message heights)",
             &[],
             exponential_bucket_interval(1.0, 1_000_000.0),
+        )
+    });
+
+    pub static NUM_CONFLICTING_CERTIFIED_BLOCKS: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "num_conflicting_certified_blocks",
+            "Number of detected pairs of conflicting certified blocks, each proving that \
+             a committee equivocated",
         )
     });
 
@@ -1526,13 +1535,11 @@ where
         Ok(updated_streams)
     }
 
-    /// Records the block references an accepted block commits to — its parent via
-    /// `previous_block_hash`, the latest message block per recipient via
-    /// `previous_message_blocks` and the latest event block per stream via
-    /// `previous_event_blocks` — in `vouched_blocks`, unless the referenced block
-    /// is already in `block_hashes`. The accepted block is trusted, so these hash
-    /// commitments remain a sufficient basis for accepting the referenced blocks
-    /// even after the epochs that certified them are revoked.
+    /// Records the blocks an accepted block commits to ([`Block::vouches_for`]) in
+    /// `vouched_blocks`, unless the referenced block is already in `block_hashes`.
+    /// The accepted block is trusted, so these hash commitments remain a sufficient
+    /// basis for accepting the referenced blocks even after the epochs that
+    /// certified them are revoked.
     ///
     /// A chain has one certified block per height, so a block committing to a
     /// different hash than the one already accepted at that height is evidence of
@@ -1541,19 +1548,7 @@ where
     /// [`ChainError::ConflictingCertifiedBlocks`], which names the certificate
     /// pair that proves the fault.
     async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
-        let block_hash = block.hash();
-        let mut references = Vec::new();
-        if let Some(parent_hash) = block.header.previous_block_hash {
-            references.push((block.header.height.try_sub_one()?, parent_hash));
-        }
-        for (hash, height) in block
-            .body
-            .previous_message_blocks
-            .values()
-            .chain(block.body.previous_event_blocks.values())
-        {
-            references.push((*height, *hash));
-        }
+        let references = block.vouches_for().collect::<Vec<_>>();
         let known_hashes = self
             .block_hashes
             .multi_get(references.iter().map(|(height, _)| height))
@@ -1563,38 +1558,18 @@ where
                 Some(known_hash) if known_hash == hash => {}
                 None => self.vouched_blocks.insert(&hash)?,
                 Some(known_hash) => {
-                    return Err(self.conflicting_blocks_error(height, known_hash, hash, block_hash));
+                    return Err(ConflictingCertifiedBlocks {
+                        chain_id: self.chain_id(),
+                        height,
+                        existing_block: known_hash,
+                        conflicting_block: hash,
+                        witness_block: block.hash(),
+                    }
+                    .into_chain_error());
                 }
             }
         }
         Ok(())
-    }
-
-    /// Builds a [`ChainError::ConflictingCertifiedBlocks`] error and logs the
-    /// conflict: a certified block asserting a different block at `height` than
-    /// the one already accepted is proof that a committee equivocated.
-    fn conflicting_blocks_error(
-        &self,
-        height: BlockHeight,
-        existing_block: CryptoHash,
-        conflicting_block: CryptoHash,
-        witness_block: CryptoHash,
-    ) -> ChainError {
-        tracing::error!(
-            chain_id = %self.chain_id(),
-            %height,
-            %existing_block,
-            %conflicting_block,
-            %witness_block,
-            "conflicting certified blocks at the same height: a committee equivocated",
-        );
-        ChainError::ConflictingCertifiedBlocks(Box::new(ConflictingCertifiedBlocks {
-            chain_id: self.chain_id(),
-            height,
-            existing_block,
-            conflicting_block,
-            witness_block,
-        }))
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -47,7 +47,8 @@ use crate::{
     manager::ChainManager,
     outbox::OutboxStateView,
     pending_blobs::PendingBlobsView,
-    ChainError, ChainExecutionContext, ExecutionError, ExecutionResultExt,
+    ChainError, ChainExecutionContext, ConflictingCertifiedBlocks, ExecutionError,
+    ExecutionResultExt,
 };
 
 #[cfg(test)]
@@ -1507,7 +1508,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
-        self.vouch_for_block_references(block).await?;
+        self.vouch_for_block_references(block, hash).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1530,7 +1531,18 @@ where
     /// is already in `block_hashes`. The accepted block is trusted, so these hash
     /// commitments remain a sufficient basis for accepting the referenced blocks
     /// even after the epochs that certified them are revoked.
-    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+    ///
+    /// A chain has one certified block per height, so a block committing to a
+    /// different hash than the one already accepted at that height is evidence of
+    /// equivocation — two conflicting certificates signed by that height's
+    /// committee. In that case the block is rejected with
+    /// [`ChainError::ConflictingCertifiedBlocks`], which names the certificate
+    /// pair that proves the fault.
+    async fn vouch_for_block_references(
+        &mut self,
+        block: &Block,
+        block_hash: CryptoHash,
+    ) -> Result<(), ChainError> {
         let mut references = Vec::new();
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
@@ -1547,25 +1559,38 @@ where
                 Some(known_hash) if known_hash == hash => {}
                 None => self.vouched_blocks.insert(&hash)?,
                 Some(known_hash) => {
-                    // A chain has one certified block per height, so a trusted
-                    // block committing to a different hash than the one already
-                    // accepted is evidence of equivocation — two conflicting
-                    // certificates signed by that height's committee. Follow the
-                    // newly accepted block's commitment (it is the one backed by
-                    // a currently trusted certificate), but flag the conflict.
-                    warn!(
-                        chain_id = %self.chain_id(),
-                        %height,
-                        %known_hash,
-                        vouched_hash = %hash,
-                        "conflicting certified blocks at the same height: \
-                         the committee for this height equivocated",
-                    );
-                    self.vouched_blocks.insert(&hash)?;
+                    return Err(self.conflicting_blocks_error(height, known_hash, hash, block_hash));
                 }
             }
         }
         Ok(())
+    }
+
+    /// Builds a [`ChainError::ConflictingCertifiedBlocks`] error and logs the
+    /// conflict: a certified block asserting a different block at `height` than
+    /// the one already accepted is proof that a committee equivocated.
+    fn conflicting_blocks_error(
+        &self,
+        height: BlockHeight,
+        existing_block: CryptoHash,
+        conflicting_block: CryptoHash,
+        witness_block: CryptoHash,
+    ) -> ChainError {
+        tracing::error!(
+            chain_id = %self.chain_id(),
+            %height,
+            %existing_block,
+            %conflicting_block,
+            %witness_block,
+            "conflicting certified blocks at the same height: a committee equivocated",
+        );
+        ChainError::ConflictingCertifiedBlocks(Box::new(ConflictingCertifiedBlocks {
+            chain_id: self.chain_id(),
+            height,
+            existing_block,
+            conflicting_block,
+            witness_block,
+        }))
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.
@@ -1587,7 +1612,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
-        self.vouch_for_block_references(block).await?;
+        self.vouch_for_block_references(block, hash).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -343,8 +343,9 @@ where
     /// Hashes of blocks that are vouched for by data this chain already trusts, but
     /// have not been processed here yet. A hash is inserted when a trusted source
     /// commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
-    /// block's `previous_block_hash` or `previous_message_blocks` links (unless the
-    /// referenced block is already in `block_hashes`). The worker accepts a cert
+    /// block's `previous_block_hash`, `previous_message_blocks` or
+    /// `previous_event_blocks` links (unless the referenced block is already in
+    /// `block_hashes`). The worker accepts a cert
     /// whose hash is in this set regardless of its epoch — the epoch may be revoked,
     /// but the hash commitment makes the block trustworthy — and removes the entry
     /// upon acceptance.
@@ -1526,8 +1527,9 @@ where
     }
 
     /// Records the block references an accepted block commits to — its parent via
-    /// `previous_block_hash` and the latest message block per recipient via
-    /// `previous_message_blocks` — in `vouched_blocks`, unless the referenced block
+    /// `previous_block_hash`, the latest message block per recipient via
+    /// `previous_message_blocks` and the latest event block per stream via
+    /// `previous_event_blocks` — in `vouched_blocks`, unless the referenced block
     /// is already in `block_hashes`. The accepted block is trusted, so these hash
     /// commitments remain a sufficient basis for accepting the referenced blocks
     /// even after the epochs that certified them are revoked.
@@ -1547,7 +1549,12 @@ where
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
         }
-        for (hash, height) in block.body.previous_message_blocks.values() {
+        for (hash, height) in block
+            .body
+            .previous_message_blocks
+            .values()
+            .chain(block.body.previous_event_blocks.values())
+        {
             references.push((*height, *hash));
         }
         let known_hashes = self

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1509,7 +1509,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
-        self.vouch_for_block_references(block, hash).await?;
+        self.vouch_for_block_references(block).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1540,11 +1540,8 @@ where
     /// committee. In that case the block is rejected with
     /// [`ChainError::ConflictingCertifiedBlocks`], which names the certificate
     /// pair that proves the fault.
-    async fn vouch_for_block_references(
-        &mut self,
-        block: &Block,
-        block_hash: CryptoHash,
-    ) -> Result<(), ChainError> {
+    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+        let block_hash = block.hash();
         let mut references = Vec::new();
         if let Some(parent_hash) = block.header.previous_block_hash {
             references.push((block.header.height.try_sub_one()?, parent_hash));
@@ -1619,7 +1616,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
-        self.vouch_for_block_references(block, hash).await?;
+        self.vouch_for_block_references(block).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -339,14 +339,15 @@ where
     /// `SystemOperation::Checkpoint` is executed.
     pub latest_checkpoint_height: RegisterView<C, Option<BlockHeight>>,
 
-    /// Hashes of pre-checkpoint sender blocks the chain has seen a checkpoint cert
-    /// vouch for via `outbox_block_hashes`, but whose actual cert bytes are not yet
-    /// in storage. The worker errors a checkpoint push with
-    /// `BlocksNotFound` when this set is non-empty, then accepts each
-    /// referenced cert (regardless of its own — possibly revoked — epoch) and
-    /// removes the entry. Once the set is empty, the checkpoint restoration can run
-    /// end-to-end.
-    pub pre_checkpoint_block_trust: SetView<C, CryptoHash>,
+    /// Hashes of blocks that are vouched for by data this chain already trusts, but
+    /// have not been processed here yet. A hash is inserted when a trusted source
+    /// commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
+    /// block's `previous_block_hash` or `previous_message_blocks` links (unless the
+    /// referenced block is already in `block_hashes`). The worker accepts a cert
+    /// whose hash is in this set regardless of its epoch — the epoch may be revoked,
+    /// but the hash commitment makes the block trustworthy — and removes the entry
+    /// upon acceptance.
+    pub vouched_blocks: SetView<C, CryptoHash>,
 
     /// The hash of the set of fully-tracked chains that `nonempty_outboxes` and
     /// `outbox_counters` were last reconciled against. On a client these two indices only hold
@@ -1506,6 +1507,7 @@ where
         }
         let updated_streams = self.process_emitted_events(block).await?;
         self.process_outgoing_messages(block, tracked).await?;
+        self.vouch_for_block_references(block).await?;
 
         // Last, reset the consensus state based on the current ownership.
         self.reset_chain_manager(block.header.height.try_add_one()?, local_time)
@@ -1520,6 +1522,50 @@ where
             self.latest_checkpoint_height.set(Some(block.header.height));
         }
         Ok(updated_streams)
+    }
+
+    /// Records the block references an accepted block commits to — its parent via
+    /// `previous_block_hash` and the latest message block per recipient via
+    /// `previous_message_blocks` — in `vouched_blocks`, unless the referenced block
+    /// is already in `block_hashes`. The accepted block is trusted, so these hash
+    /// commitments remain a sufficient basis for accepting the referenced blocks
+    /// even after the epochs that certified them are revoked.
+    async fn vouch_for_block_references(&mut self, block: &Block) -> Result<(), ChainError> {
+        let mut references = Vec::new();
+        if let Some(parent_hash) = block.header.previous_block_hash {
+            references.push((block.header.height.try_sub_one()?, parent_hash));
+        }
+        for (hash, height) in block.body.previous_message_blocks.values() {
+            references.push((*height, *hash));
+        }
+        let known_hashes = self
+            .block_hashes
+            .multi_get(references.iter().map(|(height, _)| height))
+            .await?;
+        for (known, (height, hash)) in known_hashes.into_iter().zip(references) {
+            match known {
+                Some(known_hash) if known_hash == hash => {}
+                None => self.vouched_blocks.insert(&hash)?,
+                Some(known_hash) => {
+                    // A chain has one certified block per height, so a trusted
+                    // block committing to a different hash than the one already
+                    // accepted is evidence of equivocation — two conflicting
+                    // certificates signed by that height's committee. Follow the
+                    // newly accepted block's commitment (it is the one backed by
+                    // a currently trusted certificate), but flag the conflict.
+                    warn!(
+                        chain_id = %self.chain_id(),
+                        %height,
+                        %known_hash,
+                        vouched_hash = %hash,
+                        "conflicting certified blocks at the same height: \
+                         the committee for this height equivocated",
+                    );
+                    self.vouched_blocks.insert(&hash)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Adds a block to `block_hashes` as preprocessed, and updates the outboxes where possible.
@@ -1541,6 +1587,7 @@ where
         }
         self.process_outgoing_messages(block, tracked).await?;
         let updated_streams = self.process_emitted_events(block).await?;
+        self.vouch_for_block_references(block).await?;
         self.insert_block_hash(height, hash)?;
         Ok(updated_streams)
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -237,6 +237,25 @@ pub struct ConflictingCertifiedBlocks {
     pub witness_block: CryptoHash,
 }
 
+impl ConflictingCertifiedBlocks {
+    /// Logs the equivocation, counts it in the metrics and wraps it in a
+    /// [`ChainError`]. Every detected conflict should be reported through this
+    /// method so that none is missing from the metrics.
+    pub fn into_chain_error(self) -> ChainError {
+        tracing::error!(
+            chain_id = %self.chain_id,
+            height = %self.height,
+            existing_block = %self.existing_block,
+            conflicting_block = %self.conflicting_block,
+            witness_block = %self.witness_block,
+            "conflicting certified blocks at the same height: a committee equivocated",
+        );
+        #[cfg(with_metrics)]
+        crate::chain::metrics::NUM_CONFLICTING_CERTIFIED_BLOCKS.inc();
+        ChainError::ConflictingCertifiedBlocks(Box::new(self))
+    }
+}
+
 impl ChainError {
     /// Returns whether this error is caused by an issue in the local node.
     ///

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -30,7 +30,7 @@ pub use chain::{BlockExecutionPhase, ChainIdSet, ChainStateView, ChainTipState, 
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,
-    crypto::CryptoError,
+    crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, BlockHeight, Epoch, Round, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
@@ -207,6 +207,34 @@ pub enum ChainError {
     NotTimedOutYet(Timestamp),
     #[error("Checkpoint precondition failed: {0}")]
     CheckpointPreconditionFailed(&'static str),
+    #[error(transparent)]
+    ConflictingCertifiedBlocks(Box<ConflictingCertifiedBlocks>),
+}
+
+/// The payload of [`ChainError::ConflictingCertifiedBlocks`]: a certified block
+/// asserts a different block at some height than the one already accepted there.
+/// Since a chain has one certified block per height, the two certificates
+/// together prove that a committee equivocated.
+#[derive(Error, Debug)]
+#[error(
+    "conflicting certified blocks at height {height} on chain {chain_id}: the certificate \
+     of block {witness_block} asserts {conflicting_block} at that height, but \
+     {existing_block} was already accepted — a committee equivocated"
+)]
+pub struct ConflictingCertifiedBlocks {
+    /// The chain with two conflicting certified blocks.
+    pub chain_id: ChainId,
+    /// The height at which the two blocks conflict.
+    pub height: BlockHeight,
+    /// The hash of the block already accepted at `height`.
+    pub existing_block: CryptoHash,
+    /// The conflicting hash asserted at `height` by `witness_block`'s certificate.
+    pub conflicting_block: CryptoHash,
+    /// The hash of the block whose certificate asserts `conflicting_block` at
+    /// `height`: the conflicting block itself, or an accepted block that commits
+    /// to it via `previous_block_hash` or `previous_message_blocks`. Its
+    /// certificate, together with `existing_block`'s, proves the fault.
+    pub witness_block: CryptoHash,
 }
 
 impl ChainError {
@@ -256,6 +284,7 @@ impl ChainError {
             | ChainError::RoundDoesNotTimeOut
             | ChainError::NotTimedOutYet(_)
             | ChainError::CheckpointPreconditionFailed(_)
+            | ChainError::ConflictingCertifiedBlocks(_)
             | ChainError::MissingCrossChainUpdate { .. } => false,
             ChainError::ViewError(_)
             | ChainError::UnexpectedMessage { .. }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -34,7 +34,7 @@ use linera_chain::{
         ValidatedBlockCertificate,
     },
     BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
-    ChainTipState, ExecutionResultExt as _, StreamCounts,
+    ChainTipState, ConflictingCertifiedBlocks, ExecutionResultExt as _, StreamCounts,
 };
 use linera_execution::{
     system::{EpochEventData, EventSubscriptions, EPOCH_STREAM_NAME},
@@ -332,11 +332,9 @@ where
     /// its block.
     ///
     /// A certificate from a revoked epoch no longer proves anything by itself: the
-    /// committee that signed it is not trusted any more. Such a block is only
-    /// accepted if it was already accepted while its epoch was still trusted, i.e.
-    /// it is in `block_hashes`. (Blocks vouched for by an accepted block's
-    /// `previous_block_hash` or `previous_message_blocks` links, or by a checkpoint
-    /// cert, carry a `vouched_blocks` trust mark and bypass this check.)
+    /// committee that signed it is not trusted any more. The caller must in that
+    /// case additionally have a trust mark for the block, or a prior acceptance of
+    /// it, to accept it.
     async fn ensure_epoch_trusted(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -352,17 +350,14 @@ where
                     ChainExecutionContext::Block,
                 )))
             })?;
-        if !is_revoked {
-            return Ok(());
+        if is_revoked {
+            return Err(WorkerError::EpochRevoked {
+                chain_id: header.chain_id,
+                epoch: header.epoch,
+                height: header.height,
+            });
         }
-        if self.chain.block_hashes.get(&header.height).await? == Some(certificate.hash()) {
-            return Ok(());
-        }
-        Err(WorkerError::EpochRevoked {
-            chain_id: header.chain_id,
-            epoch: header.epoch,
-            height: header.height,
-        })
+        Ok(())
     }
 
     /// Ensures that this worker may still create signatures for blocks in the given
@@ -1040,13 +1035,40 @@ where
         // We haven't processed the block - verify the certificate first.
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
+
+        // A chain has one certified block per height. Read the accepted hash at
+        // this height once: a *different* hash is proof that a committee
+        // equivocated — reject it before the certificate is written anywhere, so
+        // the conflicting certificate is never persisted; the *same* hash means we
+        // already accepted this block, which also satisfies the revoked-epoch
+        // trust requirement below.
+        let accepted_at_height = self.chain.block_hashes.get(&height).await?;
+        if let Some(existing_hash) = accepted_at_height {
+            if existing_hash != block_hash {
+                tracing::error!(
+                    %chain_id, %height, %existing_hash, conflicting_block = %block_hash,
+                    "conflicting certified blocks at the same height: a committee equivocated",
+                );
+                return Err(ChainError::ConflictingCertifiedBlocks(Box::new(
+                    ConflictingCertifiedBlocks {
+                        chain_id,
+                        height,
+                        existing_block: existing_hash,
+                        conflicting_block: block_hash,
+                        witness_block: block_hash,
+                    },
+                ))
+                .into());
+            }
+        }
+
         // If the epoch has been revoked, the quorum signature alone is no longer a
         // sufficient basis for trust: the block must also be vouched for by data
         // this worker already trusts — a `vouched_blocks` trust mark (written by a
         // checkpoint cert or by an accepted block that commits to this one via
         // `previous_block_hash` or `previous_message_blocks`) or an earlier
         // acceptance of the same block.
-        if !in_trust_set {
+        if !in_trust_set && accepted_at_height != Some(block_hash) {
             self.ensure_epoch_trusted(&certificate).await?;
         }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -333,10 +333,10 @@ where
     ///
     /// A certificate from a revoked epoch no longer proves anything by itself: the
     /// committee that signed it is not trusted any more. Such a block is only
-    /// accepted if it is transitively re-certified by a block we accepted while its
-    /// epoch was still trusted — either the block itself is already in
-    /// `block_hashes`, or an accepted child block commits to it via its
-    /// `previous_block_hash`.
+    /// accepted if it was already accepted while its epoch was still trusted, i.e.
+    /// it is in `block_hashes`. (Blocks vouched for by an accepted block's
+    /// `previous_block_hash` or `previous_message_blocks` links, or by a checkpoint
+    /// cert, carry a `vouched_blocks` trust mark and bypass this check.)
     async fn ensure_epoch_trusted(
         &self,
         certificate: &ConfirmedBlockCertificate,
@@ -355,18 +355,8 @@ where
         if !is_revoked {
             return Ok(());
         }
-        let block_hash = certificate.hash();
-        if self.chain.block_hashes.get(&header.height).await? == Some(block_hash) {
+        if self.chain.block_hashes.get(&header.height).await? == Some(certificate.hash()) {
             return Ok(());
-        }
-        let child_height = header.height.try_add_one()?;
-        if let Some(child_hash) = self.chain.block_hashes.get(&child_height).await? {
-            let child = self.storage.read_confirmed_block(child_hash).await?;
-            if child
-                .is_some_and(|child| child.block().header.previous_block_hash == Some(block_hash))
-            {
-                return Ok(());
-            }
         }
         Err(WorkerError::EpochRevoked {
             chain_id: header.chain_id,
@@ -1021,20 +1011,17 @@ where
         let height = block.header.height;
         let chain_id = block.header.chain_id;
 
-        // Trust-mark accept path: an earlier checkpoint cert recorded this block's
-        // hash in `pre_checkpoint_block_trust`. Removing the trust mark here is
+        // Trust-mark accept path: a checkpoint cert or an accepted block's
+        // `previous_block_hash` / `previous_message_blocks` links recorded this
+        // block's hash in `vouched_blocks`. Removing the trust mark here is
         // only an in-memory change; if anything below fails before `save`, the
         // mark survives on the next reload. The dispatch's `gap` definition
         // (`!=` rather than `<`) routes both above-tip and below-tip trust
         // uploads to `preprocess_certified_block` so the chain can write the
         // cert without advancing the tip.
-        let in_trust_set = self
-            .chain
-            .pre_checkpoint_block_trust
-            .contains(&block_hash)
-            .await?;
+        let in_trust_set = self.chain.vouched_blocks.contains(&block_hash).await?;
         if in_trust_set {
-            self.chain.pre_checkpoint_block_trust.remove(&block_hash)?;
+            self.chain.vouched_blocks.remove(&block_hash)?;
         }
 
         // Check if we already processed this block.
@@ -1054,10 +1041,11 @@ where
         let committee = self.committee_for_epoch(block.header.epoch).await?;
         certificate.check(&committee)?;
         // If the epoch has been revoked, the quorum signature alone is no longer a
-        // sufficient basis for trust: the block must also be vouched for by a block
-        // this worker already trusts — a checkpoint trust mark, an earlier
-        // acceptance of the same block, or an accepted child block that commits to
-        // it via `previous_block_hash`.
+        // sufficient basis for trust: the block must also be vouched for by data
+        // this worker already trusts — a `vouched_blocks` trust mark (written by a
+        // checkpoint cert or by an accepted block that commits to this one via
+        // `previous_block_hash` or `previous_message_blocks`) or an earlier
+        // acceptance of the same block.
         if !in_trust_set {
             self.ensure_epoch_trusted(&certificate).await?;
         }
@@ -1229,7 +1217,7 @@ where
         }
         if !missing_blocks.is_empty() {
             for hash in &missing_blocks {
-                self.chain.pre_checkpoint_block_trust.insert(hash)?;
+                self.chain.vouched_blocks.insert(hash)?;
             }
             self.save().await?;
             return Err(WorkerError::BlocksNotFound(missing_blocks));

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -262,25 +262,20 @@ where
         Ok((*committee).clone())
     }
 
-    /// Filters bundles destined for this chain to drop ones already received and to refuse
-    /// ones whose epoch has been revoked on the admin chain.
+    /// Filters bundles destined for this chain to drop ones already received.
     ///
-    /// A revoked-epoch bundle is still accepted if (a) it has already been executed by
-    /// anticipation (`bundle.height <= last_anticipated_block_height`), or (b) a later
-    /// bundle in the same batch is in a still-trusted epoch — that bundle's certificate
-    /// transitively re-certifies all preceding ones via prev-hash chaining.
-    pub(crate) async fn select_message_bundles(
+    /// The bundles' epochs are irrelevant here: bundles come from this node's own
+    /// worker for the sender chain, which only accepts blocks it trusts — a block
+    /// from a revoked epoch only if a trusted block vouches for it.
+    pub(crate) fn select_message_bundles(
         &self,
         origin: &ChainId,
         next_height_to_receive: BlockHeight,
-        last_anticipated_block_height: Option<BlockHeight>,
         mut bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Vec<MessageBundle>, WorkerError> {
-        let recipient = self.chain_id();
         let mut latest_height = None;
         let mut skipped_len = 0;
-        let mut trusted_len = 0;
-        for (i, (epoch, bundle)) in bundles.iter().enumerate() {
+        for (i, (_, bundle)) in bundles.iter().enumerate() {
             ensure!(
                 latest_height <= Some(bundle.height),
                 WorkerError::InvalidCrossChainRequest
@@ -289,34 +284,19 @@ where
             if bundle.height < next_height_to_receive {
                 skipped_len = i + 1;
             }
-            let is_revoked = self.is_epoch_revoked(*epoch).await?;
-            if !is_revoked || Some(bundle.height) <= last_anticipated_block_height {
-                trusted_len = i + 1;
-            }
         }
         if skipped_len > 0 {
             let (_, sample_bundle) = &bundles[skipped_len - 1];
             debug!(
-                "Ignoring repeated messages to {recipient:.8} from {origin:} at height {}",
+                "Ignoring repeated messages to {:.8} from {origin:} at height {}",
+                self.chain_id(),
                 sample_bundle.height,
             );
         }
-        if skipped_len < bundles.len() && trusted_len < bundles.len() {
-            let (sample_epoch, sample_bundle) = &bundles[trusted_len];
-            warn!(
-                "Refusing messages to {recipient:.8} from {origin:} at height {} \
-                 because the epoch {} is not trusted any more",
-                sample_bundle.height, sample_epoch,
-            );
-        }
-        Ok(if skipped_len < trusted_len {
-            bundles
-                .drain(skipped_len..trusted_len)
-                .map(|(_, bundle)| bundle)
-                .collect()
-        } else {
-            vec![]
-        })
+        Ok(bundles
+            .drain(skipped_len..)
+            .map(|(_, bundle)| bundle)
+            .collect())
     }
 
     /// Returns whether the given epoch has been revoked on the admin chain,
@@ -1497,14 +1477,9 @@ where
         bundles: Vec<(Epoch, MessageBundle)>,
         sender_previous_height: Option<BlockHeight>,
     ) -> Result<CrossChainUpdateResult, WorkerError> {
-        // Only process certificates with relevant heights and epochs.
+        // Only process certificates with relevant heights.
         let mut inbox = self.chain.inboxes.try_load_entry_mut(&origin).await?;
         let next_height_to_receive = inbox.next_block_height_to_receive()?;
-        let last_anticipated_block_height = inbox
-            .removed_bundles
-            .back()
-            .await?
-            .map(|bundle| bundle.height);
 
         // Proactive gap detection: if the sender declares a predecessor height that
         // we haven't received yet, the inbox has a gap.
@@ -1533,14 +1508,7 @@ where
             }
         }
 
-        let bundles = self
-            .select_message_bundles(
-                &origin,
-                next_height_to_receive,
-                last_anticipated_block_height,
-                bundles,
-            )
-            .await?;
+        let bundles = self.select_message_bundles(&origin, next_height_to_receive, bundles)?;
         let Some(last_updated_height) = bundles.last().map(|bundle| bundle.height) else {
             return Ok(CrossChainUpdateResult::NothingToDo);
         };

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1009,19 +1009,14 @@ where
         let accepted_at_height = self.chain.block_hashes.get(&height).await?;
         if let Some(existing_hash) = accepted_at_height {
             if existing_hash != block_hash {
-                tracing::error!(
-                    %chain_id, %height, %existing_hash, conflicting_block = %block_hash,
-                    "conflicting certified blocks at the same height: a committee equivocated",
-                );
-                return Err(ChainError::ConflictingCertifiedBlocks(Box::new(
-                    ConflictingCertifiedBlocks {
-                        chain_id,
-                        height,
-                        existing_block: existing_hash,
-                        conflicting_block: block_hash,
-                        witness_block: block_hash,
-                    },
-                ))
+                return Err(ConflictingCertifiedBlocks {
+                    chain_id,
+                    height,
+                    existing_block: existing_hash,
+                    conflicting_block: block_hash,
+                    witness_block: block_hash,
+                }
+                .into_chain_error()
                 .into());
             }
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1066,8 +1066,8 @@ where
         // sufficient basis for trust: the block must also be vouched for by data
         // this worker already trusts — a `vouched_blocks` trust mark (written by a
         // checkpoint cert or by an accepted block that commits to this one via
-        // `previous_block_hash` or `previous_message_blocks`) or an earlier
-        // acceptance of the same block.
+        // `previous_block_hash`, `previous_message_blocks` or
+        // `previous_event_blocks`) or an earlier acceptance of the same block.
         if !in_trust_set && accepted_at_height != Some(block_hash) {
             self.ensure_epoch_trusted(&certificate).await?;
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -289,16 +289,7 @@ where
             if bundle.height < next_height_to_receive {
                 skipped_len = i + 1;
             }
-            let is_revoked = self
-                .storage
-                .is_epoch_revoked(*epoch)
-                .await
-                .map_err(|error| {
-                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                        Box::new(error),
-                        ChainExecutionContext::Block,
-                    )))
-                })?;
+            let is_revoked = self.is_epoch_revoked(*epoch).await?;
             if !is_revoked || Some(bundle.height) <= last_anticipated_block_height {
                 trusted_len = i + 1;
             }
@@ -328,6 +319,17 @@ where
         })
     }
 
+    /// Returns whether the given epoch has been revoked on the admin chain,
+    /// mapping any storage error to a [`WorkerError`].
+    async fn is_epoch_revoked(&self, epoch: Epoch) -> Result<bool, WorkerError> {
+        self.storage.is_epoch_revoked(epoch).await.map_err(|error| {
+            WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                Box::new(error),
+                ChainExecutionContext::Block,
+            )))
+        })
+    }
+
     /// Ensures that the certificate's epoch is still a sufficient basis for trusting
     /// its block.
     ///
@@ -340,16 +342,7 @@ where
         certificate: &ConfirmedBlockCertificate,
     ) -> Result<(), WorkerError> {
         let header = &certificate.block().header;
-        let is_revoked = self
-            .storage
-            .is_epoch_revoked(header.epoch)
-            .await
-            .map_err(|error| {
-                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                    Box::new(error),
-                    ChainExecutionContext::Block,
-                )))
-            })?;
+        let is_revoked = self.is_epoch_revoked(header.epoch).await?;
         if is_revoked {
             return Err(WorkerError::EpochRevoked {
                 chain_id: header.chain_id,
@@ -369,16 +362,7 @@ where
         epoch: Epoch,
         height: BlockHeight,
     ) -> Result<(), WorkerError> {
-        let is_revoked = self
-            .storage
-            .is_epoch_revoked(epoch)
-            .await
-            .map_err(|error| {
-                WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                    Box::new(error),
-                    ChainExecutionContext::Block,
-                )))
-            })?;
+        let is_revoked = self.is_epoch_revoked(epoch).await?;
         ensure!(
             !is_revoked,
             WorkerError::VoteInRevokedEpoch {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1208,17 +1208,28 @@ impl<Env: Environment> Client<Env> {
                 // Race the validators instead of trying them one by one: a slow or
                 // faulty validator must not stall the walk. A validator that
                 // returns nothing counts as a failure so the others take over.
-                let heights = &heights;
                 let downloaded = communicate_concurrently(
                     nodes,
                     async move |remote_node| {
+                        // Bound the batch by the validator's chain height: a request
+                        // including heights the validator doesn't have would fail as
+                        // a whole.
+                        let info = remote_node
+                            .handle_chain_info_query(ChainInfoQuery::new(chain_id))
+                            .await?;
+                        let batch_end = info
+                            .next_block_height
+                            .0
+                            .min(u64::from(next_height).saturating_add(batch_size));
+                        let heights = (u64::from(next_height)..batch_end)
+                            .map(BlockHeight)
+                            .collect::<Vec<_>>();
+                        if heights.is_empty() {
+                            return Err(NodeError::MissingCertificateValue);
+                        }
                         let downloaded = self
                             .requests_scheduler
-                            .download_certificates_by_heights(
-                                &remote_node,
-                                chain_id,
-                                heights.clone(),
-                            )
+                            .download_certificates_by_heights(&remote_node, chain_id, heights)
                             .await?;
                         if downloaded.is_empty() {
                             return Err(NodeError::MissingCertificateValue);
@@ -1260,6 +1271,10 @@ impl<Env: Environment> Client<Env> {
         // Process the descendants newest-first, so that each block is vouched for
         // by the one processed just before it.
         for certificate in certificates.iter().rev() {
+            tracing::warn!(
+                "DBG preprocess_descendants: processing {}",
+                certificate.block().header.height
+            );
             Box::pin(self.handle_certificate_with_retry(
                 certificate,
                 nodes,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2049,33 +2049,8 @@ impl<Env: Environment> Client<Env> {
                 .await?;
         }
 
-        // If the oldest collected block's epoch has been revoked, its certificate
-        // alone won't convince the local worker. Preprocess the collected chain
-        // newest-first: accepting each block marks the `previous_message_blocks`
-        // hash it commits to as vouched, so the next-older block is accepted
-        // despite its revoked epoch — without downloading any of the intermediate
-        // blocks that sent no message to our chain. (Epoch revocation is monotone,
-        // so only the oldest block needs checking; if even the newest block's
-        // epoch is revoked, its retry logic falls back to walking contiguous
-        // descendants.)
-        if let Some(certificate) = certificates.values().next() {
-            let epoch = certificate.block().header.epoch;
-            if self
-                .storage_client()
-                .is_epoch_revoked(epoch)
-                .await
-                .map_err(LocalNodeError::from)?
-            {
-                for certificate in certificates.values().rev() {
-                    Box::pin(self.handle_certificate_with_retry(
-                        certificate,
-                        std::slice::from_ref(remote_node),
-                        ProcessConfirmedBlockMode::Preprocess,
-                    ))
-                    .await?;
-                }
-            }
-        }
+        self.recertify_if_epoch_revoked(&certificates, remote_node)
+            .await?;
 
         // Process certificates in ascending block height order (BTreeMap keeps them sorted).
         for certificate in certificates.into_values() {
@@ -2087,6 +2062,43 @@ impl<Env: Environment> Client<Env> {
             .await?;
         }
 
+        Ok(())
+    }
+
+    /// Preprocesses a sparsely collected run of blocks newest-first if the oldest one's
+    /// epoch has been revoked, so that the newer blocks vouch for the older ones.
+    ///
+    /// A revoked epoch's certificate alone doesn't convince the local worker. But
+    /// accepting a block marks the hashes it commits to in `previous_message_blocks` and
+    /// `previous_event_blocks` as vouched, so the block the oldest one was reached
+    /// through makes it acceptable despite its revoked epoch — without downloading the
+    /// intermediate blocks that sent no message and published no event. Epoch revocation
+    /// is monotone, so only the oldest block needs checking; if even the newest block's
+    /// epoch is revoked, the retry logic falls back to walking contiguous descendants.
+    async fn recertify_if_epoch_revoked(
+        &self,
+        certificates: &BTreeMap<BlockHeight, CacheArc<ConfirmedBlockCertificate>>,
+        remote_node: &RemoteNode<Env::ValidatorNode>,
+    ) -> Result<(), chain_client::Error> {
+        let Some(oldest) = certificates.values().next() else {
+            return Ok(());
+        };
+        if !self
+            .storage_client()
+            .is_epoch_revoked(oldest.block().header.epoch)
+            .await
+            .map_err(LocalNodeError::from)?
+        {
+            return Ok(());
+        }
+        for certificate in certificates.values().rev() {
+            Box::pin(self.handle_certificate_with_retry(
+                certificate,
+                std::slice::from_ref(remote_node),
+                ProcessConfirmedBlockMode::Preprocess,
+            ))
+            .await?;
+        }
         Ok(())
     }
 
@@ -2172,6 +2184,9 @@ impl<Env: Environment> Client<Env> {
 
             certificates.insert(current_height, certificate);
         }
+
+        self.recertify_if_epoch_revoked(&certificates, remote_node)
+            .await?;
 
         // Process in ascending height order.
         for certificate in certificates.into_values() {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2064,6 +2064,10 @@ impl<Env: Environment> Client<Env> {
                 .await?;
         }
 
+        // If the oldest block's epoch has been revoked, preprocess the collected run
+        // newest-first before the ascending processing below: each block vouches for
+        // the previous message block it commits to, which the local worker would
+        // otherwise reject.
         self.recertify_if_epoch_revoked(&certificates, remote_node)
             .await?;
 
@@ -2200,6 +2204,10 @@ impl<Env: Environment> Client<Env> {
             certificates.insert(current_height, certificate);
         }
 
+        // If the oldest block's epoch has been revoked, preprocess the collected run
+        // newest-first before the ascending processing below: each block vouches for
+        // the previous event blocks it commits to, which the local worker would
+        // otherwise reject.
         self.recertify_if_epoch_revoked(&certificates, remote_node)
             .await?;
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2049,6 +2049,34 @@ impl<Env: Environment> Client<Env> {
                 .await?;
         }
 
+        // If the oldest collected block's epoch has been revoked, its certificate
+        // alone won't convince the local worker. Preprocess the collected chain
+        // newest-first: accepting each block marks the `previous_message_blocks`
+        // hash it commits to as vouched, so the next-older block is accepted
+        // despite its revoked epoch — without downloading any of the intermediate
+        // blocks that sent no message to our chain. (Epoch revocation is monotone,
+        // so only the oldest block needs checking; if even the newest block's
+        // epoch is revoked, its retry logic falls back to walking contiguous
+        // descendants.)
+        if let Some(certificate) = certificates.values().next() {
+            let epoch = certificate.block().header.epoch;
+            if self
+                .storage_client()
+                .is_epoch_revoked(epoch)
+                .await
+                .map_err(LocalNodeError::from)?
+            {
+                for certificate in certificates.values().rev() {
+                    Box::pin(self.handle_certificate_with_retry(
+                        certificate,
+                        std::slice::from_ref(remote_node),
+                        ProcessConfirmedBlockMode::Preprocess,
+                    ))
+                    .await?;
+                }
+            }
+        }
+
         // Process certificates in ascending block height order (BTreeMap keeps them sorted).
         for certificate in certificates.into_values() {
             self.receive_sender_certificate(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1657,6 +1657,12 @@ where
 /// the `ChainDescription` itself should never be downloaded either — not during
 /// the initial message processing, and not during a later re-sync that routes the
 /// sender through `retry_pending_cross_chain_requests_from_sender_chains`.
+///
+/// The first message block's epoch is revoked before the receiver processes
+/// anything, so the walk must also re-certify it: the epoch-1 message block is
+/// preprocessed first and vouches for the epoch-0 one via
+/// `previous_message_blocks`. Sparseness proves the recovery did not fall back to
+/// downloading contiguous descendants.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[test_log::test(tokio::test)]
@@ -1666,7 +1672,7 @@ where
 {
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    let _admin = builder.add_root_chain(0, Amount::ZERO).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
     let owner = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
     let receiver_id = receiver.chain_id();
@@ -1694,8 +1700,13 @@ where
         .await?;
     sender.set_preferred_owner(sender_public_key.into());
     sender.synchronize_from_validators().await?;
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
 
-    // Heights 0 and 2 are burns; heights 1 and 3 send to the receiver.
+    // Height 0 is a burn; height 1 sends to the receiver. Both are epoch-0 blocks.
     let cert0 = sender
         .burn(AccountOwner::CHAIN, Amount::ONE)
         .await
@@ -1708,10 +1719,37 @@ where
         )
         .await
         .unwrap_ok_committed();
-    let cert2 = sender
-        .burn(AccountOwner::CHAIN, Amount::ONE)
+
+    // Create epoch 1. The receiver learns about it from an admin-chain `NewBlock`
+    // notification — not via `synchronize_from_validators`, which would consume
+    // the received log and deliver the height-1 transfer prematurely — and
+    // migrates to epoch 1 so it can keep proposing after epoch 0 is revoked.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
         .await
         .unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: create_cert.block().header.height,
+                    hash: create_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    // Height 2 migrates the sender to epoch 1 without sending anything; height 3
+    // sends to the receiver again, committing to the height-1 block via
+    // `previous_message_blocks`.
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let cert2 = migration_certs.last().expect("migration block").clone();
+    assert_eq!(sender.chain_info().await?.epoch, Epoch::from(1));
     let cert3 = sender
         .transfer_to_account(
             AccountOwner::CHAIN,
@@ -1720,10 +1758,37 @@ where
         )
         .await
         .unwrap_ok_committed();
+    assert_eq!(
+        cert3.block().body.previous_message_blocks,
+        BTreeMap::from([(receiver_id, (cert1.hash(), cert1.block().header.height))]),
+    );
+
+    // Revoke epoch 0, and let the receiver learn about the revocation the same way.
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: revoke_cert.block().header.height,
+                    hash: revoke_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
 
     // Process the notification about the most recent incoming message. This walks
     // back along `previous_message_blocks` and preprocesses only the sender blocks
-    // that sent to us (heights 1 and 3).
+    // that sent to us (heights 1 and 3) — height 3 first, so that it vouches for
+    // the revoked-epoch block at height 1.
     let notification = Notification {
         chain_id: receiver_id,
         reason: Reason::NewIncomingBundle {
@@ -1731,19 +1796,17 @@ where
             height: cert3.block().header.height,
         },
     };
-    let validator = builder
-        .initial_committee
-        .validator_addresses()
-        .next()
-        .unwrap();
     receiver
         .process_notification_from(notification, validator)
         .await;
     receiver.process_inbox().await?;
 
     // Only the blocks that sent something to the receiver should be in local
-    // storage. The burn blocks in between — and the sender's `ChainDescription`
-    // blob itself — should never have been downloaded.
+    // storage. The burn and migration blocks in between — and the sender's
+    // `ChainDescription` blob itself — should never have been downloaded. In
+    // particular, the revoked-epoch block at height 1 was accepted through the
+    // `previous_message_blocks` vouching, not by walking contiguous descendants
+    // (which would have downloaded the migration block at height 2).
     let storage = receiver.storage_client();
     assert!(!storage.contains_certificate(cert0.hash()).await?);
     assert!(storage.contains_certificate(cert1.hash()).await?);
@@ -4614,16 +4677,20 @@ where
         "validator 0 must not have received the pre-checkpoint non-sender block",
     );
 
-    // The trust-mark flow consumed every entry: the validator's first attempt at
-    // the checkpoint errored with `BlocksNotFound`, the client uploaded the missing
-    // sender block (entering the trust-mark accept path on the worker, which
-    // removed the entry), and the second attempt restored the chain cleanly.
+    // The trust-mark flow consumed the checkpoint's `outbox_block_hashes` entry:
+    // the validator's first attempt at the checkpoint errored with
+    // `BlocksNotFound`, the client uploaded the missing sender block (entering the
+    // trust-mark accept path on the worker, which removed the entry), and the
+    // second attempt restored the chain cleanly. What remains is the mark for the
+    // checkpoint block's own parent (`burn_1`, which was never pushed): accepting
+    // the checkpoint vouched for it via `previous_block_hash`.
     {
         let chain_view = validator_0_storage.load_chain(chain_id).await?;
-        let trusted = chain_view.pre_checkpoint_block_trust.indices().await?;
-        assert!(
-            trusted.is_empty(),
-            "validator 0's trust set should be empty after the flow, was {trusted:?}",
+        let trusted = chain_view.vouched_blocks.indices().await?;
+        assert_eq!(
+            trusted,
+            vec![burn_1.hash()],
+            "validator 0's trust set should hold exactly the checkpoint's parent",
         );
         // The checkpoint restored the producer's epoch-1 execution state, which
         // includes the epoch migration. Validator 0's chain is now at epoch 1 —

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1834,6 +1834,222 @@ where
     Ok(())
 }
 
+/// A receiver holding a sender chain sparsely must be able to push the sender's
+/// revoked-epoch message blocks to a validator that has never seen the sender chain.
+///
+/// The sender's message blocks (heights 1 and 3) are in the revoked epoch 0; the
+/// receiver holds them plus the contiguous run from height 4 (migration) to the
+/// epoch-1 block at height 5 that re-certified them — but not the burns at heights 0
+/// and 2. When the receiver's proposal needs the lagging validator's vote, the
+/// client must upload the held blocks in decreasing height order, skipping the gaps:
+/// each held block vouches for the next older one via `previous_block_hash` or
+/// `previous_message_blocks`. The validator must then also deliver the revoked-epoch
+/// bundles to the receiver's inbox, since its own sender-chain worker accepted the
+/// blocks behind them.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_sparse_sender_chain_upload_to_lagging_validator<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
+    let validator_0_key = builder.node(0).name();
+
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(6)).await?;
+    let receiver = builder.add_root_chain(2, Amount::from_tokens(2)).await?;
+    let receiver_id = receiver.chain_id();
+    let sender_id = sender.chain_id();
+
+    // The validator the receiver gets its notifications from — not the lagging one.
+    let (validator_key, validator_addr) = builder
+        .initial_committee
+        .validator_addresses()
+        .find(|(key, _)| *key != validator_0_key)
+        .map(|(key, addr)| (key, addr.to_owned()))
+        .expect("committee should have more than one validator");
+    let validator = (validator_key, validator_addr.as_str());
+
+    // Heights 0 and 2 are burns; heights 1 and 3 send to the receiver. All are
+    // epoch-0 blocks.
+    let cert0 = sender
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    let cert1 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    let cert2 = sender
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    let cert3 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(
+        cert3.block().body.previous_message_blocks,
+        BTreeMap::from([(receiver_id, (cert1.hash(), cert1.block().header.height))]),
+    );
+
+    // Create epoch 1. The receiver learns about it from an admin-chain `NewBlock`
+    // notification — not via `synchronize_from_validators`, which would consume
+    // the received log and deliver the transfers prematurely — and migrates to
+    // epoch 1. Its burn then gives its chain an epoch-1 block, so pushing its own
+    // history to the lagging validator is not blocked by the revocation.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
+        .await
+        .unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: create_cert.block().header.height,
+                    hash: create_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+    receiver
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+
+    // Height 4 migrates the sender to epoch 1 without sending anything; the burn at
+    // height 5 is its first epoch-1 block.
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let cert4 = migration_certs.last().expect("migration block").clone();
+    let cert5 = sender
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    assert_eq!(cert5.block().header.epoch, Epoch::from(1));
+
+    // Revoke epoch 0, and let the receiver learn about the revocation the same way.
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: revoke_cert.block().header.height,
+                    hash: revoke_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+
+    // Process the notification about the most recent incoming message. The walk
+    // along `previous_message_blocks` collects the revoked-epoch blocks at heights
+    // 3 and 1; re-certifying height 3 additionally downloads the contiguous run up
+    // to the epoch-1 block at height 5.
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: receiver_id,
+                reason: Reason::NewIncomingBundle {
+                    origin: sender_id,
+                    height: cert3.block().header.height,
+                },
+            },
+            validator,
+        )
+        .await;
+
+    // The receiver's copy of the sender chain is sparse: the burns at heights 0
+    // and 2 were never downloaded.
+    let storage = receiver.storage_client();
+    for (contained, cert) in [
+        (false, &cert0),
+        (true, &cert1),
+        (false, &cert2),
+        (true, &cert3),
+        (true, &cert4),
+        (true, &cert5),
+    ] {
+        assert_eq!(
+            storage.contains_certificate(cert.hash()).await?,
+            contained,
+            "unexpected sender block at height {} in the receiver's storage",
+            cert.block().header.height,
+        );
+    }
+
+    // Bring validator 0 back and push the admin chain to it, so that it knows
+    // epoch 0 is revoked before it ever sees any of the sender's blocks.
+    builder.set_fault_type([0], FaultType::Honest);
+    admin
+        .burn(AccountOwner::CHAIN, Amount::ONE)
+        .await
+        .unwrap_ok_committed();
+    let validator_0_storage = builder
+        .validator_storages
+        .get(&validator_0_key)
+        .expect("validator 0 storage")
+        .clone();
+    assert!(
+        validator_0_storage.is_epoch_revoked(Epoch::ZERO).await?,
+        "validator 0 must know epoch 0 is revoked",
+    );
+    assert!(
+        !validator_0_storage
+            .contains_certificate(cert1.hash())
+            .await?,
+        "validator 0 must not know the sender chain yet",
+    );
+
+    // Take validator 1 offline: the quorum for the receiver's next block now needs
+    // validator 0, so the client must push the sparse sender chain to it.
+    builder.set_fault_type([1], FaultType::Offline);
+    let (certs, _) = receiver.process_inbox().await?;
+    assert_eq!(
+        certs.len(),
+        1,
+        "the receiver should have received both transfers"
+    );
+
+    // The push was sparse, too: the burns at heights 0 and 2 were never uploaded.
+    for (contained, cert) in [
+        (false, &cert0),
+        (true, &cert1),
+        (false, &cert2),
+        (true, &cert3),
+        (true, &cert4),
+        (true, &cert5),
+    ] {
+        assert_eq!(
+            validator_0_storage
+                .contains_certificate(cert.hash())
+                .await?,
+            contained,
+            "unexpected sender block at height {} in validator 0's storage",
+            cert.block().header.height,
+        );
+    }
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -34,7 +34,9 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
-use linera_chain::{data_types::MessageAction, ChainError, ChainExecutionContext};
+use linera_chain::{
+    data_types::MessageAction, types::ConfirmedBlockCertificate, ChainError, ChainExecutionContext,
+};
 use linera_execution::{
     wasm_test, ExecutionError, Message, MessageKind, Operation, QueryOutcome,
     ResourceControlPolicy, SystemMessage, SystemOperation, WasmRuntime,
@@ -57,7 +59,7 @@ use crate::{
     },
     local_node::LocalNodeError,
     test_utils::{ClientOutcomeResultExt as _, FaultType},
-    worker::WorkerError,
+    worker::{Notification, Reason, WorkerError},
     Environment,
 };
 
@@ -2128,6 +2130,13 @@ async fn test_memory_read_event_downloads_publisher_chain(
 /// Tests that when a block execution needs events from a publisher chain that isn't
 /// locally available, the client automatically downloads the publisher chain certificates
 /// using the event block height index and retries.
+///
+/// The publisher chain is stored sparsely: only the blocks that emitted events are
+/// downloaded, not the ones in between. The first post's epoch is revoked before the
+/// receiver reads it, so the walk must also re-certify it: the epoch-1 post block is
+/// preprocessed first and vouches for the epoch-0 one via `previous_event_blocks`.
+/// Sparseness proves the recovery did not fall back to downloading contiguous
+/// descendants.
 async fn run_test_read_event_downloads_publisher_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
@@ -2137,8 +2146,14 @@ where
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
 
-    let sender = builder.add_root_chain(0, Amount::ONE).await?;
-    let receiver = builder.add_root_chain(1, Amount::ONE).await?;
+    let admin = builder.add_root_chain(0, Amount::ONE).await?;
+    let sender = builder.add_root_chain(1, Amount::ONE).await?;
+    let receiver = builder.add_root_chain(2, Amount::ONE).await?;
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
 
     // Deploy the social app on the receiver chain.
     let module_id = receiver.publish_wasm_example("social").await?;
@@ -2162,20 +2177,79 @@ where
         text: "Hello from sender!".to_string(),
         image_url: None,
     };
-    sender
+    let post_cert0 = sender
         .execute_operation(Operation::user(application_id, &post)?)
         .await
         .unwrap_ok_committed();
 
-    // Do NOT call receiver.synchronize_from_validators().
-    // Instead, directly execute an UpdateStreams operation that references the
-    // sender's event. The receiver doesn't have the sender's chain locally, so
-    // this will fail with EventsNotFound. The retry logic should use the event
-    // block height index to download only the needed certificates and succeed.
+    // Create epoch 1 and migrate the sender to it. The migration block emits no event,
+    // so the sender's second post commits to the first post's block directly, via
+    // `previous_event_blocks`.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
+        .await
+        .unwrap_ok_committed();
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let migration_cert = migration_certs.last().expect("migration block").clone();
+    assert_eq!(sender.chain_info().await?.epoch, Epoch::from(1));
+
+    let post = social::Operation::Post {
+        text: "Hello again!".to_string(),
+        image_url: None,
+    };
+    let post_cert1 = sender
+        .execute_operation(Operation::user(application_id, &post)?)
+        .await
+        .unwrap_ok_committed();
     let stream_id = StreamId {
         application_id: application_id.forget_abi().into(),
         stream_name: b"posts".into(),
     };
+    assert_eq!(
+        post_cert1.block().body.previous_event_blocks,
+        BTreeMap::from([(
+            stream_id.clone(),
+            (post_cert0.hash(), post_cert0.block().header.height)
+        )]),
+    );
+
+    // Migrate the receiver to epoch 1 as well, and revoke epoch 0. The receiver learns
+    // about both from admin-chain notifications, not from
+    // `synchronize_from_validators`: that would download the sender's event blocks
+    // eagerly, while epoch 0 is still live.
+    let notify_receiver = async |cert: &ConfirmedBlockCertificate| {
+        receiver
+            .process_notification_from(
+                Notification {
+                    chain_id: admin.chain_id(),
+                    reason: Reason::NewBlock {
+                        height: cert.block().header.height,
+                        hash: cert.hash(),
+                    },
+                },
+                validator,
+            )
+            .await
+    };
+    notify_receiver(&create_cert).await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    notify_receiver(&revoke_cert).await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
+
+    // Execute an UpdateStreams operation that references both of the sender's events.
+    // The receiver doesn't have the sender's chain locally, so this will fail with
+    // EventsNotFound. The retry logic should use the event block height index to
+    // download only the needed certificates and succeed.
     receiver
         .execute_operations(
             vec![SystemOperation::UpdateStream {
@@ -2183,7 +2257,7 @@ where
                 chain_id: sender.chain_id(),
                 stream_id,
                 first_index: 0,
-                next_index: 1,
+                next_index: 2,
             }
             .into()],
             vec![],
@@ -2191,7 +2265,7 @@ where
         .await
         .unwrap_ok_committed();
 
-    // Verify that the event was processed: query the received posts.
+    // Verify that the events were processed: query the received posts.
     let query = Request::new("{ receivedPosts { keys { author, index } } }");
     let outcome = receiver
         .query_user_application(application_id, &query)
@@ -2201,6 +2275,7 @@ where
             async_graphql::Value::from_json(json!({
                 "receivedPosts": {
                     "keys": [
+                        { "author": sender.chain_id(), "index": 1 },
                         { "author": sender.chain_id(), "index": 0 }
                     ]
                 }
@@ -2210,6 +2285,15 @@ where
         operations: vec![],
     };
     assert_eq!(outcome, expected);
+
+    // Only the sender's event-bearing blocks should be in the receiver's storage. In
+    // particular, the revoked-epoch post at height 0 was accepted through the
+    // `previous_event_blocks` vouching, not by walking contiguous descendants — which
+    // would have downloaded the migration block in between.
+    let storage = receiver.storage_client();
+    assert!(storage.contains_certificate(post_cert0.hash()).await?);
+    assert!(storage.contains_certificate(post_cert1.hash()).await?);
+    assert!(!storage.contains_certificate(migration_cert.hash()).await?);
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3396,6 +3396,156 @@ where
     Ok(())
 }
 
+/// Tests that a revoked-epoch sender block is accepted when a later accepted block
+/// commits to it via `previous_message_blocks` — without the worker ever seeing the
+/// non-sender block in between. This is what lets a receiver's client re-certify a
+/// sender's old messages by downloading only the message-bearing blocks.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_revoked_epoch_block_vouched_via_previous_message_blocks<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut env =
+        TestEnvironment::new_with_amount(&mut storage_builder, false, false, Amount::ZERO).await?;
+    let mut signer = InMemorySigner::new(None);
+    let owner1 = signer.generate_new().into();
+    let chain_1_desc = env.add_root_chain(1, owner1, Amount::from_tokens(3)).await;
+    let committee = env.committee().clone();
+    let admin_chain_id = env.admin_chain_id();
+    let user_id = chain_1_desc.id();
+
+    // Height 0 (epoch 0): a transfer to the admin chain — the sender block that
+    // will later need re-certification.
+    let proposal_msg0 = make_first_block(user_id)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let cert_msg0 = env.execute_proposal(proposal_msg0, vec![]).await?;
+
+    // Have the admin chain create epoch 1.
+    let committee_blob = Blob::new(BlobContent::new_committee(bcs::to_bytes(&committee)?));
+    let blob_hash = committee_blob.id().hash;
+    env.write_blobs(std::slice::from_ref(&committee_blob))
+        .await?;
+    let proposal_create = make_first_block(admin_chain_id).with_operation(SystemOperation::Admin(
+        AdminOperation::CreateCommittee {
+            epoch: Epoch::from(1),
+            blob_hash,
+        },
+    ));
+    let cert_create = env.execute_proposal(proposal_create, vec![]).await?;
+
+    // Height 1 (epoch 0): the user chain migrates to epoch 1 without sending any
+    // message. Height 2 (epoch 1): another transfer to the admin chain, which
+    // commits to the height-0 block via `previous_message_blocks`.
+    let proposal_mid = make_child_block(&cert_msg0.clone().into_value())
+        .with_operation(SystemOperation::ProcessNewEpoch(Epoch::from(1)))
+        .with_authenticated_owner(Some(owner1));
+    let cert_mid = env.execute_proposal(proposal_mid, vec![]).await?;
+    let proposal_msg1 = make_child_block(&cert_mid.clone().into_value())
+        .with_epoch(1)
+        .with_simple_transfer(admin_chain_id, Amount::ONE)
+        .with_authenticated_owner(Some(owner1));
+    let cert_msg1 = env.execute_proposal(proposal_msg1, vec![]).await?;
+    assert_eq!(
+        cert_msg1.block().body.previous_message_blocks,
+        BTreeMap::from([(admin_chain_id, (cert_msg0.hash(), BlockHeight::ZERO))]),
+    );
+
+    // Retire epoch 0.
+    let proposal_revoke = make_child_block(&cert_create.clone().into_value())
+        .with_epoch(1)
+        .with_operation(SystemOperation::Admin(AdminOperation::RemoveCommittee {
+            epoch: Epoch::ZERO,
+        }));
+    let cert_revoke = env.execute_proposal(proposal_revoke, vec![]).await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_create.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_revoke.clone(), &())
+        .await?;
+
+    // The height-0 block is rejected: its epoch is revoked and nothing vouches for
+    // it yet.
+    let error = env
+        .worker()
+        .fully_handle_certificate_with_notifications(cert_msg0.clone(), &())
+        .await
+        .unwrap_err();
+    assert_matches!(
+        error,
+        WorkerError::EpochRevoked {
+            epoch: Epoch::ZERO,
+            ..
+        }
+    );
+
+    // Preprocessing the epoch-1 sender block at height 2 vouches for the height-0
+    // block via `previous_message_blocks` (and for its parent at height 1 via
+    // `previous_block_hash`). The height-0 block is then accepted and executes —
+    // the worker never saw the non-sender block at height 1.
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg1.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg0.clone(), &())
+        .await?;
+
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(1),
+            user_chain.tip_state.get().next_block_height
+        );
+        // The height-0 message has not reached the admin chain yet:
+        // `select_message_bundles` refuses a revoked-epoch bundle that arrives on
+        // its own. It is only accepted once a later bundle from a trusted epoch is
+        // in the same batch.
+        let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
+        assert!(admin_chain.inboxes.indices().await?.is_empty());
+    }
+
+    // The migration block at height 1 is also vouched for (as the height-2 block's
+    // parent), so it is accepted despite its revoked epoch. With the chain tip then
+    // at height 2, re-sending the height-2 block executes it, which schedules its
+    // message: the outbox batch now pairs the revoked-epoch bundle with the epoch-1
+    // bundle behind it, and the admin chain accepts both.
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_mid.clone(), &())
+        .await?;
+    env.worker()
+        .fully_handle_certificate_with_notifications(cert_msg1.clone(), &())
+        .await?;
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert_eq!(
+            BlockHeight::from(3),
+            user_chain.tip_state.get().next_block_height
+        );
+        // All trust marks have been consumed.
+        assert!(user_chain.vouched_blocks.indices().await?.is_empty());
+        let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
+        let inbox = admin_chain
+            .inboxes
+            .try_load_entry(&user_id)
+            .await?
+            .expect("admin chain should have an inbox for the user chain");
+        let first_bundle = inbox.added_bundles.front().await?;
+        assert_eq!(
+            first_bundle.map(|bundle| bundle.height),
+            Some(BlockHeight::ZERO),
+            "the re-certified height-0 message should have been delivered",
+        );
+    }
+
+    Ok(())
+}
+
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let mut storage_builder = MemoryStorageBuilder::default();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3502,19 +3502,27 @@ where
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
         );
-        // The height-0 message has not reached the admin chain yet:
-        // `select_message_bundles` refuses a revoked-epoch bundle that arrives on
-        // its own. It is only accepted once a later bundle from a trusted epoch is
-        // in the same batch.
+        // The height-0 message reached the admin chain: the sender worker accepted
+        // the block through the trust mark, so its bundle is delivered even though
+        // its epoch is revoked.
         let admin_chain = env.worker().chain_state_view(admin_chain_id).await?;
-        assert!(admin_chain.inboxes.indices().await?.is_empty());
+        let inbox = admin_chain
+            .inboxes
+            .try_load_entry(&user_id)
+            .await?
+            .expect("admin chain should have an inbox for the user chain");
+        let first_bundle = inbox.added_bundles.front().await?;
+        assert_eq!(
+            first_bundle.map(|bundle| bundle.height),
+            Some(BlockHeight::ZERO),
+            "the re-certified height-0 message should have been delivered",
+        );
     }
 
     // The migration block at height 1 is also vouched for (as the height-2 block's
     // parent), so it is accepted despite its revoked epoch. With the chain tip then
     // at height 2, re-sending the height-2 block executes it, which schedules its
-    // message: the outbox batch now pairs the revoked-epoch bundle with the epoch-1
-    // bundle behind it, and the admin chain accepts both.
+    // message behind the height-0 one; the admin chain accepts it as well.
     env.worker()
         .fully_handle_certificate_with_notifications(cert_mid.clone(), &())
         .await?;
@@ -3535,11 +3543,11 @@ where
             .try_load_entry(&user_id)
             .await?
             .expect("admin chain should have an inbox for the user chain");
-        let first_bundle = inbox.added_bundles.front().await?;
+        let last_bundle = inbox.added_bundles.back().await?;
         assert_eq!(
-            first_bundle.map(|bundle| bundle.height),
-            Some(BlockHeight::ZERO),
-            "the re-certified height-0 message should have been delivered",
+            last_bundle.map(|bundle| bundle.height),
+            Some(BlockHeight::from(2)),
+            "the height-2 message should have been delivered behind the height-0 one",
         );
     }
 
@@ -3693,8 +3701,9 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let chain_1 = env
         .add_root_chain(1, AccountOwner::CHAIN, Amount::ZERO)
         .await;
-    // Mark epoch 0 as revoked so the helper rejects bundles signed by it,
-    // unless they're re-certified by a later trusted-epoch bundle.
+    // Mark epoch 0 as revoked. The helper must deliver its bundles anyway: they
+    // come from the local worker for the sender chain, which only accepts blocks
+    // it trusts.
     env.worker()
         .storage_client()
         .write_events([(
@@ -3803,19 +3812,25 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     }
 
     let worker = env.worker();
-    // Bundles from a revoked epoch are rejected.
+    // Bundles are delivered regardless of their epoch's revocation.
     assert_eq!(
         worker
-            .select_message_bundles(id1, &id0, BlockHeight::ZERO, None, bundles01.clone())
+            .select_message_bundles(id1, &id0, BlockHeight::ZERO, bundles0123.clone())
             .await?,
-        vec![]
+        without_epochs(&bundles0123)
     );
     // Already-received bundles are skipped, regardless of epoch.
     assert_eq!(
         worker
-            .select_message_bundles(id1, &id0, BlockHeight::from(2), None, bundles01.clone())
+            .select_message_bundles(id1, &id0, BlockHeight::from(2), bundles01.clone())
             .await?,
         vec![]
+    );
+    assert_eq!(
+        worker
+            .select_message_bundles(id1, &id0, BlockHeight::from(1), bundles012.clone())
+            .await?,
+        without_epochs(bundles1.iter().chain(&bundles2))
     );
     // Order of certificates is checked.
     assert_matches!(
@@ -3824,7 +3839,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
                 id1,
                 &id0,
                 BlockHeight::ZERO,
-                None,
                 bundles1
                     .iter()
                     .cloned()
@@ -3833,49 +3847,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             )
             .await,
         Err(WorkerError::InvalidCrossChainRequest)
-    );
-
-    // A later bundle in a still-trusted epoch re-certifies preceding revoked-epoch
-    // bundles via prev-hash chaining, but a trailing revoked-epoch bundle (heights 3+)
-    // beyond the trusted one is dropped.
-    assert_eq!(
-        worker
-            .select_message_bundles(id1, &id0, BlockHeight::ZERO, None, bundles0123.clone())
-            .await?,
-        without_epochs(&bundles012)
-    );
-    // Skipping bundle 0 still works with re-certification across epochs.
-    assert_eq!(
-        worker
-            .select_message_bundles(id1, &id0, BlockHeight::from(1), None, bundles012.clone())
-            .await?,
-        without_epochs(bundles1.iter().chain(&bundles2))
-    );
-    // Anticipation: bundles up to `last_anticipated_block_height` are accepted even
-    // from a revoked epoch.
-    assert_eq!(
-        worker
-            .select_message_bundles(
-                id1,
-                &id0,
-                BlockHeight::from(1),
-                Some(BlockHeight::from(1)),
-                bundles01.clone()
-            )
-            .await?,
-        without_epochs(&bundles1)
-    );
-    assert_eq!(
-        worker
-            .select_message_bundles(
-                id1,
-                &id0,
-                BlockHeight::ZERO,
-                Some(BlockHeight::from(1)),
-                bundles01.clone()
-            )
-            .await?,
-        without_epochs(&bundles01)
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3546,6 +3546,146 @@ where
     Ok(())
 }
 
+/// Tests that a block committing to a different hash than the one already accepted
+/// at that height is rejected: two certified blocks at the same height prove that
+/// the height's committee equivocated, and neither the conflicting block nor the
+/// block vouching for it must be accepted.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_conflicting_certified_blocks_are_rejected<B>(
+    mut storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let mut signer = InMemorySigner::new(None);
+    let owner_pubkey = signer.generate_new();
+    let owner = AccountOwner::from(owner_pubkey);
+    let balance = Amount::from_tokens(5);
+    let mut env = TestEnvironment::new(&mut storage_builder, false, false).await?;
+    let chain_1_desc = env.add_root_chain(1, owner, balance).await;
+    let chain_2_desc = env.add_root_chain(2, owner, Amount::ZERO).await;
+    let user_id = chain_1_desc.id();
+    let target = Account::chain(chain_2_desc.id());
+
+    // Two conflicting certified blocks at height 0, and a child of the second one.
+    let cert_a = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::ONE,
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![],
+        )
+        .await;
+    let cert_b = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::from_tokens(2),
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![],
+        )
+        .await;
+    assert_ne!(cert_a.hash(), cert_b.hash());
+    let cert_child = env
+        .make_transfer_certificate_for_epoch_unprocessable(
+            chain_1_desc.clone(),
+            owner_pubkey,
+            owner,
+            AccountOwner::CHAIN,
+            target,
+            Amount::ONE,
+            vec![],
+            Epoch::ZERO,
+            balance,
+            BTreeMap::new(),
+            vec![&cert_b],
+        )
+        .await;
+
+    // Preprocess the first block at height 0, then a child of the *conflicting*
+    // block: the child's `previous_block_hash` commitment exposes the equivocation
+    // and the child is rejected instead of vouching for the conflicting block.
+    env.worker()
+        .handle_confirmed_certificate(cert_a.clone(), ProcessConfirmedBlockMode::Preprocess, None)
+        .await?;
+    let error = env
+        .worker()
+        .handle_confirmed_certificate(
+            cert_child.clone(),
+            ProcessConfirmedBlockMode::Preprocess,
+            None,
+        )
+        .await
+        .unwrap_err();
+    let conflict = match &error {
+        WorkerError::ChainError(chain_error) => match &**chain_error {
+            ChainError::ConflictingCertifiedBlocks(conflict) => conflict,
+            other => panic!("expected a conflicting-blocks error, got {other}"),
+        },
+        other => panic!("expected a conflicting-blocks error, got {other}"),
+    };
+    // The child commits to the conflicting height-0 block via its parent link, so
+    // it is the witness; the existing block is the one accepted at that height.
+    assert_eq!(conflict.existing_block, cert_a.hash());
+    assert_eq!(conflict.conflicting_block, cert_b.hash());
+    assert_eq!(conflict.witness_block, cert_child.hash());
+    assert_eq!(conflict.height, BlockHeight::ZERO);
+
+    // Nothing was vouched for, and the child was not accepted. (The view holds a
+    // read lock on the chain worker, so drop it before the next request.)
+    {
+        let user_chain = env.worker().chain_state_view(user_id).await?;
+        assert!(user_chain.vouched_blocks.indices().await?.is_empty());
+        assert_eq!(
+            user_chain.block_hashes.get(&BlockHeight::from(1)).await?,
+            None
+        );
+    }
+
+    // Pushing the conflicting height-0 block itself is rejected the same way, with
+    // the block as its own witness — and rejected before it is written anywhere.
+    let error = env
+        .worker()
+        .handle_confirmed_certificate(cert_b.clone(), ProcessConfirmedBlockMode::Preprocess, None)
+        .await
+        .unwrap_err();
+    let conflict = match &error {
+        WorkerError::ChainError(chain_error) => match &**chain_error {
+            ChainError::ConflictingCertifiedBlocks(conflict) => conflict,
+            other => panic!("expected a conflicting-blocks error, got {other}"),
+        },
+        other => panic!("expected a conflicting-blocks error, got {other}"),
+    };
+    assert_eq!(conflict.existing_block, cert_a.hash());
+    assert_eq!(conflict.conflicting_block, cert_b.hash());
+    assert_eq!(conflict.witness_block, cert_b.hash());
+    assert!(
+        !env.worker()
+            .storage
+            .contains_certificate(cert_b.hash())
+            .await?,
+        "the rejected conflicting certificate must not be persisted",
+    );
+
+    Ok(())
+}
+
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let mut storage_builder = MemoryStorageBuilder::default();

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -13,7 +13,7 @@ use std::{
 use futures::{future, Future, StreamExt};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{ArithmeticError, BlockHeight, Epoch, Round, TimeDelta},
+    data_types::{BlockHeight, Epoch, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, BlobType, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
@@ -251,7 +251,8 @@ where
         // Certificates still to be sent, in reverse sending order: when the validator
         // rejects the top entry because its epoch is revoked, the descendants that
         // re-certify it are stacked on top of it, so every rejected block is preceded
-        // by the child vouching for it via `previous_block_hash`.
+        // by the blocks vouching for it — each one committing to the next via
+        // `previous_block_hash`, `previous_message_blocks` or `previous_event_blocks`.
         let mut stack = vec![certificate.clone()];
         let mut expanded = HashSet::new();
         loop {
@@ -893,9 +894,13 @@ where
     }
 
     /// Reads this chain's certificates from local storage, from `height + 1` up to
-    /// and including the first one from an epoch later than `epoch`. Returns `None`
-    /// if storage runs out of blocks before a later-epoch one is found — then the
-    /// vouching chain cannot be completed.
+    /// and including the first one from an epoch later than `epoch`. Heights we hold
+    /// no certificate for are skipped: on a sparsely stored chain, each held block is
+    /// committed to by the next-higher held one — via `previous_block_hash`,
+    /// `previous_message_blocks` or `previous_event_blocks` — so the validator can
+    /// still accept them in decreasing height order. Returns `None` if none of the
+    /// blocks we hold is from a later epoch — then the vouching chain cannot be
+    /// completed.
     async fn read_descendants_up_to_next_epoch(
         &self,
         chain_id: ChainId,
@@ -904,35 +909,31 @@ where
     ) -> Result<Option<Vec<CacheArc<ConfirmedBlockCertificate>>>, chain_client::Error> {
         let storage = self.client.local_node.storage_client();
         let batch_size = self.client.options().certificate_upload_batch_size as u64;
+        let end = self
+            .client
+            .local_node
+            .get_next_height_to_preprocess(chain_id)
+            .await?;
         let mut certificates = Vec::new();
         let mut next_height = height.try_add_one()?;
-        loop {
-            let heights = (0..batch_size)
-                .map(|offset| {
-                    u64::from(next_height)
-                        .checked_add(offset)
-                        .map(BlockHeight)
-                        .ok_or(ArithmeticError::Overflow)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
+        while next_height < end {
+            let batch_end = u64::from(end).min(u64::from(next_height).saturating_add(batch_size));
+            let heights = (u64::from(next_height)..batch_end)
+                .map(BlockHeight)
+                .collect::<Vec<_>>();
             let batch = storage
                 .read_certificates_by_heights(chain_id, &heights)
-                .await?
-                .into_iter()
-                .map_while(|maybe_certificate| maybe_certificate)
-                .collect::<Vec<_>>();
-            if batch.is_empty() {
-                return Ok(None);
-            }
-            for certificate in batch {
+                .await?;
+            for certificate in batch.into_iter().flatten() {
                 let is_later_epoch = certificate.block().header.epoch > epoch;
                 certificates.push(certificate);
                 if is_later_epoch {
                     return Ok(Some(certificates));
                 }
-                next_height = next_height.try_add_one()?;
             }
+            next_height = BlockHeight(batch_end);
         }
+        Ok(None)
     }
 
     /// Reads certificates for the given heights from storage.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -378,9 +378,10 @@ pub enum WorkerError {
     },
     /// The certificate's epoch has been revoked on the admin chain, so its
     /// signatures alone no longer prove anything, and no block this worker already
-    /// trusts vouches for the block. The client can recover by uploading the
-    /// block's descendants in decreasing height order: each accepted descendant
-    /// re-certifies its parent via `previous_block_hash`.
+    /// trusts vouches for the block. The client can recover by uploading blocks
+    /// that transitively commit to this one in decreasing height order: each
+    /// accepted block vouches for the blocks it references via
+    /// `previous_block_hash` and `previous_message_blocks`.
     #[error(
         "Cannot trust the certificate for block at height {height} on chain {chain_id}: \
         epoch {epoch} has been revoked and no trusted block vouches for the block"
@@ -429,11 +430,11 @@ pub enum WorkerError {
     #[error("Blobs not found: {0:?}")]
     BlobsNotFound(Vec<BlobId>),
     /// Variant raised when the chain references these block hashes via a
-    /// verified-checkpoint trust mark (`pre_checkpoint_block_trust`) but the
-    /// actual content isn't in storage yet. The caller is expected to upload
-    /// each missing block via `handle_confirmed_certificate`; the trust-mark
-    /// accept path verifies the cert against its own (possibly revoked)
-    /// epoch's committee and writes it through.
+    /// trust mark (`vouched_blocks`) but the actual content isn't in storage
+    /// yet. The caller is expected to upload each missing block via
+    /// `handle_confirmed_certificate`; the trust-mark accept path verifies the
+    /// cert against its own (possibly revoked) epoch's committee and writes it
+    /// through.
     #[error("Blocks not found: {0:?}")]
     BlocksNotFound(Vec<CryptoHash>),
     #[error("Block hash at height {height} for chain {chain_id} not found")]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1588,19 +1588,11 @@ where
         recipient: ChainId,
         origin: &ChainId,
         next_height_to_receive: BlockHeight,
-        last_anticipated_block_height: Option<BlockHeight>,
         bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Vec<MessageBundle>, WorkerError> {
         let state = self.get_or_create_chain_worker(recipient).await?;
         let guard = handle::read_lock(&state).await?;
-        guard
-            .select_message_bundles(
-                origin,
-                next_height_to_receive,
-                last_anticipated_block_height,
-                bundles,
-            )
-            .await
+        guard.select_message_bundles(origin, next_height_to_receive, bundles)
     }
 
     /// Test helper that runs `ChainWorkerState::reset_and_reexecute_chain` for the given

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -428,15 +428,16 @@ type ChainStateExtendedView {
 	"""
 	latestCheckpointHeight: BlockHeight
 	"""
-	Hashes of pre-checkpoint sender blocks the chain has seen a checkpoint cert
-	vouch for via `outbox_block_hashes`, but whose actual cert bytes are not yet
-	in storage. The worker errors a checkpoint push with
-	`BlocksNotFound` when this set is non-empty, then accepts each
-	referenced cert (regardless of its own — possibly revoked — epoch) and
-	removes the entry. Once the set is empty, the checkpoint restoration can run
-	end-to-end.
+	Hashes of blocks that are vouched for by data this chain already trusts, but
+	have not been processed here yet. A hash is inserted when a trusted source
+	commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
+	block's `previous_block_hash` or `previous_message_blocks` links (unless the
+	referenced block is already in `block_hashes`). The worker accepts a cert
+	whose hash is in this set regardless of its epoch — the epoch may be revoked,
+	but the hash commitment makes the block trustworthy — and removes the entry
+	upon acceptance.
 	"""
-	preCheckpointBlockTrust: SetView_CryptoHash_87fbb60c!
+	vouchedBlocks: SetView_CryptoHash_87fbb60c!
 	"""
 	The hash of the set of fully-tracked chains that `nonempty_outboxes` and
 	`outbox_counters` were last reconciled against. On a client these two indices only hold

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -431,8 +431,9 @@ type ChainStateExtendedView {
 	Hashes of blocks that are vouched for by data this chain already trusts, but
 	have not been processed here yet. A hash is inserted when a trusted source
 	commits to it: a checkpoint cert's `outbox_block_hashes`, or an accepted
-	block's `previous_block_hash` or `previous_message_blocks` links (unless the
-	referenced block is already in `block_hashes`). The worker accepts a cert
+	block's `previous_block_hash`, `previous_message_blocks` or
+	`previous_event_blocks` links (unless the referenced block is already in
+	`block_hashes`). The worker accepts a cert
 	whose hash is in this set regardless of its epoch — the epoch may be revoked,
 	but the hash commitment makes the block trustworthy — and removes the entry
 	upon acceptance.


### PR DESCRIPTION
## Motivation

Re-certifying a revoked-epoch block by walking its descendants means downloading every block in between, even though almost none of them are needed: on a sparse chain, a receiver may care about two message blocks a thousand heights apart.

## Proposal

Blocks already commit to the hashes of the blocks they refer to: `previous_message_blocks` points at the last block that sent a message to a given recipient, `previous_event_blocks` at the last block that emitted an event on a given stream. Treat those the same way as the parent hash: when a block is accepted, vouch for everything it commits to. A receiver can then re-certify an old sender block by downloading only the message-bearing blocks, and a subscriber only the event-bearing ones — preprocessing them newest-first, so each block vouches for the next-older one.

A block that commits to a different hash than the one already accepted at that height is proof that a committee equivocated. Reject it before it is written to storage, and log the conflict at ERROR level.

## Test Plan

CI, plus unit tests that re-certify a revoked-epoch block through a `previous_message_blocks` link and through a `previous_event_blocks` link, asserting in both cases that the blocks in between are never downloaded. Conflicting certified blocks are covered by a worker test.

## Release Plan

  - Nothing to do / These changes follow the usual release cycle.

## Links

  - Stacked on #6601.
  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)