### PR TITLE
Filter event-stream publishers by the message policy

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -189,10 +189,10 @@ Client implementation and command-line tool for the Linera blockchain
   - `ignore`:
     Don't include any messages in blocks, and don't make any decision whether to accept or reject
 
-* `--restrict-chain-ids-to <RESTRICT_CHAIN_IDS_TO>` — A set of chains to restrict incoming messages from. By default, messages from all chains are accepted. To reject messages from all chains, specify an empty string
+* `--restrict-chain-ids-to <RESTRICT_CHAIN_IDS_TO>` — A set of chains to restrict incoming messages and events from. By default, messages and events from all chains are accepted. To reject all of them, specify an empty string. The admin chain's event stream is always followed regardless of this setting
 * `--reject-message-bundles-without-application-ids <REJECT_MESSAGE_BUNDLES_WITHOUT_APPLICATION_IDS>` — A set of application IDs. If specified, only bundles with at least one message from one of these applications will be accepted
 * `--reject-message-bundles-with-other-application-ids <REJECT_MESSAGE_BUNDLES_WITH_OTHER_APPLICATION_IDS>` — A set of application IDs. If specified, only bundles where all messages are from one of these applications will be accepted
-* `--process-events-from-application-ids <PROCESS_EVENTS_FROM_APPLICATION_IDS>` — A set of application IDs. If specified, only events coming from streams created by applications from this set will be processed
+* `--process-events-from-application-ids <PROCESS_EVENTS_FROM_APPLICATION_IDS>` — A set of application IDs. If specified, only event streams created by applications from this set are processed and followed. The admin chain's event stream is always followed
 * `--never-reject-application-ids <NEVER_REJECT_APPLICATION_IDS>` — A set of application IDs whose messages must never be rejected. Bundles whose messages are all from one of these applications bypass the other rejection rules (except `--restrict-chain-ids-to`), and on execution failure they (and subsequent bundles from the same sender) are removed from the block for later retry instead of being rejected, with a warning logged. Bundles that contain any message from an application not on this list can be rejected
 * `--timings` — Enable timing reports during operations
 * `--timing-interval <TIMING_INTERVAL>` — Interval in seconds between timing reports (defaults to 5)

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -1893,9 +1893,10 @@ impl BcsHashable<'_> for Event {}
 pub struct MessagePolicy {
     /// The blanket policy applied to all messages.
     pub blanket: BlanketMessagePolicy,
-    /// A collection of chains which restrict the origin of messages to be
-    /// accepted. `Option::None` means that messages from all chains are accepted. An empty
-    /// `HashSet` denotes that messages from no chains are accepted.
+    /// A collection of chains which restrict the origin of messages and events to be
+    /// accepted. `Option::None` means that messages and events from all chains are accepted. An
+    /// empty `HashSet` denotes that none are accepted. The admin chain's event stream is always
+    /// followed regardless of this setting.
     pub restrict_chain_ids_to: Option<HashSet<ChainId>>,
     /// A collection of chains whose incoming messages should be ignored.
     pub ignore_chain_ids: HashSet<ChainId>,
@@ -1906,7 +1907,7 @@ pub struct MessagePolicy {
     /// applications will be accepted.
     pub reject_message_bundles_with_other_application_ids: Option<HashSet<GenericApplicationId>>,
     /// A collection of applications: If `Some`, only event streams from those
-    /// applications will be processed.
+    /// applications are processed and followed. The admin chain's event stream is always followed.
     pub process_events_from_application_ids: Option<HashSet<GenericApplicationId>>,
     /// A collection of applications whose messages must never be rejected. Bundles whose
     /// messages are all from one of these applications bypass the other rejection rules
@@ -1966,6 +1967,21 @@ impl MessagePolicy {
                 .restrict_chain_ids_to
                 .as_ref()
                 .is_some_and(|set| !set.contains(origin))
+    }
+
+    /// Returns `true` if events from `stream_id`, published by `chain_id`, should be followed
+    /// and processed: `restrict_chain_ids_to` (if set) must contain `chain_id`, and
+    /// `process_events_from_application_ids` (if set) must contain the stream's application. The
+    /// admin chain is exempt; callers always follow it.
+    #[instrument(level = "trace", skip(self))]
+    pub fn accepts_event_stream(&self, chain_id: &ChainId, stream_id: &StreamId) -> bool {
+        self.restrict_chain_ids_to
+            .as_ref()
+            .is_none_or(|chain_ids| chain_ids.contains(chain_id))
+            && self
+                .process_events_from_application_ids
+                .as_ref()
+                .is_none_or(|app_ids| app_ids.contains(&stream_id.application_id))
     }
 }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -164,9 +164,9 @@ pub struct Options {
     #[arg(long, default_value_t, value_enum)]
     pub blanket_message_policy: BlanketMessagePolicy,
 
-    /// A set of chains to restrict incoming messages from. By default, messages
-    /// from all chains are accepted. To reject messages from all chains, specify
-    /// an empty string.
+    /// A set of chains to restrict incoming messages and events from. By default, messages and
+    /// events from all chains are accepted. To reject all of them, specify an empty string. The
+    /// admin chain's event stream is always followed regardless of this setting.
     #[arg(long, value_parser = util::parse_chain_set)]
     pub restrict_chain_ids_to: Option<HashSet<ChainId>>,
 
@@ -180,8 +180,8 @@ pub struct Options {
     #[arg(long, value_parser = util::parse_app_set)]
     pub reject_message_bundles_with_other_application_ids: Option<HashSet<GenericApplicationId>>,
 
-    /// A set of application IDs. If specified, only events coming from streams created by
-    /// applications from this set will be processed.
+    /// A set of application IDs. If specified, only event streams created by applications from
+    /// this set are processed and followed. The admin chain's event stream is always followed.
     #[arg(long, value_parser = util::parse_app_set)]
     pub process_events_from_application_ids: Option<HashSet<GenericApplicationId>>,
 

--- a/linera-client/src/unit_tests/mod.rs
+++ b/linera-client/src/unit_tests/mod.rs
@@ -3,3 +3,4 @@
 
 mod chain_listener;
 mod client_context;
+mod util;

--- a/linera-client/src/unit_tests/util.rs
+++ b/linera-client/src/unit_tests/util.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::parse_app_set;
+
+#[test]
+fn parse_app_set_accepts_empty() {
+    assert!(parse_app_set("").unwrap().is_empty());
+    assert!(parse_app_set("   ").unwrap().is_empty());
+    assert!(parse_app_set("not-an-application-id").is_err());
+}

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -53,13 +53,18 @@ pub fn parse_chain_set(s: &str) -> Result<HashSet<ChainId>, CryptoError> {
 
 /// Parses a comma-separated list of application IDs into a set.
 pub fn parse_app_set(s: &str) -> anyhow::Result<HashSet<GenericApplicationId>> {
-    s.trim()
-        .split(",")
-        .map(|app_str| {
-            GenericApplicationId::from_str(app_str)
-                .or_else(|_| Ok(ApplicationId::from_str(app_str)?.into()))
-        })
-        .collect()
+    match s.trim() {
+        // An empty set is meaningful (e.g. `--process-events-from-application-ids ""` to follow
+        // only the admin chain), so accept it here instead of failing to parse an empty id.
+        "" => Ok(HashSet::new()),
+        s => s
+            .split(",")
+            .map(|app_str| {
+                GenericApplicationId::from_str(app_str)
+                    .or_else(|_| Ok(ApplicationId::from_str(app_str)?.into()))
+            })
+            .collect(),
+    }
 }
 
 /// Returns after the specified time or if we receive a notification that a new round has started.
@@ -91,3 +96,15 @@ macro_rules! impl_from_infallible {
 }
 
 pub(crate) use impl_from_infallible;
+
+#[cfg(test)]
+mod tests {
+    use super::parse_app_set;
+
+    #[test]
+    fn parse_app_set_accepts_empty() {
+        assert!(parse_app_set("").unwrap().is_empty());
+        assert!(parse_app_set("   ").unwrap().is_empty());
+        assert!(parse_app_set("not-an-application-id").is_err());
+    }
+}

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -96,15 +96,3 @@ macro_rules! impl_from_infallible {
 }
 
 pub(crate) use impl_from_infallible;
-
-#[cfg(test)]
-mod tests {
-    use super::parse_app_set;
-
-    #[test]
-    fn parse_app_set_accepts_empty() {
-        assert!(parse_app_set("").unwrap().is_empty());
-        assert!(parse_app_set("   ").unwrap().is_empty());
-        assert!(parse_app_set("not-an-application-id").is_err());
-    }
-}

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -502,8 +502,16 @@ impl<Env: Environment> ChainClient<Env> {
             .get_event_subscriptions(self.chain_id)
             .await?;
         let mut publishers = BTreeMap::<ChainId, BTreeSet<StreamId>>::new();
-        for ((chain_id, stream_name), _) in subscriptions {
-            publishers.entry(chain_id).or_default().insert(stream_name);
+        // Only follow publishers whose events pass the message policy; events from the others are
+        // discarded in `collect_stream_updates`, so subscribing to them is wasted work.
+        for ((chain_id, stream_id), _) in subscriptions {
+            if self
+                .options
+                .message_policy
+                .accepts_event_stream(&chain_id, &stream_id)
+            {
+                publishers.entry(chain_id).or_default().insert(stream_id);
+            }
         }
         if self.chain_id != self.client.admin_chain_id {
             // Empty streams = follow all for admin chain.
@@ -658,19 +666,10 @@ impl<Env: Environment> ChainClient<Env> {
         // Collect the indices of all new events.
         let futures = subscription_map
             .into_iter()
-            .filter(|((chain_id, _), _)| {
+            .filter(|((chain_id, stream_id), _)| {
                 self.options
                     .message_policy
-                    .restrict_chain_ids_to
-                    .as_ref()
-                    .is_none_or(|chain_set| chain_set.contains(chain_id))
-            })
-            .filter(|((_, stream_id), _)| {
-                self.options
-                    .message_policy
-                    .process_events_from_application_ids
-                    .as_ref()
-                    .is_none_or(|app_set| app_set.contains(&stream_id.application_id))
+                    .accepts_event_stream(chain_id, stream_id)
             })
             .map(|((chain_id, stream_id), subscriptions)| {
                 let client = self.client.clone();
@@ -958,7 +957,14 @@ impl<Env: Environment> ChainClient<Env> {
         // Group subscribed streams by publisher chain.
         let mut streams_by_chain = BTreeMap::<ChainId, BTreeSet<StreamId>>::new();
         for ((chain_id, stream_id), _) in &subscriptions {
-            if *chain_id != self.chain_id {
+            // The admin chain is synced separately below; other publishers are only synced if
+            // their events pass the message policy, matching what we follow and process.
+            if *chain_id != self.chain_id
+                && self
+                    .options
+                    .message_policy
+                    .accepts_event_stream(chain_id, stream_id)
+            {
                 streams_by_chain
                     .entry(*chain_id)
                     .or_default()

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -990,6 +990,11 @@ impl<Env: Environment> Client<Env> {
 
     /// Registers publisher chains in `EventsOnly` listening mode based on the event
     /// subscriptions of the given chain.
+    ///
+    /// Unlike `ChainClient::event_stream_publishers`, this deliberately does not apply the
+    /// message policy: it only records in-memory modes with no network I/O, and the `Client`
+    /// holds no single policy (each `ChainClient` has its own). Actual subscriptions and syncs
+    /// remain gated by the policy in the methods that reach validators.
     async fn update_publisher_chain_modes(&self, chain_id: ChainId) -> Result<(), LocalNodeError> {
         let subscriptions = self.local_node.get_event_subscriptions(chain_id).await?;
         let mut publishers = BTreeMap::<ChainId, BTreeSet<StreamId>>::new();

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -820,6 +820,17 @@ where
         ..Default::default()
     };
 
+    // The whitelist also stops us from *following* the senders' event streams: with no app
+    // whitelisted, only the mandatory admin chain remains.
+    assert_eq!(
+        receiver
+            .event_stream_publishers()
+            .await?
+            .into_keys()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([admin_client.chain_id()]),
+    );
+
     // Receiver should not process the event.
     let certs = receiver.process_inbox().await.unwrap().0;
     assert!(certs.is_empty());
@@ -831,6 +842,20 @@ where
         ),
         ..Default::default()
     };
+
+    // Whitelisting the social app restores following both senders (plus the admin chain).
+    assert_eq!(
+        receiver
+            .event_stream_publishers()
+            .await?
+            .into_keys()
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from([
+            sender.chain_id(),
+            sender2.chain_id(),
+            admin_client.chain_id(),
+        ]),
+    );
 
     // Receiver should process the new event now.
     let certs = receiver.process_inbox().await.unwrap().0;


### PR DESCRIPTION
## Motivation

A client that tracks a chain with many recorded event subscriptions (e.g. a user
wallet whose default chain accumulated subscriptions in old blocks) opens one
notification stream **and** one `previous_event_blocks` sync per publisher chain.
Against validators fronted by a load balancer that caps HTTP/2 at 100 concurrent
streams per connection (e.g. a GCP Application LB / GFE), this fan-out saturates the
single connection the client keeps per validator, and unrelated requests — block
proposals, chain-info queries, subscription handshakes — start timing out client-side.

The message-policy options `--process-events-from-application-ids` and
`--restrict-chain-ids-to` existed, but only filtered which events were *processed*
(`collect_stream_updates`); the set of publishers *followed and synced* ignored them,
so they could not reduce the fan-out.

## Proposal

Make the whitelist prune the follow/sync set, not just processing:

- Add `MessagePolicy::accepts_event_stream(chain_id, stream_id)` as the single source
  of truth for both filters (`restrict_chain_ids_to` + `process_events_from_application_ids`).
- Apply it in `event_stream_publishers` (notification subscriptions) and
  `synchronize_publisher_chains` (the sparse `previous_event_blocks` sync).
- Refactor `collect_stream_updates` (event processing) onto the same helper.

The admin chain stays followed and synced unconditionally, so epoch/committee
migration is unaffected. With no whitelist set, `accepts_event_stream` returns `true`
for everything, so behavior is unchanged. Also corrects the now-inaccurate docs on
`restrict_chain_ids_to` and `process_events_from_application_ids` (CLI help and the
`MessagePolicy` struct), which described them as message-only.

With this change, `--process-events-from-application-ids ""` makes a service follow
only the admin chain.

## Test Plan

- Extended the event-streams test to assert `event_stream_publishers` returns
  admin-only when the whitelist is empty, and both senders plus admin when the app is
  whitelisted.
- `cargo test -p linera-core --features wasmer -- event` -> 5 passed (incl.
  `test_synchronize_downloads_admin_chain_events` and
  `test_memory_read_event_downloads_publisher_chain`, which cover the sync/admin paths).
- Nightly `cargo fmt -- --check` and `cargo clippy --all-targets --features wasmer` clean.

## Release Plan

- Client-side only; no protocol, storage, or validator change. Follows the usual
  `testnet_conway` release cycle (SDK). A port to `main` will follow.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
