### PR TITLE
Add per-validator metrics to communicate_with_quorum

### DIFF
--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -49,7 +49,7 @@ pub(super) mod metrics {
         register_histogram_vec(
             "requests_scheduler_response_time_ms",
             "Response time for requests to validators in milliseconds",
-            &["validator"],
+            &["validator", "address"],
             exponential_bucket_latencies(10000.0), // up to 10 seconds
         )
     });
@@ -59,7 +59,7 @@ pub(super) mod metrics {
         register_int_counter_vec(
             "requests_scheduler_request_total",
             "Total number of requests made to each validator",
-            &["validator"],
+            &["validator", "address"],
         )
     });
 
@@ -68,7 +68,7 @@ pub(super) mod metrics {
         register_int_counter_vec(
             "requests_scheduler_request_success",
             "Number of successful requests to each validator",
-            &["validator"],
+            &["validator", "address"],
         )
     });
 
@@ -552,15 +552,16 @@ impl<Env: Environment> RequestsScheduler<Env> {
         #[cfg(with_metrics)]
         {
             let validator_name = public_key.to_string();
+            let address = peer.address();
             metrics::VALIDATOR_RESPONSE_TIME
-                .with_label_values(&[&validator_name])
+                .with_label_values(&[&validator_name, &address])
                 .observe(response_time_ms as f64);
             metrics::VALIDATOR_REQUEST_TOTAL
-                .with_label_values(&[&validator_name])
+                .with_label_values(&[&validator_name, &address])
                 .inc();
             if is_success {
                 metrics::VALIDATOR_REQUEST_SUCCESS
-                    .with_label_values(&[&validator_name])
+                    .with_label_values(&[&validator_name, &address])
                     .inc();
             }
         }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -47,6 +47,55 @@ pub type ClockSkewReport = (ValidatorPublicKey, TimeDelta);
 /// The maximum timeout for requests to a stake-weighted quorum if no quorum is reached.
 const MAX_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24); // 1 day.
 
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
+    };
+    use prometheus::{HistogramVec, IntCounterVec};
+
+    /// Requests dispatched to each validator while communicating with a quorum.
+    ///
+    /// Incremented at dispatch rather than on completion, so the series exists even for a
+    /// validator that never answers. Subtracting the responses below from this yields the
+    /// share of requests a validator left unanswered.
+    pub(super) static QUORUM_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "communicate_with_quorum_requests",
+            "Requests dispatched to each validator while communicating with a quorum",
+            &["validator"],
+        )
+    });
+
+    /// Responses received from each validator while communicating with a quorum.
+    ///
+    /// The `outcome` label is `before_quorum` when the response arrived while a quorum was
+    /// still outstanding, and `after_quorum` when it only arrived during the grace period
+    /// that follows a quorum being reached. A validator whose responses are consistently
+    /// `after_quorum` is holding up nothing yet, but it is the one that will stall
+    /// confirmation as soon as any other validator degrades.
+    pub(super) static QUORUM_RESPONSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "communicate_with_quorum_responses",
+            "Responses from each validator, by whether a quorum had already been reached",
+            &["validator", "outcome"],
+        )
+    });
+
+    /// Time each validator took to respond while communicating with a quorum.
+    pub(super) static QUORUM_RESPONSE_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "communicate_with_quorum_response_time_ms",
+            "Time taken by each validator to respond while communicating with a quorum, \
+             in milliseconds",
+            &["validator"],
+            exponential_bucket_latencies(60_000.0),
+        )
+    });
+}
+
 /// Used for `communicate_chain_action`
 #[derive(Clone)]
 pub enum CommunicateAction {
@@ -148,7 +197,21 @@ where
             }
             let execute = execute.clone();
             let remote_node = remote_node.clone();
-            Some(async move { (remote_node.public_key, execute(remote_node).await) })
+            #[cfg(with_metrics)]
+            metrics::QUORUM_REQUESTS
+                .with_label_values(&[&remote_node.public_key.to_string()])
+                .inc();
+            Some(async move {
+                let public_key = remote_node.public_key;
+                #[cfg(with_metrics)]
+                let request_start = Instant::now();
+                let result = execute(remote_node).await;
+                #[cfg(with_metrics)]
+                metrics::QUORUM_RESPONSE_TIME
+                    .with_label_values(&[&public_key.to_string()])
+                    .observe(request_start.elapsed().as_secs_f64() * 1000.0);
+                (public_key, result)
+            })
         })
         .collect();
 
@@ -166,6 +229,17 @@ where
     .await
     {
         remaining_votes -= committee.weight(&name);
+        #[cfg(with_metrics)]
+        metrics::QUORUM_RESPONSES
+            .with_label_values(&[
+                &name.to_string(),
+                if end_time.is_none() {
+                    "before_quorum"
+                } else {
+                    "after_quorum"
+                },
+            ])
+            .inc();
         match result {
             Ok(value) => {
                 let key = group_by(&value);

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -61,11 +61,15 @@ mod metrics {
     /// Incremented at dispatch rather than on completion, so the series exists even for a
     /// validator that never answers. Subtracting the responses below from this yields the
     /// share of requests a validator left unanswered.
+    ///
+    /// The `address` label carries the validator's gRPC URL so that dashboards and alerts can
+    /// name a validator without an out-of-band lookup of its public key. It is functionally
+    /// dependent on `validator`, so it adds no series.
     pub(super) static QUORUM_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
-            "communicate_with_quorum_requests",
+            "communicate_with_quorum_requests_total",
             "Requests dispatched to each validator while communicating with a quorum",
-            &["validator"],
+            &["validator", "address"],
         )
     });
 
@@ -78,9 +82,9 @@ mod metrics {
     /// confirmation as soon as any other validator degrades.
     pub(super) static QUORUM_RESPONSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
-            "communicate_with_quorum_responses",
+            "communicate_with_quorum_responses_total",
             "Responses from each validator, by whether a quorum had already been reached",
-            &["validator", "outcome"],
+            &["validator", "address", "outcome"],
         )
     });
 
@@ -90,7 +94,7 @@ mod metrics {
             "communicate_with_quorum_response_time_ms",
             "Time taken by each validator to respond while communicating with a quorum, \
              in milliseconds",
-            &["validator"],
+            &["validator", "address"],
             exponential_bucket_latencies(60_000.0),
         )
     });
@@ -199,16 +203,18 @@ where
             let remote_node = remote_node.clone();
             #[cfg(with_metrics)]
             metrics::QUORUM_REQUESTS
-                .with_label_values(&[&remote_node.public_key.to_string()])
+                .with_label_values(&[&remote_node.public_key.to_string(), &remote_node.address()])
                 .inc();
             Some(async move {
                 let public_key = remote_node.public_key;
+                #[cfg(with_metrics)]
+                let address = remote_node.address();
                 #[cfg(with_metrics)]
                 let request_start = Instant::now();
                 let result = execute(remote_node).await;
                 #[cfg(with_metrics)]
                 metrics::QUORUM_RESPONSE_TIME
-                    .with_label_values(&[&public_key.to_string()])
+                    .with_label_values(&[&public_key.to_string(), &address])
                     .observe(request_start.elapsed().as_secs_f64() * 1000.0);
                 (public_key, result)
             })
@@ -221,6 +227,11 @@ where
     let mut highest_key_score = 0;
     let mut value_scores: HashMap<K, (u64, Vec<(ValidatorPublicKey, V)>)> = HashMap::new();
     let mut error_scores = HashMap::new();
+    #[cfg(with_metrics)]
+    let addresses: HashMap<ValidatorPublicKey, String> = validator_clients
+        .iter()
+        .map(|remote_node| (remote_node.public_key, remote_node.address()))
+        .collect();
 
     'vote_wait: while let Ok(Some((name, result))) = timeout(
         end_time.map_or(MAX_TIMEOUT, |t| t.saturating_duration_since(Instant::now())),
@@ -233,6 +244,7 @@ where
         metrics::QUORUM_RESPONSES
             .with_label_values(&[
                 &name.to_string(),
+                addresses.get(&name).map_or("", String::as_str),
                 if end_time.is_none() {
                     "before_quorum"
                 } else {


### PR DESCRIPTION
## Motivation

`communicate_with_quorum` is the path where a slow validator actually costs us something: it
broadcasts to every validator, waits for a quorum, then grants a grace period for stragglers. A
validator that is **slow but still answering** delays block confirmation for everyone.

Today that path has no instrumentation at all — `linera-core/src/updater.rs` contains zero
Prometheus metrics. The per-validator metrics we do have (`requests_scheduler_*`) cover the routed
*read* path, and the scheduler deliberately routes away from low-scoring peers, so they say nothing
about who is holding up consensus.

That gap is tolerable while every validator is ours and we can read its own
`linera_proxy_*` / `linera_server_*` metrics. It stops being tolerable with third-party validators
at equal vote weight: for those, what our client measured is the only thing we will ever have.

Concretely, "validator N is slow to sign our blocks" is currently unanswerable from any dashboard.

## Proposal

Three metrics around the existing broadcast loop, all behind `#[cfg(with_metrics)]`:

| metric | labels | recorded |
|---|---|---|
| `communicate_with_quorum_requests` | `validator` | at dispatch |
| `communicate_with_quorum_responses` | `validator`, `outcome` | as each response is consumed |
| `communicate_with_quorum_response_time_ms` | `validator` | when each response arrives |

`outcome` is `before_quorum` if the response arrived while a quorum was still outstanding, and
`after_quorum` if it only landed during the grace period. The response that *reaches* quorum counts
as `before_quorum`, since `end_time` is only set at the end of that iteration.

This yields three things we cannot currently see:

- **Unanswered share** — `requests` is incremented at dispatch, so a validator that never replies
  still has a series. `1 - responses/requests` is the drop rate. This is why the counter is at
  dispatch rather than on completion: a validator that has never once answered since process start
  would otherwise have no series at all and be invisible.
- **Straggler ratio** — `after_quorum / responses`. A validator consistently landing after quorum is
  holding up nothing *yet*, but it is the one that stalls confirmation the moment any other
  validator degrades. That is exactly the early warning we want before onboarding external
  operators.
- **Time to respond**, per validator, on the write path.

The timer starts inside the per-validator future, which `FuturesUnordered` first polls when the loop
awaits, so all validators start from the same instant. Futures still pending when the loop breaks or
times out are dropped without observing — correct, since they never responded, and the gap remains
visible via `requests`.


## Update: human-readable validator identity (2nd commit)

André flagged that a bare public key is not good enough to act on in a dashboard or an alert. It is
worse than it first looks: the `validator` label in our Prometheus **already carries two
incompatible value formats** —

- `02585a79…` (public keys) from these client-side metrics, and
- `validator-1.testnet-conway.linera.net` (hostnames) applied by Alloy relabeling to
  validator-hosted metrics such as `linera_proxy_*`.

Same label name, two different identifier types depending on the metric family, and nothing to join
them on. So an alert firing from `linera_requests_scheduler_*` renders a hash while the neighbouring
`ProxyLatencyHigh` renders a hostname.

Second commit adds an `address` label (from `RemoteNode::address()`) to every per-validator client
metric — the three new `communicate_with_quorum_*` ones and the three pre-existing
`requests_scheduler_*` ones. `address` is functionally dependent on `validator`, so **series count is
unchanged**; each series just gains a label. Dashboards and alerts can then say
`{{address}}` and no longer need the out-of-band `app-infra` `committee.yaml` lookup.

I chose a plain label over the Prometheus `*_info` metric + `group_left` join pattern because there
are no existing consumers of these metrics yet, so relabelling is free right now, and it keeps every
panel and alert free of a join. `validator` keeps the public key, since that is the protocol identity
that `committee.yaml` is keyed on.

This touches `requests_scheduler/scheduler.rs`, which the first commit did not — flagging the scope
change explicitly. Matt's approval predates both commits.

- `cargo clippy -p linera-core --features metrics --all-targets -- -D warnings` — clean.
- `cargo clippy -p linera-core --lib -- -D warnings` (metrics off) — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt` applied.


## Test Plan (1st commit)

- `cargo clippy -p linera-core --features metrics --all-targets -- -D warnings` — clean.
- `cargo clippy -p linera-core --lib -- -D warnings` (metrics **off**) — clean. This is the case the
  `#[cfg]` attributes on the `let` bindings and statements could plausibly break.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean, and verified clean on the
  unmodified base commit for comparison.
- `cargo fmt` applied; no other files touched.
- No `Cargo.toml` changes, so dependency resolution is unchanged.

No unit test: this is metric emission with no observable behaviour change, and the existing
per-validator metrics in `requests_scheduler/scheduler.rs` are likewise untested. Happy to add one
if you'd rather.

**Cardinality**, worth a reviewer's eye: `exponential_bucket_latencies(60_000.0)` gives ~17 buckets,
so the histogram costs ~17 series per validator per process, plus 3 from the counters. At 25
validators that is ~500 series per client process. The existing scheduler histogram already has the
same shape, so this roughly doubles per-validator client series.

**Naming — resolved after Matt's question.** Counters now carry `_total`
(`communicate_with_quorum_requests_total`, `communicate_with_quorum_responses_total`), per the
[Prometheus naming guidelines](https://prometheus.io/docs/practices/naming/): "an accumulating count
has `total` as a suffix". 14 metric names in this repo already follow it, so it is also the local
majority.

I deliberately did **not** switch the histogram to base-unit seconds, even though the same page says
metrics SHOULD use base units. Measured across the repo: 13 metric names end in `_ms`, **zero** end
in `_seconds`. Renaming one metric to `_seconds` would make it the sole outlier sitting next to
`requests_scheduler_response_time_ms` in the same dashboards. If we want base units, it should be a
deliberate repo-wide migration, not a one-metric divergence.

## Release Plan

- Nothing to do / These changes follow the usual deployment cycle.

## Links

Consumer side: linera-io/linera-infra#1573 wires up the client-side validator health dashboard and
alerts from the metrics that already exist. This PR adds the write-path signal that PR calls out as
the remaining blind spot.

Still open after this, for the Web UI: `CommunicationError::{Trusted, Sample}` carries errors and
their stake weights but no validator identity, so the quorum-failure strings that reach Sentry can
never name a validator (0 events in 7 days match a validator address). Adding identity there would
make the frontend's existing errors attributable without any frontend change.

