### PR TITLE
Periodically re-run the background received-certificate sync to keep trackers fresh

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -252,6 +252,9 @@ Client implementation and command-line tool for the Linera blockchain
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
+* `--listener-background-sync-interval-ms <BACKGROUND_SYNC_INTERVAL_MS>` — The time between two background received-certificate syncs of the same chain, in milliseconds. Repeating the sync keeps the received-certificate trackers fresh, so a process restart only has to walk the short backlog accumulated since the last refresh instead of everything since the previous restart. Set to 0 to sync only once, when the chain listener starts
+
+  Default value: `900000`
 * `--wallet <WALLET_STATE_PATH>` — Sets the file storing the private state of user chains (an empty one will be created if missing)
 * `--keystore <KEYSTORE_PATH>` — Sets the file storing the keystore state
 * `-w`, `--with-wallet <WITH_WALLET>` — Given an ASCII alphanumeric parameter `X`, read the wallet state and the wallet storage config from the environment variables `LINERA_WALLET_{X}` and `LINERA_STORAGE_{X}` instead of `LINERA_WALLET` and `LINERA_STORAGE`
@@ -822,6 +825,9 @@ Run a GraphQL service to explore and extend the chains of the wallet
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
+* `--listener-background-sync-interval-ms <BACKGROUND_SYNC_INTERVAL_MS>` — The time between two background received-certificate syncs of the same chain, in milliseconds. Repeating the sync keeps the received-certificate trackers fresh, so a process restart only has to walk the short backlog accumulated since the last refresh instead of everything since the previous restart. Set to 0 to sync only once, when the chain listener starts
+
+  Default value: `900000`
 * `--port <PORT>` — The port on which to run the server
 * `--operator-application-ids <OPERATOR_APPLICATION_IDS>` — Application IDs of operator applications to watch. When specified, a task processor is started alongside the node service
 * `--controller-id <CONTROLLER_APPLICATION_ID>` — A controller to execute a dynamic set of applications running on a dynamic set of chains
@@ -881,6 +887,9 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
 * `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
 
   Default value: `0`
+* `--listener-background-sync-interval-ms <BACKGROUND_SYNC_INTERVAL_MS>` — The time between two background received-certificate syncs of the same chain, in milliseconds. Repeating the sync keeps the received-certificate trackers fresh, so a process restart only has to walk the short backlog accumulated since the last refresh instead of everything since the previous restart. Set to 0 to sync only once, when the chain listener starts
+
+  Default value: `900000`
 * `--storage-path <STORAGE_PATH>` — Path to the persistent storage file for faucet mappings
 * `--max-batch-size <MAX_BATCH_SIZE>` — Maximum number of operations to include in a single block (default: 100)
 

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -62,6 +62,24 @@ pub struct ChainListenerConfig {
         env = "LINERA_LISTENER_DELAY_AFTER"
     )]
     pub delay_after_ms: u64,
+
+    /// The time between two background received-certificate syncs of the same chain, in
+    /// milliseconds. Repeating the sync keeps the received-certificate trackers fresh,
+    /// so a process restart only has to walk the short backlog accumulated since the
+    /// last refresh instead of everything since the previous restart. Set to 0 to sync
+    /// only once, when the chain listener starts.
+    #[serde(default = "default_background_sync_interval_ms")]
+    #[arg(
+        long = "listener-background-sync-interval-ms",
+        default_value = "900000",
+        env = "LINERA_LISTENER_BACKGROUND_SYNC_INTERVAL_MS"
+    )]
+    pub background_sync_interval_ms: u64,
+}
+
+/// The default value of [`ChainListenerConfig::background_sync_interval_ms`]: 15 minutes.
+fn default_background_sync_interval_ms() -> u64 {
+    900_000
 }
 
 type ContextChainClient<C> = ChainClient<<C as ClientContext>::Environment>;
@@ -654,9 +672,19 @@ impl<C: ClientContext + 'static> ChainListener<C> {
         }
 
         let context = Arc::clone(&self.context);
+        let interval = Duration::from_millis(self.config.background_sync_interval_ms);
         Task::spawn(async move {
-            if let Err(e) = Self::background_sync_received_certificates(context, chain_id).await {
-                warn!("Background sync failed for chain {chain_id}: {e}");
+            loop {
+                if let Err(e) =
+                    Self::background_sync_received_certificates(Arc::clone(&context), chain_id)
+                        .await
+                {
+                    warn!("Background sync failed for chain {chain_id}: {e}");
+                }
+                if interval.is_zero() {
+                    return;
+                }
+                linera_base::time::timer::sleep(interval).await;
             }
         })
     }


### PR DESCRIPTION
## Motivation

Received-certificate trackers only advance while `find_received_certificates` runs, and for chains a client merely follows, that happens exactly once — at listener startup. The backlog therefore grows for the process's entire uptime, and the *next* restart pays the full inter-restart delta. On `testnet-conway` the PM workers' RPC replicas accumulated ~13 days (~5M entries) of backlog between restarts, and every restart triggered a ~20-minute walk that saturated the validators' ScyllaDB (read p99 from ~6 ms to 4+ s for all tenants, on 2026-07-15, -07-28 and -07-29).

## Proposal

Re-run the background sync for each fully-listened chain on a fixed interval (new `--listener-background-sync-interval-ms`, default 15 minutes; 0 restores the sync-once behavior). With fresh trackers, each periodic run and each restart only walks the last interval's worth of entries — a routine, cheap query instead of a storm.

`ChainListenerConfig::default()` deliberately yields 0 (the previous one-shot behavior) so programmatic constructions — including the existing unit tests and the benchmark — keep their current semantics; only explicitly-configured paths (CLI, env, serde) get the periodic refresh. The periodic loop composes with the sync-concurrency-bound PR: the semaphore permit there is acquired per sync run, inside the function this loop calls, so it is released during every sleep. A unit test for the periodic path needs a virtual-time harness and is left as a follow-up; the behavior will be validated on a canary worker.

`CLI.md` regenerated.

## Test Plan

- `cargo check`, `cargo clippy`, `cargo fmt`, `cargo test -p linera-client --lib` pass.
- `diff CLI.md <(cargo run --bin linera -- help-markdown)` is clean.
- CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Context: follow-up to #4706 / #4708.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)