### PR TITLE
Require timeout certificates to leave all non-Fast rounds

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -377,7 +377,8 @@ If the wallet holds the key pair for exactly one of the new chain's owners, that
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks. "null" is equivalent to 2^32 - 1. Absence of the option leaves the current setting unchanged
 * `--open-multi-leader-rounds` — Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners. This should only be `true` on chains with restrictive application permissions and an application-based mechanism to select block proposers
 * `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds. "null" means the fast round will not time out. Absence of the option leaves the current setting unchanged
-* `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds. Absence of the option leaves the current setting unchanged
+* `--multi-leader-round-ms <MULTI_LEADER_ROUND_DURATION>` — The duration of every multi-leader round, in milliseconds. Absence of the option leaves the current setting unchanged
+* `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader round, in milliseconds. Absence of the option leaves the current setting unchanged
 * `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round. Absence of the option leaves the current setting unchanged
 * `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds. Absence of the option leaves the current setting unchanged
 * `--execute-operations <EXECUTE_OPERATIONS>` — A JSON list of applications allowed to execute operations on this chain. If set to null, all operations will be allowed. Otherwise, only operations from the specified applications are allowed, and no system operations. Absence of the option leaves current permissions unchanged
@@ -422,7 +423,8 @@ If the chain's current preferred owner is no longer one of the chain's owners an
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks. "null" is equivalent to 2^32 - 1. Absence of the option leaves the current setting unchanged
 * `--open-multi-leader-rounds` — Whether the multi-leader rounds are unrestricted, i.e. not limited to chain owners. This should only be `true` on chains with restrictive application permissions and an application-based mechanism to select block proposers
 * `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds. "null" means the fast round will not time out. Absence of the option leaves the current setting unchanged
-* `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds. Absence of the option leaves the current setting unchanged
+* `--multi-leader-round-ms <MULTI_LEADER_ROUND_DURATION>` — The duration of every multi-leader round, in milliseconds. Absence of the option leaves the current setting unchanged
+* `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader round, in milliseconds. Absence of the option leaves the current setting unchanged
 * `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round. Absence of the option leaves the current setting unchanged
 * `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds. Absence of the option leaves the current setting unchanged
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -1342,7 +1342,7 @@ mod tests {
         );
         assert_eq!(
             description.id().to_string(),
-            "372e43034b962ee04f8242bce87fa9cd405dd824a31b6673cef4d24b937d0de5"
+            "86152d19bd562045e3a9d500e49f005b38e1dc5416e58ca98b5207a958873701"
         );
     }
 

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -39,7 +39,11 @@ pub struct TimeoutConfig {
     /// The duration of the fast round.
     #[debug(skip_if = Option::is_none)]
     pub fast_round_duration: Option<TimeDelta>,
-    /// The duration of the first single-leader and all multi-leader rounds.
+    /// The duration of every multi-leader round. Multi-leader rounds use a fixed (typically
+    /// short) duration: a quorum of timeout votes is required to leave a multi-leader round,
+    /// so this controls the retry latency under multi-leader contention.
+    pub multi_leader_round_duration: TimeDelta,
+    /// The duration of the first single-leader round.
     pub base_timeout: TimeDelta,
     /// The duration by which the timeout increases after each single-leader round.
     pub timeout_increment: TimeDelta,
@@ -52,6 +56,9 @@ impl Default for TimeoutConfig {
     fn default() -> Self {
         Self {
             fast_round_duration: None,
+            // Multi-leader rounds are meant to be cooperative, so contention should be rare;
+            // when it does happen, a short round keeps the retry latency low.
+            multi_leader_round_duration: TimeDelta::from_secs(1),
             base_timeout: TimeDelta::from_secs(10),
             timeout_increment: TimeDelta::from_secs(1),
             // This is `MAX` because the validators are not currently expected to start clients for
@@ -168,15 +175,9 @@ impl ChainOwnership {
     /// Returns the duration of the given round.
     pub fn round_timeout(&self, round: Round) -> Option<TimeDelta> {
         let tc = &self.timeout_config;
-        if round.is_fast() && self.owners.is_empty() {
-            return None; // Fast round only times out if there are regular owners.
-        }
         match round {
             Round::Fast => tc.fast_round_duration,
-            Round::MultiLeader(r) if r.saturating_add(1) == self.multi_leader_rounds => {
-                Some(tc.base_timeout)
-            }
-            Round::MultiLeader(_) => None,
+            Round::MultiLeader(_) => Some(tc.multi_leader_round_duration),
             Round::SingleLeader(r) | Round::Validator(r) => {
                 let increment = tc.timeout_increment.saturating_mul(u64::from(r));
                 Some(tc.base_timeout.saturating_add(increment))
@@ -269,6 +270,7 @@ mod tests {
             open_multi_leader_rounds: false,
             timeout_config: TimeoutConfig {
                 fast_round_duration: Some(TimeDelta::from_secs(5)),
+                multi_leader_round_duration: TimeDelta::from_secs(2),
                 base_timeout: TimeDelta::from_secs(10),
                 timeout_increment: TimeDelta::from_secs(1),
                 fallback_duration: TimeDelta::from_secs(60 * 60),
@@ -279,10 +281,13 @@ mod tests {
             ownership.round_timeout(Round::Fast),
             Some(TimeDelta::from_secs(5))
         );
-        assert_eq!(ownership.round_timeout(Round::MultiLeader(8)), None);
         assert_eq!(
-            ownership.round_timeout(Round::MultiLeader(9)),
-            Some(TimeDelta::from_secs(10))
+            ownership.round_timeout(Round::MultiLeader(0)),
+            Some(TimeDelta::from_secs(2))
+        );
+        assert_eq!(
+            ownership.round_timeout(Round::MultiLeader(8)),
+            Some(TimeDelta::from_secs(2))
         );
         assert_eq!(
             ownership.round_timeout(Round::SingleLeader(0)),

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -116,6 +116,7 @@ fn module_id_test_case() -> ModuleId {
 fn timeout_config_test_case() -> TimeoutConfig {
     TimeoutConfig {
         fast_round_duration: Some(TimeDelta::from_micros(20)),
+        multi_leader_round_duration: TimeDelta::from_millis(500),
         base_timeout: TimeDelta::from_secs(4),
         timeout_increment: TimeDelta::from_millis(125),
         fallback_duration: TimeDelta::from_secs(1_000),
@@ -148,6 +149,7 @@ fn chain_ownership_test_case() -> ChainOwnership {
         open_multi_leader_rounds: false,
         timeout_config: TimeoutConfig {
             fast_round_duration: None,
+            multi_leader_round_duration: TimeDelta::from_secs(1),
             base_timeout: TimeDelta::ZERO,
             timeout_increment: TimeDelta::from_secs(3_600),
             fallback_duration: TimeDelta::from_secs(10_000),

--- a/linera-chain/src/data_types/metadata.rs
+++ b/linera-chain/src/data_types/metadata.rs
@@ -23,7 +23,9 @@ use serde::{Deserialize, Serialize};
 pub struct TimeoutConfigMetadata {
     /// The duration of the fast round in milliseconds.
     pub fast_round_ms: Option<String>,
-    /// The duration of the first single-leader and all multi-leader rounds in milliseconds.
+    /// The duration of every multi-leader round, in milliseconds.
+    pub multi_leader_round_ms: String,
+    /// The duration of the first single-leader round, in milliseconds.
     pub base_timeout_ms: String,
     /// The duration by which the timeout increases after each single-leader round in milliseconds.
     pub timeout_increment_ms: String,
@@ -38,6 +40,8 @@ impl From<&TimeoutConfig> for TimeoutConfigMetadata {
             fast_round_ms: config
                 .fast_round_duration
                 .map(|d| (d.as_micros() / 1000).to_string()),
+            multi_leader_round_ms: (config.multi_leader_round_duration.as_micros() / 1000)
+                .to_string(),
             base_timeout_ms: (config.base_timeout.as_micros() / 1000).to_string(),
             timeout_increment_ms: (config.timeout_increment.as_micros() / 1000).to_string(),
             fallback_duration_ms: (config.fallback_duration.as_micros() / 1000).to_string(),

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -45,20 +45,20 @@
 //!
 //! ## Liveness, i.e. some block will eventually be confirmed
 //!
-//! In `Round::Fast`, liveness depends on the super owners coordinating, and proposing at most one
-//! block.
+//! Every non-`Fast` round leaves only via a timeout certificate (or a higher-round locking
+//! block). The same uniform rule applies to `Round::Fast`: if it has a configured timeout and
+//! the super owners propose nothing, validators eventually sign a timeout, and the next round
+//! opens. A chain with no `fast_round_duration` and no other owners therefore relies entirely
+//! on its super owners for progress — by design.
 //!
-//! If they propose none, and there are other owners, `Round::Fast` will eventually time out.
+//! In cooperative mode, if there is contention in a multi-leader round, validators will time out
+//! the round (using the short `multi_leader_round_duration`) and a quorum will form a timeout
+//! certificate. The next multi-leader round then opens, and an honest owner downloads the
+//! highest-round certificates and locking block known to honest validators and proposes in the
+//! new round. If there is a `ValidatedBlock` certificate they must include it and propose that
+//! block; otherwise they can propose a new block.
 //!
-//! In cooperative mode, if there is contention, the owners need to agree on a single owner as the
-//! next proposer. That owner should then download all highest-round certificates and block
-//! proposals known to the honest validators. They can then make a proposal in a round higher than
-//! all previous proposals. If there is any `ValidatedBlock` certificate they must include the
-//! highest one in their proposal, and propose that block. Otherwise they can propose a new block.
-//! Now all honest validators are allowed to vote for that proposal, and eventually confirm it.
-//!
-//! If the owners fail to cooperate, any honest owner can initiate the last multi-leader round by
-//! making a proposal there, then wait for it to time out, which starts the leader-based mode:
+//! Once the configured multi-leader rounds are exhausted, the protocol enters leader-based mode:
 //!
 //! In leader-based and fallback/public mode, an honest participant should subscribe to
 //! notifications from all validators, and follow the chain. Whenever another leader's round takes
@@ -162,12 +162,6 @@ where
     #[cfg_attr(with_graphql, graphql(skip))] // Derived from validator weights.
     #[allocative(skip)]
     pub fallback_distribution: RegisterView<C, Option<WeightedAliasIndex<u64>>>,
-    /// Highest-round authenticated block that we have received, but not necessarily
-    /// checked yet. If there are multiple proposals in the same round, this contains only the
-    /// first one. This can even contain proposals that did not execute successfully, to determine
-    /// which round to propose in.
-    #[cfg_attr(with_graphql, graphql(skip))]
-    pub signed_proposal: RegisterView<C, Option<BlockProposal>>,
     /// Highest-round authenticated block that we have received and checked. If there are multiple
     /// proposals in the same round, this contains only the first one.
     #[cfg_attr(with_graphql, graphql(skip))]
@@ -201,8 +195,9 @@ where
     /// the round to which the timeout applies.
     ///
     /// Having a leader timeout certificate in any given round causes the next one to become
-    /// current. Seeing a validated block certificate or a valid proposal in any round causes that
-    /// round to become current, unless a higher one already is.
+    /// current. A locking block from a higher round also causes that round to become current.
+    /// All other round advancement (including past multi-leader rounds) requires a timeout
+    /// certificate.
     #[cfg_attr(with_graphql, graphql(skip))]
     pub current_round: RegisterView<C, Round>,
     /// The owners that take over in fallback mode.
@@ -219,8 +214,7 @@ where
     /// the round to which the timeout applies.
     ///
     /// Having a leader timeout certificate in any given round causes the next one to become
-    /// current. Seeing a validated block certificate or a valid proposal in any round causes that
-    /// round to become current, unless a higher one already is.
+    /// current. A locking block from a higher round also causes that round to become current.
     #[graphql(derived(name = "current_round"))]
     async fn _current_round(&self) -> Round {
         self.current_round()
@@ -275,8 +269,7 @@ where
     /// the round to which the timeout applies.
     ///
     /// Having a leader timeout certificate in any given round causes the next one to become
-    /// current. Seeing a validated block certificate or a valid proposal in any round causes that
-    /// round to become current, unless a higher one already is.
+    /// current. A locking block from a higher round also causes that round to become current.
     pub fn current_round(&self) -> Round {
         *self.current_round.get()
     }
@@ -300,21 +293,9 @@ where
             // The proposal from the fast round may still be relevant as a locking block, so
             // we don't compare against the current round here.
             Round::Fast => {}
-            Round::MultiLeader(_) | Round::SingleLeader(0) => {
-                // If the fast round has not timed out yet, only a super owner is allowed to open
-                // a later round by making a proposal.
-                ensure!(
-                    self.is_super(&proposal.owner()) || !current_round.is_fast(),
-                    ChainError::WrongRound(current_round)
-                );
-                // After the fast round, proposals older than the current round are obsolete.
-                ensure!(
-                    new_round >= current_round,
-                    ChainError::InsufficientRound(new_round)
-                );
-            }
-            Round::SingleLeader(_) | Round::Validator(_) => {
-                // After the first single-leader round, only proposals from the current round are relevant.
+            // All other rounds can only be advanced via a timeout certificate. A proposal
+            // must therefore match the current round exactly.
+            Round::MultiLeader(_) | Round::SingleLeader(_) | Round::Validator(_) => {
                 ensure!(
                     new_round == current_round,
                     ChainError::WrongRound(current_round)
@@ -620,21 +601,15 @@ where
 
     /// Updates `current_round` and `round_timeout` if necessary.
     ///
-    /// This must be called after every change to `timeout`, `locking`, `proposed` or
-    /// `signed_proposal`.
+    /// This must be called after every change to `timeout` or `locking_block`.
     ///
     /// The current round starts at `Fast` if there is a super owner, `MultiLeader(0)` if at least
     /// one multi-leader round is configured, or otherwise `SingleLeader(0)`.
     ///
-    /// Single-leader rounds can only be ended by a timeout certificate for that round.
-    ///
-    /// The presence of any validated block certificate is also proof that a quorum of validators
-    /// is already in that round, even if we have not seen the corresponding timeout.
-    ///
-    /// Multi-leader rounds can always be skipped, so any correctly signed block proposal in a
-    /// later round ends a multi-leader round.
-    /// Since we don't accept proposals that violate that rule, we can compute the current round in
-    /// general by taking the maximum of all the above.
+    /// All non-Fast rounds can only be advanced by a timeout certificate for that round, except
+    /// that the presence of a locking block at round `r` is proof a quorum of validators is at
+    /// least in round `r` (since a `ValidatedBlock` certificate carries that quorum), and so
+    /// `current_round` is also raised to match.
     fn update_current_round(&mut self, local_time: Timestamp) {
         let current_round = self
             .timeout
@@ -647,16 +622,8 @@ where
                     .next_round(certificate.round)
                     .unwrap_or(Round::Validator(u32::MAX))
             })
-            // A locking block or a proposal is proof we have accepted that we are at least in
-            // this round.
+            // A locking block is proof a quorum is at least in this round.
             .chain(self.locking_block.get().as_ref().map(LockingBlock::round))
-            .chain(
-                self.proposed
-                    .get()
-                    .iter()
-                    .chain(self.signed_proposal.get())
-                    .map(|proposal| proposal.content.round),
-            )
             .max()
             .unwrap_or_default()
             // Otherwise compute the first round for this chain configuration.
@@ -721,49 +688,6 @@ where
         )
     }
 
-    /// Returns whether the owner is a super owner.
-    fn is_super(&self, owner: &AccountOwner) -> bool {
-        self.ownership.get().super_owners.contains(owner)
-    }
-
-    /// Sets the signed proposal, if it is newer than the known one, at most from the first
-    /// single-leader round. Returns whether it was updated.
-    ///
-    /// We don't update the signed proposal for any rounds later than `SingleLeader(0)`,
-    /// because single-leader rounds cannot be skipped without a timeout certificate.
-    pub fn update_signed_proposal(
-        &mut self,
-        proposal: &BlockProposal,
-        local_time: Timestamp,
-    ) -> bool {
-        if proposal.content.round > Round::SingleLeader(0) {
-            return false;
-        }
-        if let Some(old_proposal) = self.signed_proposal.get() {
-            if old_proposal.content.round >= proposal.content.round {
-                if *self.current_round.get() < old_proposal.content.round {
-                    tracing::warn!(
-                        chain_id = %proposal.content.block.chain_id,
-                        current_round = ?self.current_round.get(),
-                        proposal_round = ?old_proposal.content.round,
-                        "Proposal round is greater than current round. Updating."
-                    );
-                    self.update_current_round(local_time);
-                    return true;
-                }
-                return false;
-            }
-        }
-        if let Some(old_proposal) = self.proposed.get() {
-            if old_proposal.content.round >= proposal.content.round {
-                return false;
-            }
-        }
-        self.signed_proposal.set(Some(proposal.clone()));
-        self.update_current_round(local_time);
-        true
-    }
-
     /// Sets the proposed block, if it is newer than our known latest proposal.
     fn update_proposed(
         &mut self,
@@ -773,11 +697,6 @@ where
         if let Some(old_proposal) = self.proposed.get() {
             if old_proposal.content.round >= proposal.content.round {
                 return Ok(());
-            }
-        }
-        if let Some(old_proposal) = self.signed_proposal.get() {
-            if old_proposal.content.round <= proposal.content.round {
-                self.signed_proposal.set(None);
             }
         }
         self.proposed.set(Some(proposal));
@@ -865,9 +784,6 @@ pub struct ChainManagerInfo {
     pub ownership: ChainOwnership,
     /// The seed for the pseudo-random number generator that determines the round leaders.
     pub seed: u64,
-    /// Latest authenticated block that we have received, if requested. This can even contain
-    /// proposals that did not execute successfully, to determine which round to propose in.
-    pub requested_signed_proposal: Option<Box<BlockProposal>>,
     /// Latest authenticated block that we have received and checked, if requested.
     #[debug(skip_if = Option::is_none)]
     pub requested_proposed: Option<Box<BlockProposal>>,
@@ -923,7 +839,6 @@ where
         ChainManagerInfo {
             ownership: manager.ownership.get().clone(),
             seed: *manager.seed.get(),
-            requested_signed_proposal: None,
             requested_proposed: None,
             requested_locking: None,
             timeout: manager.timeout.get().clone().map(Box::new),
@@ -946,7 +861,6 @@ impl ChainManagerInfo {
         C: Context + Clone + 'static,
         C::Extra: ExecutionRuntimeContext,
     {
-        self.requested_signed_proposal = manager.signed_proposal.get().clone().map(Box::new);
         self.requested_proposed = manager.proposed.get().clone().map(Box::new);
         self.requested_locking = manager.locking_block.get().clone().map(Box::new);
         self.requested_confirmed = manager

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -1191,10 +1191,10 @@ impl<Env: Environment> ClientContext<Env> {
                 }
                 let chain_client = self.make_chain_client(chain_id).await?;
                 let ownership = chain_client.chain_info().await?.manager.ownership;
-                if !ownership.owners.is_empty() || ownership.super_owners.len() != 1 {
+                if !ownership.super_owners.is_empty() || ownership.owners.len() != 1 {
                     continue;
                 }
-                let owner = *ownership.super_owners.first().unwrap();
+                let owner = *ownership.owners.first_key_value().unwrap().0;
                 chain_client.process_inbox().await?;
                 benchmark_chains.push((chain_id, owner));
                 chain_clients.push(chain_client);
@@ -1305,7 +1305,10 @@ impl<Env: Environment> ClientContext<Env> {
             .iter()
             .map(|owner| {
                 let config = OpenChainConfig {
-                    ownership: ChainOwnership::single_super(*owner),
+                    // A regular owner, so the chain starts in `MultiLeader(0)`: benchmark
+                    // blocks may contain oracle responses (e.g. Wasm bytecode blob reads),
+                    // which are not allowed in the fast round.
+                    ownership: ChainOwnership::single(*owner),
                     balance,
                     application_permissions: Default::default(),
                 };

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -444,8 +444,16 @@ pub struct ChainOwnershipConfig {
     #[arg(long = "fast-round-ms", value_parser = util::parse_json_optional_millis_delta)]
     pub fast_round_duration: Option<std::option::Option<TimeDelta>>,
 
-    /// The duration of the first single-leader and all multi-leader rounds. Absence of
-    /// the option leaves the current setting unchanged.
+    /// The duration of every multi-leader round, in milliseconds. Absence of the option
+    /// leaves the current setting unchanged.
+    #[arg(
+        long = "multi-leader-round-ms",
+        value_parser = util::parse_millis_delta
+    )]
+    pub multi_leader_round_duration: Option<TimeDelta>,
+
+    /// The duration of the first single-leader round, in milliseconds. Absence of the
+    /// option leaves the current setting unchanged.
     #[arg(
         long = "base-timeout-ms",
         value_parser = util::parse_millis_delta
@@ -480,6 +488,7 @@ impl ChainOwnershipConfig {
             multi_leader_rounds,
             fast_round_duration,
             open_multi_leader_rounds,
+            multi_leader_round_duration,
             base_timeout,
             timeout_increment,
             fallback_duration,
@@ -504,6 +513,10 @@ impl ChainOwnershipConfig {
 
         if let Some(fast_round_duration) = fast_round_duration {
             chain_ownership.timeout_config.fast_round_duration = fast_round_duration;
+        }
+        if let Some(multi_leader_round_duration) = multi_leader_round_duration {
+            chain_ownership.timeout_config.multi_leader_round_duration =
+                multi_leader_round_duration;
         }
         if let Some(base_timeout) = base_timeout {
             chain_ownership.timeout_config.base_timeout = base_timeout;

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -2364,11 +2364,6 @@ where
     }
 
     /// Validates and executes a block proposed to extend this chain.
-    ///
-    /// Returns network actions alongside the result so the caller can dispatch them
-    /// even when the proposal is rejected: a `HasIncompatibleConfirmedVote` rejection
-    /// can still advance `current_round` via `update_signed_proposal`, and subscribers
-    /// need the resulting `NewRound` notification.
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
         block_height = %proposal.content.block.height
@@ -2376,35 +2371,21 @@ where
     pub(crate) async fn handle_block_proposal(
         &mut self,
         proposal: BlockProposal,
-    ) -> (Result<ChainInfoResponse, WorkerError>, NetworkActions) {
+    ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         #[cfg(with_metrics)]
         metrics::BLOCK_PROPOSALS_RECEIVED_TOTAL.inc();
         let chain_id = proposal.content.block.chain_id;
         let height = proposal.content.block.height;
-        let old_round = self.chain.manager.current_round();
-        match self.try_handle_block_proposal(proposal).await {
-            Ok((response, actions)) => (Ok(response), actions),
-            Err(err) => {
+        self.try_handle_block_proposal(proposal)
+            .await
+            .inspect_err(|err| {
                 let error_type = err.error_type();
                 #[cfg(with_metrics)]
                 metrics::BLOCK_PROPOSALS_REJECTED_TOTAL
                     .with_label_values(&[error_type.as_str()])
                     .inc();
                 debug!(%chain_id, %height, %error_type, "Block proposal rejected");
-                // Even on error, the manager's `current_round` may have advanced
-                // (the `HasIncompatibleConfirmedVote` recovery path calls
-                // `update_signed_proposal`). Surface the resulting `NewRound`
-                // notification so subscribers can react.
-                let actions = if self.chain.manager.current_round() != old_round {
-                    self.create_network_actions(Some(old_round))
-                        .await
-                        .unwrap_or_default()
-                } else {
-                    NetworkActions::default()
-                };
-                (Err(err), actions)
-            }
-        }
+            })
     }
 
     async fn try_handle_block_proposal(
@@ -2482,34 +2463,7 @@ where
                 return Ok((self.chain_info_response().await?, NetworkActions::default()));
             }
             Ok(manager::Outcome::Accept) => {}
-            Err(err) => {
-                // A `HasIncompatibleConfirmedVote` rejection means the proposer is at a
-                // round we'd otherwise be happy to sign at; only our prior confirmed vote
-                // prevents us from voting. Record the proposal so `current_round` still
-                // tracks the round the proposer is in — without it, the chain can wedge.
-                // Other rejections (e.g. `WrongRound`, `InsufficientRound`) mean the
-                // proposal is not actually valid for the chain's current state, so we
-                // shouldn't let it advance our round.
-                if matches!(err, ChainError::HasIncompatibleConfirmedVote(_, _))
-                    && self
-                        .chain
-                        .manager
-                        .update_signed_proposal(&proposal, local_time)
-                {
-                    self.save().await?;
-                }
-                return Err(err.into());
-            }
-        }
-
-        // Make sure we remember that a proposal was signed, to determine the correct round to
-        // propose in.
-        if self
-            .chain
-            .manager
-            .update_signed_proposal(&proposal, local_time)
-        {
-            self.save().await?;
+            Err(err) => return Err(err.into()),
         }
 
         let published_blobs = self.load_proposal_blobs(&proposal).await?;

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2406,29 +2406,26 @@ impl<Env: Environment> ChainClient<Env> {
     ) -> Result<Either<Round, RoundTimeout>, Error> {
         let manager = &info.manager;
         let seed = manager.seed;
-        // If there is a conflicting proposal in the current round, we can only propose if the
-        // next round can be started without a timeout, i.e. if we are in a multi-leader round.
-        // Similarly, we cannot propose a block that uses oracles in the fast round, and also
-        // skip the fast round if fast blocks are not allowed.
+        // We cannot propose a block that uses oracles in the fast round, and also need to
+        // skip the fast round if fast blocks are not allowed. Under timeout-only round
+        // advancement, that means waiting for the Fast round to time out — chains with
+        // `fast_round_duration: None` and a super owner can't skip Fast.
         let skip_fast = manager.current_round.is_fast()
             && (has_oracle_responses || !self.options.allow_fast_blocks);
         let conflict = manager
-            .requested_signed_proposal
+            .requested_proposed
             .as_ref()
-            .into_iter()
-            .chain(&manager.requested_proposed)
-            .any(|proposal| proposal.content.round == manager.current_round)
+            .is_some_and(|proposal| proposal.content.round == manager.current_round)
             || skip_fast;
         let round = if !conflict {
             manager.current_round
-        } else if let Some(round) = manager
-            .ownership
-            .next_round(manager.current_round)
-            .filter(|_| manager.current_round.is_multi_leader() || manager.current_round.is_fast())
-        {
-            round
         } else if let Some(timeout) = info.round_timeout() {
             return Ok(Either::Right(timeout));
+        } else if skip_fast {
+            return Err(Error::BlockProposalError(
+                "This block cannot be proposed in the fast round, and the fast round \
+                 never times out on this chain",
+            ));
         } else {
             return Err(Error::BlockProposalError(
                 "Conflicting proposal in the current round",

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -2186,9 +2186,6 @@ impl<Env: Environment> Client<Env> {
             self.handle_certificate::<Timeout>(*timeout).await?;
         }
         let mut proposals = Vec::new();
-        if let Some(proposal) = remote_info.manager.requested_signed_proposal {
-            proposals.push(*proposal);
-        }
         if let Some(proposal) = remote_info.manager.requested_proposed {
             proposals.push(*proposal);
         }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -126,8 +126,9 @@ where
         proposal: BlockProposal,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
         // In local nodes, cross-chain actions will be handled internally, so we discard them.
-        let (response, _actions) = Box::pin(self.node.state.handle_block_proposal(proposal)).await;
-        Ok(response?)
+        let (response, _actions) =
+            Box::pin(self.node.state.handle_block_proposal(proposal)).await?;
+        Ok(response)
     }
 
     #[instrument(level = "trace", skip_all)]

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -28,7 +28,7 @@ use linera_execution::{
     committee::Committee, system::SystemOperation, ExecutionError, Message, MessageKind, Operation,
     QueryOutcome, ResourceControlPolicy, SystemMessage, SystemQuery, SystemResponse,
 };
-use linera_storage::Storage;
+use linera_storage::{Storage, TestClock};
 use rand::Rng;
 use test_case::test_case;
 use test_helpers::{
@@ -59,6 +59,33 @@ use crate::{
     worker::{Notification, Reason, WorkerError},
     Environment,
 };
+
+/// Repeatedly runs `op`, advancing `clock` past each returned `WaitForTimeout`,
+/// until the operation produces some other `ClientOutcome` or an error.
+///
+/// Bounded at 16 iterations to avoid livelocks on broken setups.
+async fn run_through_timeouts<T, F, Fut, E>(
+    clock: &TestClock,
+    mut op: F,
+) -> Result<ClientOutcome<T>, E>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<ClientOutcome<T>, E>>,
+    E: std::fmt::Debug,
+{
+    for _ in 0..16 {
+        match op().await? {
+            ClientOutcome::WaitForTimeout(timeout) => {
+                let target = timeout.timestamp.saturating_add(TimeDelta::from_millis(1));
+                if clock.current_time() < target {
+                    clock.set(target);
+                }
+            }
+            outcome => return Ok(outcome),
+        }
+    }
+    panic!("run_through_timeouts: too many WaitForTimeout iterations");
+}
 
 /// A test to ensure that our chain client listener remains `Send`.  This is a bit of a
 /// hack, but requires that we not hold a `std::sync::Mutex` over `await` points, a
@@ -329,7 +356,9 @@ where
         Amount::from_millis(4000)
     );
     sender.synchronize_from_validators().await.unwrap();
-    // Can still use the chain.
+    // The chain is now in the `Fast` round under a single super owner; opt into fast
+    // blocks so we can keep proposing without configuring a Fast-round timeout.
+    sender.options_mut().allow_fast_blocks = true;
     sender
         .burn(AccountOwner::CHAIN, Amount::from_tokens(3))
         .await
@@ -395,6 +424,7 @@ where
 {
     let mut signer = InMemorySigner::new(None);
     let new_owner = signer.generate_new().into();
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let certificate = sender
@@ -464,8 +494,8 @@ where
         ))
     );
 
-    // Half the validators voted for one block, half for the other. We need to make a proposal in
-    // the next round to succeed.
+    // Half the validators voted for one block, half for the other. We need to wait through
+    // the multi-leader round's timeout and propose in the next round to succeed.
     builder.set_fault_type([0, 1, 2, 3], FaultType::Honest);
     client.synchronize_from_validators().await.unwrap();
     assert_eq!(
@@ -473,8 +503,7 @@ where
         Amount::from_tokens(2)
     );
     client.clear_pending_proposal().await;
-    client
-        .burn(AccountOwner::CHAIN, Amount::ONE)
+    run_through_timeouts(&clock, || client.burn(AccountOwner::CHAIN, Amount::ONE))
         .await
         .unwrap_ok_committed();
     assert_eq!(client.local_balance().await.unwrap(), Amount::ONE);
@@ -485,8 +514,7 @@ where
     assert_eq!(client.chain_info().await?, sender.chain_info().await?);
     assert_eq!(sender.local_balance().await.unwrap(), Amount::ONE);
     sender.clear_pending_proposal().await;
-    sender
-        .burn(AccountOwner::CHAIN, Amount::ONE)
+    run_through_timeouts(&clock, || sender.burn(AccountOwner::CHAIN, Amount::ONE))
         .await
         .unwrap_ok_committed();
 
@@ -915,6 +943,7 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let mut client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let owner_a = client.identity().await?;
@@ -947,8 +976,7 @@ where
 
     // Owner `b`'s client retries the pending block. The signer still holds owner `a`'s key,
     // so the proposal is signed as `a` and the worker accepts it.
-    let certificate = client
-        .process_pending_block()
+    let certificate = run_through_timeouts(&clock, || client.process_pending_block())
         .await
         .unwrap_ok_committed()
         .expect("the pending block should be committed");
@@ -1847,6 +1875,7 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
 
     let client1 = builder.add_root_chain(1, Amount::ZERO).await?;
@@ -1938,10 +1967,11 @@ where
 
     client2_b.prepare_chain().await.unwrap();
     let recipient = Account::burn_address(client2_b.chain_id());
-    let bt_certificate = client2_b
-        .transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), recipient)
-        .await
-        .unwrap_ok_committed();
+    let bt_certificate = run_through_timeouts(&clock, || {
+        client2_b.transfer_to_account(AccountOwner::CHAIN, Amount::from_tokens(1), recipient)
+    })
+    .await
+    .unwrap_ok_committed();
 
     let certificate_values = client2_b
         .read_confirmed_blocks_downward(bt_certificate.hash(), 2)
@@ -1976,6 +2006,7 @@ where
 {
     let mut signer = InMemorySigner::new(None);
     let owner2 = signer.generate_new().into();
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let client1 = builder.add_root_chain(1, Amount::ONE).await?;
     let chain_id = client1.chain_id();
@@ -2037,7 +2068,7 @@ where
 
     client1.synchronize_from_validators().await.unwrap();
     assert_matches!(
-        client1.publish_data_blob(b"foo".to_vec()).await,
+        run_through_timeouts(&clock, || client1.publish_data_blob(b"foo".to_vec())).await,
         Ok(ClientOutcome::Conflict(_))
     );
 
@@ -2058,6 +2089,7 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
 
     let client1 = builder.add_root_chain(1, Amount::ZERO).await?;
@@ -2207,9 +2239,10 @@ where
             blob_hash: blob3_hash,
         }),
     ];
-    let b1_result = client3_b
-        .execute_operations(blob_2_3_operations.clone(), vec![blob3.clone()])
-        .await;
+    let b1_result = run_through_timeouts(&clock, || {
+        client3_b.execute_operations(blob_2_3_operations.clone(), vec![blob3.clone()])
+    })
+    .await;
     assert!(b1_result.is_err());
 
     let manager = client3_b
@@ -2627,6 +2660,7 @@ where
     // Configure a chain with two regular and no super owners.
     let mut signer = InMemorySigner::new(None);
     let owner1 = signer.generate_new().into();
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
     let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
     let chain_id = client0.chain_id();
@@ -2670,7 +2704,8 @@ where
         .manager;
     assert!(manager.requested_proposed.is_some());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
-    let result = client1.publish_data_blob(b"blob1".to_vec()).await;
+    let result =
+        run_through_timeouts(&clock, || client1.publish_data_blob(b"blob1".to_vec())).await;
     assert!(result.is_err());
     assert!(!client1
         .pending_proposal()
@@ -2688,16 +2723,13 @@ where
         .await
         .unwrap()
         .manager;
-    assert_eq!(
-        manager.requested_locking.unwrap().round(),
-        Round::MultiLeader(1)
-    );
+    assert!(manager.requested_locking.is_some());
     assert!(client0.pending_proposal().await.is_some());
 
     // Client 0 now only tries to transfer 1 token. But instead, they automatically finalize the
     // pending block, which publishes the blob.
     assert_matches!(
-        client0.burn(AccountOwner::CHAIN, Amount::ONE).await,
+        run_through_timeouts(&clock, || client0.burn(AccountOwner::CHAIN, Amount::ONE)).await,
         Ok(ClientOutcome::Conflict(_))
     );
     client0.synchronize_from_validators().await.unwrap();
@@ -2737,16 +2769,7 @@ where
     let signer = InMemorySigner::new(None);
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    // Give the chain a single multi-leader round at genesis so that its initial round
-    // (`MultiLeader(0)`) times out: without multi-leader jitter, earlier multi-leader rounds
-    // do not time out. The chain still has no blocks of its own, which is the case this
-    // regression test exercises: requesting a timeout certificate then only fetches the
-    // chain's genesis description blob.
-    let client = builder
-        .add_root_chain_with_ownership(1, Amount::from_tokens(10), |owner| {
-            ChainOwnership::multiple([(owner, 100)], 1, TimeoutConfig::default())
-        })
-        .await?;
+    let client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
 
     // Advance the clock past the (default 10s) round timeout.
     clock.set(Timestamp::from(20_000_000));
@@ -2765,6 +2788,7 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
     let client = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
 
@@ -2779,10 +2803,12 @@ where
     // Now three validators are online again.
     builder.set_fault_type([2], FaultType::Honest);
 
-    // The client tries to burn another token. But instead, they finalize the
-    // pending block, which transfers 3 tokens, leaving 10 - 3 = 7.
+    // The client tries to burn another token. But instead, they finalize the pending
+    // block, which transfers 3 tokens, leaving 10 - 3 = 7. Under timeout-only round
+    // advancement, the first attempt sees the conflicting pending proposal and surfaces
+    // `WaitForTimeout`; we advance the clock through the multi-leader timeout and retry.
     assert_matches!(
-        client.burn(AccountOwner::CHAIN, Amount::ONE).await,
+        run_through_timeouts(&clock, || client.burn(AccountOwner::CHAIN, Amount::ONE)).await,
         Ok(ClientOutcome::Conflict(_))
     );
     assert_eq!(
@@ -2803,6 +2829,7 @@ where
 {
     // Configure a chain with two regular and no super owners.
     let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
     let client0 = builder.add_root_chain(1, Amount::from_tokens(10)).await?;
     let chain_id = client0.chain_id();
@@ -2866,10 +2893,17 @@ where
     assert!(manager.requested_proposed.is_some());
     assert!(manager.requested_locking.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
-    let result = client1
-        .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
-        .await;
-    assert!(result.is_err());
+    // Under timeout-only round advancement, client1 can't progress past the existing
+    // proposal in `MultiLeader(0)` until validators sign a timeout. With this fault
+    // set (validator 0 offline, validator 3 OfflineWithInfo) there aren't enough
+    // signers for a timeout quorum, so we expect `WaitForTimeout` (rather than the
+    // old behavior of silently skipping to `MultiLeader(1)` and erroring later).
+    assert_matches!(
+        client1
+            .burn(AccountOwner::CHAIN, Amount::from_tokens(2))
+            .await,
+        Ok(ClientOutcome::WaitForTimeout(_))
+    );
 
     // Finally, three validators are online and honest again. Client 1 realizes there has been a
     // validated block in round 0, and re-proposes it when it tries to burn 4 tokens.
@@ -2885,12 +2919,12 @@ where
         manager.requested_locking.unwrap().round(),
         Round::MultiLeader(0)
     );
-    assert_eq!(manager.current_round, Round::MultiLeader(1));
     assert!(client1.pending_proposal().await.is_some());
     assert_matches!(
-        client1
-            .burn(AccountOwner::CHAIN, Amount::from_tokens(4))
-            .await,
+        run_through_timeouts(&clock, || {
+            client1.burn(AccountOwner::CHAIN, Amount::from_tokens(4))
+        })
+        .await,
         Ok(ClientOutcome::Conflict(_))
     );
 
@@ -3337,6 +3371,7 @@ where
         ..ResourceControlPolicy::default()
     };
     let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer)
         .await?
         .with_policy(policy.clone());
@@ -3345,11 +3380,14 @@ where
     let mut client3 = builder.add_root_chain(3, Amount::ONE).await?;
     let chain_id3 = client3.chain_id();
 
-    // Configure the clients as super owners with fast blocks enabled.
+    // Configure the clients as super owners with fast blocks enabled. Set a Fast-
+    // round timeout so the client can fall back to a `MultiLeader(0)` block when
+    // a Fast block isn't allowed (e.g. when the block uses oracles).
     for client in [&mut client1, &mut client2, &mut client3] {
         client.options_mut().allow_fast_blocks = true;
         let owner = client.identity().await?;
-        let ownership = ChainOwnership::single_super(owner);
+        let mut ownership = ChainOwnership::single_super(owner);
+        ownership.timeout_config.fast_round_duration = Some(TimeDelta::from_secs(1));
         client.change_ownership(ownership).await.unwrap();
     }
 
@@ -3380,12 +3418,14 @@ where
     builder.set_fault_type([3], FaultType::Honest);
 
     // Client 3 should be able to update validator 3 about the blob and the message.
-    let certificate = client3
-        .execute_operation(SystemOperation::VerifyBlob { blob_id })
-        .await
-        .unwrap_ok_committed();
+    // This reads a new blob, so it cannot be a fast block; the client waits for the
+    // Fast round to time out and falls back to `MultiLeader(0)`.
+    let certificate = run_through_timeouts(&clock, || {
+        client3.execute_operation(SystemOperation::VerifyBlob { blob_id })
+    })
+    .await
+    .unwrap_ok_committed();
 
-    // This read a new blob, so it cannot be a fast block.
     assert_eq!(certificate.round, Round::MultiLeader(0));
     let block = certificate.block();
     assert_eq!(block.body.incoming_bundles().count(), 1);
@@ -3978,20 +4018,25 @@ where
     B: StorageBuilder,
 {
     let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
 
     // Create a chain and get its owner.
     let mut client = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
     let super_owner = client.identity().await?;
 
-    // Change ownership to make the owner a super owner.
+    // Change ownership to make the owner a super owner, configuring a Fast-round
+    // timeout so the client can wait it out when fast blocks are disabled.
     let owner_change_op = Operation::system(SystemOperation::ChangeOwnership {
         super_owners: vec![super_owner],
         owners: vec![],
         first_leader: None,
         multi_leader_rounds: 10,
         open_multi_leader_rounds: false,
-        timeout_config: TimeoutConfig::default(),
+        timeout_config: TimeoutConfig {
+            fast_round_duration: Some(TimeDelta::from_secs(1)),
+            ..TimeoutConfig::default()
+        },
     });
     client.execute_operation(owner_change_op).await.unwrap();
 
@@ -4007,12 +4052,14 @@ where
         "Block should be in Fast round when fast blocks are enabled"
     );
 
-    // With fast blocks disabled, the super owner creates a block in MultiLeader(0) instead.
+    // With fast blocks disabled, the client waits for the Fast round to time out
+    // and then proposes in MultiLeader(0).
     client.options_mut().allow_fast_blocks = false;
-    let certificate = client
-        .burn(AccountOwner::CHAIN, Amount::from_tokens(1))
-        .await
-        .unwrap_ok_committed();
+    let certificate = run_through_timeouts(&clock, || {
+        client.burn(AccountOwner::CHAIN, Amount::from_tokens(1))
+    })
+    .await
+    .unwrap_ok_committed();
     assert_eq!(
         certificate.round,
         Round::MultiLeader(0),

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -402,13 +402,14 @@ where
             | FaultType::Honest
             | FaultType::DontSendConfirmVote
             | FaultType::DontProcessValidated => {
-                let (response_result, _actions) = self
+                let response_result = self
                     .client
                     .lock()
                     .await
                     .state
                     .handle_block_proposal(proposal)
-                    .await;
+                    .await
+                    .map(|(response, _actions)| response);
                 let result = response_result.map_err(NodeError::from);
                 if self.fault_type == FaultType::DontSendValidateVote {
                     Err(NodeError::ClientIoError {
@@ -1033,21 +1034,6 @@ where
         index: u32,
         balance: Amount,
     ) -> anyhow::Result<ChainClient<B::Storage>> {
-        self.add_root_chain_with_ownership(index, balance, ChainOwnership::single)
-            .await
-    }
-
-    /// Creates the root chain with the given `index` and a genesis ownership built from its
-    /// freshly generated owner key, and returns a client for it.
-    ///
-    /// Root chain 0 is the admin chain and needs to be initialized first, otherwise its balance
-    /// is automatically set to zero.
-    pub async fn add_root_chain_with_ownership(
-        &mut self,
-        index: u32,
-        balance: Amount,
-        make_ownership: impl FnOnce(AccountOwner) -> ChainOwnership,
-    ) -> anyhow::Result<ChainClient<B::Storage>> {
         // Make sure the admin chain is initialized.
         if self.admin_description.is_none() && index != 0 {
             Box::pin(self.add_root_chain(0, Amount::ZERO)).await?;
@@ -1055,7 +1041,7 @@ where
         let origin = ChainOrigin::Root(index);
         let public_key = self.signer.generate_new();
         let open_chain_config = InitialChainConfig {
-            ownership: make_ownership(public_key.into()),
+            ownership: ChainOwnership::single(public_key.into()),
             epoch: Epoch(0),
             balance,
             application_permissions: ApplicationPermissions::default(),

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -1897,80 +1897,70 @@ where
     // Set two validators offline so we can't reach a quorum.
     builder.set_fault_type([2, 3], FaultType::Offline);
 
-    // Try to commit ExpireAfter(5 seconds) - should fail (no quorum).
+    // Stage three pending proposals at successive rounds, each with a different
+    // expiry. Under timeout-only round advancement, rounds can only advance via
+    // a timeout certificate (which requires a quorum), so we explicitly construct
+    // and forward one each time the prior attempt fails.
     let op1 = time_expiry::TimeExpiryOperation::ExpireAfter(TimeDelta::from_secs(5));
     let result = creator
         .execute_operation(Operation::user(app_id, &op1)?)
         .await;
     assert_matches!(result, Err(chain_client::Error::CommunicationError(_)));
-
-    // The proposal should be in round MultiLeader(0).
     let chain_info = creator.chain_info_with_manager_values().await?;
     assert_eq!(
         chain_info.manager.requested_proposed.unwrap().content.round,
         Round::MultiLeader(0)
     );
 
-    // Clear the pending proposal and try again with ExpireAfter(6 seconds).
+    // Subsequent attempts conflict with op1's proposal that the responsive validators
+    // already validated, so the client surfaces `WaitForTimeout` rather than retrying.
     creator.clear_pending_proposal().await;
     let op2 = time_expiry::TimeExpiryOperation::ExpireAfter(TimeDelta::from_secs(6));
     let result = creator
         .execute_operation(Operation::user(app_id, &op2)?)
         .await;
-    assert_matches!(result, Err(chain_client::Error::CommunicationError(_)));
+    assert_matches!(result, Ok(ClientOutcome::WaitForTimeout(_)));
 
-    // The proposal should now be in round MultiLeader(1).
-    let chain_info = creator.chain_info_with_manager_values().await?;
-    assert_eq!(
-        chain_info.manager.requested_proposed.unwrap().content.round,
-        Round::MultiLeader(1)
-    );
-
-    // Clear the pending proposal and try once more with ExpireAfter(7 seconds).
     creator.clear_pending_proposal().await;
     let op3 = time_expiry::TimeExpiryOperation::ExpireAfter(TimeDelta::from_secs(7));
     let result = creator
         .execute_operation(Operation::user(app_id, &op3)?)
         .await;
-    assert_matches!(result, Err(chain_client::Error::CommunicationError(_)));
-
-    // The proposal should now be in round SingleLeader(0).
-    let chain_info = creator.chain_info_with_manager_values().await?;
-    assert_eq!(
-        chain_info.manager.requested_proposed.unwrap().content.round,
-        Round::SingleLeader(0)
-    );
+    assert_matches!(result, Ok(ClientOutcome::WaitForTimeout(_)));
 
     // Make all validators honest again.
     builder.set_fault_type([0, 1, 2, 3], FaultType::Honest);
 
-    // Advance the clock by 10 seconds.
+    // Advance the clock by 10 seconds — past the multi-leader round timeout, so
+    // a fresh proposal can advance the round via a timeout certificate.
     clock.add(TimeDelta::from_secs(10));
 
-    // Clear pending and try to commit ExpireAfter(10 minutes) - should timeout.
+    // Clear pending and try to commit ExpireAfter(10 minutes). Under the new
+    // timeout-only round advancement, the first attempt may commit immediately,
+    // or may return `WaitForTimeout` (e.g. if a stale pending proposal still
+    // locks the round); in the latter case we retry by advancing the clock.
     creator.clear_pending_proposal().await;
     let op4 = time_expiry::TimeExpiryOperation::ExpireAfter(TimeDelta::from_secs(600));
-    let result = creator
+    let mut outcome = creator
         .execute_operation(Operation::user(app_id, &op4)?)
         .await?;
-    // The operation should return WaitForTimeout because the block expired.
-    assert_matches!(result, ClientOutcome::WaitForTimeout(_));
 
-    // Retry to process the pending block a few times. It is not guaranteed in each attempt
-    // that the client successfully updates enough validators before `communicate_with_quorum`
-    // cancels the tasks, but eventually it will succeed and all validators will agree that the
-    // round has timed out.
     let certificate = loop {
-        clock.add(TimeDelta::from_secs(20));
-        match creator.process_pending_block().await? {
-            ClientOutcome::Committed(Some(cert)) => break cert,
+        match outcome {
+            ClientOutcome::Committed(cert) => break cert,
             ClientOutcome::WaitForTimeout(_)
                 if clock.current_time()
                     < Timestamp::from(0).saturating_add(TimeDelta::from_secs(200)) =>
             {
-                continue
+                clock.add(TimeDelta::from_secs(20));
+                outcome = match creator.process_pending_block().await? {
+                    ClientOutcome::Committed(Some(cert)) => ClientOutcome::Committed(cert),
+                    ClientOutcome::Committed(None) => continue,
+                    ClientOutcome::WaitForTimeout(t) => ClientOutcome::WaitForTimeout(t),
+                    ClientOutcome::Conflict(c) => ClientOutcome::Conflict(c),
+                };
             }
-            outcome => panic!("Failed to commit the block: {outcome:?}"),
+            other => panic!("Failed to commit the block: {other:?}"),
         }
     };
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -740,7 +740,7 @@ where
     assert_matches!(
         env.executing_worker()
             .handle_block_proposal(bad_signature_block_proposal)
-            .await.0,
+            .await,
             Err(WorkerError::CryptoError(error))
                 if matches!(error, linera_base::crypto::CryptoError::InvalidSignature {..})
     );
@@ -780,7 +780,7 @@ where
     assert_matches!(
     env.executing_worker()
         .handle_block_proposal(zero_amount_block_proposal)
-        .await.0,
+        .await,
         Err(
             WorkerError::ChainError(error)
         ) if matches!(&*error, ChainError::ExecutionError(
@@ -828,8 +828,7 @@ where
         assert_matches!(
             env.executing_worker()
                 .handle_block_proposal(block_proposal)
-                .await
-                .0,
+                .await,
             Err(WorkerError::InvalidTimestamp { .. })
         );
     }
@@ -869,7 +868,7 @@ where
             .unwrap();
         // Timestamp older than previous one
         assert_matches!(
-            env.executing_worker().handle_block_proposal(block_proposal).await.0,
+            env.executing_worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(error))
                 if matches!(*error, ChainError::InvalidBlockTimestamp { .. })
         );
@@ -930,7 +929,7 @@ where
         )
         .await?;
     // Past timestamp should be handled immediately (and succeed).
-    let (result, _actions) = env
+    let result = env
         .executing_worker()
         .handle_block_proposal(block_proposal)
         .await;
@@ -961,7 +960,7 @@ where
             BundleExecutionPolicy::committed(),
         )
         .await?;
-    let (result, _actions) = env
+    let result = env
         .executing_worker()
         .handle_block_proposal(block_proposal)
         .await;
@@ -1012,7 +1011,7 @@ where
     clock.set(future_timestamp);
 
     // Now the future should complete.
-    let (result, _actions) = future.as_mut().await;
+    let result = future.as_mut().await;
     assert!(
         result.is_ok(),
         "Future timestamp within grace period should succeed after delay"
@@ -1037,8 +1036,7 @@ where
     assert_matches!(
         env.executing_worker()
             .handle_block_proposal(block_proposal)
-            .await
-            .0,
+            .await,
         Err(WorkerError::InvalidTimestamp { .. })
     );
 
@@ -1075,8 +1073,7 @@ where
     assert_matches!(
         env.executing_worker()
             .handle_block_proposal(unknown_sender_block_proposal)
-            .await
-            .0,
+            .await,
         Err(WorkerError::InvalidOwner)
     );
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
@@ -1126,7 +1123,7 @@ where
         .unwrap();
 
     assert_matches!(
-        env.worker().handle_block_proposal(block_proposal1.clone()).await.0,
+        env.worker().handle_block_proposal(block_proposal1.clone()).await,
         Err(WorkerError::ChainError(error)) if matches!(
             *error,
             ChainError::UnexpectedBlockHeight {
@@ -1142,8 +1139,7 @@ where
     drop(chain);
     env.worker()
         .handle_block_proposal(block_proposal0.clone())
-        .await
-        .0?;
+        .await?;
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
     let block = chain.manager.validated_vote().unwrap().value().block();
@@ -1171,8 +1167,7 @@ where
     drop(chain);
     env.worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await
-        .0?;
+        .await?;
 
     let chain = env.worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
@@ -1181,7 +1176,7 @@ where
     assert!(chain.manager.confirmed_vote().is_none());
     drop(chain);
     assert_matches!(
-        env.worker().handle_block_proposal(block_proposal0).await.0,
+        env.worker().handle_block_proposal(block_proposal0).await,
         Err(WorkerError::ChainError(error)) if matches!(
             *error,
             ChainError::UnexpectedBlockHeight {
@@ -1273,8 +1268,7 @@ where
     let proposal_result = env
         .worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await
-        .0;
+        .await;
     assert_matches!(
         proposal_result,
         Err(WorkerError::ChainError(err)) if matches!(*err, ChainError::UnexpectedBlockHeight {
@@ -1310,8 +1304,7 @@ where
     let proposal_result = env
         .worker()
         .handle_block_proposal(block_proposal1.clone())
-        .await
-        .0;
+        .await;
     assert_matches!(proposal_result, Ok(_));
 
     Ok(())
@@ -1441,7 +1434,7 @@ where
             .unwrap();
         // Insufficient funding
         assert_matches!(
-                env.worker().handle_block_proposal(block_proposal).await.0,
+                env.worker().handle_block_proposal(block_proposal).await,
                 Err(
                     WorkerError::ChainError(error)
                 ) if matches!(&*error, ChainError::ExecutionError(
@@ -1497,7 +1490,7 @@ where
             .unwrap();
         // Inconsistent received messages.
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await.0,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::UnexpectedMessage { .. })
         );
@@ -1523,7 +1516,7 @@ where
             .unwrap();
         // Skipped message.
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await.0,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::CannotSkipMessage { .. })
         );
@@ -1574,7 +1567,7 @@ where
             .unwrap();
         // Inconsistent order in received messages (heights).
         assert_matches!(
-            env.worker().handle_block_proposal(block_proposal).await.0,
+            env.worker().handle_block_proposal(block_proposal).await,
             Err(WorkerError::ChainError(chain_error))
                 if matches!(*chain_error, ChainError::CannotSkipMessage { .. })
         );
@@ -1604,8 +1597,7 @@ where
         // Taking the first message only is ok.
         env.worker()
             .handle_block_proposal(block_proposal.clone())
-            .await
-            .0?;
+            .await?;
         let certificate = env
             .execute_proposal(block_proposal.content.block, vec![])
             .await?;
@@ -1662,8 +1654,7 @@ where
             .unwrap();
         env.worker()
             .handle_block_proposal(block_proposal.clone())
-            .await
-            .0?;
+            .await?;
     }
     Ok(())
 }
@@ -1694,7 +1685,7 @@ where
         .await
         .unwrap();
     assert_matches!(
-        env.executing_worker().handle_block_proposal(block_proposal).await.0,
+        env.executing_worker().handle_block_proposal(block_proposal).await,
         Err(
             WorkerError::ChainError(error)
         ) if matches!(&*error, ChainError::ExecutionError(
@@ -1734,11 +1725,10 @@ where
         .await
         .unwrap();
 
-    let chain_info_response = env
+    let (chain_info_response, _actions) = env
         .executing_worker()
         .handle_block_proposal(block_proposal)
-        .await
-        .0?;
+        .await?;
     chain_info_response.check(env.executing_worker().public_key())?;
     let chain = env.executing_worker().chain_state_view(chain_1).await?;
     assert!(chain.is_active().await?);
@@ -1790,17 +1780,15 @@ where
         .await
         .unwrap();
 
-    let response = env
+    let (response, _) = env
         .executing_worker()
         .handle_block_proposal(block_proposal.clone())
-        .await
-        .0?;
+        .await?;
     response.check(env.executing_worker().public_key())?;
-    let replay_response = env
+    let (replay_response, _) = env
         .executing_worker()
         .handle_block_proposal(block_proposal)
-        .await
-        .0?;
+        .await?;
     // Workaround lack of equality.
     assert_eq!(
         CryptoHash::new(&*response.info),
@@ -3562,14 +3550,14 @@ where
         .into_proposal_with_round(owner1, &signer, Round::SingleLeader(0))
         .await
         .unwrap();
-    let (result, _actions) = env.executing_worker().handle_block_proposal(proposal).await;
+    let result = env.executing_worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal = make_child_block(&value0)
         .with_simple_transfer(chain_1, small_transfer)
         .into_proposal_with_round(owner0, &signer, Round::SingleLeader(1))
         .await
         .unwrap();
-    let (result, _actions) = env.executing_worker().handle_block_proposal(proposal).await;
+    let result = env.executing_worker().handle_block_proposal(proposal).await;
 
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::SingleLeader(0)))
@@ -3628,19 +3616,17 @@ where
     let result = env
         .executing_worker()
         .handle_block_proposal(proposal1_wrong_owner)
-        .await
-        .0;
+        .await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal1 = proposed_block1
         .clone()
         .into_proposal_with_round(owner0, &signer, Round::SingleLeader(1))
         .await
         .unwrap();
-    let response = env
+    let (response, _) = env
         .executing_worker()
         .handle_block_proposal(proposal1)
-        .await
-        .0?;
+        .await?;
     let value1 = ValidatedBlock::new(block1.clone());
 
     // If we send the validated block certificate to the worker, it votes to confirm.
@@ -3706,7 +3692,7 @@ where
         .into_proposal_with_round(owner1, &signer, Round::SingleLeader(5))
         .await
         .unwrap();
-    let (result, _actions) = env
+    let result = env
         .executing_worker()
         .handle_block_proposal(proposal.clone())
         .await;
@@ -3728,8 +3714,7 @@ where
     let lite_value2 = LiteValue::new(&value2);
     env.executing_worker()
         .handle_block_proposal(proposal)
-        .await
-        .0?;
+        .await?;
     let response = env
         .executing_worker()
         .handle_chain_info_query(query_values.clone())
@@ -3759,7 +3744,7 @@ where
         .into_proposal_with_round(owner0, &signer, Round::SingleLeader(6))
         .await
         .unwrap();
-    let (result, _actions) = env
+    let result = env
         .executing_worker()
         .handle_block_proposal(proposal.clone())
         .await;
@@ -3852,13 +3837,13 @@ where
         .into_proposal_with_round(owner1, &signer, Round::Fast)
         .await
         .unwrap();
-    let (result, _actions) = env.executing_worker().handle_block_proposal(proposal).await;
+    let result = env.executing_worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::InvalidOwner));
     let proposal = make_child_block(&value0)
         .into_proposal_with_round(owner1, &signer, Round::MultiLeader(0))
         .await
         .unwrap();
-    let (result, _actions) = env.executing_worker().handle_block_proposal(proposal).await;
+    let result = env.executing_worker().handle_block_proposal(proposal).await;
     assert_matches!(result, Err(WorkerError::ChainError(ref error))
         if matches!(**error, ChainError::WrongRound(Round::Fast))
     );
@@ -3896,26 +3881,32 @@ where
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
     assert_eq!(response.info.manager.leader, None);
 
-    // Now any owner can propose a block. And multi-leader rounds can be skipped without timeout.
+    // Now any owner can propose a block — but only in the current round.
     let block1 = make_child_block(&value0).with_simple_transfer(chain_id, small_transfer);
-    let proposal1 = block1
+    let skip_proposal = block1
         .clone()
         .with_authenticated_owner(Some(owner1))
         .into_proposal_with_round(owner1, &signer, Round::MultiLeader(1))
         .await
         .unwrap();
-    let (result, actions) = env
+    let result = env
+        .executing_worker()
+        .handle_block_proposal(skip_proposal)
+        .await;
+    assert_matches!(result, Err(WorkerError::ChainError(ref error))
+        if matches!(**error, ChainError::WrongRound(Round::MultiLeader(0)))
+    );
+    let proposal1 = block1
+        .with_authenticated_owner(Some(owner1))
+        .into_proposal_with_round(owner1, &signer, Round::MultiLeader(0))
+        .await
+        .unwrap();
+    let (response, _) = env
         .executing_worker()
         .handle_block_proposal(proposal1)
-        .await;
-    result?;
-    assert_matches!(actions.notifications[0].reason, Reason::NewRound { .. });
-    let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
-    let response = env
-        .executing_worker()
-        .handle_chain_info_query(query_values)
         .await?;
-    assert_eq!(response.info.manager.current_round, Round::MultiLeader(1));
+    assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
+    assert!(response.info.manager.pending.is_some());
     Ok(())
 }
 
@@ -3998,11 +3989,10 @@ where
         )
         .await?;
     let value1 = ConfirmedBlock::new(block1);
-    let response = env
+    let (response, _) = env
         .executing_worker()
         .handle_block_proposal(proposal1.clone())
-        .await
-        .0?;
+        .await?;
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.round, Round::Fast);
     assert_eq!(vote.value.value_hash, value1.hash());
@@ -4020,45 +4010,48 @@ where
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
     assert_eq!(response.info.manager.leader, None);
 
-    // Now any owner can propose a block. But block1 is locked. Re-proposing it is allowed.
-    let proposal1b =
-        BlockProposal::new_retry_fast(owner1, Round::MultiLeader(0), proposal1.clone(), &signer)
-            .await
-            .unwrap();
-    let response = env
-        .executing_worker()
-        .handle_block_proposal(proposal1b)
-        .await
-        .0?;
-
-    let vote = response.info.manager.pending.as_ref().unwrap();
-    assert_eq!(vote.round, Round::MultiLeader(0));
-    assert_eq!(vote.value.value_hash, value1.hash());
-
-    // Proposing a different block is not.
+    // Proposing a different block in the current MultiLeader(0) round is not allowed,
+    // because we already confirmed block1 in the Fast round.
     let proposed_block2 = make_child_block(&value0)
         .with_simple_transfer(chain_id, Amount::ONE)
         .with_authenticated_owner(Some(owner1));
     let proposal2 = proposed_block2
         .clone()
-        .into_proposal_with_round(owner1, &signer, Round::MultiLeader(1))
+        .into_proposal_with_round(owner1, &signer, Round::MultiLeader(0))
         .await
         .unwrap();
-    let (result, _actions) = env
+    let result = env
         .executing_worker()
         .handle_block_proposal(proposal2)
         .await;
     assert_matches!(result, Err(WorkerError::ChainError(err))
         if matches!(*err, ChainError::HasIncompatibleConfirmedVote(_, Round::Fast))
     );
-    let proposal3 =
-        BlockProposal::new_retry_fast(owner0, Round::MultiLeader(2), proposal1.clone(), &signer)
+
+    // Re-proposing the locked block1 in MultiLeader(0) is allowed.
+    let proposal1b =
+        BlockProposal::new_retry_fast(owner1, Round::MultiLeader(0), proposal1.clone(), &signer)
             .await
             .unwrap();
+    let (response, _) = env
+        .executing_worker()
+        .handle_block_proposal(proposal1b)
+        .await?;
+
+    let vote = response.info.manager.pending.as_ref().unwrap();
+    assert_eq!(vote.round, Round::MultiLeader(0));
+    assert_eq!(vote.value.value_hash, value1.hash());
+
+    // Advance to MultiLeader(2) via two timeout certificates.
+    let ml_timeout = Timeout::new(chain_id, BlockHeight::from(1), Epoch::from(0));
+    let cert_ml0 = env.make_certificate_with_round(ml_timeout.clone(), Round::MultiLeader(0));
     env.executing_worker()
-        .handle_block_proposal(proposal3)
-        .await
-        .0?;
+        .handle_timeout_certificate(cert_ml0)
+        .await?;
+    let cert_ml1 = env.make_certificate_with_round(ml_timeout, Round::MultiLeader(1));
+    env.executing_worker()
+        .handle_timeout_certificate(cert_ml1)
+        .await?;
 
     // A validated block certificate from a later round can override the locked fast block.
     let (_, block2, _, _, _) = env
@@ -4071,10 +4064,10 @@ where
         )
         .await?;
     let value2 = ValidatedBlock::new(block2.clone());
-    let certificate2 = env.make_certificate_with_round(value2.clone(), Round::MultiLeader(0));
+    let certificate2 = env.make_certificate_with_round(value2.clone(), Round::MultiLeader(1));
     let proposal = BlockProposal::new_retry_regular(
         owner1,
-        Round::MultiLeader(3),
+        Round::MultiLeader(2),
         certificate2.clone(),
         &signer,
     )
@@ -4083,8 +4076,7 @@ where
     let lite_value2 = LiteValue::new(&value2);
     env.executing_worker()
         .handle_block_proposal(proposal)
-        .await
-        .0?;
+        .await?;
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let response = env
         .executing_worker()
@@ -4096,7 +4088,7 @@ where
     );
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.value, lite_value2);
-    assert_eq!(vote.round, Round::MultiLeader(3));
+    assert_eq!(vote.round, Round::MultiLeader(2));
     Ok(())
 }
 
@@ -4377,8 +4369,7 @@ where
         .unwrap();
     env.executing_worker()
         .handle_block_proposal(block_proposal)
-        .await
-        .0?;
+        .await?;
 
     for local_time in queries_before_confirmation {
         clock.set(local_time);
@@ -4591,7 +4582,7 @@ where
         .unwrap();
 
     assert_matches!(
-        env.executing_worker().handle_block_proposal(bad_proposal).await.0,
+        env.executing_worker().handle_block_proposal(bad_proposal).await,
         Err(WorkerError::ChainError(chain_error))
             if matches!(*chain_error, ChainError::IncorrectMessageOrder { .. })
     );

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -973,11 +973,7 @@ where
         }
 
         // Finally, try to push a proposal at the current round.
-        for proposal in manager
-            .requested_proposed
-            .iter()
-            .chain(manager.requested_signed_proposal.iter())
-        {
+        for proposal in manager.requested_proposed.iter() {
             if proposal.content.round == target_round {
                 match self
                     .remote_node

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1616,7 +1616,7 @@ where
     pub async fn handle_block_proposal(
         &self,
         proposal: BlockProposal,
-    ) -> (Result<ChainInfoResponse, WorkerError>, NetworkActions) {
+    ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname(), proposal);
         #[cfg(with_metrics)]
         let round = proposal.content.round;
@@ -1634,22 +1634,18 @@ where
             self.storage.clock().sleep_until(block_timestamp).await;
         }
 
-        let outcome = self
+        let result = self
             .chain_write(chain_id, move |mut guard| async move {
-                Ok::<_, WorkerError>(guard.handle_block_proposal(proposal).await)
+                guard.handle_block_proposal(proposal).await
             })
             .await;
-        let (result, actions) = match outcome {
-            Ok((result, actions)) => (result, actions),
-            Err(err) => (Err(err), NetworkActions::default()),
-        };
         #[cfg(with_metrics)]
         if result.is_ok() {
             metrics::NUM_ROUNDS_IN_BLOCK_PROPOSAL
                 .with_label_values(&[round.type_name()])
                 .observe(round.number() as f64);
         }
-        (result, actions)
+        result
     }
 
     /// Processes a certificate, e.g. to extend a chain with a confirmed block.

--- a/linera-execution/solidity/Linera.sol
+++ b/linera-execution/solidity/Linera.sol
@@ -120,6 +120,7 @@ library Linera {
 
     struct TimeoutConfig {
         opt_TimeDelta fast_round_duration;
+        TimeDelta multi_leader_round_duration;
         TimeDelta base_timeout;
         TimeDelta timeout_increment;
         TimeDelta fallback_duration;
@@ -131,6 +132,7 @@ library Linera {
         returns (TimeoutConfig memory)
     {
         return TimeoutConfig(opt_timedelta_from(entry.fast_round_duration),
+                             timedelta_from(entry.multi_leader_round_duration),
                              timedelta_from(entry.base_timeout),
                              timedelta_from(entry.timeout_increment),
                              timedelta_from(entry.fallback_duration));

--- a/linera-execution/solidity/LineraTypes.sol
+++ b/linera-execution/solidity/LineraTypes.sol
@@ -2103,6 +2103,7 @@ library LineraTypes {
 
     struct TimeoutConfig {
         opt_TimeDelta fast_round_duration;
+        TimeDelta multi_leader_round_duration;
         TimeDelta base_timeout;
         TimeDelta timeout_increment;
         TimeDelta fallback_duration;
@@ -2114,6 +2115,7 @@ library LineraTypes {
         returns (bytes memory)
     {
         bytes memory result = bcs_serialize_opt_TimeDelta(input.fast_round_duration);
+        result = abi.encodePacked(result, bcs_serialize_TimeDelta(input.multi_leader_round_duration));
         result = abi.encodePacked(result, bcs_serialize_TimeDelta(input.base_timeout));
         result = abi.encodePacked(result, bcs_serialize_TimeDelta(input.timeout_increment));
         return abi.encodePacked(result, bcs_serialize_TimeDelta(input.fallback_duration));
@@ -2127,13 +2129,15 @@ library LineraTypes {
         uint256 new_pos;
         opt_TimeDelta memory fast_round_duration;
         (new_pos, fast_round_duration) = bcs_deserialize_offset_opt_TimeDelta(pos, input);
+        TimeDelta memory multi_leader_round_duration;
+        (new_pos, multi_leader_round_duration) = bcs_deserialize_offset_TimeDelta(new_pos, input);
         TimeDelta memory base_timeout;
         (new_pos, base_timeout) = bcs_deserialize_offset_TimeDelta(new_pos, input);
         TimeDelta memory timeout_increment;
         (new_pos, timeout_increment) = bcs_deserialize_offset_TimeDelta(new_pos, input);
         TimeDelta memory fallback_duration;
         (new_pos, fallback_duration) = bcs_deserialize_offset_TimeDelta(new_pos, input);
-        return (new_pos, TimeoutConfig(fast_round_duration, base_timeout, timeout_increment, fallback_duration));
+        return (new_pos, TimeoutConfig(fast_round_duration, multi_leader_round_duration, base_timeout, timeout_increment, fallback_duration));
     }
 
     function bcs_deserialize_TimeoutConfig(bytes memory input)

--- a/linera-execution/solidity/LineraTypes.yaml
+++ b/linera-execution/solidity/LineraTypes.yaml
@@ -4,6 +4,8 @@ TimeoutConfig:
     - fast_round_duration:
         OPTION:
           TYPENAME: TimeDelta
+    - multi_leader_round_duration:
+        TYPENAME: TimeDelta
     - base_timeout:
         TYPENAME: TimeDelta
     - timeout_increment:

--- a/linera-execution/tests/contract_runtime_apis.rs
+++ b/linera-execution/tests/contract_runtime_apis.rs
@@ -105,13 +105,14 @@ async fn test_transfer_system_api(
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
     let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
-    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
-        .execute_message(
+    Box::pin(
+        ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller).execute_message(
             create_dummy_message_context(chain_id, None),
             outgoing_messages[0].message.clone(),
             None,
-        )
-        .await?;
+        ),
+    )
+    .await?;
 
     recipient.verify_recipient(&view.system, amount).await?;
 
@@ -275,13 +276,14 @@ async fn test_claim_system_api(
     assert!(matches!(outgoing_messages[0].message, Message::System(_)));
 
     let mut tracker = TransactionTracker::new_replaying(Vec::new());
-    ExecutionStateActor::new(&mut source_view, &mut tracker, &mut controller)
-        .execute_message(
+    Box::pin(
+        ExecutionStateActor::new(&mut source_view, &mut tracker, &mut controller).execute_message(
             create_dummy_message_context(source_chain_id, None),
             outgoing_messages[0].message.clone(),
             None,
-        )
-        .await?;
+        ),
+    )
+    .await?;
 
     assert_eq!(*source_view.system.balance.get(), Amount::ZERO);
     source_view
@@ -309,9 +311,14 @@ async fn test_claim_system_api(
         chain_id: claimer_chain_id,
         ..create_dummy_message_context(claimer_chain_id, None)
     };
-    ExecutionStateActor::new(&mut claimer_view, &mut tracker, &mut controller)
-        .execute_message(context, outgoing_messages[0].message.clone(), None)
-        .await?;
+    Box::pin(
+        ExecutionStateActor::new(&mut claimer_view, &mut tracker, &mut controller).execute_message(
+            context,
+            outgoing_messages[0].message.clone(),
+            None,
+        ),
+    )
+    .await?;
 
     recipient
         .verify_recipient(&claimer_view.system, amount)

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -289,8 +289,8 @@ async fn test_fee_consumption(
     };
     let mut grant = initial_grant.unwrap_or_default();
     let mut txn_tracker = TransactionTracker::new_replaying(oracle_responses);
-    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
-        .execute_message(
+    Box::pin(
+        ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller).execute_message(
             context,
             Message::User {
                 application_id,
@@ -301,8 +301,9 @@ async fn test_fee_consumption(
             } else {
                 None
             },
-        )
-        .await?;
+        ),
+    )
+    .await?;
 
     let txn_outcome = txn_tracker.into_outcome()?;
     assert!(txn_outcome.outgoing_messages.is_empty());
@@ -489,16 +490,17 @@ async fn test_free_app_message_no_fees() -> anyhow::Result<()> {
         timestamp: Timestamp::default(),
     };
     let mut txn_tracker = TransactionTracker::new_replaying(oracle_responses);
-    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
-        .execute_message(
+    Box::pin(
+        ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller).execute_message(
             context,
             Message::User {
                 application_id,
                 bytes: vec![],
             },
             None,
-        )
-        .await?;
+        ),
+    )
+    .await?;
 
     // Verify no fees were deducted: balances should remain exactly as set.
     assert_eq!(*view.system.balance.get(), chain_balance);

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1392,16 +1392,17 @@ async fn test_message_receipt_spending_chain_balance(
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new_replaying_blobs(blobs);
 
-    let execution_result = ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
-        .execute_message(
+    let execution_result = Box::pin(
+        ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller).execute_message(
             context,
             Message::User {
                 application_id,
                 bytes: vec![],
             },
             None,
-        )
-        .await;
+        ),
+    )
+    .await;
 
     Ok(execution_result)
 }

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -86,9 +86,14 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     };
     let mut controller = ResourceController::default();
     let mut txn_tracker = TransactionTracker::new_replaying(Vec::new());
-    ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller)
-        .execute_message(context, Message::System(message), None)
-        .await?;
+    Box::pin(
+        ExecutionStateActor::new(&mut view, &mut txn_tracker, &mut controller).execute_message(
+            context,
+            Message::System(message),
+            None,
+        ),
+    )
+    .await?;
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));
     let txn_outcome = txn_tracker.into_outcome().unwrap();
     assert!(txn_outcome.outgoing_messages.is_empty());

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -743,14 +743,10 @@ where
         let traffic_type = Self::get_traffic_type(&request);
         let proposal = request.into_inner().try_into()?;
         trace!(?proposal, "Handling block proposal");
-        let (result, actions) = self.state.clone().handle_block_proposal(proposal).await;
-        // Dispatch actions whether or not the proposal was accepted: a rejected
-        // proposal can still advance the manager's `current_round` (via
-        // `update_signed_proposal` on the `HasIncompatibleConfirmedVote` recovery
-        // path), and subscribers need the resulting `NewRound` notification.
-        self.handle_network_actions(actions);
+        let result = self.state.clone().handle_block_proposal(proposal).await;
         Ok(Response::new(match result {
-            Ok(info) => {
+            Ok((info, actions)) => {
+                self.handle_network_actions(actions);
                 Self::log_request_success("handle_block_proposal", traffic_type);
                 info.try_into()?
             }

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -210,15 +210,11 @@ where
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
         let reply = match message {
             RpcMessage::BlockProposal(message) => {
-                let (result, actions) = self.server.state.handle_block_proposal(*message).await;
-                // Dispatch actions whether or not the proposal was accepted: a
-                // rejected proposal can still advance the manager's `current_round`
-                // (via `update_signed_proposal` on the `HasIncompatibleConfirmedVote`
-                // recovery path), and subscribers need the resulting `NewRound`
-                // notification.
-                self.handle_network_actions(actions);
-                match result {
-                    Ok(info) => Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info)))),
+                match self.server.state.handle_block_proposal(*message).await {
+                    Ok((info, actions)) => {
+                        self.handle_network_actions(actions);
+                        Ok(Some(RpcMessage::ChainInfoResponse(Box::new(info))))
+                    }
                     Err(error) => {
                         self.log_error(&error, "Failed to handle block proposal");
                         Err(error.into())

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -379,9 +379,6 @@ ChainManagerInfo:
     - ownership:
         TYPENAME: ChainOwnership
     - seed: U64
-    - requested_signed_proposal:
-        OPTION:
-          TYPENAME: BlockProposal
     - requested_proposed:
         OPTION:
           TYPENAME: BlockProposal
@@ -1415,6 +1412,8 @@ TimeoutConfig:
     - fast_round_duration:
         OPTION:
           TYPENAME: TimeDelta
+    - multi_leader_round_duration:
+        TYPENAME: TimeDelta
     - base_timeout:
         TYPENAME: TimeDelta
     - timeout_increment:

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -104,12 +104,14 @@ macro_rules! impl_from_wit {
             fn from(guest: $wit_base_api::TimeoutConfig) -> TimeoutConfig {
                 let $wit_base_api::TimeoutConfig {
                     fast_round_duration,
+                    multi_leader_round_duration,
                     base_timeout,
                     timeout_increment,
                     fallback_duration,
                 } = guest;
                 TimeoutConfig {
                     fast_round_duration: fast_round_duration.map(TimeDelta::from),
+                    multi_leader_round_duration: multi_leader_round_duration.into(),
                     base_timeout: base_timeout.into(),
                     timeout_increment: timeout_increment.into(),
                     fallback_duration: fallback_duration.into(),

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -176,12 +176,14 @@ impl From<TimeoutConfig> for wit_contract_api::TimeoutConfig {
     fn from(config: TimeoutConfig) -> Self {
         let TimeoutConfig {
             fast_round_duration,
+            multi_leader_round_duration,
             base_timeout,
             timeout_increment,
             fallback_duration,
         } = config;
         Self {
             fast_round_duration: fast_round_duration.map(Into::into),
+            multi_leader_round_duration: multi_leader_round_duration.into(),
             base_timeout: base_timeout.into(),
             timeout_increment: timeout_increment.into(),
             fallback_duration: fallback_duration.into(),

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -150,6 +150,7 @@ interface base-runtime-api {
 
     record timeout-config {
         fast-round-duration: option<time-delta>,
+        multi-leader-round-duration: time-delta,
         base-timeout: time-delta,
         timeout-increment: time-delta,
         fallback-duration: time-delta,

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -138,6 +138,7 @@ interface contract-runtime-api {
 
     record timeout-config {
         fast-round-duration: option<time-delta>,
+        multi-leader-round-duration: time-delta,
         base-timeout: time-delta,
         timeout-increment: time-delta,
         fallback-duration: time-delta,

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -413,6 +413,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
                 openMultiLeaderRounds
                 timeoutConfig {
                   fastRoundMs
+                  multiLeaderRoundMs
                   baseTimeoutMs
                   timeoutIncrementMs
                   fallbackDurationMs
@@ -592,6 +593,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
                 openMultiLeaderRounds
                 timeoutConfig {
                   fastRoundMs
+                  multiLeaderRoundMs
                   baseTimeoutMs
                   timeoutIncrementMs
                   fallbackDurationMs

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -318,8 +318,7 @@ type ChainManager {
 	the round to which the timeout applies.
 	
 	Having a leader timeout certificate in any given round causes the next one to become
-	current. Seeing a validated block certificate or a valid proposal in any round causes that
-	round to become current, unless a higher one already is.
+	current. A locking block from a higher round also causes that round to become current.
 	"""
 	currentRound: Round!
 }
@@ -1103,7 +1102,11 @@ type MutationRoot {
 		"""
 		fastRoundMs: Int,
 		"""
-		The duration of the first single-leader and all multi-leader rounds
+		The duration of every multi-leader round, in milliseconds
+		"""
+		multiLeaderRoundMs: Int! = 1000,
+		"""
+		The duration of the first single-leader round, in milliseconds
 		"""
 		baseTimeoutMs: Int! = 10000,
 		"""
@@ -1170,7 +1173,11 @@ type MutationRoot {
 		"""
 		fastRoundMs: Int,
 		"""
-		The duration of the first single-leader and all multi-leader rounds
+		The duration of every multi-leader round, in milliseconds
+		"""
+		multiLeaderRoundMs: Int! = 1000,
+		"""
+		The duration of the first single-leader round, in milliseconds
 		"""
 		baseTimeoutMs: Int! = 10000,
 		"""
@@ -1726,7 +1733,11 @@ type TimeoutConfigMetadata {
 	"""
 	fastRoundMs: String
 	"""
-	The duration of the first single-leader and all multi-leader rounds in milliseconds.
+	The duration of every multi-leader round, in milliseconds.
+	"""
+	multiLeaderRoundMs: String!
+	"""
+	The duration of the first single-leader round, in milliseconds.
 	"""
 	baseTimeoutMs: String!
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -270,6 +270,18 @@ mod from {
                         })
                         .transpose()?
                         .map(|ms| TimeDelta::from_micros(ms * 1000)),
+                    multi_leader_round_duration: TimeDelta::from_micros(
+                        change_ownership
+                            .timeout_config
+                            .multi_leader_round_ms
+                            .parse::<u64>()
+                            .map_err(|_| {
+                                ConversionError::UnexpectedCertificateType(
+                                    "Invalid multi_leader_round_ms value".to_string(),
+                                )
+                            })?
+                            * 1000,
+                    ),
                     base_timeout: TimeDelta::from_micros(
                         change_ownership
                             .timeout_config

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -1005,7 +1005,7 @@ impl Runnable for Job {
                                     let mut chain_ids = Vec::new();
                                     for _ in 0..chains_per_wallet {
                                         let (chain_id, _owner) = client
-                                            .open_chain_super_owner(
+                                            .open_chain(
                                                 default_chain_id,
                                                 None,
                                                 benchmark_options.tokens_per_chain,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -477,7 +477,12 @@ where
         #[graphql(desc = "The duration of the fast round, in milliseconds; default: no timeout")]
         fast_round_ms: Option<u64>,
         #[graphql(
-            desc = "The duration of the first single-leader and all multi-leader rounds",
+            desc = "The duration of every multi-leader round, in milliseconds",
+            default = 1_000
+        )]
+        multi_leader_round_ms: u64,
+        #[graphql(
+            desc = "The duration of the first single-leader round, in milliseconds",
             default = 10_000
         )]
         base_timeout_ms: u64,
@@ -512,6 +517,7 @@ where
         let multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
         let timeout_config = TimeoutConfig {
             fast_round_duration: fast_round_ms.map(TimeDelta::from_millis),
+            multi_leader_round_duration: TimeDelta::from_millis(multi_leader_round_ms),
             base_timeout: TimeDelta::from_millis(base_timeout_ms),
             timeout_increment: TimeDelta::from_millis(timeout_increment_ms),
             fallback_duration: TimeDelta::from_millis(fallback_duration_ms),
@@ -588,7 +594,12 @@ where
         #[graphql(desc = "The duration of the fast round, in milliseconds; default: no timeout")]
         fast_round_ms: Option<u64>,
         #[graphql(
-            desc = "The duration of the first single-leader and all multi-leader rounds",
+            desc = "The duration of every multi-leader round, in milliseconds",
+            default = 1_000
+        )]
+        multi_leader_round_ms: u64,
+        #[graphql(
+            desc = "The duration of the first single-leader round, in milliseconds",
             default = 10_000
         )]
         base_timeout_ms: u64,
@@ -607,6 +618,7 @@ where
     ) -> Result<CryptoHash, Error> {
         let timeout_config = TimeoutConfig {
             fast_round_duration: fast_round_ms.map(TimeDelta::from_millis),
+            multi_leader_round_duration: TimeDelta::from_millis(multi_leader_round_ms),
             base_timeout: TimeDelta::from_millis(base_timeout_ms),
             timeout_increment: TimeDelta::from_millis(timeout_increment_ms),
             fallback_duration: TimeDelta::from_millis(fallback_duration_ms),


### PR DESCRIPTION
## Motivation

Multi-leader rounds can be skipped by any valid proposal in a later round. Supporting that requires tracking the highest signed proposal (`signed_proposal`), a recovery path that advances the round on rejected proposals, and special round-comparison rules — logic that complicates the protocol.

## Proposal

Now every non-`Fast` round ends only via a timeout certificate for that round (or a locking block from a higher round, which proves a quorum already reached it). Proposals must match the current round exactly. `Fast` proposals remain exempt: the existing vote and locking-block checks prevent them from conflicting with later-round blocks.

- Add `TimeoutConfig::multi_leader_round_duration` (default 1 second): multi-leader rounds are meant to be cooperative, so contention should be rare, and a short round keeps retry latency low. Single-leader rounds keep `base_timeout` plus `timeout_increment`.
- The fast round times out iff `fast_round_duration` is configured, regardless of whether there are regular owners. A chain with only super owners and no fast-round duration relies on them for progress.
- Remove the `signed_proposal` register, its recovery path, and `requested_signed_proposal` from `ChainManagerInfo`; `Worker::handle_block_proposal` returns `Result` again since a rejected proposal can no longer produce notifications.
- Expose the new duration as `--multi-leader-round-ms` in the CLI and `multiLeaderRoundMs` in GraphQL, and fix the `base_timeout` docs.

## Test Plan

Tests were updated and extended.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
