### PR TITLE
Rebuild the web client in `make demo-frontend`

### DIFF
--- a/linera-bridge/Makefile
+++ b/linera-bridge/Makefile
@@ -113,8 +113,8 @@ down: ## Stop the bridge docker compose network and remove volumes
 demo-setup: ## Run the bridge demo setup script (deploy contracts + Linera apps)
 	cd $(DEMO_DIR) && bash setup.sh --compose-file $(CURDIR)/$(COMPOSE_FILE)
 
-demo-frontend: ## Install deps and start the Vite dev server
-	cd $(DEMO_DIR) && pnpm install && pnpm dev
+demo-frontend: ## Install deps, rebuild the web client, and start the Vite dev server
+	cd $(DEMO_DIR) && pnpm install && pnpm --filter @linera/client build && pnpm dev
 
 demo-logs: ## Tail logs from the relay service
 	docker compose -f $(COMPOSE_FILE) -p $(PROJECT) logs -f linera-relay


### PR DESCRIPTION
## Motivation

Unexpectedly, running `make demo-frontend` didn't always rebuild the linera wasm client

## Proposal

pnpm only runs a workspace dependency's `prepare` script on first install, so `@linera/client`'s wasm went stale and failed to deserialize certificates from newer validators ("Unexpected certificate value"). Build it explicitly before starting Vite.

## Test Plan

Manual

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
