### PR TITLE
feat(base): derive PartialOrd/Ord for Account

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -124,6 +124,8 @@ impl From<CryptoHash> for AccountOwner {
     Debug,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     Hash,
     Copy,
     Clone,


### PR DESCRIPTION
## Motivation

Since removal of `Account` the sdk the `linera-base` version is left without `Ord` and `PartialOrd` impls. This breaks some usage in `pm-app`.

## Proposal

Lets applications key ordered collections (`BTreeSet`/`BTreeMap`) by account. Both fields already implement `Ord`.

## Test Plan

CI

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
