### PR TITLE
Remove the unused `finalized_sent_messages` map

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -255,7 +255,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         let context = MessageContext {
             chain_id: self.chain_id,
             origin: incoming_bundle.origin,
-            origin_certificate_hash: incoming_bundle.bundle.certificate_hash,
             origin_timestamp: incoming_bundle.bundle.timestamp,
             is_bouncing: posted_message.is_bouncing(),
             height: self.block_height,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -675,8 +675,6 @@ pub struct MessageContext {
     pub chain_id: ChainId,
     /// The chain ID where the message originated from.
     pub origin: ChainId,
-    /// The hash of the certified block on the origin chain that sent the message.
-    pub origin_certificate_hash: CryptoHash,
     /// The timestamp of the block on the origin chain that sent the message.
     pub origin_timestamp: Timestamp,
     /// Whether the message was rejected by the original receiver and is now bouncing back.

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -122,11 +122,6 @@ pub struct SystemExecutionStateView<C> {
     pub event_subscriptions: MapView<C, (ChainId, StreamId), EventSubscriptions>,
     /// The number of events in the streams that this chain is writing to.
     pub stream_event_counts: MapView<C, StreamId, u32>,
-    /// For each chain that previously received messages from this one and has since
-    /// notified us via [`SystemMessage::CheckpointAck`], records the cursor past the last
-    /// message we sent that the recipient finalized, together with the hash of the
-    /// recipient's block carrying the notification.
-    pub finalized_sent_messages: MapView<C, ChainId, (Cursor, CryptoHash)>,
     /// For each recipient chain, the cursors `(block_height, transaction_index)` of
     /// our outgoing bundles that haven't yet been acknowledged via
     /// [`SystemMessage::CheckpointAck`]. Maintained on-chain (as opposed to the local
@@ -171,7 +166,6 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
             used_blobs: self.used_blobs.with_context(ctx.clone()).await,
             event_subscriptions: self.event_subscriptions.with_context(ctx.clone()).await,
             stream_event_counts: self.stream_event_counts.with_context(ctx.clone()).await,
-            finalized_sent_messages: self.finalized_sent_messages.with_context(ctx.clone()).await,
             unfinalized_message_blocks: self
                 .unfinalized_message_blocks
                 .with_context(ctx.clone())
@@ -364,9 +358,9 @@ pub enum SystemMessage {
     /// Sent by a chain that just executed `SystemOperation::Checkpoint` to each chain
     /// it has received at least one non-`CheckpointAck` message from since its
     /// previous checkpoint. `latest_received_cursor` is the position past the last
-    /// bundle from the recipient that the sender has consumed. The recipient records
-    /// this in `finalized_sent_messages` so that, when it later checkpoints its own
-    /// state, it can drop already-delivered outgoing messages from its outbox dump.
+    /// bundle from the recipient that the sender has consumed. The recipient trims
+    /// its `unfinalized_message_blocks` accordingly, so that its next checkpoint
+    /// drops already-delivered outgoing messages from its outbox dump.
     CheckpointAck { latest_received_cursor: Cursor },
 }
 
@@ -928,10 +922,6 @@ where
             CheckpointAck {
                 latest_received_cursor,
             } => {
-                self.finalized_sent_messages.insert(
-                    &context.origin,
-                    (latest_received_cursor, context.origin_certificate_hash),
-                )?;
                 // Drop every cursor the recipient has consumed. `split_off(&k)` on a
                 // `BTreeSet<Cursor>` returns the entries `>= k`, so this trims the
                 // strict prefix below `latest_received_cursor` and leaves any

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -11,7 +11,7 @@ mod system_execution_state;
 use std::{collections::BTreeMap, sync::Arc, thread, vec};
 
 use linera_base::{
-    crypto::{AccountPublicKey, CryptoHash, ValidatorPublicKey},
+    crypto::{AccountPublicKey, ValidatorPublicKey},
     data_types::{
         Amount, Blob, BlockHeight, ChainDescription, ChainOrigin, CompressedBytecode, Epoch,
         InitialChainConfig, OracleResponse, Timestamp,
@@ -129,7 +129,6 @@ pub fn create_dummy_message_context(
     MessageContext {
         chain_id,
         origin: chain_id,
-        origin_certificate_hash: CryptoHash::default(),
         origin_timestamp: Default::default(),
         is_bouncing: false,
         authenticated_owner,

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -276,7 +276,7 @@ async fn checkpoint_roundtrip_via_separate_view_yields_matching_hash() -> anyhow
 
 #[tokio::test]
 async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyhow::Result<()> {
-    use linera_base::{crypto::CryptoHash, data_types::Cursor};
+    use linera_base::data_types::Cursor;
 
     let origin_a = dummy_chain_description(1).id();
     let origin_b = dummy_chain_description(2).id();
@@ -331,10 +331,9 @@ async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyho
 
     // Receiver side: pre-populate `unfinalized_message_blocks` with three heights
     // from origin_a (the block-end hook would normally do this), then deliver the
-    // checkpoint message and verify both halves of the receive logic:
-    //   - `finalized_sent_messages[origin_a]` records (cursor, cert_hash).
-    //   - `unfinalized_message_blocks[origin_a]` drops heights strictly below the
-    //     cursor's height and retains heights at-or-above (per-block granularity).
+    // checkpoint message and verify that `unfinalized_message_blocks[origin_a]`
+    // drops heights strictly below the cursor's height and retains heights
+    // at-or-above (per-block granularity).
     let mut receiver = SystemExecutionState {
         description: Some(dummy_chain_description(3)),
         ..SystemExecutionState::default()
@@ -370,11 +369,9 @@ async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyho
             },
         ]),
     )?;
-    let sender_cert_hash = CryptoHash::test_hash("sender block");
     let context = MessageContext {
         chain_id: dummy_chain_description(3).id(),
         origin: origin_a,
-        origin_certificate_hash: sender_cert_hash,
         origin_timestamp: Default::default(),
         is_bouncing: false,
         authenticated_owner: None,
@@ -393,14 +390,6 @@ async fn checkpoint_notifies_origins_and_receive_records_finalization() -> anyho
         )
         .await?;
     assert!(produced.is_empty());
-    assert_eq!(
-        receiver
-            .system
-            .finalized_sent_messages
-            .get(&origin_a)
-            .await?,
-        Some((cursor_a, sender_cert_hash))
-    );
     assert_eq!(
         receiver
             .system

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -6,7 +6,7 @@
 use std::{collections::BTreeSet, sync::Arc, vec};
 
 use linera_base::{
-    crypto::{AccountPublicKey, CryptoHash},
+    crypto::AccountPublicKey,
     data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
     http,
     identifiers::{Account, AccountOwner, StreamName},
@@ -278,7 +278,6 @@ async fn test_fee_consumption(
     let context = MessageContext {
         chain_id,
         origin: chain_id,
-        origin_certificate_hash: CryptoHash::default(),
         origin_timestamp: Timestamp::default(),
         is_bouncing: false,
         authenticated_owner,
@@ -479,7 +478,6 @@ async fn test_free_app_message_no_fees() -> anyhow::Result<()> {
     let context = MessageContext {
         chain_id,
         origin: chain_id,
-        origin_certificate_hash: CryptoHash::default(),
         origin_timestamp: Timestamp::default(),
         is_bouncing: false,
         authenticated_owner: Some(signer),

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    crypto::{AccountSecretKey, CryptoHash},
+    crypto::AccountSecretKey,
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, AccountOwner},
     ownership::ChainOwnership,
@@ -75,7 +75,6 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     let context = MessageContext {
         chain_id,
         origin: chain_id,
-        origin_certificate_hash: CryptoHash::default(),
         origin_timestamp: Default::default(),
         is_bouncing: false,
         height: BlockHeight(0),


### PR DESCRIPTION
## Motivation

The map is written on every received `CheckpointAck` but never read: trimming `unfinalized_message_blocks` in the same handler is what actually drops delivered messages from the next checkpoint's outbox dump.

## Proposal

Remove it, along with the `MessageContext` field that only exists to populate it.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
