### PR TITLE
Remove linera-bridge image push step from bridge workflow

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -148,12 +148,6 @@ jobs:
             linera-bridge:latest
             ${{ github.event_name != 'workflow_dispatch' && format('{0}/linera-bridge:{1}', env.GCP_REGISTRY, github.base_ref || github.ref_name) || '' }}
 
-      - name: Push bridge image to registry
-        if: steps.build-bridge.outcome == 'success' && github.event_name != 'workflow_dispatch'
-        run: |
-          BRANCH="${{ github.base_ref || github.ref_name }}"
-          docker push "${GCP_REGISTRY}/linera-bridge:${BRANCH}"
-
       - name: Build evm-bridge Wasm module
         run: cargo build --release --target wasm32-unknown-unknown
         working-directory: linera-bridge/contracts/evm-bridge


### PR DESCRIPTION
## Motivation

We're in the process of extracting linera-bridge to a separate repo.

## Proposal

Removed step to push bridge image to registry based on build outcome.


## Test Plan

Manual

## Release Plan

None

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
