### PR TITLE
Record `used_blobs` per epoch, forgetting blobs unused for two epochs

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1421,11 +1421,12 @@ pub enum OracleResponse {
     Checkpoint {
         /// Content hashes of the execution-state-dump blobs, in restore order.
         execution_state_blobs: Vec<CryptoHash>,
-        /// All blobs whose recorded last use on the chain is live (current or previous
-        /// epoch) at the time of the checkpoint. A bootstrapping node must have each of
-        /// these in shared blob storage before applying the checkpoint, otherwise
-        /// subsequent operations on the chain could try to read blob content the node
-        /// doesn't actually have.
+        /// All blobs whose use on the chain was recorded since the previous checkpoint
+        /// — exactly the `used_blobs` records still live after this checkpoint rotates
+        /// out older entries. A bootstrapping node must have each of these in shared
+        /// blob storage before applying the checkpoint, otherwise subsequent
+        /// operations on the chain could try to read blob content the node doesn't
+        /// actually have.
         used_blobs: Vec<BlobId>,
         /// Hashes of every block on this chain that the chain's outboxes still reference
         /// at the time of the checkpoint — i.e. the heights with cross-chain messages

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1421,10 +1421,11 @@ pub enum OracleResponse {
     Checkpoint {
         /// Content hashes of the execution-state-dump blobs, in restore order.
         execution_state_blobs: Vec<CryptoHash>,
-        /// All blobs the chain references in its `used_blobs` set at the time of the
-        /// checkpoint. A bootstrapping node must have each of these in shared blob
-        /// storage before applying the checkpoint, otherwise subsequent operations on
-        /// the chain could try to read blob content the node doesn't actually have.
+        /// All blobs whose recorded last use on the chain is live (current or previous
+        /// epoch) at the time of the checkpoint. A bootstrapping node must have each of
+        /// these in shared blob storage before applying the checkpoint, otherwise
+        /// subsequent operations on the chain could try to read blob content the node
+        /// doesn't actually have.
         used_blobs: Vec<BlobId>,
         /// Hashes of every block on this chain that the chain's outboxes still reference
         /// at the time of the checkpoint — i.e. the heights with cross-chain messages

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -893,13 +893,14 @@ where
         );
 
         for blob in published_blobs {
-            let blob_id = blob.id();
             resource_controller
                 .policy()
                 .check_blob_size(blob.content())
                 .with_execution_context(ChainExecutionContext::Block)?;
-            chain.system.record_used_blob(&blob_id).await?;
         }
+        chain
+            .system
+            .record_used_blobs(published_blobs.iter().map(|blob| blob.id()))?;
 
         let mut block_execution_tracker = BlockExecutionTracker::new(
             &mut resource_controller,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -898,7 +898,7 @@ where
                 .policy()
                 .check_blob_size(blob.content())
                 .with_execution_context(ChainExecutionContext::Block)?;
-            chain.system.used_blobs.insert(&blob_id)?;
+            chain.system.record_used_blob(&blob_id).await?;
         }
 
         let mut block_execution_tracker = BlockExecutionTracker::new(

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -946,10 +946,9 @@ where
         // Trust-mark accept path: an earlier checkpoint cert recorded this block's
         // hash in `pre_checkpoint_block_trust`. Removing the trust mark here is
         // only an in-memory change; if anything below fails before `save`, the
-        // mark survives on the next reload. The dispatch's `gap` definition
-        // (`!=` rather than `<`) routes both above-tip and below-tip trust
-        // uploads to `preprocess_certified_block` so the chain can write the
-        // cert without advancing the tip.
+        // mark survives on the next reload. Below-tip uploads are routed to
+        // `preprocess_certified_block` so the chain can write the cert without
+        // advancing the tip.
         let in_trust_set = self
             .chain
             .pre_checkpoint_block_trust
@@ -959,9 +958,19 @@ where
             self.chain.pre_checkpoint_block_trust.remove(&block_hash)?;
         }
 
-        // Check if we already processed this block.
+        // Check if we already processed this block. Being below the tip is not enough
+        // to tell: a chain bootstrapped from a checkpoint is sparse, so a below-tip
+        // block may never have been seen — e.g. the client pushes the block that
+        // published a blob the latest checkpoint no longer vouches for, so that this
+        // worker learns the blob. Skip only if the block's hash is recorded on the
+        // chain or its certificate is in storage (certificates are written together
+        // with their blobs); otherwise fall through and process it.
         let tip = self.chain.tip_state.get().clone();
-        if !in_trust_set && tip.next_block_height > height {
+        if !in_trust_set
+            && tip.next_block_height > height
+            && (self.chain.block_hashes.contains_key(&height).await?
+                || self.storage.contains_certificate(block_hash).await?)
+        {
             let actions = self.create_network_actions(None).await?;
             self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
                 .await;
@@ -1009,6 +1018,15 @@ where
             .into_iter()
             .map(|blob| (blob.id(), blob))
             .collect::<BTreeMap<_, _>>();
+
+        // A below-tip block is never executed and never restores a checkpoint — that
+        // would rewind the chain. It is only written to storage (together with its
+        // blobs, above) and preprocessed, whatever the mode.
+        if height < tip.next_block_height {
+            return self
+                .preprocess_certified_block(certificate, notify_when_messages_are_delivered)
+                .await;
+        }
 
         // Dispatch on the actual outcome (preprocess / checkpoint-restore-then-execute
         // / contiguous execute):

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -34,7 +34,9 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
     vm::VmRuntime,
 };
-use linera_chain::{data_types::MessageAction, ChainError, ChainExecutionContext};
+use linera_chain::{
+    data_types::MessageAction, types::ConfirmedBlockCertificate, ChainError, ChainExecutionContext,
+};
 use linera_execution::{
     wasm_test, ExecutionError, Message, MessageKind, Operation, QueryOutcome,
     ResourceControlPolicy, SystemMessage, SystemOperation, WasmRuntime,
@@ -1339,6 +1341,107 @@ async fn test_memory_checkpoint_comprehensive(wasm_runtime: WasmRuntime) -> anyh
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_checkpoint_comprehensive(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_checkpoint(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
+}
+
+/// Returns the `used_blobs` list of a checkpoint certificate's oracle response.
+fn checkpoint_used_blob_ids(certificate: &ConfirmedBlockCertificate) -> Vec<BlobId> {
+    match certificate
+        .block()
+        .body
+        .oracle_responses
+        .first()
+        .and_then(|responses| responses.first())
+    {
+        Some(OracleResponse::Checkpoint { used_blobs, .. }) => used_blobs.clone(),
+        other => panic!("expected OracleResponse::Checkpoint, got {other:?}"),
+    }
+}
+
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_memory_app_call_after_checkpoint_bootstrap_when_expired(
+    wasm_runtime: WasmRuntime,
+) -> anyhow::Result<()> {
+    run_test_app_call_after_checkpoint_bootstrap_when_expired(
+        MemoryStorageBuilder::with_wasm_runtime(wasm_runtime),
+    )
+    .await
+}
+
+/// A dormant application must survive the expiry of its blobs' `used_blobs` records:
+/// after two checkpoints without any use of the application, the latest checkpoint's
+/// `used_blobs` no longer lists its description and bytecode blobs, so a validator
+/// bootstrapped from that checkpoint has neither. An application call whose quorum
+/// requires that validator's vote must still commit: the proposing client holds all
+/// the content and supplies the missing blobs by pushing the blocks that published
+/// them.
+async fn run_test_app_call_after_checkpoint_bootstrap_when_expired<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let keys = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, keys).await?;
+
+    // Validator 0 misses the whole chain; it only ever learns the chain description.
+    builder.set_fault_type([0], FaultType::NoChains);
+
+    let creator = builder.add_root_chain(0, Amount::from_tokens(10)).await?;
+    let validator_0_key = builder.node(0).name();
+
+    // Publish the counter bytecode and instantiate the application: its bytecode and
+    // description blobs get recorded in `used_blobs`.
+    let module_id = creator.publish_wasm_example("counter").await?;
+    let module_id = module_id.with_abi::<counter::CounterAbi, (), u64>();
+    let (application_id, _) = creator
+        .create_application(module_id, &(), &10_u64, vec![])
+        .await
+        .unwrap_ok_committed();
+    let description_blob_id = application_id.forget_abi().description_blob_id();
+
+    // Two checkpoints without any use of the application: the first still lists its
+    // description blob, the second drops the expired record.
+    let checkpoint_1 = creator.checkpoint().await.unwrap().unwrap();
+    assert!(
+        checkpoint_used_blob_ids(&checkpoint_1).contains(&description_blob_id),
+        "checkpoint #1 must vouch for the application description blob",
+    );
+    let checkpoint_2 = creator.checkpoint().await.unwrap().unwrap();
+    assert!(
+        !checkpoint_used_blob_ids(&checkpoint_2).contains(&description_blob_id),
+        "checkpoint #2 must have forgotten the dormant application's description blob",
+    );
+
+    // Bring validator 0 back; take validator 1 down. Quorum (3 of 4) now requires
+    // validator 0, which gets bootstrapped from checkpoint #2 by the next proposal —
+    // a checkpoint that no longer vouches for the application's blobs.
+    builder.set_fault_type([0], FaultType::Honest);
+    builder.set_fault_type([1], FaultType::Offline);
+
+    let increment = counter::CounterOperation::Increment { value: 5 };
+    let result = creator
+        .execute_operation(Operation::user(application_id, &increment)?)
+        .await;
+
+    let validator_0_storage = builder
+        .validator_storages
+        .get(&validator_0_key)
+        .expect("validator 0 storage")
+        .clone();
+    assert!(
+        result.is_ok(),
+        "calling a dormant application must remain possible when the proposing client \
+        holds its blobs, even with a checkpoint-bootstrapped validator in the quorum; \
+        got: {:?}; validator 0 has the description blob: {}",
+        result.err(),
+        validator_0_storage
+            .contains_blob(description_blob_id)
+            .await?,
+    );
+
+    Ok(())
 }
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -163,9 +163,11 @@ where
 
     /// Registers the pre-block-computed checkpoint inputs (from
     /// [`Self::prepare_checkpoint`]) with the transaction tracker. This: publishes the
-    /// execution-state blobs, records the matching [`OracleResponse::Checkpoint`] (which
-    /// also lists every blob with a live `used_blobs` record so a
-    /// bootstrapping node can fetch them from shared storage), and emits a
+    /// execution-state blobs, starts a new `used_blobs` generation (forgetting blobs
+    /// last used before the previous checkpoint), records the matching
+    /// [`OracleResponse::Checkpoint`] (which lists the blobs still live after the
+    /// rotation — those used since the previous checkpoint — so a bootstrapping node
+    /// can fetch them from shared storage), and emits a
     /// [`SystemMessage::CheckpointAck`] to each origin chain so the origin can later trim
     /// its outbox dump of already-delivered messages.
     pub async fn apply_checkpoint(
@@ -180,6 +182,7 @@ where
             outbox_block_hashes,
         } = prepared;
         let execution_state_blobs = blobs.iter().map(|blob| blob.id().hash).collect();
+        self.system.start_checkpoint_generation().await?;
         let used_blobs = self.system.used_blob_ids().await?;
         for blob in blobs {
             txn_tracker.add_created_blob(blob);

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -164,7 +164,7 @@ where
     /// Registers the pre-block-computed checkpoint inputs (from
     /// [`Self::prepare_checkpoint`]) with the transaction tracker. This: publishes the
     /// execution-state blobs, records the matching [`OracleResponse::Checkpoint`] (which
-    /// also lists every blob the chain currently references in `used_blobs` so a
+    /// also lists every blob with a live `used_blobs` record so a
     /// bootstrapping node can fetch them from shared storage), and emits a
     /// [`SystemMessage::CheckpointAck`] to each origin chain so the origin can later trim
     /// its outbox dump of already-delivered messages.
@@ -180,7 +180,7 @@ where
             outbox_block_hashes,
         } = prepared;
         let execution_state_blobs = blobs.iter().map(|blob| blob.id().hash).collect();
-        let used_blobs = self.system.used_blobs.indices().await?;
+        let used_blobs = self.system.used_blob_ids().await?;
         for blob in blobs {
             txn_tracker.add_created_blob(blob);
         }
@@ -267,9 +267,9 @@ where
         let application_id = From::from(&application_description);
         let blob = Blob::new_application_description(&application_description);
 
-        self.system.used_blobs.insert(&blob.id())?;
-        self.system.used_blobs.insert(&contract_blob.id())?;
-        self.system.used_blobs.insert(&service_blob.id())?;
+        self.system.record_used_blob(&blob.id()).await?;
+        self.system.record_used_blob(&contract_blob.id()).await?;
+        self.system.record_used_blob(&service_blob.id()).await?;
 
         self.context()
             .extra()

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -267,9 +267,8 @@ where
         let application_id = From::from(&application_description);
         let blob = Blob::new_application_description(&application_description);
 
-        self.system.record_used_blob(&blob.id()).await?;
-        self.system.record_used_blob(&contract_blob.id()).await?;
-        self.system.record_used_blob(&service_blob.id()).await?;
+        self.system
+            .record_used_blobs([blob.id(), contract_blob.id(), service_blob.id()])?;
 
         self.context()
             .extra()

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -116,16 +116,21 @@ pub struct SystemExecutionStateView<C> {
     pub closed: RegisterView<C, bool>,
     /// Permissions for applications on this chain.
     pub application_permissions: LazyRegisterView<C, ApplicationPermissions>,
-    /// Blobs that have been used or published on this chain, with the epoch in which
-    /// their use was last recorded. Every use re-records the blob under the current
-    /// epoch, and a blob recorded in the current or the previous epoch can be read
-    /// without an oracle call. A blob that goes unrecorded for two consecutive epochs
-    /// is forgotten — reading it again becomes an oracle request — which keeps both
-    /// this map and the blob list embedded in each checkpoint bounded by recent
-    /// activity rather than by chain lifetime. Entries older than the previous epoch
-    /// are removed when the chain advances its epoch, so all remaining entries are
-    /// live.
-    pub used_blobs: MapView<C, BlobId, Epoch>,
+    /// The number of `SystemOperation::Checkpoint`s executed on this chain. Serves as
+    /// the current generation for `used_blobs` records: each checkpoint starts a new
+    /// generation.
+    pub num_checkpoints: RegisterView<C, u64>,
+    /// Blobs that have been used or published on this chain, with the checkpoint
+    /// generation (the value of `num_checkpoints` at the time) in which their use was
+    /// last recorded. Every use re-records the blob under the current generation, and
+    /// a blob recorded in the current or the previous generation — i.e. used since the
+    /// second-most-recent checkpoint — can be read without an oracle call. A blob that
+    /// goes unrecorded for two consecutive checkpoints is forgotten — reading it again
+    /// becomes an oracle request — which keeps both this map and the blob list
+    /// embedded in each checkpoint bounded by recent activity rather than by chain
+    /// lifetime. Entries older than the previous generation are removed when a
+    /// checkpoint executes, so all remaining entries are live.
+    pub used_blobs: MapView<C, BlobId, u64>,
     /// The event stream subscriptions of applications on this chain.
     pub event_subscriptions: MapView<C, (ChainId, StreamId), EventSubscriptions>,
     /// The number of events in the streams that this chain is writing to.
@@ -176,6 +181,7 @@ impl<C: Context, C2: Context> ReplaceContext<C2> for SystemExecutionStateView<C>
             allowances: self.allowances.with_context(ctx.clone()).await,
             closed: self.closed.with_context(ctx.clone()).await,
             application_permissions: self.application_permissions.with_context(ctx.clone()).await,
+            num_checkpoints: self.num_checkpoints.with_context(ctx.clone()).await,
             used_blobs: self.used_blobs.with_context(ctx.clone()).await,
             event_subscriptions: self.event_subscriptions.with_context(ctx.clone()).await,
             stream_event_counts: self.stream_event_counts.with_context(ctx.clone()).await,
@@ -532,7 +538,7 @@ where
                             .await?;
                         self.blob_used(txn_tracker, blob_id).await?;
                         self.committee_hash.set(Some(blob_hash));
-                        self.advance_epoch(epoch).await?;
+                        self.epoch.set(epoch);
                         let event_data = EpochEventData {
                             blob_hash,
                             timestamp: context.timestamp,
@@ -622,7 +628,7 @@ where
                     .await?;
                 self.blob_used(txn_tracker, blob_id).await?;
                 self.committee_hash.set(Some(event_data.blob_hash));
-                self.advance_epoch(epoch).await?;
+                self.epoch.set(epoch);
             }
             UpdateStream {
                 application_id,
@@ -1128,33 +1134,35 @@ where
     }
 
     /// Records a blob that is used in this block. If the blob's last recorded use is
-    /// not in the current or previous epoch, creates an oracle response for it.
+    /// not in the current or previous checkpoint generation, creates an oracle
+    /// response for it.
     pub(crate) async fn blob_used(
         &mut self,
         txn_tracker: &mut TransactionTracker,
         blob_id: BlobId,
     ) -> Result<bool, ExecutionError> {
-        let current_epoch = *self.epoch.get();
+        let current_generation = *self.num_checkpoints.get();
         let last_used = self.used_blobs.get(&blob_id).await?;
-        self.blob_used_at(txn_tracker, blob_id, last_used, current_epoch)
+        self.blob_used_at(txn_tracker, blob_id, last_used, current_generation)
     }
 
     /// Records blobs that are used in this block, loading all their last-use records
     /// from storage in a single round trip. Creates an oracle response for each blob
-    /// whose last recorded use is not in the current or previous epoch.
+    /// whose last recorded use is not in the current or previous checkpoint
+    /// generation.
     pub(crate) async fn blobs_used(
         &mut self,
         txn_tracker: &mut TransactionTracker,
         blob_ids: Vec<BlobId>,
     ) -> Result<(), ExecutionError> {
-        let current_epoch = *self.epoch.get();
+        let current_generation = *self.num_checkpoints.get();
         let last_used = self.used_blobs.multi_get(&blob_ids).await?;
         // `multi_get` returns the pre-batch records, so a repeated ID would otherwise
         // look unused a second time and produce a duplicate oracle response.
         let mut seen = BTreeSet::new();
         for (blob_id, last_used) in blob_ids.into_iter().zip(last_used) {
             if seen.insert(blob_id) {
-                self.blob_used_at(txn_tracker, blob_id, last_used, current_epoch)?;
+                self.blob_used_at(txn_tracker, blob_id, last_used, current_generation)?;
             }
         }
         Ok(())
@@ -1165,17 +1173,17 @@ where
         &mut self,
         txn_tracker: &mut TransactionTracker,
         blob_id: BlobId,
-        last_used: Option<Epoch>,
-        current_epoch: Epoch,
+        last_used: Option<u64>,
+        current_generation: u64,
     ) -> Result<bool, ExecutionError> {
-        if last_used == Some(current_epoch) {
+        if last_used == Some(current_generation) {
             return Ok(false); // Nothing to do.
         }
-        // Every use re-records the blob under the current epoch, so blobs in active
-        // use never expire.
-        self.used_blobs.insert(&blob_id, current_epoch)?;
-        let is_live =
-            last_used.is_some_and(|epoch| epoch.try_add_one().ok() == Some(current_epoch));
+        // Every use re-records the blob under the current generation, so blobs in
+        // active use never expire.
+        self.used_blobs.insert(&blob_id, current_generation)?;
+        let is_live = last_used
+            .is_some_and(|generation| generation.checked_add(1) == Some(current_generation));
         if is_live {
             return Ok(false);
         }
@@ -1195,13 +1203,13 @@ where
         Ok(())
     }
 
-    /// Records `blob_id` as used in the current epoch.
+    /// Records `blob_id` as used in the current checkpoint generation.
     pub fn record_used_blob(&mut self, blob_id: &BlobId) -> Result<(), ViewError> {
-        let epoch = *self.epoch.get();
-        self.used_blobs.insert(blob_id, epoch)
+        let generation = *self.num_checkpoints.get();
+        self.used_blobs.insert(blob_id, generation)
     }
 
-    /// Records all the given blobs as used in the current epoch.
+    /// Records all the given blobs as used in the current checkpoint generation.
     pub fn record_used_blobs(
         &mut self,
         blob_ids: impl IntoIterator<Item = BlobId>,
@@ -1217,12 +1225,18 @@ where
         self.used_blobs.indices().await
     }
 
-    /// Advances the chain to `epoch` and forgets the blobs whose last recorded use is
-    /// now older than the previous epoch.
-    async fn advance_epoch(&mut self, epoch: Epoch) -> Result<(), ViewError> {
-        self.epoch.set(epoch);
+    /// Starts a new `used_blobs` generation for the checkpoint being executed:
+    /// increments `num_checkpoints` and forgets the blobs whose last recorded use
+    /// predates the previous checkpoint.
+    pub(crate) async fn start_checkpoint_generation(&mut self) -> Result<(), ExecutionError> {
+        let generation = self
+            .num_checkpoints
+            .get()
+            .checked_add(1)
+            .ok_or(ArithmeticError::Overflow)?;
+        self.num_checkpoints.set(generation);
         for (blob_id, last_used) in self.used_blobs.index_values().await? {
-            if last_used.0.saturating_add(1) < epoch.0 {
+            if last_used.saturating_add(1) < generation {
                 self.used_blobs.remove(&blob_id)?;
             }
         }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -520,8 +520,7 @@ where
                         self.blob_published(
                             &BlobId::new(blob_hash, BlobType::Committee),
                             txn_tracker,
-                        )
-                        .await?;
+                        )?;
                     }
                     AdminOperation::CreateCommittee { epoch, blob_hash } => {
                         self.check_next_epoch(epoch)?;
@@ -560,7 +559,7 @@ where
             }
             PublishModule { module_id } => {
                 for blob_id in module_id.bytecode_blob_ids() {
-                    self.blob_published(&blob_id, txn_tracker).await?;
+                    self.blob_published(&blob_id, txn_tracker)?;
                 }
             }
             CreateApplication {
@@ -582,8 +581,7 @@ where
                 new_application = Some((app_id, instantiation_argument));
             }
             PublishDataBlob { blob_hash } => {
-                self.blob_published(&BlobId::new(blob_hash, BlobType::Data), txn_tracker)
-                    .await?;
+                self.blob_published(&BlobId::new(blob_hash, BlobType::Data), txn_tracker)?;
             }
             VerifyBlob { blob_id } => {
                 self.assert_blob_exists(blob_id).await?;
@@ -1066,11 +1064,9 @@ where
         let application_index = txn_tracker.next_application_index();
 
         let blob_ids = self.check_bytecode_blobs(&module_id, txn_tracker).await?;
-        // We only remember to register the blobs that aren't recorded in a live
-        // `used_blobs` generation already.
-        for blob_id in blob_ids {
-            self.blob_used(txn_tracker, blob_id).await?;
-        }
+        // We only remember to register the blobs that don't have a live `used_blobs`
+        // record already.
+        self.blobs_used(txn_tracker, blob_ids).await?;
 
         let application_description = ApplicationDescription {
             module_id,
@@ -1084,7 +1080,7 @@ where
             .await?;
 
         let blob = Blob::new_application_description(&application_description);
-        self.record_used_blob(&blob.id()).await?;
+        self.record_used_blob(&blob.id())?;
         txn_tracker.add_created_blob(blob);
 
         Ok(CreateApplicationResult {
@@ -1121,11 +1117,9 @@ where
         let blob_ids = self
             .check_bytecode_blobs(&description.module_id, txn_tracker)
             .await?;
-        // We only remember to register the blobs that aren't recorded in a live
-        // `used_blobs` generation already.
-        for blob_id in blob_ids {
-            self.blob_used(txn_tracker, blob_id).await?;
-        }
+        // We only remember to register the blobs that don't have a live `used_blobs`
+        // record already.
+        self.blobs_used(txn_tracker, blob_ids).await?;
 
         self.check_required_applications(&description, txn_tracker)
             .await?;
@@ -1142,6 +1136,38 @@ where
     ) -> Result<bool, ExecutionError> {
         let current_epoch = *self.epoch.get();
         let last_used = self.used_blobs.get(&blob_id).await?;
+        self.blob_used_at(txn_tracker, blob_id, last_used, current_epoch)
+    }
+
+    /// Records blobs that are used in this block, loading all their last-use records
+    /// from storage in a single round trip. Creates an oracle response for each blob
+    /// whose last recorded use is not in the current or previous epoch.
+    pub(crate) async fn blobs_used(
+        &mut self,
+        txn_tracker: &mut TransactionTracker,
+        blob_ids: Vec<BlobId>,
+    ) -> Result<(), ExecutionError> {
+        let current_epoch = *self.epoch.get();
+        let last_used = self.used_blobs.multi_get(&blob_ids).await?;
+        // `multi_get` returns the pre-batch records, so a repeated ID would otherwise
+        // look unused a second time and produce a duplicate oracle response.
+        let mut seen = BTreeSet::new();
+        for (blob_id, last_used) in blob_ids.into_iter().zip(last_used) {
+            if seen.insert(blob_id) {
+                self.blob_used_at(txn_tracker, blob_id, last_used, current_epoch)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Applies a single blob use, given the blob's pre-fetched last recorded use.
+    fn blob_used_at(
+        &mut self,
+        txn_tracker: &mut TransactionTracker,
+        blob_id: BlobId,
+        last_used: Option<Epoch>,
+        current_epoch: Epoch,
+    ) -> Result<bool, ExecutionError> {
         if last_used == Some(current_epoch) {
             return Ok(false); // Nothing to do.
         }
@@ -1159,20 +1185,31 @@ where
 
     /// Records a blob that is published in this block. This does not create an oracle entry, and
     /// the blob can be used without using an oracle on this chain while its record is live.
-    async fn blob_published(
+    fn blob_published(
         &mut self,
         blob_id: &BlobId,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(), ExecutionError> {
-        self.record_used_blob(blob_id).await?;
+        self.record_used_blob(blob_id)?;
         txn_tracker.add_published_blob(*blob_id);
         Ok(())
     }
 
     /// Records `blob_id` as used in the current epoch.
-    pub async fn record_used_blob(&mut self, blob_id: &BlobId) -> Result<(), ViewError> {
+    pub fn record_used_blob(&mut self, blob_id: &BlobId) -> Result<(), ViewError> {
         let epoch = *self.epoch.get();
         self.used_blobs.insert(blob_id, epoch)
+    }
+
+    /// Records all the given blobs as used in the current epoch.
+    pub fn record_used_blobs(
+        &mut self,
+        blob_ids: impl IntoIterator<Item = BlobId>,
+    ) -> Result<(), ViewError> {
+        for blob_id in blob_ids {
+            self.record_used_blob(&blob_id)?;
+        }
+        Ok(())
     }
 
     /// Returns the IDs of all blobs whose recorded last use is live, in sorted order.

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -116,8 +116,16 @@ pub struct SystemExecutionStateView<C> {
     pub closed: RegisterView<C, bool>,
     /// Permissions for applications on this chain.
     pub application_permissions: LazyRegisterView<C, ApplicationPermissions>,
-    /// Blobs that have been used or published on this chain.
-    pub used_blobs: SetView<C, BlobId>,
+    /// Blobs that have been used or published on this chain, with the epoch in which
+    /// their use was last recorded. Every use re-records the blob under the current
+    /// epoch, and a blob recorded in the current or the previous epoch can be read
+    /// without an oracle call. A blob that goes unrecorded for two consecutive epochs
+    /// is forgotten — reading it again becomes an oracle request — which keeps both
+    /// this map and the blob list embedded in each checkpoint bounded by recent
+    /// activity rather than by chain lifetime. Entries older than the previous epoch
+    /// are removed when the chain advances its epoch, so all remaining entries are
+    /// live.
+    pub used_blobs: MapView<C, BlobId, Epoch>,
     /// The event stream subscriptions of applications on this chain.
     pub event_subscriptions: MapView<C, (ChainId, StreamId), EventSubscriptions>,
     /// The number of events in the streams that this chain is writing to.
@@ -512,7 +520,8 @@ where
                         self.blob_published(
                             &BlobId::new(blob_hash, BlobType::Committee),
                             txn_tracker,
-                        )?;
+                        )
+                        .await?;
                     }
                     AdminOperation::CreateCommittee { epoch, blob_hash } => {
                         self.check_next_epoch(epoch)?;
@@ -524,7 +533,7 @@ where
                             .await?;
                         self.blob_used(txn_tracker, blob_id).await?;
                         self.committee_hash.set(Some(blob_hash));
-                        self.epoch.set(epoch);
+                        self.advance_epoch(epoch).await?;
                         let event_data = EpochEventData {
                             blob_hash,
                             timestamp: context.timestamp,
@@ -551,7 +560,7 @@ where
             }
             PublishModule { module_id } => {
                 for blob_id in module_id.bytecode_blob_ids() {
-                    self.blob_published(&blob_id, txn_tracker)?;
+                    self.blob_published(&blob_id, txn_tracker).await?;
                 }
             }
             CreateApplication {
@@ -573,7 +582,8 @@ where
                 new_application = Some((app_id, instantiation_argument));
             }
             PublishDataBlob { blob_hash } => {
-                self.blob_published(&BlobId::new(blob_hash, BlobType::Data), txn_tracker)?;
+                self.blob_published(&BlobId::new(blob_hash, BlobType::Data), txn_tracker)
+                    .await?;
             }
             VerifyBlob { blob_id } => {
                 self.assert_blob_exists(blob_id).await?;
@@ -614,7 +624,7 @@ where
                     .await?;
                 self.blob_used(txn_tracker, blob_id).await?;
                 self.committee_hash.set(Some(event_data.blob_hash));
-                self.epoch.set(epoch);
+                self.advance_epoch(epoch).await?;
             }
             UpdateStream {
                 application_id,
@@ -1056,8 +1066,8 @@ where
         let application_index = txn_tracker.next_application_index();
 
         let blob_ids = self.check_bytecode_blobs(&module_id, txn_tracker).await?;
-        // We only remember to register the blobs that aren't recorded in `used_blobs`
-        // already.
+        // We only remember to register the blobs that aren't recorded in a live
+        // `used_blobs` generation already.
         for blob_id in blob_ids {
             self.blob_used(txn_tracker, blob_id).await?;
         }
@@ -1074,7 +1084,7 @@ where
             .await?;
 
         let blob = Blob::new_application_description(&application_description);
-        self.used_blobs.insert(&blob.id())?;
+        self.record_used_blob(&blob.id()).await?;
         txn_tracker.add_created_blob(blob);
 
         Ok(CreateApplicationResult {
@@ -1111,8 +1121,8 @@ where
         let blob_ids = self
             .check_bytecode_blobs(&description.module_id, txn_tracker)
             .await?;
-        // We only remember to register the blobs that aren't recorded in `used_blobs`
-        // already.
+        // We only remember to register the blobs that aren't recorded in a live
+        // `used_blobs` generation already.
         for blob_id in blob_ids {
             self.blob_used(txn_tracker, blob_id).await?;
         }
@@ -1123,30 +1133,62 @@ where
         Ok(description)
     }
 
-    /// Records a blob that is used in this block. If this is the first use on this chain, creates
-    /// an oracle response for it.
+    /// Records a blob that is used in this block. If the blob's last recorded use is
+    /// not in the current or previous epoch, creates an oracle response for it.
     pub(crate) async fn blob_used(
         &mut self,
         txn_tracker: &mut TransactionTracker,
         blob_id: BlobId,
     ) -> Result<bool, ExecutionError> {
-        if self.used_blobs.contains(&blob_id).await? {
+        let current_epoch = *self.epoch.get();
+        let last_used = self.used_blobs.get(&blob_id).await?;
+        if last_used == Some(current_epoch) {
             return Ok(false); // Nothing to do.
         }
-        self.used_blobs.insert(&blob_id)?;
+        // Every use re-records the blob under the current epoch, so blobs in active
+        // use never expire.
+        self.used_blobs.insert(&blob_id, current_epoch)?;
+        let is_live =
+            last_used.is_some_and(|epoch| epoch.try_add_one().ok() == Some(current_epoch));
+        if is_live {
+            return Ok(false);
+        }
         txn_tracker.replay_oracle_response(OracleResponse::Blob(blob_id))?;
         Ok(true)
     }
 
     /// Records a blob that is published in this block. This does not create an oracle entry, and
-    /// the blob can be used without using an oracle in the future on this chain.
-    fn blob_published(
+    /// the blob can be used without using an oracle on this chain while its record is live.
+    async fn blob_published(
         &mut self,
         blob_id: &BlobId,
         txn_tracker: &mut TransactionTracker,
     ) -> Result<(), ExecutionError> {
-        self.used_blobs.insert(blob_id)?;
+        self.record_used_blob(blob_id).await?;
         txn_tracker.add_published_blob(*blob_id);
+        Ok(())
+    }
+
+    /// Records `blob_id` as used in the current epoch.
+    pub async fn record_used_blob(&mut self, blob_id: &BlobId) -> Result<(), ViewError> {
+        let epoch = *self.epoch.get();
+        self.used_blobs.insert(blob_id, epoch)
+    }
+
+    /// Returns the IDs of all blobs whose recorded last use is live, in sorted order.
+    pub async fn used_blob_ids(&self) -> Result<Vec<BlobId>, ViewError> {
+        self.used_blobs.indices().await
+    }
+
+    /// Advances the chain to `epoch` and forgets the blobs whose last recorded use is
+    /// now older than the previous epoch.
+    async fn advance_epoch(&mut self, epoch: Epoch) -> Result<(), ViewError> {
+        self.epoch.set(epoch);
+        for (blob_id, last_used) in self.used_blobs.index_values().await? {
+            if last_used.0.saturating_add(1) < epoch.0 {
+                self.used_blobs.remove(&blob_id)?;
+            }
+        }
         Ok(())
     }
 

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -42,7 +42,7 @@ pub struct SystemExecutionState {
     /// The latest timestamp recorded for the chain.
     pub timestamp: Timestamp,
     /// The set of blobs that have been used by the chain. Recorded in the view as
-    /// last used in the state's `epoch`.
+    /// last used in the current checkpoint generation.
     pub used_blobs: BTreeSet<BlobId>,
     /// Whether the chain has been closed.
     #[debug(skip_if = Not::not)]

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -104,7 +104,8 @@ impl SystemExecutionState {
             .as_ref()
             .expect("Chain description should be set")
             .into();
-        Box::pin(self.into_view_with(chain_id, ExecutionRuntimeConfig::default())).await
+        self.into_view_with(chain_id, ExecutionRuntimeConfig::default())
+            .await
     }
 
     /// Converts this state into an execution state view for the given chain ID and runtime
@@ -179,12 +180,9 @@ impl SystemExecutionState {
                 .insert(&account_owner, balance)
                 .expect("insertion of balances should not fail");
         }
-        for blob_id in used_blobs {
-            view.system
-                .record_used_blob(&blob_id)
-                .await
-                .expect("inserting blob IDs should not fail");
-        }
+        view.system
+            .record_used_blobs(used_blobs)
+            .expect("inserting blob IDs should not fail");
         view.system.closed.set(closed);
         view.system
             .application_permissions

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -41,7 +41,8 @@ pub struct SystemExecutionState {
     pub balances: BTreeMap<AccountOwner, Amount>,
     /// The latest timestamp recorded for the chain.
     pub timestamp: Timestamp,
-    /// The set of blobs that have been used by the chain.
+    /// The set of blobs that have been used by the chain. Recorded in the view as
+    /// last used in the state's `epoch`.
     pub used_blobs: BTreeSet<BlobId>,
     /// Whether the chain has been closed.
     #[debug(skip_if = Not::not)]
@@ -103,8 +104,7 @@ impl SystemExecutionState {
             .as_ref()
             .expect("Chain description should be set")
             .into();
-        self.into_view_with(chain_id, ExecutionRuntimeConfig::default())
-            .await
+        Box::pin(self.into_view_with(chain_id, ExecutionRuntimeConfig::default())).await
     }
 
     /// Converts this state into an execution state view for the given chain ID and runtime
@@ -181,8 +181,8 @@ impl SystemExecutionState {
         }
         for blob_id in used_blobs {
             view.system
-                .used_blobs
-                .insert(&blob_id)
+                .record_used_blob(&blob_id)
+                .await
                 .expect("inserting blob IDs should not fail");
         }
         view.system.closed.set(closed);

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -443,3 +443,42 @@ async fn execute_checkpoint_rejects_chain_with_published_events() -> anyhow::Res
     ));
     Ok(())
 }
+
+#[tokio::test]
+async fn used_blobs_expire_after_two_unused_epochs() -> anyhow::Result<()> {
+    let mut view = SystemExecutionState {
+        description: Some(dummy_chain_description(0)),
+        epoch: Epoch(5),
+        ..SystemExecutionState::default()
+    }
+    .into_view()
+    .await;
+
+    let hot_blob = BlobId::new(CryptoHash::test_hash("hot"), BlobType::Data);
+    let cold_blob = BlobId::new(CryptoHash::test_hash("cold"), BlobType::Data);
+    let mut txn_tracker = TransactionTracker::default();
+
+    // The first use of each blob creates an oracle response; a repeated use in the
+    // same epoch does not.
+    assert!(view.system.blob_used(&mut txn_tracker, hot_blob).await?);
+    assert!(view.system.blob_used(&mut txn_tracker, cold_blob).await?);
+    assert!(!view.system.blob_used(&mut txn_tracker, hot_blob).await?);
+
+    // Epoch 6: both blobs are still known, having been used in the previous epoch.
+    // Using the hot blob re-records it under the current epoch.
+    view.system.advance_epoch(Epoch(6)).await?;
+    assert!(!view.system.blob_used(&mut txn_tracker, hot_blob).await?);
+    let mut expected = vec![hot_blob, cold_blob];
+    expected.sort();
+    assert_eq!(view.system.used_blob_ids().await?, expected);
+
+    // Epoch 7: the hot blob was refreshed in epoch 6 and survives, while the cold
+    // blob was last used in epoch 5 and is forgotten, so using it again requires a
+    // new oracle response.
+    view.system.advance_epoch(Epoch(7)).await?;
+    assert_eq!(view.system.used_blob_ids().await?, vec![hot_blob]);
+    assert!(!view.system.blob_used(&mut txn_tracker, hot_blob).await?);
+    assert!(view.system.blob_used(&mut txn_tracker, cold_blob).await?);
+
+    Ok(())
+}

--- a/linera-execution/src/unit_tests/system_tests.rs
+++ b/linera-execution/src/unit_tests/system_tests.rs
@@ -444,11 +444,43 @@ async fn execute_checkpoint_rejects_chain_with_published_events() -> anyhow::Res
     Ok(())
 }
 
+/// Saves the view, then prepares and applies a checkpoint, returning the blob IDs
+/// listed in the resulting [`OracleResponse::Checkpoint`].
+async fn checkpoint_used_blobs(
+    view: &mut ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>,
+) -> anyhow::Result<Vec<BlobId>> {
+    use linera_base::data_types::OracleResponse;
+    use linera_views::{batch::Batch, store::WritableKeyValueStore as _, views::View as _};
+
+    let mut batch = Batch::new();
+    view.pre_save(&mut batch)?;
+    view.context().store().write_batch(batch).await?;
+    view.post_save();
+
+    let blobs = view.prepare_checkpoint(u64::MAX).await?;
+    let mut txn_tracker = TransactionTracker::default();
+    view.apply_checkpoint(
+        PreparedCheckpoint {
+            blobs,
+            origin_cursors: Vec::new(),
+            inbox_cursors: Vec::new(),
+            outbox_block_hashes: Vec::new(),
+        },
+        &mut txn_tracker,
+    )
+    .await?;
+    let outcome = txn_tracker.into_outcome()?;
+    let [OracleResponse::Checkpoint { used_blobs, .. }] = outcome.oracle_responses.as_slice()
+    else {
+        anyhow::bail!("expected a single checkpoint oracle response");
+    };
+    Ok(used_blobs.clone())
+}
+
 #[tokio::test]
-async fn used_blobs_expire_after_two_unused_epochs() -> anyhow::Result<()> {
+async fn used_blobs_expire_after_two_unused_checkpoints() -> anyhow::Result<()> {
     let mut view = SystemExecutionState {
         description: Some(dummy_chain_description(0)),
-        epoch: Epoch(5),
         ..SystemExecutionState::default()
     }
     .into_view()
@@ -459,24 +491,23 @@ async fn used_blobs_expire_after_two_unused_epochs() -> anyhow::Result<()> {
     let mut txn_tracker = TransactionTracker::default();
 
     // The first use of each blob creates an oracle response; a repeated use in the
-    // same epoch does not.
+    // same generation does not.
     assert!(view.system.blob_used(&mut txn_tracker, hot_blob).await?);
     assert!(view.system.blob_used(&mut txn_tracker, cold_blob).await?);
     assert!(!view.system.blob_used(&mut txn_tracker, hot_blob).await?);
 
-    // Epoch 6: both blobs are still known, having been used in the previous epoch.
-    // Using the hot blob re-records it under the current epoch.
-    view.system.advance_epoch(Epoch(6)).await?;
-    assert!(!view.system.blob_used(&mut txn_tracker, hot_blob).await?);
+    // First checkpoint: both blobs were used since the chain's creation, so the
+    // checkpoint lists both and keeps their records. Using the hot blob afterwards
+    // re-records it under the new generation without a new oracle response.
     let mut expected = vec![hot_blob, cold_blob];
     expected.sort();
-    assert_eq!(view.system.used_blob_ids().await?, expected);
+    assert_eq!(checkpoint_used_blobs(&mut view).await?, expected);
+    assert!(!view.system.blob_used(&mut txn_tracker, hot_blob).await?);
 
-    // Epoch 7: the hot blob was refreshed in epoch 6 and survives, while the cold
-    // blob was last used in epoch 5 and is forgotten, so using it again requires a
-    // new oracle response.
-    view.system.advance_epoch(Epoch(7)).await?;
-    assert_eq!(view.system.used_blob_ids().await?, vec![hot_blob]);
+    // Second checkpoint: the refreshed hot blob survives, while the cold blob's
+    // last recorded use predates the previous checkpoint, so it is forgotten and
+    // using it again requires a new oracle response.
+    assert_eq!(checkpoint_used_blobs(&mut view).await?, vec![hot_blob]);
     assert!(!view.system.blob_used(&mut txn_tracker, hot_blob).await?);
     assert!(view.system.blob_used(&mut txn_tracker, cold_blob).await?);
 


### PR DESCRIPTION
## Motivation

The set of blobs used or published on a chain only ever grows, and every checkpoint embeds the full list in its oracle response, so both the chain state and the checkpoint block size grow with the chain's entire lifetime.

## Proposal

Instead, store the epoch in which each blob's use was last recorded: every use re-records the blob under the current epoch, so a blob recorded in the current or previous epoch is readable without an oracle call, while a blob that goes unrecorded for two consecutive epochs is forgotten and reading it again becomes an oracle request. Stale entries are removed when the chain advances its epoch, bounding the state by recent activity.

## Test Plan

A unit test was added.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
