### PR TITLE
Record validators' confirmation votes in a per-epoch vote ledger

### DIFF
--- a/linera-chain/src/certificate/confirmed.rs
+++ b/linera-chain/src/certificate/confirmed.rs
@@ -13,11 +13,13 @@ use linera_base::{
 use linera_execution::committee::Committee;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{generic::GenericCertificate, Certificate, Certified, LiteCertificate};
+use super::{
+    generic::GenericCertificate, Certificate, Certified, LiteCertificate, ValidatedBlockCertificate,
+};
 use crate::{
-    block::{Block, ConfirmedBlock, ConversionError},
+    block::{Block, ConfirmedBlock, ConversionError, ValidatedBlock},
     data_types::MessageBundle,
-    justification::JustificationChain,
+    justification::{CommittedQuorum, JustificationChain},
     ChainError,
 };
 
@@ -89,6 +91,49 @@ impl ConfirmedBlockCertificate {
     /// Consumes this certificate, returning the signed quorum and the justification chain.
     pub fn into_parts(self) -> (GenericCertificate<ConfirmedBlock>, JustificationChain) {
         (self.quorum, self.justification)
+    }
+
+    /// Reconstructs the validated-block certificate with the given justification
+    /// commitment from this certificate's justification chain, or `None` if no link
+    /// of the chain has that commitment. This recovers the quorum that a
+    /// confirmation vote for this block cited, from stored data alone: the cited
+    /// quorum is a link of the chain whenever the vote's round is at most the round
+    /// this certificate was formed in.
+    pub fn cited_validated_certificate(
+        &self,
+        justification_commitment: CryptoHash,
+    ) -> Option<ValidatedBlockCertificate> {
+        let value_hash = self.hash();
+        let links = self.justification.links();
+        let mut previous = None;
+        let mut unlocking_round = None;
+        for (index, link) in links.iter().enumerate() {
+            let commitment = CommittedQuorum {
+                value_hash,
+                round: link.round,
+                unlocking_round,
+                previous,
+                signatures: link.signatures.clone(),
+            }
+            .commitment();
+            if commitment == justification_commitment {
+                let quorum = GenericCertificate::new_with_payload(
+                    ValidatedBlock::new(self.block().clone()),
+                    link.round,
+                    unlocking_round,
+                    false,
+                    previous,
+                    link.signatures.clone(),
+                );
+                return Some(ValidatedBlockCertificate::from_parts(
+                    quorum,
+                    JustificationChain::new(links[..index].to_vec()),
+                ));
+            }
+            previous = Some(commitment);
+            unlocking_round = Some(link.round);
+        }
+        None
     }
 
     /// Returns the round in which the value was certified.

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -25,6 +25,7 @@ mod outbox;
 mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
+pub mod vote_ledger;
 
 pub use chain::{BlockExecutionPhase, ChainIdSet, ChainStateView, ChainTipState, StreamCounts};
 use data_types::{MessageBundle, PostedMessage};

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -74,7 +74,7 @@ use allocative::Allocative;
 use custom_debug_derive::Debug;
 use futures::future::Either;
 use linera_base::{
-    crypto::{AccountPublicKey, ValidatorSecretKey},
+    crypto::{AccountPublicKey, CryptoHash, ValidatorSecretKey},
     data_types::{Blob, BlockHeight, Epoch, NonCanonicalBTreeMap, Round, Timestamp},
     ensure,
     identifiers::{AccountOwner, BlobId, ChainId},
@@ -95,7 +95,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     block::{Block, ConfirmedBlock, Timeout, ValidatedBlock},
     data_types::{BlockProposal, LiteVote, OriginalProposal, ProposedBlock, Vote},
-    types::{TimeoutCertificate, ValidatedBlockCertificate},
+    types::{CertificateValue as _, TimeoutCertificate, ValidatedBlockCertificate},
+    vote_ledger::{JustifiedVote, LedgerDelta, VoteRecord},
     ChainError,
 };
 
@@ -142,6 +143,36 @@ impl LockingBlock {
     }
 }
 
+/// The latest confirmation vote this validator cast, stored together with the
+/// validated-block certificate it cited — the same pairing the vote ledger
+/// records. Keeping them as one value means that later updates to the locking
+/// block can never orphan the vote's justification.
+#[derive(Debug, Clone, Serialize, Deserialize, Allocative)]
+pub struct JustifiedConfirmedVote {
+    /// The confirmation vote.
+    pub vote: Vote<ConfirmedBlock>,
+    /// The validated-block certificate the vote cited, or `None` for a vote in the
+    /// chain's first round, which cites none.
+    pub justification: Option<ValidatedBlockCertificate>,
+}
+
+impl JustifiedConfirmedVote {
+    /// Returns the vote as a [`JustifiedVote`], the form in which the vote ledger
+    /// and epoch commitments keep superseded votes.
+    fn justified_vote(&self) -> JustifiedVote {
+        JustifiedVote {
+            record: VoteRecord::new(&self.vote),
+            justification: self.justification.clone(),
+        }
+    }
+
+    /// Returns the vote as a [`JustifiedVote`] if its block differs from the given
+    /// one: the vote lost out at its height and must be preserved as superseded.
+    fn superseded_by(&self, block_hash: CryptoHash) -> Option<JustifiedVote> {
+        (self.vote.value().hash() != block_hash).then(|| self.justified_vote())
+    }
+}
+
 /// The state of the certification process for a chain's next block.
 #[cfg_attr(with_graphql, derive(async_graphql::SimpleObject), graphql(complex))]
 #[derive(Debug, View, ClonableView, Allocative)]
@@ -183,9 +214,10 @@ where
     /// Latest leader timeout certificate we have received.
     #[cfg_attr(with_graphql, graphql(skip))]
     pub timeout: RegisterView<C, Option<TimeoutCertificate>>,
-    /// Latest vote we cast to confirm a block.
+    /// Latest vote we cast to confirm a block, together with the validated
+    /// certificate it cited.
     #[cfg_attr(with_graphql, graphql(skip))]
-    pub confirmed_vote: RegisterView<C, Option<Vote<ConfirmedBlock>>>,
+    pub confirmed_vote: RegisterView<C, Option<JustifiedConfirmedVote>>,
     /// Latest vote we cast to validate a block.
     #[cfg_attr(with_graphql, graphql(skip))]
     pub validated_vote: RegisterView<C, Option<Vote<ValidatedBlock>>>,
@@ -263,6 +295,12 @@ where
 
     /// Returns the most recent confirmed vote we cast.
     pub fn confirmed_vote(&self) -> Option<&Vote<ConfirmedBlock>> {
+        Some(&self.confirmed_vote.get().as_ref()?.vote)
+    }
+
+    /// Returns the most recent confirmed vote we cast, together with the validated
+    /// certificate it cited.
+    pub fn justified_confirmed_vote(&self) -> Option<&JustifiedConfirmedVote> {
         self.confirmed_vote.get().as_ref()
     }
 
@@ -435,8 +473,8 @@ where
     ) -> Result<Outcome, ChainError> {
         let new_block = certificate.block();
         let new_round = certificate.round;
-        if let Some(Vote { value, round, .. }) = self.confirmed_vote.get() {
-            if value.block() == new_block && *round == new_round {
+        if let Some(vote) = self.confirmed_vote() {
+            if vote.value().block() == new_block && vote.round == new_round {
                 return Ok(Outcome::Skip); // We already voted to confirm this block.
             }
         }
@@ -455,7 +493,8 @@ where
         Ok(Outcome::Accept)
     }
 
-    /// Signs a vote to validate the proposed block.
+    /// Signs a vote to validate the proposed block. Along with the vote, returns
+    /// the ledger delta to persist if a confirmation vote was cast.
     pub fn create_vote(
         &mut self,
         proposal: &BlockProposal,
@@ -463,7 +502,7 @@ where
         key_pair: Option<&ValidatorSecretKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
-    ) -> Result<Option<ValidatedOrConfirmedVote<'_>>, ChainError> {
+    ) -> Result<(Option<ValidatedOrConfirmedVote<'_>>, Option<LedgerDelta>), ChainError> {
         let round = proposal.content.round;
 
         match &proposal.original_proposal {
@@ -509,21 +548,37 @@ where
 
         let Some(key_pair) = key_pair else {
             // Not a validator.
-            return Ok(None);
+            return Ok((None, None));
         };
 
         // If this is a fast block, vote to confirm. Otherwise vote to validate.
         if round.is_fast() {
             self.validated_vote.set(None);
             let value = ConfirmedBlock::new(block);
+            let epoch = value.block().header.epoch;
             // Attest that this confirmation is in the chain's first round, so the justification
             // chain may be omitted: such a block is always the lower one in any fork. A fast
             // block needs no validation, so there is no quorum to commit to.
             let first_round = round == self.ownership.get().first_round();
             let vote = Vote::new_with_first_round(value, round, first_round, None, key_pair);
-            Ok(Some(Either::Right(
-                self.confirmed_vote.get_mut().insert(vote),
-            )))
+            let superseded = self
+                .confirmed_vote
+                .get()
+                .as_ref()
+                .and_then(|old| old.superseded_by(vote.value().hash()));
+            let delta = LedgerDelta {
+                epoch,
+                latest: VoteRecord::new(&vote),
+                superseded,
+            };
+            let justified = self
+                .confirmed_vote
+                .get_mut()
+                .insert(JustifiedConfirmedVote {
+                    vote,
+                    justification: None,
+                });
+            Ok((Some(Either::Right(&justified.vote)), Some(delta)))
         } else {
             // The unlocking round we sign is the round of the justification this proposal relies
             // on, and the justification commitment is the hash of that justifying quorum — by
@@ -546,22 +601,25 @@ where
                 justification_commitment,
                 key_pair,
             );
-            Ok(Some(Either::Left(
-                self.validated_vote.get_mut().insert(vote),
-            )))
+            Ok((
+                Some(Either::Left(self.validated_vote.get_mut().insert(vote))),
+                None,
+            ))
         }
     }
 
-    /// Signs a vote to confirm the validated block.
+    /// Signs a vote to confirm the validated block. Returns the ledger delta to
+    /// persist if a vote was cast.
     pub fn create_final_vote(
         &mut self,
         validated: ValidatedBlockCertificate,
         key_pair: Option<&ValidatorSecretKey>,
         local_time: Timestamp,
         blobs: BTreeMap<BlobId, Blob>,
-    ) -> Result<(), ViewError> {
+    ) -> Result<Option<LedgerDelta>, ViewError> {
         let round = validated.round;
         let confirmed_block = ConfirmedBlock::new(validated.inner().block().clone());
+        let epoch = confirmed_block.block().header.epoch;
         // Vote to confirm. Attest whether this confirmation is in the chain's first round, so the
         // justification chain may be omitted: such a block is always the lower one in any fork.
         // Otherwise commit to the quorum that validated the block, attesting that we verified it
@@ -572,11 +630,14 @@ where
         } else {
             Some(validated.full_justification_commitment())
         };
+        // A vote in the chain's first round signs no justification commitment, so it must carry
+        // no justification either.
+        let justification = (!first_round).then(|| validated.clone());
         self.update_locking(LockingBlock::Regular(validated), blobs)?;
         self.update_current_round(local_time);
         if let Some(key_pair) = key_pair {
             if self.current_round() != round {
-                return Ok(()); // We never vote in a past round.
+                return Ok(None); // We never vote in a past round.
             }
             let vote = Vote::new_with_first_round(
                 confirmed_block,
@@ -585,11 +646,25 @@ where
                 justification_commitment,
                 key_pair,
             );
+            let superseded = self
+                .confirmed_vote
+                .get()
+                .as_ref()
+                .and_then(|old| old.superseded_by(vote.value().hash()));
+            let delta = LedgerDelta {
+                epoch,
+                latest: VoteRecord::new(&vote),
+                superseded,
+            };
             // Ok to overwrite validation votes with confirmation votes at equal or higher round.
-            self.confirmed_vote.set(Some(vote));
+            self.confirmed_vote.set(Some(JustifiedConfirmedVote {
+                vote,
+                justification,
+            }));
             self.validated_vote.set(None);
+            return Ok(Some(delta));
         }
-        Ok(())
+        Ok(None)
     }
 
     /// Returns the requested blob if it belongs to the proposal or the locking block.
@@ -813,7 +888,7 @@ where
 /// being tricked into double-signing at a height/round it has already voted on.
 #[derive(Debug, Default)]
 pub struct ManagerSafetySnapshot {
-    confirmed_vote: Option<Vote<ConfirmedBlock>>,
+    confirmed_vote: Option<JustifiedConfirmedVote>,
     validated_vote: Option<Vote<ValidatedBlock>>,
     timeout_vote: Option<Vote<Timeout>>,
     fallback_vote: Option<Vote<Timeout>>,
@@ -910,7 +985,7 @@ where
 {
     fn from(manager: &ChainManager<C>) -> Self {
         let current_round = manager.current_round();
-        let pending = match (manager.confirmed_vote.get(), manager.validated_vote.get()) {
+        let pending = match (manager.confirmed_vote(), manager.validated_vote()) {
             (None, None) => None,
             (Some(confirmed_vote), Some(validated_vote))
                 if validated_vote.round > confirmed_vote.round =>
@@ -950,9 +1025,7 @@ impl ChainManagerInfo {
         self.requested_proposed = manager.proposed.get().clone().map(Box::new);
         self.requested_locking = manager.locking_block.get().clone().map(Box::new);
         self.requested_confirmed = manager
-            .confirmed_vote
-            .get()
-            .as_ref()
+            .confirmed_vote()
             .map(|vote| Box::new(vote.value.clone()));
         self.requested_validated = manager
             .validated_vote

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -11,6 +11,7 @@ use super::*;
 use crate::{
     block::{Block, BlockBodyField, ConfirmedBlock, ValidatedBlock},
     test::{make_first_block, BlockTestExt},
+    types::{ConfirmedBlockCertificate, GenericCertificate, ValidatedBlockCertificate},
 };
 
 fn dummy_chain_id(index: u32) -> ChainId {
@@ -333,4 +334,45 @@ fn round_ordering() {
     assert!(Round::SingleLeader(1) < Round::SingleLeader(2));
     assert!(Round::SingleLeader(2) < Round::Validator(0));
     assert!(Round::Validator(1) < Round::Validator(2))
+}
+
+#[test]
+fn test_cited_validated_certificate() {
+    let block = sample_block();
+    let validated = ValidatedBlock::new(block.clone());
+    // A lineage of two validated quorums: one in round 1, one in round 2 citing it.
+    let validated1 =
+        ValidatedBlockCertificate::new(validated.clone(), Round::SingleLeader(1), vec![]);
+    let validated2 = ValidatedBlockCertificate::from_parts(
+        GenericCertificate::new_with_payload(
+            validated,
+            Round::SingleLeader(2),
+            Some(Round::SingleLeader(1)),
+            false,
+            Some(validated1.full_justification_commitment()),
+            vec![],
+        ),
+        validated1.full_justification(),
+    );
+    // A certificate confirming the block in round 2, carrying the full chain.
+    let confirmed = ConfirmedBlockCertificate::from_parts(
+        GenericCertificate::new_with_payload(
+            ConfirmedBlock::new(block),
+            Round::SingleLeader(2),
+            None,
+            false,
+            Some(validated2.full_justification_commitment()),
+            vec![],
+        ),
+        validated2.full_justification(),
+    );
+    // Each quorum in the chain is reconstructible by its commitment.
+    for original in [&validated2, &validated1] {
+        let commitment = original.full_justification_commitment();
+        let cited = confirmed.cited_validated_certificate(commitment).unwrap();
+        assert_eq!(cited, *original);
+    }
+    assert!(confirmed
+        .cited_validated_certificate(CryptoHash::test_hash("unrelated"))
+        .is_none());
 }

--- a/linera-chain/src/vote_ledger.rs
+++ b/linera-chain/src/vote_ledger.rs
@@ -1,0 +1,136 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Vote ledger
+//!
+//! A validator's durable record of every confirmation vote it signs, kept per epoch
+//! and chain. The chain manager only holds the current height's vote and the
+//! certificate it cites; both are overwritten as the chain advances, so without
+//! this ledger a validator cannot reconstruct what it signed — in particular votes
+//! for blocks that never got a quorum, or votes superseded by a justified re-vote
+//! at the same height.
+//!
+//! When an epoch is revoked, the ledger is what the validator's *commitment* is
+//! assembled from: per chain, the last confirmation-voted block — which covers all
+//! earlier votes on that chain of blocks via the parent-hash links — plus every
+//! superseded vote, each with the justification it cited.
+
+use linera_base::{
+    crypto::{CryptoError, CryptoHash, ValidatorPublicKey, ValidatorSignature},
+    data_types::{BlockHeight, Epoch, Round},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    data_types::{Vote, VoteValue},
+    types::{CertificateKind, CertificateValue as _, ConfirmedBlock, ValidatedBlockCertificate},
+};
+
+/// A confirmation vote a validator signed: the voted block's height and hash, the
+/// round the vote was cast in, the justification commitment it signed, and the
+/// signature itself.
+///
+/// Height, round, block hash and justification commitment identify the vote's
+/// entire signed payload (see [`VoteValue`]): a confirmation vote signs no
+/// unlocking round, and its first-round attestation is `true` exactly when it
+/// cites no quorum. The signature is kept so that votes for the same payload can
+/// be aggregated into a regular certificate — in particular from a quorum of
+/// commitments to the same block.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoteRecord {
+    /// The height of the voted block.
+    pub height: BlockHeight,
+    /// The round the vote was cast in.
+    pub round: Round,
+    /// The hash of the voted block.
+    pub block_hash: CryptoHash,
+    /// The justification commitment the vote signed: the hash of the validated
+    /// quorum it cited, or `None` for a vote in the chain's first round (including
+    /// the fast round), which cites none.
+    pub justification_commitment: Option<CryptoHash>,
+    /// The validator's signature on the vote.
+    pub signature: ValidatorSignature,
+}
+
+impl VoteRecord {
+    /// Creates the record of the given confirmation vote.
+    pub fn new(vote: &Vote<ConfirmedBlock>) -> Self {
+        VoteRecord {
+            height: vote.value().block().header.height,
+            round: vote.round,
+            block_hash: vote.value().hash(),
+            justification_commitment: vote.justification_commitment,
+            signature: vote.signature,
+        }
+    }
+
+    /// Verifies that this record's signature is the given validator's signature on
+    /// the payload the record identifies.
+    pub fn check_signature(&self, public_key: ValidatorPublicKey) -> Result<(), CryptoError> {
+        let value = VoteValue(
+            self.block_hash,
+            self.round,
+            CertificateKind::Confirmed,
+            None,
+            self.justification_commitment.is_none(),
+            self.justification_commitment,
+        );
+        self.signature.check(&value, public_key)
+    }
+}
+
+/// A confirmation vote together with the justification it cited. The
+/// justification is what distinguishes a legitimate re-vote from double-signing,
+/// so a vote must never be shown without it.
+///
+/// In a [`LedgerEntry`] this is a *superseded* vote — one for a block that lost
+/// out at its height, either because the validator later cast a justified
+/// confirmation vote for a different block there, or because a different block was
+/// confirmed there without the validator's vote. The protocol allows both, and the
+/// certificate the vote cited is not otherwise retained once the chain moves on.
+/// In a commitment entry, the *committed* vote takes this form too.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct JustifiedVote {
+    /// The vote.
+    pub record: VoteRecord,
+    /// The validated-block certificate the vote cited, or `None` for a vote cast in
+    /// a chain's first round, which cites no validated quorum.
+    pub justification: Option<ValidatedBlockCertificate>,
+}
+
+/// All confirmation votes a validator signed on one chain in one epoch: the latest
+/// vote, which covers all earlier votes on the same chain of blocks via the
+/// parent-hash links, and any superseded votes, which lie off that chain.
+///
+/// The latest vote's justification is needed too when the commitment is assembled,
+/// but it is not stored here: it is recoverable at that point in each of the three
+/// states the vote can be in. If the vote is still pending at the chain's tip, the
+/// chain manager holds it together with the certificate it cited. If the voted
+/// block was confirmed, its stored certificate carries the justification. And if a
+/// different block was confirmed at the vote's height, the vote was recorded as
+/// superseded — together with its justification — at that moment.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+pub struct LedgerEntry {
+    /// The latest confirmation vote on this chain.
+    pub latest: VoteRecord,
+    /// Votes for blocks that lost out at their height.
+    pub superseded: Vec<JustifiedVote>,
+}
+
+/// The vote ledger's view of one confirmation vote being cast, as reported by the
+/// chain manager: the new vote, and the same-height vote it displaced, if that
+/// vote was for a different block. The worker persists this in the ledger before
+/// saving the chain state, so that no vote can leave the validator without being
+/// recorded.
+#[derive(Debug, Clone)]
+pub struct LedgerDelta {
+    /// The epoch of the voted block.
+    pub epoch: Epoch,
+    /// The new confirmation vote.
+    pub latest: VoteRecord,
+    /// The superseded previous vote, if the new vote replaced one for a different
+    /// block at the same height.
+    pub superseded: Option<JustifiedVote>,
+}

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -30,9 +30,10 @@ use linera_chain::{
     },
     manager::{self, ManagerSafetySnapshot},
     types::{
-        Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
-        ValidatedBlockCertificate,
+        Block, CertificateValue as _, ConfirmedBlock, ConfirmedBlockCertificate,
+        TimeoutCertificate, ValidatedBlockCertificate,
     },
+    vote_ledger::{JustifiedVote, LedgerDelta, VoteRecord},
     BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
     ChainTipState, ExecutionResultExt as _, StreamCounts,
 };
@@ -326,6 +327,58 @@ where
         } else {
             vec![]
         })
+    }
+
+    /// Persists a ledger delta reported by a chain manager operation that cast a
+    /// confirmation vote. This must run before the chain state is saved, so that no
+    /// vote can leave this worker without being in the ledger.
+    async fn record_ledger_delta(&self, delta: Option<LedgerDelta>) -> Result<(), WorkerError> {
+        if let Some(delta) = delta {
+            self.storage
+                .record_confirmed_vote(delta.epoch, self.chain_id(), delta.latest, delta.superseded)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// If this validator's pending confirmation vote would become unrecoverable
+    /// once the confirmed block about to be executed clears the manager state,
+    /// persists it in the vote ledger. That is the case when a different block was
+    /// confirmed at the vote's height (the vote was bypassed), and also when the
+    /// vote is for the confirmed block itself but the certificate's justification
+    /// chain does not contain the quorum the vote cited — then the certificate
+    /// cannot reproduce it later.
+    async fn record_bypassed_vote(
+        &self,
+        certificate: &ConfirmedBlockCertificate,
+    ) -> Result<(), WorkerError> {
+        let Some(justified) = self.chain.manager.justified_confirmed_vote() else {
+            return Ok(());
+        };
+        let vote = &justified.vote;
+        if vote.value().hash() == certificate.hash() {
+            let recoverable_from_certificate = match vote.justification_commitment {
+                None => true, // The vote cited nothing; the latest-vote entry suffices.
+                Some(commitment) => certificate
+                    .cited_validated_certificate(commitment)
+                    .is_some(),
+            };
+            if recoverable_from_certificate {
+                return Ok(());
+            }
+        }
+        let epoch = vote.value().block().header.epoch;
+        self.storage
+            .record_superseded_vote(
+                epoch,
+                self.chain_id(),
+                JustifiedVote {
+                    record: VoteRecord::new(vote),
+                    justification: justified.justification.clone(),
+                },
+            )
+            .await?;
+        Ok(())
     }
 
     /// Returns whether this chain is known to be active (initialized).
@@ -911,12 +964,13 @@ where
             .filter_map(|(blob_id, maybe_blob)| Some((blob_id, maybe_blob?)))
             .collect();
         let old_round = self.chain.manager.current_round();
-        self.chain.manager.create_final_vote(
+        let delta = self.chain.manager.create_final_vote(
             certificate,
             self.config.key_pair(),
             self.storage.clock().current_time(),
             blobs,
         )?;
+        self.record_ledger_delta(delta).await?;
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
         Ok((
@@ -1128,6 +1182,8 @@ where
                 inbox_cursors.clone(),
             )
         };
+        self.record_bypassed_vote(&certificate).await?;
+
         // Every pre-checkpoint sender block the oracle response names must already
         // be in storage before we touch any chain state. If some aren't, record
         // their hashes as trusted-by-this-checkpoint and error with `BlocksNotFound`
@@ -1266,6 +1322,8 @@ where
         self.initialize_and_save_if_needed().await?;
         let (epoch, _) = self.chain.current_committee().await?;
         check_block_epoch(epoch, chain_id, block.header.epoch)?;
+
+        self.record_bypassed_vote(&certificate).await?;
 
         // The chain is initialized and this block has not executed yet, so the current ownership
         // is the configuration the block was proposed under — even for the chain's first block,
@@ -2564,7 +2622,8 @@ where
             .await?;
         let key_pair = self.config.key_pair();
         let manager = &mut self.chain.manager;
-        match manager.create_vote(&proposal, block, key_pair, local_time, blobs)? {
+        let (vote, delta) = manager.create_vote(&proposal, block, key_pair, local_time, blobs)?;
+        match vote {
             // Cache the value we voted on, so the client doesn't have to send it again.
             Some(Either::Left(vote)) => {
                 self.block_values
@@ -2576,6 +2635,7 @@ where
             }
             None => (),
         }
+        self.record_ledger_delta(delta).await?;
         self.save().await?;
         let actions = self.create_network_actions(Some(old_round)).await?;
         Ok((self.chain_info_response().await?, actions))

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -53,7 +53,7 @@ use linera_chain::{
         PostedMessage, ProposedBlock, Transaction, Vote,
     },
     justification::{JustificationChain, JustificationLink},
-    manager::LockingBlock,
+    manager::{JustifiedConfirmedVote, LockingBlock},
     test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     types::{
         CertificateKind, CertificateValue, Certified, ConfirmedBlock, ConfirmedBlockCertificate,
@@ -3659,6 +3659,25 @@ where
     let value = ConfirmedBlock::new(block1.clone());
     assert_eq!(vote.value, LiteValue::new(&value));
 
+    // The confirmation vote is recorded in the vote ledger.
+    let entry = env
+        .executing_worker()
+        .storage_client()
+        .read_vote_ledger_entry(Epoch::ZERO, chain_1)
+        .await?
+        .unwrap();
+    assert_eq!(entry.latest.height, BlockHeight::from(1));
+    assert_eq!(entry.latest.round, Round::SingleLeader(1));
+    assert_eq!(entry.latest.block_hash, LiteValue::new(&value).value_hash);
+    assert_eq!(
+        entry.latest.justification_commitment,
+        Some(certificate1.full_justification_commitment())
+    );
+    entry
+        .latest
+        .check_signature(env.executing_worker().public_key())?;
+    assert!(entry.superseded.is_empty());
+
     // Instead of submitting the confirmed block certificate, let rounds 2 to 4 time out, too.
     let certificate_timeout =
         env.make_certificate_with_round(value_timeout.clone(), Round::SingleLeader(4));
@@ -3792,6 +3811,65 @@ where
         response.info.manager.pending.unwrap().kind(),
         CertificateKind::Confirmed
     );
+
+    // In round 8, a validated certificate for block2 lets the worker vote to
+    // confirm it, superseding its earlier confirmation vote for block1. The vote
+    // ledger lists the superseded vote together with the justification it cited:
+    // `certificate1` — which the manager kept paired with the vote even though the
+    // locking block had long moved on from it.
+    let certificate2b = env.make_certificate_with_round(value2.clone(), Round::SingleLeader(8));
+    worker
+        .handle_validated_certificate(certificate2b.clone())
+        .await?;
+    let entry = worker
+        .storage_client()
+        .read_vote_ledger_entry(Epoch::ZERO, chain_1)
+        .await?
+        .unwrap();
+    assert_eq!(entry.latest.height, BlockHeight::from(1));
+    assert_eq!(entry.latest.round, Round::SingleLeader(8));
+    assert_eq!(
+        entry.latest.block_hash,
+        LiteValue::new(&ConfirmedBlock::new(block2.clone())).value_hash
+    );
+    assert_eq!(
+        entry.latest.justification_commitment,
+        Some(certificate2b.full_justification_commitment())
+    );
+    entry.latest.check_signature(worker.public_key())?;
+    assert_eq!(entry.superseded.len(), 1);
+    let superseded = &entry.superseded[0].record;
+    assert_eq!(superseded.height, BlockHeight::from(1));
+    assert_eq!(superseded.round, Round::SingleLeader(1));
+    assert_eq!(
+        superseded.block_hash,
+        LiteValue::new(&ConfirmedBlock::new(block1.clone())).value_hash
+    );
+    assert_eq!(
+        superseded.justification_commitment,
+        Some(certificate1.full_justification_commitment())
+    );
+    superseded.check_signature(worker.public_key())?;
+    assert_eq!(entry.superseded[0].justification, Some(certificate1));
+
+    // Block1 gets confirmed without this validator's vote: the bypassed vote for
+    // block2 is preserved in the ledger too, with its justification, while the
+    // latest-vote entry is untouched.
+    let confirmed1 = env
+        .make_certificate_with_round(ConfirmedBlock::new(block1.clone()), Round::SingleLeader(1));
+    worker
+        .fully_handle_certificate_with_notifications(confirmed1, &())
+        .await?;
+    let entry = worker
+        .storage_client()
+        .read_vote_ledger_entry(Epoch::ZERO, chain_1)
+        .await?
+        .unwrap();
+    assert_eq!(entry.latest.round, Round::SingleLeader(8));
+    assert_eq!(entry.superseded.len(), 2);
+    assert_eq!(entry.superseded[1].record.round, Round::SingleLeader(8));
+    assert_eq!(entry.superseded[1].justification, Some(certificate2b));
+
     Ok(())
 }
 
@@ -4814,7 +4892,13 @@ where
         let key_pair = env.worker.chain_worker_config.key_pair().unwrap().copy();
         let mut chain = storage.load_chain(chain_id).await?;
         let vote = Vote::new(cert_0.value().clone(), Round::Fast, &key_pair);
-        chain.manager.confirmed_vote.set(Some(vote.clone()));
+        chain
+            .manager
+            .confirmed_vote
+            .set(Some(JustifiedConfirmedVote {
+                vote: vote.clone(),
+                justification: None,
+            }));
         chain.save().await?;
         vote
     };
@@ -4938,9 +5022,9 @@ where
     // manager during the course of the retry.
     {
         let chain = worker_with_recovery.chain_state_view(chain_id).await?;
-        let restored_vote = chain.manager.confirmed_vote.get().as_ref();
+        let restored_vote = chain.manager.confirmed_vote();
         assert_eq!(
-            restored_vote.map(|v| v.signature),
+            restored_vote.map(|vote| vote.signature),
             Some(planted_vote.signature),
             "confirmed_vote should be restored after reset-and-reexecute"
         );

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -12,13 +12,14 @@ use async_trait::async_trait;
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, BlockHeight, NetworkDescription, TimeDelta, Timestamp},
+    data_types::{Blob, BlockHeight, Epoch, NetworkDescription, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, EventId, IndexAndEvent, StreamId},
     time::Duration,
 };
 use linera_cache::{Arc as CacheArc, ValueCache};
 use linera_chain::{
     types::{CertificateValue, ConfirmedBlock, ConfirmedBlockCertificate, LiteCertificate},
+    vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainStateView,
 };
 use linera_execution::{
@@ -253,6 +254,27 @@ pub mod metrics {
         )
     });
 
+    /// The metric counting how often a confirmation vote is written to the vote
+    /// ledger.
+    #[doc(hidden)]
+    pub(super) static WRITE_CONFIRMED_VOTE_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "write_confirmed_vote",
+            "The metric counting how often a confirmation vote is written to the vote ledger",
+        )
+    });
+
+    /// The metric counting how often a superseded confirmation vote is written to
+    /// the vote ledger.
+    #[doc(hidden)]
+    pub(super) static WRITE_SUPERSEDED_VOTE_COUNTER: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "write_superseded_vote",
+            "The metric counting how often a superseded confirmation vote is written to the \
+            vote ledger",
+        )
+    });
+
     /// The metric counting how often a block hash is read by height from storage.
     #[doc(hidden)]
     pub(super) static READ_BLOCK_HASH_BY_HEIGHT_COUNTER: LazyLock<IntCounterVec> =
@@ -419,6 +441,46 @@ impl MultiPartitionBatch {
         self.put_key_value(root_key, key, value);
     }
 
+    /// Adds a confirmation vote to the epoch's vote ledger: overwrites the chain's
+    /// latest-vote entry, and stores the replaced vote under its own key if the new
+    /// vote superseded one at the same height. Both are blind writes, so recording
+    /// a vote never requires a read.
+    fn add_confirmed_vote(
+        &mut self,
+        epoch: Epoch,
+        chain_id: &ChainId,
+        record: &VoteRecord,
+        superseded: Option<&JustifiedVote>,
+    ) -> Result<(), ViewError> {
+        #[cfg(with_metrics)]
+        metrics::WRITE_CONFIRMED_VOTE_COUNTER.inc();
+        let root_key = to_vote_ledger_root_key(epoch, chain_id);
+        let key = to_vote_ledger_latest_key(chain_id);
+        let value = bcs::to_bytes(record)?;
+        self.put_key_value(root_key.clone(), key, value);
+        if let Some(superseded) = superseded {
+            self.add_superseded_vote(epoch, chain_id, superseded)?;
+        }
+        Ok(())
+    }
+
+    /// Adds a superseded confirmation vote to the epoch's vote ledger, without
+    /// touching the chain's latest-vote entry.
+    fn add_superseded_vote(
+        &mut self,
+        epoch: Epoch,
+        chain_id: &ChainId,
+        superseded: &JustifiedVote,
+    ) -> Result<(), ViewError> {
+        #[cfg(with_metrics)]
+        metrics::WRITE_SUPERSEDED_VOTE_COUNTER.inc();
+        let root_key = to_vote_ledger_root_key(epoch, chain_id);
+        let key = to_vote_ledger_superseded_key(chain_id, &superseded.record);
+        let value = bcs::to_bytes(superseded)?;
+        self.put_key_value(root_key, key, value);
+        Ok(())
+    }
+
     fn add_network_description(
         &mut self,
         information: &NetworkDescription,
@@ -565,6 +627,10 @@ pub enum RootKey {
     BlockByHeight(ChainId),
     /// The event-to-block-height index of a chain.
     EventBlockHeight(ChainId),
+    /// One bucket of this validator's own confirmation votes in an epoch, keyed
+    /// by chain. Buckets split the ledger by the chain ID's first byte, so that no
+    /// single partition has to hold a whole epoch's votes.
+    VoteLedger(Epoch, u8),
 }
 
 const CHAIN_ID_TAG: u8 = 2;
@@ -594,6 +660,38 @@ fn to_event_key(event_id: &EventId) -> Vec<u8> {
 
 pub(crate) fn to_height_key(height: BlockHeight) -> Vec<u8> {
     bcs::to_bytes(&height).unwrap()
+}
+
+/// Tag prefix for a chain's latest confirmation vote in a `VoteLedger` partition.
+const VOTE_LEDGER_LATEST_TAG: u8 = 0;
+/// Tag prefix for a chain's superseded confirmation votes in a `VoteLedger`
+/// partition.
+const VOTE_LEDGER_SUPERSEDED_TAG: u8 = 1;
+
+/// Returns the root key of the vote-ledger bucket holding this chain's entries.
+/// Chain IDs are hashes, so the buckets split an epoch's ledger uniformly into
+/// 256 partitions.
+fn to_vote_ledger_root_key(epoch: Epoch, chain_id: &ChainId) -> Vec<u8> {
+    let bucket = bcs::to_bytes(chain_id).unwrap()[0];
+    RootKey::VoteLedger(epoch, bucket).bytes()
+}
+
+fn to_vote_ledger_latest_key(chain_id: &ChainId) -> Vec<u8> {
+    let mut key = vec![VOTE_LEDGER_LATEST_TAG];
+    key.extend(bcs::to_bytes(chain_id).unwrap());
+    key
+}
+
+fn to_vote_ledger_superseded_prefix(chain_id: &ChainId) -> Vec<u8> {
+    let mut key = vec![VOTE_LEDGER_SUPERSEDED_TAG];
+    key.extend(bcs::to_bytes(chain_id).unwrap());
+    key
+}
+
+fn to_vote_ledger_superseded_key(chain_id: &ChainId, record: &VoteRecord) -> Vec<u8> {
+    let mut key = to_vote_ledger_superseded_prefix(chain_id);
+    key.extend(bcs::to_bytes(&(record.height, record.round)).unwrap());
+    key
 }
 
 fn is_chain_state(root_key: &[u8]) -> bool {
@@ -1558,6 +1656,68 @@ where
             batch.add_event(&event_id, value);
         }
         self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all, fields(chain_id = %chain_id, epoch = %epoch))]
+    async fn record_confirmed_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        record: VoteRecord,
+        superseded: Option<JustifiedVote>,
+    ) -> Result<(), ViewError> {
+        let mut batch = MultiPartitionBatch::new();
+        batch.add_confirmed_vote(epoch, &chain_id, &record, superseded.as_ref())?;
+        self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all, fields(chain_id = %chain_id, epoch = %epoch))]
+    async fn record_superseded_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        superseded: JustifiedVote,
+    ) -> Result<(), ViewError> {
+        let mut batch = MultiPartitionBatch::new();
+        batch.add_superseded_vote(epoch, &chain_id, &superseded)?;
+        self.write_batch(batch).await
+    }
+
+    #[instrument(skip_all, fields(chain_id = %chain_id, epoch = %epoch))]
+    async fn read_vote_ledger_entry(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+    ) -> Result<Option<LedgerEntry>, ViewError> {
+        let root_key = to_vote_ledger_root_key(epoch, &chain_id);
+        let store = self.database.open_shared(&root_key)?;
+        let Some(latest) = store
+            .read_value::<VoteRecord>(&to_vote_ledger_latest_key(&chain_id))
+            .await?
+        else {
+            return Ok(None);
+        };
+        let prefix = to_vote_ledger_superseded_prefix(&chain_id);
+        let mut superseded = Vec::new();
+        for (_, value) in store.find_key_values_by_prefix(&prefix).await? {
+            superseded.push(bcs::from_bytes(&value)?);
+        }
+        Ok(Some(LedgerEntry { latest, superseded }))
+    }
+
+    #[instrument(skip_all, fields(epoch = %epoch))]
+    async fn vote_ledger_chain_ids(&self, epoch: Epoch) -> Result<Vec<ChainId>, ViewError> {
+        // Ascending buckets, and sorted keys within each, so the result is ordered
+        // by serialized chain ID.
+        let mut chain_ids = Vec::new();
+        for bucket in 0..=u8::MAX {
+            let root_key = RootKey::VoteLedger(epoch, bucket).bytes();
+            let store = self.database.open_shared(&root_key)?;
+            for short_key in store.find_keys_by_prefix(&[VOTE_LEDGER_LATEST_TAG]).await? {
+                chain_ids.push(bcs::from_bytes(&short_key)?);
+            }
+        }
+        Ok(chain_ids)
     }
 
     #[instrument(skip_all)]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -24,6 +24,7 @@ use linera_base::{
 pub use linera_cache::{Arc, DEFAULT_CLEANUP_INTERVAL_SECS};
 use linera_chain::{
     types::{ConfirmedBlock, ConfirmedBlockCertificate},
+    vote_ledger::{JustifiedVote, LedgerEntry, VoteRecord},
     ChainError, ChainStateView,
 };
 use linera_execution::{
@@ -245,6 +246,38 @@ pub trait Storage: linera_base::util::traits::AutoTraits + Sized {
         &self,
         events: impl IntoIterator<Item = (EventId, Vec<u8>)> + Send,
     ) -> Result<(), ViewError>;
+
+    /// Records a confirmation vote this validator signed, in the vote ledger for
+    /// the given epoch. If the vote replaced an earlier confirmation vote at the
+    /// same height, the replaced vote must be passed as `superseded`.
+    async fn record_confirmed_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        record: VoteRecord,
+        superseded: Option<JustifiedVote>,
+    ) -> Result<(), ViewError>;
+
+    /// Records a superseded confirmation vote in the vote ledger for the given
+    /// epoch, without touching the chain's latest-vote entry. This is used when a
+    /// block other than the voted one is confirmed at the vote's height without
+    /// the validator casting a new vote there.
+    async fn record_superseded_vote(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+        superseded: JustifiedVote,
+    ) -> Result<(), ViewError>;
+
+    /// Reads the vote-ledger entry for the given epoch and chain.
+    async fn read_vote_ledger_entry(
+        &self,
+        epoch: Epoch,
+        chain_id: ChainId,
+    ) -> Result<Option<LedgerEntry>, ViewError>;
+
+    /// Lists the chains with a vote-ledger entry for the given epoch.
+    async fn vote_ledger_chain_ids(&self, epoch: Epoch) -> Result<Vec<ChainId>, ViewError>;
 
     /// Reads the network description.
     async fn read_network_description(&self) -> Result<Option<NetworkDescription>, ViewError>;
@@ -675,7 +708,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use linera_base::{
-        crypto::{AccountPublicKey, CryptoHash},
+        crypto::{AccountPublicKey, CryptoHash, TestString, ValidatorKeypair, ValidatorSignature},
         data_types::{
             Amount, ApplicationPermissions, Blob, BlockHeight, ChainDescription, ChainOrigin,
             Epoch, InitialChainConfig, NetworkDescription, Round, Timestamp,
@@ -1010,6 +1043,109 @@ mod tests {
         Ok(())
     }
 
+    async fn test_storage_vote_ledger<S: Storage + Sync>(storage: &S) -> Result<(), ViewError> {
+        let epoch = Epoch::from(1);
+        let chain_id = ChainId(CryptoHash::test_hash("vote ledger chain"));
+        assert!(storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .is_none());
+        assert!(storage.vote_ledger_chain_ids(epoch).await?.is_empty());
+
+        // The ledger only stores and lists records; any signature value works here.
+        let keypair = ValidatorKeypair::generate();
+        let signature = ValidatorSignature::new(&TestString::new("vote"), &keypair.secret_key);
+
+        // The first vote on the chain.
+        let vote1 = VoteRecord {
+            height: BlockHeight::ZERO,
+            round: Round::MultiLeader(0),
+            block_hash: CryptoHash::test_hash("block A"),
+            justification_commitment: None,
+            signature,
+        };
+        storage
+            .record_confirmed_vote(epoch, chain_id, vote1.clone(), None)
+            .await?;
+        let entry = storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .unwrap();
+        assert_eq!(entry.latest, vote1);
+        assert!(entry.superseded.is_empty());
+
+        // A justified re-vote at the same height supersedes the first vote.
+        let vote2 = VoteRecord {
+            height: BlockHeight::ZERO,
+            round: Round::MultiLeader(1),
+            block_hash: CryptoHash::test_hash("block B"),
+            justification_commitment: Some(CryptoHash::test_hash("quorum B")),
+            signature,
+        };
+        let superseded = JustifiedVote {
+            record: vote1,
+            justification: None,
+        };
+        storage
+            .record_confirmed_vote(epoch, chain_id, vote2, Some(superseded.clone()))
+            .await?;
+
+        // A vote at the next height overwrites the latest vote and keeps the
+        // superseded one.
+        let vote3 = VoteRecord {
+            height: BlockHeight::from(1),
+            round: Round::MultiLeader(0),
+            block_hash: CryptoHash::test_hash("block C"),
+            justification_commitment: None,
+            signature,
+        };
+        storage
+            .record_confirmed_vote(epoch, chain_id, vote3.clone(), None)
+            .await?;
+        let entry = storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .unwrap();
+        assert_eq!(entry.latest, vote3);
+        assert_eq!(entry.superseded, vec![superseded.clone()]);
+
+        // A different block gets confirmed at height 1 without this validator's
+        // vote: the bypassed vote is recorded as superseded on its own, without
+        // touching the latest-vote entry.
+        let bypassed = JustifiedVote {
+            record: vote3.clone(),
+            justification: None,
+        };
+        storage
+            .record_superseded_vote(epoch, chain_id, bypassed.clone())
+            .await?;
+        let entry = storage
+            .read_vote_ledger_entry(epoch, chain_id)
+            .await?
+            .unwrap();
+        assert_eq!(entry.latest, vote3);
+        assert_eq!(entry.superseded, vec![superseded, bypassed]);
+
+        // Entries are kept per epoch and per chain.
+        assert!(storage
+            .read_vote_ledger_entry(Epoch::from(2), chain_id)
+            .await?
+            .is_none());
+        assert_eq!(storage.vote_ledger_chain_ids(epoch).await?, vec![chain_id]);
+
+        // Chains land in different buckets of the epoch's ledger; the listing spans
+        // all of them and is ordered by serialized chain ID.
+        let chain_id2 = ChainId(CryptoHash::test_hash("vote ledger chain 2"));
+        storage
+            .record_confirmed_vote(epoch, chain_id2, vote3, None)
+            .await?;
+        let mut expected = vec![chain_id, chain_id2];
+        expected.sort_by_key(|id| bcs::to_bytes(id).unwrap());
+        assert_eq!(storage.vote_ledger_chain_ids(epoch).await?, expected);
+
+        Ok(())
+    }
+
     /// Generic test function to test Storage trait features
     #[test_case(DbStorage::<MemoryDatabase, _>::make_test_storage(None).await; "memory")]
     #[cfg_attr(feature = "scylladb", test_case(DbStorage::<ScyllaDbDatabase, _>::make_test_storage(None).await; "scylla_db"))]
@@ -1023,6 +1159,7 @@ mod tests {
         test_storage_certificate(&storage).await?;
         test_storage_event(&storage).await?;
         test_storage_network_description(&storage).await?;
+        test_storage_vote_ledger(&storage).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

As a defense against long-range attacks, validators will publish *epoch commitments* when an epoch is revoked: per chain, the last block they signed a confirmation vote for, plus any votes superseded at their height, each with the justification it cited (see the draft PR #6595 for the full picture). The chain manager only holds the current vote and locking certificate transiently and overwrites them as the chain advances, so without a durable record a validator cannot later reconstruct what it signed.

This is the first, self-contained slice of that work, carved out of #6595: the vote ledger itself. It only records data — no behavior changes, no new RPCs or operations.

## Proposal

- Add `vote_ledger` types to `linera-chain`: a `VoteRecord` identifies a confirmation vote's entire signed payload (height, round, block hash, and the justification commitment it signed); a `JustifiedVote` pairs a record with the validated-block certificate it cited.
- Store the ledger per epoch and chain in validator storage: the latest vote per chain (a blind overwrite on the signing path — no read-modify-write), plus superseded votes under their own keys. Each epoch's ledger is split into 256 buckets by the chain ID's first byte so no single partition holds a whole epoch's votes.
- Record votes in the chain worker at the moments where they would otherwise become unrecoverable:
  - when a new vote is created (proposal or validated-certificate handling), superseding a same-height predecessor if there was one;
  - when the locking certificate a pending vote cited is replaced without a new vote being cast — the ledger is then the only remaining home of the vote–justification pairing;
  - when a block other than the voted one is confirmed at the vote's height (the vote was bypassed), or when the confirming certificate's justification chain cannot reproduce the cited quorum.
- Add `ConfirmedBlockCertificate::cited_validated_certificate`, which reconstructs the validated certificate a vote cited from the confirmed certificate's justification chain; this is what makes same-block votes recoverable without storing them redundantly.

## Test Plan

- New `test_storage_vote_ledger` in `linera-storage` covers recording, supersession, bypassed votes, per-epoch separation, and bucket-spanning listing.
- `test_timeouts` in `linera-core` now asserts the ledger contents through a real re-vote flow: initial vote, justified re-vote at the same height (superseded vote captured with its justification), and a bypassing confirmation (bypassed vote captured).
- New `test_cited_validated_certificate` in `linera-chain` checks quorum reconstruction from the justification chain.
- Workspace clippy (all features) and the wasm32 web build are clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Full commitments mechanism this is carved out of: #6595
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)