### PR TITLE
[testnet] Backport #6606: TokenAmount and configurable-precision fungible

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -675,7 +675,7 @@ impl AmmContract {
         let token = self.fungible_id(token_idx);
         let operation = FungibleOperation::Transfer {
             owner: source_owner,
-            amount,
+            amount: amount.into(),
             target_account,
         };
 
@@ -686,7 +686,7 @@ impl AmmContract {
         let balance = FungibleOperation::Balance { owner: *owner };
         let token = self.fungible_id(token_idx);
         match self.runtime.call_application(true, token, &balance) {
-            FungibleResponse::Balance(balance) => balance,
+            FungibleResponse::Balance(balance) => balance.into(),
             response => panic!("Unexpected response from fungible token application: {response:?}"),
         }
     }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -106,7 +106,7 @@ impl CrowdFundingContract {
         let target_account = Account { chain_id, owner };
         let call = FungibleOperation::Transfer {
             owner,
-            amount,
+            amount: amount.into(),
             target_account,
         };
         let fungible_id = self.fungible_id();
@@ -203,7 +203,7 @@ impl CrowdFundingContract {
             self.runtime
                 .call_application(true, fungible_id, &FungibleOperation::Balance { owner });
         match response {
-            fungible::FungibleResponse::Balance(balance) => balance,
+            fungible::FungibleResponse::Balance(balance) => balance.into(),
             response => panic!("Unexpected response from fungible token application: {response:?}"),
         }
     }
@@ -216,7 +216,7 @@ impl CrowdFundingContract {
         };
         let transfer = FungibleOperation::Transfer {
             owner: self.runtime.application_id().into(),
-            amount,
+            amount: amount.into(),
             target_account,
         };
         let fungible_id = self.fungible_id();
@@ -231,7 +231,7 @@ impl CrowdFundingContract {
         };
         let transfer = FungibleOperation::Transfer {
             owner,
-            amount,
+            amount: amount.into(),
             target_account,
         };
         let fungible_id = self.fungible_id();

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -4,11 +4,11 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 use fungible::{
-    state::FungibleTokenState, Account, FungibleOperation, FungibleResponse, FungibleTokenAbi,
-    InitialState, Message, Parameters,
+    state::FungibleTokenState, Account, Fungible, FungibleAmount, FungibleOperation,
+    FungibleResponse, FungibleTokenAbi, InitialState, Message, Parameters,
 };
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, WithContractAbi},
+    linera_base_types::{AccountOwner, WithContractAbi},
     views::{RootView, View},
     Contract, ContractRuntime,
 };
@@ -30,7 +30,8 @@ impl Contract for FungibleTokenContract {
     type InstantiationArgument = InitialState;
     type EventValue = ();
 
-    async fn load(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(mut runtime: ContractRuntime<Self>) -> Self {
+        Fungible::configure_decimals(runtime.application_parameters().decimals);
         let state = FungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
@@ -41,11 +42,11 @@ impl Contract for FungibleTokenContract {
         // Validate that the application parameters were configured correctly.
         self.runtime.application_parameters();
 
-        let mut total_supply = Amount::ZERO;
+        let mut total_supply = FungibleAmount::ZERO;
         for value in state.accounts.values() {
-            total_supply.saturating_add_assign(*value);
+            total_supply.saturating_add_assign((*value).into());
         }
-        if total_supply == Amount::ZERO {
+        if total_supply == FungibleAmount::ZERO {
             panic!("The total supply is zero, therefore we cannot instantiate the contract");
         }
         self.state.initialize_accounts(state).await;
@@ -55,7 +56,7 @@ impl Contract for FungibleTokenContract {
         match operation {
             FungibleOperation::Balance { owner } => {
                 let balance = self.state.balance_or_default(&owner).await;
-                FungibleResponse::Balance(balance)
+                FungibleResponse::Balance(balance.into())
             }
 
             FungibleOperation::TickerSymbol => {
@@ -71,7 +72,7 @@ impl Contract for FungibleTokenContract {
                 self.runtime
                     .check_account_permission(owner)
                     .expect("Permission for Transfer operation");
-                self.state.approve(owner, spender, allowance).await;
+                self.state.approve(owner, spender, allowance.into()).await;
                 FungibleResponse::Ok
             }
 
@@ -84,6 +85,7 @@ impl Contract for FungibleTokenContract {
                 self.runtime
                     .check_account_permission(owner)
                     .expect("Permission for Transfer operation");
+                let amount: FungibleAmount = amount.into();
                 self.state.debit(owner, amount).await;
                 self.finish_transfer_to_account(amount, target_account, owner)
                     .await;
@@ -99,6 +101,7 @@ impl Contract for FungibleTokenContract {
                 self.runtime
                     .check_account_permission(spender)
                     .expect("Permission for Transfer operation");
+                let amount: FungibleAmount = amount.into();
                 self.state
                     .debit_for_transfer_from(owner, spender, amount)
                     .await;
@@ -115,6 +118,7 @@ impl Contract for FungibleTokenContract {
                 self.runtime
                     .check_account_permission(source_account.owner)
                     .expect("Permission for Claim operation");
+                let amount: FungibleAmount = amount.into();
                 self.claim(source_account, amount, target_account).await;
                 FungibleResponse::Ok
             }
@@ -134,7 +138,7 @@ impl Contract for FungibleTokenContract {
                     .message_is_bouncing()
                     .expect("Delivery status is available when executing a message");
                 let receiver = if is_bouncing { source } else { target };
-                self.state.credit(receiver, amount).await;
+                self.state.credit(receiver, amount.into()).await;
             }
             // ANCHOR_END: execute_message_credit
             Message::Withdraw {
@@ -145,6 +149,7 @@ impl Contract for FungibleTokenContract {
                 self.runtime
                     .check_account_permission(owner)
                     .expect("Permission for Withdraw message");
+                let amount: FungibleAmount = amount.into();
                 self.state.debit(owner, amount).await;
                 self.finish_transfer_to_account(amount, target_account, owner)
                     .await;
@@ -161,7 +166,12 @@ impl Contract for FungibleTokenContract {
 }
 
 impl FungibleTokenContract {
-    async fn claim(&mut self, source_account: Account, amount: Amount, target_account: Account) {
+    async fn claim(
+        &mut self,
+        source_account: Account,
+        amount: FungibleAmount,
+        target_account: Account,
+    ) {
         if source_account.chain_id == self.runtime.chain_id() {
             self.state.debit(source_account.owner, amount).await;
             self.finish_transfer_to_account(amount, target_account, source_account.owner)
@@ -169,7 +179,7 @@ impl FungibleTokenContract {
         } else {
             let message = Message::Withdraw {
                 owner: source_account.owner,
-                amount,
+                amount: amount.into(),
                 target_account,
             };
             self.runtime
@@ -183,7 +193,7 @@ impl FungibleTokenContract {
     /// Executes the final step of a transfer where the tokens are sent to the destination.
     async fn finish_transfer_to_account(
         &mut self,
-        amount: Amount,
+        amount: FungibleAmount,
         target_account: Account,
         source: AccountOwner,
     ) {
@@ -192,7 +202,7 @@ impl FungibleTokenContract {
         } else {
             let message = Message::Credit {
                 target: target_account.owner,
-                amount,
+                amount: amount.into(),
                 source,
             };
             self.runtime

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -7,14 +7,22 @@ pub mod state;
 
 use async_graphql::scalar;
 pub use linera_sdk::abis::fungible::*;
-use linera_sdk::linera_base_types::{AccountOwner, Amount};
+use linera_sdk::linera_base_types::{AccountOwner, TokenAmount, U128};
 use serde::{Deserialize, Serialize};
+
+// The brand for this application's token amounts. Its precision is set at runtime from the
+// `decimals` application parameter, in `Contract::load` and `Service::new`.
+linera_sdk::branded_token!(pub struct Fungible = "FungibleAmount");
+
+/// A branded, decimal-aware token amount used internally by the application (state and logic).
+/// It crosses the ABI boundary as a raw [`U128`].
+pub type FungibleAmount = TokenAmount<Fungible>;
 #[cfg(all(any(test, feature = "test"), not(target_arch = "wasm32")))]
 use {
     async_graphql::InputType,
     futures::{stream, StreamExt},
     linera_sdk::{
-        linera_base_types::{ApplicationId, ModuleId},
+        linera_base_types::{Amount, ApplicationId, ModuleId},
         test::{ActiveChain, QueryOutcome, TestValidator},
     },
 };
@@ -29,7 +37,7 @@ pub enum Message {
         /// Target account to credit amount to
         target: AccountOwner,
         /// Amount to be credited
-        amount: Amount,
+        amount: U128,
         /// Source account to remove amount from
         source: AccountOwner,
     },
@@ -39,7 +47,7 @@ pub enum Message {
         /// Account to withdraw from
         owner: AccountOwner,
         /// Amount to be withdrawn
-        amount: Amount,
+        amount: U128,
         /// Target account to transfer amount to
         target_account: Account,
     },
@@ -159,7 +167,7 @@ pub async fn create_with_accounts(
                             chain_id: token_chain.id(),
                             owner: *account,
                         },
-                        amount: *initial_amount,
+                        amount: (*initial_amount).into(),
                         target_account: Account {
                             chain_id: chain.id(),
                             owner: *account,

--- a/examples/fungible/src/service.rs
+++ b/examples/fungible/src/service.rs
@@ -6,11 +6,11 @@
 use std::sync::Arc;
 
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
-use fungible::{state::FungibleTokenState, OwnerSpender, Parameters};
+use fungible::{state::FungibleTokenState, Fungible, FungibleAmount, OwnerSpender, Parameters};
 use linera_sdk::{
     abis::fungible::FungibleOperation,
     graphql::GraphQLMutationRoot,
-    linera_base_types::{AccountOwner, Amount, WithServiceAbi},
+    linera_base_types::{AccountOwner, WithServiceAbi},
     views::{MapView, View},
     Service, ServiceRuntime,
 };
@@ -31,6 +31,7 @@ impl Service for FungibleTokenService {
     type Parameters = Parameters;
 
     async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        Fungible::configure_decimals(runtime.application_parameters().decimals);
         let state = FungibleTokenState::load(runtime.root_view_storage_context())
             .await
             .expect("Failed to load state");
@@ -53,11 +54,11 @@ impl Service for FungibleTokenService {
 
 #[Object]
 impl FungibleTokenService {
-    async fn accounts(&self) -> &MapView<AccountOwner, Amount> {
+    async fn accounts(&self) -> &MapView<AccountOwner, FungibleAmount> {
         &self.state.accounts
     }
 
-    async fn allowances(&self) -> &MapView<OwnerSpender, Amount> {
+    async fn allowances(&self) -> &MapView<OwnerSpender, FungibleAmount> {
         &self.state.allowances
     }
 

--- a/examples/fungible/src/state.rs
+++ b/examples/fungible/src/state.rs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount},
+    linera_base_types::AccountOwner,
     views::{linera_views, MapView, RootView, ViewStorageContext},
 };
 
-use crate::{InitialState, OwnerSpender};
+use crate::{FungibleAmount, InitialState, OwnerSpender};
 
 /// The application state.
 #[derive(RootView)]
 #[view(context = ViewStorageContext)]
 pub struct FungibleTokenState {
-    pub accounts: MapView<AccountOwner, Amount>,
-    pub allowances: MapView<OwnerSpender, Amount>,
+    pub accounts: MapView<AccountOwner, FungibleAmount>,
+    pub allowances: MapView<OwnerSpender, FungibleAmount>,
 }
 
 #[allow(dead_code)]
@@ -21,7 +21,8 @@ impl FungibleTokenState {
     /// Initializes the application state with some accounts with initial balances.
     pub async fn initialize_accounts(&mut self, state: InitialState) {
         for (k, v) in state.accounts {
-            if v != Amount::ZERO {
+            let v: FungibleAmount = v.into();
+            if v != FungibleAmount::ZERO {
                 self.accounts
                     .insert(&k, v)
                     .expect("Error in insert statement");
@@ -30,7 +31,7 @@ impl FungibleTokenState {
     }
 
     /// Obtains the balance for an `account`, returning `None` if there's no entry for the account.
-    pub async fn balance(&self, account: &AccountOwner) -> Option<Amount> {
+    pub async fn balance(&self, account: &AccountOwner) -> Option<FungibleAmount> {
         self.accounts
             .get(account)
             .await
@@ -38,15 +39,20 @@ impl FungibleTokenState {
     }
 
     /// Obtains the balance for an `account`.
-    pub async fn balance_or_default(&self, account: &AccountOwner) -> Amount {
+    pub async fn balance_or_default(&self, account: &AccountOwner) -> FungibleAmount {
         self.balance(account).await.unwrap_or_default()
     }
 
     /// Sets the `spender`'s allowance over the `owner`'s tokens to `allowance`,
-    /// overwriting any previous value. Passing `Amount::ZERO` revokes the allowance.
-    pub async fn approve(&mut self, owner: AccountOwner, spender: AccountOwner, allowance: Amount) {
+    /// overwriting any previous value. Passing `FungibleAmount::ZERO` revokes the allowance.
+    pub async fn approve(
+        &mut self,
+        owner: AccountOwner,
+        spender: AccountOwner,
+        allowance: FungibleAmount,
+    ) {
         let owner_spender = OwnerSpender::new(owner, spender);
-        if allowance == Amount::ZERO {
+        if allowance == FungibleAmount::ZERO {
             self.allowances
                 .remove(&owner_spender)
                 .expect("Failed to remove allowance");
@@ -64,9 +70,9 @@ impl FungibleTokenState {
         &mut self,
         owner: AccountOwner,
         spender: AccountOwner,
-        amount: Amount,
+        amount: FungibleAmount,
     ) {
-        if amount == Amount::ZERO {
+        if amount == FungibleAmount::ZERO {
             return;
         }
         let mut balance = self
@@ -78,7 +84,7 @@ impl FungibleTokenState {
         balance.try_sub_assign(amount).unwrap_or_else(|_| {
             panic!("Source owner {owner} does not have sufficient balance for transfer_from")
         });
-        if balance == Amount::ZERO {
+        if balance == FungibleAmount::ZERO {
             self.accounts
                 .remove(&owner)
                 .expect("Failed to remove an empty account");
@@ -97,7 +103,7 @@ impl FungibleTokenState {
         allowance.try_sub_assign(amount).unwrap_or_else(|_| {
             panic!("Spender {spender} does not have a sufficient from owner {owner} for transfer_from; allowance={allowance} amount={amount}")
         });
-        if allowance == Amount::ZERO {
+        if allowance == FungibleAmount::ZERO {
             self.allowances
                 .remove(&owner_spender)
                 .expect("Failed to remove an empty account");
@@ -109,8 +115,8 @@ impl FungibleTokenState {
     }
 
     /// Credits an `account` with the provided `amount`.
-    pub async fn credit(&mut self, account: AccountOwner, amount: Amount) {
-        if amount == Amount::ZERO {
+    pub async fn credit(&mut self, account: AccountOwner, amount: FungibleAmount) {
+        if amount == FungibleAmount::ZERO {
             return;
         }
         let mut balance = self.balance_or_default(&account).await;
@@ -121,15 +127,15 @@ impl FungibleTokenState {
     }
 
     /// Tries to debit the requested `amount` from an `account`.
-    pub async fn debit(&mut self, account: AccountOwner, amount: Amount) {
-        if amount == Amount::ZERO {
+    pub async fn debit(&mut self, account: AccountOwner, amount: FungibleAmount) {
+        if amount == FungibleAmount::ZERO {
             return;
         }
         let mut balance = self.balance_or_default(&account).await;
         balance.try_sub_assign(amount).unwrap_or_else(|_| {
             panic!("Source account {account} does not have sufficient balance for transfer")
         });
-        if balance == Amount::ZERO {
+        if balance == FungibleAmount::ZERO {
             self.accounts
                 .remove(&account)
                 .expect("Failed to remove an empty account");

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -44,7 +44,7 @@ async fn test_cross_chain_transfer() {
                 application_id,
                 FungibleOperation::Transfer {
                     owner: sender_account,
-                    amount: transfer_amount,
+                    amount: transfer_amount.into(),
                     target_account: Account {
                         chain_id: receiver_chain.id(),
                         owner: receiver_account,
@@ -99,7 +99,7 @@ async fn test_bouncing_tokens() {
                 application_id,
                 FungibleOperation::Transfer {
                     owner: sender_account,
-                    amount: transfer_amount,
+                    amount: transfer_amount.into(),
                     target_account: Account {
                         chain_id: receiver_chain.id(),
                         owner: receiver_account,

--- a/examples/fungible/tests/snapshots/format__format.snap
+++ b/examples/fungible/tests/snapshots/format__format.snap
@@ -28,15 +28,13 @@ REGISTRY:
                 TYPENAME: AccountOwner
             - spender:
                 TYPENAME: AccountOwner
-            - allowance:
-                TYPENAME: Amount
+            - allowance: U128
       3:
         Transfer:
           STRUCT:
             - owner:
                 TYPENAME: AccountOwner
-            - amount:
-                TYPENAME: Amount
+            - amount: U128
             - target_account:
                 TYPENAME: Account
       4:
@@ -46,8 +44,7 @@ REGISTRY:
                 TYPENAME: AccountOwner
             - spender:
                 TYPENAME: AccountOwner
-            - amount:
-                TYPENAME: Amount
+            - amount: U128
             - target_account:
                 TYPENAME: Account
       5:
@@ -55,8 +52,7 @@ REGISTRY:
           STRUCT:
             - source_account:
                 TYPENAME: Account
-            - amount:
-                TYPENAME: Amount
+            - amount: U128
             - target_account:
                 TYPENAME: Account
   FungibleResponse:
@@ -65,8 +61,7 @@ REGISTRY:
         Ok: UNIT
       1:
         Balance:
-          NEWTYPE:
-            TYPENAME: Amount
+          NEWTYPE: U128
       2:
         TickerSymbol:
           NEWTYPE: STR
@@ -76,8 +71,7 @@ REGISTRY:
           MAP:
             KEY:
               TYPENAME: AccountOwner
-            VALUE:
-              TYPENAME: Amount
+            VALUE: U128
   Message:
     ENUM:
       0:
@@ -85,8 +79,7 @@ REGISTRY:
           STRUCT:
             - target:
                 TYPENAME: AccountOwner
-            - amount:
-                TYPENAME: Amount
+            - amount: U128
             - source:
                 TYPENAME: AccountOwner
       1:
@@ -94,13 +87,13 @@ REGISTRY:
           STRUCT:
             - owner:
                 TYPENAME: AccountOwner
-            - amount:
-                TYPENAME: Amount
+            - amount: U128
             - target_account:
                 TYPENAME: Account
   Parameters:
     STRUCT:
       - ticker_symbol: STR
+      - decimals: U8
 OPERATION:
   TYPENAME: FungibleOperation
 RESPONSE:

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -195,7 +195,7 @@ impl MatchingEngineContract {
     ) {
         let transfer = fungible::FungibleOperation::Transfer {
             owner,
-            amount,
+            amount: amount.into(),
             target_account,
         };
         let token = self.fungible_id(token_idx);

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -7,7 +7,7 @@
 
 use async_graphql::InputType;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ApplicationPermissions},
+    linera_base_types::{AccountOwner, Amount, ApplicationId, ApplicationPermissions, U128},
     test::{ActiveChain, QueryOutcome, TestValidator},
 };
 use matching_engine::{
@@ -83,8 +83,8 @@ async fn single_transaction() {
         .publish_bytecode_files_in::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>("../fungible")
         .await;
 
-    let initial_state_a =
-        fungible::InitialStateBuilder::default().with_account(owner_a, Amount::from_tokens(10));
+    let initial_state_a = fungible::InitialStateBuilder::default()
+        .with_account(owner_a, U128(Amount::from_tokens(10).to_inner()));
     let params_a = fungible::Parameters::new("A");
     let token_id_a = user_chain_a
         .create_application(
@@ -94,8 +94,8 @@ async fn single_transaction() {
             vec![],
         )
         .await;
-    let initial_state_b =
-        fungible::InitialStateBuilder::default().with_account(owner_b, Amount::from_tokens(9));
+    let initial_state_b = fungible::InitialStateBuilder::default()
+        .with_account(owner_b, U128(Amount::from_tokens(9).to_inner()));
     let params_b = fungible::Parameters::new("B");
     let token_id_b = user_chain_b
         .create_application(

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -7,7 +7,7 @@
 
 use async_graphql::InputType;
 use linera_sdk::{
-    linera_base_types::{AccountOwner, Amount, ApplicationId, ApplicationPermissions, U128},
+    linera_base_types::{AccountOwner, Amount, ApplicationId, ApplicationPermissions},
     test::{ActiveChain, QueryOutcome, TestValidator},
 };
 use matching_engine::{
@@ -83,8 +83,8 @@ async fn single_transaction() {
         .publish_bytecode_files_in::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>("../fungible")
         .await;
 
-    let initial_state_a = fungible::InitialStateBuilder::default()
-        .with_account(owner_a, U128(Amount::from_tokens(10).to_inner()));
+    let initial_state_a =
+        fungible::InitialStateBuilder::default().with_account(owner_a, Amount::from_tokens(10));
     let params_a = fungible::Parameters::new("A");
     let token_id_a = user_chain_a
         .create_application(
@@ -94,8 +94,8 @@ async fn single_transaction() {
             vec![],
         )
         .await;
-    let initial_state_b = fungible::InitialStateBuilder::default()
-        .with_account(owner_b, U128(Amount::from_tokens(9).to_inner()));
+    let initial_state_b =
+        fungible::InitialStateBuilder::default().with_account(owner_b, Amount::from_tokens(9));
     let params_b = fungible::Parameters::new("B");
     let token_id_b = user_chain_b
         .create_application(

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -43,7 +43,8 @@ impl Contract for NativeFungibleTokenContract {
                 chain_id: self.runtime.chain_id(),
                 owner,
             };
-            self.runtime.transfer(AccountOwner::CHAIN, account, amount);
+            self.runtime
+                .transfer(AccountOwner::CHAIN, account, amount.into());
         }
     }
 
@@ -53,7 +54,7 @@ impl Contract for NativeFungibleTokenContract {
                 log::info!("balance check for owner={}", owner);
 
                 let balance = self.runtime.owner_balance(owner);
-                FungibleResponse::Balance(balance)
+                FungibleResponse::Balance(balance.into())
             }
 
             NativeFungibleOperation::TickerSymbol => {

--- a/examples/native-fungible/tests/snapshots/format__format.snap
+++ b/examples/native-fungible/tests/snapshots/format__format.snap
@@ -24,8 +24,7 @@ REGISTRY:
         Ok: UNIT
       1:
         Balance:
-          NEWTYPE:
-            TYPENAME: Amount
+          NEWTYPE: U128
       2:
         TickerSymbol:
           NEWTYPE: STR

--- a/examples/native-fungible/tests/transfers.rs
+++ b/examples/native-fungible/tests/transfers.rs
@@ -18,6 +18,7 @@ use linera_sdk::{
 async fn chain_balance_transfers() {
     let parameters = fungible::Parameters {
         ticker_symbol: "NAT".to_owned(),
+        decimals: 18,
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
@@ -55,6 +56,7 @@ async fn chain_balance_transfers() {
 async fn transfer_to_owner() {
     let parameters = fungible::Parameters {
         ticker_symbol: "NAT".to_owned(),
+        decimals: 18,
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
@@ -89,6 +91,7 @@ async fn transfer_to_owner() {
 async fn transfer_to_multiple_owners() {
     let parameters = fungible::Parameters {
         ticker_symbol: "NAT".to_owned(),
+        decimals: 18,
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<
@@ -137,6 +140,7 @@ async fn transfer_to_multiple_owners() {
 async fn emptied_account_disappears_from_queries() {
     let parameters = fungible::Parameters {
         ticker_symbol: "NAT".to_owned(),
+        decimals: 18,
     };
     let initial_state = fungible::InitialStateBuilder::default().build();
     let (validator, _application_id, recipient_chain) = TestValidator::with_current_application::<

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -9,7 +9,7 @@ use fungible::{Account, FungibleOperation, FungibleTokenAbi};
 use linera_sdk::{
     linera_base_types::{
         AccountOwner, Amount, ApplicationPermissions, ChainId, ChainOwnership, TimeoutConfig,
-        WithContractAbi,
+        WithContractAbi, U128,
     },
     views::{RootView, View},
     Contract, ContractRuntime,
@@ -140,7 +140,7 @@ impl Contract for RfqContract {
                 let token_pair = awaiting_tokens.token_pair;
                 let transfer = FungibleOperation::Transfer {
                     owner,
-                    amount: awaiting_tokens.amount_offered,
+                    amount: U128((awaiting_tokens.amount_offered).to_inner()),
                     target_account: Account {
                         chain_id: temp_chain_id,
                         owner: self.runtime.application_id().into(),
@@ -269,7 +269,7 @@ impl Contract for RfqContract {
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                             &FungibleOperation::Transfer {
                                 owner,
-                                amount: tokens.amount,
+                                amount: U128((tokens.amount).to_inner()),
                                 target_account: tokens.owner,
                             },
                         );
@@ -283,7 +283,7 @@ impl Contract for RfqContract {
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                             &FungibleOperation::Transfer {
                                 owner,
-                                amount: tokens.amount,
+                                amount: U128((tokens.amount).to_inner()),
                                 target_account: held_tokens.owner,
                             },
                         );
@@ -294,7 +294,7 @@ impl Contract for RfqContract {
                                 .with_abi::<fungible::FungibleTokenAbi>(),
                             &FungibleOperation::Transfer {
                                 owner,
-                                amount: held_tokens.amount,
+                                amount: U128((held_tokens.amount).to_inner()),
                                 target_account: tokens.owner,
                             },
                         );
@@ -338,7 +338,7 @@ impl RfqContract {
         // transfer tokens to the new chain
         let transfer = FungibleOperation::Transfer {
             owner,
-            amount: quote_provided.get_amount(),
+            amount: U128((quote_provided.get_amount()).to_inner()),
             target_account: Account {
                 chain_id: temp_chain_id,
                 owner: self.runtime.application_id().into(),
@@ -381,7 +381,7 @@ impl RfqContract {
                 tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                 &FungibleOperation::Transfer {
                     owner,
-                    amount: tokens.amount,
+                    amount: U128((tokens.amount).to_inner()),
                     target_account: tokens.owner,
                 },
             );

--- a/examples/rfq/src/contract.rs
+++ b/examples/rfq/src/contract.rs
@@ -9,7 +9,7 @@ use fungible::{Account, FungibleOperation, FungibleTokenAbi};
 use linera_sdk::{
     linera_base_types::{
         AccountOwner, Amount, ApplicationPermissions, ChainId, ChainOwnership, TimeoutConfig,
-        WithContractAbi, U128,
+        WithContractAbi,
     },
     views::{RootView, View},
     Contract, ContractRuntime,
@@ -140,7 +140,7 @@ impl Contract for RfqContract {
                 let token_pair = awaiting_tokens.token_pair;
                 let transfer = FungibleOperation::Transfer {
                     owner,
-                    amount: U128((awaiting_tokens.amount_offered).to_inner()),
+                    amount: awaiting_tokens.amount_offered.into(),
                     target_account: Account {
                         chain_id: temp_chain_id,
                         owner: self.runtime.application_id().into(),
@@ -269,7 +269,7 @@ impl Contract for RfqContract {
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                             &FungibleOperation::Transfer {
                                 owner,
-                                amount: U128((tokens.amount).to_inner()),
+                                amount: tokens.amount.into(),
                                 target_account: tokens.owner,
                             },
                         );
@@ -283,7 +283,7 @@ impl Contract for RfqContract {
                             tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                             &FungibleOperation::Transfer {
                                 owner,
-                                amount: U128((tokens.amount).to_inner()),
+                                amount: tokens.amount.into(),
                                 target_account: held_tokens.owner,
                             },
                         );
@@ -294,7 +294,7 @@ impl Contract for RfqContract {
                                 .with_abi::<fungible::FungibleTokenAbi>(),
                             &FungibleOperation::Transfer {
                                 owner,
-                                amount: U128((held_tokens.amount).to_inner()),
+                                amount: held_tokens.amount.into(),
                                 target_account: tokens.owner,
                             },
                         );
@@ -338,7 +338,7 @@ impl RfqContract {
         // transfer tokens to the new chain
         let transfer = FungibleOperation::Transfer {
             owner,
-            amount: U128((quote_provided.get_amount()).to_inner()),
+            amount: quote_provided.get_amount().into(),
             target_account: Account {
                 chain_id: temp_chain_id,
                 owner: self.runtime.application_id().into(),
@@ -381,7 +381,7 @@ impl RfqContract {
                 tokens.token_id.with_abi::<fungible::FungibleTokenAbi>(),
                 &FungibleOperation::Transfer {
                     owner,
-                    amount: U128((tokens.amount).to_inner()),
+                    amount: tokens.amount.into(),
                     target_account: tokens.owner,
                 },
             );

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -23,6 +23,7 @@ use async_graphql::{InputObject, SimpleObject};
 use custom_debug_derive::Debug;
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
 use serde_with::{serde_as, Bytes};
 use thiserror::Error;
 use tracing::instrument;
@@ -292,24 +293,11 @@ where
     }
 }
 
-/// A non-negative amount of tokens.
+/// A non-negative amount of native tokens.
 ///
 /// This is a fixed-point fraction, with [`Amount::DECIMAL_PLACES`] digits after the point.
 /// [`Amount::ONE`] is one whole token, divisible into `10.pow(Amount::DECIMAL_PLACES)` parts.
-#[derive(
-    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, WitType, WitLoad, WitStore,
-)]
-#[cfg_attr(
-    all(with_testing, not(target_arch = "wasm32")),
-    derive(test_strategy::Arbitrary)
-)]
-pub struct Amount(u128);
-
-impl Allocative for Amount {
-    fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
-        visitor.visit_simple_sized::<Self>();
-    }
-}
+pub type Amount = TokenAmount<NativeToken>;
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename = "Amount")]
@@ -319,48 +307,618 @@ struct AmountString(String);
 #[serde(rename = "Amount")]
 struct AmountU128(u128);
 
-impl Serialize for Amount {
+impl<T> From<TokenAmount<T>> for U256 {
+    fn from(amount: TokenAmount<T>) -> U256 {
+        U256::from(amount.to_inner())
+    }
+}
+
+impl<T: Token> From<TokenAmount<T>> for f64 {
+    /// Returns the amount as a floating-point number of whole tokens. This is
+    /// lossy for large or high-precision amounts; intended for telemetry, not
+    /// for arithmetic.
+    fn from(amount: TokenAmount<T>) -> f64 {
+        amount.to_inner() as f64 / TokenAmount::<T>::one().to_inner() as f64
+    }
+}
+
+impl<T> TryFrom<U256> for TokenAmount<T> {
+    type Error = ArithmeticError;
+    fn try_from(value: U256) -> Result<Self, Self::Error> {
+        let value: u128 = value.try_into().map_err(|_| ArithmeticError::Overflow)?;
+        Ok(Self::new(value))
+    }
+}
+
+/// A non-negative amount of tokens with fixed (yet configurable) precision.
+///
+/// The type is "branded" by a type `T` implementing [`Token`]
+///
+/// The standard traits are implemented by hand rather than derived: the wrapper's behaviour
+/// never depends on `T` (its only fields are a `u128` and a `PhantomData<T>`), so deriving them
+/// would add spurious `T: Trait` bounds and force every `Token` marker to implement them too.
+#[derive(WitType, WitLoad, WitStore)]
+pub struct TokenAmount<T> {
+    inner: u128,
+    // `fn() -> T` rather than `T` so the wrapper is `Send + Sync` regardless of `T` (it never
+    // actually holds a `T`), as required by the GraphQL `InputType`/`OutputType` impls.
+    // `#[witty(skip)]` keeps the zero-sized marker out of the WIT interface (a `unit` record
+    // field is not valid WIT); it is reconstructed via `Default` on load.
+    #[witty(skip)]
+    tag: std::marker::PhantomData<fn() -> T>,
+}
+
+// Hand-written (with a `T: Token` bound) rather than derived, because `proptest::Arbitrary`
+// requires `Debug`, which is only implemented when `T: Token`.
+#[cfg(all(with_testing, not(target_arch = "wasm32")))]
+impl<T: Token + 'static> proptest::arbitrary::Arbitrary for TokenAmount<T> {
+    type Parameters = ();
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        use proptest::strategy::Strategy as _;
+
+        proptest::arbitrary::any::<u128>()
+            .prop_map(Self::new)
+            .boxed()
+    }
+}
+
+impl<T> Clone for TokenAmount<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for TokenAmount<T> {}
+
+impl<T> PartialEq for TokenAmount<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<T> Eq for TokenAmount<T> {}
+
+impl<T> PartialOrd for TokenAmount<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for TokenAmount<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.inner.cmp(&other.inner)
+    }
+}
+
+impl<T> Hash for TokenAmount<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.inner.hash(state);
+    }
+}
+
+impl<T> Default for TokenAmount<T> {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
+impl<T: Token> fmt::Debug for TokenAmount<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple(T::NAME).field(&self.inner).finish()
+    }
+}
+
+/// The specification of a token for [`TokenAmount`].
+pub trait Token {
+    /// The name of the token.
+    const NAME: &'static str;
+
+    /// Whether [`Display`] and [`FromStr`] use the decimal fixed-point form. When `false`, the
+    /// inner `u128` value is used directly.
+    const DECIMAL_DISPLAY: bool = true;
+
+    /// The precision given as a number of decimals.
+    fn decimals() -> u8;
+
+    /// Returns `10.pow(exponent)`, panicking if the result does not fit in a `u128`.
+    fn pow10(exponent: u8) -> u128 {
+        10u128
+            .checked_pow(exponent as u32)
+            .expect("token precision is too high to represent as a fixed-point u128")
+    }
+}
+
+/// The native token.
+pub struct NativeToken;
+
+impl Token for NativeToken {
+    const NAME: &str = "Amount";
+
+    fn decimals() -> u8 {
+        Amount::DECIMAL_PLACES
+    }
+}
+
+impl Amount {
+    /// The base-10 exponent representing how much a token can be divided.
+    pub const DECIMAL_PLACES: u8 = 18;
+
+    /// One token.
+    pub const ONE: Self = Self::new(10u128.pow(Self::DECIMAL_PLACES as u32));
+
+    /// Returns the number of attotokens.
+    pub const fn to_attos(self) -> u128 {
+        self.to_inner()
+    }
+}
+
+impl<T: Token> Allocative for TokenAmount<T> {
+    fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
+        visitor.visit_simple_sized::<Self>();
+    }
+}
+
+impl<T: Token> Display for TokenAmount<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !T::DECIMAL_DISPLAY {
+            return Display::fmt(&self.inner, f);
+        }
+        // Print the wrapped integer, padded with zeros to cover a digit before the decimal point.
+        let places = T::decimals() as usize;
+        let min_digits = places + 1;
+        let decimals = format!("{:0min_digits$}", self.inner);
+        let integer_part = &decimals[..(decimals.len() - places)];
+        let fractional_part = decimals[(decimals.len() - places)..].trim_end_matches('0');
+
+        // For now, we never trim non-zero digits so we don't lose any precision.
+        let precision = f.precision().unwrap_or(0).max(fractional_part.len());
+        let sign = if f.sign_plus() && self.inner > 0 {
+            "+"
+        } else {
+            ""
+        };
+        // A token with fractional places always shows the point (e.g. `1.`), matching the
+        // convention that its output round-trips through `FromStr`. A zero-decimal token is an
+        // integer, so the point only appears when a precision was explicitly requested.
+        let point = if places > 0 || precision > 0 { "." } else { "" };
+        // The amount of padding: desired width minus sign, point and number of digits.
+        let pad_width = f.width().map_or(0, |w| {
+            w.saturating_sub(precision)
+                .saturating_sub(sign.len() + integer_part.len() + point.len())
+        });
+        let left_pad = match f.align() {
+            None | Some(fmt::Alignment::Right) => pad_width,
+            Some(fmt::Alignment::Center) => pad_width / 2,
+            Some(fmt::Alignment::Left) => 0,
+        };
+
+        for _ in 0..left_pad {
+            write!(f, "{}", f.fill())?;
+        }
+        write!(
+            f,
+            "{sign}{integer_part}{point}{fractional_part:0<precision$}"
+        )?;
+        for _ in left_pad..pad_width {
+            write!(f, "{}", f.fill())?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: Token> FromStr for TokenAmount<T> {
+    type Err = ParseAmountError;
+
+    fn from_str(src: &str) -> Result<Self, Self::Err> {
+        if !T::DECIMAL_DISPLAY {
+            let inner = src
+                .trim()
+                .parse::<u128>()
+                .map_err(|_| ParseAmountError::Parse)?;
+            return Ok(Self::new(inner));
+        }
+        let mut result: u128 = 0;
+        let mut decimals: Option<u8> = None;
+        let mut chars = src.trim().chars().peekable();
+        if chars.peek() == Some(&'+') {
+            chars.next();
+        }
+        for char in chars {
+            match char {
+                '_' => {}
+                '.' if decimals.is_some() => return Err(ParseAmountError::Parse),
+                '.' => decimals = Some(T::decimals()),
+                char => {
+                    let digit = u128::from(char.to_digit(10).ok_or(ParseAmountError::Parse)?);
+                    if let Some(d) = &mut decimals {
+                        *d = d.checked_sub(1).ok_or(ParseAmountError::TooManyDigits)?;
+                    }
+                    result = result
+                        .checked_mul(10)
+                        .and_then(|r| r.checked_add(digit))
+                        .ok_or(ParseAmountError::TooHigh)?;
+                }
+            }
+        }
+        result = result
+            .checked_mul(T::pow10(decimals.unwrap_or_else(T::decimals)))
+            .ok_or(ParseAmountError::TooHigh)?;
+        Ok(Self::new(result))
+    }
+}
+
+impl<T: Token> Serialize for TokenAmount<T> {
     fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Override the container names below.
+        let serializer = SerializeNameAdapter::new(serializer, T::NAME);
         if serializer.is_human_readable() {
             AmountString(self.to_string()).serialize(serializer)
         } else {
-            AmountU128(self.0).serialize(serializer)
+            AmountU128(self.inner).serialize(serializer)
         }
     }
 }
 
-impl<'de> Deserialize<'de> for Amount {
+impl<'de, T: Token> Deserialize<'de> for TokenAmount<T> {
     fn deserialize<D: serde::de::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Override the container names below.
+        let deserializer = DeserializeNameAdapter::new(deserializer, T::NAME);
         if deserializer.is_human_readable() {
             let AmountString(s) = AmountString::deserialize(deserializer)?;
             s.parse().map_err(serde::de::Error::custom)
         } else {
-            Ok(Amount(AmountU128::deserialize(deserializer)?.0))
+            Ok(Self::new(AmountU128::deserialize(deserializer)?.0))
         }
     }
 }
 
-impl From<Amount> for U256 {
-    fn from(amount: Amount) -> U256 {
-        U256::from(amount.0)
+// A GraphQL scalar named after the token, using the same string representation as the serde
+// human-readable format (i.e. `Display`/`FromStr`). Implemented by hand rather than via
+// `doc_scalar!` because the type is generic and the scalar name is `T::NAME`.
+fn token_amount_scalar_meta<T: Token>() -> async_graphql::registry::MetaType {
+    async_graphql::registry::MetaType::Scalar {
+        name: T::NAME.to_owned(),
+        description: Some("A non-negative amount of tokens.".to_string()),
+        is_valid: Some(std::sync::Arc::new(|value| {
+            <TokenAmount<T> as async_graphql::ScalarType>::is_valid(value)
+        })),
+        visible: None,
+        inaccessible: false,
+        tags: Default::default(),
+        specified_by_url: None,
+        directive_invocations: Default::default(),
+        requires_scopes: Default::default(),
     }
 }
 
-impl From<Amount> for f64 {
-    /// Returns the amount as a floating-point number of whole tokens. This is
-    /// lossy for large or high-precision amounts; intended for telemetry, not
-    /// for arithmetic.
-    fn from(amount: Amount) -> f64 {
-        amount.0 as f64 / Amount::ONE.0 as f64
+impl<T: Token> async_graphql::ScalarType for TokenAmount<T> {
+    fn parse(value: async_graphql::Value) -> async_graphql::InputValueResult<Self> {
+        Ok(async_graphql::from_value(value)?)
+    }
+
+    fn to_value(&self) -> async_graphql::Value {
+        async_graphql::to_value(self).unwrap_or(async_graphql::Value::Null)
     }
 }
 
-impl TryFrom<U256> for Amount {
-    type Error = ArithmeticError;
+impl<T: Token> async_graphql::InputType for TokenAmount<T> {
+    type RawValueType = Self;
 
-    fn try_from(value: U256) -> Result<Amount, ArithmeticError> {
-        let value: u128 = value.try_into().map_err(|_| ArithmeticError::Overflow)?;
-        Ok(Amount::from_attos(value))
+    fn type_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(T::NAME)
+    }
+
+    fn create_type_info(registry: &mut async_graphql::registry::Registry) -> String {
+        registry.create_input_type::<Self, _>(async_graphql::registry::MetaTypeId::Scalar, |_| {
+            token_amount_scalar_meta::<T>()
+        })
+    }
+
+    fn parse(value: Option<async_graphql::Value>) -> async_graphql::InputValueResult<Self> {
+        <Self as async_graphql::ScalarType>::parse(value.unwrap_or_default())
+    }
+
+    fn to_value(&self) -> async_graphql::Value {
+        <Self as async_graphql::ScalarType>::to_value(self)
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+}
+
+impl<T: Token> async_graphql::OutputType for TokenAmount<T> {
+    fn type_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed(T::NAME)
+    }
+
+    fn create_type_info(registry: &mut async_graphql::registry::Registry) -> String {
+        registry.create_output_type::<Self, _>(async_graphql::registry::MetaTypeId::Scalar, |_| {
+            token_amount_scalar_meta::<T>()
+        })
+    }
+
+    async fn resolve(
+        &self,
+        _: &async_graphql::ContextSelectionSet<'_>,
+        _field: &async_graphql::Positioned<async_graphql::parser::types::Field>,
+    ) -> async_graphql::ServerResult<async_graphql::Value> {
+        Ok(async_graphql::ScalarType::to_value(self))
+    }
+}
+
+impl<'a, T: Token> iter::Sum<&'a TokenAmount<T>> for TokenAmount<T> {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |a, b| a.saturating_add(*b))
+    }
+}
+
+impl<T> From<TokenAmount<T>> for u128 {
+    fn from(value: TokenAmount<T>) -> Self {
+        value.inner
+    }
+}
+
+// A `U128` is an explicit raw value, so converting to and from a `TokenAmount` is a deliberate
+// crossing of the wire/typed boundary and available outside of tests (unlike the bare `u128`
+// conversions below).
+impl<T> From<TokenAmount<T>> for U128 {
+    fn from(value: TokenAmount<T>) -> Self {
+        U128(value.inner)
+    }
+}
+
+impl<T> From<U128> for TokenAmount<T> {
+    fn from(value: U128) -> Self {
+        Self::new(value.0)
+    }
+}
+
+// Cannot directly create values for a wrapped type, except for testing.
+#[cfg(with_testing)]
+impl<T> From<u128> for TokenAmount<T> {
+    fn from(value: u128) -> Self {
+        Self::new(value)
+    }
+}
+
+#[cfg(with_testing)]
+impl<T> ops::Add for TokenAmount<T> {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self::new(self.inner + other.inner)
+    }
+}
+
+#[cfg(with_testing)]
+impl<T> ops::Sub for TokenAmount<T> {
+    type Output = Self;
+
+    fn sub(self, other: Self) -> Self {
+        Self::new(self.inner - other.inner)
+    }
+}
+
+#[cfg(with_testing)]
+impl<T> ops::Mul<u128> for TokenAmount<T> {
+    type Output = Self;
+
+    fn mul(self, other: u128) -> Self {
+        Self::new(self.inner * other)
+    }
+}
+
+impl<T> TokenAmount<T> {
+    const fn new(inner: u128) -> Self {
+        Self {
+            inner,
+            tag: std::marker::PhantomData,
+        }
+    }
+
+    /// Zero tokens.
+    pub const ZERO: Self = Self::new(0);
+
+    /// The maximum representable amount.
+    pub const MAX: Self = Self::new(u128::MAX);
+
+    /// Returns the inner value.
+    pub const fn to_inner(self) -> u128 {
+        self.inner
+    }
+
+    /// Wraps a raw inner value, given in the token's smallest unit. Inverse of [`to_inner`].
+    ///
+    /// [`to_inner`]: Self::to_inner
+    pub const fn from_inner(inner: u128) -> Self {
+        Self::new(inner)
+    }
+
+    /// Returns whether this amount is 0.
+    pub fn is_zero(&self) -> bool {
+        self.inner == 0
+    }
+
+    /// Divides this by the other amount. If the other is 0, it returns `u128::MAX`.
+    pub fn saturating_ratio(self, other: Self) -> u128 {
+        self.inner.checked_div(other.inner).unwrap_or(u128::MAX)
+    }
+
+    /// Helper function to obtain the 64 most significant bits of the inner value.
+    pub const fn upper_half(self) -> u64 {
+        (self.inner >> 64) as u64
+    }
+
+    /// Helper function to obtain the 64 least significant bits of the inner value.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "intentional: returns the low 64 bits"
+    )]
+    pub const fn lower_half(self) -> u64 {
+        self.inner as u64
+    }
+}
+
+impl<T: Token> TokenAmount<T> {
+    /// The precision in decimals.
+    pub fn decimals() -> u8 {
+        T::decimals()
+    }
+
+    /// One token.
+    pub fn one() -> Self {
+        TokenAmount::new(T::pow10(T::decimals()))
+    }
+
+    /// Checked addition.
+    pub fn try_add(self, other: Self) -> Result<Self, ArithmeticError> {
+        let val = self
+            .inner
+            .checked_add(other.inner)
+            .ok_or(ArithmeticError::Overflow)?;
+        Ok(Self::new(val))
+    }
+
+    /// Checked increment.
+    pub fn try_add_one(self) -> Result<Self, ArithmeticError> {
+        let val = self.inner.checked_add(1).ok_or(ArithmeticError::Overflow)?;
+        Ok(Self::new(val))
+    }
+
+    /// Saturating addition.
+    pub const fn saturating_add(self, other: Self) -> Self {
+        let val = self.inner.saturating_add(other.inner);
+        Self::new(val)
+    }
+
+    /// Checked subtraction.
+    pub fn try_sub(self, other: Self) -> Result<Self, ArithmeticError> {
+        let val = self
+            .inner
+            .checked_sub(other.inner)
+            .ok_or(ArithmeticError::Underflow)?;
+        Ok(Self::new(val))
+    }
+
+    /// Checked decrement.
+    pub fn try_sub_one(self) -> Result<Self, ArithmeticError> {
+        let val = self
+            .inner
+            .checked_sub(1)
+            .ok_or(ArithmeticError::Underflow)?;
+        Ok(Self::new(val))
+    }
+
+    /// Saturating subtraction.
+    pub const fn saturating_sub(self, other: Self) -> Self {
+        let val = self.inner.saturating_sub(other.inner);
+        Self::new(val)
+    }
+
+    /// Returns the absolute difference between `self` and `other`.
+    pub fn abs_diff(self, other: Self) -> Self {
+        Self::new(self.inner.abs_diff(other.inner))
+    }
+
+    /// Returns the midpoint of `self` and `other`, rounded down.
+    pub const fn midpoint(self, other: Self) -> Self {
+        Self::new(self.inner.midpoint(other.inner))
+    }
+
+    /// Checked in-place addition.
+    pub fn try_add_assign(&mut self, other: Self) -> Result<(), ArithmeticError> {
+        self.inner = self
+            .inner
+            .checked_add(other.inner)
+            .ok_or(ArithmeticError::Overflow)?;
+        Ok(())
+    }
+
+    /// Checked in-place increment.
+    pub fn try_add_assign_one(&mut self) -> Result<(), ArithmeticError> {
+        self.inner = self.inner.checked_add(1).ok_or(ArithmeticError::Overflow)?;
+        Ok(())
+    }
+
+    /// Saturating in-place addition.
+    pub const fn saturating_add_assign(&mut self, other: Self) {
+        self.inner = self.inner.saturating_add(other.inner);
+    }
+
+    /// Checked in-place subtraction.
+    pub fn try_sub_assign(&mut self, other: Self) -> Result<(), ArithmeticError> {
+        self.inner = self
+            .inner
+            .checked_sub(other.inner)
+            .ok_or(ArithmeticError::Underflow)?;
+        Ok(())
+    }
+
+    /// Saturating division.
+    pub fn saturating_div(&self, other: u128) -> Self {
+        Self::new(self.inner.checked_div(other).unwrap_or(u128::MAX))
+    }
+
+    /// Saturating multiplication.
+    pub const fn saturating_mul(&self, other: u128) -> Self {
+        Self::new(self.inner.saturating_mul(other))
+    }
+
+    /// Checked multiplication.
+    pub fn try_mul(self, other: u128) -> Result<Self, ArithmeticError> {
+        let val = self
+            .inner
+            .checked_mul(other)
+            .ok_or(ArithmeticError::Overflow)?;
+        Ok(Self::new(val))
+    }
+
+    /// Checked in-place multiplication.
+    pub fn try_mul_assign(&mut self, other: u128) -> Result<(), ArithmeticError> {
+        self.inner = self
+            .inner
+            .checked_mul(other)
+            .ok_or(ArithmeticError::Overflow)?;
+        Ok(())
+    }
+
+    /// Returns a `TokenAmount` for `amount` in units of `10.pow(-unit_decimals)` tokens,
+    /// saturating on overflow and truncating any sub-unit remainder towards zero.
+    fn from_subunits(amount: u128, unit_decimals: u8) -> Self {
+        let decimals = T::decimals();
+        if decimals >= unit_decimals {
+            Self::new(T::pow10(decimals - unit_decimals)).saturating_mul(amount)
+        } else {
+            Self::new(amount / T::pow10(unit_decimals - decimals))
+        }
+    }
+
+    /// Returns a `TokenAmount` corresponding to that many tokens, or [`TokenAmount::MAX`] if saturated.
+    pub fn from_tokens(tokens: u128) -> Self {
+        Self::from_subunits(tokens, 0)
+    }
+
+    /// Returns a `TokenAmount` corresponding to that many millitokens, or [`TokenAmount::MAX`] if saturated.
+    pub fn from_millis(millitokens: u128) -> Self {
+        Self::from_subunits(millitokens, 3)
+    }
+
+    /// Returns a `TokenAmount` corresponding to that many microtokens, or [`TokenAmount::MAX`] if saturated.
+    pub fn from_micros(microtokens: u128) -> Self {
+        Self::from_subunits(microtokens, 6)
+    }
+
+    /// Returns a `TokenAmount` corresponding to that many nanotokens, or [`TokenAmount::MAX`] if saturated.
+    pub fn from_nanos(nanotokens: u128) -> Self {
+        Self::from_subunits(nanotokens, 9)
+    }
+
+    /// Returns a `TokenAmount` corresponding to that many attotokens, or [`TokenAmount::MAX`] if saturated.
+    pub fn from_attos(attotokens: u128) -> Self {
+        Self::from_subunits(attotokens, 18)
     }
 }
 
@@ -840,44 +1398,9 @@ impl TryFrom<BlockHeight> for usize {
     }
 }
 
-impl_wrapped_number!(Amount, u128);
 impl_wrapped_number!(U128, u128);
 impl_wrapped_number!(BlockHeight, u64);
 impl_wrapped_number!(TimeDelta, u64);
-
-impl Display for Amount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Print the wrapped integer, padded with zeros to cover a digit before the decimal point.
-        let places = Amount::DECIMAL_PLACES as usize;
-        let min_digits = places + 1;
-        let decimals = format!("{:0min_digits$}", self.0);
-        let integer_part = &decimals[..(decimals.len() - places)];
-        let fractional_part = decimals[(decimals.len() - places)..].trim_end_matches('0');
-
-        // For now, we never trim non-zero digits so we don't lose any precision.
-        let precision = f.precision().unwrap_or(0).max(fractional_part.len());
-        let sign = if f.sign_plus() && self.0 > 0 { "+" } else { "" };
-        // The amount of padding: desired width minus sign, point and number of digits.
-        let pad_width = f.width().map_or(0, |w| {
-            w.saturating_sub(precision)
-                .saturating_sub(sign.len() + integer_part.len() + 1)
-        });
-        let left_pad = match f.align() {
-            None | Some(fmt::Alignment::Right) => pad_width,
-            Some(fmt::Alignment::Center) => pad_width / 2,
-            Some(fmt::Alignment::Left) => 0,
-        };
-
-        for _ in 0..left_pad {
-            write!(f, "{}", f.fill())?;
-        }
-        write!(f, "{sign}{integer_part}.{fractional_part:0<precision$}")?;
-        for _ in left_pad..pad_width {
-            write!(f, "{}", f.fill())?;
-        }
-        Ok(())
-    }
-}
 
 #[derive(Error, Debug)]
 #[allow(missing_docs)]
@@ -888,40 +1411,6 @@ pub enum ParseAmountError {
     TooHigh,
     #[error("cannot represent amount: too many decimal places after the point")]
     TooManyDigits,
-}
-
-impl FromStr for Amount {
-    type Err = ParseAmountError;
-
-    fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let mut result: u128 = 0;
-        let mut decimals: Option<u8> = None;
-        let mut chars = src.trim().chars().peekable();
-        if chars.peek() == Some(&'+') {
-            chars.next();
-        }
-        for char in chars {
-            match char {
-                '_' => {}
-                '.' if decimals.is_some() => return Err(ParseAmountError::Parse),
-                '.' => decimals = Some(Amount::DECIMAL_PLACES),
-                char => {
-                    let digit = u128::from(char.to_digit(10).ok_or(ParseAmountError::Parse)?);
-                    if let Some(d) = &mut decimals {
-                        *d = d.checked_sub(1).ok_or(ParseAmountError::TooManyDigits)?;
-                    }
-                    result = result
-                        .checked_mul(10)
-                        .and_then(|r| r.checked_add(digit))
-                        .ok_or(ParseAmountError::TooHigh)?;
-                }
-            }
-        }
-        result = result
-            .checked_mul(10u128.pow(decimals.unwrap_or(Amount::DECIMAL_PLACES) as u32))
-            .ok_or(ParseAmountError::TooHigh)?;
-        Ok(Amount(result))
-    }
 }
 
 impl Display for BlockHeight {
@@ -984,70 +1473,6 @@ impl Round {
             Round::SingleLeader(_) => "single",
             Round::Validator(_) => "validator",
         }
-    }
-}
-
-impl<'a> iter::Sum<&'a Amount> for Amount {
-    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
-        iter.fold(Self::ZERO, |a, b| a.saturating_add(*b))
-    }
-}
-
-impl Amount {
-    /// The base-10 exponent representing how much a token can be divided.
-    pub const DECIMAL_PLACES: u8 = 18;
-
-    /// One token.
-    pub const ONE: Amount = Amount(10u128.pow(Amount::DECIMAL_PLACES as u32));
-
-    /// Returns an `Amount` corresponding to that many tokens, or `Amount::MAX` if saturated.
-    pub const fn from_tokens(tokens: u128) -> Amount {
-        Self::ONE.saturating_mul(tokens)
-    }
-
-    /// Returns an `Amount` corresponding to that many millitokens, or `Amount::MAX` if saturated.
-    pub const fn from_millis(millitokens: u128) -> Amount {
-        Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 3)).saturating_mul(millitokens)
-    }
-
-    /// Returns an `Amount` corresponding to that many microtokens, or `Amount::MAX` if saturated.
-    pub const fn from_micros(microtokens: u128) -> Amount {
-        Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 6)).saturating_mul(microtokens)
-    }
-
-    /// Returns an `Amount` corresponding to that many nanotokens, or `Amount::MAX` if saturated.
-    pub const fn from_nanos(nanotokens: u128) -> Amount {
-        Amount(10u128.pow(Amount::DECIMAL_PLACES as u32 - 9)).saturating_mul(nanotokens)
-    }
-
-    /// Returns an `Amount` corresponding to that many attotokens.
-    pub const fn from_attos(attotokens: u128) -> Amount {
-        Amount(attotokens)
-    }
-
-    /// Returns the number of attotokens.
-    pub const fn to_attos(self) -> u128 {
-        self.0
-    }
-
-    /// Helper function to obtain the 64 most significant bits of the balance.
-    pub const fn upper_half(self) -> u64 {
-        (self.0 >> 64) as u64
-    }
-
-    /// Helper function to obtain the 64 least significant bits of the balance.
-    pub const fn lower_half(self) -> u64 {
-        self.0 as u64
-    }
-
-    /// Divides this by the other amount. If the other is 0, it returns `u128::MAX`.
-    pub fn saturating_ratio(self, other: Amount) -> u128 {
-        self.0.checked_div(other.0).unwrap_or(u128::MAX)
-    }
-
-    /// Returns whether this amount is 0.
-    pub fn is_zero(&self) -> bool {
-        *self == Amount::ZERO
     }
 }
 
@@ -1970,7 +2395,6 @@ impl MessagePolicy {
 }
 
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
-doc_scalar!(Amount, "A non-negative amount of tokens.");
 doc_scalar!(U128, "A 128-bit unsigned integer.");
 doc_scalar!(
     Epoch,
@@ -2041,6 +2465,8 @@ mod metrics {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+
+    use alloy_primitives::U256;
 
     use super::{Amount, ApplicationDescription, BlobContent};
     use crate::{
@@ -2120,10 +2546,10 @@ mod tests {
         assert_eq!("1.", Amount::ONE.to_string());
         assert_eq!("1.", Amount::from_str("1.").unwrap().to_string());
         assert_eq!(
-            Amount(10_000_000_000_000_000_000),
+            Amount::from(10_000_000_000_000_000_000),
             Amount::from_str("10").unwrap()
         );
-        assert_eq!("10.", Amount(10_000_000_000_000_000_000).to_string());
+        assert_eq!("10.", Amount::from(10_000_000_000_000_000_000).to_string());
         assert_eq!(
             "1001.3",
             (Amount::from_str("1.1")
@@ -2139,6 +2565,193 @@ mod tests {
             "~+12.34~~",
             format!("{:~^+9.1}", Amount::from_str("12.34").unwrap())
         );
+        // `Debug` uses the token name (`NativeToken::NAME`), matching the old derived output.
+        assert_eq!("Amount(1000000000000000000)", format!("{:?}", Amount::ONE));
+    }
+
+    #[test]
+    fn display_token_amount() {
+        use super::{Token, TokenAmount};
+
+        // A token with two decimal places.
+        struct Cents;
+        impl Token for Cents {
+            const NAME: &'static str = "Cents";
+
+            fn decimals() -> u8 {
+                2
+            }
+        }
+
+        // A zero-decimal (integer) token.
+        struct Units;
+        impl Token for Units {
+            const NAME: &'static str = "Units";
+
+            fn decimals() -> u8 {
+                0
+            }
+        }
+
+        // `Debug` is tagged with the token's name.
+        assert_eq!("Cents(100)", format!("{:?}", TokenAmount::<Cents>::one()));
+
+        // A fractional token keeps the trailing point on whole numbers, like `Amount`.
+        assert_eq!("1.", TokenAmount::<Cents>::one().to_string());
+        assert_eq!(
+            "1.23",
+            TokenAmount::<Cents>::from_str("1.23").unwrap().to_string()
+        );
+        assert_eq!("1.00", format!("{:.2}", TokenAmount::<Cents>::one()));
+
+        // A zero-decimal token prints as a bare integer, with no dangling point.
+        assert_eq!(
+            "5",
+            TokenAmount::<Units>::from_str("5").unwrap().to_string()
+        );
+        assert_eq!("0", TokenAmount::<Units>::ZERO.to_string());
+        // ... unless a precision is explicitly requested.
+        assert_eq!(
+            "5.00",
+            format!("{:.2}", TokenAmount::<Units>::from_str("5").unwrap())
+        );
+
+        // `MAX` is the largest inner value, independent of the precision.
+        assert_eq!(u128::MAX, TokenAmount::<Cents>::MAX.to_inner());
+        assert_eq!(u128::MAX, TokenAmount::<Units>::MAX.to_inner());
+    }
+
+    #[test]
+    fn token_amount_from_subunits() {
+        use super::{Token, TokenAmount};
+
+        // A token with two decimal places, coarser than milli/micro/etc.
+        struct Cents;
+        impl Token for Cents {
+            const NAME: &'static str = "Cents";
+
+            fn decimals() -> u8 {
+                2
+            }
+        }
+
+        // Units at or coarser than the token's precision scale up exactly.
+        assert_eq!("1.", TokenAmount::<Cents>::from_tokens(1).to_string());
+        assert_eq!("2.5", TokenAmount::<Cents>::from_millis(2500).to_string());
+
+        // Finer units than the token can represent are truncated towards zero rather than
+        // panicking: 1500 millitokens = 1.5 tokens, but 1 millitoken (0.001) rounds down to 0.
+        assert_eq!("1.5", TokenAmount::<Cents>::from_millis(1500).to_string());
+        assert_eq!("0.", TokenAmount::<Cents>::from_millis(1).to_string());
+        assert_eq!(
+            "0.12",
+            TokenAmount::<Cents>::from_micros(123_456).to_string()
+        );
+        assert_eq!("0.", TokenAmount::<Cents>::from_micros(9999).to_string());
+
+        // Scaling up saturates instead of overflowing.
+        assert_eq!(
+            TokenAmount::<Cents>::MAX,
+            TokenAmount::<Cents>::from_tokens(u128::MAX)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "token precision is too high")]
+    fn token_amount_precision_too_high_panics() {
+        use super::{Token, TokenAmount};
+
+        // 39 decimals cannot be represented: `10.pow(39)` overflows a `u128`.
+        struct TooPrecise;
+        impl Token for TooPrecise {
+            const NAME: &'static str = "TooPrecise";
+
+            fn decimals() -> u8 {
+                39
+            }
+        }
+
+        // Panics loudly rather than silently wrapping in release builds.
+        TokenAmount::<TooPrecise>::one();
+    }
+
+    #[test]
+    fn token_amount_raw_u128_display() {
+        use super::{Token, TokenAmount};
+
+        // A token that displays and parses as its raw inner `u128`.
+        struct Raw;
+        impl Token for Raw {
+            const NAME: &'static str = "Raw";
+            const DECIMAL_DISPLAY: bool = false;
+
+            fn decimals() -> u8 {
+                18
+            }
+        }
+
+        // Display writes the inner value verbatim, ignoring `decimals()`; no decimal point.
+        assert_eq!(
+            "12345",
+            TokenAmount::<Raw>::from_str("12345").unwrap().to_string()
+        );
+        assert_eq!("0", TokenAmount::<Raw>::ZERO.to_string());
+
+        // FromStr parses a plain integer straight into the inner value, round-tripping.
+        let parsed = TokenAmount::<Raw>::from_str("999").unwrap();
+        assert_eq!(999, parsed.to_inner());
+        assert_eq!("999", parsed.to_string());
+        assert!(TokenAmount::<Raw>::from_str("1.5").is_err());
+    }
+
+    #[test]
+    fn token_amount_json_and_graphql_match_display() {
+        use async_graphql::ScalarType;
+
+        use super::{Token, TokenAmount};
+
+        // A decimal token and a raw-u128 token.
+        struct Cents;
+        impl Token for Cents {
+            const NAME: &'static str = "Cents";
+
+            fn decimals() -> u8 {
+                2
+            }
+        }
+        struct Raw;
+        impl Token for Raw {
+            const NAME: &'static str = "Raw";
+            const DECIMAL_DISPLAY: bool = false;
+
+            fn decimals() -> u8 {
+                2
+            }
+        }
+
+        let cents = TokenAmount::<Cents>::from_str("1.5").unwrap();
+        let raw = TokenAmount::<Raw>::from_str("12345").unwrap();
+
+        // JSON serializes as the `Display` string and round-trips through `FromStr`.
+        assert_eq!("\"1.5\"", serde_json::to_string(&cents).unwrap());
+        assert_eq!("\"12345\"", serde_json::to_string(&raw).unwrap());
+        assert_eq!(cents, serde_json::from_str("\"1.5\"").unwrap());
+        assert_eq!(raw, serde_json::from_str("\"12345\"").unwrap());
+
+        // The GraphQL scalar uses the same string form for both output and input.
+        assert_eq!(
+            async_graphql::Value::String(cents.to_string()),
+            cents.to_value()
+        );
+        assert_eq!(
+            async_graphql::Value::String(raw.to_string()),
+            raw.to_value()
+        );
+        assert_eq!(
+            cents,
+            TokenAmount::<Cents>::parse(cents.to_value()).unwrap()
+        );
+        assert_eq!(raw, TokenAmount::<Raw>::parse(raw.to_value()).unwrap());
     }
 
     #[test]
@@ -2170,6 +2783,42 @@ mod tests {
 
         assert_eq!(hash1, hash2, "Hashes should be equal for same content");
         assert_eq!(blob1.bytes(), blob2.bytes(), "Byte content should be equal");
+    }
+
+    #[test]
+    fn test_conversion_amount_u256() {
+        let value_amount = Amount::from_tokens(15656565652209004332);
+        let value_u256: U256 = value_amount.into();
+        let value_amount_rev = Amount::try_from(value_u256).expect("Failed conversion");
+        assert_eq!(value_amount, value_amount_rev);
+    }
+
+    #[test]
+    fn token_amount_generic_conversions() {
+        use super::{Token, TokenAmount};
+
+        // A branded (non-native) token exercises the generalized conversions.
+        struct Cents;
+        impl Token for Cents {
+            const NAME: &'static str = "Cents";
+
+            fn decimals() -> u8 {
+                2
+            }
+        }
+
+        // `upper_half`/`lower_half` operate on the raw inner value.
+        let amount = TokenAmount::<Cents>::from_str("1.50").unwrap();
+        assert_eq!(150, amount.to_inner());
+        assert_eq!(0, amount.upper_half());
+        assert_eq!(150, amount.lower_half());
+
+        // `U256` conversions round-trip for any token.
+        let value_u256: U256 = amount.into();
+        assert_eq!(amount, TokenAmount::<Cents>::try_from(value_u256).unwrap());
+
+        // `f64` uses the token's own precision: 150 base units = 1.5 whole tokens.
+        assert_eq!(1.5, f64::from(amount));
     }
 
     /// `linera-explorer` running on `wasm32` does not have access to the

--- a/linera-client/src/benchmark.rs
+++ b/linera-client/src/benchmark.rs
@@ -873,7 +873,7 @@ pub fn fungible_transfer(
     };
     let bytes = bcs::to_bytes(&FungibleOperation::Transfer {
         owner: sender,
-        amount,
+        amount: amount.into(),
         target_account,
     })
     .expect("should serialize fungible token operation");

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -498,7 +498,12 @@ where
     let receiver2_owner = receiver2.preferred_owner().unwrap();
 
     let accounts = BTreeMap::from_iter([(sender_owner, Amount::from_tokens(1_000_000))]);
-    let state = InitialState { accounts };
+    let state = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     let params = Parameters::new("FUN");
     let (application_id, _cert) = sender
         .create_application(module_id, &params, &state, vec![])
@@ -1266,7 +1271,12 @@ where
     let fungible_module =
         fungible_module.with_abi::<fungible::FungibleTokenAbi, Parameters, InitialState>();
     let accounts = BTreeMap::from_iter([(pledger_owner, Amount::from_tokens(1_000))]);
-    let state = InitialState { accounts };
+    let state = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     let params = Parameters::new("FUN");
     let (fungible_id, _cert) = pledger_chain
         .create_application(fungible_module, &params, &state, vec![])

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1984,12 +1984,12 @@ where
             && timestamp == Timestamp::from(0)
             && matches!(messages[..], [PostedMessage {
                 authenticated_signer: None,
-                grant: Amount::ZERO,
+                grant,
                 refund_grant_to: None,
                 kind: MessageKind::Tracked,
                 index: 0,
                 message: Message::System(SystemMessage::Credit { amount, .. }),
-            }] if amount == Amount::from_tokens(995)),
+            }] if grant == Amount::ZERO && amount == Amount::from_tokens(995)),
         "Unexpected bundle",
     );
     assert_eq!(chain.confirmed_log.count(), 1);
@@ -2169,12 +2169,12 @@ where
         && timestamp == Timestamp::from(0)
         && matches!(messages[..], [PostedMessage {
             authenticated_signer: None,
-            grant: Amount::ZERO,
+            grant,
             refund_grant_to: None,
             kind: MessageKind::Tracked,
             index: 0,
             message: Message::System(SystemMessage::Credit { amount, .. })
-        }] if amount == Amount::ONE),
+        }] if grant == Amount::ZERO && amount == Amount::ONE),
         "Unexpected bundle",
     );
 
@@ -2247,12 +2247,12 @@ where
         && timestamp == Timestamp::from(0)
         && matches!(messages[..], [PostedMessage {
             authenticated_signer: None,
-            grant: Amount::ZERO,
+            grant,
             refund_grant_to: None,
             kind: MessageKind::Tracked,
             index: 0,
             message: Message::System(SystemMessage::Credit { amount, .. })
-        }] if amount == Amount::from_tokens(10)),
+        }] if grant == Amount::ZERO && amount == Amount::from_tokens(10)),
         "Unexpected bundle",
     );
     assert_eq!(chain.confirmed_log.count(), 0);

--- a/linera-sdk/src/abis/fungible.rs
+++ b/linera-sdk/src/abis/fungible.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 use async_graphql::{InputObject, Request, Response, SimpleObject};
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
-    data_types::Amount,
+    data_types::{Amount, U128},
     identifiers::{AccountOwner, ChainId},
 };
 use linera_sdk_derive::GraphQLMutationRootInCrate;
@@ -76,14 +76,14 @@ pub enum FungibleOperation {
         /// The spender account
         spender: AccountOwner,
         /// Maximum amount to be transferred
-        allowance: Amount,
+        allowance: U128,
     },
     /// Transfers tokens from a (locally owned) account to a (possibly remote) account.
     Transfer {
         /// Owner to transfer from
         owner: AccountOwner,
         /// Amount to be transferred
-        amount: Amount,
+        amount: U128,
         /// Target account to transfer the amount to
         target_account: Account,
     },
@@ -94,7 +94,7 @@ pub enum FungibleOperation {
         /// The spender of the amount.
         spender: AccountOwner,
         /// Amount to be transferred
-        amount: Amount,
+        amount: U128,
         /// Target account to transfer the amount to
         target_account: Account,
     },
@@ -105,7 +105,7 @@ pub enum FungibleOperation {
         /// Source account to claim amount from
         source_account: Account,
         /// Amount to be claimed
-        amount: Amount,
+        amount: U128,
         /// Target account to claim the amount into
         target_account: Account,
     },
@@ -131,7 +131,7 @@ pub enum FungibleResponse {
     #[default]
     Ok,
     /// Balance response
-    Balance(Amount),
+    Balance(U128),
     /// Ticker symbol response
     TickerSymbol(String),
 }
@@ -140,7 +140,12 @@ pub enum FungibleResponse {
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct InitialState {
     /// Accounts and their respective initial balances
-    pub accounts: BTreeMap<AccountOwner, Amount>,
+    pub accounts: BTreeMap<AccountOwner, U128>,
+}
+
+/// The default number of decimal places used to display token amounts.
+fn default_decimals() -> u8 {
+    18
 }
 
 /// The parameters to instantiate fungible with
@@ -148,13 +153,25 @@ pub struct InitialState {
 pub struct Parameters {
     /// Ticker symbol for the fungible
     pub ticker_symbol: String,
+    /// Number of decimal places used to display token amounts
+    #[serde(default = "default_decimals")]
+    pub decimals: u8,
 }
 
 impl Parameters {
-    /// Instantiate parameters
+    /// Instantiate parameters with the default precision of 18 decimals.
     pub fn new(ticker_symbol: &str) -> Self {
         let ticker_symbol = ticker_symbol.to_string();
-        Self { ticker_symbol }
+        Self {
+            ticker_symbol,
+            decimals: default_decimals(),
+        }
+    }
+
+    /// Sets the number of decimal places used to display token amounts.
+    pub fn with_decimals(mut self, decimals: u8) -> Self {
+        self.decimals = decimals;
+        self
     }
 }
 
@@ -184,12 +201,12 @@ pub struct Account {
 #[derive(Debug, Default)]
 pub struct InitialStateBuilder {
     /// Accounts and their respective initial balances
-    account_balances: BTreeMap<AccountOwner, Amount>,
+    account_balances: BTreeMap<AccountOwner, U128>,
 }
 
 impl InitialStateBuilder {
     /// Adds an account to the initial state of the application.
-    pub fn with_account(mut self, account: AccountOwner, balance: impl Into<Amount>) -> Self {
+    pub fn with_account(mut self, account: AccountOwner, balance: impl Into<U128>) -> Self {
         self.account_balances.insert(account, balance.into());
         self
     }

--- a/linera-sdk/src/base/conversions_from_wit.rs
+++ b/linera-sdk/src/base/conversions_from_wit.rs
@@ -62,9 +62,9 @@ macro_rules! impl_from_wit {
             }
         }
 
-        impl From<$wit_base_api::Amount> for Amount {
-            fn from(balance: $wit_base_api::Amount) -> Self {
-                let (lower_half, upper_half) = balance.inner0;
+        impl From<$wit_base_api::TokenAmount> for Amount {
+            fn from(balance: $wit_base_api::TokenAmount) -> Self {
+                let (lower_half, upper_half) = balance.inner;
                 let value = ((upper_half as u128) << 64) | (lower_half as u128);
                 Amount::from_attos(value)
             }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -91,9 +91,9 @@ impl From<wit_contract_api::ChainId> for ChainId {
     }
 }
 
-impl From<wit_contract_api::Amount> for Amount {
-    fn from(balance: wit_contract_api::Amount) -> Self {
-        let (lower_half, upper_half) = balance.inner0;
+impl From<wit_contract_api::TokenAmount> for Amount {
+    fn from(balance: wit_contract_api::TokenAmount) -> Self {
+        let (lower_half, upper_half) = balance.inner;
         let value = ((upper_half as u128) << 64) | (lower_half as u128);
         Amount::from_attos(value)
     }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -55,10 +55,10 @@ impl From<[u8; 20]> for wit_contract_api::Array20 {
     }
 }
 
-impl From<Amount> for wit_contract_api::Amount {
+impl From<Amount> for wit_contract_api::TokenAmount {
     fn from(host: Amount) -> Self {
-        wit_contract_api::Amount {
-            inner0: (host.lower_half(), host.upper_half()),
+        wit_contract_api::TokenAmount {
+            inner: (host.lower_half(), host.upper_half()),
         }
     }
 }

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -72,6 +72,73 @@ pub use self::{
     views::{KeyValueStore, ViewStorageContext},
 };
 
+/// Declares a token marker type implementing [`Token`](linera_base_types::Token), for use as
+/// the brand of a [`TokenAmount`](linera_base_types::TokenAmount).
+///
+/// Two forms are supported:
+///
+/// - **Runtime precision** — the number of decimals is set once, from the application
+///   parameters, via the generated `configure_decimals` associated function. Call it in
+///   `Contract::load` and `Service::new`. Reading the precision before it is configured panics.
+///
+///   ```ignore
+///   linera_sdk::branded_token!(pub struct MyToken = "MyToken");
+///   // in load()/new():
+///   MyToken::configure_decimals(runtime.application_parameters().decimals);
+///   ```
+///
+/// - **Fixed precision** — the number of decimals is known at compile time; no global is used.
+///
+///   ```ignore
+///   linera_sdk::branded_token!(pub struct MyToken = "MyToken", decimals = 6);
+///   ```
+///
+/// The string literal is the token's [`Token::NAME`](linera_base_types::Token::NAME), used as
+/// the serde/GraphQL container name.
+#[macro_export]
+macro_rules! branded_token {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident = $wire:literal $(,)?) => {
+        $(#[$meta])*
+        $vis struct $name;
+
+        const _: () = {
+            static DECIMALS: ::std::sync::OnceLock<u8> = ::std::sync::OnceLock::new();
+
+            impl $crate::linera_base_types::Token for $name {
+                const NAME: &'static str = $wire;
+
+                fn decimals() -> u8 {
+                    *DECIMALS.get().expect(::core::concat!(
+                        ::core::stringify!($name),
+                        "::decimals() called before configure_decimals()"
+                    ))
+                }
+            }
+
+            impl $name {
+                /// Sets this token's precision. Call exactly once, in `Contract::load` and
+                /// `Service::new`, from the application parameters. Subsequent calls are ignored.
+                $vis fn configure_decimals(decimals: u8) {
+                    DECIMALS.get_or_init(|| decimals);
+                }
+            }
+        };
+    };
+
+    ($(#[$meta:meta])* $vis:vis struct $name:ident = $wire:literal, decimals = $decimals:expr $(,)?) => {
+        $(#[$meta])*
+        $vis struct $name;
+
+        impl $crate::linera_base_types::Token for $name {
+            const NAME: &'static str = $wire;
+
+            fn decimals() -> u8 {
+                $decimals
+            }
+        }
+    };
+}
+
 /// The contract interface of a Linera application.
 ///
 /// As opposed to the [`Service`] interface of an application, contract entry points
@@ -151,3 +218,42 @@ pub trait Service: WithServiceAbi + ServiceAbi + Sized {
     async fn handle_query(&self, query: Self::Query) -> Self::QueryResponse;
 }
 // ANCHOR_END: service
+
+#[cfg(test)]
+mod tests {
+    #![allow(dead_code)]
+
+    use crate::linera_base_types::{Token, TokenAmount};
+
+    branded_token!(struct FixedToken = "FixedToken", decimals = 6);
+    branded_token!(struct RuntimeToken = "RuntimeToken");
+
+    #[test]
+    fn fixed_precision_token() {
+        assert_eq!(6, FixedToken::decimals());
+        assert_eq!(
+            "1.5",
+            TokenAmount::<FixedToken>::from_inner(1_500_000).to_string()
+        );
+    }
+
+    #[test]
+    fn runtime_precision_token_configures_once() {
+        RuntimeToken::configure_decimals(2);
+        assert_eq!(2, RuntimeToken::decimals());
+        // Subsequent calls are ignored (first wins).
+        RuntimeToken::configure_decimals(9);
+        assert_eq!(2, RuntimeToken::decimals());
+        assert_eq!(
+            "1.5",
+            TokenAmount::<RuntimeToken>::from_inner(150).to_string()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "configure_decimals")]
+    fn runtime_precision_panics_before_configuration() {
+        branded_token!(struct UnconfiguredToken = "UnconfiguredToken");
+        UnconfiguredToken::decimals();
+    }
+}

--- a/linera-sdk/wit/base-runtime-api.wit
+++ b/linera-sdk/wit/base-runtime-api.wit
@@ -10,9 +10,9 @@ interface base-runtime-api {
     get-chain-ownership: func() -> chain-ownership;
     get-application-permissions: func() -> application-permissions;
     read-system-timestamp: func() -> timestamp;
-    read-chain-balance: func() -> amount;
-    read-owner-balance: func(owner: account-owner) -> amount;
-    read-owner-balances: func() -> list<tuple<account-owner, amount>>;
+    read-chain-balance: func() -> token-amount;
+    read-owner-balance: func(owner: account-owner) -> token-amount;
+    read-owner-balances: func() -> list<tuple<account-owner, token-amount>>;
     read-balance-owners: func() -> list<account-owner>;
     perform-http-request: func(request: http-request) -> http-response;
     assert-before: func(timestamp: timestamp);
@@ -36,10 +36,6 @@ interface base-runtime-api {
         reserved(u8),
         address32(crypto-hash),
         address20(array20),
-    }
-
-    record amount {
-        inner0: u128,
     }
 
     record application-description {
@@ -154,6 +150,10 @@ interface base-runtime-api {
 
     record timestamp {
         inner0: u64,
+    }
+
+    record token-amount {
+        inner: u128,
     }
 
     type u128 = tuple<u64, u64>;

--- a/linera-sdk/wit/contract-runtime-api.wit
+++ b/linera-sdk/wit/contract-runtime-api.wit
@@ -6,9 +6,9 @@ interface contract-runtime-api {
     message-origin-chain-id: func() -> option<chain-id>;
     authenticated-caller-id: func() -> option<application-id>;
     send-message: func(message: send-message-request);
-    transfer: func(source: account-owner, destination: account, amount: amount);
-    claim: func(source: account, destination: account, amount: amount);
-    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
+    transfer: func(source: account-owner, destination: account, amount: token-amount);
+    claim: func(source: account, destination: account, amount: token-amount);
+    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: token-amount) -> chain-id;
     close-chain: func() -> result<tuple<>, close-chain-error>;
     change-ownership: func(ownership: chain-ownership) -> result<tuple<>, change-ownership-error>;
     change-application-permissions: func(application-permissions: application-permissions) -> result<tuple<>, change-application-permissions-error>;
@@ -34,10 +34,6 @@ interface contract-runtime-api {
         reserved(u8),
         address32(crypto-hash),
         address20(array20),
-    }
-
-    record amount {
-        inner0: u128,
     }
 
     record application-id {
@@ -144,6 +140,10 @@ interface contract-runtime-api {
         base-timeout: time-delta,
         timeout-increment: time-delta,
         fallback-duration: time-delta,
+    }
+
+    record token-amount {
+        inner: u128,
     }
 
     type u128 = tuple<u64, u64>;

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -632,7 +632,7 @@ type Cursor {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_AccountOwner_Amount_aaf96548 {
+type Entry_AccountOwner_Amount_c18a0712 {
 	key: AccountOwner!
 	value: Amount
 }
@@ -867,11 +867,11 @@ input MapInput_StreamIdInput_b7c3909d {
 	filters: MapFilters_StreamIdInput_b7c3909d
 }
 
-type MapView_AccountOwner_Amount_11ef1379 {
+type MapView_AccountOwner_Amount_495dd16a {
 	keys(count: Int): [AccountOwner!]!
 	count: Int!
-	entry(key: AccountOwner!): Entry_AccountOwner_Amount_aaf96548!
-	entries(input: MapInput_AccountOwner_d6668c53): [Entry_AccountOwner_Amount_aaf96548!]!
+	entry(key: AccountOwner!): Entry_AccountOwner_Amount_c18a0712!
+	entries(input: MapInput_AccountOwner_d6668c53): [Entry_AccountOwner_Amount_c18a0712!]!
 }
 
 type MapView_BlobId_Blob_3711e760 {
@@ -1425,7 +1425,7 @@ type SystemExecutionStateView {
 	committees: JSONObject!
 	ownership: ChainOwnership!
 	balance: Amount!
-	balances: MapView_AccountOwner_Amount_11ef1379!
+	balances: MapView_AccountOwner_Amount_495dd16a!
 	timestamp: Timestamp!
 }
 

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -64,7 +64,12 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) -> anyhow::Result
     let (contract, service) = client.build_example("fungible").await?;
     let vm_runtime = VmRuntime::Wasm;
     let accounts = BTreeMap::from([(owner, Amount::from_tokens(9))]);
-    let state = InitialState { accounts };
+    let state = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     let params = fungible::Parameters::new("FUN");
     let _application_id = client
         .publish_and_create::<FungibleTokenAbi, fungible::Parameters, InitialState>(

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -164,7 +164,10 @@ async fn benchmark_with_fungible(
             let owner = client.get_owner().context("missing owner")?;
             let default_chain = client.default_chain().context("missing default chain")?;
             let initial_state = InitialState {
-                accounts: BTreeMap::from([(owner, Amount::from_tokens(num_transactions as u128))]),
+                accounts: BTreeMap::from([(
+                    owner,
+                    Amount::from_tokens(num_transactions as u128).into(),
+                )]),
             };
             let parameters = Parameters::new(format!("FUN{i}").leak());
             let application_id = node_service
@@ -290,7 +293,7 @@ impl FungibleApp {
         let mutation = format!(
             "transfer(owner: {}, amount: \"{}\", targetAccount: {})",
             account_owner.to_value(),
-            amount_transfer,
+            amount_transfer.to_inner(),
             destination.to_value(),
         );
         self.0.mutate(mutation).await

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -24,7 +24,9 @@ use crate::{
     cli::validator, query_subscription::parse_subscription_ttl, task_processor::parse_operator,
 };
 
-const DEFAULT_TOKENS_PER_CHAIN: Amount = Amount::from_millis(100);
+fn default_tokens_per_chain() -> Amount {
+    Amount::from_millis(100)
+}
 const DEFAULT_TRANSACTIONS_PER_BLOCK: usize = 1;
 const DEFAULT_WRAP_UP_MAX_IN_FLIGHT: usize = 5;
 const DEFAULT_NUM_CHAINS: usize = 10;
@@ -72,7 +74,7 @@ pub struct BenchmarkOptions {
 
     /// How many tokens to assign to each newly created chain.
     /// These need to cover the transaction fees per chain for the benchmark.
-    #[arg(long, default_value_t = DEFAULT_TOKENS_PER_CHAIN)]
+    #[arg(long, default_value_t = default_tokens_per_chain())]
     pub tokens_per_chain: Amount,
 
     /// How many transactions to put in each block.
@@ -140,7 +142,7 @@ impl Default for BenchmarkOptions {
     fn default() -> Self {
         Self {
             num_chains: DEFAULT_NUM_CHAINS,
-            tokens_per_chain: DEFAULT_TOKENS_PER_CHAIN,
+            tokens_per_chain: default_tokens_per_chain(),
             transactions_per_block: DEFAULT_TRANSACTIONS_PER_BLOCK,
             wrap_up_max_in_flight: DEFAULT_WRAP_UP_MAX_IN_FLIGHT,
             fungible_application_id: None,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2383,7 +2383,12 @@ async fn test_wasm_end_to_end_allowances_fungible(config: impl LineraNetConfig) 
         (owner1, Amount::from_tokens(9)),
         (owner2, Amount::from_tokens(19)),
     ]);
-    let state = InitialState { accounts };
+    let state = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     // Setting up the application and verifying
     let (contract, service) = client1.build_example("fungible").await?;
     let params = Parameters::new("DEL");
@@ -2569,7 +2574,12 @@ async fn test_wasm_end_to_end_fungible(
         (account_owner1, Amount::from_tokens(5)),
         (account_owner2, Amount::from_tokens(2)),
     ]);
-    let state = InitialState { accounts };
+    let state = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     // Setting up the application and verifying
     let params = if example_name == "native-fungible" {
         // Native Fungible has a fixed NAT ticker symbol, anything else will be rejected
@@ -2718,7 +2728,12 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
         (account_owner1, Amount::from_tokens(5)),
         (account_owner2, Amount::from_tokens(2)),
     ]);
-    let state = InitialState { accounts };
+    let state = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     // Setting up the application and verifying
     let params = if example_name == "native-fungible" {
         // Native Fungible has a fixed NAT ticker symbol, anything else will be rejected
@@ -2735,7 +2750,11 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 
     let app1 = NativeFungibleApp(node_service.make_application(&chain1, &application_id)?);
 
-    let expected_balances: Vec<(AccountOwner, Amount)> = state.accounts.into_iter().collect();
+    let expected_balances: Vec<(AccountOwner, Amount)> = state
+        .accounts
+        .into_iter()
+        .map(|(owner, amount)| (owner, amount.into()))
+        .collect();
 
     app1.assert_balances(expected_balances.clone()).await;
     app1.assert_entries(expected_balances).await;
@@ -3092,7 +3111,12 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
 
     // The initial accounts on chain1
     let accounts = BTreeMap::from([(account_owner1, Amount::from_tokens(6))]);
-    let state_fungible = InitialState { accounts };
+    let state_fungible = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
 
     // Setting up the application fungible
     let (contract_fungible, service_fungible) = client1.build_example("fungible").await?;
@@ -3226,11 +3250,11 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // The initial accounts on chain_a and chain_b
     let accounts0 = BTreeMap::from([(owner_a, Amount::from_tokens(10))]);
     let state_fungible0 = fungible::InitialState {
-        accounts: accounts0,
+        accounts: accounts0.into_iter().map(|(o, a)| (o, a.into())).collect(),
     };
     let accounts1 = BTreeMap::from([(owner_b, Amount::from_tokens(9))]);
     let state_fungible1 = fungible::InitialState {
-        accounts: accounts1,
+        accounts: accounts1.into_iter().map(|(o, a)| (o, a.into())).collect(),
     };
 
     // Setting up the application fungible on chain_a and chain_b
@@ -3488,12 +3512,12 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
 
     // Amounts of token0 that will be owned by each user
     let state_fungible0 = fungible::InitialState {
-        accounts: BTreeMap::from([(owner_amm_chain, Amount::from_tokens(270))]),
+        accounts: BTreeMap::from([(owner_amm_chain, Amount::from_tokens(270).into())]),
     };
 
     // Amounts of token1 that will be owned by each user
     let state_fungible1 = fungible::InitialState {
-        accounts: BTreeMap::from([(owner_amm_chain, Amount::from_tokens(250))]),
+        accounts: BTreeMap::from([(owner_amm_chain, Amount::from_tokens(250).into())]),
     };
 
     // Create fungible applications on the AMM chain, which will hold
@@ -4189,7 +4213,12 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     // Create a fungible token application with 10 tokens for owner 1.
     let owner = get_account_owner(&client);
     let accounts = BTreeMap::from([(owner, Amount::from_tokens(10))]);
-    let state = fungible::InitialState { accounts };
+    let state = fungible::InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     let (contract, service) = client.build_example("fungible").await?;
     let params = fungible::Parameters::new("FUN");
     let application_id = client

--- a/linera-service/tests/local_net_tests.rs
+++ b/linera-service/tests/local_net_tests.rs
@@ -863,7 +863,12 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     // native token.
     let account_owner = get_fungible_account_owner(&client);
     let accounts = BTreeMap::from([(account_owner, Amount::from_tokens(1_000_000))]);
-    let state = InitialState { accounts };
+    let state = InitialState {
+        accounts: accounts
+            .into_iter()
+            .map(|(owner, amount)| (owner, amount.into()))
+            .collect(),
+    };
     let (contract, service) = client.build_example("fungible").await?;
     let params = Parameters::new("FUN");
     let application_id = client


### PR DESCRIPTION
## Motivation

Backport of #6606 (`TokenAmount<T>` + `Amount` alias + configurable-precision fungible token)
to `testnet_conway`.

## Proposal

Cherry-picks the change onto `testnet_conway`, reconciled with this branch's divergences:

- `linera-base` — `TokenAmount<T>`, the `Amount` type alias, and all conversions. The generic
  `TryFrom<U256>` uses this branch's `ArithmeticError` (not `AmountConversionError`, which
  `testnet_conway` had already removed).
- `linera-sdk` — the `branded_token!` macro, the shared `FungibleTokenAbi` moved to `U128`
  amounts + a `decimals` parameter (default 18), and the WIT type rename `amount` →
  `token-amount` (a rename only; the flat layout is unchanged, so it stays ABI-compatible).
- Examples on the shared `FungibleTokenAbi` (fungible, amm, matching-engine, crowd-funding,
  rfq) adapt at the `U128` boundary.

**Scope note:** `testnet_conway` splits the ABI into `FungibleTokenAbi` and a separate
`NativeFungibleTokenAbi` (still on `Amount`) that `main` never had. The `native-fungible`
example uses that separate ABI, so it is **left on `Amount`** here — only its shared
`InitialState`/`FungibleResponse`/`Parameters` touch points are converted. The generalized
`From<U128>`/`.into()` cleanup from the tail of #6606 is not included and can follow separately.

## Test Plan

CI. Regenerated the WIT files, the `linera-service` GraphQL schema, and the fungible /
native-fungible format snapshots for this branch; `CLI.md` and `binary_formats` are unaffected.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Backport of #6606
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)