### PR TITLE
Remove image push step from CI workflow

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -100,11 +100,6 @@ jobs:
             linera-bridge:latest
             ${{ github.event_name == 'push' && format('{0}/linera-bridge:{1}', env.GCP_REGISTRY, github.ref_name) || '' }}
 
-      - name: Push bridge image to registry
-        if: steps.build-bridge.outcome == 'success' && github.event_name == 'push'
-        run: |
-          docker push "${GCP_REGISTRY}/linera-bridge:${{ github.ref_name }}"
-
       - name: Build evm-bridge Wasm module
         run: cargo build --locked --release --target wasm32-unknown-unknown
         working-directory: linera-bridge/contracts/evm-bridge


### PR DESCRIPTION
## Motivation

We will be pushing from a separate repo

## Proposal

Removed step to push bridge image to registry after build.

## Test Plan

None

## Release Plan

- Nothing to do 

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
