### PR TITLE
Fix the validator address examples: the CLI parses grpcs:host:port, not a URL

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1442,7 +1442,7 @@ Adds a new validator with the specified public key, account key, network address
 
 * `--public-key <PUBLIC_KEY>` — Public key of the validator to add
 * `--account-key <ACCOUNT_KEY>` — Account public key for receiving payments and rewards
-* `--address <ADDRESS>` — Network address where the validator can be reached (e.g., grpcs://host:port)
+* `--address <ADDRESS>` — Network address where the validator can be reached (e.g., grpcs:host:port)
 * `--votes <VOTES>` — Voting weight for consensus (default: 1)
 * `--skip-online-check` — Skip online connectivity verification before adding
 
@@ -1478,7 +1478,7 @@ PREREQUISITE: the read layers are only meaningful if the candidate already holds
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the candidate validator (e.g. `grpcs://host:port`)
+* `<ADDRESS>` — Network address of the candidate validator (e.g. `grpcs:host:port`)
 
 ###### **Options:**
 
@@ -1577,7 +1577,7 @@ Connects to a validator at the specified network address and queries its view of
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the validator (e.g., grpcs://host:port)
+* `<ADDRESS>` — Network address of the validator (e.g., grpcs:host:port)
 
 ###### **Options:**
 
@@ -1596,7 +1596,7 @@ Connects to a validator at the specified network address and queries its view of
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the validator (e.g., grpcs://host:port)
+* `<ADDRESS>` — Network address of the validator (e.g., grpcs:host:port)
 
 ###### **Options:**
 
@@ -1630,7 +1630,7 @@ Pushes the current chain state from local storage to a validator node, ensuring 
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the validator to sync (e.g., grpcs://host:port)
+* `<ADDRESS>` — Network address of the validator to sync (e.g., grpcs:host:port)
 
 ###### **Options:**
 

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -114,7 +114,7 @@ pub struct Add {
     /// Account public key for receiving payments and rewards
     #[arg(long)]
     account_key: AccountPublicKey,
-    /// Network address where the validator can be reached (e.g., grpcs://host:port)
+    /// Network address where the validator can be reached (e.g., grpcs:host:port)
     #[arg(long)]
     address: url::Url,
     /// Voting weight for consensus (default: 1)
@@ -182,7 +182,7 @@ pub struct List {
 /// view of the blockchain state, including block height and committee information.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Query {
-    /// Network address of the validator (e.g., grpcs://host:port)
+    /// Network address of the validator (e.g., grpcs:host:port)
     address: String,
     /// Chain ID to query about (defaults to default chain)
     #[arg(long)]
@@ -198,7 +198,7 @@ pub struct Query {
 /// view of the blockchain.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct QueryBlock {
-    /// Network address of the validator (e.g., grpcs://host:port)
+    /// Network address of the validator (e.g., grpcs:host:port)
     address: String,
     /// Chain ID to query about (defaults to default chain)
     #[arg(long)]
@@ -228,7 +228,7 @@ pub struct Remove {
 /// ensuring the validator has up-to-date information about specified chains.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Sync {
-    /// Network address of the validator to sync (e.g., grpcs://host:port)
+    /// Network address of the validator to sync (e.g., grpcs:host:port)
     address: String,
     /// Chain IDs to synchronize (defaults to all chains in wallet)
     #[arg(long)]

--- a/linera-service/src/cli/validator_benchmark/config.rs
+++ b/linera-service/src/cli/validator_benchmark/config.rs
@@ -20,7 +20,7 @@ use linera_base::{crypto::ValidatorPublicKey, identifiers::ChainId};
 /// warns when a chain is not held.
 #[derive(Debug, Clone, clap::Parser, serde::Serialize)]
 pub struct Benchmark {
-    /// Network address of the candidate validator (e.g. `grpcs://host:port`).
+    /// Network address of the candidate validator (e.g. `grpcs:host:port`).
     pub address: String,
 
     /// Expected public key of the validator (identity verification).


### PR DESCRIPTION
## Motivation

Five `--help` strings advertise an address form the CLI rejects:

```
<ADDRESS> — Network address of the validator (e.g., grpcs://host:port)
```

but the parser those arguments reach requires exactly three colon-separated parts:

```rust
let parts = s.split(':').collect::<Vec<_>>();
anyhow::ensure!(parts.len() == 3, "Expecting format `(tcp|udp|grpc|grpcs):host:port`");
```

`grpcs://host:443` splits into four, so following the documented example gives:

```
Error is Grpc error: error creating channel: failed to connect to address: invalid URI
```

This cost real time while onboarding an external validator to testnet-conway: the
address in the committee is `grpcs:host:443` — the form the chain stores and the
faucet serves — while the help said to type `grpcs://host:443`.

Affected, all of which reach `node_provider.make_node()` with an `address: String`:

| command | field |
| --- | --- |
| `validator query` | `Query.address` |
| `validator query-block` | `QueryBlock.address` |
| `validator sync` | `Sync.address` |
| `validator benchmark` | `Benchmark.address` |

**`validator add` is the one that can do lasting damage.** Its `--address` is a
`url::Url`, which accepts *both* spellings — and the value is written into the
committee verbatim:

```rust
network_address: me.address.to_string(),
```

Every client then re-parses that string with the strict parser above. So
`--address grpcs://host:443`, exactly as the help suggests, produces a committee
entry no client can connect to.

## Proposal

Correct the example to `grpcs:host:port` in all five places. Doc comments only, no
behaviour change.

Worth considering separately: make the parser accept an optional `//` so both
spellings work. That is a behaviour change with a compatibility question — what
should `validator add` then store on chain? — so this PR only makes the
documentation match the code.

## Test Plan

- `CLI.md` is updated to exactly the five mirrored strings, which is what
  `linera help-markdown` emits for this change, so the existing CI check
  (`diff CLI.md <(cargo run --bin linera -- help-markdown)`) stays satisfied.
- `cargo clippy --workspace --all-targets --exclude linera-web -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- Verified against the live network: `validator query grpcs:linera-testnet.rubynodes.io:443`
  returns the validator's chain info, while `grpcs://…` fails with `invalid URI`;
  and every address in testnet-conway's committee is in the `grpcs:host:port` form.