### PR TITLE
Bound the number of concurrent background received-certificate syncs

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -26,11 +26,17 @@ use linera_core::{
     Environment, Wallet,
 };
 use linera_storage::{Arc as CacheArc, Storage as _};
-use tokio::sync::{mpsc::UnboundedReceiver, Notify};
+use tokio::sync::{mpsc::UnboundedReceiver, Notify, Semaphore};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn, Instrument as _};
 
 use crate::error::{self, Error};
+
+/// Maximum number of chains whose background received-certificate sync may run at the
+/// same time. Syncs beyond this limit wait for a permit, so all chains still get synced
+/// eventually; small backlogs are unaffected in practice because their syncs finish in
+/// well under a second.
+const MAX_CONCURRENT_BACKGROUND_SYNCS: usize = 2;
 
 /// The configuration for the chain listener.
 #[derive(Default, Debug, Clone, clap::Args, serde::Serialize, serde::Deserialize, tsify::Tsify)]
@@ -345,6 +351,10 @@ pub struct ChainListener<C: ClientContext> {
     command_receiver: UnboundedReceiver<ListenerCommand>,
     /// Whether to fully sync chains in the background.
     enable_background_sync: bool,
+    /// Bounds how many background received-certificate syncs may run at the same time.
+    /// Without a bound, a process that listens to many chains starts one sync per chain
+    /// at startup, and the combined backlog walks can overwhelm the validators' storage.
+    background_sync_semaphore: Arc<Semaphore>,
 }
 
 impl<C: ClientContext + 'static> ChainListener<C> {
@@ -366,6 +376,7 @@ impl<C: ClientContext + 'static> ChainListener<C> {
             event_subscribers: Default::default(),
             command_receiver,
             enable_background_sync,
+            background_sync_semaphore: Arc::new(Semaphore::new(MAX_CONCURRENT_BACKGROUND_SYNCS)),
         }
     }
 
@@ -582,11 +593,19 @@ impl<C: ClientContext + 'static> ChainListener<C> {
 
     /// Background task that syncs received certificates in small batches.
     /// This discovers unacknowledged sender blocks gradually without overwhelming the system.
-    #[instrument(skip(context))]
+    /// The semaphore bounds how many of these syncs run concurrently; the permit is held
+    /// for the duration of one sync, not for the lifetime of the task.
+    #[instrument(skip(context, semaphore))]
     async fn background_sync_received_certificates(
         context: Arc<Mutex<C>>,
         chain_id: ChainId,
+        semaphore: Arc<Semaphore>,
     ) -> Result<(), Error> {
+        let Ok(_permit) = semaphore.acquire().await else {
+            // The semaphore is never closed, so this is unreachable; if it ever
+            // happens, skipping the background sync is the safe fallback.
+            return Ok(());
+        };
         info!("Starting background certificate sync");
         let client = context.lock().await.make_chain_client(chain_id).await?;
 
@@ -654,8 +673,11 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         }
 
         let context = Arc::clone(&self.context);
+        let semaphore = Arc::clone(&self.background_sync_semaphore);
         Task::spawn(async move {
-            if let Err(e) = Self::background_sync_received_certificates(context, chain_id).await {
+            if let Err(e) =
+                Self::background_sync_received_certificates(context, chain_id, semaphore).await
+            {
                 warn!("Background sync failed for chain {chain_id}: {e}");
             }
         })


### PR DESCRIPTION
## Motivation

At listener startup every fully-listened chain spawns its own background received-certificate sync, all at once. A worker following several chains with large backlogs multiplies the load of the received-log walk (`find_received_certificates`) on the validators: during the 2026-07-28/29 `testnet-conway` incidents, two restarted PM workers drove validator ScyllaDB from ~100 to ~9,000 statement-class disk reads/s for 20-70 minutes, taking read p99 from ~6 ms to over 4 s for every tenant.

## Proposal

Bound the number of concurrently running background syncs with a semaphore (2 permits). The permit is acquired inside `background_sync_received_certificates` — i.e. per sync run, not per task — so every chain still gets synced eventually, and a future change that re-runs the sync periodically re-acquires the permit on every run. Small backlogs finish in well under a second, so in the common case the bound is unobservable.

A sync that stalls holds its permit until it finishes or fails; the longest any single wait inside the sync can take is bounded by the communication layer's one-day ceiling, and while syncs queue, notification-driven message delivery is unaffected — the background sync is a catch-up net, not the delivery path.

## Test Plan

- `cargo check`, `cargo clippy`, `cargo fmt`, `cargo test -p linera-client --lib` pass.
- Compiles for wasm32-unknown-unknown with `--features web-default`.
- CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Context: restart-triggered received-log walks saturating validator ScyllaDB; follow-up to #4708, which removed the original `sync_sleep_ms` throttling introduced in #4706.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)