### PR TITLE
Log progress of large received-certificate syncs at info level

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -79,6 +79,15 @@ use crate::{
     worker::{Notification, Reason, WorkerError},
 };
 
+/// Number of received-log entries above which `find_received_certificates` reports its
+/// start, progress, and completion at `info` level. Smaller syncs stay quiet outside
+/// `debug`/`trace` logging.
+const LARGE_RECEIVED_CERTIFICATE_SYNC_THRESHOLD: usize = 50_000;
+
+/// Number of certificates processed between two `info`-level progress messages during a
+/// large sync of received certificates.
+const RECEIVED_CERTIFICATE_SYNC_PROGRESS_INTERVAL: usize = 100_000;
+
 /// Options that configure the behavior of a [`ChainClient`].
 #[derive(Debug, Clone)]
 pub struct Options {
@@ -1003,6 +1012,7 @@ impl<Env: Environment> ChainClient<Env> {
     #[instrument(level = "debug", skip(self), fields(chain_id = %self.chain_id))]
     pub async fn find_received_certificates(&self) -> Result<(), Error> {
         debug!("starting find_received_certificates");
+        let sync_start = Instant::now();
         #[cfg(with_metrics)]
         let _latency = super::metrics::FIND_RECEIVED_CERTIFICATES_LATENCY.measure_latency();
         // Use network information from the local chain.
@@ -1072,18 +1082,51 @@ impl<Env: Environment> ChainClient<Env> {
             "find_received_certificates: total number of chains and certificates to sync",
         );
 
+        let num_certs = received_logs.num_certs();
+        let is_large_sync = num_certs >= LARGE_RECEIVED_CERTIFICATE_SYNC_THRESHOLD;
+        if is_large_sync {
+            info!(
+                %chain_id,
+                num_chains = %received_logs.num_chains(),
+                %num_certs,
+                "starting a large sync of received certificates",
+            );
+        }
         let max_blocks_per_chain =
             self.options.sender_certificate_download_batch_size / self.options.max_joined_tasks * 2;
+        let mut num_synced_certs = 0;
+        let mut next_progress_message = RECEIVED_CERTIFICATE_SYNC_PROGRESS_INTERVAL;
         for received_log in received_logs.into_batches(
             self.options.sender_certificate_download_batch_size,
             max_blocks_per_chain,
         ) {
+            num_synced_certs += received_log.num_certs();
             validator_trackers = self
                 .receive_sender_certificates(received_log, validator_trackers, &nodes)
                 .await?;
 
             self.update_received_certificate_trackers(&validator_trackers)
                 .await;
+
+            if is_large_sync && num_synced_certs >= next_progress_message {
+                info!(
+                    %chain_id,
+                    %num_synced_certs,
+                    %num_certs,
+                    "received-certificate sync in progress",
+                );
+                next_progress_message =
+                    num_synced_certs + RECEIVED_CERTIFICATE_SYNC_PROGRESS_INTERVAL;
+            }
+        }
+
+        if is_large_sync {
+            info!(
+                %chain_id,
+                %num_certs,
+                elapsed_secs = %sync_start.elapsed().as_secs(),
+                "finished a large sync of received certificates",
+            );
         }
 
         trace!("find_received_certificates finished");

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -62,6 +62,11 @@ use crate::{
     ChainWorkerConfig, ProcessConfirmedBlockMode, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
+/// Number of received-log pages downloaded from one validator between two `info`-level
+/// progress messages. One page holds up to [`CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES`]
+/// entries, so with the default page size a message is emitted every 500,000 entries.
+const RECEIVED_LOG_PAGES_PER_PROGRESS_MESSAGE: usize = 25;
+
 /// The client for interacting with a single chain.
 pub mod chain_client;
 pub use chain_client::ChainClient;
@@ -1806,6 +1811,7 @@ impl<Env: Environment> Client<Env> {
 
         // Retrieve the list of newly received certificates from this validator.
         let mut remote_log = Vec::new();
+        let mut num_pages = 0usize;
         loop {
             trace!("get_received_log_from_validator: looping");
             let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
@@ -1818,6 +1824,15 @@ impl<Env: Environment> Client<Env> {
                 %received_entries,
                 "get_received_log_from_validator: received log batch",
             );
+            num_pages += 1;
+            if num_pages.is_multiple_of(RECEIVED_LOG_PAGES_PER_PROGRESS_MESSAGE) {
+                info!(
+                    %chain_id,
+                    remote_node = remote_node.address(),
+                    num_entries = remote_log.len(),
+                    "still downloading the received log",
+                );
+            }
             if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
                 break;
             }


### PR DESCRIPTION
## Motivation

When a node service restarts, `find_received_certificates` can walk a very large received-log backlog (millions of entries on busy chains). Today the entire walk logs only at `debug`/`trace`, so at the default `info` level a worker prints one line per chain and then stays completely silent for tens of minutes while it hammers the validators' storage. During the 2026-07-28/29 incidents on `testnet-conway` (validator ScyllaDB read p99 going from ~6 ms to 4+ s for 20-70 minutes after PM worker restarts), operators had no way to see from the logs what the restarted workers were doing.

## Proposal

Report large syncs at `info` level, without adding any noise for small ones:

- While downloading the received log from a validator, log progress every 25 full pages (500,000 entries at the default page size).
- When the collected backlog exceeds 50,000 certificates, log the start of the sync (number of chains and certificates), progress every 100,000 processed certificates, and completion with the elapsed time.

Syncs below the threshold behave exactly as before. No behavior change other than logging. The elapsed time in the completion message covers the whole sync, including the received-log download phase. If the sync aborts on an error, the "starting" line has no matching "finished" line by design: the existing `Background sync failed for chain ...` warning from the chain listener closes the bracket.

Note for merging alongside the pacing PR: the two PRs touch the same paging loop with deliberately distinct counters (`num_pages` here vs `num_full_pages` there), so they compose without hidden interaction.

## Test Plan

- `cargo check`, `cargo clippy` and `cargo fmt` pass with no warnings.
- CI.
- The thresholds mean a steady-state sync (a few entries) emits nothing new; the 2026-07-28 storm (~5M entries) would have emitted roughly one line per minute.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Context: restart-triggered received-log walks saturating validator ScyllaDB; follow-ups to #4706 / #4708.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)