### PR TITLE
linera-core: extract the confirmed-certificate sender from ValidatorUpdater

### DIFF
--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -33,7 +33,8 @@ pub mod worker;
 pub(crate) mod updater;
 
 pub use local_node::LocalNodeError;
-pub use updater::DEFAULT_QUORUM_GRACE_PERIOD;
+pub use remote_node::RemoteNode;
+pub use updater::{confirmed_sender::ConfirmedCertificateSender, DEFAULT_QUORUM_GRACE_PERIOD};
 
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};
 

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -34,7 +34,10 @@ pub(crate) mod updater;
 
 pub use local_node::LocalNodeError;
 pub use remote_node::RemoteNode;
-pub use updater::{confirmed_sender::ConfirmedCertificateSender, DEFAULT_QUORUM_GRACE_PERIOD};
+pub use updater::{
+    confirmed_sender::{ConfirmedCertificateSender, LocalChainState},
+    DEFAULT_QUORUM_GRACE_PERIOD,
+};
 
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};
 

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -33,11 +33,7 @@ pub mod worker;
 pub(crate) mod updater;
 
 pub use local_node::LocalNodeError;
-pub use remote_node::RemoteNode;
-pub use updater::{
-    confirmed_sender::{ConfirmedCertificateSender, LocalChainState},
-    DEFAULT_QUORUM_GRACE_PERIOD,
-};
+pub use updater::DEFAULT_QUORUM_GRACE_PERIOD;
 
 pub use crate::join_set_ext::{JoinSetExt, TaskHandle};
 

--- a/linera-core/src/remote_node.rs
+++ b/linera-core/src/remote_node.rs
@@ -29,7 +29,9 @@ use crate::{
 /// A validator node together with the validator's name.
 #[derive(Clone, Debug)]
 pub struct RemoteNode<N> {
+    /// The validator's public key.
     pub public_key: ValidatorPublicKey,
+    /// The client used to communicate with the validator node.
     #[debug(skip)]
     pub node: N,
 }
@@ -197,6 +199,8 @@ impl<N: ValidatorNode> RemoteNode<N> {
         Ok(())
     }
 
+    /// Downloads a blob from the validator, returning `None` if the validator does not have it
+    /// or returns an invalid blob.
     #[instrument(level = "trace")]
     pub async fn download_blob(&self, blob_id: BlobId) -> Result<Option<Blob>, NodeError> {
         match self.node.download_blob(blob_id).await {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -12,7 +12,7 @@ use std::{
 
 use futures::{future, Future, StreamExt};
 use linera_base::{
-    crypto::ValidatorPublicKey,
+    crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{BlockHeight, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, ChainId},
@@ -35,11 +35,50 @@ use crate::{
     environment::Environment,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
-    updater::confirmed_sender::ConfirmedCertificateSender,
+    updater::confirmed_sender::{ConfirmedCertificateSender, LocalChainState},
     LocalNodeError,
 };
 
 pub(crate) mod confirmed_sender;
+
+/// Answers chain-level queries through the local worker, which owns the chain state views.
+struct WorkerChainState<Env: Environment> {
+    client: Arc<Client<Env>>,
+}
+
+impl<Env: Environment> Clone for WorkerChainState<Env> {
+    fn clone(&self) -> Self {
+        WorkerChainState {
+            client: self.client.clone(),
+        }
+    }
+}
+
+impl<Env: Environment> LocalChainState for WorkerChainState<Env> {
+    async fn next_block_height(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        Ok(self
+            .client
+            .local_node
+            .chain_info(chain_id)
+            .await?
+            .next_block_height)
+    }
+
+    async fn block_hashes(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> Result<Vec<CryptoHash>, chain_client::Error> {
+        Ok(self
+            .client
+            .local_node
+            .get_block_hashes(chain_id, heights)
+            .await?)
+    }
+}
 
 /// The default amount of time we wait for additional validators to contribute
 /// to the result, as a fraction of how long it took to reach a quorum.
@@ -663,10 +702,13 @@ where
     /// neither the wallet, the signer, nor the local worker.
     fn confirmed_certificate_sender(
         &self,
-    ) -> ConfirmedCertificateSender<Env::Storage, Env::ValidatorNode> {
+    ) -> ConfirmedCertificateSender<Env::Storage, Env::ValidatorNode, WorkerChainState<Env>> {
         ConfirmedCertificateSender::new(
             self.client.local_node.storage_client(),
             self.remote_node.clone(),
+            WorkerChainState {
+                client: self.client.clone(),
+            },
             self.admin_chain_id,
             self.client.options().certificate_upload_batch_size,
         )

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -12,7 +12,7 @@ use std::{
 
 use futures::{future, Future, StreamExt};
 use linera_base::{
-    crypto::{CryptoHash, ValidatorPublicKey},
+    crypto::ValidatorPublicKey,
     data_types::{BlockHeight, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, ChainId},
@@ -35,50 +35,11 @@ use crate::{
     environment::Environment,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
-    updater::confirmed_sender::{ConfirmedCertificateSender, LocalChainState},
+    updater::confirmed_sender::ConfirmedCertificateSender,
     LocalNodeError,
 };
 
 pub(crate) mod confirmed_sender;
-
-/// Answers chain-level queries through the local worker, which owns the chain state views.
-struct WorkerChainState<Env: Environment> {
-    client: Arc<Client<Env>>,
-}
-
-impl<Env: Environment> Clone for WorkerChainState<Env> {
-    fn clone(&self) -> Self {
-        WorkerChainState {
-            client: self.client.clone(),
-        }
-    }
-}
-
-impl<Env: Environment> LocalChainState for WorkerChainState<Env> {
-    async fn next_block_height(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<BlockHeight, chain_client::Error> {
-        Ok(self
-            .client
-            .local_node
-            .chain_info(chain_id)
-            .await?
-            .next_block_height)
-    }
-
-    async fn block_hashes(
-        &self,
-        chain_id: ChainId,
-        heights: Vec<BlockHeight>,
-    ) -> Result<Vec<CryptoHash>, chain_client::Error> {
-        Ok(self
-            .client
-            .local_node
-            .get_block_hashes(chain_id, heights)
-            .await?)
-    }
-}
 
 /// The default amount of time we wait for additional validators to contribute
 /// to the result, as a fraction of how long it took to reach a quorum.
@@ -702,13 +663,10 @@ where
     /// neither the wallet, the signer, nor the local worker.
     fn confirmed_certificate_sender(
         &self,
-    ) -> ConfirmedCertificateSender<Env::Storage, Env::ValidatorNode, WorkerChainState<Env>> {
+    ) -> ConfirmedCertificateSender<Env::Storage, Env::ValidatorNode> {
         ConfirmedCertificateSender::new(
-            self.client.local_node.storage_client(),
             self.remote_node.clone(),
-            WorkerChainState {
-                client: self.client.clone(),
-            },
+            self.client.local_node.clone(),
             self.admin_chain_id,
             self.client.options().certificate_upload_batch_size,
         )

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -20,7 +20,6 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, LiteVote},
-    manager::LockingBlock,
     types::{ConfirmedBlock, GenericCertificate, ValidatedBlock, ValidatedBlockCertificate},
 };
 use linera_execution::committee::Committee;
@@ -36,7 +35,6 @@ use crate::{
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
     updater::confirmed_sender::ConfirmedCertificateSender,
-    LocalNodeError,
 };
 
 pub(crate) mod confirmed_sender;
@@ -671,6 +669,7 @@ where
             self.client.options().certificate_upload_batch_size,
         )
         .with_height_index_backfill()
+        .with_consensus_round_sync()
     }
 
     /// Sends chain information to bring a validator up to date with a specific chain.
@@ -726,128 +725,9 @@ where
         delivery: CrossChainMessageDelivery,
         latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
-        // Phase 1: Height synchronization (delegated to the reusable, storage-only primitive).
-        let info = self
-            .confirmed_certificate_sender()
+        self.confirmed_certificate_sender()
             .send_confirmed_chain(chain_id, target_block_height, delivery, latest_certificate)
             .await?;
-
-        // Phase 2: Round synchronization (if needed)
-        // Height synchronization is complete. Now check if we need to synchronize
-        // the consensus round at this height.
-        let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
-        let query = ChainInfoQuery::new(chain_id).with_manager_values();
-        let local_info = match self.client.local_node.handle_chain_info_query(query).await {
-            Ok(response) => response.info,
-            // If we don't have the full chain description locally, we can't help the
-            // validator with round synchronization. This is not an error - the validator
-            // should retry later once the chain is fully initialized locally.
-            Err(LocalNodeError::BlobsNotFound(_)) => {
-                tracing::debug!("local chain description not fully available, skipping round sync");
-                return Ok(());
-            }
-            Err(error) => return Err(error.into()),
-        };
-
-        let manager = local_info.manager;
-        if local_info.next_block_height != remote_height || manager.current_round <= remote_round {
-            return Ok(());
-        }
-
-        // Validator is at our height but behind on consensus round
-        self.sync_consensus_round(remote_round, &manager).await
-    }
-
-    /// Synchronizes the consensus round state with the validator.
-    ///
-    /// If the validator is at the same height but an earlier round, sends the evidence
-    /// (proposal, validated block, or timeout certificate) that justifies the current round.
-    ///
-    /// This is a best-effort operation - failures are logged but don't fail the entire sync.
-    async fn sync_consensus_round(
-        &self,
-        remote_round: Round,
-        manager: &linera_chain::manager::ChainManagerInfo,
-    ) -> Result<(), chain_client::Error> {
-        let target_round = manager.current_round;
-
-        // First, push the locking certificate if it justifies our current round. A
-        // locking block from an earlier round is not enough on its own to advance the
-        // remote: the remote may still be ahead via a timeout or signed proposal, and
-        // pushing a stale lock would not move them. Push only the current-round lock.
-        if let Some(LockingBlock::Regular(validated)) = manager.requested_locking.as_deref() {
-            if validated.round == target_round {
-                match self
-                    .remote_node
-                    .handle_optimized_validated_certificate(
-                        validated,
-                        CrossChainMessageDelivery::NonBlocking,
-                    )
-                    .await
-                {
-                    Ok(info) => {
-                        tracing::debug!("successfully sent validated block for round sync");
-                        if info.manager.current_round >= target_round {
-                            return Ok(());
-                        }
-                    }
-                    Err(error) => {
-                        tracing::debug!(%error, "failed to send validated block");
-                    }
-                }
-            }
-        }
-
-        // Try to send a timeout certificate. The remote applies `next_round(cert.round)`
-        // to its current round, which (for the cert we hold) lands at our current round.
-        if let Some(cert) = &manager.timeout {
-            if cert.round >= remote_round {
-                match self
-                    .remote_node
-                    .handle_timeout_certificate(cert.as_ref().clone())
-                    .await
-                {
-                    Ok(info) => {
-                        tracing::debug!(round = %cert.round, "successfully sent timeout certificate");
-                        if info.manager.current_round >= target_round {
-                            return Ok(());
-                        }
-                    }
-                    Err(error) => {
-                        tracing::debug!(%error, round = %cert.round, "failed to send timeout certificate");
-                    }
-                }
-            }
-        }
-
-        // Finally, try to push a proposal at the current round.
-        for proposal in manager
-            .requested_proposed
-            .iter()
-            .chain(manager.requested_signed_proposal.iter())
-        {
-            if proposal.content.round == target_round {
-                match self
-                    .remote_node
-                    .handle_block_proposal(proposal.clone())
-                    .await
-                {
-                    Ok(info) => {
-                        tracing::debug!("successfully sent block proposal for round sync");
-                        if info.manager.current_round >= target_round {
-                            return Ok(());
-                        }
-                    }
-                    Err(error) => {
-                        tracing::debug!(%error, "failed to send block proposal");
-                    }
-                }
-            }
-        }
-
-        // If we reach here, either we had no round sync data to send, or all attempts failed.
-        // This is not a fatal error - height sync succeeded which is the primary goal.
-        tracing::debug!("round sync not performed: no applicable data or all attempts failed");
         Ok(())
     }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -15,7 +15,7 @@ use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{BlockHeight, Round, TimeDelta},
     ensure,
-    identifiers::{BlobId, BlobType, ChainId, StreamId},
+    identifiers::{BlobId, ChainId},
     time::{timer::timeout, Duration, Instant},
 };
 use linera_chain::{
@@ -23,11 +23,11 @@ use linera_chain::{
     manager::LockingBlock,
     types::{ConfirmedBlock, GenericCertificate, ValidatedBlock, ValidatedBlockCertificate},
 };
-use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
-use linera_storage::{Arc as CacheArc, Clock, ResultReadCertificates, Storage};
+use linera_execution::committee::Committee;
+use linera_storage::{Arc as CacheArc, Clock, Storage};
 use thiserror::Error;
 use tokio::sync::mpsc;
-use tracing::{instrument, Level};
+use tracing::instrument;
 
 use crate::{
     client::{chain_client, Client},
@@ -35,8 +35,11 @@ use crate::{
     environment::Environment,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
+    updater::confirmed_sender::ConfirmedCertificateSender,
     LocalNodeError,
 };
+
+pub(crate) mod confirmed_sender;
 
 /// The default amount of time we wait for additional validators to contribute
 /// to the result, as a fraction of how long it took to reach a quorum.
@@ -253,67 +256,6 @@ where
                 %err,
                 "unexpected error from validator",
             );
-        }
-    }
-
-    #[instrument(
-        level = "trace", skip_all, err(level = Level::DEBUG),
-        fields(chain_id = %certificate.block().header.chain_id)
-    )]
-    async fn send_confirmed_certificate(
-        &mut self,
-        certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<Box<ChainInfo>, chain_client::Error> {
-        let mut result = self
-            .remote_node
-            .handle_optimized_confirmed_certificate(certificate, delivery)
-            .await;
-
-        let mut sent_admin_chain = false;
-        let mut sent_blobs = false;
-        loop {
-            match result {
-                Err(NodeError::EventsNotFound(event_ids))
-                    if !sent_admin_chain
-                        && certificate.inner().chain_id() != self.admin_chain_id
-                        && event_ids.iter().all(|event_id| {
-                            event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
-                                && event_id.chain_id == self.admin_chain_id
-                        }) =>
-                {
-                    // The validator doesn't have the committee that signed the certificate.
-                    self.update_admin_chain().await?;
-                    sent_admin_chain = true;
-                }
-                Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
-                    // The validator is missing the blobs required by the certificate.
-                    self.remote_node
-                        .check_blobs_not_found(certificate, &blob_ids)?;
-                    // The certificate is confirmed, so the blobs must be in storage.
-                    let maybe_blobs = self
-                        .client
-                        .local_node
-                        .read_blobs_from_storage(&blob_ids)
-                        .await?;
-                    let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
-                    self.remote_node
-                        .node
-                        .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
-                        .await?;
-                    sent_blobs = true;
-                }
-                result => {
-                    if let Err(err) = &result {
-                        self.warn_if_unexpected(err);
-                    }
-                    return Ok(result?);
-                }
-            }
-            result = self
-                .remote_node
-                .handle_confirmed_certificate(certificate.clone(), delivery)
-                .await;
         }
     }
 
@@ -699,11 +641,12 @@ where
                         .await?;
 
                     tracing::debug!("Sending chains for missing blobs");
-                    self.send_chain_info_for_blobs(
-                        &missing_blob_ids,
-                        CrossChainMessageDelivery::NonBlocking,
-                    )
-                    .await?;
+                    self.confirmed_certificate_sender()
+                        .send_chain_info_for_blobs(
+                            &missing_blob_ids,
+                            CrossChainMessageDelivery::NonBlocking,
+                        )
+                        .await?;
                 }
                 // Fail immediately on other errors.
                 Err(err) => {
@@ -714,19 +657,20 @@ where
         }
     }
 
-    async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
-        let local_admin_info = self
-            .client
-            .local_node
-            .chain_info(self.admin_chain_id)
-            .await?;
-        Box::pin(self.send_chain_information(
+    /// Builds a [`ConfirmedCertificateSender`] for this updater's target validator.
+    ///
+    /// The sender reads confirmed blocks and their dependencies straight from storage, so it needs
+    /// neither the wallet, the signer, nor the local worker.
+    fn confirmed_certificate_sender(
+        &self,
+    ) -> ConfirmedCertificateSender<Env::Storage, Env::ValidatorNode> {
+        ConfirmedCertificateSender::new(
+            self.client.local_node.storage_client(),
+            self.remote_node.clone(),
             self.admin_chain_id,
-            local_admin_info.next_block_height,
-            CrossChainMessageDelivery::NonBlocking,
-            None,
-        ))
-        .await
+            self.client.options().certificate_upload_batch_size,
+        )
+        .with_height_index_backfill()
     }
 
     /// Sends chain information to bring a validator up to date with a specific chain.
@@ -738,7 +682,7 @@ where
     ///    for the current consensus round.
     ///
     /// Only certificates that are actually in our local storage are sent; heights we don't have are
-    /// silently skipped (see [`Self::read_certificates_for_heights`]). This is deliberate and is what
+    /// silently skipped (see [`ConfirmedCertificateSender`]). This is deliberate and is what
     /// makes the "leave gaps on the validator side" behavior (#4181) work: a chain we merely *receive*
     /// from is stored only at its message-bearing heights, so we push exactly those. The validator
     /// executes the contiguous prefix and preprocesses any block that sits above a gap — enough to
@@ -782,13 +726,11 @@ where
         delivery: CrossChainMessageDelivery,
         latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<(), chain_client::Error> {
-        // Phase 1: Height synchronization
-        let info = if target_block_height.0 > 0 {
-            self.sync_chain_height(chain_id, target_block_height, delivery, latest_certificate)
-                .await?
-        } else {
-            self.initialize_new_chain_on_validator(chain_id).await?
-        };
+        // Phase 1: Height synchronization (delegated to the reusable, storage-only primitive).
+        let info = self
+            .confirmed_certificate_sender()
+            .send_confirmed_chain(chain_id, target_block_height, delivery, latest_certificate)
+            .await?;
 
         // Phase 2: Round synchronization (if needed)
         // Height synchronization is complete. Now check if we need to synchronize
@@ -814,161 +756,6 @@ where
 
         // Validator is at our height but behind on consensus round
         self.sync_consensus_round(remote_round, &manager).await
-    }
-
-    /// Synchronizes a validator to a specific block height by sending the certificates we hold.
-    ///
-    /// Uses an optimistic approach: sends the last certificate first, then, based on the
-    /// validator's reported height, sends the earlier certificates in the range. Only the heights
-    /// we actually have in local storage are sent — any we're missing are silently skipped rather
-    /// than treated as an error, which is what leaves genuine gaps on the validator (see
-    /// [`Self::send_chain_information`] for why that is both safe and intended).
-    ///
-    /// Returns the [`ChainInfo`] from the validator after synchronization.
-    async fn sync_chain_height(
-        &mut self,
-        chain_id: ChainId,
-        target_block_height: BlockHeight,
-        delivery: CrossChainMessageDelivery,
-        latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
-    ) -> Result<Box<ChainInfo>, chain_client::Error> {
-        let height = target_block_height.try_sub_one()?;
-
-        // Get the certificate for the last block we want to send
-        let certificate = if let Some(cert) = latest_certificate {
-            cert
-        } else {
-            self.read_certificates_for_heights(chain_id, vec![height])
-                .await?
-                .into_iter()
-                .next()
-                .ok_or_else(|| {
-                    chain_client::Error::InternalError(
-                        "failed to read latest certificate for height sync",
-                    )
-                })?
-        };
-
-        // Optimistically try sending just the last certificate
-        let info = match self
-            .send_confirmed_certificate(&certificate, delivery)
-            .await
-        {
-            Ok(info) => info,
-            Err(error) => {
-                tracing::debug!(
-                    address = self.remote_node.address(), %error,
-                    "validator failed to handle confirmed certificate; sending whole chain",
-                );
-                let query = ChainInfoQuery::new(chain_id);
-                self.remote_node.handle_chain_info_query(query).await?
-            }
-        };
-
-        // Calculate which block heights the validator is still missing
-        let heights: Vec<_> = (info.next_block_height.0..target_block_height.0)
-            .map(BlockHeight)
-            .collect();
-
-        if heights.is_empty() {
-            return Ok(info);
-        }
-
-        let batch_size = self.client.options().certificate_upload_batch_size as usize;
-        for chunk in heights.chunks(batch_size) {
-            let certificates = self
-                .read_certificates_for_heights(chain_id, chunk.to_vec())
-                .await?;
-
-            for certificate in certificates {
-                self.send_confirmed_certificate(&certificate, delivery)
-                    .await?;
-            }
-        }
-
-        Ok(info)
-    }
-
-    /// Reads certificates for the given heights from local storage.
-    ///
-    /// First attempts to use the optimized `read_certificates_by_heights` method.
-    /// Falls back to the traditional `get_block_hashes` + `read_certificates` approach
-    /// if the direct height lookup doesn't return all certificates.
-    ///
-    /// When using the fallback, writes the discovered height->hash indices back to storage
-    /// so subsequent lookups can use the optimized path.
-    ///
-    /// Heights we don't have are silently dropped: the returned vector contains only the
-    /// certificates actually present, so callers naturally skip any block we never downloaded
-    /// (e.g. a sender's non-message-bearing blocks). Callers must not assume the result covers
-    /// every requested height.
-    async fn read_certificates_for_heights(
-        &self,
-        chain_id: ChainId,
-        heights: Vec<BlockHeight>,
-    ) -> Result<Vec<CacheArc<GenericCertificate<ConfirmedBlock>>>, chain_client::Error> {
-        let storage = self.client.local_node.storage_client();
-
-        // First, try the direct height-based lookup
-        let certificates_by_height = storage
-            .read_certificates_by_heights(chain_id, &heights)
-            .await?;
-
-        // Check if we got all certificates (no None values)
-        let all_found = certificates_by_height.len() == heights.len()
-            && certificates_by_height.iter().all(|c| c.is_some());
-
-        if all_found {
-            return Ok(certificates_by_height.into_iter().flatten().collect());
-        }
-
-        // Fallback to the traditional approach
-        let hashes = self
-            .client
-            .local_node
-            .get_block_hashes(chain_id, heights.clone())
-            .await?;
-
-        let certificates = storage.read_certificates(&hashes).await?;
-
-        match ResultReadCertificates::new(certificates, hashes.clone()) {
-            ResultReadCertificates::Certificates(certs) => {
-                // Write back the height->hash indices we learned from the fallback
-                let indices: Vec<_> = heights.into_iter().zip(hashes.clone()).collect();
-                storage
-                    .write_certificate_height_indices(chain_id, &indices)
-                    .await?;
-                Ok(certs
-                    .into_iter()
-                    .map(|c| storage.cache_certificate(c))
-                    .collect())
-            }
-            ResultReadCertificates::InvalidHashes(hashes) => {
-                Err(chain_client::Error::ReadCertificatesError(hashes))
-            }
-        }
-    }
-
-    /// Initializes a new chain on the validator by sending the chain description and dependencies.
-    ///
-    /// This is called when the validator doesn't know about the chain yet.
-    ///
-    /// Returns the [`ChainInfo`] from the validator after initialization.
-    async fn initialize_new_chain_on_validator(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<Box<ChainInfo>, chain_client::Error> {
-        // Send chain description and all dependency chains
-        self.send_chain_info_for_blobs(
-            &[BlobId::new(chain_id.0, BlobType::ChainDescription)],
-            CrossChainMessageDelivery::NonBlocking,
-        )
-        .await?;
-
-        // Query the validator's state for this chain
-        let query = ChainInfoQuery::new(chain_id);
-        let info = self.remote_node.handle_chain_info_query(query).await?;
-        Ok(info)
     }
 
     /// Synchronizes the consensus round state with the validator.
@@ -1061,76 +848,6 @@ where
         // If we reach here, either we had no round sync data to send, or all attempts failed.
         // This is not a fatal error - height sync succeeded which is the primary goal.
         tracing::debug!("round sync not performed: no applicable data or all attempts failed");
-        Ok(())
-    }
-
-    /// Sends chain information for all chains referenced by the given blobs.
-    ///
-    /// Reads blob states from storage, determines the specific chain heights needed,
-    /// and sends chain information for those heights. With sparse chains, this only
-    /// sends the specific blocks containing the blobs, not all blocks up to those heights.
-    async fn send_chain_info_for_blobs(
-        &self,
-        blob_ids: &[BlobId],
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<(), chain_client::Error> {
-        let blob_states = self
-            .client
-            .local_node
-            .read_blob_states_from_storage(blob_ids)
-            .await?;
-
-        let mut chain_heights: BTreeMap<ChainId, BTreeSet<BlockHeight>> = BTreeMap::new();
-        for blob_state in blob_states {
-            let block_chain_id = blob_state.chain_id;
-            let block_height = blob_state.block_height;
-            chain_heights
-                .entry(block_chain_id)
-                .or_default()
-                .insert(block_height);
-        }
-
-        self.send_chain_info_at_heights(chain_heights, delivery)
-            .await
-    }
-
-    /// Sends the blocks at exactly the specified heights on multiple chains.
-    ///
-    /// Unlike [`Self::send_chain_info_up_to_heights`], this sends *only* the blocks at the given
-    /// heights, not the locally-held prefix leading up to them. Use it only when the required
-    /// blocks are fully self-describing to the validator — e.g. bringing over the specific blocks
-    /// that carry a set of blobs.
-    async fn send_chain_info_at_heights(
-        &self,
-        chain_heights: impl IntoIterator<Item = (ChainId, BTreeSet<BlockHeight>)>,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<(), chain_client::Error> {
-        future::try_join_all(chain_heights.into_iter().map(|(chain_id, heights)| {
-            let mut updater = self.clone();
-            async move {
-                // Get all block hashes for this chain at the specified heights in one call
-                let heights_vec = heights.into_iter().collect::<Vec<_>>();
-                let certificates = updater
-                    .client
-                    .local_node
-                    .storage_client()
-                    .read_certificates_by_heights(chain_id, &heights_vec)
-                    .await?
-                    .into_iter()
-                    .flatten()
-                    .collect::<Vec<_>>();
-
-                // Send each certificate
-                for certificate in certificates {
-                    updater
-                        .send_confirmed_certificate(&certificate, delivery)
-                        .await?;
-                }
-
-                Ok::<_, chain_client::Error>(())
-            }
-        }))
-        .await?;
         Ok(())
     }
 

--- a/linera-core/src/updater/confirmed_sender.rs
+++ b/linera-core/src/updater/confirmed_sender.rs
@@ -5,11 +5,12 @@
 //! validator.
 //!
 //! [`ConfirmedCertificateSender`] extracts the confirmed-certificate synchronization path out of
-//! [`crate::updater::ValidatorUpdater`] so it can be reused by clients that do not construct a
-//! full [`crate::client::Client`] or [`crate::local_node::LocalNodeClient`] (e.g. the block
-//! exporter). It operates directly on a [`Storage`] handle, a [`RemoteNode`], and the admin chain
-//! id, reusing the existing dependency-upload logic (missing blobs, missing epoch/committee events
-//! via the admin chain, and ancestor certificates).
+//! [`crate::updater::ValidatorUpdater`], which owns an [`crate::client::Client`], so that it can
+//! also be used where no client exists — in particular by the chain workers in the server binary,
+//! which push the blocks they execute to the other validators in the committee. It operates on a
+//! [`Storage`] handle, a [`RemoteNode`], and the admin chain id, reusing the existing
+//! dependency-upload logic (missing blobs, and missing epoch/committee events via the admin
+//! chain).
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -39,7 +40,7 @@ use crate::{
 /// while it is running: loading it elsewhere races with the worker and can corrupt data. Consumers
 /// therefore supply their own way to answer these queries — the client routes them through its
 /// local worker.
-pub trait LocalChainState {
+pub(crate) trait LocalChainState {
     /// Returns the next block height of the given chain, according to local state.
     async fn next_block_height(
         &self,
@@ -60,9 +61,9 @@ pub trait LocalChainState {
 /// needed.
 ///
 /// This is the confirmed-certificate synchronization path shared by the client's
-/// `ValidatorUpdater` and by out-of-crate consumers such as the block exporter.
-/// Certificates and blobs are read from `storage` directly, and the remaining chain-level queries
-/// go through [`LocalChainState`], so this requires neither a wallet nor a signer.
+/// `ValidatorUpdater` and by the server's chain workers. Certificates and blobs are read from
+/// `storage` directly, and the remaining chain-level queries go through [`LocalChainState`], so
+/// this requires neither a client, a wallet, nor a signer.
 ///
 /// A confirmed certificate can be rejected by a validator that is missing one of the certificate's
 /// dependencies. This type reproduces the client's recovery logic:
@@ -72,7 +73,7 @@ pub trait LocalChainState {
 ///   from `storage` and uploaded.
 ///
 /// The certificate is then retried.
-pub struct ConfirmedCertificateSender<S, N, L> {
+pub(crate) struct ConfirmedCertificateSender<S, N, L> {
     storage: S,
     remote_node: RemoteNode<N>,
     local_chain_state: L,
@@ -111,7 +112,7 @@ where
     /// `admin_chain_id` identifies the chain whose epoch stream carries committee events.
     /// `certificate_upload_batch_size` bounds how many certificates are read and pushed per batch
     /// during height synchronization.
-    pub fn new(
+    pub(crate) fn new(
         storage: S,
         remote_node: RemoteNode<N>,
         local_chain_state: L,
@@ -132,7 +133,7 @@ where
     /// were only found through the block-hash-list fallback.
     ///
     /// This is meant for consumers that own the storage they read from. Consumers that merely read
-    /// another component's storage, such as the block exporter, must leave it disabled.
+    /// another component's storage must leave it disabled.
     pub(crate) fn with_height_index_backfill(mut self) -> Self {
         self.backfill_height_indices = true;
         self
@@ -154,7 +155,7 @@ where
     /// (`target_next_block_height == 0`) it sends the chain description and dependencies first, then
     /// queries the validator's state.
     #[instrument(level = "debug", skip_all, fields(%chain_id))]
-    pub async fn send_confirmed_chain(
+    pub(crate) async fn send_confirmed_chain(
         &mut self,
         chain_id: ChainId,
         target_next_block_height: BlockHeight,

--- a/linera-core/src/updater/confirmed_sender.rs
+++ b/linera-core/src/updater/confirmed_sender.rs
@@ -60,7 +60,7 @@ pub trait LocalChainState {
 /// needed.
 ///
 /// This is the confirmed-certificate synchronization path shared by the client's
-/// [`crate::updater::ValidatorUpdater`] and by out-of-crate consumers such as the block exporter.
+/// `ValidatorUpdater` and by out-of-crate consumers such as the block exporter.
 /// Certificates and blobs are read from `storage` directly, and the remaining chain-level queries
 /// go through [`LocalChainState`], so this requires neither a wallet nor a signer.
 ///
@@ -144,8 +144,7 @@ where
     ///
     /// This is the height-synchronization phase: it sends the certificates in storage for the range
     /// `[validator_next_height, target_next_block_height)`, in order. Only heights actually present
-    /// in storage are sent; missing heights are silently skipped (see
-    /// [`Self::read_certificates_for_heights`]). This is what makes the "leave gaps on the validator
+    /// in storage are sent; missing heights are silently skipped. This is what makes the "leave gaps on the validator
     /// side" behavior (#4181) work: a chain we merely *receive* from is stored only at its
     /// message-bearing heights, so exactly those are pushed. The validator executes the contiguous
     /// prefix and preprocesses any block that sits above a gap.

--- a/linera-core/src/updater/confirmed_sender.rs
+++ b/linera-core/src/updater/confirmed_sender.rs
@@ -16,7 +16,6 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use futures::future;
 use linera_base::{
-    crypto::CryptoHash,
     data_types::{Blob, BlockHeight},
     identifiers::{BlobId, BlobType, ChainId, StreamId},
 };
@@ -28,42 +27,19 @@ use tracing::{instrument, Level};
 use crate::{
     client::chain_client,
     data_types::{ChainInfo, ChainInfoQuery},
+    local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
     LocalNodeError,
 };
 
-/// Answers the few chain-level queries that cannot be served from the certificate, blob, and
-/// height-index partitions.
-///
-/// Those partitions can be read directly, but a chain's own state view is owned by the chain worker
-/// while it is running: loading it elsewhere races with the worker and can corrupt data. Consumers
-/// therefore supply their own way to answer these queries — the client routes them through its
-/// local worker.
-pub(crate) trait LocalChainState {
-    /// Returns the next block height of the given chain, according to local state.
-    async fn next_block_height(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<BlockHeight, chain_client::Error>;
-
-    /// Returns the hashes of the given chain's blocks at the given heights.
-    ///
-    /// Heights the chain does not have are omitted, so the result may be shorter than `heights`.
-    async fn block_hashes(
-        &self,
-        chain_id: ChainId,
-        heights: Vec<BlockHeight>,
-    ) -> Result<Vec<CryptoHash>, chain_client::Error>;
-}
-
 /// Pushes confirmed-block certificates to a single validator, uploading their dependencies as
 /// needed.
 ///
 /// This is the confirmed-certificate synchronization path shared by the client's
-/// `ValidatorUpdater` and by the server's chain workers. Certificates and blobs are read from
-/// `storage` directly, and the remaining chain-level queries go through [`LocalChainState`], so
-/// this requires neither a client, a wallet, nor a signer.
+/// `ValidatorUpdater` and by the server's chain workers. Certificates and blobs are read straight
+/// from storage, and the remaining chain-level queries go through the local worker, so this
+/// requires neither a client, a wallet, nor a signer.
 ///
 /// A confirmed certificate can be rejected by a validator that is missing one of the certificate's
 /// dependencies. This type reproduces the client's recovery logic:
@@ -73,26 +49,25 @@ pub(crate) trait LocalChainState {
 ///   from `storage` and uploaded.
 ///
 /// The certificate is then retried.
-pub(crate) struct ConfirmedCertificateSender<S, N, L> {
+pub(crate) struct ConfirmedCertificateSender<S: Storage, N> {
     storage: S,
     remote_node: RemoteNode<N>,
-    local_chain_state: L,
+    local_node: LocalNodeClient<S>,
     admin_chain_id: ChainId,
     certificate_upload_batch_size: u64,
     backfill_height_indices: bool,
 }
 
-impl<S, N, L> Clone for ConfirmedCertificateSender<S, N, L>
+impl<S, N> Clone for ConfirmedCertificateSender<S, N>
 where
-    S: Clone,
+    S: Storage + Clone,
     N: Clone,
-    L: Clone,
 {
     fn clone(&self) -> Self {
         ConfirmedCertificateSender {
             storage: self.storage.clone(),
             remote_node: self.remote_node.clone(),
-            local_chain_state: self.local_chain_state.clone(),
+            local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
             certificate_upload_batch_size: self.certificate_upload_batch_size,
             backfill_height_indices: self.backfill_height_indices,
@@ -100,29 +75,32 @@ where
     }
 }
 
-impl<S, N, L> ConfirmedCertificateSender<S, N, L>
+impl<S, N> ConfirmedCertificateSender<S, N>
 where
     S: Storage + Clone,
     N: ValidatorNode + Clone,
-    L: LocalChainState + Clone,
 {
     /// Creates a new sender targeting `remote_node`, reading confirmed blocks and their
-    /// dependencies from `storage`.
+    /// dependencies from the storage behind `local_node`.
+    ///
+    /// `local_node` also answers the few chain-level queries that the certificate, blob, and
+    /// height-index partitions cannot: those partitions can be read directly, but a chain's own
+    /// state view is owned by its chain worker while it is running, and loading it elsewhere races
+    /// with the worker. Routing them through the local worker is what avoids that.
     ///
     /// `admin_chain_id` identifies the chain whose epoch stream carries committee events.
     /// `certificate_upload_batch_size` bounds how many certificates are read and pushed per batch
     /// during height synchronization.
     pub(crate) fn new(
-        storage: S,
         remote_node: RemoteNode<N>,
-        local_chain_state: L,
+        local_node: LocalNodeClient<S>,
         admin_chain_id: ChainId,
         certificate_upload_batch_size: u64,
     ) -> Self {
         ConfirmedCertificateSender {
-            storage,
+            storage: local_node.storage_client(),
             remote_node,
-            local_chain_state,
+            local_node,
             admin_chain_id,
             certificate_upload_batch_size,
             backfill_height_indices: false,
@@ -274,9 +252,10 @@ where
     /// without a local worker.
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let admin_next_block_height = self
-            .local_chain_state
-            .next_block_height(self.admin_chain_id)
-            .await?;
+            .local_node
+            .chain_info(self.admin_chain_id)
+            .await?
+            .next_block_height;
         Box::pin(self.send_confirmed_chain(
             self.admin_chain_id,
             admin_next_block_height,
@@ -395,8 +374,8 @@ where
         }
 
         let hashes = self
-            .local_chain_state
-            .block_hashes(chain_id, heights.clone())
+            .local_node
+            .get_block_hashes(chain_id, heights.clone())
             .await?;
 
         let certificates = self.storage.read_certificates(&hashes).await?;

--- a/linera-core/src/updater/confirmed_sender.rs
+++ b/linera-core/src/updater/confirmed_sender.rs
@@ -16,10 +16,13 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use futures::future;
 use linera_base::{
-    data_types::{Blob, BlockHeight},
+    data_types::{Blob, BlockHeight, Round},
     identifiers::{BlobId, BlobType, ChainId, StreamId},
 };
-use linera_chain::types::{ConfirmedBlock, GenericCertificate};
+use linera_chain::{
+    manager::LockingBlock,
+    types::{ConfirmedBlock, GenericCertificate},
+};
 use linera_execution::{system::EPOCH_STREAM_NAME, BlobState};
 use linera_storage::{Arc as CacheArc, ResultReadCertificates, Storage};
 use tracing::{instrument, Level};
@@ -56,6 +59,7 @@ pub(crate) struct ConfirmedCertificateSender<S: Storage, N> {
     admin_chain_id: ChainId,
     certificate_upload_batch_size: u64,
     backfill_height_indices: bool,
+    sync_consensus_rounds: bool,
 }
 
 impl<S, N> Clone for ConfirmedCertificateSender<S, N>
@@ -71,6 +75,7 @@ where
             admin_chain_id: self.admin_chain_id,
             certificate_upload_batch_size: self.certificate_upload_batch_size,
             backfill_height_indices: self.backfill_height_indices,
+            sync_consensus_rounds: self.sync_consensus_rounds,
         }
     }
 }
@@ -104,7 +109,20 @@ where
             admin_chain_id,
             certificate_upload_batch_size,
             backfill_height_indices: false,
+            sync_consensus_rounds: false,
         }
+    }
+
+    /// Also synchronizes the validator's *consensus round* after its height, when it turns out to
+    /// be at our height but in an earlier round.
+    ///
+    /// Height synchronization delivers confirmed blocks; this additionally pushes the evidence
+    /// that justifies a later round — a locking certificate, a timeout certificate, or a proposal.
+    /// That is consensus participation rather than replication, so it is opt-in: the client wants
+    /// it, and a chain worker pushing the blocks it has executed does not.
+    pub(crate) fn with_consensus_round_sync(mut self) -> Self {
+        self.sync_consensus_rounds = true;
+        self
     }
 
     /// Enables writing `(chain_id, height) -> hash` indices back to storage for certificates that
@@ -140,17 +158,148 @@ where
         delivery: CrossChainMessageDelivery,
         latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
-        if target_next_block_height.0 > 0 {
+        let info = if target_next_block_height.0 > 0 {
             self.sync_chain_height(
                 chain_id,
                 target_next_block_height,
                 delivery,
                 latest_certificate,
             )
-            .await
+            .await?
         } else {
-            self.initialize_new_chain_on_validator(chain_id).await
+            self.initialize_new_chain_on_validator(chain_id).await?
+        };
+
+        if self.sync_consensus_rounds {
+            self.sync_round_at_height(chain_id, &info).await?;
         }
+        Ok(info)
+    }
+
+    /// Brings the validator's consensus round up to ours, if it is at our height but behind.
+    ///
+    /// Only reachable once height synchronization has finished, and it returns immediately unless
+    /// the validator's height already equals ours — so this can never be what delivers a block or
+    /// an event the validator was missing. It exists purely to unstick a round.
+    async fn sync_round_at_height(
+        &self,
+        chain_id: ChainId,
+        info: &ChainInfo,
+    ) -> Result<(), chain_client::Error> {
+        let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
+        let query = ChainInfoQuery::new(chain_id).with_manager_values();
+        let local_info = match self.local_node.handle_chain_info_query(query).await {
+            Ok(response) => response.info,
+            // If we don't have the full chain description locally, we can't help the
+            // validator with round synchronization. This is not an error - the validator
+            // should retry later once the chain is fully initialized locally.
+            Err(LocalNodeError::BlobsNotFound(_)) => {
+                tracing::debug!("local chain description not fully available, skipping round sync");
+                return Ok(());
+            }
+            Err(error) => return Err(error.into()),
+        };
+
+        let manager = local_info.manager;
+        if local_info.next_block_height != remote_height || manager.current_round <= remote_round {
+            return Ok(());
+        }
+
+        // Validator is at our height but behind on consensus round
+        self.sync_consensus_round(remote_round, &manager).await
+    }
+
+    /// Synchronizes the consensus round state with the validator.
+    ///
+    /// If the validator is at the same height but an earlier round, sends the evidence
+    /// (proposal, validated block, or timeout certificate) that justifies the current round.
+    ///
+    /// This is a best-effort operation - failures are logged but don't fail the entire sync.
+    async fn sync_consensus_round(
+        &self,
+        remote_round: Round,
+        manager: &linera_chain::manager::ChainManagerInfo,
+    ) -> Result<(), chain_client::Error> {
+        let target_round = manager.current_round;
+
+        // First, push the locking certificate if it justifies our current round. A
+        // locking block from an earlier round is not enough on its own to advance the
+        // remote: the remote may still be ahead via a timeout or signed proposal, and
+        // pushing a stale lock would not move them. Push only the current-round lock.
+        if let Some(LockingBlock::Regular(validated)) = manager.requested_locking.as_deref() {
+            if validated.round == target_round {
+                match self
+                    .remote_node
+                    .handle_optimized_validated_certificate(
+                        validated,
+                        CrossChainMessageDelivery::NonBlocking,
+                    )
+                    .await
+                {
+                    Ok(info) => {
+                        tracing::debug!("successfully sent validated block for round sync");
+                        if info.manager.current_round >= target_round {
+                            return Ok(());
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(%error, "failed to send validated block");
+                    }
+                }
+            }
+        }
+
+        // Try to send a timeout certificate. The remote applies `next_round(cert.round)`
+        // to its current round, which (for the cert we hold) lands at our current round.
+        if let Some(cert) = &manager.timeout {
+            if cert.round >= remote_round {
+                match self
+                    .remote_node
+                    .handle_timeout_certificate(cert.as_ref().clone())
+                    .await
+                {
+                    Ok(info) => {
+                        tracing::debug!(round = %cert.round, "successfully sent timeout certificate");
+                        if info.manager.current_round >= target_round {
+                            return Ok(());
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(%error, round = %cert.round, "failed to send timeout certificate");
+                    }
+                }
+            }
+        }
+
+        // Finally, try to push a proposal at the current round.
+        for proposal in manager
+            .requested_proposed
+            .iter()
+            .chain(manager.requested_signed_proposal.iter())
+        {
+            if proposal.content.round == target_round {
+                match self
+                    .remote_node
+                    .handle_block_proposal(proposal.clone())
+                    .await
+                {
+                    Ok(info) => {
+                        tracing::debug!("successfully sent block proposal for round sync");
+                        if info.manager.current_round >= target_round {
+                            return Ok(());
+                        }
+                    }
+                    Err(error) => {
+                        tracing::debug!(%error, "failed to send block proposal");
+                    }
+                }
+            }
+        }
+
+        // If we reach here, either we had no round sync data to send, or all attempts failed.
+        // This is not a fatal error - height sync succeeded which is the primary goal.
+        tracing::debug!("round sync not performed: no applicable data or all attempts failed");
+        Ok(())
     }
 
     /// Sends chain information for all chains referenced by the given blobs.
@@ -246,10 +395,9 @@ where
     /// storage.
     ///
     /// Called when the validator reports that it is missing the committee that signed a
-    /// certificate. Unlike the client's `ValidatorUpdater`, this performs only height
-    /// synchronization (no consensus-round synchronization), which is all that is required to
-    /// deliver the confirmed committee events and all that the storage-only primitive can do
-    /// without a local worker.
+    /// certificate. Committee events are emitted by *confirmed* blocks, so height synchronization
+    /// is what resolves the error; a consumer that opted into round synchronization gets that too,
+    /// unchanged from before this path was extracted.
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let admin_next_block_height = self
             .local_node

--- a/linera-core/src/updater/confirmed_sender.rs
+++ b/linera-core/src/updater/confirmed_sender.rs
@@ -1,0 +1,493 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A lightweight, reusable primitive for pushing confirmed-block certificates to a single
+//! validator.
+//!
+//! [`ConfirmedCertificateSender`] extracts the confirmed-certificate synchronization path out of
+//! [`crate::updater::ValidatorUpdater`] so it can be reused by clients that do not construct a
+//! full [`crate::client::Client`] or [`crate::local_node::LocalNodeClient`] (e.g. the block
+//! exporter). It operates directly on a [`Storage`] handle, a [`RemoteNode`], and the admin chain
+//! id, reusing the existing dependency-upload logic (missing blobs, missing epoch/committee events
+//! via the admin chain, and ancestor certificates).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use futures::future;
+use linera_base::{
+    data_types::{Blob, BlockHeight},
+    identifiers::{BlobId, BlobType, ChainId, StreamId},
+};
+use linera_chain::types::{ConfirmedBlock, GenericCertificate};
+use linera_execution::{system::EPOCH_STREAM_NAME, BlobState};
+use linera_storage::{Arc as CacheArc, ResultReadCertificates, Storage};
+use tracing::{instrument, Level};
+
+use crate::{
+    client::chain_client,
+    data_types::{ChainInfo, ChainInfoQuery},
+    node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
+    remote_node::RemoteNode,
+    LocalNodeError,
+};
+
+/// Pushes confirmed-block certificates to a single validator, uploading their dependencies as
+/// needed.
+///
+/// This is the confirmed-certificate synchronization path shared by the client's
+/// [`crate::updater::ValidatorUpdater`] and by out-of-crate consumers such as the block exporter.
+/// It reads everything it needs from `storage` directly, so it requires neither a wallet, a signer,
+/// nor a local worker.
+///
+/// A confirmed certificate can be rejected by a validator that is missing one of the certificate's
+/// dependencies. This type reproduces the client's recovery logic:
+/// - `EventsNotFound` for the admin chain's epoch stream means the validator does not yet know the
+///   committee that signed the certificate, so the admin chain's confirmed blocks are pushed.
+/// - `BlobsNotFound` means the validator is missing blobs the certificate requires, which are read
+///   from `storage` and uploaded.
+///
+/// The certificate is then retried.
+pub struct ConfirmedCertificateSender<S, N> {
+    storage: S,
+    remote_node: RemoteNode<N>,
+    admin_chain_id: ChainId,
+    certificate_upload_batch_size: u64,
+    backfill_height_indices: bool,
+}
+
+impl<S, N> Clone for ConfirmedCertificateSender<S, N>
+where
+    S: Clone,
+    N: Clone,
+{
+    fn clone(&self) -> Self {
+        ConfirmedCertificateSender {
+            storage: self.storage.clone(),
+            remote_node: self.remote_node.clone(),
+            admin_chain_id: self.admin_chain_id,
+            certificate_upload_batch_size: self.certificate_upload_batch_size,
+            backfill_height_indices: self.backfill_height_indices,
+        }
+    }
+}
+
+impl<S, N> ConfirmedCertificateSender<S, N>
+where
+    S: Storage + Clone,
+    N: ValidatorNode + Clone,
+{
+    /// Creates a new sender targeting `remote_node`, reading confirmed blocks and their
+    /// dependencies from `storage`.
+    ///
+    /// `admin_chain_id` identifies the chain whose epoch stream carries committee events.
+    /// `certificate_upload_batch_size` bounds how many certificates are read and pushed per batch
+    /// during height synchronization.
+    pub fn new(
+        storage: S,
+        remote_node: RemoteNode<N>,
+        admin_chain_id: ChainId,
+        certificate_upload_batch_size: u64,
+    ) -> Self {
+        ConfirmedCertificateSender {
+            storage,
+            remote_node,
+            admin_chain_id,
+            certificate_upload_batch_size,
+            backfill_height_indices: false,
+        }
+    }
+
+    /// Enables writing `(chain_id, height) -> hash` indices back to storage for certificates that
+    /// were only found through the block-hash-list fallback.
+    ///
+    /// This is meant for consumers that own the storage they read from. Consumers that merely read
+    /// another component's storage, such as the block exporter, must leave it disabled.
+    pub(crate) fn with_height_index_backfill(mut self) -> Self {
+        self.backfill_height_indices = true;
+        self
+    }
+
+    /// Synchronizes the validator to `target_next_block_height` by sending the confirmed
+    /// certificates held in storage for the chain, and returns the validator's [`ChainInfo`]
+    /// afterwards.
+    ///
+    /// This is the height-synchronization phase: it sends the certificates in storage for the range
+    /// `[validator_next_height, target_next_block_height)`, in order. Only heights actually present
+    /// in storage are sent; missing heights are silently skipped (see
+    /// [`Self::read_certificates_for_heights`]). This is what makes the "leave gaps on the validator
+    /// side" behavior (#4181) work: a chain we merely *receive* from is stored only at its
+    /// message-bearing heights, so exactly those are pushed. The validator executes the contiguous
+    /// prefix and preprocesses any block that sits above a gap.
+    ///
+    /// For an existing chain (`target_next_block_height > 0`) it optimistically sends the last
+    /// certificate first, then any earlier locally-held certificates in order. For a new chain
+    /// (`target_next_block_height == 0`) it sends the chain description and dependencies first, then
+    /// queries the validator's state.
+    #[instrument(level = "debug", skip_all, fields(%chain_id))]
+    pub async fn send_confirmed_chain(
+        &mut self,
+        chain_id: ChainId,
+        target_next_block_height: BlockHeight,
+        delivery: CrossChainMessageDelivery,
+        latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
+    ) -> Result<Box<ChainInfo>, chain_client::Error> {
+        if target_next_block_height.0 > 0 {
+            self.sync_chain_height(
+                chain_id,
+                target_next_block_height,
+                delivery,
+                latest_certificate,
+            )
+            .await
+        } else {
+            self.initialize_new_chain_on_validator(chain_id).await
+        }
+    }
+
+    /// Sends chain information for all chains referenced by the given blobs.
+    ///
+    /// Reads blob states from storage, determines the specific chain heights needed, and sends the
+    /// confirmed certificates at exactly those heights. With sparse chains, this only sends the
+    /// specific blocks containing the blobs, not all blocks up to those heights.
+    pub(crate) async fn send_chain_info_for_blobs(
+        &self,
+        blob_ids: &[BlobId],
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<(), chain_client::Error> {
+        let blob_states = self.read_blob_states_from_storage(blob_ids).await?;
+
+        let mut chain_heights: BTreeMap<ChainId, BTreeSet<BlockHeight>> = BTreeMap::new();
+        for blob_state in blob_states {
+            chain_heights
+                .entry(blob_state.chain_id)
+                .or_default()
+                .insert(blob_state.block_height);
+        }
+
+        self.send_chain_info_at_heights(chain_heights, delivery)
+            .await
+    }
+
+    /// Sends a single confirmed certificate to the validator, uploading its missing dependencies
+    /// (admin-chain committee events, blobs) and retrying as needed.
+    #[instrument(
+        level = "trace", skip_all, err(level = Level::DEBUG),
+        fields(chain_id = %certificate.block().header.chain_id)
+    )]
+    async fn send_confirmed_certificate(
+        &mut self,
+        certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<Box<ChainInfo>, chain_client::Error> {
+        let mut result = self
+            .remote_node
+            .handle_optimized_confirmed_certificate(certificate, delivery)
+            .await;
+
+        let mut sent_admin_chain = false;
+        let mut sent_blobs = false;
+        loop {
+            match result {
+                Err(NodeError::EventsNotFound(event_ids))
+                    if !sent_admin_chain
+                        && certificate.inner().chain_id() != self.admin_chain_id
+                        && event_ids.iter().all(|event_id| {
+                            event_id.stream_id == StreamId::system(EPOCH_STREAM_NAME)
+                                && event_id.chain_id == self.admin_chain_id
+                        }) =>
+                {
+                    // The validator doesn't have the committee that signed the certificate.
+                    self.update_admin_chain().await?;
+                    sent_admin_chain = true;
+                }
+                Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
+                    // The validator is missing the blobs required by the certificate.
+                    self.remote_node
+                        .check_blobs_not_found(certificate, &blob_ids)?;
+                    // The certificate is confirmed, so the blobs must be in storage.
+                    let maybe_blobs: Option<Vec<CacheArc<Blob>>> = self
+                        .storage
+                        .read_blobs(&blob_ids)
+                        .await
+                        .map_err(LocalNodeError::from)?
+                        .into_iter()
+                        .collect();
+                    let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
+                    self.remote_node
+                        .node
+                        .upload_blobs(blobs.into_iter().map(|blob| blob.into_std()).collect())
+                        .await?;
+                    sent_blobs = true;
+                }
+                result => {
+                    if let Err(err) = &result {
+                        self.warn_if_unexpected(err);
+                    }
+                    return Ok(result?);
+                }
+            }
+            result = self
+                .remote_node
+                .handle_confirmed_certificate(certificate.clone(), delivery)
+                .await;
+        }
+    }
+
+    /// Pushes the admin chain's confirmed blocks to the validator, up to the height we hold in
+    /// storage.
+    ///
+    /// Called when the validator reports that it is missing the committee that signed a
+    /// certificate. Unlike the client's `ValidatorUpdater`, this performs only height
+    /// synchronization (no consensus-round synchronization), which is all that is required to
+    /// deliver the confirmed committee events and all that the storage-only primitive can do
+    /// without a local worker.
+    async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
+        let admin_next_block_height = self
+            .storage
+            .load_chain(self.admin_chain_id)
+            .await
+            .map_err(LocalNodeError::from)?
+            .tip_state
+            .get()
+            .next_block_height;
+        Box::pin(self.send_confirmed_chain(
+            self.admin_chain_id,
+            admin_next_block_height,
+            CrossChainMessageDelivery::NonBlocking,
+            None,
+        ))
+        .await?;
+        Ok(())
+    }
+
+    /// Synchronizes a validator to a specific block height by sending the certificates held in
+    /// storage.
+    ///
+    /// Uses an optimistic approach: sends the last certificate first, then, based on the validator's
+    /// reported height, sends the earlier certificates in the range. Only the heights actually
+    /// present in storage are sent — any that are missing are silently skipped rather than treated
+    /// as an error, which is what leaves genuine gaps on the validator (see
+    /// [`Self::send_confirmed_chain`] for why that is both safe and intended).
+    ///
+    /// Returns the [`ChainInfo`] from the validator after synchronization.
+    async fn sync_chain_height(
+        &mut self,
+        chain_id: ChainId,
+        target_next_block_height: BlockHeight,
+        delivery: CrossChainMessageDelivery,
+        latest_certificate: Option<CacheArc<GenericCertificate<ConfirmedBlock>>>,
+    ) -> Result<Box<ChainInfo>, chain_client::Error> {
+        let height = target_next_block_height.try_sub_one()?;
+
+        // Get the certificate for the last block we want to send.
+        let certificate = if let Some(certificate) = latest_certificate {
+            certificate
+        } else {
+            self.read_certificates_for_heights(chain_id, vec![height])
+                .await?
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    chain_client::Error::InternalError(
+                        "failed to read latest certificate for height sync",
+                    )
+                })?
+        };
+
+        // Optimistically try sending just the last certificate.
+        let info = match self
+            .send_confirmed_certificate(&certificate, delivery)
+            .await
+        {
+            Ok(info) => info,
+            Err(error) => {
+                tracing::debug!(
+                    address = self.remote_node.address(), %error,
+                    "validator failed to handle confirmed certificate; sending whole chain",
+                );
+                let query = ChainInfoQuery::new(chain_id);
+                self.remote_node.handle_chain_info_query(query).await?
+            }
+        };
+
+        // Calculate which block heights the validator is still missing.
+        let heights: Vec<_> = (info.next_block_height.0..target_next_block_height.0)
+            .map(BlockHeight)
+            .collect();
+
+        if heights.is_empty() {
+            return Ok(info);
+        }
+
+        let batch_size = self.certificate_upload_batch_size as usize;
+        for chunk in heights.chunks(batch_size) {
+            let certificates = self
+                .read_certificates_for_heights(chain_id, chunk.to_vec())
+                .await?;
+
+            for certificate in certificates {
+                self.send_confirmed_certificate(&certificate, delivery)
+                    .await?;
+            }
+        }
+
+        Ok(info)
+    }
+
+    /// Reads confirmed certificates for the given heights directly from storage, by height.
+    ///
+    /// Heights that are not present are silently dropped: the returned vector contains only the
+    /// certificates actually in storage, so callers naturally skip any block that was never stored
+    /// (e.g. a sender's non-message-bearing blocks). Callers must not assume the result covers every
+    /// requested height.
+    ///
+    /// First attempts the direct `(chain_id, height) -> hash` index, then falls back to the chain's
+    /// block-hash list. The fallback covers certificates that were persisted before that index was
+    /// introduced, which the direct read cannot see.
+    ///
+    /// Height indices discovered through the fallback are written back to storage only if
+    /// [`Self::with_height_index_backfill`] was enabled, so that a consumer reading another
+    /// component's storage never writes to it.
+    async fn read_certificates_for_heights(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> Result<Vec<CacheArc<GenericCertificate<ConfirmedBlock>>>, chain_client::Error> {
+        let certificates_by_height = self
+            .storage
+            .read_certificates_by_heights(chain_id, &heights)
+            .await?;
+
+        let all_found = certificates_by_height.len() == heights.len()
+            && certificates_by_height
+                .iter()
+                .all(|certificate| certificate.is_some());
+
+        if all_found {
+            return Ok(certificates_by_height.into_iter().flatten().collect());
+        }
+
+        let hashes = self
+            .storage
+            .load_chain(chain_id)
+            .await?
+            .block_hashes(heights.clone())
+            .await?;
+
+        let certificates = self.storage.read_certificates(&hashes).await?;
+
+        match ResultReadCertificates::new(certificates, hashes.clone()) {
+            ResultReadCertificates::Certificates(certificates) => {
+                if self.backfill_height_indices {
+                    let indices: Vec<_> = heights.into_iter().zip(hashes).collect();
+                    self.storage
+                        .write_certificate_height_indices(chain_id, &indices)
+                        .await?;
+                }
+                Ok(certificates
+                    .into_iter()
+                    .map(|certificate| self.storage.cache_certificate(certificate))
+                    .collect())
+            }
+            ResultReadCertificates::InvalidHashes(hashes) => {
+                Err(chain_client::Error::ReadCertificatesError(hashes))
+            }
+        }
+    }
+
+    /// Initializes a new chain on the validator by sending the chain description and dependencies.
+    ///
+    /// This is called when the validator doesn't know about the chain yet. Returns the
+    /// [`ChainInfo`] from the validator after initialization.
+    async fn initialize_new_chain_on_validator(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<Box<ChainInfo>, chain_client::Error> {
+        // Send chain description and all dependency chains.
+        self.send_chain_info_for_blobs(
+            &[BlobId::new(chain_id.0, BlobType::ChainDescription)],
+            CrossChainMessageDelivery::NonBlocking,
+        )
+        .await?;
+
+        // Query the validator's state for this chain.
+        let query = ChainInfoQuery::new(chain_id);
+        let info = self.remote_node.handle_chain_info_query(query).await?;
+        Ok(info)
+    }
+
+    /// Reads blob states for the given blobs from storage, failing if any is missing.
+    async fn read_blob_states_from_storage(
+        &self,
+        blob_ids: &[BlobId],
+    ) -> Result<Vec<BlobState>, chain_client::Error> {
+        let mut blobs_not_found = Vec::new();
+        let mut blob_states = Vec::new();
+        for (blob_state, blob_id) in self
+            .storage
+            .read_blob_states(blob_ids)
+            .await
+            .map_err(LocalNodeError::from)?
+            .into_iter()
+            .zip(blob_ids)
+        {
+            match blob_state {
+                None => blobs_not_found.push(*blob_id),
+                Some(blob_state) => blob_states.push(blob_state),
+            }
+        }
+        if !blobs_not_found.is_empty() {
+            return Err(LocalNodeError::BlobsNotFound(blobs_not_found).into());
+        }
+        Ok(blob_states)
+    }
+
+    /// Sends the blocks at exactly the specified heights on multiple chains.
+    ///
+    /// Unlike a "send up to height" sync, this sends *only* the blocks at the given heights, not the
+    /// locally-held prefix leading up to them. Use it only when the required blocks are fully
+    /// self-describing to the validator — e.g. bringing over the specific blocks that carry a set of
+    /// blobs.
+    async fn send_chain_info_at_heights(
+        &self,
+        chain_heights: impl IntoIterator<Item = (ChainId, BTreeSet<BlockHeight>)>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<(), chain_client::Error> {
+        future::try_join_all(chain_heights.into_iter().map(|(chain_id, heights)| {
+            let mut sender = self.clone();
+            async move {
+                // Get all certificates for this chain at the specified heights in one call.
+                let heights = heights.into_iter().collect::<Vec<_>>();
+                let certificates = sender
+                    .storage
+                    .read_certificates_by_heights(chain_id, &heights)
+                    .await?
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+
+                // Send each certificate.
+                for certificate in certificates {
+                    sender
+                        .send_confirmed_certificate(&certificate, delivery)
+                        .await?;
+                }
+
+                Ok::<_, chain_client::Error>(())
+            }
+        }))
+        .await?;
+        Ok(())
+    }
+
+    /// Logs a warning if the error is not an expected part of the protocol flow.
+    fn warn_if_unexpected(&self, err: &NodeError) {
+        if !err.is_expected() {
+            tracing::warn!(
+                remote_node = self.remote_node.address(),
+                %err,
+                "unexpected error from validator",
+            );
+        }
+    }
+}

--- a/linera-core/src/updater/confirmed_sender.rs
+++ b/linera-core/src/updater/confirmed_sender.rs
@@ -15,6 +15,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use futures::future;
 use linera_base::{
+    crypto::CryptoHash,
     data_types::{Blob, BlockHeight},
     identifiers::{BlobId, BlobType, ChainId, StreamId},
 };
@@ -31,13 +32,37 @@ use crate::{
     LocalNodeError,
 };
 
+/// Answers the few chain-level queries that cannot be served from the certificate, blob, and
+/// height-index partitions.
+///
+/// Those partitions can be read directly, but a chain's own state view is owned by the chain worker
+/// while it is running: loading it elsewhere races with the worker and can corrupt data. Consumers
+/// therefore supply their own way to answer these queries — the client routes them through its
+/// local worker.
+pub trait LocalChainState {
+    /// Returns the next block height of the given chain, according to local state.
+    async fn next_block_height(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<BlockHeight, chain_client::Error>;
+
+    /// Returns the hashes of the given chain's blocks at the given heights.
+    ///
+    /// Heights the chain does not have are omitted, so the result may be shorter than `heights`.
+    async fn block_hashes(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> Result<Vec<CryptoHash>, chain_client::Error>;
+}
+
 /// Pushes confirmed-block certificates to a single validator, uploading their dependencies as
 /// needed.
 ///
 /// This is the confirmed-certificate synchronization path shared by the client's
 /// [`crate::updater::ValidatorUpdater`] and by out-of-crate consumers such as the block exporter.
-/// It reads everything it needs from `storage` directly, so it requires neither a wallet, a signer,
-/// nor a local worker.
+/// Certificates and blobs are read from `storage` directly, and the remaining chain-level queries
+/// go through [`LocalChainState`], so this requires neither a wallet nor a signer.
 ///
 /// A confirmed certificate can be rejected by a validator that is missing one of the certificate's
 /// dependencies. This type reproduces the client's recovery logic:
@@ -47,23 +72,26 @@ use crate::{
 ///   from `storage` and uploaded.
 ///
 /// The certificate is then retried.
-pub struct ConfirmedCertificateSender<S, N> {
+pub struct ConfirmedCertificateSender<S, N, L> {
     storage: S,
     remote_node: RemoteNode<N>,
+    local_chain_state: L,
     admin_chain_id: ChainId,
     certificate_upload_batch_size: u64,
     backfill_height_indices: bool,
 }
 
-impl<S, N> Clone for ConfirmedCertificateSender<S, N>
+impl<S, N, L> Clone for ConfirmedCertificateSender<S, N, L>
 where
     S: Clone,
     N: Clone,
+    L: Clone,
 {
     fn clone(&self) -> Self {
         ConfirmedCertificateSender {
             storage: self.storage.clone(),
             remote_node: self.remote_node.clone(),
+            local_chain_state: self.local_chain_state.clone(),
             admin_chain_id: self.admin_chain_id,
             certificate_upload_batch_size: self.certificate_upload_batch_size,
             backfill_height_indices: self.backfill_height_indices,
@@ -71,10 +99,11 @@ where
     }
 }
 
-impl<S, N> ConfirmedCertificateSender<S, N>
+impl<S, N, L> ConfirmedCertificateSender<S, N, L>
 where
     S: Storage + Clone,
     N: ValidatorNode + Clone,
+    L: LocalChainState + Clone,
 {
     /// Creates a new sender targeting `remote_node`, reading confirmed blocks and their
     /// dependencies from `storage`.
@@ -85,12 +114,14 @@ where
     pub fn new(
         storage: S,
         remote_node: RemoteNode<N>,
+        local_chain_state: L,
         admin_chain_id: ChainId,
         certificate_upload_batch_size: u64,
     ) -> Self {
         ConfirmedCertificateSender {
             storage,
             remote_node,
+            local_chain_state,
             admin_chain_id,
             certificate_upload_batch_size,
             backfill_height_indices: false,
@@ -243,13 +274,9 @@ where
     /// without a local worker.
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let admin_next_block_height = self
-            .storage
-            .load_chain(self.admin_chain_id)
-            .await
-            .map_err(LocalNodeError::from)?
-            .tip_state
-            .get()
-            .next_block_height;
+            .local_chain_state
+            .next_block_height(self.admin_chain_id)
+            .await?;
         Box::pin(self.send_confirmed_chain(
             self.admin_chain_id,
             admin_next_block_height,
@@ -368,10 +395,8 @@ where
         }
 
         let hashes = self
-            .storage
-            .load_chain(chain_id)
-            .await?
-            .block_hashes(heights.clone())
+            .local_chain_state
+            .block_hashes(chain_id, heights.clone())
             .await?;
 
         let certificates = self.storage.read_certificates(&hashes).await?;


### PR DESCRIPTION
## Motivation

The plan is for the chain workers in the server binary to push each block they execute straight to
the other validators: at that moment the certificate and its blobs are already in memory, so
nothing has to be re-read from storage or relayed through another process. Those workers need the
client's existing dependency-upload logic — uploading blobs the destination is missing, and pushing
the admin chain when the destination does not yet know the committee that signed the certificate.

That logic currently lives inside `ValidatorUpdater`, which owns an `Arc<Client>`. A chain worker
has no client, no wallet and no signer, and cannot get one. So the choice is to duplicate the
recovery logic in the server or to extract it; this extracts it.

## Proposal

Extract the confirmed-certificate synchronization path out of `ValidatorUpdater` into a reusable
primitive, `ConfirmedCertificateSender<S, N>` (new `linera-core/src/updater/confirmed_sender.rs`),
holding a `RemoteNode`, a `LocalNodeClient`, the admin chain id and the upload batch size — no
client, wallet, or signer.

Moved, and preserved verbatim: `send_confirmed_certificate` (the dependency-upload retry loop),
the height sync, `read_certificates_for_heights`, `initialize_new_chain_on_validator`,
`update_admin_chain`, `send_chain_info_for_blobs`, and the consensus-round sync. Blob and
certificate reads that went through the local node become direct storage reads.

`ValidatorUpdater::send_chain_information` is now a straight delegation to the primitive, which is
why `updater.rs` gets ~124 lines shorter.

**Chain state views must not be loaded outside the chain worker** (`scripts/check_chain_loads.sh`:
loading one elsewhere races with the worker and can corrupt data). The two chain-level reads this
path needs — the admin chain's local tip, and the block-hash fallback — therefore go through
`LocalNodeClient`, i.e. worker-mediated, exactly as `ValidatorUpdater` did before. The server's
chain workers hold one too, so both consumers use the same mechanism.

Two behaviours are opt-in rather than unconditional, because they are correct for the client and
wrong for a chain worker:

- `with_height_index_backfill()` — writes `(chain_id, height) -> hash` indices back for
  certificates found only through the block-hash-list fallback. Only for a consumer that owns the
  storage it reads.
- `with_consensus_round_sync()` — after height sync, pushes the evidence that justifies a later
  consensus round (locking certificate, timeout certificate, or proposal). That is consensus
  participation rather than replication. The client enables both, preserving its behaviour exactly.

## Test Plan

No behaviour change is intended for the client: it enables both flags, so every path it takes is
the one it took before. The refactor is covered by the existing `linera-core` suite.

```
cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web
cargo clippy --locked -p linera-core --no-default-features
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
cargo test -p linera-core --lib      # 158 passed, 0 failed
cargo +nightly fmt -- --check
bash scripts/check_chain_loads.sh
cargo machete
```

One fix worth calling out, found while reviewing this: the `read_certificates_for_heights`
block-hash fallback was initially dropped. Storage written before the `(chain_id, height) -> hash`
index existed can only be read through that fallback, so a deep catch-up against older storage
would have silently skipped legacy certificates. It is restored, with the index write-back behind
the flag above.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6639 builds on this: in-worker export of executed blocks
- #6641 relays that export through the proxy, so shards need no internet access
- #4095 — the unbounded exporter partition this line of work removes
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)