### PR TITLE
Add a `linera checkpoint` CLI command

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -13,6 +13,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera set-preferred-owner`↴](#linera-set-preferred-owner)
 * [`linera change-application-permissions`↴](#linera-change-application-permissions)
 * [`linera close-chain`↴](#linera-close-chain)
+* [`linera checkpoint`↴](#linera-checkpoint)
 * [`linera show-network-description`↴](#linera-show-network-description)
 * [`linera local-balance`↴](#linera-local-balance)
 * [`linera query-balance`↴](#linera-query-balance)
@@ -97,6 +98,7 @@ Client implementation and command-line tool for the Linera blockchain
 * `set-preferred-owner` — Change the preferred owner of a chain
 * `change-application-permissions` — Changes the application permissions configuration
 * `close-chain` — Close an existing chain
+* `checkpoint` — Publish a checkpoint of the chain's execution state
 * `show-network-description` — Print out the network description
 * `local-balance` — Read the current native-token balance of the given account directly from the local state
 * `query-balance` — Simulate the execution of one block made of pending messages from the local inbox, then read the native-token balance of the account from the local state
@@ -469,6 +471,20 @@ A closed chain cannot execute operations or accept messages anymore. It can stil
 ###### **Arguments:**
 
 * `<CHAIN_ID>` — Chain ID (must be one of our chains)
+
+
+
+## `linera checkpoint`
+
+Publish a checkpoint of the chain's execution state.
+
+The resulting block contains a single checkpoint operation. Future nodes can bootstrap from the published state snapshot instead of replaying the chain's earlier history.
+
+**Usage:** `linera checkpoint [CHAIN_ID]`
+
+###### **Arguments:**
+
+* `<CHAIN_ID>` — The chain to checkpoint. If not specified, the wallet's default chain is used
 
 
 

--- a/linera-service/src/cli/command.rs
+++ b/linera-service/src/cli/command.rs
@@ -466,6 +466,16 @@ pub enum ClientCommand {
         chain_id: ChainId,
     },
 
+    /// Publish a checkpoint of the chain's execution state.
+    ///
+    /// The resulting block contains a single checkpoint operation. Future nodes can
+    /// bootstrap from the published state snapshot instead of replaying the chain's
+    /// earlier history.
+    Checkpoint {
+        /// The chain to checkpoint. If not specified, the wallet's default chain is used.
+        chain_id: Option<ChainId>,
+    },
+
     /// Print out the network description.
     ShowNetworkDescription,
 
@@ -1127,6 +1137,7 @@ impl ClientCommand {
             | ClientCommand::SetPreferredOwner { .. }
             | ClientCommand::ChangeApplicationPermissions { .. }
             | ClientCommand::CloseChain { .. }
+            | ClientCommand::Checkpoint { .. }
             | ClientCommand::ShowNetworkDescription
             | ClientCommand::LocalBalance { .. }
             | ClientCommand::QueryBalance { .. }

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -397,6 +397,30 @@ impl Runnable for Job {
                 debug!("{:?}", certificate);
             }
 
+            Checkpoint { chain_id } => {
+                let mut context = options
+                    .create_client_context(storage, wallet, keystore)
+                    .await?;
+                let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
+                let chain_client = context.make_chain_client(chain_id).await?;
+                info!("Checkpointing chain {}", chain_id);
+                let time_start = Instant::now();
+                let certificate = context
+                    .apply_client_command(&chain_client, |chain_client| {
+                        let chain_client = chain_client.clone();
+                        async move { chain_client.checkpoint().await }
+                    })
+                    .await
+                    .context("Failed to checkpoint chain")?;
+                let time_total = time_start.elapsed();
+                info!(
+                    "Checkpoint confirmed after {} ms at height {}",
+                    time_total.as_millis(),
+                    certificate.value().block().header.height,
+                );
+                debug!("{:?}", certificate);
+            }
+
             ShowNetworkDescription => {
                 let network_description = storage.read_network_description().await?;
                 let json = serde_json::to_string_pretty(&network_description)?;


### PR DESCRIPTION
## Motivation

`ChainClient::checkpoint` exists since the checkpoint feature was merged, but there was no way to trigger a checkpoint manually: its only callers are unit tests, and neither the CLI nor the node-service GraphQL API exposes it.

## Proposal

Add a `linera checkpoint [CHAIN_ID]` command that publishes a checkpoint of the given chain (defaulting to the wallet's default chain), retrying via `apply_client_command` like the other operation commands, and printing the height of the resulting block.

## Test Plan

CI, plus a manual end-to-end test against the `devnet-2026-07-08` devnet (validators at 13206a28, client from this branch):

* Two wallets with faucet chains A and B; several transfers in both directions with inbox processing.
* `linera checkpoint` on A (with a still-unreceived A→B transfer in flight) — checkpoint block certified by the devnet validators; B then received the pre-checkpoint message.
* Full `CheckpointAck` cycle: checkpoint on B, A received the ack in a block and checkpointed again.
* Fresh third wallet, `linera wallet follow-chain A --sync`: bootstrapped from the *latest* checkpoint without replaying history — local state and balance match the owner wallet, and the local node stores only the checkpoint block (a `blocks` GraphQL query walks back from the tip and stops at the checkpoint block because its parent was never downloaded).
* `change-ownership`/`assign` to the third wallet, which then successfully proposed blocks (a transfer to a fresh chain, and another checkpoint) on the bootstrapped chain.

The test also reproduced two known limitations on `main` (addressed by the upcoming #6599):

* The bootstrapped wallet cannot send to a recipient whose `previous_message_blocks` anchor predates the checkpoint (`Corrupted chain state: missing entry in block_hashes`, locally in the proposing client), and its local node can no longer sync the chain once another owner does so.
* After both sender and recipient have checkpointed, a new message on the previously-used A→B lane is never delivered to the recipient's inbox on the validators (a transfer to a fresh recipient sent at the same time was delivered normally).

## Release Plan

- Nothing to do / These changes follow the usual release cycle.
