### PR TITLE
Reimplement `ChainClient::sync_validator` on top of ValidatorUpdater

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1636,6 +1636,7 @@ Pushes the current chain state from local storage to a validator node, ensuring 
 
 * `--chains <CHAINS>` — Chain IDs to synchronize (defaults to all chains in wallet)
 * `--check-online` — Verify validator is online before syncing
+* `--public-key <PUBLIC_KEY>` — Public key of the validator, used to verify its responses. Defaults to the key registered for this network address in the current committee; required if the validator is not (yet) a committee member
 
 
 

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -75,7 +75,7 @@ use crate::{
         ValidatorNodeProvider as _,
     },
     remote_node::RemoteNode,
-    updater::{communicate_with_quorum, CommunicateAction, CommunicationError},
+    updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
     worker::{Notification, Reason, WorkerError},
 };
 
@@ -3462,67 +3462,31 @@ impl<Env: Environment> ChainClient<Env> {
         Ok(validator_tasks.collect())
     }
 
-    /// Attempts to update a validator with the local information.
-    #[instrument(level = "trace", skip(remote_node))]
-    pub async fn sync_validator(&self, remote_node: Env::ValidatorNode) -> Result<(), Error> {
-        let validator_next_block_height = match remote_node
-            .handle_chain_info_query(ChainInfoQuery::new(self.chain_id))
-            .await
-        {
-            Ok(info) => info.info.next_block_height,
-            // The validator doesn't have this chain's description blob yet.
-            Err(NodeError::BlobsNotFound(_)) => BlockHeight::ZERO,
-            Err(err) => return Err(err.into()),
-        };
+    /// Attempts to update a validator with the local information: sends any confirmed
+    /// block certificates the validator is missing, along with the blobs and other
+    /// chains' blocks they depend on, and evidence for the current consensus round.
+    ///
+    /// The public key is used to verify the validator's responses.
+    #[instrument(level = "trace", skip(node))]
+    pub async fn sync_validator(
+        &self,
+        public_key: ValidatorPublicKey,
+        node: Env::ValidatorNode,
+    ) -> Result<(), Error> {
         let local_next_block_height = self.chain_info().await?.next_block_height;
-
-        if validator_next_block_height >= local_next_block_height {
-            debug!("Validator is up-to-date with local state");
-            return Ok(());
-        }
-
-        let heights = (validator_next_block_height.0..local_next_block_height.0)
-            .map(BlockHeight)
-            .collect::<Vec<_>>();
-
-        let certificates = self
-            .client
-            .storage_client()
-            .read_certificates_by_heights(self.chain_id, &heights)
-            .await?
-            .into_iter()
-            .flatten();
-
-        for certificate in certificates {
-            let missing_blob_ids = match remote_node
-                .handle_confirmed_certificate(
-                    certificate.clone(),
-                    CrossChainMessageDelivery::NonBlocking,
-                )
-                .await
-            {
-                Ok(_) => continue,
-                Err(NodeError::BlobsNotFound(missing_blob_ids)) => missing_blob_ids,
-                Err(err) => return Err(err.into()),
-            };
-            // The validator is missing blobs the certificate depends on
-            // (including possibly the chain description). Upload and retry.
-            let missing_blobs = self
-                .client
-                .storage_client()
-                .read_blobs(&missing_blob_ids)
-                .await?
-                .into_iter()
-                .flatten()
-                .map(|b| b.into_std())
-                .collect();
-            remote_node.upload_blobs(missing_blobs).await?;
-            remote_node
-                .handle_confirmed_certificate(certificate, CrossChainMessageDelivery::NonBlocking)
-                .await?;
-        }
-
-        Ok(())
+        let mut updater = ValidatorUpdater {
+            remote_node: RemoteNode { public_key, node },
+            client: self.client.clone(),
+            admin_chain_id: self.client.admin_chain_id,
+        };
+        updater
+            .send_chain_information(
+                self.chain_id,
+                local_next_block_height,
+                CrossChainMessageDelivery::NonBlocking,
+                None,
+            )
+            .await
     }
 }
 

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -236,6 +236,11 @@ pub struct Sync {
     /// Verify validator is online before syncing
     #[arg(long)]
     check_online: bool,
+    /// Public key of the validator, used to verify its responses. Defaults to the key
+    /// registered for this network address in the current committee; required if the
+    /// validator is not (yet) a committee member.
+    #[arg(long)]
+    public_key: Option<ValidatorPublicKey>,
 }
 
 /// Parse a batch operations file or stdin.
@@ -844,12 +849,33 @@ impl Sync {
         let node_provider = context.make_node_provider();
         let validator = node_provider.make_node(&self.address)?;
 
+        // The validator's public key, to verify its responses: either given explicitly
+        // or looked up in the current committee by network address.
+        let public_key = match self.public_key {
+            Some(public_key) => public_key,
+            None => {
+                let admin_chain = context.make_chain_client(context.admin_chain_id()).await?;
+                let (_, committee) = admin_chain.admin_committee().await?;
+                let public_key = committee
+                    .validator_addresses()
+                    .find(|(_, address)| *address == self.address)
+                    .map(|(public_key, _)| public_key);
+                public_key.with_context(|| {
+                    format!(
+                        "validator {} is not in the current committee; \
+                         use --public-key to sync it",
+                        self.address
+                    )
+                })?
+            }
+        };
+
         // Sync each chain
         for chain_id in chains_to_sync {
             tracing::info!("Syncing chain {} to {}", chain_id, self.address);
             let chain = context.make_chain_client(chain_id).await?;
 
-            Box::pin(chain.sync_validator(validator.clone())).await?;
+            Box::pin(chain.sync_validator(public_key, validator.clone())).await?;
             tracing::info!("Chain {} synced successfully", chain_id);
         }
 


### PR DESCRIPTION
## Motivation

`ChainClient::sync_validator` is a from-scratch reimplementation of "bring a validator up to date with a chain".

## Proposal

Replace its body with a call to `ValidatorUpdater::send_chain_information`, which also gains it upload batching, the lite-certificate fast path, checkpoint push, admin-chain healing, round-evidence sync, and response verification.

The verification requires the validator's public key: `linera validator sync` now resolves it from the current committee by network address, or takes it via a new optional `--public-key` argument for validators that are not (yet) committee members.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
