### PR TITLE
Pace long received-log downloads to avoid monopolizing validator storage

### DIFF
--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -62,6 +62,11 @@ use crate::{
     ChainWorkerConfig, ProcessConfirmedBlockMode, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 
+/// Number of full received-log pages a download may fetch back-to-back before pacing
+/// kicks in. With pages of [`CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES`] entries this lets
+/// backlogs of up to just under 100,000 entries sync at full speed.
+const RECEIVED_LOG_PAGES_BEFORE_PACING: usize = 5;
+
 /// The client for interacting with a single chain.
 pub mod chain_client;
 pub use chain_client::ChainClient;
@@ -1806,10 +1811,13 @@ impl<Env: Environment> Client<Env> {
 
         // Retrieve the list of newly received certificates from this validator.
         let mut remote_log = Vec::new();
+        let mut num_full_pages = 0usize;
         loop {
             trace!("get_received_log_from_validator: looping");
             let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_n(offset);
+            let page_start = linera_base::time::Instant::now();
             let info = remote_node.handle_chain_info_query(query).await?;
+            let page_duration = page_start.elapsed();
             let received_entries = info.requested_received_log.len();
             offset += received_entries as u64;
             remote_log.extend(info.requested_received_log);
@@ -1820,6 +1828,17 @@ impl<Env: Environment> Client<Env> {
             );
             if received_entries < CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES {
                 break;
+            }
+            // Serving a page makes the validator read one storage row per log entry, so
+            // walking a long backlog page after page can monopolize the validator's
+            // storage and degrade its read latency for everyone else. Once the walk is
+            // clearly a backlog walk, pause between pages for as long as the previous
+            // page took: this caps the walk at roughly half of the validator's serving
+            // capacity and automatically backs off further when the validator slows
+            // down. Short syncs never reach this point and are unaffected.
+            num_full_pages += 1;
+            if num_full_pages >= RECEIVED_LOG_PAGES_BEFORE_PACING {
+                linera_base::time::timer::sleep(page_duration).await;
             }
         }
 


### PR DESCRIPTION
## Motivation

`get_received_log_from_validator` pages through the received log back-to-back until the backlog is drained. Serving one 20,000-entry page makes the validator read one storage row per entry inside a single ScyllaDB partition, so a long walk keeps the validator's storage at full tilt for its entire duration. On 2026-07-28/29 (`testnet-conway`), restarted PM workers walking multi-million-entry backlogs drove ScyllaDB statement-class disk reads from ~100/s to ~9,000/s on all four validators for 20-70 minutes, degrading read p99 from ~6 ms to over 4 s for every other tenant. #4706 originally shipped this sync with sleep-based throttling "to limit interference with the other node service tasks"; #4708 removed it.

## Proposal

Reintroduce throttling, adaptively: once a download has fetched 5 full pages back-to-back (~100,000 entries — clearly a backlog walk, not a routine refresh), pause between pages for as long as the previous page took to serve. This caps the walk at roughly half the validator's serving capacity and automatically backs off further when the validator slows down. Routine syncs never reach the threshold and are completely unaffected; the walk itself is a background task, so the added wall-clock time does not delay anything user-facing.

The page counter is named `num_full_pages` (only full pages count, and the final short page breaks out of the loop before ever sleeping) — deliberately distinct from the `num_pages` counter the progress-logging PR adds to the same loop, so the two merge without hidden interaction. Pacing does not change which validators survive the quorum grace period: the grace is proportional to time-to-quorum, and pacing scales all validators' walks uniformly.

## Test Plan

- `cargo check`, `cargo clippy`, `cargo fmt` pass with no warnings.
- CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- #4706 (original throttled design), #4708 (throttle removal).
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)