### PR TITLE
Serve received-log page queries from a read lock on the chain worker

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -15,8 +15,8 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::{CryptoHash, ValidatorPublicKey},
     data_types::{
-        ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, OracleResponse, Round,
-        Timestamp,
+        Amount, ApplicationDescription, ArithmeticError, Blob, BlockHeight, Epoch, OracleResponse,
+        Round, Timestamp,
     },
     ensure,
     hashed::Hashed,
@@ -25,8 +25,8 @@ use linera_base::{
 use linera_cache::{Arc as CacheArc, UniqueValueCache, ValueCache};
 use linera_chain::{
     data_types::{
-        BlockProposal, BundleExecutionPolicy, IncomingBundle, MessageAction, MessageBundle,
-        OriginalProposal, ProposalContent, ProposedBlock,
+        BlockProposal, BundleExecutionPolicy, ChainAndHeight, IncomingBundle, MessageAction,
+        MessageBundle, OriginalProposal, ProposalContent, ProposedBlock,
     },
     manager::{self, ManagerSafetySnapshot},
     types::{
@@ -412,6 +412,64 @@ where
             self.vote_for_fallback().await?;
         }
         self.prepare_chain_info_response(query).await
+    }
+
+    /// Serves a received-log page query (see [`ChainInfoQuery::is_received_log_page`])
+    /// under a read lock. Serving a page of a long backlog reads tens of thousands of
+    /// storage rows; doing that under the write lock blocks all other work on the
+    /// chain, including block processing, for the duration of every page.
+    ///
+    /// Returns `Ok(None)` if the chain is not active: the caller must then retry
+    /// through the write path, which may initialize the chain state. The response
+    /// leaves `state_hash` unset — computing it memoizes the hash and therefore
+    /// needs mutable access — which is fine because the received-log pager does not
+    /// read it.
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn handle_received_log_page_query(
+        &self,
+        query: ChainInfoQuery,
+    ) -> Result<Option<ChainInfoResponse>, WorkerError> {
+        debug_assert!(query.is_received_log_page());
+        if !self.knows_chain_is_active() && !self.chain.is_active().await? {
+            return Ok(None);
+        }
+        let mut info = ChainInfo::from_chain_view_without_state_hash(&self.chain).await?;
+        info.requested_owner_balance = self
+            .requested_owner_balance(query.request_owner_balance)
+            .await?;
+        if let Some(start) = query.request_received_log_excluding_first_n {
+            info.requested_received_log = self.read_received_log_page(start).await?;
+        }
+        Ok(Some(ChainInfoResponse::new(info, self.config.key_pair())))
+    }
+
+    /// Reads the balance requested via [`ChainInfoQuery::request_owner_balance`].
+    async fn requested_owner_balance(
+        &self,
+        owner: AccountOwner,
+    ) -> Result<Option<Amount>, WorkerError> {
+        if owner == AccountOwner::CHAIN {
+            Ok(Some(*self.chain.execution_state.system.balance.get()))
+        } else {
+            Ok(self
+                .chain
+                .execution_state
+                .system
+                .balances
+                .get(&owner)
+                .await?)
+        }
+    }
+
+    /// Reads one page of the received log, starting at entry number `start` and
+    /// bounded by the configured maximum number of entries per response.
+    async fn read_received_log_page(&self, start: u64) -> Result<Vec<ChainAndHeight>, WorkerError> {
+        let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
+        let max_received_log_entries = self.config.chain_info_max_received_log_entries;
+        let end = start
+            .saturating_add(max_received_log_entries)
+            .min(self.chain.received_log.count());
+        Ok(self.chain.received_log.read(start..end).await?)
     }
 
     /// Returns the requested blob, if it belongs to the current locking block or pending proposal.
@@ -2591,17 +2649,10 @@ where
     ) -> Result<ChainInfoResponse, WorkerError> {
         self.initialize_and_save_if_needed().await?;
         let mut info = ChainInfo::from_chain_view(&mut self.chain).await?;
+        info.requested_owner_balance = self
+            .requested_owner_balance(query.request_owner_balance)
+            .await?;
         let chain = &self.chain;
-        if query.request_owner_balance == AccountOwner::CHAIN {
-            info.requested_owner_balance = Some(*chain.execution_state.system.balance.get());
-        } else {
-            info.requested_owner_balance = chain
-                .execution_state
-                .system
-                .balances
-                .get(&query.request_owner_balance)
-                .await?;
-        }
         if let Some(next_block_height) = query.test_next_block_height {
             // If not, send the same error as if a block with next_block_height was proposed.
             ensure!(
@@ -2653,12 +2704,7 @@ where
             .await?;
         info.requested_sent_certificate_hashes = hashes;
         if let Some(start) = query.request_received_log_excluding_first_n {
-            let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
-            let max_received_log_entries = self.config.chain_info_max_received_log_entries;
-            let end = start
-                .saturating_add(max_received_log_entries)
-                .min(chain.received_log.count());
-            info.requested_received_log = chain.received_log.read(start..end).await?;
+            info.requested_received_log = self.read_received_log_page(start).await?;
         }
         if query.request_manager_values {
             info.manager.add_values(&chain.manager);

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -114,6 +114,38 @@ impl ChainInfoQuery {
         self
     }
 
+    /// Returns whether this query only pages the received log — the shape issued by
+    /// the received-certificate sync. Such queries request no votes, no pending
+    /// message bundles, and nothing else that requires mutable access to the chain
+    /// state, so a worker may serve them from a read lock, without a state hash.
+    pub fn is_received_log_page(&self) -> bool {
+        // Exhaustively destructured (no `..`) on purpose: adding a field to
+        // `ChainInfoQuery` must force a decision here on whether the read-only page
+        // handler can serve or must reject queries carrying it.
+        let Self {
+            chain_id: _,
+            test_next_block_height,
+            request_owner_balance: _,
+            request_pending_message_bundles,
+            request_received_log_excluding_first_n,
+            request_manager_values,
+            request_leader_timeout,
+            request_fallback,
+            request_sent_certificate_hashes_by_heights,
+            request_previous_event_blocks,
+            request_latest_checkpoint_height,
+        } = self;
+        request_received_log_excluding_first_n.is_some()
+            && test_next_block_height.is_none()
+            && !request_pending_message_bundles
+            && !request_manager_values
+            && request_leader_timeout.is_none()
+            && !request_fallback
+            && request_sent_certificate_hashes_by_heights.is_empty()
+            && request_previous_event_blocks.is_empty()
+            && !request_latest_checkpoint_height
+    }
+
     /// Also requests the values from the chain manager, not just the votes.
     pub fn with_manager_values(mut self) -> Self {
         self.request_manager_values = true;
@@ -283,6 +315,22 @@ impl ChainInfo {
         C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
         ChainRuntimeContext<S>: ExecutionRuntimeContext,
     {
+        let mut info = Self::from_chain_view_without_state_hash(view).await?;
+        info.state_hash = Some(view.execution_state.crypto_hash_mut().await?);
+        Ok(info)
+    }
+
+    /// Same as [`Self::from_chain_view`], but leaves `state_hash` unset. Computing the
+    /// hash memoizes it in the view and therefore needs a mutable reference; this
+    /// variant allows building the response under a read lock for queries that do not
+    /// consume the state hash.
+    pub async fn from_chain_view_without_state_hash<C, S>(
+        view: &ChainStateView<C>,
+    ) -> Result<Self, ViewError>
+    where
+        C: Context<Extra = ChainRuntimeContext<S>> + Clone + 'static,
+        ChainRuntimeContext<S>: ExecutionRuntimeContext,
+    {
         let system_state = &view.execution_state.system;
         let tip_state = view.tip_state.get();
         Ok(ChainInfo {
@@ -294,7 +342,7 @@ impl ChainInfo {
             block_hash: tip_state.block_hash,
             next_block_height: tip_state.next_block_height,
             timestamp: view.execution_state.system.progress.get().timestamp,
-            state_hash: Some(view.execution_state.crypto_hash_mut().await?),
+            state_hash: None,
             committee_hash: *view.execution_state.system.committee_hash.get(),
             requested_owner_balance: None,
             requested_pending_message_bundles: Vec::new(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2498,6 +2498,7 @@ where
         assert_eq!(recipient_chain.received_log.count(), 1);
     }
     let query = ChainInfoQuery::new(chain_2).with_received_log_excluding_first_n(0);
+    assert!(query.is_received_log_page());
     let response = env
         .executing_worker()
         .handle_chain_info_query(query)
@@ -2510,6 +2511,8 @@ where
             height: BlockHeight::ZERO
         }
     );
+    // Received-log pages are served under a read lock and skip the state hash.
+    assert!(response.info.state_hash.is_none());
     Ok(())
 }
 
@@ -2551,6 +2554,22 @@ where
     assert_eq!(BlockHeight::from(1), info.next_block_height);
     assert_eq!(Some(certificate.hash()), info.block_hash);
     assert!(info.manager.pending.is_none());
+
+    // A received-log page query against an inactive chain must fall back from the
+    // read path to the write path and fail exactly like any other chain info query.
+    let page_query = ChainInfoQuery::new(chain_2).with_received_log_excluding_first_n(0);
+    assert!(page_query.is_received_log_page());
+    let page_error = env
+        .executing_worker()
+        .handle_chain_info_query(page_query)
+        .await
+        .unwrap_err();
+    let plain_error = env
+        .executing_worker()
+        .handle_chain_info_query(ChainInfoQuery::new(chain_2))
+        .await
+        .unwrap_err();
+    assert_eq!(format!("{page_error:?}"), format!("{plain_error:?}"));
     Ok(())
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1772,6 +1772,29 @@ where
         #[cfg(with_metrics)]
         metrics::CHAIN_INFO_QUERIES.inc();
         let chain_id = query.chain_id;
+        // Received-log pages are served under a read lock so that paging a long
+        // backlog does not block block processing on the chain. The read path bows
+        // out (`Ok(None)`) if the chain state was never initialized; only then take
+        // the write lock, which initializes it.
+        if query.is_received_log_page() {
+            let read_query = query.clone();
+            let read_result = self
+                .chain_read(chain_id, move |guard| async move {
+                    guard.handle_received_log_page_query(read_query).await
+                })
+                .await;
+            match read_result {
+                Ok(Some(response)) => {
+                    trace!("{} --> {:?}", self.nickname(), response);
+                    return Ok(response);
+                }
+                Ok(None) => (),
+                Err(error) => {
+                    trace!("{} --> {:?}", self.nickname(), error);
+                    return Err(error);
+                }
+            }
+        }
         let result = self
             .chain_write(chain_id, move |mut guard| async move {
                 guard.handle_chain_info_query(query).await


### PR DESCRIPTION
## Motivation

Every `ChainInfoQuery` is served under the chain worker's exclusive write lock, because parts of the handler can vote or write. A received-log page — the query issued repeatedly by the received-certificate sync — makes the validator read up to 20,000 storage rows while holding that lock, so paging a multi-million-entry backlog (the 2026-07-28/29 testnet-conway incidents) serializes block processing on the queried chain behind hours of cold storage reads.

## Proposal

Route queries matching `ChainInfoQuery::is_received_log_page` — received-log paging and nothing that votes, returns pending bundles, or otherwise needs mutable access — through `chain_read` and a read-only handler. Two deliberate design points:

- The response leaves `state_hash` unset: computing it memoizes the hash in the view (hence `&mut`), and the only production issuer of this query shape (`get_received_log_from_validator`) never reads it. `ChainInfo::from_chain_view` is split so the write path behavior is unchanged.
- If the chain is not verifiably active (fresh worker instance, `is_active()` false), the read path bows out with `Ok(None)` and the query falls back to the write path, which may initialize the chain state — error behavior for unknown/inactive chains is exactly the old one (asserted by test).

`is_received_log_page` exhaustively destructures the query (no `..`), so adding a field to `ChainInfoQuery` forces a decision about the read path at compile time. The owner-balance and log-page blocks are factored into helpers shared by both paths so their semantics cannot silently diverge.

## Test Plan

- `cargo test -p linera-core --lib` — 164/164 pass, including a new assertion that page responses omit `state_hash` and a new fallback test asserting identical errors for page-shaped vs plain queries on an inactive chain.
- `cargo clippy` (native and wasm32/web-default, all targets/features) and `cargo fmt` clean.
- Adversarially reviewed: all `state_hash` consumers grepped (none receive page-shaped responses); tokio RwLock is write-preferring, so paging cannot starve writers.

## Release Plan

- These changes should be backported to the latest `testnet` branch, then
    - be released in a validator hotfix.

## Links

- Companion to #6631 / #6634 (client-side pacing and slicing of the same walk); this PR removes the per-page write-lock serialization on the validator side.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)