### PR TITLE
Fix the validator address examples: the CLI parses grpcs:host:port, not a URL (backport of #6637)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -1418,7 +1418,7 @@ Adds a new validator with the specified public key, account key, network address
 
 * `--public-key <PUBLIC_KEY>` — Public key of the validator to add
 * `--account-key <ACCOUNT_KEY>` — Account public key for receiving payments and rewards
-* `--address <ADDRESS>` — Network address where the validator can be reached (e.g., grpcs://host:port)
+* `--address <ADDRESS>` — Network address where the validator can be reached (e.g., grpcs:host:port)
 * `--votes <VOTES>` — Voting weight for consensus (default: 1)
 * `--skip-online-check` — Skip online connectivity verification before adding
 
@@ -1454,7 +1454,7 @@ PREREQUISITE: the read layers are only meaningful if the candidate already holds
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the candidate validator (e.g. `grpcs://host:port`)
+* `<ADDRESS>` — Network address of the candidate validator (e.g. `grpcs:host:port`)
 
 ###### **Options:**
 
@@ -1553,7 +1553,7 @@ Connects to a validator at the specified network address and queries its view of
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the validator (e.g., grpcs://host:port)
+* `<ADDRESS>` — Network address of the validator (e.g., grpcs:host:port)
 
 ###### **Options:**
 
@@ -1572,7 +1572,7 @@ Connects to a validator at the specified network address and queries its view of
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the validator (e.g., grpcs://host:port)
+* `<ADDRESS>` — Network address of the validator (e.g., grpcs:host:port)
 
 ###### **Options:**
 
@@ -1606,7 +1606,7 @@ Pushes the current chain state from local storage to a validator node, ensuring 
 
 ###### **Arguments:**
 
-* `<ADDRESS>` — Network address of the validator to sync (e.g., grpcs://host:port)
+* `<ADDRESS>` — Network address of the validator to sync (e.g., grpcs:host:port)
 
 ###### **Options:**
 

--- a/linera-service/src/cli/validator.rs
+++ b/linera-service/src/cli/validator.rs
@@ -114,7 +114,7 @@ pub struct Add {
     /// Account public key for receiving payments and rewards
     #[arg(long)]
     account_key: AccountPublicKey,
-    /// Network address where the validator can be reached (e.g., grpcs://host:port)
+    /// Network address where the validator can be reached (e.g., grpcs:host:port)
     #[arg(long)]
     address: url::Url,
     /// Voting weight for consensus (default: 1)
@@ -182,7 +182,7 @@ pub struct List {
 /// view of the blockchain state, including block height and committee information.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Query {
-    /// Network address of the validator (e.g., grpcs://host:port)
+    /// Network address of the validator (e.g., grpcs:host:port)
     address: String,
     /// Chain ID to query about (defaults to default chain)
     #[arg(long)]
@@ -198,7 +198,7 @@ pub struct Query {
 /// view of the blockchain.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct QueryBlock {
-    /// Network address of the validator (e.g., grpcs://host:port)
+    /// Network address of the validator (e.g., grpcs:host:port)
     address: String,
     /// Chain ID to query about (defaults to default chain)
     #[arg(long)]
@@ -228,7 +228,7 @@ pub struct Remove {
 /// ensuring the validator has up-to-date information about specified chains.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct Sync {
-    /// Network address of the validator to sync (e.g., grpcs://host:port)
+    /// Network address of the validator to sync (e.g., grpcs:host:port)
     address: String,
     /// Chain IDs to synchronize (defaults to all chains in wallet)
     #[arg(long)]

--- a/linera-service/src/cli/validator_benchmark/config.rs
+++ b/linera-service/src/cli/validator_benchmark/config.rs
@@ -20,7 +20,7 @@ use linera_base::{crypto::ValidatorPublicKey, identifiers::ChainId};
 /// warns when a chain is not held.
 #[derive(Debug, Clone, clap::Parser, serde::Serialize)]
 pub struct Benchmark {
-    /// Network address of the candidate validator (e.g. `grpcs://host:port`).
+    /// Network address of the candidate validator (e.g. `grpcs:host:port`).
     pub address: String,
 
     /// Expected public key of the validator (identity verification).


### PR DESCRIPTION
## Motivation

Backport of #6637 to `testnet_conway`, which is where this actually bites: the
conway client is the one operators run against the live network.

Five `--help` strings advertise an address form the CLI rejects:

```
<ADDRESS> — Network address of the validator (e.g., grpcs://host:port)
```

while the parser those arguments reach requires exactly three colon-separated
parts:

```rust
let parts = s.split(':').collect::<Vec<_>>();
anyhow::ensure!(parts.len() == 3, "Expecting format `(tcp|udp|grpc|grpcs):host:port`");
```

Following the documented example gives:

```
Error is Grpc error: error creating channel: failed to connect to address: invalid URI
```

Hit while onboarding the first external validator to testnet-conway: every address
in the live committee is `grpcs:host:443`, and the help said to type
`grpcs://host:443`.

`validator add --address` is the one that can do lasting damage — it is a
`url::Url`, accepts both spellings, and the value is written to the committee
verbatim (`network_address: me.address.to_string()`), where every client re-parses
it with the strict parser above. The documented form would produce an entry no
client can connect to.

## Proposal

Identical to #6637: correct the example to `grpcs:host:port` in all five places
(`validator add`, `query`, `query-block`, `sync`, `benchmark`) plus the mirrored
`CLI.md` lines. Doc comments only, no behaviour change.

## Test Plan

- The `CLI.md` diff is exactly the five strings mirrored from the doc comments, so
  the existing `diff CLI.md <(cargo run --bin linera -- help-markdown)` check stays
  satisfied.
- `cargo fmt --check`: clean.
- Verified against the live network with the conway client
  (`linera-8ad67c79…`): `validator query grpcs:linera-testnet.rubynodes.io:443
  --chain-id <admin> --public-key <pk>` returns the validator's chain info, while
  the `grpcs://…` form fails with `invalid URI`.
- `cargo clippy --workspace --all-targets --exclude linera-web` could not be run
  here: it fails on `testnet_conway` in my environment before reaching any of my
  changes (`linera-views`, `graphql_client`, `alloy-provider` — a toolchain/feature
  mismatch, reproduced identically on a clean tree with the change stashed). Since
  this PR changes only doc comments and a generated markdown file, CI is the real
  check.