### PR TITLE
docker: split into linera-validator and linera-client images

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
+          target: tests
           tags: linera-test
           load: true
           build-args: |

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -12,13 +12,14 @@ on:
         required: true
         type: choice
         options:
-          - main
+          - validator
+          - client
           - indexer
           - explorer
           - exporter
           - bridge
           - all
-        default: main
+        default: validator
       image_tag:
         description: 'Image tag (e.g., testnet_conway, a branch name, or arbitrary label)'
         required: true
@@ -93,6 +94,10 @@ jobs:
             local DOCKERFILE=$1
             local IMAGE_NAME=$2
             local BUILD_NAME=$3
+            # Optional. docker/Dockerfile now REQUIRES an explicit --target (a
+            # guard stage fails the build otherwise); the single-target
+            # Dockerfiles (indexer/explorer/exporter/bridge) pass nothing.
+            local TARGET=${4:-}
             local LOG_FILE="/tmp/build-${BUILD_NAME}.log"
 
             local IMAGE_TAGGED="${REGISTRY_BASE}/${IMAGE_NAME}:${IMAGE_TAG}"
@@ -109,6 +114,7 @@ jobs:
                 -t "${IMAGE_SHORT}" \
                 -t "${IMAGE_LONG}" \
                 -f "${DOCKERFILE}" \
+                ${TARGET:+--target "${TARGET}"} \
                 --build-arg "git_commit=${GIT_COMMIT_LONG}" \
                 --build-arg "build_date=${BUILD_DATE}" \
                 --build-arg "build_flag=${BUILD_FLAG}" \
@@ -127,7 +133,8 @@ jobs:
           build_image_by_type() {
             local TYPE=$1
             case "${TYPE}" in
-              main)     build_and_push "docker/Dockerfile"           "linera"          "main"     ;;
+              validator) build_and_push "docker/Dockerfile"          "linera-validator" "validator" "validator" ;;
+              client)   build_and_push "docker/Dockerfile"           "linera-client"   "client"   "client"  ;;
               indexer)  build_and_push "docker/Dockerfile.indexer"   "linera-indexer"  "indexer"  ;;
               explorer) build_and_push "docker/Dockerfile.explorer"  "linera-explorer" "explorer" ;;
               exporter) build_and_push "docker/Dockerfile.exporter"  "linera-exporter" "exporter" ;;
@@ -137,7 +144,7 @@ jobs:
           }
 
           if [ "${IMAGE_TYPE}" = "all" ]; then
-            TYPES="main indexer explorer exporter bridge"
+            TYPES="validator client indexer explorer exporter bridge"
           else
             TYPES="${IMAGE_TYPE}"
           fi

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -65,7 +65,7 @@ jobs:
 
           REGISTRY_BASE="us-docker.pkg.dev/linera-io-dev/linera-public-registry"
 
-          for IMAGE_VAR in LINERA:linera LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
+          for IMAGE_VAR in LINERA_VALIDATOR:linera-validator LINERA_CLIENT:linera-client LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
             VAR="${IMAGE_VAR%%:*}"
             NAME="${IMAGE_VAR##*:}"
             echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_TAG}" >> "$GITHUB_ENV"
@@ -125,9 +125,19 @@ jobs:
 
           echo "Starting parallel builds..."
 
+          # linera-validator: linera-server + linera-proxy. Same feature set as
+          # `linera` — this split changes which binaries ship, not features.
           build_and_push "docker/Dockerfile" \
-            "${LINERA_IMAGE_BRANCH}" "${LINERA_IMAGE_SHORT}" "${LINERA_IMAGE_LONG}" "Linera" "runtime" &
-          PID_LINERA=$!
+            "${LINERA_VALIDATOR_IMAGE_BRANCH}" "${LINERA_VALIDATOR_IMAGE_SHORT}" "${LINERA_VALIDATOR_IMAGE_LONG}" "LineraValidator" "validator" &
+          PID_LINERA_VALIDATOR=$!
+
+          # linera-client: the client binary only. Also what the validator
+          # chart's *-initializer init containers need (they run
+          # `linera storage check-existence`), so they can stop pulling the
+          # all-three image.
+          build_and_push "docker/Dockerfile" \
+            "${LINERA_CLIENT_IMAGE_BRANCH}" "${LINERA_CLIENT_IMAGE_SHORT}" "${LINERA_CLIENT_IMAGE_LONG}" "LineraClient" "client" &
+          PID_LINERA_CLIENT=$!
 
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
@@ -158,7 +168,7 @@ jobs:
 
           SUCCESS_NAMES=""
           FAILED_NAMES=""
-          for NAME_PID in Linera:$PID_LINERA LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
+          for NAME_PID in LineraValidator:$PID_LINERA_VALIDATOR LineraClient:$PID_LINERA_CLIENT LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
             if wait "$PID"; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,21 +4,43 @@
 #
 # - `git_commit` is the hash of the current git commit — used for
 #   versioning information inside the binaries.
-# - `build_date` is the date and time of when the docker image was
-#   built
-# - `binaries` is the path to the directory containing the Linera
-#   binaries. Leave unset to build the binaries from scratch.
+# - `build_date` is the date and time of when the docker image was built.
 # - `build_flag` is either "--release" or an empty string.
 # - `build_folder` is either "release" or "debug".
-# - `build_features` is a comma-separated list of features to build the binaries with.
+# - `build_features` is the feature set for EVERY target. Built WITHOUT
+#   --no-default-features, so the crate defaults (wasmer, rocksdb,
+#   storage-service) are added on top, exactly as before this file was split.
+#
+# This split changes WHICH BINARIES each image carries — deliberately NOT which
+# features they are built with. Curating features per image (dropping
+# storage-service / rocksdb from the validator) is a separate follow-up with its
+# own runtime gate, so a regression can never be ambiguous between the two.
+#
+# Targets — ALWAYS pass --target. A bare `docker build` with no --target hits
+# the `default` guard stage and fails fast (see the end of this file). Before
+# the guard existed, `tests` was the last stage and therefore the implicit
+# default, so most call sites silently paid `cargo test --no-run` of
+# linera_net_tests:
+#
+#   validator   linera-server + linera-proxy   -> linera-validator
+#   client      linera                         -> linera-client
+#   tests       all three + remote-net test binary + linera-benchmark + example wasm
+#
+# There is no combined image. Every consumer takes exactly one of the two:
+# anything running the client (the validator chart's *-initializer init
+# containers, the faucet, PM workers, CLI users) takes linera-client; anything
+# running server/proxy takes linera-validator. `tests` is the sole place needing
+# all three in one filesystem, because `linera net up` spawns linera-server and
+# linera-proxy as child processes (cli_wrappers/local_net.rs command_for_binary).
+#
+# `--target X` builds only X's FROM-chain, so a validator build never compiles
+# the client binary or the tests stage, and vice versa.
 #
 # Requires BuildKit for `RUN --mount=type=cache` (DOCKER_BUILDKIT=1, `docker buildx`,
 # or recent Docker Desktop/Engine).
 
 ARG git_commit
 ARG build_date
-ARG binaries=
-ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
 ARG build_features=scylladb,metrics,jemalloc
@@ -81,13 +103,14 @@ RUN set -e && \
         done; \
     done
 
-# ── Stage 2: builder — cook deps (cached), then build source ──
+# ── Stage 2: cook_base — shared pre-cook setup ──
+# Everything the per-binary builder stages need BEFORE `cargo chef cook`, so the
+# fragile bits (build.rs include!() inputs, examples stubs, env) are written
+# ONCE and shared by every builder. Only the cook/build RUN lines differ per
+# binary set.
 
-FROM chef AS builder_src
+FROM chef AS cook_base
 ARG git_commit
-ARG build_flag
-ARG build_folder
-ARG build_features
 ARG rustflags
 
 COPY --from=planner /app/recipe.json recipe.json
@@ -108,9 +131,17 @@ COPY --from=planner /examples-stubs examples
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}
 
+# ── Stage 3a: builder_src — all three binaries, for the `tests` image only ──
+# `tests` needs the client AND server/proxy in one filesystem (linera net up
+# spawns them), so it builds them together here rather than composing the two
+# split images, which would mean three separate cargo builds for one image.
+
+FROM cook_base AS builder_src
+ARG build_flag
+ARG build_folder
+ARG build_features
+
 # Cook dependencies — cached until Cargo.toml / Cargo.lock change.
-# The three cache mounts persist cargo's registry, git deps, and the
-# compilation target/ across builds so unchanged deps never recompile.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
@@ -121,10 +152,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --bin linera \
     ${build_features:+--features $build_features}
 
-# Copy full source and build (only changed crates recompile).
+# Copy full source and build (only changed crates recompile). target/ is a
+# cache mount — build + copy binaries OUT of it in the same RUN so they persist
+# in the image layer (cache mounts don't survive the RUN).
 COPY . .
-# target/ is a cache mount — build + copy binaries OUT of it in the same RUN
-# so they persist in the image layer (cache mounts don't survive the RUN).
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
@@ -139,23 +170,75 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         target/"$build_folder"/linera-server \
         /
 
-# Optionally copy binaries instead of using the build stage above
-FROM scratch AS builder_src_copy
-ARG binaries
-COPY \
-    "$binaries"/linera \
-    "$binaries"/linera-server \
-    "$binaries"/linera-proxy \
-    /
+# ── Stage 3b: validator_builder — the two validator binaries ──
+# Same feature set as every other stage. This PR splits WHICH BINARIES each
+# image carries, deliberately not which features they are built with: curating
+# features (dropping storage-service / rocksdb, adding --no-default-features)
+# is a separate change with its own runtime gate, so that if something breaks
+# it is never ambiguous whether the split or a feature did it.
+# The win here is that `--target validator` never builds the `linera` binary,
+# nor the tests stage.
 
-FROM builder_src$copy AS binaries
+FROM cook_base AS validator_builder
+ARG build_flag
+ARG build_folder
+ARG build_features
 
-# ── Stage 3: runtime ──
-FROM debian:bookworm-slim AS runtime
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo chef cook ${build_flag:+"$build_flag"} \
+    --recipe-path recipe.json \
+    --bin linera-proxy \
+    --bin linera-server \
+    ${build_features:+--features $build_features}
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build ${build_flag:+"$build_flag"} \
+        --bin linera-proxy \
+        --bin linera-server \
+        ${build_features:+--features $build_features} \
+    && cp \
+        target/"$build_folder"/linera-proxy \
+        target/"$build_folder"/linera-server \
+        /
+
+# ── Stage 3c: client_builder — the client binary only ──
+# Same features as everything else (see the note on validator_builder).
+# `--target client` never compiles linera-server or linera-proxy.
+
+FROM cook_base AS client_builder
+ARG build_flag
+ARG build_folder
+ARG build_features
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo chef cook ${build_flag:+"$build_flag"} \
+    --recipe-path recipe.json \
+    --bin linera \
+    ${build_features:+--features $build_features}
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build ${build_flag:+"$build_flag"} \
+        --bin linera \
+        ${build_features:+--features $build_features} \
+    && cp \
+        target/"$build_folder"/linera \
+        /
+
+# ── Stage 4: runtime_base — OS deps shared by every runtime image ──
+FROM debian:bookworm-slim AS runtime_base
 
 ARG git_commit
 LABEL git_commit=$git_commit
-
 ARG build_date
 LABEL build_date=$build_date
 
@@ -166,18 +249,39 @@ RUN apt-get update && apt-get install -y \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=binaries \
-    /linera \
+# ── Stage 4a: validator runtime — linera-server + linera-proxy ──
+# Published as `linera-validator`. Note the validator Helm chart also invokes
+# the CLIENT binary (`linera storage check-existence` / `initialize`) — but only
+# from init containers (linera-server-initializer, linera-proxy-initializer,
+# linera-exporter-initializer), which take their own image. Those move to
+# `linera-client`; this image does not need the client binary.
+FROM runtime_base AS validator
+COPY --from=validator_builder \
     /linera-server \
     /linera-proxy \
     ./
 
-# ── Stage 4: tests-builder — compile the remote-net integration test ──
-# Builds /linera_net_tests and /linera-benchmark; also pre-compiles all
-# example Wasm contracts so the test binary can publish them without needing
-# cargo or source code at runtime.  The test binary lives in
-# /app/target/release/deps/ (a cache mount) so it must be copied out in the
-# same RUN.
+# ── Stage 4b: client runtime — the linera client binary only ──
+# Published as `linera-client`.
+FROM runtime_base AS client
+COPY --from=client_builder \
+    /linera \
+    ./
+
+# ── Stage 4c: nothing. There is no all-three image.
+# Every consumer maps to exactly one of the two above: anything running the
+# client (validator *-initializer init containers, the faucet, PM workers, CLI
+# users) takes linera-client; anything running server/proxy takes
+# linera-validator. `tests` is the one place that needs all three in a single
+# filesystem — `linera net up` spawns linera-server/linera-proxy as child
+# processes (cli_wrappers/local_net.rs command_for_binary) — and it gets them by
+# copying from both builders below, not from a published combined image.
+
+# ── Stage 5: tests-builder — remote-net test binary + benchmark + example wasm ──
+# Builds /linera_net_tests and /linera-benchmark; also pre-compiles all example
+# Wasm contracts so the test binary can publish them without needing cargo or
+# source at runtime. The test binary lives in /app/target/release/deps/ (a cache
+# mount) so it must be copied out in the same RUN.
 
 FROM builder_src AS tests-builder
 ARG build_flag
@@ -216,12 +320,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         -maxdepth 1 -name "*.wasm" \
         -exec cp {} /wasm-examples/ \;
 
-# ── Stage 5: tests runtime — runtime image + remote-net test binary ──
-# Used by linera-infra's network-health-check CronJob; production image
-# `linera:<tag>` (target=runtime) is unchanged. The test binary spawns
+# ── Stage 6: tests runtime — runtime image + remote-net test binary ──
+# Used by linera-infra's network-health-check CronJob. The test binary spawns
 # the linera CLI via PATH, so /linera is symlinked into /usr/local/bin.
 
-FROM runtime AS tests
+FROM runtime_base AS tests
+COPY --from=builder_src \
+    /linera \
+    /linera-server \
+    /linera-proxy \
+    ./
 RUN ln -s /linera /usr/local/bin/linera
 COPY --from=tests-builder /linera_net_tests /usr/local/bin/linera-net-tests
 COPY --from=tests-builder /linera-benchmark /usr/local/bin/linera-benchmark
@@ -237,3 +345,11 @@ RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/cargo && chmod +x /usr/local/b
 # source tree (.dockerignore strips target/) and overlay the pre-built wasm.
 COPY examples /examples
 COPY --from=tests-builder /wasm-examples/ /examples/target/wasm32-unknown-unknown/release/
+
+# ── Final stage: guard ──
+# Building with no --target used to silently build the expensive `tests` image.
+# There is no "build everything" production image — every caller must choose a
+# target. Placed last so a bare `docker build` resolves here and fails fast
+# (this stage has no builder ancestors, so chef/planner/cargo never run).
+FROM debian:bookworm-slim AS default
+RUN echo "ERROR: this Dockerfile requires an explicit --target (validator | client | tests)" >&2 && exit 1

--- a/docker/build-image.yaml
+++ b/docker/build-image.yaml
@@ -14,6 +14,11 @@ steps:
         "${_IMAGE_NAME_LONG_COMMIT}",
         "-f",
         "docker/Dockerfile",
+        # docker/Dockerfile now requires an explicit --target; without one the
+        # guard stage fails the build. `runtime` is the all-three-binaries
+        # image this config has always produced.
+        "--target",
+        "tests",
         ".",
         "--build-arg",
         "git_commit=${_GIT_COMMIT}",

--- a/docker/ci-compose.sh
+++ b/docker/ci-compose.sh
@@ -41,11 +41,11 @@ GIT_COMMIT=$(git rev-parse --short HEAD)
 export DOCKER_BUILDKIT=1
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera || exit 1
+    docker build --build-arg git_commit="$GIT_COMMIT" --target tests -f docker/Dockerfile . -t linera || exit 1
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
     if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera . || exit 1
+        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu --target tests -f docker/Dockerfile -t linera . || exit 1
     else
         echo "Unsupported Architecture: $CPU_ARCH"
         exit 1

--- a/docker/make-all-build.sh
+++ b/docker/make-all-build.sh
@@ -4,7 +4,7 @@ echo "Building linera images..."
 set -e
 docker build -f ./Dockerfile.indexer -t linera-indexer ..
 docker build -f ./Dockerfile.exporter -t linera-exporter ..
-docker build -f ./Dockerfile -t linera-test ..
+docker build -f ./Dockerfile --target tests -t linera-test ..
 docker build -f ./Dockerfile.explorer -t linera-explorer-new .. --build-arg VITE_API_BASE_URL=http://localhost:3002/api
 
 echo "Done building images"

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -287,12 +287,13 @@ build_local_image() {
 	log INFO "Building local Docker image from commit ${git_commit}..."
 
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
-		log INFO "[DRY RUN] Would build: docker build --build-arg git_commit=${git_commit} -f docker/Dockerfile . -t ${image_tag}"
+		log INFO "[DRY RUN] Would build: docker build --build-arg git_commit=${git_commit} --target validator -f docker/Dockerfile . -t ${image_tag}"
 		return 0
 	fi
 
 	if ! docker build \
 		--build-arg git_commit="${git_commit}" \
+		--target validator \
 		-f "${REPO_ROOT}/docker/Dockerfile" \
 		"${REPO_ROOT}" \
 		-t "${image_tag}"; then


### PR DESCRIPTION
## Motivation

`docker/Dockerfile` builds one image carrying all three binaries — `linera`, `linera-server`,
`linera-proxy` — so every consumer pulls binaries it does not run. Validators never invoke the
client; a client user has no use for the server or proxy.

There is also a sharp edge: the `tests` stage was **last**, making it the implicit default for
any `docker build` without `--target`. Almost every call site did exactly that, so they were all
paying `cargo test --no-run` of `linera_net_tests` and shipping the test payload unintentionally.

**Scope: this PR changes which BINARIES each image carries, not which FEATURES they are built
with.** Every target keeps today's feature set. Curating features per image (dropping
`storage-service`/`rocksdb` from the validator, adding `--no-default-features`) is a separate
follow-up with its own runtime gate, so a regression can never be ambiguous between the two.

## Proposal

Two published images, and no combined one:

| target | binaries | published as |
|---|---|---|
| `validator` | linera-server, linera-proxy | `linera-validator` |
| `client` | linera | `linera-client` |
| `tests` | all three + linera_net_tests + linera-benchmark + example wasm | `linera-tests` |

Every consumer maps to exactly one: anything running the client — the validator chart's
`linera-server-initializer` / `linera-proxy-initializer` / `linera-exporter-initializer` init
containers (`linera storage check-existence`), the faucet, PM workers, CLI users — takes
`linera-client`; anything running server/proxy takes `linera-validator`. Init containers carry
their own image, so a validator pod needs no client binary in its main image.

`tests` is the one place needing all three in a single filesystem, because `linera net up`
spawns `linera-server`/`linera-proxy` as **child processes** from its own path
(`cli_wrappers/local_net.rs` `command_for_binary` → `Command::new(path)`). It builds them
together in one stage rather than composing the two published images, which would mean three
separate cargo builds for one image.

A guard stage is placed last:

```dockerfile
FROM debian:bookworm-slim AS default
RUN echo "ERROR: this Dockerfile requires an explicit --target (validator | client | tests)" >&2 && exit 1
```

It has no builder ancestors, so a `--target`-less build fails in under a second instead of
silently building `tests`.

### Call sites

The guard turns a silent misbuild into a hard failure, so all of them had to be found and given
a target:

| call site | target | why |
|---|---|---|
| `scripts/deploy-validator.sh` | `validator` | only runs `/linera-server generate` (verified: no client use) |
| `docker/ci-compose.sh` (x2), `docker/make-all-build.sh`, `docker/build-image.yaml`, `bridge-e2e.yml` | `tests` | all run `linera net up` / a full local stack from one image |
| `build_image.yml` | — | its `main` image type is replaced by `validator` and `client` |

`build_image.yml`'s `build_and_push()` took only three positional args with no `--target`
support, so a target passed to it would have been silently dropped and the build would have hit
the guard. It now takes an optional 4th argument; the single-target Dockerfiles
(indexer/explorer/exporter/bridge) pass nothing and are unaffected.

## Test Plan

No docker daemon in my environment, so this is verified by graph analysis plus a real CI build.

**Stage-graph closure, parsed from the Dockerfile** — the property the PR rests on:

```
--target validator  cargo-build stages: [validator_builder]
--target client     cargo-build stages: [client_builder]
--target tests      cargo-build stages: [builder_src, tests-builder]   (tests-builder is FROM builder_src -> one build)
```

`validator` never pulls `builder_src` or `client_builder`, so it never compiles the client;
`client` never compiles server/proxy. The `default` guard has no ancestors.

**Every parallel build is awaited** in `docker_image.yml` — assigned and waited PID sets are
identical, so no build can fail silently in the background.

**`Docker Image` does not run on pull requests** (it triggers on push to `main`/`devnet_*`/
`testnet_*` plus `workflow_dispatch`), and `compose` / `bridge-e2e` are gated to
`merge_group`/`workflow_dispatch`/`push`. So a green PR here does **not** mean the images built.
I dispatched `Docker Image` manually against this branch to build all of them before merge —
that run is the actual gate, not the PR checks.

Workflow and Cloud Build YAML parse; hadolint passes.

## Release Plan

- These changes follow the usual deployment cycle.

**This is a coordinated change — `linera` is no longer published.** Existing digest pins keep
resolving (digests are immutable), but no new `linera:<commit>` tag will exist, so consumers must
move in step:

- linera-infra: validator `lineraImage` → `linera-validator`; the `*-initializer` init containers
  → `linera-client`; the conway faucet and PM workers' `lineraClientImage` → `linera-client`;
  `scripts/find-deploy-candidate.sh` resolves the image by name and needs updating.
- linera-artifacts: `docker-compose.yml`, `.env.production.template`, `QUICKSTART.md` and the
  Helm charts reference the image by name — this is the EXTERNAL operator surface, so it needs a
  deprecation note rather than a silent rename.
