### PR TITLE
Keep the received log per sender epoch

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
 };
 
@@ -25,7 +25,7 @@ use linera_execution::{
     ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
-    collection_view::CollectionView,
+    collection_view::CustomCollectionView,
     context::Context,
     log_view::LogView,
     map_view::{CustomMapView, MapView},
@@ -313,11 +313,12 @@ where
     /// cannot verify those certificates on their own anymore, and blocks that still
     /// matter are re-certified via `previous_block_hash` /
     /// `previous_message_blocks` links instead.
-    pub received_log: CollectionView<C, Epoch, LogView<C, ChainAndHeight>>,
+    pub received_log: CustomCollectionView<C, Epoch, LogView<C, ChainAndHeight>>,
     /// The number of `received_log` entries we have synchronized, per validator and
-    /// per sender epoch.
-    pub received_certificate_trackers:
-        RegisterView<C, HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>>,
+    /// per sender epoch. Node-local synchronization bookkeeping, not exposed via
+    /// GraphQL.
+    #[cfg_attr(with_graphql, graphql(skip))]
+    pub received_certificate_trackers: MapView<C, (ValidatorPublicKey, Epoch), u64>,
 
     /// Mailboxes used to receive messages indexed by their origin.
     pub inboxes: ReentrantCollectionView<C, ChainId, InboxStateView<C>>,
@@ -661,29 +662,22 @@ where
     }
 
     /// Updates the `received_log` trackers.
-    pub fn update_received_certificate_trackers(
+    pub async fn update_received_certificate_trackers(
         &mut self,
         new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
-    ) {
+    ) -> Result<(), ChainError> {
         for (name, epoch_trackers) in new_trackers {
-            let trackers = self
-                .received_certificate_trackers
-                .get_mut()
-                .entry(name)
-                .or_default();
             for (epoch, tracker) in epoch_trackers {
-                trackers
-                    .entry(epoch)
-                    .and_modify(|t| {
-                        // Because several synchronizations could happen in parallel, we need to
-                        // make sure to never go backward.
-                        if tracker > *t {
-                            *t = tracker;
-                        }
-                    })
-                    .or_insert(tracker);
+                let key = (name, epoch);
+                // Because several synchronizations could happen in parallel, we need to
+                // make sure to never go backward.
+                let current = self.received_certificate_trackers.get(&key).await?;
+                if current.is_none_or(|current| tracker > current) {
+                    self.received_certificate_trackers.insert(&key, tracker)?;
+                }
             }
         }
+        Ok(())
     }
 
     /// Returns the current epoch and committee of this chain.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -25,6 +25,7 @@ use linera_execution::{
     ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
+    collection_view::CollectionView,
     context::Context,
     log_view::LogView,
     map_view::{CustomMapView, MapView},
@@ -306,10 +307,17 @@ where
     /// `height < next_block_height` is executed; a block at `height >= next_block_height`
     /// is preprocessed (verified but not yet executed) and may not be contiguous.
     pub block_hashes: CustomMapView<C, BlockHeight, CryptoHash>,
-    /// Sender chain and height of all certified blocks known as a receiver (local ordering).
-    pub received_log: LogView<C, ChainAndHeight>,
-    /// The number of `received_log` entries we have synchronized, for each validator.
-    pub received_certificate_trackers: RegisterView<C, HashMap<ValidatorPublicKey, u64>>,
+    /// Sender chain and height of all certified blocks known as a receiver (local
+    /// ordering), keyed by the epoch of the sender block's certificate. Partitioned
+    /// by epoch so that a revoked epoch's log can be dropped wholesale: clients
+    /// cannot verify those certificates on their own anymore, and blocks that still
+    /// matter are re-certified via `previous_block_hash` /
+    /// `previous_message_blocks` links instead.
+    pub received_log: CollectionView<C, Epoch, LogView<C, ChainAndHeight>>,
+    /// The number of `received_log` entries we have synchronized, per validator and
+    /// per sender epoch.
+    pub received_certificate_trackers:
+        RegisterView<C, HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>>,
 
     /// Mailboxes used to receive messages indexed by their origin.
     pub inboxes: ReentrantCollectionView<C, ChainId, InboxStateView<C>>,
@@ -598,6 +606,7 @@ where
         &mut self,
         inbox: &mut InboxStateView<C>,
         origin: &ChainId,
+        epoch: Epoch,
         bundle: MessageBundle,
         local_time: Timestamp,
         add_to_received_log: bool,
@@ -643,7 +652,10 @@ where
 
         // Remember the certificate for future validator/client synchronizations.
         if add_to_received_log {
-            self.received_log.push(chain_and_height);
+            self.received_log
+                .load_entry_mut(&epoch)
+                .await?
+                .push(chain_and_height);
         }
         Ok(())
     }
@@ -651,20 +663,26 @@ where
     /// Updates the `received_log` trackers.
     pub fn update_received_certificate_trackers(
         &mut self,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) {
-        for (name, tracker) in new_trackers {
-            self.received_certificate_trackers
+        for (name, epoch_trackers) in new_trackers {
+            let trackers = self
+                .received_certificate_trackers
                 .get_mut()
                 .entry(name)
-                .and_modify(|t| {
-                    // Because several synchronizations could happen in parallel, we need to make
-                    // sure to never go backward.
-                    if tracker > *t {
-                        *t = tracker;
-                    }
-                })
-                .or_insert(tracker);
+                .or_default();
+            for (epoch, tracker) in epoch_trackers {
+                trackers
+                    .entry(epoch)
+                    .and_modify(|t| {
+                        // Because several synchronizations could happen in parallel, we need to
+                        // make sure to never go backward.
+                        if tracker > *t {
+                            *t = tracker;
+                        }
+                    })
+                    .or_insert(tracker);
+            }
         }
     }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -315,10 +315,12 @@ where
     /// `previous_message_blocks` links instead.
     pub received_log: CustomCollectionView<C, Epoch, LogView<C, ChainAndHeight>>,
     /// The number of `received_log` entries we have synchronized, per validator and
-    /// per sender epoch. Node-local synchronization bookkeeping, not exposed via
-    /// GraphQL.
+    /// per sender epoch. There are only few epochs at a time, so we keep them all in a
+    /// single entry per validator. Node-local synchronization bookkeeping, not exposed
+    /// via GraphQL.
     #[cfg_attr(with_graphql, graphql(skip))]
-    pub received_certificate_trackers: MapView<C, (ValidatorPublicKey, Epoch), u64>,
+    pub received_certificate_trackers:
+        MapView<C, ValidatorPublicKey, NonCanonicalBTreeMap<Epoch, u64>>,
 
     /// Mailboxes used to receive messages indexed by their origin.
     pub inboxes: ReentrantCollectionView<C, ChainId, InboxStateView<C>>,
@@ -667,14 +669,22 @@ where
         new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), ChainError> {
         for (name, epoch_trackers) in new_trackers {
+            let mut trackers = self
+                .received_certificate_trackers
+                .get(&name)
+                .await?
+                .unwrap_or_default();
+            let mut changed = false;
             for (epoch, tracker) in epoch_trackers {
-                let key = (name, epoch);
                 // Because several synchronizations could happen in parallel, we need to
                 // make sure to never go backward.
-                let current = self.received_certificate_trackers.get(&key).await?;
-                if current.is_none_or(|current| tracker > current) {
-                    self.received_certificate_trackers.insert(&key, tracker)?;
+                if tracker > trackers.get(&epoch).copied().unwrap_or(0) {
+                    trackers.insert(epoch, tracker);
+                    changed = true;
                 }
+            }
+            if changed {
+                self.received_certificate_trackers.insert(&name, trackers)?;
             }
         }
         Ok(())

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -54,9 +54,7 @@ use tracing::{debug, info, instrument, trace, warn};
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
     client::{ChainModes, ListeningMode},
-    data_types::{
-        ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest, ReceivedLogQuery,
-    },
+    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
 
@@ -436,41 +434,49 @@ where
         if query.request_fallback {
             self.vote_for_fallback().await?;
         }
-        if let Some(ReceivedLogQuery { epoch, .. }) = query.request_received_log {
-            self.prune_revoked_received_logs(epoch).await?;
+        if let Some(up_to) = query.request_received_log.keys().next().copied() {
+            self.prune_revoked_received_logs(up_to).await?;
         }
         self.prepare_chain_info_response(query).await
     }
 
     /// Removes the received logs of revoked epochs below `up_to`. Run whenever a
-    /// client asks for a received log: entries of revoked epochs are useless to
-    /// clients — the certificates they point to can no longer be verified on their
-    /// own, and blocks that still matter are re-certified via
-    /// `previous_block_hash` / `previous_message_blocks` links instead.
+    /// client asks for received logs, with `up_to` the lowest requested epoch:
+    /// entries of revoked epochs are useless to clients — the certificates they
+    /// point to can no longer be verified on their own, and blocks that still
+    /// matter are re-certified via `previous_block_hash` /
+    /// `previous_message_blocks` links instead.
     async fn prune_revoked_received_logs(&mut self, up_to: Epoch) -> Result<(), WorkerError> {
-        let mut pruned = false;
-        for stored_epoch in self.chain.received_log.indices().await? {
-            if stored_epoch >= up_to {
-                continue;
-            }
-            let is_revoked =
-                self.storage
-                    .is_epoch_revoked(stored_epoch)
-                    .await
-                    .map_err(|error| {
-                        WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                            Box::new(error),
-                            ChainExecutionContext::Block,
-                        )))
-                    })?;
+        // `indices` returns the stored epochs in ascending order. Walk the ones
+        // below `up_to` from newest to oldest: revocation is monotone, so the
+        // first revoked epoch found — and everything below it — can be pruned
+        // without further checks.
+        let mut stored = self.chain.received_log.indices().await?;
+        stored.retain(|epoch| *epoch < up_to);
+        let mut prunable = None;
+        for (position, epoch) in stored.iter().enumerate().rev() {
+            let is_revoked = self
+                .storage
+                .is_epoch_revoked(*epoch)
+                .await
+                .map_err(|error| {
+                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                        Box::new(error),
+                        ChainExecutionContext::Block,
+                    )))
+                })?;
             if is_revoked {
-                self.chain.received_log.remove_entry(&stored_epoch)?;
-                pruned = true;
+                prunable = Some(position);
+                break;
             }
         }
-        if pruned {
-            self.save().await?;
+        let Some(position) = prunable else {
+            return Ok(());
+        };
+        for epoch in &stored[..=position] {
+            self.chain.received_log.remove_entry(epoch)?;
         }
+        self.save().await?;
         Ok(())
     }
 
@@ -1986,7 +1992,38 @@ where
         new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), WorkerError> {
         self.chain
-            .update_received_certificate_trackers(new_trackers);
+            .update_received_certificate_trackers(new_trackers)
+            .await?;
+        // Drop tracker entries for revoked epochs: those epochs' received logs are
+        // pruned by validators and never queried again. Revocation is monotone, so
+        // the walk over the ascending epoch set can stop at the first live one.
+        let keys = self.chain.received_certificate_trackers.indices().await?;
+        let epochs = keys
+            .iter()
+            .map(|(_, epoch)| *epoch)
+            .collect::<BTreeSet<_>>();
+        let mut revoked_epochs = BTreeSet::new();
+        for epoch in epochs {
+            let is_revoked = self
+                .storage
+                .is_epoch_revoked(epoch)
+                .await
+                .map_err(|error| {
+                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                        Box::new(error),
+                        ChainExecutionContext::Block,
+                    )))
+                })?;
+            if !is_revoked {
+                break;
+            }
+            revoked_epochs.insert(epoch);
+        }
+        for key in keys {
+            if revoked_epochs.contains(&key.1) {
+                self.chain.received_certificate_trackers.remove(&key)?;
+            }
+        }
         self.save().await?;
         Ok(())
     }
@@ -2132,7 +2169,19 @@ where
     pub(crate) async fn get_received_certificate_trackers(
         &self,
     ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, WorkerError> {
-        Ok(self.chain.received_certificate_trackers.get().clone())
+        let mut trackers = HashMap::<_, BTreeMap<Epoch, u64>>::new();
+        for ((validator, epoch), tracker) in self
+            .chain
+            .received_certificate_trackers
+            .index_values()
+            .await?
+        {
+            trackers
+                .entry(validator)
+                .or_default()
+                .insert(epoch, tracker);
+        }
+        Ok(trackers)
     }
 
     /// Gets tip state and outbox info for next_outbox_heights calculation.
@@ -2741,15 +2790,24 @@ where
             .block_hashes_for_heights(query.request_sent_certificate_hashes_by_heights)
             .await?;
         info.requested_sent_certificate_hashes = hashes;
-        if let Some(ReceivedLogQuery { epoch, skip }) = query.request_received_log {
-            let skip = usize::try_from(skip).map_err(|_| ArithmeticError::Overflow)?;
-            let max_received_log_entries = self.config.chain_info_max_received_log_entries;
-            if let Some(log) = chain.received_log.try_load_entry(&epoch).await? {
-                let end = skip
-                    .saturating_add(max_received_log_entries)
-                    .min(log.count());
+        if !query.request_received_log.is_empty() {
+            // Serve the requested epochs in ascending order, bounding the total
+            // number of entries in the response: if the bound cuts an epoch's log
+            // short, the client repeats the request with advanced offsets.
+            let mut remaining = self.config.chain_info_max_received_log_entries;
+            for (epoch, skip) in query.request_received_log {
+                if remaining == 0 {
+                    break;
+                }
+                let skip = usize::try_from(skip).map_err(|_| ArithmeticError::Overflow)?;
+                let Some(log) = chain.received_log.try_load_entry(&epoch).await? else {
+                    continue;
+                };
+                let end = skip.saturating_add(remaining).min(log.count());
                 if skip < end {
-                    info.requested_received_log = log.read(skip..end).await?;
+                    let entries = log.read(skip..end).await?;
+                    remaining -= entries.len();
+                    info.requested_received_log.insert(epoch, entries);
                 }
             }
         }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -447,36 +447,29 @@ where
     /// matter are re-certified via `previous_block_hash` /
     /// `previous_message_blocks` links instead.
     async fn prune_revoked_received_logs(&mut self, up_to: Epoch) -> Result<(), WorkerError> {
-        // `indices` returns the stored epochs in ascending order. Walk the ones
-        // below `up_to` from newest to oldest: revocation is monotone, so the
-        // first revoked epoch found — and everything below it — can be pruned
-        // without further checks.
-        let mut stored = self.chain.received_log.indices().await?;
-        stored.retain(|epoch| *epoch < up_to);
-        let mut prunable = None;
-        for (position, epoch) in stored.iter().enumerate().rev() {
-            let is_revoked = self
-                .storage
-                .is_epoch_revoked(*epoch)
-                .await
-                .map_err(|error| {
-                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                        Box::new(error),
-                        ChainExecutionContext::Block,
-                    )))
-                })?;
-            if is_revoked {
-                prunable = Some(position);
+        // Find the highest revoked epoch below `up_to`. Since revocation is
+        // monotone, every stored epoch at or below it is revoked and prunable.
+        // Walk the stored epochs below `up_to` from highest to lowest and stop at
+        // the first revoked one.
+        let stored = self.chain.received_log.indices().await?;
+        let mut highest_revoked = None;
+        for epoch in stored.iter().rev().filter(|epoch| **epoch < up_to) {
+            if self.is_epoch_revoked(*epoch).await? {
+                highest_revoked = Some(*epoch);
                 break;
             }
         }
-        let Some(position) = prunable else {
+        let Some(highest_revoked) = highest_revoked else {
             return Ok(());
         };
-        for epoch in &stored[..=position] {
+        let mut pruned = false;
+        for epoch in stored.iter().filter(|epoch| **epoch <= highest_revoked) {
             self.chain.received_log.remove_entry(epoch)?;
+            pruned = true;
         }
-        self.save().await?;
+        if pruned {
+            self.save().await?;
+        }
         Ok(())
     }
 
@@ -2004,16 +1997,7 @@ where
             .collect::<BTreeSet<_>>();
         let mut revoked_epochs = BTreeSet::new();
         for epoch in epochs {
-            let is_revoked = self
-                .storage
-                .is_epoch_revoked(epoch)
-                .await
-                .map_err(|error| {
-                    WorkerError::ChainError(Box::new(ChainError::ExecutionError(
-                        Box::new(error),
-                        ChainExecutionContext::Block,
-                    )))
-                })?;
+            let is_revoked = self.is_epoch_revoked(epoch).await?;
             if !is_revoked {
                 break;
             }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -54,7 +54,9 @@ use tracing::{debug, info, instrument, trace, warn};
 use crate::{
     chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
     client::{ChainModes, ListeningMode},
-    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    data_types::{
+        ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest, ReceivedLogQuery,
+    },
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
 
@@ -272,7 +274,7 @@ where
         origin: &ChainId,
         next_height_to_receive: BlockHeight,
         mut bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Vec<MessageBundle>, WorkerError> {
+    ) -> Result<Vec<(Epoch, MessageBundle)>, WorkerError> {
         let mut latest_height = None;
         let mut skipped_len = 0;
         for (i, (_, bundle)) in bundles.iter().enumerate() {
@@ -293,10 +295,7 @@ where
                 sample_bundle.height,
             );
         }
-        Ok(bundles
-            .drain(skipped_len..)
-            .map(|(_, bundle)| bundle)
-            .collect())
+        Ok(bundles.drain(skipped_len..).collect())
     }
 
     /// Returns whether the given epoch has been revoked on the admin chain,
@@ -437,7 +436,42 @@ where
         if query.request_fallback {
             self.vote_for_fallback().await?;
         }
+        if let Some(ReceivedLogQuery { epoch, .. }) = query.request_received_log {
+            self.prune_revoked_received_logs(epoch).await?;
+        }
         self.prepare_chain_info_response(query).await
+    }
+
+    /// Removes the received logs of revoked epochs below `up_to`. Run whenever a
+    /// client asks for a received log: entries of revoked epochs are useless to
+    /// clients — the certificates they point to can no longer be verified on their
+    /// own, and blocks that still matter are re-certified via
+    /// `previous_block_hash` / `previous_message_blocks` links instead.
+    async fn prune_revoked_received_logs(&mut self, up_to: Epoch) -> Result<(), WorkerError> {
+        let mut pruned = false;
+        for stored_epoch in self.chain.received_log.indices().await? {
+            if stored_epoch >= up_to {
+                continue;
+            }
+            let is_revoked =
+                self.storage
+                    .is_epoch_revoked(stored_epoch)
+                    .await
+                    .map_err(|error| {
+                        WorkerError::ChainError(Box::new(ChainError::ExecutionError(
+                            Box::new(error),
+                            ChainExecutionContext::Block,
+                        )))
+                    })?;
+            if is_revoked {
+                self.chain.received_log.remove_entry(&stored_epoch)?;
+                pruned = true;
+            }
+        }
+        if pruned {
+            self.save().await?;
+        }
+        Ok(())
     }
 
     /// Returns the requested blob, if it belongs to the current locking block or pending proposal.
@@ -1504,13 +1538,13 @@ where
         }
 
         let bundles = self.select_message_bundles(&origin, next_height_to_receive, bundles)?;
-        let Some(last_updated_height) = bundles.last().map(|bundle| bundle.height) else {
+        let Some(last_updated_height) = bundles.last().map(|(_, bundle)| bundle.height) else {
             return Ok(CrossChainUpdateResult::NothingToDo);
         };
         // Process the received messages in certificates.
         let local_time = self.storage.clock().current_time();
         let mut previous_height = None;
-        for bundle in bundles {
+        for (epoch, bundle) in bundles {
             let add_to_received_log = previous_height != Some(bundle.height);
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
@@ -1518,6 +1552,7 @@ where
                 .receive_message_bundle_with_inbox(
                     &mut inbox,
                     &origin,
+                    epoch,
                     bundle,
                     local_time,
                     add_to_received_log,
@@ -1948,7 +1983,7 @@ where
     ))]
     pub(crate) async fn update_received_certificate_trackers(
         &mut self,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), WorkerError> {
         self.chain
             .update_received_certificate_trackers(new_trackers);
@@ -2096,7 +2131,7 @@ where
     /// Gets received certificate trackers.
     pub(crate) async fn get_received_certificate_trackers(
         &self,
-    ) -> Result<HashMap<ValidatorPublicKey, u64>, WorkerError> {
+    ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, WorkerError> {
         Ok(self.chain.received_certificate_trackers.get().clone())
     }
 
@@ -2706,13 +2741,17 @@ where
             .block_hashes_for_heights(query.request_sent_certificate_hashes_by_heights)
             .await?;
         info.requested_sent_certificate_hashes = hashes;
-        if let Some(start) = query.request_received_log_excluding_first_n {
-            let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
+        if let Some(ReceivedLogQuery { epoch, skip }) = query.request_received_log {
+            let skip = usize::try_from(skip).map_err(|_| ArithmeticError::Overflow)?;
             let max_received_log_entries = self.config.chain_info_max_received_log_entries;
-            let end = start
-                .saturating_add(max_received_log_entries)
-                .min(chain.received_log.count());
-            info.requested_received_log = chain.received_log.read(start..end).await?;
+            if let Some(log) = chain.received_log.try_load_entry(&epoch).await? {
+                let end = skip
+                    .saturating_add(max_received_log_entries)
+                    .min(log.count());
+                if skip < end {
+                    info.requested_received_log = log.read(skip..end).await?;
+                }
+            }
         }
         if query.request_manager_values {
             info.manager.add_values(&chain.manager);

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1990,10 +1990,14 @@ where
         // Drop tracker entries for revoked epochs: those epochs' received logs are
         // pruned by validators and never queried again. Revocation is monotone, so
         // the walk over the ascending epoch set can stop at the first live one.
-        let keys = self.chain.received_certificate_trackers.indices().await?;
-        let epochs = keys
+        let all_trackers = self
+            .chain
+            .received_certificate_trackers
+            .index_values()
+            .await?;
+        let epochs = all_trackers
             .iter()
-            .map(|(_, epoch)| *epoch)
+            .flat_map(|(_, trackers)| trackers.keys().copied())
             .collect::<BTreeSet<_>>();
         let mut revoked_epochs = BTreeSet::new();
         for epoch in epochs {
@@ -2003,9 +2007,19 @@ where
             }
             revoked_epochs.insert(epoch);
         }
-        for key in keys {
-            if revoked_epochs.contains(&key.1) {
-                self.chain.received_certificate_trackers.remove(&key)?;
+        for (validator, mut trackers) in all_trackers {
+            if !trackers.keys().any(|epoch| revoked_epochs.contains(epoch)) {
+                continue;
+            }
+            trackers.retain(|epoch, _| !revoked_epochs.contains(epoch));
+            if trackers.is_empty() {
+                self.chain
+                    .received_certificate_trackers
+                    .remove(&validator)?;
+            } else {
+                self.chain
+                    .received_certificate_trackers
+                    .insert(&validator, trackers)?;
             }
         }
         self.save().await?;
@@ -2153,19 +2167,14 @@ where
     pub(crate) async fn get_received_certificate_trackers(
         &self,
     ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, WorkerError> {
-        let mut trackers = HashMap::<_, BTreeMap<Epoch, u64>>::new();
-        for ((validator, epoch), tracker) in self
+        Ok(self
             .chain
             .received_certificate_trackers
             .index_values()
             .await?
-        {
-            trackers
-                .entry(validator)
-                .or_default()
-                .insert(epoch, tracker);
-        }
-        Ok(trackers)
+            .into_iter()
+            .map(|(validator, trackers)| (validator, trackers.into()))
+            .collect())
     }
 
     /// Gets tip state and outbox info for next_outbox_heights calculation.

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1190,6 +1190,7 @@ impl<Env: Environment> ChainClient<Env> {
                 Some(async move {
                     client
                         .download_and_process_sender_chain(
+                            self.chain_id,
                             sender_chain_id,
                             &nodes,
                             received_logs,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1046,22 +1046,23 @@ impl<Env: Environment> ChainClient<Env> {
                 let trackers = &trackers;
                 let received_log_batches = Arc::clone(&received_log_batches);
                 Box::pin(async move {
-                    for epoch in live_epochs {
-                        let tracker = trackers
-                            .get(&remote_node.public_key)
-                            .and_then(|trackers| trackers.get(epoch))
-                            .copied()
-                            .unwrap_or(0);
-                        let batch = client
-                            .get_received_log_from_validator(
-                                chain_id,
-                                &remote_node,
-                                *epoch,
-                                tracker,
-                            )
-                            .await?;
-                        let mut batches = received_log_batches.lock().unwrap();
-                        batches.push((remote_node.public_key, *epoch, batch));
+                    let offsets = live_epochs
+                        .iter()
+                        .map(|epoch| {
+                            let tracker = trackers
+                                .get(&remote_node.public_key)
+                                .and_then(|trackers| trackers.get(epoch))
+                                .copied()
+                                .unwrap_or(0);
+                            (*epoch, tracker)
+                        })
+                        .collect();
+                    let remote_logs = client
+                        .get_received_log_from_validator(chain_id, &remote_node, offsets)
+                        .await?;
+                    let mut batches = received_log_batches.lock().unwrap();
+                    for (epoch, batch) in remote_logs {
+                        batches.push((remote_node.public_key, epoch, batch));
                     }
                     Ok(())
                 })

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -1001,7 +1001,7 @@ impl<Env: Environment> ChainClient<Env> {
         let _latency = super::metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
         // Use network information from the local chain.
         let chain_id = self.chain_id;
-        let (_, committee) = self.admin_committee().await?;
+        let (current_epoch, committee) = self.admin_committee().await?;
         let nodes = self.client.make_nodes(&committee)?;
 
         let trackers = self
@@ -1012,6 +1012,28 @@ impl<Env: Environment> ChainClient<Env> {
 
         trace!("find_received_certificates: read trackers");
 
+        // The received log is kept per sender epoch, and validators may prune the
+        // logs of revoked epochs, so only the live epochs are queried. Revocation
+        // is monotone, so these are exactly the epochs from the lowest live one up
+        // to the current one.
+        let mut live_epochs = Vec::new();
+        let mut epoch = current_epoch;
+        loop {
+            let is_revoked = self
+                .storage_client()
+                .is_epoch_revoked(epoch)
+                .await
+                .map_err(LocalNodeError::from)?;
+            if is_revoked {
+                break;
+            }
+            live_epochs.push(epoch);
+            let Some(previous_epoch) = epoch.0.checked_sub(1) else {
+                break;
+            };
+            epoch = Epoch(previous_epoch);
+        }
+
         let received_log_batches = Arc::new(std::sync::Mutex::new(Vec::new()));
         // Proceed to downloading received logs.
         let result = communicate_with_quorum(
@@ -1020,14 +1042,27 @@ impl<Env: Environment> ChainClient<Env> {
             |_| (),
             |remote_node| {
                 let client = &self.client;
-                let tracker = trackers.get(&remote_node.public_key).copied().unwrap_or(0);
+                let live_epochs = &live_epochs;
+                let trackers = &trackers;
                 let received_log_batches = Arc::clone(&received_log_batches);
                 Box::pin(async move {
-                    let batch = client
-                        .get_received_log_from_validator(chain_id, &remote_node, tracker)
-                        .await?;
-                    let mut batches = received_log_batches.lock().unwrap();
-                    batches.push((remote_node.public_key, batch));
+                    for epoch in live_epochs {
+                        let tracker = trackers
+                            .get(&remote_node.public_key)
+                            .and_then(|trackers| trackers.get(epoch))
+                            .copied()
+                            .unwrap_or(0);
+                        let batch = client
+                            .get_received_log_from_validator(
+                                chain_id,
+                                &remote_node,
+                                *epoch,
+                                tracker,
+                            )
+                            .await?;
+                        let mut batches = received_log_batches.lock().unwrap();
+                        batches.push((remote_node.public_key, *epoch, batch));
+                    }
                     Ok(())
                 })
             },
@@ -1049,7 +1084,7 @@ impl<Env: Environment> ChainClient<Env> {
 
         debug!(
             received_logs_len = %received_logs.len(),
-            received_logs_total = %received_logs.iter().map(|x| x.1.len()).sum::<usize>(),
+            received_logs_total = %received_logs.iter().map(|x| x.2.len()).sum::<usize>(),
             "collected received logs"
         );
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1941,32 +1941,37 @@ impl<Env: Environment> Client<Env> {
         trace!("find_received_certificates: finished processing chain");
     }
 
-    /// Downloads the log of messages received from senders in the given epoch for a
-    /// chain from a validator.
-    #[instrument(level = "trace", skip(self))]
+    /// Downloads the per-epoch logs of messages received from senders in the given
+    /// epochs for a chain from a validator, starting at the given per-epoch
+    /// offsets. All epochs are requested in a single query; the validator bounds
+    /// the total number of entries per response, so the request is repeated with
+    /// advanced offsets until nothing is cut short anymore.
+    #[instrument(level = "trace", skip(self, offsets))]
     async fn get_received_log_from_validator(
         &self,
         chain_id: ChainId,
         remote_node: &RemoteNode<Env::ValidatorNode>,
-        epoch: Epoch,
-        tracker: u64,
-    ) -> Result<Vec<ChainAndHeight>, chain_client::Error> {
-        let mut offset = tracker;
-
+        mut offsets: BTreeMap<Epoch, u64>,
+    ) -> Result<BTreeMap<Epoch, Vec<ChainAndHeight>>, chain_client::Error> {
         // Retrieve the list of newly received certificates from this validator.
-        let mut remote_log = Vec::new();
+        let mut remote_logs = BTreeMap::<Epoch, Vec<ChainAndHeight>>::new();
         loop {
             trace!("get_received_log_from_validator: looping");
-            let query = ChainInfoQuery::new(chain_id).with_received_log(epoch, offset);
+            let query = ChainInfoQuery::new(chain_id).with_received_logs(offsets.clone());
             let info = remote_node.handle_chain_info_query(query).await?;
-            let received_entries = info.requested_received_log.len();
-            offset += received_entries as u64;
-            remote_log.extend(info.requested_received_log);
+            let received_entries: usize = info.requested_received_log.values().map(Vec::len).sum();
+            for (epoch, entries) in info.requested_received_log {
+                if let Some(offset) = offsets.get_mut(&epoch) {
+                    *offset += entries.len() as u64;
+                    remote_logs.entry(epoch).or_default().extend(entries);
+                }
+            }
             trace!(
                 remote_node = remote_node.address(),
                 %received_entries,
                 "get_received_log_from_validator: received log batch",
             );
+            // A response below the total bound means no epoch's log was cut short.
             if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
                 break;
             }
@@ -1974,11 +1979,11 @@ impl<Env: Environment> Client<Env> {
 
         trace!(
             remote_node = remote_node.address(),
-            num_entries = remote_log.len(),
+            num_entries = remote_logs.values().map(Vec::len).sum::<usize>(),
             "get_received_log_from_validator: returning downloaded log",
         );
 
-        Ok(remote_log)
+        Ok(remote_logs)
     }
 
     /// Downloads a specific sender block and recursively downloads any earlier blocks

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1774,6 +1774,7 @@ impl<Env: Environment> Client<Env> {
     #[instrument(level = "debug", skip_all, fields(chain_id = %sender_chain_id))]
     async fn download_and_process_sender_chain(
         &self,
+        receiver_chain_id: ChainId,
         sender_chain_id: ChainId,
         nodes: &[RemoteNode<Env::ValidatorNode>],
         received_log: &ReceivedLogs,
@@ -1781,6 +1782,55 @@ impl<Env: Environment> Client<Env> {
         sender: mpsc::UnboundedSender<ChainAndHeight>,
     ) {
         let mut nodes = nodes.to_vec();
+        // Process the lowest block together with its earlier message blocks first:
+        // its `previous_message_blocks` chain may reach into revoked epochs, whose
+        // received-log entries are pruned by validators and therefore missing from
+        // `remote_heights`. The ancestor walk downloads exactly the message-bearing
+        // predecessors (re-certifying revoked-epoch ones via the blocks that
+        // commit to them), so that the newer blocks' messages can actually be
+        // scheduled in the outbox. The downloaded certificates land in storage,
+        // where the loop below picks them up.
+        if let Some(lowest_height) = remote_heights.first().copied() {
+            let received_log = &received_log;
+            let result = communicate_concurrently(
+                &nodes,
+                async move |remote_node| {
+                    if !received_log.validator_has_block(
+                        &remote_node.public_key,
+                        sender_chain_id,
+                        lowest_height,
+                    ) {
+                        // The validator's log didn't contain the block; let the
+                        // others handle it.
+                        return Err(chain_client::Error::RemoteNodeError(
+                            NodeError::MissingCertificateValue,
+                        ));
+                    }
+                    self.download_sender_block_with_sending_ancestors(
+                        receiver_chain_id,
+                        sender_chain_id,
+                        lowest_height,
+                        &remote_node,
+                    )
+                    .await
+                },
+                self.options.certificate_batch_download_hedge_delay,
+                self.storage_client().clock(),
+            )
+            .await;
+            if let Err(errors) = result {
+                for (validator, error) in errors {
+                    warn!(
+                        %validator,
+                        %sender_chain_id,
+                        %lowest_height,
+                        %error,
+                        "failed to process the lowest sender block with its \
+                         sending ancestors",
+                    );
+                }
+            }
+        }
         while !remote_heights.is_empty() {
             // Check local storage first — certificates may already be available from
             // a prior sync cycle, another receiver chain, or a concurrent notification.

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1941,12 +1941,14 @@ impl<Env: Environment> Client<Env> {
         trace!("find_received_certificates: finished processing chain");
     }
 
-    /// Downloads the log of received messages for a chain from a validator.
+    /// Downloads the log of messages received from senders in the given epoch for a
+    /// chain from a validator.
     #[instrument(level = "trace", skip(self))]
     async fn get_received_log_from_validator(
         &self,
         chain_id: ChainId,
         remote_node: &RemoteNode<Env::ValidatorNode>,
+        epoch: Epoch,
         tracker: u64,
     ) -> Result<Vec<ChainAndHeight>, chain_client::Error> {
         let mut offset = tracker;
@@ -1955,7 +1957,7 @@ impl<Env: Environment> Client<Env> {
         let mut remote_log = Vec::new();
         loop {
             trace!("get_received_log_from_validator: looping");
-            let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
+            let query = ChainInfoQuery::new(chain_id).with_received_log(epoch, offset);
             let info = remote_node.handle_chain_info_query(query).await?;
             let received_entries = info.requested_received_log.len();
             offset += received_entries as u64;

--- a/linera-core/src/client/received_log.rs
+++ b/linera-core/src/client/received_log.rs
@@ -3,7 +3,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use linera_base::{crypto::ValidatorPublicKey, data_types::BlockHeight, identifiers::ChainId};
+use linera_base::{
+    crypto::ValidatorPublicKey,
+    data_types::{BlockHeight, Epoch},
+    identifiers::ChainId,
+};
 use linera_chain::data_types::ChainAndHeight;
 
 /// Struct keeping track of the blocks sending messages to some chain, from chains identified by
@@ -14,15 +18,19 @@ pub(super) struct ReceivedLogs(
 );
 
 impl ReceivedLogs {
-    /// Converts a set of logs received from validators into a single log.
+    /// Converts a set of per-epoch logs received from validators into a single log.
     pub(super) fn from_received_result(
-        result: Vec<(ValidatorPublicKey, Vec<ChainAndHeight>)>,
+        result: Vec<(ValidatorPublicKey, Epoch, Vec<ChainAndHeight>)>,
     ) -> Self {
-        Self::from_iterator(result.into_iter().flat_map(|(validator, received_log)| {
-            received_log
+        Self::from_iterator(
+            result
                 .into_iter()
-                .map(move |chain_and_height| (chain_and_height, validator))
-        }))
+                .flat_map(|(validator, _epoch, received_log)| {
+                    received_log
+                        .into_iter()
+                        .map(move |chain_and_height| (chain_and_height, validator))
+                }),
+        )
     }
 
     /// Returns a map that assigns to each chain ID the set of heights. The returned map contains
@@ -203,6 +211,7 @@ impl Iterator for BatchingHelper {
 mod tests {
     use linera_base::{
         crypto::{CryptoHash, ValidatorKeypair},
+        data_types::Epoch,
         identifiers::ChainId,
     };
     use linera_chain::data_types::ChainAndHeight;
@@ -224,6 +233,7 @@ mod tests {
         let validator = ValidatorKeypair::generate().public_key;
         let test_log = ReceivedLogs::from_received_result(vec![(
             validator,
+            Epoch::ZERO,
             vec![
                 (chain1, 1),
                 (chain1, 2),
@@ -330,6 +340,7 @@ mod tests {
         let validator = ValidatorKeypair::generate().public_key;
         let test_log = ReceivedLogs::from_received_result(vec![(
             validator,
+            Epoch::ZERO,
             vec![
                 (chain1, 1),
                 (chain1, 2),
@@ -436,6 +447,7 @@ mod tests {
         let test_log = ReceivedLogs::from_received_result(vec![
             (
                 validator1,
+                Epoch::ZERO,
                 vec![
                     (chain1, 1),
                     (chain1, 2),
@@ -456,6 +468,7 @@ mod tests {
             ),
             (
                 validator2,
+                Epoch::ZERO,
                 vec![
                     (chain1, 1),
                     (chain1, 2),

--- a/linera-core/src/client/validator_trackers.rs
+++ b/linera-core/src/client/validator_trackers.rs
@@ -3,28 +3,34 @@
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
-use linera_base::{crypto::ValidatorPublicKey, data_types::BlockHeight, identifiers::ChainId};
+use linera_base::{
+    crypto::ValidatorPublicKey,
+    data_types::{BlockHeight, Epoch},
+    identifiers::ChainId,
+};
 use linera_chain::data_types::ChainAndHeight;
 
 use super::received_log::ReceivedLogs;
 
-/// Keeps multiple `ValidatorTracker`s for multiple validators.
-pub(super) struct ValidatorTrackers(BTreeMap<ValidatorPublicKey, ValidatorTracker>);
+/// Keeps a `ValidatorTracker` per validator and sender epoch.
+pub(super) struct ValidatorTrackers(BTreeMap<(ValidatorPublicKey, Epoch), ValidatorTracker>);
 
 impl ValidatorTrackers {
     /// Creates a new `ValidatorTrackers`.
     pub(super) fn new(
-        received_logs: Vec<(ValidatorPublicKey, Vec<ChainAndHeight>)>,
-        trackers: &HashMap<ValidatorPublicKey, u64>,
+        received_logs: Vec<(ValidatorPublicKey, Epoch, Vec<ChainAndHeight>)>,
+        trackers: &HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Self {
         Self(
             received_logs
                 .into_iter()
-                .map(|(validator, log)| {
-                    (
-                        validator,
-                        ValidatorTracker::new(*trackers.get(&validator).unwrap_or(&0), log),
-                    )
+                .map(|(validator, epoch, log)| {
+                    let tracker = trackers
+                        .get(&validator)
+                        .and_then(|trackers| trackers.get(&epoch))
+                        .copied()
+                        .unwrap_or(0);
+                    ((validator, epoch), ValidatorTracker::new(tracker, log))
                 })
                 .collect(),
         )
@@ -38,13 +44,16 @@ impl ValidatorTrackers {
         }
     }
 
-    /// Converts the `ValidatorTrackers` into a map of per-validator tracker values
-    /// (indices into the validators' received logs).
-    pub(super) fn to_map(&self) -> BTreeMap<ValidatorPublicKey, u64> {
-        self.0
-            .iter()
-            .map(|(validator, tracker)| (*validator, tracker.current_tracker_value))
-            .collect()
+    /// Converts the `ValidatorTrackers` into a map of per-validator and per-epoch
+    /// tracker values (indices into the validators' per-epoch received logs).
+    pub(super) fn to_map(&self) -> BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>> {
+        let mut map = BTreeMap::<ValidatorPublicKey, BTreeMap<Epoch, u64>>::new();
+        for ((validator, epoch), tracker) in &self.0 {
+            map.entry(*validator)
+                .or_default()
+                .insert(*epoch, tracker.current_tracker_value);
+        }
+        map
     }
 
     /// Compares validators' received logs of sender chains with local node information and returns
@@ -127,9 +136,11 @@ impl ValidatorTracker {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use linera_base::{
         crypto::{CryptoHash, ValidatorKeypair},
-        data_types::BlockHeight,
+        data_types::{BlockHeight, Epoch},
         identifiers::ChainId,
     };
     use linera_chain::data_types::ChainAndHeight;
@@ -193,14 +204,17 @@ mod test {
         })
         .collect();
 
-        let mut received_log = ReceivedLogs::from_received_result(vec![(validator, log.clone())]);
+        let mut received_log =
+            ReceivedLogs::from_received_result(vec![(validator, Epoch::ZERO, log.clone())]);
 
         assert_eq!(received_log.num_chains(), 2);
         assert_eq!(received_log.num_certs(), 7);
 
         let mut tracker = ValidatorTrackers::new(
-            vec![(validator, log)],
-            &vec![(validator, 0)].into_iter().collect(),
+            vec![(validator, Epoch::ZERO, log)],
+            &vec![(validator, BTreeMap::from([(Epoch::ZERO, 0)]))]
+                .into_iter()
+                .collect(),
         );
 
         let local_heights = vec![(chain1, BlockHeight(3)), (chain2, BlockHeight(3))]
@@ -213,6 +227,9 @@ mod test {
         assert_eq!(received_log.num_certs(), 1);
 
         // tracker should have shifted to point to (chain1, 3)
-        assert_eq!(tracker.0[&validator].current_tracker_value, 5);
+        assert_eq!(
+            tracker.0[&(validator, Epoch::ZERO)].current_tracker_value,
+            5
+        );
     }
 }

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -41,11 +41,11 @@ pub struct ChainInfoQuery {
     #[debug(skip_if = Not::not)]
     pub request_pending_message_bundles: bool,
     /// Query new certificate sender chain IDs and block heights received from the
-    /// chain: the entries of the given sender epoch's received log, excluding the
-    /// first `skip`.
-    #[debug(skip_if = Option::is_none)]
-    #[cfg_attr(with_testing, strategy(proptest::strategy::Just(None)))]
-    pub request_received_log: Option<ReceivedLogQuery>,
+    /// chain: for each requested sender epoch, the entries of that epoch's received
+    /// log, excluding the first `skip`.
+    #[debug(skip_if = BTreeMap::is_empty)]
+    #[cfg_attr(with_testing, strategy(proptest::strategy::Just(BTreeMap::new())))]
+    pub request_received_log: BTreeMap<Epoch, u64>,
     /// Query values from the chain manager, not just votes.
     #[debug(skip_if = Not::not)]
     pub request_manager_values: bool,
@@ -77,7 +77,7 @@ impl ChainInfoQuery {
             test_next_block_height: None,
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log: None,
+            request_received_log: BTreeMap::new(),
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: false,
@@ -111,10 +111,17 @@ impl ChainInfoQuery {
         self
     }
 
-    /// Also requests the given sender epoch's received log entries, excluding the
-    /// first `skip`.
+    /// Also requests one sender epoch's received log entries, excluding the first
+    /// `skip`. Can be called repeatedly to request several epochs' logs at once.
     pub fn with_received_log(mut self, epoch: Epoch, skip: u64) -> Self {
-        self.request_received_log = Some(ReceivedLogQuery { epoch, skip });
+        self.request_received_log.insert(epoch, skip);
+        self
+    }
+
+    /// Also requests the given sender epochs' received log entries, each excluding
+    /// the given number of entries at the front of that epoch's log.
+    pub fn with_received_logs(mut self, queries: impl IntoIterator<Item = (Epoch, u64)>) -> Self {
+        self.request_received_log.extend(queries);
         self
     }
 
@@ -136,16 +143,6 @@ impl ChainInfoQuery {
         self.request_fallback = true;
         self
     }
-}
-
-/// A request for entries of one sender epoch's received log.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-#[cfg_attr(with_testing, derive(Eq, PartialEq))]
-pub struct ReceivedLogQuery {
-    /// The sender epoch whose received log to read.
-    pub epoch: Epoch,
-    /// The number of entries at the front of that epoch's log to skip.
-    pub skip: u64,
 }
 
 /// Information about a chain, returned in response to a [`ChainInfoQuery`].
@@ -186,10 +183,12 @@ pub struct ChainInfo {
     /// The response to `request_sent_certificate_hashes_by_heights`.
     #[debug(skip_if = Vec::is_empty)]
     pub requested_sent_certificate_hashes: Vec<CryptoHash>,
-    /// The response to `request_received_log`: the entries of the requested sender
-    /// epoch's received log, after the requested offset.
-    #[debug(skip_if = Vec::is_empty)]
-    pub requested_received_log: Vec<ChainAndHeight>,
+    /// The response to `request_received_log`: per requested sender epoch, the
+    /// entries of that epoch's received log after the requested offset. The total
+    /// number of entries is bounded, so epochs may be missing or cut short; the
+    /// client continues with adjusted offsets.
+    #[debug(skip_if = BTreeMap::is_empty)]
+    pub requested_received_log: BTreeMap<Epoch, Vec<ChainAndHeight>>,
     /// The response to `request_previous_event_blocks`.
     #[debug(skip_if = BTreeMap::is_empty)]
     pub requested_previous_event_blocks: BTreeMap<StreamId, (BlockHeight, CryptoHash)>,
@@ -312,7 +311,7 @@ impl ChainInfo {
             requested_owner_balance: None,
             requested_pending_message_bundles: Vec::new(),
             requested_sent_certificate_hashes: Vec::new(),
-            requested_received_log: Vec::new(),
+            requested_received_log: BTreeMap::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
         })

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -111,13 +111,6 @@ impl ChainInfoQuery {
         self
     }
 
-    /// Also requests one sender epoch's received log entries, excluding the first
-    /// `skip`. Can be called repeatedly to request several epochs' logs at once.
-    pub fn with_received_log(mut self, epoch: Epoch, skip: u64) -> Self {
-        self.request_received_log.insert(epoch, skip);
-        self
-    }
-
     /// Also requests the given sender epochs' received log entries, each excluding
     /// the given number of entries at the front of that epoch's log.
     pub fn with_received_logs(mut self, queries: impl IntoIterator<Item = (Epoch, u64)>) -> Self {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -40,9 +40,12 @@ pub struct ChainInfoQuery {
     /// Query the received messages that are waiting to be picked in the next block.
     #[debug(skip_if = Not::not)]
     pub request_pending_message_bundles: bool,
-    /// Query new certificate sender chain IDs and block heights received from the chain.
+    /// Query new certificate sender chain IDs and block heights received from the
+    /// chain: the entries of the given sender epoch's received log, excluding the
+    /// first `skip`.
     #[debug(skip_if = Option::is_none)]
-    pub request_received_log_excluding_first_n: Option<u64>,
+    #[cfg_attr(with_testing, strategy(proptest::strategy::Just(None)))]
+    pub request_received_log: Option<ReceivedLogQuery>,
     /// Query values from the chain manager, not just votes.
     #[debug(skip_if = Not::not)]
     pub request_manager_values: bool,
@@ -74,7 +77,7 @@ impl ChainInfoQuery {
             test_next_block_height: None,
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log_excluding_first_n: None,
+            request_received_log: None,
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: false,
@@ -108,9 +111,10 @@ impl ChainInfoQuery {
         self
     }
 
-    /// Also requests the received log entries, excluding the first `n`.
-    pub fn with_received_log_excluding_first_n(mut self, n: u64) -> Self {
-        self.request_received_log_excluding_first_n = Some(n);
+    /// Also requests the given sender epoch's received log entries, excluding the
+    /// first `skip`.
+    pub fn with_received_log(mut self, epoch: Epoch, skip: u64) -> Self {
+        self.request_received_log = Some(ReceivedLogQuery { epoch, skip });
         self
     }
 
@@ -132,6 +136,16 @@ impl ChainInfoQuery {
         self.request_fallback = true;
         self
     }
+}
+
+/// A request for entries of one sender epoch's received log.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct ReceivedLogQuery {
+    /// The sender epoch whose received log to read.
+    pub epoch: Epoch,
+    /// The number of entries at the front of that epoch's log to skip.
+    pub skip: u64,
 }
 
 /// Information about a chain, returned in response to a [`ChainInfoQuery`].
@@ -172,9 +186,8 @@ pub struct ChainInfo {
     /// The response to `request_sent_certificate_hashes_by_heights`.
     #[debug(skip_if = Vec::is_empty)]
     pub requested_sent_certificate_hashes: Vec<CryptoHash>,
-    /// The current number of received certificates (useful for `request_received_log_excluding_first_n`)
-    pub count_received_log: usize,
-    /// The response to `request_received_certificates_excluding_first_n`
+    /// The response to `request_received_log`: the entries of the requested sender
+    /// epoch's received log, after the requested offset.
     #[debug(skip_if = Vec::is_empty)]
     pub requested_received_log: Vec<ChainAndHeight>,
     /// The response to `request_previous_event_blocks`.
@@ -299,7 +312,6 @@ impl ChainInfo {
             requested_owner_balance: None,
             requested_pending_message_bundles: Vec::new(),
             requested_sent_certificate_hashes: Vec::new(),
-            count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -10,7 +10,7 @@ use std::{
 use futures::{stream::FuturesUnordered, TryStreamExt as _};
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
-    data_types::{ArithmeticError, Blob, BlockHeight},
+    data_types::{ArithmeticError, Blob, BlockHeight, Epoch},
     identifiers::{BlobId, ChainId, EventId, StreamId},
 };
 use linera_chain::{
@@ -391,7 +391,7 @@ where
     pub async fn update_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), LocalNodeError> {
         self.node
             .state
@@ -495,7 +495,7 @@ where
     pub async fn get_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-    ) -> Result<HashMap<ValidatorPublicKey, u64>, LocalNodeError> {
+    ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, LocalNodeError> {
         Ok(self
             .node
             .state

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -19,7 +19,9 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
-    data_types::{IncomingBundle, MessageAction, MessageBundle, PostedMessage, Transaction},
+    data_types::{
+        ChainAndHeight, IncomingBundle, MessageAction, MessageBundle, PostedMessage, Transaction,
+    },
     manager::LockingBlock,
     types::Timeout,
     ChainError, ChainExecutionContext,
@@ -1819,9 +1821,10 @@ where
 
     // `process_notification_from` does not advance the client's
     // `received_certificate_trackers`, so a subsequent `synchronize_from_validators`
-    // still sees (sender, 1) and (sender, 3) in the received log. But the sender's
-    // outbox has those heights scheduled locally now, so `find_received_certificates`
-    // filters them out and routes the sender through
+    // still sees (sender, 3) in epoch 1's received log (epoch 0's log is not even
+    // queried: the epoch is revoked). But the sender's outbox has that height
+    // scheduled locally now, so `find_received_certificates` filters it out and
+    // routes the sender through
     // `retry_pending_cross_chain_requests_from_sender_chains`. Before the fix this
     // initialized the sender's chain worker inside the receiver's node and, on
     // failing to find the `ChainDescription` blob in storage, triggered a download.
@@ -1830,6 +1833,37 @@ where
         !storage.contains_blob(sender_chain_desc_blob_id).await?,
         "retry_pending_cross_chain_requests must not download the ChainDescription",
     );
+
+    // Serving a live epoch's received log prunes the revoked epochs' logs: after
+    // the query below, validator 0 holds only epoch 1's log for the receiver.
+    let response = builder
+        .node(0)
+        .handle_chain_info_query(
+            crate::data_types::ChainInfoQuery::new(receiver_id)
+                .with_received_log(Epoch::from(1), 0),
+        )
+        .await?;
+    assert_eq!(
+        response.info.requested_received_log,
+        vec![ChainAndHeight {
+            chain_id: sender_id,
+            height: cert3.block().header.height,
+        }],
+    );
+    {
+        let validator_0_key = builder.node(0).name();
+        let validator_0_storage = builder
+            .validator_storages
+            .get(&validator_0_key)
+            .expect("validator 0 storage")
+            .clone();
+        let chain_view = validator_0_storage.load_chain(receiver_id).await?;
+        assert_eq!(
+            chain_view.received_log.indices().await?,
+            vec![Epoch::from(1)],
+            "the revoked epoch's received log should have been pruned",
+        );
+    }
 
     Ok(())
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1845,10 +1845,13 @@ where
         .await?;
     assert_eq!(
         response.info.requested_received_log,
-        vec![ChainAndHeight {
-            chain_id: sender_id,
-            height: cert3.block().header.height,
-        }],
+        BTreeMap::from([(
+            Epoch::from(1),
+            vec![ChainAndHeight {
+                chain_id: sender_id,
+                height: cert3.block().header.height,
+            }],
+        )]),
     );
     {
         let validator_0_key = builder.node(0).name();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1840,7 +1840,7 @@ where
         .node(0)
         .handle_chain_info_query(
             crate::data_types::ChainInfoQuery::new(receiver_id)
-                .with_received_log(Epoch::from(1), 0),
+                .with_received_logs([(Epoch::from(1), 0)]),
         )
         .await?;
     assert_eq!(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2087,6 +2087,118 @@ where
     Ok(())
 }
 
+/// A receiver syncing via the received log only sees live epochs' entries, but a
+/// sender block from a revoked epoch may still be undelivered. The sync must
+/// process the lowest listed block together with its sending ancestors, so that
+/// the pruned-epoch message is re-certified and delivered — otherwise the newer
+/// messages could never be scheduled behind the missing one.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_bulk_sync_across_revoked_epoch<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let admin = builder.add_root_chain(0, Amount::from_tokens(3)).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let receiver = builder.add_root_chain(2, Amount::ZERO).await?;
+    let receiver_id = receiver.chain_id();
+    let validator = builder
+        .initial_committee
+        .validator_addresses()
+        .next()
+        .unwrap();
+
+    // Height 0 (epoch 0): send to the receiver.
+    let cert0 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // Create epoch 1. The receiver learns about it from an admin-chain `NewBlock`
+    // notification — not via `synchronize_from_validators`, which would deliver
+    // the height-0 transfer before the epoch is revoked — and migrates to epoch 1.
+    let create_cert = admin
+        .stage_new_committee(builder.initial_committee.clone())
+        .await
+        .unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: create_cert.block().header.height,
+                    hash: create_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    receiver.process_inbox().await?;
+    assert_eq!(receiver.chain_info().await?.epoch, Epoch::from(1));
+
+    // Height 1 migrates the sender to epoch 1 without sending anything; height 2
+    // (epoch 1) sends to the receiver again.
+    sender.synchronize_from_validators().await?;
+    let (migration_certs, _) = sender.process_inbox().await?;
+    let cert1 = migration_certs.last().expect("migration block").clone();
+    let cert2 = sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::ONE,
+            Account::chain(receiver_id),
+        )
+        .await
+        .unwrap_ok_committed();
+
+    // Revoke epoch 0, and let the receiver learn about the revocation the same way.
+    let revoke_cert = admin.revoke_epochs(Epoch::ZERO).await.unwrap_ok_committed();
+    receiver
+        .process_notification_from(
+            Notification {
+                chain_id: admin.chain_id(),
+                reason: Reason::NewBlock {
+                    height: revoke_cert.block().header.height,
+                    hash: revoke_cert.hash(),
+                },
+            },
+            validator,
+        )
+        .await;
+    assert!(
+        receiver
+            .storage_client()
+            .is_epoch_revoked(Epoch::ZERO)
+            .await?,
+        "the receiver's local node should know that epoch 0 is revoked",
+    );
+
+    // Sync via the received log: only epoch 1's log is queried, listing only the
+    // height-2 block. Its `previous_message_blocks` walk must fetch and
+    // re-certify the height-0 block, so both transfers get delivered.
+    receiver.synchronize_from_validators().await?;
+    receiver.process_inbox().await?;
+    assert_eq!(
+        receiver.local_balance().await?,
+        Amount::from_tokens(2),
+        "both transfers should have been received",
+    );
+
+    // The sender blocks were downloaded, but not the migration block in between.
+    let storage = receiver.storage_client();
+    assert!(storage.contains_certificate(cert0.hash()).await?);
+    assert!(!storage.contains_certificate(cert1.hash()).await?);
+    assert!(storage.contains_certificate(cert2.hash()).await?);
+
+    Ok(())
+}
+
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2507,7 +2507,7 @@ where
             .expect("no received log for epoch 0");
         assert_eq!(received_log.count(), 1);
     }
-    let query = ChainInfoQuery::new(chain_2).with_received_log(Epoch::ZERO, 0);
+    let query = ChainInfoQuery::new(chain_2).with_received_logs([(Epoch::ZERO, 0)]);
     let response = env
         .executing_worker()
         .handle_chain_info_query(query)

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2252,7 +2252,12 @@ where
     );
     assert_eq!(chain.tip_state.get().next_block_height, BlockHeight(0));
     assert_eq!(None, chain.tip_state.get().block_hash);
-    assert_eq!(chain.received_log.count(), 1);
+    let received_log = chain
+        .received_log
+        .try_load_entry(&Epoch::ZERO)
+        .await?
+        .expect("no received log for epoch 0");
+    assert_eq!(received_log.count(), 1);
     Ok(())
 }
 
@@ -2495,9 +2500,14 @@ where
             recipient_chain.tip_state.get().block_hash,
             Some(certificate.hash())
         );
-        assert_eq!(recipient_chain.received_log.count(), 1);
+        let received_log = recipient_chain
+            .received_log
+            .try_load_entry(&Epoch::ZERO)
+            .await?
+            .expect("no received log for epoch 0");
+        assert_eq!(received_log.count(), 1);
     }
-    let query = ChainInfoQuery::new(chain_2).with_received_log_excluding_first_n(0);
+    let query = ChainInfoQuery::new(chain_2).with_received_log(Epoch::ZERO, 0);
     let response = env
         .executing_worker()
         .handle_chain_info_query(query)
@@ -3802,22 +3812,13 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         .chain(bundles3.iter().cloned())
         .collect::<Vec<_>>();
 
-    fn without_epochs<'a>(
-        bundles: impl IntoIterator<Item = &'a (Epoch, MessageBundle)>,
-    ) -> Vec<MessageBundle> {
-        bundles
-            .into_iter()
-            .map(|(_, bundle)| bundle.clone())
-            .collect()
-    }
-
     let worker = env.worker();
     // Bundles are delivered regardless of their epoch's revocation.
     assert_eq!(
         worker
             .select_message_bundles(id1, &id0, BlockHeight::ZERO, bundles0123.clone())
             .await?,
-        without_epochs(&bundles0123)
+        bundles0123
     );
     // Already-received bundles are skipped, regardless of epoch.
     assert_eq!(
@@ -3830,7 +3831,11 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         worker
             .select_message_bundles(id1, &id0, BlockHeight::from(1), bundles012.clone())
             .await?,
-        without_epochs(bundles1.iter().chain(&bundles2))
+        bundles1
+            .iter()
+            .cloned()
+            .chain(bundles2.iter().cloned())
+            .collect::<Vec<_>>()
     );
     // Order of certificates is checked.
     assert_matches!(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2512,13 +2512,15 @@ where
         .executing_worker()
         .handle_chain_info_query(query)
         .await?;
-    assert_eq!(response.info.requested_received_log.len(), 1);
     assert_eq!(
-        response.info.requested_received_log[0],
-        ChainAndHeight {
-            chain_id: chain_1,
-            height: BlockHeight::ZERO
-        }
+        response.info.requested_received_log,
+        BTreeMap::from([(
+            Epoch::ZERO,
+            vec![ChainAndHeight {
+                chain_id: chain_1,
+                height: BlockHeight::ZERO,
+            }],
+        )])
     );
     Ok(())
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1589,7 +1589,7 @@ where
         origin: &ChainId,
         next_height_to_receive: BlockHeight,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Vec<MessageBundle>, WorkerError> {
+    ) -> Result<Vec<(Epoch, MessageBundle)>, WorkerError> {
         let state = self.get_or_create_chain_worker(recipient).await?;
         let guard = handle::read_lock(&state).await?;
         guard.select_message_bundles(origin, next_height_to_receive, bundles)
@@ -1937,7 +1937,7 @@ where
     pub async fn update_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-        new_trackers: BTreeMap<ValidatorPublicKey, u64>,
+        new_trackers: BTreeMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>,
     ) -> Result<(), WorkerError> {
         self.chain_write(chain_id, move |mut guard| async move {
             guard
@@ -2065,7 +2065,7 @@ where
     pub async fn get_received_certificate_trackers(
         &self,
         chain_id: ChainId,
-    ) -> Result<HashMap<ValidatorPublicKey, u64>, WorkerError> {
+    ) -> Result<HashMap<ValidatorPublicKey, BTreeMap<Epoch, u64>>, WorkerError> {
         self.chain_read(chain_id, |guard| async move {
             guard.get_received_certificate_trackers().await
         })

--- a/linera-explorer/src/components/Chain.vue
+++ b/linera-explorer/src/components/Chain.vue
@@ -24,6 +24,14 @@ function pendingBundleCount(): number {
   }
   return count
 }
+
+function receivedLogCount(): number {
+  let count = 0
+  for (const entry of props.chain.receivedLog?.entries || []) {
+    count += entry.value?.entries?.length || 0
+  }
+  return count
+}
 </script>
 
 <template>
@@ -374,16 +382,19 @@ function pendingBundleCount(): number {
         </div>
 
         <!-- Received Log -->
-        <li v-if="chain.receivedLog?.entries?.length" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#chain-'+chain.chainId+'-receivedlog-collapse'">
-          <span><strong>Received Log</strong> ({{ chain.receivedLog.entries.length }})</span>
+        <li v-if="receivedLogCount()" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#chain-'+chain.chainId+'-receivedlog-collapse'">
+          <span><strong>Received Log</strong> ({{ receivedLogCount() }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
-        <div v-if="chain.receivedLog?.entries?.length" class="collapse" :id="'chain-'+chain.chainId+'-receivedlog-collapse'">
+        <div v-if="receivedLogCount()" class="collapse" :id="'chain-'+chain.chainId+'-receivedlog-collapse'">
           <div class="list-group small">
-            <div v-for="(entry, i) in chain.receivedLog.entries" :key="i" class="list-group-item p-1 ps-3">
-              <a @click="$root.route(undefined, [['chain', entry.chainId]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(entry.chainId) }}</a>
-              <span class="ms-1">height {{ displayValue(entry.height) }}</span>
-            </div>
+            <template v-for="epochLog in chain.receivedLog.entries" :key="epochLog.key">
+              <div v-for="(entry, i) in epochLog.value?.entries || []" :key="epochLog.key + '-' + i" class="list-group-item p-1 ps-3">
+                <a @click="$root.route(undefined, [['chain', entry.chainId]])" class="btn btn-link btn-sm p-0 font-monospace">{{ short_hash(entry.chainId) }}</a>
+                <span class="ms-1">height {{ displayValue(entry.height) }}</span>
+                <span class="ms-1 text-body-secondary">epoch {{ displayValue(epochLog.key) }}</span>
+              </div>
+            </template>
           </div>
         </div>
 

--- a/linera-exporter/src/test_utils.rs
+++ b/linera-exporter/src/test_utils.rs
@@ -225,7 +225,7 @@ impl ValidatorNode for DummyValidator {
             committee_hash: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            requested_received_log: vec![],
+            requested_received_log: BTreeMap::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
         };

--- a/linera-exporter/src/test_utils.rs
+++ b/linera-exporter/src/test_utils.rs
@@ -225,7 +225,6 @@ impl ValidatorNode for DummyValidator {
             committee_hash: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            count_received_log: 0,
             requested_received_log: vec![],
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -230,15 +230,6 @@ message RevertConfirm {
   BlockHeight retransmit_from = 3;
 }
 
-// A request for entries of one sender epoch's received log.
-message ReceivedLogQuery {
-  // The sender epoch whose received log to read.
-  uint32 epoch = 1;
-
-  // The number of entries at the front of that epoch's log to skip.
-  uint64 skip = 2;
-}
-
 // Request information on a chain.
 message ChainInfoQuery {
   // The chain ID
@@ -250,9 +241,9 @@ message ChainInfoQuery {
   // Query the received messages that are waiting to be picked in the next block.
   bool request_pending_message_bundles = 3;
 
-  // Query the entries of one sender epoch's received log, skipping the first
-  // `skip` entries.
-  optional ReceivedLogQuery request_received_log = 4;
+  // Query the entries of the given sender epochs' received logs, skipping the
+  // given number of entries at the front of each epoch's log.
+  map<uint32, uint64> request_received_log = 4;
 
   // Query values from the chain manager, not just votes.
   bool request_manager_values = 5;

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -230,6 +230,15 @@ message RevertConfirm {
   BlockHeight retransmit_from = 3;
 }
 
+// A request for entries of one sender epoch's received log.
+message ReceivedLogQuery {
+  // The sender epoch whose received log to read.
+  uint32 epoch = 1;
+
+  // The number of entries at the front of that epoch's log to skip.
+  uint64 skip = 2;
+}
+
 // Request information on a chain.
 message ChainInfoQuery {
   // The chain ID
@@ -241,8 +250,9 @@ message ChainInfoQuery {
   // Query the received messages that are waiting to be picked in the next block.
   bool request_pending_message_bundles = 3;
 
-  // Query new certificate removed from the chain.
-  optional uint64 request_received_log_excluding_first_n = 4;
+  // Query the entries of one sender epoch's received log, skipping the first
+  // `skip` entries.
+  optional ReceivedLogQuery request_received_log = 4;
 
   // Query values from the chain manager, not just votes.
   bool request_manager_values = 5;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -22,7 +22,6 @@ use linera_chain::{
 use linera_core::{
     data_types::{
         CertificatesByHeightRequest, ChainInfoQuery, ChainInfoResponse, CrossChainRequest,
-        ReceivedLogQuery,
     },
     node::NodeError,
     worker::Notification,
@@ -699,12 +698,11 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_owner_balance: try_proto_convert(chain_info_query.request_owner_balance)?,
             request_pending_message_bundles: chain_info_query.request_pending_message_bundles,
             chain_id: try_proto_convert(chain_info_query.chain_id)?,
-            request_received_log: chain_info_query.request_received_log.map(|query| {
-                ReceivedLogQuery {
-                    epoch: Epoch(query.epoch),
-                    skip: query.skip,
-                }
-            }),
+            request_received_log: chain_info_query
+                .request_received_log
+                .into_iter()
+                .map(|(epoch, skip)| (Epoch(epoch), skip))
+                .collect(),
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
@@ -738,12 +736,11 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_sent_certificate_hashes_by_heights: Some(
                 request_sent_certificate_hashes_by_heights,
             ),
-            request_received_log: chain_info_query.request_received_log.map(|query| {
-                api::ReceivedLogQuery {
-                    epoch: query.epoch.0,
-                    skip: query.skip,
-                }
-            }),
+            request_received_log: chain_info_query
+                .request_received_log
+                .into_iter()
+                .map(|(epoch, skip)| (epoch.0, skip))
+                .collect(),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
@@ -1257,7 +1254,7 @@ pub mod tests {
             requested_owner_balance: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            requested_received_log: vec![],
+            requested_received_log: BTreeMap::new(),
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
         });
@@ -1290,7 +1287,7 @@ pub mod tests {
             test_next_block_height: Some(BlockHeight::from(10)),
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log: None,
+            request_received_log: BTreeMap::from([(Epoch(3), 7)]),
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: true,

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -6,7 +6,7 @@ use linera_base::{
         AccountPublicKey, AccountSignature, CryptoError, CryptoHash, ValidatorPublicKey,
         ValidatorSignature,
     },
-    data_types::{BlobContent, BlockHeight, NetworkDescription},
+    data_types::{BlobContent, BlockHeight, Epoch, NetworkDescription},
     ensure,
     identifiers::{AccountOwner, BlobId, ChainId, EventId},
 };
@@ -22,6 +22,7 @@ use linera_chain::{
 use linera_core::{
     data_types::{
         CertificatesByHeightRequest, ChainInfoQuery, ChainInfoResponse, CrossChainRequest,
+        ReceivedLogQuery,
     },
     node::NodeError,
     worker::Notification,
@@ -698,8 +699,12 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_owner_balance: try_proto_convert(chain_info_query.request_owner_balance)?,
             request_pending_message_bundles: chain_info_query.request_pending_message_bundles,
             chain_id: try_proto_convert(chain_info_query.chain_id)?,
-            request_received_log_excluding_first_n: chain_info_query
-                .request_received_log_excluding_first_n,
+            request_received_log: chain_info_query.request_received_log.map(|query| {
+                ReceivedLogQuery {
+                    epoch: Epoch(query.epoch),
+                    skip: query.skip,
+                }
+            }),
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
@@ -733,8 +738,12 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_sent_certificate_hashes_by_heights: Some(
                 request_sent_certificate_hashes_by_heights,
             ),
-            request_received_log_excluding_first_n: chain_info_query
-                .request_received_log_excluding_first_n,
+            request_received_log: chain_info_query.request_received_log.map(|query| {
+                api::ReceivedLogQuery {
+                    epoch: query.epoch.0,
+                    skip: query.skip,
+                }
+            }),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
@@ -1248,7 +1257,6 @@ pub mod tests {
             requested_owner_balance: None,
             requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
-            count_received_log: 0,
             requested_received_log: vec![],
             requested_previous_event_blocks: BTreeMap::new(),
             requested_latest_checkpoint_height: None,
@@ -1282,7 +1290,7 @@ pub mod tests {
             test_next_block_height: Some(BlockHeight::from(10)),
             request_owner_balance: AccountOwner::CHAIN,
             request_pending_message_bundles: false,
-            request_received_log_excluding_first_n: None,
+            request_received_log: None,
             request_manager_values: false,
             request_leader_timeout: None,
             request_fallback: true,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -326,7 +326,6 @@ ChainInfo:
     - requested_sent_certificate_hashes:
         SEQ:
           TYPENAME: CryptoHash
-    - count_received_log: U64
     - requested_received_log:
         SEQ:
           TYPENAME: ChainAndHeight
@@ -351,8 +350,9 @@ ChainInfoQuery:
     - request_owner_balance:
         TYPENAME: AccountOwner
     - request_pending_message_bundles: BOOL
-    - request_received_log_excluding_first_n:
-        OPTION: U64
+    - request_received_log:
+        OPTION:
+          TYPENAME: ReceivedLogQuery
     - request_manager_values: BOOL
     - request_leader_timeout:
         OPTION:
@@ -1061,6 +1061,11 @@ Reason:
               TYPENAME: BlockHeight
           - hash:
               TYPENAME: CryptoHash
+ReceivedLogQuery:
+  STRUCT:
+    - epoch:
+        TYPENAME: Epoch
+    - skip: U64
 Response:
   STRUCT:
     - status: U16

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -327,8 +327,12 @@ ChainInfo:
         SEQ:
           TYPENAME: CryptoHash
     - requested_received_log:
-        SEQ:
-          TYPENAME: ChainAndHeight
+        MAP:
+          KEY:
+            TYPENAME: Epoch
+          VALUE:
+            SEQ:
+              TYPENAME: ChainAndHeight
     - requested_previous_event_blocks:
         MAP:
           KEY:
@@ -351,8 +355,10 @@ ChainInfoQuery:
         TYPENAME: AccountOwner
     - request_pending_message_bundles: BOOL
     - request_received_log:
-        OPTION:
-          TYPENAME: ReceivedLogQuery
+        MAP:
+          KEY:
+            TYPENAME: Epoch
+          VALUE: U64
     - request_manager_values: BOOL
     - request_leader_timeout:
         OPTION:
@@ -1061,11 +1067,6 @@ Reason:
               TYPENAME: BlockHeight
           - hash:
               TYPENAME: CryptoHash
-ReceivedLogQuery:
-  STRUCT:
-    - epoch:
-        TYPENAME: Epoch
-    - skip: U64
 Response:
   STRUCT:
     - status: U16

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -157,9 +157,15 @@ query Chain(
       }
     }
     receivedLog {
+      keys
       entries {
-        chainId
-        height
+        key
+        value {
+          entries {
+            chainId
+            height
+          }
+        }
       }
     }
     inboxes {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -376,12 +376,7 @@ type ChainStateExtendedView {
 	matter are re-certified via `previous_block_hash` /
 	`previous_message_blocks` links instead.
 	"""
-	receivedLog: CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2!
-	"""
-	The number of `received_log` entries we have synchronized, per validator and
-	per sender epoch.
-	"""
-	receivedCertificateTrackers: JSONObject!
+	receivedLog: CustomCollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2!
 	"""
 	Mailboxes used to receive messages indexed by their origin.
 	"""
@@ -556,13 +551,6 @@ type ClaimOperationMetadata {
 	amount: Amount!
 }
 
-type CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2 {
-	keys: [Epoch!]!
-	count: Int!
-	entry(key: Epoch!): Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!
-	entries(input: MapInput_Epoch_530caf4b): [Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!]!
-}
-
 """
 A set of validators (identified by their public keys) and their voting rights.
 """
@@ -655,6 +643,13 @@ type Cursor {
 	The transaction index within the block.
 	"""
 	index: Int!
+}
+
+type CustomCollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2 {
+	keys: [Epoch!]!
+	count: Int!
+	entry(key: Epoch!): Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!
+	entries(input: MapInput_Epoch_530caf4b): [Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!]!
 }
 
 type CustomMapView_BlockHeight_CryptoHash_1bae6d76 {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -369,11 +369,17 @@ type ChainStateExtendedView {
 	"""
 	blockHashes: CustomMapView_BlockHeight_CryptoHash_1bae6d76!
 	"""
-	Sender chain and height of all certified blocks known as a receiver (local ordering).
+	Sender chain and height of all certified blocks known as a receiver (local
+	ordering), keyed by the epoch of the sender block's certificate. Partitioned
+	by epoch so that a revoked epoch's log can be dropped wholesale: clients
+	cannot verify those certificates on their own anymore, and blocks that still
+	matter are re-certified via `previous_block_hash` /
+	`previous_message_blocks` links instead.
 	"""
-	receivedLog: LogView_ChainAndHeight_7af83576!
+	receivedLog: CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2!
 	"""
-	The number of `received_log` entries we have synchronized, for each validator.
+	The number of `received_log` entries we have synchronized, per validator and
+	per sender epoch.
 	"""
 	receivedCertificateTrackers: JSONObject!
 	"""
@@ -550,6 +556,13 @@ type ClaimOperationMetadata {
 	amount: Amount!
 }
 
+type CollectionView_Epoch_LogView_ChainAndHeight_7af83576_e5e7eea2 {
+	keys: [Epoch!]!
+	count: Int!
+	entry(key: Epoch!): Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!
+	entries(input: MapInput_Epoch_530caf4b): [Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a!]!
+}
+
 """
 A set of validators (identified by their public keys) and their voting rights.
 """
@@ -709,6 +722,14 @@ type Entry_ChainId_OutboxStateView_855dcf53 {
 """
 A GraphQL-visible map item, complete with key.
 """
+type Entry_Epoch_LogView_ChainAndHeight_7af83576_a2d4b47a {
+	key: Epoch!
+	value: LogView_ChainAndHeight_7af83576!
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
 type Entry_StreamId_StreamCounts_d5e24a40 {
 	key: StreamId!
 	value: StreamCounts
@@ -852,6 +873,10 @@ input MapFilters_ChainId_37f83aa9 {
 	keys: [ChainId!]
 }
 
+input MapFilters_Epoch_530caf4b {
+	keys: [Epoch!]
+}
+
 input MapFilters_StreamIdInput_b7c3909d {
 	keys: [StreamIdInput!]
 }
@@ -870,6 +895,10 @@ input MapInput_BlockHeight_e824a938 {
 
 input MapInput_ChainId_37f83aa9 {
 	filters: MapFilters_ChainId_37f83aa9
+}
+
+input MapInput_Epoch_530caf4b {
+	filters: MapFilters_Epoch_530caf4b
 }
 
 input MapInput_StreamIdInput_b7c3909d {

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -316,6 +316,19 @@ impl CustomSerialize for linera_base::data_types::BlockHeight {
     }
 }
 
+impl CustomSerialize for linera_base::data_types::Epoch {
+    fn to_custom_bytes(&self) -> Result<Vec<u8>, ViewError> {
+        Ok(self.0.to_be_bytes().to_vec())
+    }
+
+    fn from_custom_bytes(bytes: &[u8]) -> Result<Self, ViewError> {
+        let array: [u8; 4] = bytes
+            .try_into()
+            .map_err(|_| ViewError::PostLoadValuesError)?;
+        Ok(Self(u32::from_be_bytes(array)))
+    }
+}
+
 /// This computes the offset of the BCS serialization of a vector.
 /// The formula that should be satisfied is
 /// `serialized_size(vec![v_1, ...., v_n]) = get_uleb128_size(n)`


### PR DESCRIPTION
 ## Motivation

Validators keep every chain's received log forever, including entries that point at certificates from revoked epochs — which clients cannot verify on their own anymore. The log can't simply be truncated: clients track their position in it by index, so removing entries would shift every index behind them.

## Proposal

Partition the received log by the epoch of the sender's certificate, so a revoked epoch's log can be dropped wholesale, and its client-side tracker with it. Validators prune revoked epochs when a client asks for a live epoch's log. Clients keep one tracker per validator and epoch, and request all live epochs in a single query, so a network with many live epochs doesn't pay for one round trip per epoch.

Since a sync then only sees live epochs' entries, an undelivered message from a pruned epoch could otherwise block the messages behind it forever. The client therefore processes the lowest listed block together with its sending ancestors, which re-certifies the pruned-epoch message through the links introduced in the previous PR.

## Test Plan

CI, plus unit tests covering per-epoch log serving and pruning, the batched multi-epoch query, and a regression test for bulk-syncing across a revoked epoch.

## Release Plan

- Backporting is not possible but we may want to deploy a new `devnet` and release a new
    SDK soon.

## Links

  - Stacked on #6603.
  - [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)