### PR TITLE
[backport] Add per-validator metrics to communicate_with_quorum

### DIFF
--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -49,7 +49,7 @@ pub(super) mod metrics {
         register_histogram_vec(
             "requests_scheduler_response_time_ms",
             "Response time for requests to validators in milliseconds",
-            &["validator"],
+            &["validator", "address"],
             exponential_bucket_latencies(10000.0), // up to 10 seconds
         )
     });
@@ -59,7 +59,7 @@ pub(super) mod metrics {
         register_int_counter_vec(
             "requests_scheduler_request_total",
             "Total number of requests made to each validator",
-            &["validator"],
+            &["validator", "address"],
         )
     });
 
@@ -68,7 +68,7 @@ pub(super) mod metrics {
         register_int_counter_vec(
             "requests_scheduler_request_success",
             "Number of successful requests to each validator",
-            &["validator"],
+            &["validator", "address"],
         )
     });
 
@@ -545,15 +545,16 @@ impl<Env: Environment> RequestsScheduler<Env> {
         #[cfg(with_metrics)]
         {
             let validator_name = public_key.to_string();
+            let address = peer.address();
             metrics::VALIDATOR_RESPONSE_TIME
-                .with_label_values(&[&validator_name])
+                .with_label_values(&[&validator_name, &address])
                 .observe(response_time_ms as f64);
             metrics::VALIDATOR_REQUEST_TOTAL
-                .with_label_values(&[&validator_name])
+                .with_label_values(&[&validator_name, &address])
                 .inc();
             if is_success {
                 metrics::VALIDATOR_REQUEST_SUCCESS
-                    .with_label_values(&[&validator_name])
+                    .with_label_values(&[&validator_name, &address])
                     .inc();
             }
         }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -61,11 +61,15 @@ mod metrics {
     /// Incremented at dispatch rather than on completion, so the series exists even for a
     /// validator that never answers. Subtracting the responses below from this yields the
     /// share of requests a validator left unanswered.
+    ///
+    /// The `address` label carries the validator's gRPC URL so that dashboards and alerts can
+    /// name a validator without an out-of-band lookup of its public key. It is functionally
+    /// dependent on `validator`, so it adds no series.
     pub(super) static QUORUM_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
-            "communicate_with_quorum_requests",
+            "communicate_with_quorum_requests_total",
             "Requests dispatched to each validator while communicating with a quorum",
-            &["validator"],
+            &["validator", "address"],
         )
     });
 
@@ -78,9 +82,9 @@ mod metrics {
     /// confirmation as soon as any other validator degrades.
     pub(super) static QUORUM_RESPONSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
-            "communicate_with_quorum_responses",
+            "communicate_with_quorum_responses_total",
             "Responses from each validator, by whether a quorum had already been reached",
-            &["validator", "outcome"],
+            &["validator", "address", "outcome"],
         )
     });
 
@@ -90,7 +94,7 @@ mod metrics {
             "communicate_with_quorum_response_time_ms",
             "Time taken by each validator to respond while communicating with a quorum, \
              in milliseconds",
-            &["validator"],
+            &["validator", "address"],
             exponential_bucket_latencies(60_000.0),
         )
     });
@@ -199,16 +203,18 @@ where
             let remote_node = remote_node.clone();
             #[cfg(with_metrics)]
             metrics::QUORUM_REQUESTS
-                .with_label_values(&[&remote_node.public_key.to_string()])
+                .with_label_values(&[&remote_node.public_key.to_string(), &remote_node.address()])
                 .inc();
             Some(async move {
                 let public_key = remote_node.public_key;
+                #[cfg(with_metrics)]
+                let address = remote_node.address();
                 #[cfg(with_metrics)]
                 let request_start = Instant::now();
                 let result = execute(remote_node).await;
                 #[cfg(with_metrics)]
                 metrics::QUORUM_RESPONSE_TIME
-                    .with_label_values(&[&public_key.to_string()])
+                    .with_label_values(&[&public_key.to_string(), &address])
                     .observe(request_start.elapsed().as_secs_f64() * 1000.0);
                 (public_key, result)
             })
@@ -224,6 +230,11 @@ where
     let mut value_scores: HashMap<K, (u64, Vec<(ValidatorPublicKey, V)>)> = HashMap::new();
     let mut error_scores = HashMap::new();
     let mut responses_received = 0;
+    #[cfg(with_metrics)]
+    let addresses: HashMap<ValidatorPublicKey, String> = validator_clients
+        .iter()
+        .map(|remote_node| (remote_node.public_key, remote_node.address()))
+        .collect();
 
     'vote_wait: while let Ok(Some((name, result))) = timeout(
         end_time.map_or(MAX_TIMEOUT, |t| t.saturating_duration_since(Instant::now())),
@@ -237,6 +248,7 @@ where
         metrics::QUORUM_RESPONSES
             .with_label_values(&[
                 &name.to_string(),
+                addresses.get(&name).map_or("", String::as_str),
                 if end_time.is_none() {
                     "before_quorum"
                 } else {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -47,6 +47,55 @@ const MAX_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24); // 1 day.
 /// A report of clock skew from a validator, sent before retrying due to `InvalidTimestamp`.
 pub type ClockSkewReport = (ValidatorPublicKey, TimeDelta);
 
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{
+        exponential_bucket_latencies, register_histogram_vec, register_int_counter_vec,
+    };
+    use prometheus::{HistogramVec, IntCounterVec};
+
+    /// Requests dispatched to each validator while communicating with a quorum.
+    ///
+    /// Incremented at dispatch rather than on completion, so the series exists even for a
+    /// validator that never answers. Subtracting the responses below from this yields the
+    /// share of requests a validator left unanswered.
+    pub(super) static QUORUM_REQUESTS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "communicate_with_quorum_requests",
+            "Requests dispatched to each validator while communicating with a quorum",
+            &["validator"],
+        )
+    });
+
+    /// Responses received from each validator while communicating with a quorum.
+    ///
+    /// The `outcome` label is `before_quorum` when the response arrived while a quorum was
+    /// still outstanding, and `after_quorum` when it only arrived during the grace period
+    /// that follows a quorum being reached. A validator whose responses are consistently
+    /// `after_quorum` is holding up nothing yet, but it is the one that will stall
+    /// confirmation as soon as any other validator degrades.
+    pub(super) static QUORUM_RESPONSES: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "communicate_with_quorum_responses",
+            "Responses from each validator, by whether a quorum had already been reached",
+            &["validator", "outcome"],
+        )
+    });
+
+    /// Time each validator took to respond while communicating with a quorum.
+    pub(super) static QUORUM_RESPONSE_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "communicate_with_quorum_response_time_ms",
+            "Time taken by each validator to respond while communicating with a quorum, \
+             in milliseconds",
+            &["validator"],
+            exponential_bucket_latencies(60_000.0),
+        )
+    });
+}
+
 /// Used for `communicate_chain_action`
 #[derive(Clone)]
 pub enum CommunicateAction {
@@ -148,7 +197,21 @@ where
             }
             let execute = execute.clone();
             let remote_node = remote_node.clone();
-            Some(async move { (remote_node.public_key, execute(remote_node).await) })
+            #[cfg(with_metrics)]
+            metrics::QUORUM_REQUESTS
+                .with_label_values(&[&remote_node.public_key.to_string()])
+                .inc();
+            Some(async move {
+                let public_key = remote_node.public_key;
+                #[cfg(with_metrics)]
+                let request_start = Instant::now();
+                let result = execute(remote_node).await;
+                #[cfg(with_metrics)]
+                metrics::QUORUM_RESPONSE_TIME
+                    .with_label_values(&[&public_key.to_string()])
+                    .observe(request_start.elapsed().as_secs_f64() * 1000.0);
+                (public_key, result)
+            })
         })
         .collect();
     let total_validators = responses.len();
@@ -170,6 +233,17 @@ where
     {
         responses_received += 1;
         remaining_votes -= committee.weight(&name);
+        #[cfg(with_metrics)]
+        metrics::QUORUM_RESPONSES
+            .with_label_values(&[
+                &name.to_string(),
+                if end_time.is_none() {
+                    "before_quorum"
+                } else {
+                    "after_quorum"
+                },
+            ])
+            .inc();
         match result {
             Ok(value) => {
                 let key = group_by(&value);


### PR DESCRIPTION
## Motivation

Backport of #6625 to `testnet_conway`.

This is not routine branch hygiene — the consumer of these metrics is inert without it.
linera-io/linera-infra#1573 adds a dashboard and four alerts built on the per-validator client
metrics, and every one of those series comes from the PM workers and faucets. Those build from
`testnet_conway`, not `main`:

```
$ gh api repos/linera-io/pm-app/contents/linera-protocol?ref=main --jq .sha
b490b7e9ff3b28db4a75d2721509a7f9bbaa61ab

$ gh api repos/linera-io/linera-protocol/compare/testnet_conway...b490b7e9 --jq .status
identical
$ gh api repos/linera-io/linera-protocol/compare/main...b490b7e9 --jq .status
diverged
```

So until this lands, #1573's alerts would keep rendering 66-character public keys and the new
write-path metrics would not exist at all.

## Proposal

Two cherry-picks from `main`, oldest first:

| main | here | commit |
|---|---|---|
| `8b26640` | `5bf14e5` | Add per-validator metrics to communicate_with_quorum |
| `cb7edb2` | `23686a5` | Label per-validator client metrics with the validator address |

**One conflict, in `linera-core/src/updater.rs`.** `testnet_conway` carries observability that `main`
does not — a `responses_received` counter and a `tracing::debug!(total_validators, …)` line — and my
`addresses` map lands on an adjacent line. Resolved by **keeping both**; taking either side alone
would have been wrong (dropping conway's `responses_received` also breaks the build, since it is
incremented inside the loop).

Worth noting separately: that conway-only debug logging looks like a **missing frontport** to `main`.
Not touched here.

## Test Plan

- **`cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web -- -D warnings`**
  — clean. This is the exact invocation from `.github/workflows/rust.yml`, chosen deliberately: the
  plain `--workspace --all-targets` form cannot pass on this branch, because conway's root workspace
  lists `web/@linera/client` (package `linera-web`) as a member and it is wasm32-only. That is why CI
  excludes it, and it is a conway-vs-main difference, not a regression from these commits.
- `cargo clippy -p linera-core --features metrics --all-targets -- -D warnings` — clean.
- `cargo clippy -p linera-core --lib -- -D warnings` (metrics **off**) — clean; this is the
  configuration the `#[cfg(with_metrics)]` bindings could break.
- `cargo fmt` — no diff; the cherry-picks were already formatted.
- Verified both commits applied in full (all six metric declarations, the `addresses` map, the
  three-label `QUORUM_RESPONSES`, and `peer.address()` in the scheduler) rather than trusting a clean
  `cherry-pick --continue`.

## Release Plan

- This **is** the backport of #6625 to `testnet_conway`.

Deploy chain before #1573 becomes fully usable, for whoever picks this up:
1. #6625 merges to `main`, this merges to `testnet_conway`
2. pm-app's `linera-protocol` submodule bumped to the new `testnet_conway` commit
3. pm-app release (pm-infra workers + faucet) — see the client/operator decoupling caveat, digests
   bump separately
4. `address` label appears in Prometheus; #1573's alerts start naming validators automatically
   (they already prefer `address` and fall back to the key)
5. Small follow-up infra PR to switch the dashboard legends from `{{validator}}` to `{{address}}`

## Links

- Main PR: #6625 (approved by @ma2bd)
- Consumer: linera-io/linera-infra#1573
