### PR TITLE
linera-core: export executed blocks to the committee from the chain workers, relayed through the proxy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -385,7 +385,7 @@ jobs:
         cargo test -p linera-service --test exporter_tests --features storage-service -- --ignored --nocapture
     - name: Run the block export integration test
       run: |
-        cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored --nocapture
+        cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored --nocapture --test-threads=1
 
   check-wit-files:
     needs: changed-files

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -385,7 +385,7 @@ jobs:
         cargo test -p linera-service --test exporter_tests --features storage-service -- --ignored --nocapture
     - name: Run the block export integration test
       run: |
-        cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored --nocapture --test-threads=1
+        cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored --nocapture
 
   check-wit-files:
     needs: changed-files

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -383,6 +383,9 @@ jobs:
     - name: Run the exporter integration test
       run: |
         cargo test -p linera-service --test exporter_tests --features storage-service -- --ignored --nocapture
+    - name: Run the block export integration test
+      run: |
+        cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored --nocapture
 
   check-wit-files:
     needs: changed-files

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -323,14 +323,11 @@ where
     // blocks pushed since the last save are missing here, and a crash loses the reports that were
     // never folded in. That is deliberate — re-sending a block the destination already has is
     // skipped by an integer comparison before signature verification, whereas *under*-sending
-    // would leave a permanent gap. Validators that leave the committee are pruned, so this stays
-    // bounded by the committee size.
-    //
-    // This field must stay **last**: the `RootView` derive assigns each field's storage tag
-    // positionally, so appending is what makes an existing database readable by the new code.
+    // would leave a permanent gap.
     /// The height of the highest block of this chain that has been pushed to each of the other
     /// committee validators. A validator with no entry has not been exported to yet, and is
-    /// queried before the first push.
+    /// queried before the first push. Validators that leave the committee are pruned, so this
+    /// stays bounded by the committee size.
     pub exported_heights: RegisterView<C, NonCanonicalBTreeMap<ValidatorPublicKey, BlockHeight>>,
 }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -319,23 +319,18 @@ where
     /// that tracks all chains and never filters.
     pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
 
+    // A *lower* bound, not an exact record: the export task reports progress asynchronously, so
+    // blocks pushed since the last save are missing here, and a crash loses the reports that were
+    // never folded in. That is deliberate — re-sending a block the destination already has is
+    // skipped by an integer comparison before signature verification, whereas *under*-sending
+    // would leave a permanent gap. Validators that leave the committee are pruned, so this stays
+    // bounded by the committee size.
+    //
+    // This field must stay **last**: the `RootView` derive assigns each field's storage tag
+    // positionally, so appending is what makes an existing database readable by the new code.
     /// The height of the highest block of this chain that has been pushed to each of the other
-    /// committee validators, as reported by this chain's export task the last time the chain was
-    /// saved.
-    ///
-    /// This is a *lower* bound on what the destination has: the export task reports progress
-    /// asynchronously, so blocks pushed since the last save are missing here, and a crash loses
-    /// the reports that were never folded in. That is deliberate — re-sending a block the
-    /// destination already has is skipped by an integer comparison before signature verification,
-    /// whereas *under*-sending would leave a permanent gap. An entry that is absent (a validator
-    /// we have never exported to, or a pre-existing database entry from before this field was
-    /// added) simply means the export task queries the destination before its first send.
-    ///
-    /// Validators that leave the committee are pruned, so this stays bounded by the committee
-    /// size.
-    ///
-    /// This field must stay **last**: the `RootView` derive assigns each field's storage tag
-    /// positionally, so appending is what makes an existing database readable by the new code.
+    /// committee validators. A validator with no entry has not been exported to yet, and is
+    /// queried before the first push.
     pub exported_heights: RegisterView<C, NonCanonicalBTreeMap<ValidatorPublicKey, BlockHeight>>,
 }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -318,6 +318,25 @@ where
     /// they have never been filtered — a pre-existing database entry (migration), or a validator
     /// that tracks all chains and never filters.
     pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
+
+    /// The height of the highest block of this chain that has been pushed to each of the other
+    /// committee validators, as reported by this chain's export task the last time the chain was
+    /// saved.
+    ///
+    /// This is a *lower* bound on what the destination has: the export task reports progress
+    /// asynchronously, so blocks pushed since the last save are missing here, and a crash loses
+    /// the reports that were never folded in. That is deliberate — re-sending a block the
+    /// destination already has is skipped by an integer comparison before signature verification,
+    /// whereas *under*-sending would leave a permanent gap. An entry that is absent (a validator
+    /// we have never exported to, or a pre-existing database entry from before this field was
+    /// added) simply means the export task queries the destination before its first send.
+    ///
+    /// Validators that leave the committee are pruned, so this stays bounded by the committee
+    /// size.
+    ///
+    /// This field must stay **last**: the `RootView` derive assigns each field's storage tag
+    /// positionally, so appending is what makes an existing database readable by the new code.
+    pub exported_heights: RegisterView<C, NonCanonicalBTreeMap<ValidatorPublicKey, BlockHeight>>,
 }
 
 /// Block-chaining state.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -319,15 +319,11 @@ where
     /// that tracks all chains and never filters.
     pub outbox_index_tracked_hash: RegisterView<C, Option<CryptoHash>>,
 
-    // A *lower* bound, not an exact record: the export task reports progress asynchronously, so
-    // blocks pushed since the last save are missing here, and a crash loses the reports that were
-    // never folded in. That is deliberate — re-sending a block the destination already has is
-    // skipped by an integer comparison before signature verification, whereas *under*-sending
-    // would leave a permanent gap.
-    /// The height of the highest block of this chain that has been pushed to each of the other
-    /// committee validators. A validator with no entry has not been exported to yet, and is
-    /// queried before the first push. Validators that leave the committee are pruned, so this
-    /// stays bounded by the committee size.
+    // A lower bound, not an exact record: progress is reported asynchronously, so a crash loses
+    // whatever was not folded in. Deliberate — a re-sent block the destination already has is
+    // skipped on an integer compare, whereas under-sending would leave a permanent gap.
+    /// The highest block of this chain pushed to each other committee validator. A validator with
+    /// no entry is queried before its first push; ones that leave the committee are pruned.
     pub exported_heights: RegisterView<C, NonCanonicalBTreeMap<ValidatorPublicKey, BlockHeight>>,
 }
 

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -42,6 +42,9 @@ pub struct ChainWorkerConfig {
     /// cross-chain message. When exceeded, the bundles are split into multiple requests.
     /// Defaults to `usize::MAX` (no chunking).
     pub cross_chain_message_chunk_limit: usize,
+    /// How often, at most, export progress is folded into the persisted `exported_heights` of an
+    /// active chain — the fold rewrites the whole register.
+    pub exported_heights_fold_interval: linera_base::time::Duration,
     /// Maximum number of cross-chain requests coalesced into a single batch by the
     /// per-chain driver. Smaller values bound the worst-case write-lock hold time at
     /// the cost of more lock acquisitions; larger values amortize lock and storage
@@ -97,6 +100,7 @@ impl Default for ChainWorkerConfig {
             block_cache_size: crate::worker::DEFAULT_BLOCK_CACHE_SIZE,
             execution_state_cache_size: crate::worker::DEFAULT_EXECUTION_STATE_CACHE_SIZE,
             cross_chain_message_chunk_limit: usize::MAX,
+            exported_heights_fold_interval: linera_base::time::Duration::from_secs(5),
             cross_chain_batch_size_limit: 1000,
             allow_revert_confirm: false,
             reset_on_corrupted_chain_state: None,

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -675,9 +675,16 @@ impl<N> DestState<N> {
     }
 
     /// Moves the cursor past the last chain considered, so the next round advances.
+    ///
+    /// A round that considered nothing — a saturated destination breaks before looking at its
+    /// first candidate — leaves the cursor alone. Clearing it there restarts the next drain at
+    /// the lowest chain id, which is the starvation the cursor exists to prevent, and a busy
+    /// destination is saturated on almost every tick.
     fn advance_cursor(&mut self, last_considered: Option<ChainId>) {
-        self.lagging_cursor =
-            last_considered.and_then(|id| self.lagging.range(id..).nth(1).copied());
+        let Some(last) = last_considered else {
+            return;
+        };
+        self.lagging_cursor = self.lagging.range(last..).nth(1).copied();
     }
 }
 
@@ -1499,7 +1506,7 @@ where
         jobs: &mut FuturesUnordered<JobFuture>,
         now: Instant,
     ) {
-        if dest.retry_at.is_some_and(|at| at > now) {
+        if dest.retry_at.is_some_and(|at| at > now) || dest.in_flight >= dest.window {
             return;
         }
         // Only as far as the window allows, so the cost is the sends we are about to make and
@@ -1511,6 +1518,7 @@ where
         // a backlog of ineligible entries cannot turn this back into a full scan.
         let ordered = dest.drain_candidates(dest.window.saturating_mul(LAGGING_SCAN_FACTOR));
         let mut spawn = Vec::new();
+        let mut stale = Vec::new();
         let mut last_visited = None;
         for chain_id in ordered {
             if dest.in_flight + spawn.len() >= dest.window {
@@ -1518,6 +1526,9 @@ where
             }
             last_visited = Some(chain_id);
             let Some(record) = chains.get(&chain_id) else {
+                // The chain was forgotten under us; drop the entry rather than walk past it on
+                // every drain from here on.
+                stale.push(chain_id);
                 continue;
             };
             let Some(chain_dest) = record.dest(index) else {
@@ -1532,6 +1543,9 @@ where
             }
         }
         dest.advance_cursor(last_visited);
+        for chain_id in stale {
+            dest.lagging.remove(&chain_id);
+        }
         for chain_id in spawn {
             let Some(record) = chains.get_mut(&chain_id) else {
                 continue;
@@ -1867,45 +1881,66 @@ mod tests {
 
     /// The drain rotates through the backlog instead of always serving its lowest chain ids.
     ///
-    /// The maintained set replaced a FIFO, and a set is *ordered* — iterating it from the start
+    /// The maintained set replaced a FIFO, and a set is *ordered* — walking it from the start
     /// every tick hands the whole window to the same few chains and starves everything after
     /// them, which at a large backlog means those chains are never exported at all.
     #[test]
     fn draining_rotates_through_the_backlog() {
         let mut dest = test_dest_state();
-        dest.window = 2;
-        let ids = (0..6u8)
-            .map(|i| ChainId(CryptoHash::test_hash(format!("chain{i}"))))
-            .collect::<Vec<_>>();
-        dest.lagging = ids.iter().copied().collect();
+        dest.lagging = test_chain_ids(6).into_iter().collect();
 
-        // Two passes with the window's worth of work each; the second must move on.
-        let first = drained(&dest, 2);
-        dest.lagging_cursor = first
-            .last()
-            .and_then(|id| dest.lagging.range(*id..).nth(1).copied());
-        let second = drained(&dest, 2);
+        // Two rounds of a two-chain window; the second must move past the first.
+        let first = dest.drain_candidates(2);
+        dest.advance_cursor(first.last().copied());
+        let second = dest.drain_candidates(2);
 
         assert_eq!(first.len(), 2);
         assert_eq!(second.len(), 2);
         assert!(
             first.iter().all(|id| !second.contains(id)),
-            "the second pass repeated the first: {first:?} then {second:?}",
+            "the second round repeated the first: {first:?} then {second:?}",
         );
     }
 
-    /// The candidate ordering `drain_ready` walks, without the spawning around it.
-    fn drained(dest: &DestState<()>, budget: usize) -> Vec<ChainId> {
-        match dest.lagging_cursor {
-            Some(cursor) => dest
-                .lagging
-                .range(cursor..)
-                .chain(dest.lagging.iter().take_while(|id| **id < cursor))
-                .copied()
-                .take(budget)
-                .collect(),
-            None => dest.lagging.iter().copied().take(budget).collect(),
-        }
+    /// A round that considered nothing must not throw the rotation away.
+    ///
+    /// `drain_ready` returns before looking at a single candidate when the destination is
+    /// already at its window, which for a destination with a backlog is almost every tick. If
+    /// that round reset the cursor, the next one would restart at the lowest chain id and the
+    /// tail of the backlog would never be reached — the starvation the cursor exists to prevent,
+    /// reintroduced by the cursor's own bookkeeping.
+    #[test]
+    fn a_round_that_visits_nothing_keeps_its_place() {
+        let mut dest = test_dest_state();
+        let ids = test_chain_ids(6);
+        dest.lagging = ids.iter().copied().collect();
+
+        let first = dest.drain_candidates(2);
+        dest.advance_cursor(first.last().copied());
+        let parked = dest.lagging_cursor;
+        assert!(parked.is_some(), "the first round must park the cursor");
+
+        // The saturated round: no candidate is visited, so nothing was considered.
+        dest.advance_cursor(None);
+
+        assert_eq!(
+            dest.lagging_cursor, parked,
+            "a round that visited nothing moved the cursor",
+        );
+        let resumed = dest.drain_candidates(2);
+        assert!(
+            resumed.iter().all(|id| !first.contains(id)),
+            "the drain restarted at the front of the backlog: {first:?} then {resumed:?}",
+        );
+    }
+
+    /// Chain ids in the order `lagging` holds them, so a test can name "the front" of a backlog.
+    fn test_chain_ids(count: usize) -> Vec<ChainId> {
+        let mut ids = (0..count)
+            .map(|i| ChainId(CryptoHash::test_hash(format!("chain{i}"))))
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids
     }
 
     /// Destinations indexed the way `sync_destinations` assigns them: in registration order.

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -40,7 +40,7 @@
 //! full history of a chain that never produces blocks again is out of scope here.
 
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap},
     iter,
     sync::{Arc, Mutex},
 };
@@ -309,10 +309,26 @@ impl Clone for BlockExportHandle {
     }
 }
 
+/// A destination's dense index, assigned once per public key and never reused.
+///
+/// All per-chain state is keyed by this rather than by `ValidatorPublicKey`, which is 88 bytes
+/// and whose `Ord` re-encodes the curve point on *every comparison* — measured at 36 ns, against
+/// about 1 ns for an integer. Per-chain state is the one place that cost is multiplied by the
+/// number of chains a down destination leaves behind.
+type DestIndex = u32;
+
 /// The highest height each destination has acknowledged, per chain, written by the queue task
 /// and folded into each chain's `exported_heights` by its worker on save. Entries are removed
 /// when a chain converges, so this holds lagging chains only.
-type SharedProgress = Arc<Mutex<HashMap<ChainId, BTreeMap<ValidatorPublicKey, BlockHeight>>>>;
+#[derive(Default)]
+struct ProgressMap {
+    /// What the indices below refer to. Append-only: an index keeps its meaning for the life of
+    /// the process, so a validator that leaves and rejoins cannot inherit another's cursors.
+    validators: Vec<ValidatorPublicKey>,
+    heights: HashMap<ChainId, Vec<(DestIndex, BlockHeight)>>,
+}
+
+type SharedProgress = Arc<Mutex<ProgressMap>>;
 
 /// The height after each chain's newest announced block. Written on every `export` call before
 /// the queue is tried, so a block the full queue drops still raises the repair target the tick
@@ -407,13 +423,18 @@ impl BlockExportHandle {
             .progress
             .lock()
             .expect("progress mutex is never poisoned");
-        let Some(chain_progress) = progress.get(&chain_id) else {
+        let Some(chain_progress) = progress.heights.get(&chain_id) else {
             return BTreeMap::new();
         };
         chain_progress
             .iter()
-            .filter(|(validator, _)| committee.validators().contains_key(*validator))
-            .map(|(validator, height)| (*validator, *height))
+            .filter_map(|(index, height)| {
+                let validator = progress.validators.get(*index as usize)?;
+                committee
+                    .validators()
+                    .contains_key(validator)
+                    .then_some((*validator, *height))
+            })
             .collect()
     }
 }
@@ -454,8 +475,10 @@ where
         committee_dirty: false,
         admin_chain_id: None,
         ticks_until_scan: 0,
+        ticks_until_sweep: TICKS_PER_CONVERGENCE_SWEEP,
         chains: HashMap::new(),
-        destinations: HashMap::new(),
+        destinations: BTreeMap::new(),
+        dest_indices: BTreeMap::new(),
         next_generation: 0,
         announced_epoch: None,
         scan_attempted_for: None,
@@ -485,7 +508,10 @@ struct ChainRecord {
     tip: BlockHeight,
     /// When this chain last saw a block or a completed send, for the convergence sweep.
     last_activity: Instant,
-    dests: BTreeMap<ValidatorPublicKey, ChainDest>,
+    /// Sorted by index, so lookups binary-search integers. A flat vector rather than a map
+    /// because this is allocated per tracked chain: a `BTreeMap` pays for an eleven-slot leaf
+    /// whatever the committee size.
+    dests: Vec<(DestIndex, ChainDest)>,
 }
 
 impl ChainRecord {
@@ -497,24 +523,25 @@ impl ChainRecord {
     /// path used to miss the seeding, and nothing in the suite could see it.
     fn new<N>(
         now: Instant,
-        destinations: &HashMap<ValidatorPublicKey, DestState<N>>,
+        destinations: &BTreeMap<DestIndex, DestState<N>>,
         exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
     ) -> Self {
         ChainRecord {
             tip: BlockHeight::ZERO,
             last_activity: now,
+            // Already in index order, which is the order `dests` must keep.
             dests: destinations
-                .keys()
-                .map(|validator| {
+                .iter()
+                .map(|(index, dest)| {
                     // Seeded here rather than by a later fill: a cursor pre-populated as `None`
                     // and then only `or_insert`-ed would silently swallow the persisted height,
                     // leaving `exported_heights` write-only and costing a query per destination
                     // on every restart.
                     let next_height = exported_heights
-                        .get(validator)
+                        .get(&dest.validator)
                         .and_then(|height| height.try_add_one().ok());
                     (
-                        *validator,
+                        *index,
                         ChainDest {
                             next_height,
                             ..ChainDest::default()
@@ -523,6 +550,34 @@ impl ChainRecord {
                 })
                 .collect(),
         }
+    }
+
+    fn dest(&self, index: DestIndex) -> Option<&ChainDest> {
+        let at = self
+            .dests
+            .binary_search_by_key(&index, |(at, _)| *at)
+            .ok()?;
+        Some(&self.dests[at].1)
+    }
+
+    fn dest_mut(&mut self, index: DestIndex) -> Option<&mut ChainDest> {
+        let at = self
+            .dests
+            .binary_search_by_key(&index, |(at, _)| *at)
+            .ok()?;
+        Some(&mut self.dests[at].1)
+    }
+
+    /// The cursor for `index`, created empty if this record does not have one yet.
+    fn dest_entry(&mut self, index: DestIndex) -> &mut ChainDest {
+        let at = match self.dests.binary_search_by_key(&index, |(at, _)| *at) {
+            Ok(at) => at,
+            Err(at) => {
+                self.dests.insert(at, (index, ChainDest::default()));
+                at
+            }
+        };
+        &mut self.dests[at].1
     }
 }
 
@@ -539,14 +594,14 @@ impl ChainRecord {
     /// the cursor in either direction.
     fn seed_missing_cursors<N>(
         &mut self,
-        destinations: &HashMap<ValidatorPublicKey, DestState<N>>,
+        destinations: &BTreeMap<DestIndex, DestState<N>>,
         exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
     ) {
-        for validator in destinations.keys() {
+        for (index, dest) in destinations {
             let seed = exported_heights
-                .get(validator)
+                .get(&dest.validator)
                 .and_then(|height| height.try_add_one().ok());
-            let chain_dest = self.dests.entry(*validator).or_default();
+            let chain_dest = self.dest_entry(*index);
             if chain_dest.next_height.is_none() && chain_dest.in_flight.is_none() {
                 chain_dest.next_height = seed;
             }
@@ -564,8 +619,6 @@ struct ChainDest {
     /// the generation is what stops a stale job's completion from clearing a *newer* job's flag
     /// and breaking the one-send-per-pair ordering invariant.
     in_flight: Option<u64>,
-    /// Whether this chain already sits in the destination's ready list, to keep it there once.
-    queued: bool,
     /// Backoff for *chain-scoped* failures — the destination is healthy but cannot accept this
     /// chain yet, e.g. it lacks the committee and the admin chain's export has not reached it.
     retry_at: Option<Instant>,
@@ -575,6 +628,8 @@ struct ChainDest {
 /// One destination validator: its connection and the health state every chain shares.
 struct DestState<N> {
     node: N,
+    /// Kept here because per-chain state refers to this destination by index, not by key.
+    validator: ValidatorPublicKey,
     address: String,
     /// Bumped whenever this state is rebuilt, so a send started against a previous incarnation
     /// cannot corrupt the new one's accounting when it completes.
@@ -587,8 +642,43 @@ struct DestState<N> {
     /// Backoff for *destination-scoped* failures: transport errors and timeouts.
     retry_at: Option<Instant>,
     failures: u32,
-    /// Chains with work for this destination, drained as the window allows.
-    ready: VecDeque<ChainId>,
+    /// Chains this destination is behind on, maintained as pairs fall behind and converge
+    /// rather than rediscovered by scanning every chain each tick — that scan was O(tracked
+    /// chains x destinations) at 5 Hz, which at a million lagging chains took longer than the
+    /// tick interval itself and starved the queue of everything else.
+    ///
+    /// Membership *is* the "needs work" flag, so there is no separate `queued` bit to fall out
+    /// of step with it.
+    lagging: BTreeSet<ChainId>,
+    /// Where the next drain resumes in `lagging`. Without it the set's ordering hands the window
+    /// to the same lowest chain ids every time and starves the rest of the backlog — the
+    /// fairness the previous FIFO had for free.
+    lagging_cursor: Option<ChainId>,
+}
+
+impl<N> DestState<N> {
+    /// The chains to consider this round, resuming where the last one stopped and wrapping around.
+    ///
+    /// The rotation is the point: `lagging` is ordered, so walking it from the start every tick
+    /// would hand the window to the same lowest chain ids forever and starve the rest.
+    fn drain_candidates(&self, budget: usize) -> Vec<ChainId> {
+        match self.lagging_cursor {
+            Some(cursor) => self
+                .lagging
+                .range(cursor..)
+                .chain(self.lagging.iter().take_while(|id| **id < cursor))
+                .copied()
+                .take(budget)
+                .collect(),
+            None => self.lagging.iter().copied().take(budget).collect(),
+        }
+    }
+
+    /// Moves the cursor past the last chain considered, so the next round advances.
+    fn advance_cursor(&mut self, last_considered: Option<ChainId>) {
+        self.lagging_cursor =
+            last_considered.and_then(|id| self.lagging.range(id..).nth(1).copied());
+    }
 }
 
 /// How one send ended, scoped to what the error tells us about.
@@ -623,8 +713,14 @@ where
     admin_chain_id: Option<ChainId>,
     /// Ticks until the next storage scan for a committee no block has carried yet.
     ticks_until_scan: u32,
+    /// Ticks until the next sweep of converged chains.
+    ticks_until_sweep: u32,
     chains: HashMap<ChainId, ChainRecord>,
-    destinations: HashMap<ValidatorPublicKey, DestState<P::Node>>,
+    destinations: BTreeMap<DestIndex, DestState<P::Node>>,
+    /// Every validator ever registered as a destination, and the index its per-chain state uses.
+    /// Never pruned, so a validator that rejoins reuses its index rather than taking a departed
+    /// one's.
+    dest_indices: BTreeMap<ValidatorPublicKey, DestIndex>,
     /// The last destination generation handed out; never reused within this queue's lifetime.
     next_generation: u64,
     /// The newest epoch any exported block has announced; the tick loads its committee when it
@@ -648,6 +744,18 @@ where
 
 /// How many ticks apart the queue probes storage for committees no block has announced.
 const TICKS_PER_COMMITTEE_SCAN: u32 = 10;
+
+/// How many times the window a single drain may look past before giving up for this tick, so a
+/// backlog of ineligible entries cannot turn the drain back into a full scan.
+const LAGGING_SCAN_FACTOR: usize = 4;
+
+/// How many ticks apart converged chains are swept. The window they are held for is minutes, so
+/// this only decides how promptly the memory comes back.
+const TICKS_PER_CONVERGENCE_SWEEP: u32 = 25;
+
+/// How many chains one sweep may forget, bounding how long it holds the progress mutex that every
+/// chain worker takes on every block.
+const MAX_FORGET_PER_SWEEP: usize = 4096;
 
 impl<S, P> BlockExportQueue<S, P>
 where
@@ -752,13 +860,14 @@ where
         record.tip = record.tip.max(tip);
         record.last_activity = now;
         record.seed_missing_cursors(&self.destinations, &block.exported_heights);
-        let validators = self.destinations.keys().copied().collect::<Vec<_>>();
-        for validator in validators {
+        let indices = self.destinations.keys().copied().collect::<Vec<_>>();
+        for index in indices {
             let record = self.chains.get_mut(&chain_id).expect("inserted above");
-            let chain_dest = record.dests.entry(validator).or_default();
+            let record_tip = record.tip;
+            let chain_dest = record.dest_entry(index);
             let dest = self
                 .destinations
-                .get_mut(&validator)
+                .get_mut(&index)
                 .expect("iterating destinations");
             let contiguous = chain_dest.next_height == Some(height);
             let can_send_now = chain_dest.in_flight.is_none()
@@ -773,21 +882,20 @@ where
                     &self.storage,
                     &self.config,
                     chain_id,
-                    validator,
+                    index,
                     dest,
                     chain_dest,
-                    record.tip,
+                    record_tip,
                     Some((block.certificate.clone(), block.blobs.clone())),
                 );
-            } else if !chain_dest.queued {
-                chain_dest.queued = true;
-                dest.ready.push_back(chain_id);
+            } else if chain_dest.next_height.is_none_or(|next| next < record_tip) {
+                dest.lagging.insert(chain_id);
                 if can_send_now {
                     Self::drain_ready(
                         &mut self.chains,
                         &self.storage,
                         &self.config,
-                        validator,
+                        index,
                         dest,
                         jobs,
                         now,
@@ -800,20 +908,21 @@ where
     /// Folds one finished send back into the destination's and the chain's state.
     fn on_done(
         &mut self,
-        (chain_id, validator, generation, outcome): JobDone,
+        (chain_id, index, generation, outcome): JobDone,
         jobs: &mut FuturesUnordered<JobFuture>,
     ) {
         let now = Instant::now();
-        let Some(dest) = self.destinations.get_mut(&validator) else {
+        let Some(dest) = self.destinations.get_mut(&index) else {
             return; // The validator left the committee while its send was in flight.
         };
+        let validator = dest.validator;
         if dest.generation != generation {
             // The send ran against a previous incarnation of this destination; its slot was
             // never counted here and its result must not touch the fresh state.
             if let Some(chain_dest) = self
                 .chains
                 .get_mut(&chain_id)
-                .and_then(|record| record.dests.get_mut(&validator))
+                .and_then(|record| record.dest_mut(index))
             {
                 // Only the flag this very job set — the pair may since carry a newer job's.
                 if chain_dest.in_flight == Some(generation) {
@@ -867,7 +976,8 @@ where
 
         if let Some(record) = self.chains.get_mut(&chain_id) {
             record.last_activity = now;
-            if let Some(chain_dest) = record.dests.get_mut(&validator) {
+            let record_tip = record.tip;
+            if let Some(chain_dest) = record.dest_mut(index) {
                 if chain_dest.in_flight == Some(generation) {
                     chain_dest.in_flight = None;
                 }
@@ -894,14 +1004,17 @@ where
                             chain_dest.failures = 0;
                             chain_dest.retry_at = None;
                             if let Ok(acked) = next_height.try_sub_one() {
-                                self.progress
+                                let mut progress = self
+                                    .progress
                                     .lock()
-                                    .expect("progress mutex is never poisoned")
-                                    .entry(chain_id)
-                                    .or_default()
-                                    .insert(validator, acked);
+                                    .expect("progress mutex is never poisoned");
+                                let heights = progress.heights.entry(chain_id).or_default();
+                                match heights.binary_search_by_key(&index, |(at, _)| *at) {
+                                    Ok(at) => heights[at].1 = acked,
+                                    Err(at) => heights.insert(at, (index, acked)),
+                                }
                             }
-                        } else if *next_height < record.tip {
+                        } else if *next_height < record_tip {
                             // Answered but moved nothing — a gap our storage cannot fill — so
                             // back this pair off rather than spinning on it.
                             back_off(
@@ -941,17 +1054,16 @@ where
         }
         // A pair that advanced but is still behind continues on the next free slot rather than
         // waiting for a tick — multi-round catch-up must not depend on a process-wide lull.
-        let dest = self
-            .destinations
-            .get_mut(&validator)
-            .expect("checked above");
+        let dest = self.destinations.get_mut(&index).expect("checked above");
         if let Some(record) = self.chains.get_mut(&chain_id) {
             let tip = record.tip;
-            if let Some(chain_dest) = record.dests.get_mut(&validator) {
-                let behind = chain_dest.next_height.is_none_or(|next| next < tip);
-                if behind && !chain_dest.queued && chain_dest.in_flight.is_none() {
-                    chain_dest.queued = true;
-                    dest.ready.push_back(chain_id);
+            if let Some(chain_dest) = record.dest_mut(index) {
+                // Membership tracks "behind", so convergence removes it and nothing else has
+                // to remember to.
+                if chain_dest.next_height.is_none_or(|next| next < tip) {
+                    dest.lagging.insert(chain_id);
+                } else {
+                    dest.lagging.remove(&chain_id);
                 }
             }
         }
@@ -959,7 +1071,7 @@ where
             &mut self.chains,
             &self.storage,
             &self.config,
-            validator,
+            index,
             dest,
             jobs,
             now,
@@ -1001,16 +1113,32 @@ where
                 .chains
                 .entry(chain_id)
                 .or_insert_with(|| ChainRecord::new(now, &self.destinations, &BTreeMap::new()));
+            let advanced = record.tip < tip;
             record.tip = record.tip.max(tip);
+            if advanced {
+                // The scan that used to notice this is gone, so a tip moving forward records
+                // the chains it just put behind, here and now.
+                for (index, dest) in &mut self.destinations {
+                    let chain_dest = record.dest_entry(*index);
+                    if chain_dest.next_height.is_none_or(|next| next < record.tip) {
+                        dest.lagging.insert(chain_id);
+                    }
+                }
+            }
         }
         // When the destination set changed, every destination gets a cursor on every tracked
         // chain, so a validator that joined after a chain's last block is still caught up on it.
         // Gated on the change: this walks every record.
         if self.destinations_changed {
             self.destinations_changed = false;
-            for record in self.chains.values_mut() {
-                for validator in self.destinations.keys() {
-                    record.dests.entry(*validator).or_default();
+            // The one place a full pass is unavoidable: a destination that just joined has no
+            // idea which chains it is behind on. It runs per committee change, not per tick.
+            for (chain_id, record) in &mut self.chains {
+                for (index, dest) in &mut self.destinations {
+                    let chain_dest = record.dest_entry(*index);
+                    if chain_dest.next_height.is_none_or(|next| next < record.tip) {
+                        dest.lagging.insert(*chain_id);
+                    }
                 }
             }
         }
@@ -1023,65 +1151,66 @@ where
         let retention = self.config.converged_chain_retention;
         let destinations = &self.destinations;
         let mut forgotten = Vec::new();
-        self.chains.retain(|chain_id, record| {
-            let converged = destinations.keys().all(|validator| {
-                record.dests.get(validator).is_some_and(|chain_dest| {
-                    // `>=`: a destination is routinely *ahead* of our tip — the client
-                    // broadcasts to everyone — and ahead must count as done, not as never
-                    // converging.
-                    chain_dest.in_flight.is_none()
-                        && chain_dest
-                            .next_height
-                            .is_some_and(|next| next >= record.tip)
-                })
+        // On its own cadence: this walks every tracked chain, while the retention window it
+        // enforces is measured in minutes. Running it per tick spent a quarter of a core at
+        // 100k chains to reclaim memory a few seconds sooner.
+        if self.ticks_until_sweep == 0 {
+            self.ticks_until_sweep = TICKS_PER_CONVERGENCE_SWEEP;
+            self.chains.retain(|chain_id, record| {
+                // Bounded per sweep: the removals below are what the chain workers block on, so
+                // the mutex hold has to be a constant, not a function of how much converged at
+                // once. The remainder goes on the next sweep.
+                if forgotten.len() >= MAX_FORGET_PER_SWEEP {
+                    return true;
+                }
+                let converged = destinations.keys().all(|index| {
+                    record.dest(*index).is_some_and(|chain_dest| {
+                        // `>=`: a destination is routinely *ahead* of our tip — the client
+                        // broadcasts to everyone — and ahead must count as done, not as never
+                        // converging.
+                        chain_dest.in_flight.is_none()
+                            && chain_dest
+                                .next_height
+                                .is_some_and(|next| next >= record.tip)
+                    })
+                });
+                if converged && now.duration_since(record.last_activity) > retention {
+                    forgotten.push(*chain_id);
+                    false
+                } else {
+                    true
+                }
             });
-            if converged && now.duration_since(record.last_activity) > retention {
-                forgotten.push(*chain_id);
-                false
-            } else {
-                true
+            // `retain` never shrinks the table, so without this a one-off burst of chains would
+            // hold its peak allocation for the life of the process.
+            if self.chains.capacity() > self.chains.len().saturating_mul(4) {
+                self.chains.shrink_to_fit();
             }
-        });
+        } else {
+            self.ticks_until_sweep -= 1;
+        }
         if !forgotten.is_empty() {
             let mut progress = self
                 .progress
                 .lock()
                 .expect("progress mutex is never poisoned");
             for chain_id in &forgotten {
-                progress.remove(chain_id);
+                progress.heights.remove(chain_id);
             }
         }
 
         #[cfg(with_metrics)]
         metrics::TRACKED_CHAINS.set(self.chains.len() as i64);
 
-        // Requeue everything whose backoff expired and is still behind.
-        for (chain_id, record) in &mut self.chains {
-            for (validator, chain_dest) in &mut record.dests {
-                let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
-                if behind
-                    && chain_dest.in_flight.is_none()
-                    && !chain_dest.queued
-                    && chain_dest.retry_at.is_none_or(|at| at <= now)
-                {
-                    if let Some(dest) = self.destinations.get_mut(validator) {
-                        chain_dest.queued = true;
-                        dest.ready.push_back(*chain_id);
-                    }
-                }
-            }
-        }
-        let validators = self.destinations.keys().copied().collect::<Vec<_>>();
-        for validator in validators {
-            let dest = self
-                .destinations
-                .get_mut(&validator)
-                .expect("iterating destinations");
+        // No requeue scan: each destination's `lagging` set already *is* the list of chains it
+        // owes work on, kept current as pairs fall behind and converge. Draining it is
+        // proportional to the work available, not to how much state the process is holding.
+        for (index, dest) in &mut self.destinations {
             Self::drain_ready(
                 &mut self.chains,
                 &self.storage,
                 &self.config,
-                validator,
+                *index,
                 dest,
                 jobs,
                 now,
@@ -1148,26 +1277,39 @@ where
     /// Brings the destination set in line with the latest committee: adds joiners, drops
     /// leavers, and re-resolves a changed address.
     fn sync_destinations(&mut self) {
-        let Some(committee) = &self.committee else {
+        // Cloned so the index registry below can be updated while the committee is read.
+        let Some(committee) = self.committee.clone() else {
             return;
         };
         self.committee_dirty = false;
-        let mut rebuilt = Vec::new();
+        // A destination whose address merely changed keeps the backlog it had accumulated: it is
+        // the same peer, and rediscovering that list costs a pass over every tracked chain.
+        let mut carried = BTreeMap::new();
+        let mut rebuilt_any = false;
         #[cfg(with_metrics)]
         let mut rebuilt_addresses = Vec::new();
-        self.destinations.retain(|validator, dest| {
+        self.destinations.retain(|index, dest| {
             let keep = committee
                 .validators()
-                .get(validator)
+                .get(&dest.validator)
                 .is_some_and(|state| state.network_address == dest.address);
             if !keep {
-                rebuilt.push(*validator);
+                rebuilt_any = true;
+                if committee.validators().contains_key(&dest.validator) {
+                    carried.insert(
+                        *index,
+                        (
+                            std::mem::take(&mut dest.lagging),
+                            dest.lagging_cursor.take(),
+                        ),
+                    );
+                }
                 #[cfg(with_metrics)]
                 rebuilt_addresses.push(dest.address.clone());
             }
             keep
         });
-        if !rebuilt.is_empty() {
+        if rebuilt_any {
             self.destinations_changed = true;
         }
         // Drop the metric series of every address that just went away, so a departed validator
@@ -1187,18 +1329,12 @@ where
                 .remove_label_values(&[address])
                 .ok();
         }
-        // A dropped DestState takes its ready list with it, so clear the queued marks that
-        // pointed into it — a queued pair is invisible to every requeue path.
-        for record in self.chains.values_mut() {
-            for validator in &rebuilt {
-                if let Some(chain_dest) = record.dests.get_mut(validator) {
-                    chain_dest.queued = false;
-                }
-            }
-        }
         for (validator, address) in committee.validator_addresses() {
-            if Some(validator) == self.own_public_key || self.destinations.contains_key(&validator)
-            {
+            if Some(validator) == self.own_public_key {
+                continue;
+            }
+            let index = self.dest_index(validator);
+            if self.destinations.contains_key(&index) {
                 continue;
             }
             // One at a time: a batch fails whole on the first bad address, and one unresolvable
@@ -1216,17 +1352,20 @@ where
                         // a stale in-flight send corrupt a fresh incarnation's accounting.
                         self.next_generation += 1;
                         self.destinations_changed = true;
+                        let (lagging, lagging_cursor) = carried.remove(&index).unwrap_or_default();
                         self.destinations.insert(
-                            validator,
+                            index,
                             DestState {
                                 node,
+                                validator,
                                 address: address.to_owned(),
                                 generation: self.next_generation,
                                 in_flight: 0,
                                 window: self.config.max_in_flight_per_destination,
                                 retry_at: None,
                                 failures: 0,
-                                ready: VecDeque::new(),
+                                lagging,
+                                lagging_cursor,
                             },
                         );
                     }
@@ -1241,18 +1380,36 @@ where
             }
         }
         // A validator that left takes its cursors with it.
-        self.chains.retain(|_, record| {
+        let destinations = &self.destinations;
+        for record in self.chains.values_mut() {
             record
                 .dests
-                .retain(|validator, _| self.destinations.contains_key(validator));
-            true
-        });
+                .retain(|(index, _)| destinations.contains_key(index));
+        }
+    }
+
+    /// The index `validator`'s per-chain state is keyed by, registering it on first sight.
+    ///
+    /// Published to the handles under the progress mutex, because the chain workers read that
+    /// map back and only the registry can name the validators in it.
+    fn dest_index(&mut self, validator: ValidatorPublicKey) -> DestIndex {
+        if let Some(index) = self.dest_indices.get(&validator) {
+            return *index;
+        }
+        let mut progress = self
+            .progress
+            .lock()
+            .expect("progress mutex is never poisoned");
+        let index = progress.validators.len() as DestIndex;
+        progress.validators.push(validator);
+        self.dest_indices.insert(validator, index);
+        index
     }
 }
 
 /// The result of one send job: which pair it was for, under which destination generation, and
 /// how it went.
-type JobDone = (ChainId, ValidatorPublicKey, u64, SendOutcome);
+type JobDone = (ChainId, DestIndex, u64, SendOutcome);
 
 /// One send in flight, boxed so jobs from different call sites share a queue.
 #[cfg(not(web))]
@@ -1274,7 +1431,7 @@ where
         storage: &S,
         config: &BlockExportConfig,
         chain_id: ChainId,
-        validator: ValidatorPublicKey,
+        index: DestIndex,
         dest: &mut DestState<P::Node>,
         chain_dest: &mut ChainDest,
         target: BlockHeight,
@@ -1282,11 +1439,10 @@ where
     ) {
         let generation = dest.generation;
         chain_dest.in_flight = Some(generation);
-        chain_dest.queued = false;
         dest.in_flight += 1;
         let mut sender = BlockSender {
             remote_node: RemoteNode {
-                public_key: validator,
+                public_key: dest.validator,
                 node: dest.node.clone(),
             },
             storage: storage.clone(),
@@ -1325,7 +1481,7 @@ where
                 Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(Box::new(error)),
                 Err(error) => SendOutcome::DestinationScoped(Box::new(error)),
             };
-            (chain_id, validator, generation, outcome)
+            (chain_id, index, generation, outcome)
         };
         #[cfg(not(web))]
         jobs.push(job.boxed());
@@ -1338,7 +1494,7 @@ where
         chains: &mut HashMap<ChainId, ChainRecord>,
         storage: &S,
         config: &BlockExportConfig,
-        validator: ValidatorPublicKey,
+        index: DestIndex,
         dest: &mut DestState<P::Node>,
         jobs: &mut FuturesUnordered<JobFuture>,
         now: Instant,
@@ -1346,26 +1502,46 @@ where
         if dest.retry_at.is_some_and(|at| at > now) {
             return;
         }
-        while dest.in_flight < dest.window {
-            let Some(chain_id) = dest.ready.pop_front() else {
-                return;
-            };
-            let Some(record) = chains.get_mut(&chain_id) else {
-                continue; // Converged and dropped while queued.
-            };
-            let Some(chain_dest) = record.dests.get_mut(&validator) else {
+        // Only as far as the window allows, so the cost is the sends we are about to make and
+        // not the size of the backlog. Entries stay in `lagging` until they converge: one that
+        // is mid-send or serving its own backoff is skipped here and picked up by a later tick,
+        // with nothing to remember to re-add it.
+        // From the cursor onwards, then wrapping to the start: every chain gets its turn even
+        // when the backlog is far larger than the window. Bounded by a multiple of the window so
+        // a backlog of ineligible entries cannot turn this back into a full scan.
+        let ordered = dest.drain_candidates(dest.window.saturating_mul(LAGGING_SCAN_FACTOR));
+        let mut spawn = Vec::new();
+        let mut last_visited = None;
+        for chain_id in ordered {
+            if dest.in_flight + spawn.len() >= dest.window {
+                break;
+            }
+            last_visited = Some(chain_id);
+            let Some(record) = chains.get(&chain_id) else {
                 continue;
             };
-            chain_dest.queued = false;
+            let Some(chain_dest) = record.dest(index) else {
+                continue;
+            };
             let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
-            if chain_dest.in_flight.is_some()
-                || !behind
-                || chain_dest.retry_at.is_some_and(|at| at > now)
+            if behind
+                && chain_dest.in_flight.is_none()
+                && chain_dest.retry_at.is_none_or(|at| at <= now)
             {
-                continue; // The tick that queued it has been overtaken; it requeues if needed.
+                spawn.push(chain_id);
             }
+        }
+        dest.advance_cursor(last_visited);
+        for chain_id in spawn {
+            let Some(record) = chains.get_mut(&chain_id) else {
+                continue;
+            };
+            let tip = record.tip;
+            let Some(chain_dest) = record.dest_mut(index) else {
+                continue;
+            };
             Self::spawn_job(
-                jobs, storage, config, chain_id, validator, dest, chain_dest, record.tip, None,
+                jobs, storage, config, chain_id, index, dest, chain_dest, tip, None,
             );
         }
     }
@@ -1576,6 +1752,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use linera_base::crypto::CryptoHash;
+
     use super::*;
 
     /// Every rejection in `check()` guards a distinct failure mode, so each invalid field must be
@@ -1644,21 +1822,19 @@ mod tests {
     fn records_start_from_the_persisted_heights() {
         let validator = ValidatorPublicKey::test_key(1);
         let other = ValidatorPublicKey::test_key(2);
-        let destinations: HashMap<ValidatorPublicKey, DestState<()>> =
-            [(validator, test_dest_state()), (other, test_dest_state())]
-                .into_iter()
-                .collect();
+        let destinations = test_destinations([validator, other]);
         let exported = [(validator, BlockHeight(41))].into_iter().collect();
 
         let record = ChainRecord::new(Instant::now(), &destinations, &exported);
 
         assert_eq!(
-            record.dests[&validator].next_height,
+            record.dest(0).unwrap().next_height,
             Some(BlockHeight(42)),
             "a persisted height must seed the cursor for the block after it",
         );
         assert_eq!(
-            record.dests[&other].next_height, None,
+            record.dest(1).unwrap().next_height,
+            None,
             "a destination with nothing persisted must be queried, not assumed",
         );
     }
@@ -1672,34 +1848,95 @@ mod tests {
     #[test]
     fn a_cursor_left_unset_is_still_seeded() {
         let validator = ValidatorPublicKey::test_key(1);
-        let destinations: HashMap<ValidatorPublicKey, DestState<()>> =
-            [(validator, test_dest_state())].into_iter().collect();
+        let destinations = test_destinations([validator]);
         let exported: BTreeMap<_, _> = [(validator, BlockHeight(7))].into_iter().collect();
 
         // As the tick builds it: no heights to hand over, so the cursor starts unset.
         let mut record = ChainRecord::new(Instant::now(), &destinations, &BTreeMap::new());
-        assert_eq!(record.dests[&validator].next_height, None);
+        assert_eq!(record.dest(0).unwrap().next_height, None);
 
         // The fill `on_block` performs once a block for that chain arrives.
         record.seed_missing_cursors(&destinations, &exported);
 
         assert_eq!(
-            record.dests[&validator].next_height,
+            record.dest(0).unwrap().next_height,
             Some(BlockHeight(8)),
             "a record the tick created must still pick up the persisted cursor",
         );
     }
 
+    /// The drain rotates through the backlog instead of always serving its lowest chain ids.
+    ///
+    /// The maintained set replaced a FIFO, and a set is *ordered* — iterating it from the start
+    /// every tick hands the whole window to the same few chains and starves everything after
+    /// them, which at a large backlog means those chains are never exported at all.
+    #[test]
+    fn draining_rotates_through_the_backlog() {
+        let mut dest = test_dest_state();
+        dest.window = 2;
+        let ids = (0..6u8)
+            .map(|i| ChainId(CryptoHash::test_hash(format!("chain{i}"))))
+            .collect::<Vec<_>>();
+        dest.lagging = ids.iter().copied().collect();
+
+        // Two passes with the window's worth of work each; the second must move on.
+        let first = drained(&dest, 2);
+        dest.lagging_cursor = first
+            .last()
+            .and_then(|id| dest.lagging.range(*id..).nth(1).copied());
+        let second = drained(&dest, 2);
+
+        assert_eq!(first.len(), 2);
+        assert_eq!(second.len(), 2);
+        assert!(
+            first.iter().all(|id| !second.contains(id)),
+            "the second pass repeated the first: {first:?} then {second:?}",
+        );
+    }
+
+    /// The candidate ordering `drain_ready` walks, without the spawning around it.
+    fn drained(dest: &DestState<()>, budget: usize) -> Vec<ChainId> {
+        match dest.lagging_cursor {
+            Some(cursor) => dest
+                .lagging
+                .range(cursor..)
+                .chain(dest.lagging.iter().take_while(|id| **id < cursor))
+                .copied()
+                .take(budget)
+                .collect(),
+            None => dest.lagging.iter().copied().take(budget).collect(),
+        }
+    }
+
+    /// Destinations indexed the way `sync_destinations` assigns them: in registration order.
+    fn test_destinations(
+        validators: impl IntoIterator<Item = ValidatorPublicKey>,
+    ) -> BTreeMap<DestIndex, DestState<()>> {
+        validators
+            .into_iter()
+            .enumerate()
+            .map(|(index, validator)| {
+                let dest = DestState {
+                    validator,
+                    ..test_dest_state()
+                };
+                (index as DestIndex, dest)
+            })
+            .collect()
+    }
+
     fn test_dest_state() -> DestState<()> {
         DestState {
             node: (),
+            validator: ValidatorPublicKey::test_key(0),
             address: "grpc:localhost:1".to_string(),
             generation: 1,
             in_flight: 0,
             window: 1,
             retry_at: None,
             failures: 0,
-            ready: VecDeque::new(),
+            lagging: BTreeSet::new(),
+            lagging_cursor: None,
         }
     }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -598,12 +598,13 @@ impl ChainRecord {
         exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
     ) {
         for (index, dest) in destinations {
-            let seed = exported_heights
-                .get(&dest.validator)
-                .and_then(|height| height.try_add_one().ok());
             let chain_dest = self.dest_entry(*index);
+            // Guard first: this runs per block, and in the steady state every cursor is set, so
+            // the pubkey lookup would be pure waste.
             if chain_dest.next_height.is_none() && chain_dest.in_flight.is_none() {
-                chain_dest.next_height = seed;
+                chain_dest.next_height = exported_heights
+                    .get(&dest.validator)
+                    .and_then(|height| height.try_add_one().ok());
             }
         }
     }
@@ -1203,6 +1204,11 @@ where
                 .expect("progress mutex is never poisoned");
             for chain_id in &forgotten {
                 progress.heights.remove(chain_id);
+            }
+            // Same reason as `chains` above: `remove` never shrinks the table, and this one is
+            // sized by the same burst.
+            if progress.heights.capacity() > progress.heights.len().saturating_mul(4) {
+                progress.heights.shrink_to_fit();
             }
         }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -122,7 +122,10 @@ pub struct BlockExportConfig {
     /// destinations are behind.
     ///
     /// Live blocks always win: catching up only happens when nothing has arrived for this long,
-    /// and only one round per interval, so it can never crowd out export or spin.
+    /// and only one round per interval, so it can never crowd out export or spin. Together with
+    /// `max_catch_up_blocks` this sets the backfill rate — blocks per interval — so the two should
+    /// be tuned as a pair; a shorter interval with a proportionally smaller bound keeps the same
+    /// throughput while returning to live blocks sooner.
     pub idle_catch_up_interval: Duration,
     /// How many missing blocks are pushed to one destination in a single round.
     ///
@@ -131,6 +134,9 @@ pub struct BlockExportConfig {
     /// rounds keeps one far-behind destination from holding up every other destination and every
     /// later block of the chain; the remainder is picked up on subsequent rounds, including while
     /// the chain is idle.
+    ///
+    /// The bound is what a live block may have to wait behind, so it is deliberately small: the
+    /// backfill rate is set by how often rounds happen, not by how much each one does.
     pub max_catch_up_blocks: u64,
 }
 
@@ -140,8 +146,8 @@ impl Default for BlockExportConfig {
             certificate_upload_batch_size: crate::client::DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
             retry_delay: Duration::from_secs(1),
             max_retry_delay: Duration::from_secs(60),
-            idle_catch_up_interval: Duration::from_secs(1),
-            max_catch_up_blocks: 1_000,
+            idle_catch_up_interval: Duration::from_millis(200),
+            max_catch_up_blocks: 200,
         }
     }
 }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -48,11 +48,11 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{Blob, BlockHeight, Epoch},
-    identifiers::{BlobId, ChainId},
+    identifiers::{BlobId, ChainId, EventId, StreamId},
     time::{timer::timeout, Duration, Instant},
 };
 use linera_chain::types::ConfirmedBlockCertificate;
-use linera_execution::committee::Committee;
+use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
 use linera_storage::{Arc as CacheArc, Storage};
 use tokio::sync::mpsc;
 use tracing::{debug, instrument, warn};
@@ -70,9 +70,9 @@ mod metrics {
 
     use linera_base::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
-        register_histogram_vec, register_int_counter, register_int_gauge,
+        register_histogram_vec, register_int_counter, register_int_gauge, register_int_gauge_vec,
     };
-    use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge};
+    use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge, IntGaugeVec};
 
     /// Blocks waiting in the export queue.
     pub static QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
@@ -120,12 +120,11 @@ mod metrics {
     });
 
     /// How many concurrent sends each destination is currently allowed.
-    pub static DESTINATION_WINDOW: LazyLock<HistogramVec> = LazyLock::new(|| {
-        register_histogram_vec(
+    pub static DESTINATION_WINDOW: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
             "block_export_destination_window",
-            "AIMD in-flight window per destination validator, sampled at each change",
+            "AIMD in-flight window per destination validator",
             &["validator"],
-            exponential_bucket_interval(1.0, 1_024.0),
         )
     });
 
@@ -144,7 +143,9 @@ mod metrics {
 /// Configuration for pushing executed blocks to the other committee validators.
 #[derive(Clone, Debug)]
 pub struct BlockExportConfig {
-    /// How many certificates are read from storage per catch-up read.
+    /// How many certificates are read from storage per catch-up read. Smaller than the
+    /// client's 500: a chunk lives inside one send job, and `max_catch_up_blocks` bounds the
+    /// round anyway.
     pub certificate_upload_batch_size: u64,
     /// How many blocks the export queue holds before dropping new ones for catch-up to repair.
     pub queue_size: usize,
@@ -241,6 +242,9 @@ struct ExportedBlock {
     /// in this block is exported to immediately.
     epoch: Epoch,
     committee: Arc<Committee>,
+    /// The persisted `exported_heights` of the chain, seeding cursors on its first block this
+    /// process so a restart re-sends at most one block per destination instead of a history.
+    exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
     /// Blob payload bytes, counted at enqueue so the dequeue can decrement the same amount.
     #[cfg(with_metrics)]
     blob_bytes: i64,
@@ -252,6 +256,7 @@ struct ExportedBlock {
 pub struct BlockExportHandle {
     blocks: mpsc::Sender<ExportedBlock>,
     progress: SharedProgress,
+    tips: SharedTips,
 }
 
 impl Clone for BlockExportHandle {
@@ -259,6 +264,7 @@ impl Clone for BlockExportHandle {
         BlockExportHandle {
             blocks: self.blocks.clone(),
             progress: self.progress.clone(),
+            tips: self.tips.clone(),
         }
     }
 }
@@ -268,16 +274,32 @@ impl Clone for BlockExportHandle {
 /// when a chain converges, so this holds lagging chains only.
 type SharedProgress = Arc<Mutex<HashMap<ChainId, BTreeMap<ValidatorPublicKey, BlockHeight>>>>;
 
+/// The height after each chain's newest announced block. Written on every `export` call before
+/// the queue is tried, so a block the full queue drops still raises the repair target the tick
+/// measures destinations against.
+type SharedTips = Arc<Mutex<HashMap<ChainId, BlockHeight>>>;
+
 impl BlockExportHandle {
     /// Queues a block for export and returns immediately. A full queue drops the block — never
-    /// blocks the worker — and the queue's catch-up re-sends it from storage.
+    /// blocks the worker — and the tip announced below is what lets catch-up re-send it from
+    /// storage. `exported_heights` seeds the chain's cursors on its first block this process.
     pub(crate) fn export(
         &self,
         certificate: CacheArc<ConfirmedBlockCertificate>,
         blobs: Vec<CacheArc<Blob>>,
         epoch: Epoch,
         committee: Arc<Committee>,
+        exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
     ) {
+        // Announced before the queue is tried: a dropped block must still raise the repair
+        // target, or a chain whose *last* block was dropped would never be repaired at all.
+        {
+            let header = &certificate.block().header;
+            let tip = header.height.try_add_one().unwrap_or(BlockHeight::MAX);
+            let mut tips = self.tips.lock().expect("tips mutex is never poisoned");
+            let entry = tips.entry(header.chain_id).or_insert(tip);
+            *entry = (*entry).max(tip);
+        }
         #[cfg(with_metrics)]
         let blob_bytes = blobs
             .iter()
@@ -288,6 +310,7 @@ impl BlockExportHandle {
             blobs,
             epoch,
             committee,
+            exported_heights,
             #[cfg(with_metrics)]
             blob_bytes,
             #[cfg(with_metrics)]
@@ -355,6 +378,7 @@ where
 {
     let (blocks, receiver) = mpsc::channel(config.queue_size);
     let progress: SharedProgress = Arc::default();
+    let tips: SharedTips = Arc::default();
 
     let task = BlockExportQueue {
         storage,
@@ -363,13 +387,22 @@ where
         own_public_key,
         latest_epoch: None,
         committee: None,
+        committee_dirty: false,
+        admin_chain_id: None,
+        ticks_until_scan: 0,
         chains: HashMap::new(),
         destinations: HashMap::new(),
         progress: progress.clone(),
+        tips: tips.clone(),
+        draining: false,
     };
     linera_base::Task::spawn(task.run(receiver)).forget();
 
-    BlockExportHandle { blocks, progress }
+    BlockExportHandle {
+        blocks,
+        progress,
+        tips,
+    }
 }
 
 /// What we know of one chain: its tip, and each destination's position below it. Kept while some
@@ -403,6 +436,9 @@ struct ChainDest {
 struct DestState<N> {
     node: N,
     address: String,
+    /// Bumped whenever this state is rebuilt, so a send started against a previous incarnation
+    /// cannot corrupt the new one's accounting when it completes.
+    generation: u64,
     /// Sends currently running against this destination, over all chains.
     in_flight: usize,
     /// How many concurrent sends the AIMD control currently allows: +1 per success up to the
@@ -440,10 +476,25 @@ where
     /// newcomer, and current committee members need every chain regardless of its epoch.
     latest_epoch: Option<Epoch>,
     committee: Option<Arc<Committee>>,
+    /// Set when `committee` changed and the destination set has not been rebuilt yet, so the
+    /// rebuild runs per committee change rather than per block.
+    committee_dirty: bool,
+    /// The admin chain, read from the network description once, for the silent epoch probe.
+    admin_chain_id: Option<ChainId>,
+    /// Ticks until the next storage scan for a committee no block has carried yet.
+    ticks_until_scan: u32,
     chains: HashMap<ChainId, ChainRecord>,
     destinations: HashMap<ValidatorPublicKey, DestState<P::Node>>,
     progress: SharedProgress,
+    /// The highest height each chain has announced, written by every `export` call — including
+    /// ones the full queue dropped — so a dropped block still moves the repair target.
+    tips: SharedTips,
+    /// True once every handle is dropped: completions may finish, nothing new starts.
+    draining: bool,
 }
+
+/// How many ticks apart the queue probes storage for committees no block has announced.
+const TICKS_PER_COMMITTEE_SCAN: u32 = 10;
 
 impl<S, P> BlockExportQueue<S, P>
 where
@@ -451,28 +502,44 @@ where
     P: ValidatorNodeProvider,
     P::Node: Clone + Send + 'static,
 {
-    /// Exports blocks until every handle is dropped, interleaving catch-up while idle.
+    /// Exports blocks until every handle is dropped, ticking every `idle_catch_up_interval`
+    /// whether or not sends are in flight — backoff expiry and gap repair must not wait for a
+    /// process-wide lull that a busy validator never has.
     #[instrument(level = "debug", skip_all)]
     async fn run(mut self, mut receiver: mpsc::Receiver<ExportedBlock>) {
+        /// What woke the loop, decided inside the select so its borrows end before handling.
+        enum Wake {
+            Done(JobDone),
+            Block(Option<ExportedBlock>),
+            Tick,
+        }
         let mut jobs = FuturesUnordered::new();
         loop {
-            if jobs.is_empty() {
+            let wake = if jobs.is_empty() {
                 match timeout(self.config.idle_catch_up_interval, receiver.recv()).await {
-                    Ok(Some(block)) => self.on_block(block, &mut jobs),
-                    Ok(None) => break,
-                    Err(_) => self.tick(&mut jobs).await,
+                    Ok(received) => Wake::Block(received),
+                    Err(_) => Wake::Tick,
                 }
             } else {
-                tokio::select! {
-                    Some(done) = jobs.next() => self.on_done(done, &mut jobs),
-                    received = receiver.recv() => match received {
-                        Some(block) => self.on_block(block, &mut jobs),
-                        None => break,
-                    },
+                // `futures::select_biased` rather than `tokio::select`, which does not compile
+                // for the web target. Completions first, then fresh blocks, then the tick.
+                futures::select_biased! {
+                    done = jobs.next() => Wake::Done(done.expect("jobs is not empty")),
+                    received = receiver.recv().fuse() => Wake::Block(received),
+                    _ = linera_base::time::timer::sleep(self.config.idle_catch_up_interval)
+                        .fuse() => Wake::Tick,
                 }
+            };
+            match wake {
+                Wake::Done(done) => self.on_done(done, &mut jobs),
+                Wake::Block(Some(block)) => self.on_block(block, &mut jobs),
+                Wake::Block(None) => break,
+                Wake::Tick => self.tick(&mut jobs).await,
             }
         }
-        // The workers are gone; let in-flight sends finish rather than cutting them off.
+        // The workers are gone. Let in-flight sends finish, without starting new ones — every
+        // completion would otherwise drain more catch-up work and hold shutdown open.
+        self.draining = true;
         while let Some(done) = jobs.next().await {
             self.on_done(done, &mut jobs);
         }
@@ -494,15 +561,34 @@ where
         if self.latest_epoch.is_none_or(|epoch| block.epoch > epoch) {
             self.latest_epoch = Some(block.epoch);
             self.committee = Some(block.committee.clone());
+            self.committee_dirty = true;
         }
-        self.sync_destinations();
+        // Per committee change, not per block: the rebuild walks every tracked chain.
+        if self.committee_dirty || self.destinations.is_empty() {
+            self.sync_destinations();
+        }
 
         let now = Instant::now();
         let tip = height.try_add_one().unwrap_or(BlockHeight::MAX);
         let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
             tip: BlockHeight::ZERO,
             last_activity: now,
-            dests: BTreeMap::new(),
+            // Seeded from what the chain last persisted: at worst one block per destination is
+            // re-offered and skipped, instead of one query per destination per restart.
+            dests: block
+                .exported_heights
+                .iter()
+                .filter_map(|(validator, height)| {
+                    let next = height.try_add_one().ok()?;
+                    Some((
+                        *validator,
+                        ChainDest {
+                            next_height: Some(next),
+                            ..ChainDest::default()
+                        },
+                    ))
+                })
+                .collect(),
         });
         record.tip = record.tip.max(tip);
         record.last_activity = now;
@@ -554,13 +640,25 @@ where
     /// Folds one finished send back into the destination's and the chain's state.
     fn on_done(
         &mut self,
-        (chain_id, validator, outcome): JobDone,
+        (chain_id, validator, generation, outcome): JobDone,
         jobs: &mut FuturesUnordered<JobFuture>,
     ) {
         let now = Instant::now();
         let Some(dest) = self.destinations.get_mut(&validator) else {
             return; // The validator left the committee while its send was in flight.
         };
+        if dest.generation != generation {
+            // The send ran against a previous incarnation of this destination; its slot was
+            // never counted here and its result must not touch the fresh state.
+            if let Some(chain_dest) = self
+                .chains
+                .get_mut(&chain_id)
+                .and_then(|record| record.dests.get_mut(&validator))
+            {
+                chain_dest.in_flight = false;
+            }
+            return;
+        }
         dest.in_flight = dest.in_flight.saturating_sub(1);
 
         if let Some(record) = self.chains.get_mut(&chain_id) {
@@ -570,7 +668,10 @@ where
                 match &outcome {
                     SendOutcome::Reached(next_height) => {
                         let advanced = chain_dest.next_height.is_none_or(|n| *next_height > n);
-                        chain_dest.next_height = Some(*next_height);
+                        // Only ever forward: a stale response must not drag the cursor back.
+                        if advanced {
+                            chain_dest.next_height = Some(*next_height);
+                        }
                         if advanced {
                             chain_dest.failures = 0;
                             chain_dest.retry_at = None;
@@ -584,13 +685,15 @@ where
                                 &self.config,
                             );
                         }
-                        if let Ok(acked) = next_height.try_sub_one() {
-                            self.progress
-                                .lock()
-                                .expect("progress mutex is never poisoned")
-                                .entry(chain_id)
-                                .or_default()
-                                .insert(validator, acked);
+                        if advanced {
+                            if let Ok(acked) = next_height.try_sub_one() {
+                                self.progress
+                                    .lock()
+                                    .expect("progress mutex is never poisoned")
+                                    .entry(chain_id)
+                                    .or_default()
+                                    .insert(validator, acked);
+                            }
                         }
                         dest.failures = 0;
                         dest.retry_at = None;
@@ -639,14 +742,29 @@ where
                 #[cfg(with_metrics)]
                 metrics::DESTINATION_WINDOW
                     .with_label_values(&[&dest.address])
-                    .observe(dest.window as f64);
+                    .set(dest.window as i64);
             }
         }
 
+        if self.draining {
+            return;
+        }
+        // A pair that advanced but is still behind continues on the next free slot rather than
+        // waiting for a tick — multi-round catch-up must not depend on a process-wide lull.
         let dest = self
             .destinations
             .get_mut(&validator)
             .expect("checked above");
+        if let Some(record) = self.chains.get_mut(&chain_id) {
+            let tip = record.tip;
+            if let Some(chain_dest) = record.dests.get_mut(&validator) {
+                let behind = chain_dest.next_height.is_none_or(|next| next < tip);
+                if behind && !chain_dest.queued && !chain_dest.in_flight {
+                    chain_dest.queued = true;
+                    dest.ready.push_back(chain_id);
+                }
+            }
+        }
         Self::drain_ready(
             &mut self.chains,
             &self.storage,
@@ -660,39 +778,77 @@ where
 
     /// An idle moment: pick up committee changes from storage and requeue expired backoffs.
     async fn tick(&mut self, jobs: &mut FuturesUnordered<JobFuture>) {
-        // Scan forward for committees this process has not seen via blocks — how a validator
-        // admitted while every chain is idle still becomes a destination.
-        let mut next = self
-            .latest_epoch
-            .map_or(0, |epoch| epoch.0.saturating_add(1));
-        while let Ok(Some(committee)) = self.storage.get_or_load_committee(Epoch(next)).await {
-            self.latest_epoch = Some(Epoch(next));
-            self.committee = Some(committee);
-            next = next.saturating_add(1);
+        let now = Instant::now();
+        // Occasionally scan storage for committees no block has carried — how a validator
+        // admitted while every chain is idle still becomes a destination. On its own cadence
+        // because the probe reads storage, and ticks now fire even under load.
+        if self.ticks_until_scan == 0 {
+            self.ticks_until_scan = TICKS_PER_COMMITTEE_SCAN;
+            self.scan_committees().await;
+        } else {
+            self.ticks_until_scan -= 1;
         }
-        self.sync_destinations();
+        if self.committee_dirty || (self.destinations.is_empty() && self.committee.is_some()) {
+            self.sync_destinations();
+        }
+
+        // Fold announced tips in: this is what repairs a block the full queue dropped, and what
+        // creates the record when even a chain's first block was dropped.
+        {
+            let tips = self
+                .tips
+                .lock()
+                .expect("tips mutex is never poisoned")
+                .clone();
+            for (chain_id, tip) in tips {
+                let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
+                    tip: BlockHeight::ZERO,
+                    last_activity: now,
+                    dests: BTreeMap::new(),
+                });
+                record.tip = record.tip.max(tip);
+            }
+        }
+        // Every current destination gets a cursor on every tracked chain, so a validator that
+        // joined after a chain's last block is still caught up on it.
+        for record in self.chains.values_mut() {
+            for validator in self.destinations.keys() {
+                record.dests.entry(*validator).or_default();
+            }
+        }
 
         // Forget chains that converged and stayed quiet past the retention window, so memory
         // tracks recent and lagging chains rather than every chain ever seen. The grace window
         // is what lets the chain's worker fold the final heights in before they vanish.
-        let now = Instant::now();
+        // Convergence is judged against the *current* destination set — an empty one (a
+        // single-validator committee) is trivially converged, not immortal.
         let retention = self.config.converged_chain_retention;
-        let progress = &self.progress;
+        let destinations = &self.destinations;
+        let mut forgotten = Vec::new();
         self.chains.retain(|chain_id, record| {
-            let converged = !record.dests.is_empty()
-                && record.dests.values().all(|chain_dest| {
+            let converged = destinations.keys().all(|validator| {
+                record.dests.get(validator).is_some_and(|chain_dest| {
                     !chain_dest.in_flight && chain_dest.next_height == Some(record.tip)
-                });
+                })
+            });
             if converged && now.duration_since(record.last_activity) > retention {
-                progress
-                    .lock()
-                    .expect("progress mutex is never poisoned")
-                    .remove(chain_id);
+                forgotten.push(*chain_id);
                 false
             } else {
                 true
             }
         });
+        if !forgotten.is_empty() {
+            let mut progress = self
+                .progress
+                .lock()
+                .expect("progress mutex is never poisoned");
+            let mut tips = self.tips.lock().expect("tips mutex is never poisoned");
+            for chain_id in &forgotten {
+                progress.remove(chain_id);
+                tips.remove(chain_id);
+            }
+        }
 
         // Requeue everything whose backoff expired and is still behind.
         for (chain_id, record) in &mut self.chains {
@@ -728,18 +884,90 @@ where
         }
     }
 
+    /// Scans storage forward for committees newer than any block has announced, probing the
+    /// epoch event directly so a missing next epoch — the steady state — stays silent.
+    async fn scan_committees(&mut self) {
+        if self.admin_chain_id.is_none() {
+            self.admin_chain_id = match self.storage.read_network_description().await {
+                Ok(Some(description)) => Some(description.admin_chain_id),
+                Ok(None) => return,
+                Err(error) => {
+                    debug!(%error, "Cannot read the network description to scan for committees");
+                    return;
+                }
+            };
+        }
+        let Some(admin_chain_id) = self.admin_chain_id else {
+            return;
+        };
+        loop {
+            let next = self
+                .latest_epoch
+                .map_or(0, |epoch| epoch.0.saturating_add(1));
+            let event_present = if next == 0 {
+                // Epoch 0 comes from the genesis blob, not an event; only `get_or_load` knows.
+                Ok(true)
+            } else {
+                self.storage
+                    .read_event(EventId {
+                        chain_id: admin_chain_id,
+                        stream_id: StreamId::system(EPOCH_STREAM_NAME),
+                        index: next,
+                    })
+                    .await
+                    .map(|found| found.is_some())
+            };
+            match event_present {
+                Ok(true) => match self.storage.get_or_load_committee(Epoch(next)).await {
+                    Ok(Some(committee)) => {
+                        self.latest_epoch = Some(Epoch(next));
+                        self.committee = Some(committee);
+                        self.committee_dirty = true;
+                    }
+                    Ok(None) | Err(_) => return,
+                },
+                Ok(false) => return,
+                Err(error) => {
+                    debug!(%error, "Cannot probe for a new committee");
+                    return;
+                }
+            }
+        }
+    }
+
     /// Brings the destination set in line with the latest committee: adds joiners, drops
     /// leavers, and re-resolves a changed address.
     fn sync_destinations(&mut self) {
         let Some(committee) = &self.committee else {
             return;
         };
+        self.committee_dirty = false;
+        let mut generation = self
+            .destinations
+            .values()
+            .map(|dest| dest.generation)
+            .max()
+            .unwrap_or(0);
+        let mut rebuilt = Vec::new();
         self.destinations.retain(|validator, dest| {
-            committee
+            let keep = committee
                 .validators()
                 .get(validator)
-                .is_some_and(|state| state.network_address == dest.address)
+                .is_some_and(|state| state.network_address == dest.address);
+            if !keep {
+                rebuilt.push(*validator);
+            }
+            keep
         });
+        // A dropped DestState takes its ready list with it, so clear the queued marks that
+        // pointed into it — a queued pair is invisible to every requeue path.
+        for record in self.chains.values_mut() {
+            for validator in &rebuilt {
+                if let Some(chain_dest) = record.dests.get_mut(validator) {
+                    chain_dest.queued = false;
+                }
+            }
+        }
         for (validator, address) in committee.validator_addresses() {
             if Some(validator) == self.own_public_key || self.destinations.contains_key(&validator)
             {
@@ -753,11 +981,13 @@ where
             {
                 Ok(mut nodes) => {
                     if let Some((_, node)) = nodes.next() {
+                        generation += 1;
                         self.destinations.insert(
                             validator,
                             DestState {
                                 node,
                                 address: address.to_owned(),
+                                generation,
                                 in_flight: 0,
                                 window: self.config.max_in_flight_per_destination,
                                 retry_at: None,
@@ -786,8 +1016,9 @@ where
     }
 }
 
-/// The result of one send job: which pair it was for, and how it went.
-type JobDone = (ChainId, ValidatorPublicKey, SendOutcome);
+/// The result of one send job: which pair it was for, under which destination generation, and
+/// how it went.
+type JobDone = (ChainId, ValidatorPublicKey, u64, SendOutcome);
 
 /// One send in flight, boxed so jobs from different call sites share a queue.
 #[cfg(not(web))]
@@ -818,6 +1049,7 @@ where
         chain_dest.in_flight = true;
         chain_dest.queued = false;
         dest.in_flight += 1;
+        let generation = dest.generation;
         let mut sender = BlockSender {
             remote_node: RemoteNode {
                 public_key: validator,
@@ -859,7 +1091,7 @@ where
                 Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(error),
                 Err(error) => SendOutcome::DestinationScoped(error),
             };
-            (chain_id, validator, outcome)
+            (chain_id, validator, generation, outcome)
         };
         #[cfg(not(web))]
         jobs.push(job.boxed());
@@ -913,6 +1145,9 @@ fn is_chain_scoped(error: &chain_client::Error) -> bool {
                 | NodeError::BlobsNotFound(_)
                 | NodeError::InactiveChain(_)
         ) | chain_client::Error::ReadCertificatesError(_)
+            // Our own storage failing to read is nobody's health signal; halving the
+            // destination's window for it would punish the wrong side.
+            | chain_client::Error::ViewError(_)
     )
 }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -355,9 +355,7 @@ impl ProgressMap {
         for chain_id in forgotten {
             self.heights.remove(chain_id);
         }
-        if self.heights.len() <= MAX_FORGET_PER_SWEEP
-            && self.heights.capacity() > self.heights.len().saturating_mul(4)
-        {
+        if self.heights.capacity() > self.heights.len().saturating_mul(4) {
             let survivors = self.heights.drain().collect();
             return Some(std::mem::replace(&mut self.heights, survivors));
         }
@@ -661,6 +659,54 @@ struct ChainDest {
     /// chain yet, e.g. it lacks the committee and the admin chain's export has not reached it.
     retry_at: Option<Instant>,
     failures: u32,
+    /// How many times this destination has reported a *lower* height than it had. Counted apart
+    /// from `failures` because an advance clears those, and a peer alternating advance with
+    /// regression would otherwise reset its own penalty on every second answer and never
+    /// escalate. Fits in `ChainDest`'s existing padding.
+    regressions: u32,
+}
+
+impl ChainDest {
+    /// Folds in a height the destination reported, returning the height to record as
+    /// acknowledged, if any.
+    ///
+    /// The validator is authoritative about its own height in *both* directions: only one send
+    /// per pair is ever in flight and stale generations are filtered out, so a lower report is
+    /// not a race. One restored from a backup reports lower, and refusing to believe it would
+    /// leave that gap unrepaired for good — we would think it caught up and never re-send what
+    /// it lost. Believing it is therefore required; paying for it is what stops a peer from
+    /// lying its way into an unthrottled re-send loop.
+    fn record_reached(
+        &mut self,
+        reported: BlockHeight,
+        tip: BlockHeight,
+        now: Instant,
+        config: &BlockExportConfig,
+    ) -> Option<BlockHeight> {
+        let previous = self.next_height;
+        let advanced = previous.is_none_or(|height| reported > height);
+        let regressed = previous.is_some_and(|height| reported < height);
+        self.next_height = Some(reported);
+        if advanced {
+            self.failures = 0;
+            self.retry_at = None;
+        } else if regressed {
+            // Escalates on the regression count, which an advance does not clear: a genuine
+            // restore regresses once and pays one delay, an oscillating peer pays double each
+            // time it lies.
+            let attempt = self.failures.max(self.regressions);
+            self.retry_at = Some(now + backoff_delay(attempt, config));
+            self.regressions = self.regressions.saturating_add(1);
+        } else if reported < tip {
+            // Answered but moved nothing — a gap our storage cannot fill — so back this pair
+            // off rather than spinning on it.
+            back_off(&mut self.failures, &mut self.retry_at, now, config);
+            return None;
+        } else {
+            return None;
+        }
+        reported.try_sub_one().ok()
+    }
 }
 
 /// One destination validator: its connection and the health state every chain shares.
@@ -1032,60 +1078,18 @@ where
                 }
                 match &outcome {
                     SendOutcome::Reached(next_height) => {
-                        let previous = chain_dest.next_height;
-                        let advanced = previous.is_none_or(|n| *next_height > n);
-                        // The validator is authoritative about its own height, in both
-                        // directions: only one send per pair is ever in flight and stale
-                        // generations are filtered above, so this is not a race. One restored
-                        // from a backup reports a *lower* height, and refusing to believe it
-                        // would leave that gap unrepaired for good — we would think it caught
-                        // up and never send the blocks it lost.
-                        //
-                        // Untested: the in-process harness has no way to make a validator lose
-                        // state, so this direction rests on the argument above rather than on a
-                        // failing-first test. A regression is noticed only once a send happens,
-                        // which needs the chain's tip to be above the cursor. One that regresses while we
-                        // believe it fully converged waits for the chain's next block; probing
-                        // converged pairs instead would cost a query per chain per destination
-                        // forever, to catch something only a restore causes.
-                        chain_dest.next_height = Some(*next_height);
-                        let regressed = previous.is_some_and(|n| *next_height < n);
-                        if advanced || regressed {
-                            // A regression is believed but backed off, not cleared: a real
-                            // restore pays one delay once, while a peer oscillating its
-                            // reported height would otherwise hold this pair in a zero-delay
-                            // re-send loop for as long as it keeps lying.
-                            if advanced {
-                                chain_dest.failures = 0;
-                                chain_dest.retry_at = None;
-                            } else {
-                                back_off(
-                                    &mut chain_dest.failures,
-                                    &mut chain_dest.retry_at,
-                                    now,
-                                    &self.config,
-                                );
+                        if let Some(acked) =
+                            chain_dest.record_reached(*next_height, record_tip, now, &self.config)
+                        {
+                            let mut progress = self
+                                .progress
+                                .lock()
+                                .expect("progress mutex is never poisoned");
+                            let heights = progress.heights.entry(chain_id).or_default();
+                            match heights.binary_search_by_key(&index, |(at, _)| *at) {
+                                Ok(at) => heights[at].1 = acked,
+                                Err(at) => heights.insert(at, (index, acked)),
                             }
-                            if let Ok(acked) = next_height.try_sub_one() {
-                                let mut progress = self
-                                    .progress
-                                    .lock()
-                                    .expect("progress mutex is never poisoned");
-                                let heights = progress.heights.entry(chain_id).or_default();
-                                match heights.binary_search_by_key(&index, |(at, _)| *at) {
-                                    Ok(at) => heights[at].1 = acked,
-                                    Err(at) => heights.insert(at, (index, acked)),
-                                }
-                            }
-                        } else if *next_height < record_tip {
-                            // Answered but moved nothing — a gap our storage cannot fill — so
-                            // back this pair off rather than spinning on it.
-                            back_off(
-                                &mut chain_dest.failures,
-                                &mut chain_dest.retry_at,
-                                now,
-                                &self.config,
-                            );
                         }
                     }
                     SendOutcome::ChainScoped(error) => {
@@ -1647,12 +1651,16 @@ fn back_off(
     now: Instant,
     config: &BlockExportConfig,
 ) {
-    let backoff = config
-        .retry_delay
-        .saturating_mul(1u32.checked_shl(*failures).unwrap_or(u32::MAX))
-        .min(config.max_retry_delay);
-    *retry_at = Some(now + backoff);
+    *retry_at = Some(now + backoff_delay(*failures, config));
     *failures = failures.saturating_add(1);
+}
+
+/// The delay after `attempt` consecutive failures: doubles per attempt, capped.
+fn backoff_delay(attempt: u32, config: &BlockExportConfig) -> linera_base::time::Duration {
+    config
+        .retry_delay
+        .saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX))
+        .min(config.max_retry_delay)
 }
 
 /// Sends this validator's blocks to one other validator, reading everything it needs from
@@ -1993,6 +2001,70 @@ mod tests {
             resumed.iter().all(|id| !first.contains(id)),
             "the drain restarted at the front of the backlog: {first:?} then {resumed:?}",
         );
+    }
+
+    /// A peer that alternates advancing and regressing its reported height pays a doubling
+    /// penalty, while one that genuinely restored pays a single delay.
+    ///
+    /// The first attempt at this backed a regression off using the shared `failures` counter,
+    /// which an advance resets — so alternating answers pinned the delay at the base value
+    /// forever and the "throttled" peer kept a pair re-reading its whole catch-up window at
+    /// roughly two sends a second.
+    #[test]
+    fn an_oscillating_peer_escalates_but_a_restored_one_does_not() {
+        let config = BlockExportConfig {
+            retry_delay: Duration::from_millis(100),
+            max_retry_delay: Duration::from_secs(60),
+            ..BlockExportConfig::default()
+        };
+        let now = Instant::now();
+        let tip = BlockHeight(100);
+
+        // A genuine restore: one regression, then it advances from there for good.
+        let mut restored = ChainDest {
+            next_height: Some(BlockHeight(50)),
+            ..ChainDest::default()
+        };
+        assert!(restored
+            .record_reached(BlockHeight(10), tip, now, &config)
+            .is_some());
+        let restore_penalty = restored.retry_at.expect("a regression backs the pair off");
+        assert_eq!(restore_penalty, now + Duration::from_millis(100));
+        restored.record_reached(BlockHeight(20), tip, now, &config);
+        assert_eq!(
+            restored.retry_at, None,
+            "an advance after the restore must clear the penalty",
+        );
+
+        // An oscillator: every regression costs double the last, however many advances it
+        // interleaves.
+        let mut liar = ChainDest {
+            next_height: Some(BlockHeight(50)),
+            ..ChainDest::default()
+        };
+        let mut penalties = Vec::new();
+        for round in 0..4 {
+            liar.record_reached(BlockHeight(10), tip, now, &config);
+            penalties.push(liar.retry_at.expect("a regression backs the pair off") - now);
+            liar.record_reached(BlockHeight(50 + round), tip, now, &config);
+        }
+        assert_eq!(
+            penalties,
+            vec![
+                Duration::from_millis(100),
+                Duration::from_millis(200),
+                Duration::from_millis(400),
+                Duration::from_millis(800),
+            ],
+            "an advance between regressions reset the penalty",
+        );
+    }
+
+    /// The regression counter has to be free: this is per (chain, destination), and a down peer
+    /// holds one per tracked chain.
+    #[test]
+    fn the_regression_counter_costs_no_memory() {
+        assert_eq!(size_of::<ChainDest>(), 56);
     }
 
     /// A drained burst hands back its peak-sized table for freeing off the mutex; a live one

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -238,10 +238,9 @@ struct ExportedBlock {
     /// for a blob this very block publishes — is served without a read from storage. Held as the
     /// storage cache's pointers, so queued blocks share the allocations rather than copying them.
     blobs: Vec<CacheArc<Blob>>,
-    /// The chain's epoch and committee *after* the block was applied, so that a validator joining
-    /// in this block is exported to immediately.
+    /// The chain's epoch *after* the block was applied — a hint that lets the queue load a newer
+    /// committee from storage, so a validator joining in this block is exported to immediately.
     epoch: Epoch,
-    committee: Arc<Committee>,
     /// The persisted `exported_heights` of the chain, seeding cursors on its first block this
     /// process so a restart re-sends at most one block per destination instead of a history.
     exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
@@ -288,7 +287,6 @@ impl BlockExportHandle {
         certificate: CacheArc<ConfirmedBlockCertificate>,
         blobs: Vec<CacheArc<Blob>>,
         epoch: Epoch,
-        committee: Arc<Committee>,
         exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
     ) {
         // Announced before the queue is tried: a dropped block must still raise the repair
@@ -309,7 +307,6 @@ impl BlockExportHandle {
             certificate,
             blobs,
             epoch,
-            committee,
             exported_heights,
             #[cfg(with_metrics)]
             blob_bytes,
@@ -532,7 +529,7 @@ where
             };
             match wake {
                 Wake::Done(done) => self.on_done(done, &mut jobs),
-                Wake::Block(Some(block)) => self.on_block(block, &mut jobs),
+                Wake::Block(Some(block)) => self.on_block(block, &mut jobs).await,
                 Wake::Block(None) => break,
                 Wake::Tick => self.tick(&mut jobs).await,
             }
@@ -548,7 +545,7 @@ where
 
     /// Folds a fresh block in: advances the chain's tip and fans out to every destination that
     /// can take it now; the rest catch up from storage when their turn comes.
-    fn on_block(&mut self, block: ExportedBlock, jobs: &mut FuturesUnordered<JobFuture>) {
+    async fn on_block(&mut self, block: ExportedBlock, jobs: &mut FuturesUnordered<JobFuture>) {
         #[cfg(with_metrics)]
         {
             metrics::QUEUE_SIZE.dec();
@@ -559,9 +556,21 @@ where
         let header = &block.certificate.block().header;
         let (chain_id, height) = (header.chain_id, header.height);
         if self.latest_epoch.is_none_or(|epoch| block.epoch > epoch) {
-            self.latest_epoch = Some(block.epoch);
-            self.committee = Some(block.committee.clone());
-            self.committee_dirty = true;
+            // The block only carries the epoch; the committee itself comes from storage, where
+            // the chain that executed under it has already stored the event and blob.
+            match self.storage.get_or_load_committee(block.epoch).await {
+                Ok(Some(committee)) => {
+                    self.latest_epoch = Some(block.epoch);
+                    self.committee = Some(committee);
+                    self.committee_dirty = true;
+                }
+                Ok(None) => {
+                    debug!(epoch = %block.epoch, "Cannot load the committee for an exported block");
+                }
+                Err(error) => {
+                    debug!(%error, epoch = %block.epoch, "Cannot load a committee from storage");
+                }
+            }
         }
         // Per committee change, not per block: the rebuild walks every tracked chain.
         if self.committee_dirty || self.destinations.is_empty() {

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -468,13 +468,32 @@ impl ChainRecord {
     /// unrepresentable: a record with no cursors is invisible to the requeue loop and trivially
     /// "converged" to the sweep, so such a chain would be abandoned in silence. One creation
     /// path used to miss the seeding, and nothing in the suite could see it.
-    fn new<N>(now: Instant, destinations: &HashMap<ValidatorPublicKey, DestState<N>>) -> Self {
+    fn new<N>(
+        now: Instant,
+        destinations: &HashMap<ValidatorPublicKey, DestState<N>>,
+        exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
+    ) -> Self {
         ChainRecord {
             tip: BlockHeight::ZERO,
             last_activity: now,
             dests: destinations
                 .keys()
-                .map(|validator| (*validator, ChainDest::default()))
+                .map(|validator| {
+                    // Seeded here rather than by a later fill: a cursor pre-populated as `None`
+                    // and then only `or_insert`-ed would silently swallow the persisted height,
+                    // leaving `exported_heights` write-only and costing a query per destination
+                    // on every restart.
+                    let next_height = exported_heights
+                        .get(validator)
+                        .and_then(|height| height.try_add_one().ok());
+                    (
+                        *validator,
+                        ChainDest {
+                            next_height,
+                            ..ChainDest::default()
+                        },
+                    )
+                })
                 .collect(),
         }
     }
@@ -662,8 +681,10 @@ where
         {
             self.announced_epoch = Some(block.epoch);
         }
-        // Per committee change, not per block: the rebuild walks every tracked chain.
-        if self.committee_dirty || self.destinations.is_empty() {
+        // Per committee change only. Never on "destinations are empty": when a committee's
+        // addresses cannot be resolved that stays true, and the rebuild walks every tracked
+        // chain and re-warns per member — on the block-execution path. The tick retries it.
+        if self.committee_dirty {
             self.sync_destinations();
         }
 
@@ -672,20 +693,19 @@ where
         let record = self
             .chains
             .entry(chain_id)
-            .or_insert_with(|| ChainRecord::new(now, &self.destinations));
+            .or_insert_with(|| ChainRecord::new(now, &self.destinations, &block.exported_heights));
         record.tip = record.tip.max(tip);
         record.last_activity = now;
-        // Seed *missing* pairs from what the chain last persisted — on every block, not only at
-        // record creation, so a record the tick created from a dropped block's tip still picks
-        // the cursors up. At worst one block per destination is re-offered and skipped, instead
-        // of one query per destination per restart.
-        for (validator, height) in &block.exported_heights {
-            if let Ok(next) = height.try_add_one() {
-                record.dests.entry(*validator).or_insert_with(|| ChainDest {
-                    next_height: Some(next),
-                    ..ChainDest::default()
-                });
-            }
+        // A destination that joined after this record did still needs a cursor, and the chain's
+        // persisted height is a better start than none.
+        for validator in self.destinations.keys() {
+            record.dests.entry(*validator).or_insert_with(|| ChainDest {
+                next_height: block
+                    .exported_heights
+                    .get(validator)
+                    .and_then(|height| height.try_add_one().ok()),
+                ..ChainDest::default()
+            });
         }
         let validators = self.destinations.keys().copied().collect::<Vec<_>>();
         for validator in validators {
@@ -931,7 +951,7 @@ where
             let record = self
                 .chains
                 .entry(chain_id)
-                .or_insert_with(|| ChainRecord::new(now, &self.destinations));
+                .or_insert_with(|| ChainRecord::new(now, &self.destinations, &BTreeMap::new()));
             record.tip = record.tip.max(tip);
         }
         // When the destination set changed, every destination gets a cursor on every tracked
@@ -1081,6 +1101,8 @@ where
         };
         self.committee_dirty = false;
         let mut rebuilt = Vec::new();
+        #[cfg(with_metrics)]
+        let mut rebuilt_addresses = Vec::new();
         self.destinations.retain(|validator, dest| {
             let keep = committee
                 .validators()
@@ -1088,11 +1110,27 @@ where
                 .is_some_and(|state| state.network_address == dest.address);
             if !keep {
                 rebuilt.push(*validator);
+                #[cfg(with_metrics)]
+                rebuilt_addresses.push(dest.address.clone());
             }
             keep
         });
         if !rebuilt.is_empty() {
             self.destinations_changed = true;
+        }
+        // Drop the metric series of every address that just went away, so a departed validator
+        // does not leave a window gauge frozen at its last value and a lag histogram that never
+        // moves again — both read as a live destination that simply stopped changing.
+        #[cfg(with_metrics)]
+        for address in &rebuilt_addresses {
+            // A series that was never created is simply absent; nothing to report either way.
+            metrics::DESTINATION_WINDOW
+                .remove_label_values(&[address])
+                .ok();
+            metrics::SEND_LATENCY.remove_label_values(&[address]).ok();
+            metrics::DESTINATION_LAG
+                .remove_label_values(&[address])
+                .ok();
         }
         // A dropped DestState takes its ready list with it, so clear the queued marks that
         // pointed into it — a queued pair is invisible to every requeue path.
@@ -1530,6 +1568,50 @@ mod tests {
         ];
         for config in invalid {
             assert!(config.check().is_err(), "accepted: {config:?}");
+        }
+    }
+
+    /// A record starts from what the chain persisted, so a restart does not re-query every
+    /// destination of every chain.
+    ///
+    /// This is the one place the persisted `exported_heights` enters the queue. It regressed
+    /// twice — once when the seeding ran only at record creation and the tick could create
+    /// records without it, once when adding the cursor-always-present invariant made the seeding
+    /// a silent no-op — and neither showed up in any behavioural test, because a missing seed
+    /// only costs a query.
+    #[test]
+    fn records_start_from_the_persisted_heights() {
+        let validator = ValidatorPublicKey::test_key(1);
+        let other = ValidatorPublicKey::test_key(2);
+        let destinations: HashMap<ValidatorPublicKey, DestState<()>> =
+            [(validator, test_dest_state()), (other, test_dest_state())]
+                .into_iter()
+                .collect();
+        let exported = [(validator, BlockHeight(41))].into_iter().collect();
+
+        let record = ChainRecord::new(Instant::now(), &destinations, &exported);
+
+        assert_eq!(
+            record.dests[&validator].next_height,
+            Some(BlockHeight(42)),
+            "a persisted height must seed the cursor for the block after it",
+        );
+        assert_eq!(
+            record.dests[&other].next_height, None,
+            "a destination with nothing persisted must be queried, not assumed",
+        );
+    }
+
+    fn test_dest_state() -> DestState<()> {
+        DestState {
+            node: (),
+            address: "grpc:localhost:1".to_string(),
+            generation: 1,
+            in_flight: 0,
+            window: 1,
+            retry_at: None,
+            failures: 0,
+            ready: VecDeque::new(),
         }
     }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -174,6 +174,27 @@ mod metrics {
         )
     });
 
+    /// Blocks this validator still owes each destination, summed over every chain it is behind
+    /// on. The aggregate backlog, which is what "is that validator caught up" actually asks.
+    pub static BLOCKS_OWED: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "block_export_blocks_owed",
+            "Blocks still to send to a destination validator, summed over all chains",
+            &["validator"],
+        )
+    });
+
+    /// The furthest behind any single chain is for a destination. A quantile over chains would
+    /// need a per-pair observation, measured at 150 ms per sweep at a million pairs against
+    /// 2 ms for this; and the maximum is the tail a quantile would hide anyway.
+    pub static MAX_CHAIN_GAP: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+        register_int_gauge_vec(
+            "block_export_max_chain_gap",
+            "Blocks the furthest-behind chain owes a destination validator",
+            &["validator"],
+        )
+    });
+
     /// The queue-wide in-flight budget, halved whenever our own storage fails a read.
     pub static TOTAL_WINDOW: LazyLock<IntGauge> = LazyLock::new(|| {
         register_int_gauge(
@@ -199,7 +220,7 @@ mod metrics {
             "block_export_destination_lag",
             "Blocks a destination validator was missing when a block was pushed to it",
             &["validator"],
-            exponential_bucket_interval(1.0, 100_000.0),
+            exponential_bucket_interval(1.0, 10_000_000.0),
         )
     });
 }
@@ -561,6 +582,8 @@ where
         admin_chain_id: None,
         ticks_until_scan: 0,
         ticks_until_sweep: TICKS_PER_CONVERGENCE_SWEEP,
+        #[cfg(with_metrics)]
+        ticks_until_census: 0,
         chains: HashMap::new(),
         destinations: BTreeMap::new(),
         dest_indices: BTreeMap::new(),
@@ -868,6 +891,9 @@ where
     ticks_until_scan: u32,
     /// Ticks until the next sweep of converged chains.
     ticks_until_sweep: u32,
+    /// Ticks until the next backlog census.
+    #[cfg(with_metrics)]
+    ticks_until_census: u32,
     chains: HashMap<ChainId, ChainRecord>,
     destinations: BTreeMap<DestIndex, DestState<P::Node>>,
     /// Every validator ever registered as a destination, and the index its per-chain state uses.
@@ -910,6 +936,11 @@ const LAGGING_SCAN_FACTOR: usize = 4;
 /// How many ticks apart converged chains are swept. The window they are held for is minutes, so
 /// this only decides how promptly the memory comes back.
 const TICKS_PER_CONVERGENCE_SWEEP: u32 = 25;
+
+/// How many ticks apart the backlog census runs. Slower than the sweep because it costs the size
+/// of the real backlog and answers a dashboard question, not a scheduling one.
+#[cfg(with_metrics)]
+const TICKS_PER_BACKLOG_CENSUS: u32 = 300;
 
 /// How many chains one sweep may forget, bounding how long it holds the progress mutex that every
 /// chain worker takes on every block.
@@ -1387,6 +1418,12 @@ where
                 .sum::<usize>();
             metrics::LAGGING_PAIRS.set(lagging_pairs as i64);
             metrics::TOTAL_WINDOW.set(self.total_window as i64);
+            if self.ticks_until_census == 0 {
+                self.ticks_until_census = TICKS_PER_BACKLOG_CENSUS;
+                self.publish_backlog();
+            } else {
+                self.ticks_until_census -= 1;
+            }
         }
 
         // No requeue scan: each destination's `lagging` set already *is* the list of chains it
@@ -1525,6 +1562,8 @@ where
             metrics::CHAIN_SCOPED_BACKOFFS
                 .remove_label_values(&[address])
                 .ok();
+            metrics::BLOCKS_OWED.remove_label_values(&[address]).ok();
+            metrics::MAX_CHAIN_GAP.remove_label_values(&[address]).ok();
         }
         for (validator, address) in committee.validator_addresses() {
             if Some(validator) == self.own_public_key {
@@ -1582,6 +1621,46 @@ where
             record
                 .dests
                 .retain(|(index, _)| destinations.contains_key(index));
+        }
+    }
+
+    /// Publishes how far behind each destination is, walking the `lagging` sets rather than
+    /// every tracked chain.
+    ///
+    /// Those sets already name exactly the chains a destination owes blocks on, so this costs
+    /// the size of the real backlog: nothing when everyone is caught up, and proportional to the
+    /// outage when they are not. Folding it into the convergence sweep instead would have cost
+    /// that sweep its short-circuit — measured at +142 ms per sweep at 100k chains and a
+    /// 20-member committee, against 9 ms for this.
+    ///
+    /// The maximum rather than a quantile: a per-pair histogram observation measured 150 ms per
+    /// sweep at a million pairs, and the maximum is the tail a quantile would hide anyway.
+    #[cfg(with_metrics)]
+    fn publish_backlog(&self) {
+        for (index, dest) in &self.destinations {
+            let mut owed = 0u64;
+            let mut worst = 0u64;
+            for chain_id in &dest.lagging {
+                let Some(record) = self.chains.get(chain_id) else {
+                    continue;
+                };
+                let Some(chain_dest) = record.dest(*index) else {
+                    continue;
+                };
+                let gap = chain_dest
+                    .next_height
+                    .map_or(record.tip.0, |next| record.tip.0.saturating_sub(next.0));
+                owed = owed.saturating_add(gap);
+                worst = worst.max(gap);
+            }
+            // Published for every destination, not just the ones behind: a gauge left at its last
+            // value would read as a permanent debt after the peer caught up.
+            metrics::BLOCKS_OWED
+                .with_label_values(&[&dest.address])
+                .set(owed as i64);
+            metrics::MAX_CHAIN_GAP
+                .with_label_values(&[&dest.address])
+                .set(worst as i64);
         }
     }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -149,6 +149,9 @@ pub struct BlockExportConfig {
     pub certificate_upload_batch_size: u64,
     /// How many blocks the export queue holds before dropping new ones for catch-up to repair.
     pub queue_size: usize,
+    /// The most blob payload bytes queued blocks may pin before new ones are dropped for
+    /// catch-up to repair — a block count alone lets 1024 blob-heavy blocks pin gigabytes.
+    pub queue_bytes: usize,
     /// The most concurrent sends one destination is ever allowed — the AIMD window's ceiling.
     pub max_in_flight_per_destination: usize,
     /// How long a destination is skipped after a failed push, doubling up to `max_retry_delay`.
@@ -183,6 +186,10 @@ impl BlockExportConfig {
         if self.queue_size == 0 {
             // Every block would be dropped and export would run on catch-up alone.
             return Err("block export queue size must be greater than zero".into());
+        }
+        if self.queue_bytes == 0 {
+            // Every block carrying any blob would be dropped.
+            return Err("block export queue byte budget must be greater than zero".into());
         }
         if self.max_in_flight_per_destination == 0 {
             // No destination could ever be sent anything.
@@ -221,6 +228,7 @@ impl Default for BlockExportConfig {
         BlockExportConfig {
             certificate_upload_batch_size: 100,
             queue_size: 1024,
+            queue_bytes: 256 * 1024 * 1024,
             max_in_flight_per_destination: 8,
             retry_delay: Duration::from_secs(1),
             max_retry_delay: Duration::from_secs(60),
@@ -241,12 +249,12 @@ struct ExportedBlock {
     /// The chain's epoch *after* the block was applied — a hint that lets the queue load a newer
     /// committee from storage, so a validator joining in this block is exported to immediately.
     epoch: Epoch,
-    /// The persisted `exported_heights` of the chain, seeding cursors on its first block this
-    /// process so a restart re-sends at most one block per destination instead of a history.
+    /// The persisted `exported_heights` of the chain, seeding missing cursors so a restart
+    /// re-sends at most one block per destination instead of a history.
     exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
-    /// Blob payload bytes, counted at enqueue so the dequeue can decrement the same amount.
-    #[cfg(with_metrics)]
-    blob_bytes: i64,
+    /// Blob payload bytes, counted at enqueue so the dequeue releases the same amount of the
+    /// byte budget.
+    blob_bytes: usize,
     #[cfg(with_metrics)]
     queued_at: Instant,
 }
@@ -256,6 +264,10 @@ pub struct BlockExportHandle {
     blocks: mpsc::Sender<ExportedBlock>,
     progress: SharedProgress,
     tips: SharedTips,
+    /// Blob payload bytes currently pinned by queued blocks, enforced against
+    /// [`BlockExportConfig::queue_bytes`].
+    queued_bytes: Arc<std::sync::atomic::AtomicUsize>,
+    queue_bytes_budget: usize,
 }
 
 impl Clone for BlockExportHandle {
@@ -264,6 +276,8 @@ impl Clone for BlockExportHandle {
             blocks: self.blocks.clone(),
             progress: self.progress.clone(),
             tips: self.tips.clone(),
+            queued_bytes: self.queued_bytes.clone(),
+            queue_bytes_budget: self.queue_bytes_budget,
         }
     }
 }
@@ -298,27 +312,38 @@ impl BlockExportHandle {
             let entry = tips.entry(header.chain_id).or_insert(tip);
             *entry = (*entry).max(tip);
         }
-        #[cfg(with_metrics)]
-        let blob_bytes = blobs
-            .iter()
-            .map(|blob| blob.bytes().len() as i64)
-            .sum::<i64>();
+        let blob_bytes = blobs.iter().map(|blob| blob.bytes().len()).sum::<usize>();
+        // The byte budget is enforced, not merely measured: a block count alone would let a few
+        // blob-heavy blocks pin memory far past the cache's own bounds.
+        let queued = self.queued_bytes.load(std::sync::atomic::Ordering::Relaxed);
+        if queued.saturating_add(blob_bytes) > self.queue_bytes_budget {
+            debug!(
+                chain_id = %certificate.block().header.chain_id,
+                height = %certificate.block().header.height,
+                queued, blob_bytes,
+                "Export queue byte budget exhausted; dropping the block for catch-up to re-send",
+            );
+            #[cfg(with_metrics)]
+            metrics::DROPPED_BLOCKS.inc();
+            return;
+        }
         let block = ExportedBlock {
             certificate,
             blobs,
             epoch,
             exported_heights,
-            #[cfg(with_metrics)]
             blob_bytes,
             #[cfg(with_metrics)]
             queued_at: Instant::now(),
         };
         match self.blocks.try_send(block) {
             Ok(()) => {
+                self.queued_bytes
+                    .fetch_add(blob_bytes, std::sync::atomic::Ordering::Relaxed);
                 #[cfg(with_metrics)]
                 {
                     metrics::QUEUE_SIZE.inc();
-                    metrics::QUEUE_BYTES.add(blob_bytes);
+                    metrics::QUEUE_BYTES.add(blob_bytes as i64);
                 }
             }
             Err(mpsc::error::TrySendError::Full(block)) => {
@@ -373,9 +398,16 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     P::Node: Send + Sync,
 {
+    // Enforced here rather than only at the CLI: every constructor, tests included, must go
+    // through it, and an invalid config panics at startup instead of mid-export.
+    if let Err(message) = config.check() {
+        panic!("invalid block export configuration: {message}");
+    }
     let (blocks, receiver) = mpsc::channel(config.queue_size);
     let progress: SharedProgress = Arc::default();
     let tips: SharedTips = Arc::default();
+    let queued_bytes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let queue_bytes_budget = config.queue_bytes;
 
     let task = BlockExportQueue {
         storage,
@@ -389,6 +421,9 @@ where
         ticks_until_scan: 0,
         chains: HashMap::new(),
         destinations: HashMap::new(),
+        next_generation: 0,
+        destinations_changed: false,
+        queued_bytes: queued_bytes.clone(),
         progress: progress.clone(),
         tips: tips.clone(),
         draining: false,
@@ -399,6 +434,8 @@ where
         blocks,
         progress,
         tips,
+        queued_bytes,
+        queue_bytes_budget,
     }
 }
 
@@ -482,6 +519,13 @@ where
     ticks_until_scan: u32,
     chains: HashMap<ChainId, ChainRecord>,
     destinations: HashMap<ValidatorPublicKey, DestState<P::Node>>,
+    /// The last destination generation handed out; never reused within this queue's lifetime.
+    next_generation: u64,
+    /// Set when `sync_destinations` changed the set, so the per-record cursor fill runs once
+    /// per change instead of once per tick.
+    destinations_changed: bool,
+    /// Blob bytes pinned by queued blocks, shared with every handle for budget enforcement.
+    queued_bytes: Arc<std::sync::atomic::AtomicUsize>,
     progress: SharedProgress,
     /// The highest height each chain has announced, written by every `export` call — including
     /// ones the full queue dropped — so a dropped block still moves the repair target.
@@ -511,9 +555,22 @@ where
             Tick,
         }
         let mut jobs = FuturesUnordered::new();
+        // One deadline carried across iterations: a timer rebuilt per iteration restarts on
+        // every completion or block, so under sustained load it would never fire — and with it
+        // would die every tick-only duty (drop repair, backoff expiry, the committee scan, the
+        // convergence sweep).
+        let interval = self.config.idle_catch_up_interval;
+        let mut next_tick = Instant::now() + interval;
         loop {
+            let now = Instant::now();
+            if now >= next_tick {
+                self.tick(&mut jobs).await;
+                next_tick = Instant::now() + interval;
+                continue;
+            }
+            let until_tick = next_tick.duration_since(now);
             let wake = if jobs.is_empty() {
-                match timeout(self.config.idle_catch_up_interval, receiver.recv()).await {
+                match timeout(until_tick, receiver.recv()).await {
                     Ok(received) => Wake::Block(received),
                     Err(_) => Wake::Tick,
                 }
@@ -523,15 +580,17 @@ where
                 futures::select_biased! {
                     done = jobs.next() => Wake::Done(done.expect("jobs is not empty")),
                     received = receiver.recv().fuse() => Wake::Block(received),
-                    _ = linera_base::time::timer::sleep(self.config.idle_catch_up_interval)
-                        .fuse() => Wake::Tick,
+                    _ = linera_base::time::timer::sleep(until_tick).fuse() => Wake::Tick,
                 }
             };
             match wake {
                 Wake::Done(done) => self.on_done(done, &mut jobs),
                 Wake::Block(Some(block)) => self.on_block(block, &mut jobs).await,
                 Wake::Block(None) => break,
-                Wake::Tick => self.tick(&mut jobs).await,
+                Wake::Tick => {
+                    self.tick(&mut jobs).await;
+                    next_tick = Instant::now() + interval;
+                }
             }
         }
         // The workers are gone. Let in-flight sends finish, without starting new ones — every
@@ -546,10 +605,12 @@ where
     /// Folds a fresh block in: advances the chain's tip and fans out to every destination that
     /// can take it now; the rest catch up from storage when their turn comes.
     async fn on_block(&mut self, block: ExportedBlock, jobs: &mut FuturesUnordered<JobFuture>) {
+        self.queued_bytes
+            .fetch_sub(block.blob_bytes, std::sync::atomic::Ordering::Relaxed);
         #[cfg(with_metrics)]
         {
             metrics::QUEUE_SIZE.dec();
-            metrics::QUEUE_BYTES.sub(block.blob_bytes);
+            metrics::QUEUE_BYTES.sub(block.blob_bytes as i64);
             metrics::EXPORT_LATENCY
                 .finish_measurement(block.queued_at.elapsed().as_secs_f64() * 1000.0);
         }
@@ -582,25 +643,22 @@ where
         let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
             tip: BlockHeight::ZERO,
             last_activity: now,
-            // Seeded from what the chain last persisted: at worst one block per destination is
-            // re-offered and skipped, instead of one query per destination per restart.
-            dests: block
-                .exported_heights
-                .iter()
-                .filter_map(|(validator, height)| {
-                    let next = height.try_add_one().ok()?;
-                    Some((
-                        *validator,
-                        ChainDest {
-                            next_height: Some(next),
-                            ..ChainDest::default()
-                        },
-                    ))
-                })
-                .collect(),
+            dests: BTreeMap::new(),
         });
         record.tip = record.tip.max(tip);
         record.last_activity = now;
+        // Seed *missing* pairs from what the chain last persisted — on every block, not only at
+        // record creation, so a record the tick created from a dropped block's tip still picks
+        // the cursors up. At worst one block per destination is re-offered and skipped, instead
+        // of one query per destination per restart.
+        for (validator, height) in &block.exported_heights {
+            if let Ok(next) = height.try_add_one() {
+                record.dests.entry(*validator).or_insert_with(|| ChainDest {
+                    next_height: Some(next),
+                    ..ChainDest::default()
+                });
+            }
+        }
         let validators = self.destinations.keys().copied().collect::<Vec<_>>();
         for validator in validators {
             let record = self.chains.get_mut(&chain_id).expect("inserted above");
@@ -670,6 +728,47 @@ where
         }
         dest.in_flight = dest.in_flight.saturating_sub(1);
 
+        // Destination health comes from the outcome alone, never gated on the chain record —
+        // a transport failure must shrink the window and set the backoff even for a chain the
+        // queue has since forgotten.
+        match &outcome {
+            SendOutcome::Reached(_) => {
+                dest.failures = 0;
+                dest.retry_at = None;
+                dest.window = (dest.window + 1).min(self.config.max_in_flight_per_destination);
+            }
+            SendOutcome::ChainScoped(_) => {}
+            SendOutcome::DestinationScoped(error) => {
+                warn!(
+                    validator = %dest.address, %chain_id, %error,
+                    "Failed to export to a validator; backing it off and re-resolving",
+                );
+                dest.window = (dest.window / 2).max(1);
+                back_off(&mut dest.failures, &mut dest.retry_at, now, &self.config);
+                // Re-resolve so a relayed transport draws the next proxy from the rotation; the
+                // backoff above still applies if the validator itself is the problem. Resolved
+                // through the list API because the test provider resolves by *key*, which only
+                // the list variant carries.
+                match self
+                    .node_provider
+                    .make_nodes_from_list(iter::once((validator, dest.address.clone())))
+                {
+                    Ok(mut nodes) => {
+                        if let Some((_, node)) = nodes.next() {
+                            dest.node = node;
+                        }
+                    }
+                    Err(error) => {
+                        warn!(%validator, %error, "Cannot re-resolve a failing destination");
+                    }
+                }
+            }
+        }
+        #[cfg(with_metrics)]
+        metrics::DESTINATION_WINDOW
+            .with_label_values(&[&dest.address])
+            .set(dest.window as i64);
+
         if let Some(record) = self.chains.get_mut(&chain_id) {
             record.last_activity = now;
             if let Some(chain_dest) = record.dests.get_mut(&validator) {
@@ -677,13 +776,19 @@ where
                 match &outcome {
                     SendOutcome::Reached(next_height) => {
                         let advanced = chain_dest.next_height.is_none_or(|n| *next_height > n);
-                        // Only ever forward: a stale response must not drag the cursor back.
                         if advanced {
+                            // Only ever forward: a stale response must not drag the cursor back.
                             chain_dest.next_height = Some(*next_height);
-                        }
-                        if advanced {
                             chain_dest.failures = 0;
                             chain_dest.retry_at = None;
+                            if let Ok(acked) = next_height.try_sub_one() {
+                                self.progress
+                                    .lock()
+                                    .expect("progress mutex is never poisoned")
+                                    .entry(chain_id)
+                                    .or_default()
+                                    .insert(validator, acked);
+                            }
                         } else if *next_height < record.tip {
                             // Answered but moved nothing — a gap our storage cannot fill — so
                             // back this pair off rather than spinning on it.
@@ -694,20 +799,6 @@ where
                                 &self.config,
                             );
                         }
-                        if advanced {
-                            if let Ok(acked) = next_height.try_sub_one() {
-                                self.progress
-                                    .lock()
-                                    .expect("progress mutex is never poisoned")
-                                    .entry(chain_id)
-                                    .or_default()
-                                    .insert(validator, acked);
-                            }
-                        }
-                        dest.failures = 0;
-                        dest.retry_at = None;
-                        dest.window =
-                            (dest.window + 1).min(self.config.max_in_flight_per_destination);
                     }
                     SendOutcome::ChainScoped(error) => {
                         debug!(
@@ -722,36 +813,10 @@ where
                             &self.config,
                         );
                     }
-                    SendOutcome::DestinationScoped(error) => {
-                        warn!(
-                            validator = %dest.address, %chain_id, %error,
-                            "Failed to export to a validator; backing it off and re-resolving",
-                        );
+                    SendOutcome::DestinationScoped(_) => {
                         chain_dest.next_height = None;
-                        dest.window = (dest.window / 2).max(1);
-                        back_off(&mut dest.failures, &mut dest.retry_at, now, &self.config);
-                        // Re-resolve so a relayed transport draws the next proxy from the
-                        // rotation; the backoff above still applies if the validator itself is
-                        // the problem.
-                        match self
-                            .node_provider
-                            .make_nodes_from_list(iter::once((validator, dest.address.clone())))
-                        {
-                            Ok(mut nodes) => {
-                                if let Some((_, node)) = nodes.next() {
-                                    dest.node = node;
-                                }
-                            }
-                            Err(error) => {
-                                warn!(%validator, %error, "Cannot re-resolve a failing destination");
-                            }
-                        }
                     }
                 }
-                #[cfg(with_metrics)]
-                metrics::DESTINATION_WINDOW
-                    .with_label_values(&[&dest.address])
-                    .set(dest.window as i64);
             }
         }
 
@@ -801,28 +866,28 @@ where
             self.sync_destinations();
         }
 
-        // Fold announced tips in: this is what repairs a block the full queue dropped, and what
-        // creates the record when even a chain's first block was dropped.
-        {
-            let tips = self
-                .tips
-                .lock()
-                .expect("tips mutex is never poisoned")
-                .clone();
-            for (chain_id, tip) in tips {
-                let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
-                    tip: BlockHeight::ZERO,
-                    last_activity: now,
-                    dests: BTreeMap::new(),
-                });
-                record.tip = record.tip.max(tip);
-            }
+        // Drain announced tips in: this is what repairs a block the full queue dropped, and what
+        // creates the record when even a chain's first block was dropped. Taken rather than
+        // cloned — the workers contend on this mutex every block, and once folded the records
+        // carry the truth.
+        let tips = std::mem::take(&mut *self.tips.lock().expect("tips mutex is never poisoned"));
+        for (chain_id, tip) in tips {
+            let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
+                tip: BlockHeight::ZERO,
+                last_activity: now,
+                dests: BTreeMap::new(),
+            });
+            record.tip = record.tip.max(tip);
         }
-        // Every current destination gets a cursor on every tracked chain, so a validator that
-        // joined after a chain's last block is still caught up on it.
-        for record in self.chains.values_mut() {
-            for validator in self.destinations.keys() {
-                record.dests.entry(*validator).or_default();
+        // When the destination set changed, every destination gets a cursor on every tracked
+        // chain, so a validator that joined after a chain's last block is still caught up on it.
+        // Gated on the change: this walks every record.
+        if self.destinations_changed {
+            self.destinations_changed = false;
+            for record in self.chains.values_mut() {
+                for validator in self.destinations.keys() {
+                    record.dests.entry(*validator).or_default();
+                }
             }
         }
 
@@ -837,7 +902,13 @@ where
         self.chains.retain(|chain_id, record| {
             let converged = destinations.keys().all(|validator| {
                 record.dests.get(validator).is_some_and(|chain_dest| {
-                    !chain_dest.in_flight && chain_dest.next_height == Some(record.tip)
+                    // `>=`: a destination is routinely *ahead* of our tip — the client
+                    // broadcasts to everyone — and ahead must count as done, not as never
+                    // converging.
+                    !chain_dest.in_flight
+                        && chain_dest
+                            .next_height
+                            .is_some_and(|next| next >= record.tip)
                 })
             });
             if converged && now.duration_since(record.last_activity) > retention {
@@ -852,10 +923,8 @@ where
                 .progress
                 .lock()
                 .expect("progress mutex is never poisoned");
-            let mut tips = self.tips.lock().expect("tips mutex is never poisoned");
             for chain_id in &forgotten {
                 progress.remove(chain_id);
-                tips.remove(chain_id);
             }
         }
 
@@ -951,12 +1020,6 @@ where
             return;
         };
         self.committee_dirty = false;
-        let mut generation = self
-            .destinations
-            .values()
-            .map(|dest| dest.generation)
-            .max()
-            .unwrap_or(0);
         let mut rebuilt = Vec::new();
         self.destinations.retain(|validator, dest| {
             let keep = committee
@@ -968,6 +1031,9 @@ where
             }
             keep
         });
+        if !rebuilt.is_empty() {
+            self.destinations_changed = true;
+        }
         // A dropped DestState takes its ready list with it, so clear the queued marks that
         // pointed into it — a queued pair is invisible to every requeue path.
         for record in self.chains.values_mut() {
@@ -983,20 +1049,26 @@ where
                 continue;
             }
             // One at a time: a batch fails whole on the first bad address, and one unresolvable
-            // validator must not keep every other one out of the destination set.
+            // validator must not keep every other one out of the destination set. Through the
+            // list API rather than `make_node`, because the test provider resolves by *key*,
+            // which only the list variant carries.
             match self
                 .node_provider
                 .make_nodes_from_list(iter::once((validator, address)))
             {
                 Ok(mut nodes) => {
                     if let Some((_, node)) = nodes.next() {
-                        generation += 1;
+                        // Monotonic across the queue's lifetime: derived from surviving
+                        // destinations it could repeat after the set empties, and a repeat lets
+                        // a stale in-flight send corrupt a fresh incarnation's accounting.
+                        self.next_generation += 1;
+                        self.destinations_changed = true;
                         self.destinations.insert(
                             validator,
                             DestState {
                                 node,
                                 address: address.to_owned(),
-                                generation,
+                                generation: self.next_generation,
                                 in_flight: 0,
                                 window: self.config.max_in_flight_per_destination,
                                 retry_at: None,
@@ -1284,25 +1356,31 @@ where
         held: &[CacheArc<Blob>],
     ) -> Result<Box<crate::data_types::ChainInfo>, chain_client::Error> {
         let delivery = CrossChainMessageDelivery::NonBlocking;
-        let result = self
+        let mut result = self
             .remote_node
             .handle_optimized_confirmed_certificate(certificate, delivery)
             .await;
-        match result {
-            Err(NodeError::BlobsNotFound(blob_ids)) => {
-                self.remote_node
-                    .check_blobs_not_found(certificate, &blob_ids)?;
-                let blobs = self.resolve_blobs(&blob_ids, held).await?;
-                self.remote_node
-                    .node
-                    .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
-                    .await?;
-                Ok(self
-                    .remote_node
-                    .handle_confirmed_certificate(certificate.clone(), delivery)
-                    .await?)
+        // The same once-per-cause loop as the client's `RemoteNodeUpdater`: a second
+        // `BlobsNotFound` naming new blobs is still recoverable, only repeating a cause is not.
+        let mut sent_blobs = false;
+        loop {
+            match result {
+                Err(NodeError::BlobsNotFound(blob_ids)) if !sent_blobs => {
+                    self.remote_node
+                        .check_blobs_not_found(certificate, &blob_ids)?;
+                    let blobs = self.resolve_blobs(&blob_ids, held).await?;
+                    self.remote_node
+                        .node
+                        .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
+                        .await?;
+                    sent_blobs = true;
+                }
+                result => return Ok(result?),
             }
-            result => Ok(result?),
+            result = self
+                .remote_node
+                .handle_confirmed_certificate(certificate.clone(), delivery)
+                .await;
         }
     }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -26,7 +26,7 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{Blob, BlockHeight},
-    identifiers::ChainId,
+    identifiers::{BlobId, ChainId},
     time::{timer::timeout, Duration, Instant},
 };
 use linera_chain::types::ConfirmedBlockCertificate;
@@ -36,11 +36,10 @@ use tokio::sync::mpsc;
 use tracing::{debug, instrument, warn};
 
 use crate::{
+    client::chain_client,
     data_types::ChainInfoQuery,
-    local_node::LocalNodeClient,
-    node::{ValidatorNode, ValidatorNodeProvider},
+    node::{CrossChainMessageDelivery, NodeError, ValidatorNode, ValidatorNodeProvider},
     remote_node::RemoteNode,
-    updater::RemoteNodeUpdater,
 };
 
 #[cfg(with_metrics)]
@@ -156,10 +155,10 @@ impl Default for BlockExportConfig {
 pub struct ChainExportSetup<S: Storage> {
     /// The chain whose blocks this task exports.
     pub chain_id: ChainId,
-    /// Read access to the chains this process serves, used for the few chain-level queries that
-    /// the certificate partitions cannot answer — the admin chain's height, and block hashes for
-    /// certificates that predate the height index.
-    pub local_node: LocalNodeClient<S>,
+    /// Read access to this validator's storage, for certificates and blobs during catch-up.
+    /// Deliberately not a local node: going through one loads chain workers, and an export task
+    /// that touches a chain worker resets its TTL and keeps it resident forever.
+    pub storage: S,
     /// The heights already exported to each validator, as last persisted by the worker.
     pub exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
 }
@@ -176,11 +175,8 @@ struct ExportedBlock {
     /// storage cache's pointers, so queued blocks share the allocations rather than copying them.
     blobs: Vec<CacheArc<Blob>>,
     /// The chain's committee *after* the block was applied, so that a validator joining in this
-    /// block is exported to immediately, including the admin-chain block that admitted it.
+    /// block is exported to immediately.
     committee: Arc<Committee>,
-    /// The chain carrying the epoch events, needed when a destination does not yet know the
-    /// committee that signed the certificate.
-    admin_chain_id: ChainId,
     /// When the worker queued this block, so that `EXPORT_LATENCY` covers the wait as well as
     /// the sending. The queue is where the delay shows up once export falls behind, which is
     /// exactly when the metric is worth reading.
@@ -206,13 +202,11 @@ impl ChainExporter {
         certificate: CacheArc<ConfirmedBlockCertificate>,
         blobs: Vec<CacheArc<Blob>>,
         committee: Arc<Committee>,
-        admin_chain_id: ChainId,
     ) {
         let block = ExportedBlock {
             certificate,
             blobs,
             committee,
-            admin_chain_id,
             #[cfg(with_metrics)]
             queued_at: Instant::now(),
         };
@@ -269,12 +263,11 @@ where
     let task = ChainExportTask {
         chain_id: setup.chain_id,
         node_provider,
-        local_node: setup.local_node,
+        storage: setup.storage,
         config,
         own_public_key,
         destinations: HashMap::new(),
         chain_next_height: BlockHeight::ZERO,
-        admin_chain_id: None,
         progress: progress.clone(),
     };
     linera_base::Task::spawn(task.run(receiver)).forget();
@@ -284,7 +277,7 @@ where
 
 /// One destination validator, and what we believe it holds of this chain.
 struct Destination<S: Storage, N> {
-    updater: RemoteNodeUpdater<S, N>,
+    sender: BlockSender<S, N>,
     address: String,
     /// The next height the validator needs, or `None` when we have to ask it — before the first
     /// push, and after any failed one.
@@ -304,9 +297,7 @@ where
 {
     chain_id: ChainId,
     node_provider: Arc<P>,
-    /// Answers the chain-level queries the certificate partitions cannot, through the local
-    /// worker that owns the chain state views.
-    local_node: LocalNodeClient<S>,
+    storage: S,
     config: BlockExportConfig,
     own_public_key: Option<ValidatorPublicKey>,
     destinations: HashMap<ValidatorPublicKey, Destination<S, P::Node>>,
@@ -314,9 +305,6 @@ where
     /// be considered caught up. Used to keep catching a lagging destination up while the chain is
     /// idle, so that convergence does not depend on the chain producing more blocks.
     chain_next_height: BlockHeight,
-    /// The chain carrying the epoch events, learned from the first block exported. `None` until
-    /// then, which is also when there is nothing to catch anyone up on.
-    admin_chain_id: Option<ChainId>,
     /// The highest height each validator has acknowledged. Seeded from what the worker had
     /// persisted, so a destination we meet for the first time — after a restart, or after the
     /// chain worker was dropped and reloaded — starts from there instead of being queried.
@@ -355,29 +343,6 @@ where
         debug!("Chain worker dropped; stopping block export");
     }
 
-    /// Brings the destination set in line with the committee as the worker sees it now. Asked of
-    /// the worker rather than read from the chain view, which the worker owns while running.
-    async fn sync_destinations_from_local_node(&mut self) {
-        let query = ChainInfoQuery::new(self.chain_id).with_committees();
-        let info = match self.local_node.handle_chain_info_query(query).await {
-            Ok(response) => response.info,
-            Err(error) => {
-                debug!(%error, "Cannot read the committee while catching up");
-                return;
-            }
-        };
-        let Some(committee) = info
-            .requested_committees
-            .and_then(|committees| committees.into_iter().next_back().map(|(_, c)| c))
-        else {
-            return;
-        };
-        let Some(admin_chain_id) = self.admin_chain_id else {
-            return;
-        };
-        self.sync_destinations_with(&committee, admin_chain_id);
-    }
-
     /// Remakes the node of every destination whose last push failed, drawing the next proxy from
     /// the rotation so a dead proxy is stepped over rather than retried. Keeps the failure count
     /// and backoff, so this cannot become a way to hammer a validator that is simply offline.
@@ -391,16 +356,24 @@ where
         if stuck.is_empty() {
             return;
         }
-        let nodes = match self.node_provider.make_nodes_from_list(stuck) {
-            Ok(nodes) => nodes.collect::<Vec<_>>(),
-            Err(error) => {
-                warn!(%error, "Cannot rebuild connections to lagging validators");
-                return;
-            }
-        };
-        for (validator, node) in nodes {
-            if let Some(destination) = self.destinations.get_mut(&validator) {
-                destination.updater.remote_node.node = node;
+        // One at a time: a batch fails whole on the first bad address, and one unresolvable
+        // destination must not block reconnecting the others.
+        for (validator, address) in stuck {
+            match self
+                .node_provider
+                .make_nodes_from_list(iter::once((validator, address)))
+            {
+                Ok(nodes) => {
+                    if let (Some((_, node)), Some(destination)) = (
+                        nodes.into_iter().next(),
+                        self.destinations.get_mut(&validator),
+                    ) {
+                        destination.sender.remote_node.node = node;
+                    }
+                }
+                Err(error) => {
+                    warn!(%validator, %error, "Cannot rebuild the connection to a lagging validator");
+                }
             }
         }
     }
@@ -409,10 +382,10 @@ where
     ///
     /// Runs only when nothing is queued, so live blocks always take priority over backfill.
     async fn catch_up_round(&mut self) {
-        // Pick up committee changes too. A validator admitted while this chain happens to be idle
-        // would otherwise never become a destination at all — `sync_destinations` runs off an
-        // exported block, and there is no next block to carry the new committee.
-        self.sync_destinations_from_local_node().await;
+        // The destination set stays as of the last exported block. That loses nothing: a chain's
+        // own committee only changes when the chain executes a block (`CreateCommittee` and
+        // `ProcessNewEpoch` both mutate it in the executing block), so there is no committee
+        // change for an idle chain to discover.
         self.refresh_stuck_destinations();
         let now = Instant::now();
         let (config, chain_id, target) = (&self.config, self.chain_id, self.chain_next_height);
@@ -475,13 +448,12 @@ where
     /// Brings the destination set in line with the block's committee: adds validators that joined,
     /// drops those that left, and re-creates a node whose address changed.
     fn sync_destinations(&mut self, block: &ExportedBlock) {
-        self.admin_chain_id = Some(block.admin_chain_id);
-        self.sync_destinations_with(&block.committee, block.admin_chain_id);
+        self.sync_destinations_with(&block.committee);
     }
 
     /// Adds destinations for validators in `committee` we do not have, and drops those that have
     /// left it or changed address.
-    fn sync_destinations_with(&mut self, committee: &Committee, admin_chain_id: ChainId) {
+    fn sync_destinations_with(&mut self, committee: &Committee) {
         self.destinations.retain(|validator, destination| {
             committee
                 .validators()
@@ -545,17 +517,13 @@ where
             else {
                 continue;
             };
-            let updater = RemoteNodeUpdater {
+            let sender = BlockSender {
                 remote_node: RemoteNode {
                     public_key: validator,
                     node,
                 },
-                local_node: self.local_node.clone(),
-                admin_chain_id,
+                storage: self.storage.clone(),
                 certificate_upload_batch_size: self.config.certificate_upload_batch_size,
-                // Export replicates blocks; it does not take part in the destination's consensus.
-                sync_consensus_rounds: false,
-                max_admin_catch_up_blocks: Some(self.config.max_catch_up_blocks),
             };
             // Rebuilding a stuck destination keeps its failure count and retry time: only the
             // connection is replaced, so a validator that is itself down keeps backing off.
@@ -563,7 +531,7 @@ where
             self.destinations.insert(
                 validator,
                 Destination {
-                    updater,
+                    sender,
                     address,
                     // An acknowledged height was reported by the validator itself, so the block
                     // after it is the one the validator needs next.
@@ -606,7 +574,7 @@ where
 
         let height = block.certificate.block().header.height;
         let result = self
-            .updater
+            .sender
             .send_block(
                 &block.certificate,
                 &block.blobs,
@@ -643,8 +611,9 @@ where
         let _latency = send_latency.measure_latency();
 
         let previous = self.next_height;
+        let failures_before = self.failures;
         let result = self
-            .updater
+            .sender
             .send_missing_blocks(
                 chain_id,
                 target,
@@ -657,9 +626,12 @@ where
         // A round can succeed and advance nothing, since a chain we merely receive from is
         // stored only at its message-bearing blocks; without backing off, a destination we can
         // never finish would spin the task. Success only: `record_outcome` handles failures.
+        // Restore the pre-success failure count first — `record_outcome` just reset it, and a
+        // backoff computed from zero would never escalate past the base delay.
         if let Some(reached) = outcome {
             let advanced = previous.is_none_or(|before| reached > before);
             if !advanced {
+                self.failures = failures_before;
                 self.back_off(now, config);
             }
         }
@@ -714,5 +686,163 @@ where
             // We have no cursor, so we are about to query; report the gap as unknown-but-nonzero.
             None => 1,
         }
+    }
+}
+
+/// Sends this validator's blocks to one other validator, reading everything it needs from
+/// storage.
+///
+/// This is deliberately not [`crate::updater::RemoteNodeUpdater`]: that is the client's tool and
+/// holds a local node, and anything on the export path that reaches a chain worker resets its
+/// TTL. Blobs and certificates for committed blocks are always durable before export sees them
+/// (`write_blobs_and_certificate` precedes execution), so storage is sufficient.
+pub(crate) struct BlockSender<S, N> {
+    pub(crate) remote_node: RemoteNode<N>,
+    pub(crate) storage: S,
+    pub(crate) certificate_upload_batch_size: u64,
+}
+
+impl<S, N> BlockSender<S, N>
+where
+    S: Storage + Clone + 'static,
+    N: ValidatorNode + Clone + 'static,
+{
+    /// Pushes a block the caller already holds, first closing up to `max_catch_up` of any gap
+    /// below it, and returns the height the validator reports afterwards.
+    ///
+    /// The held block is sent only once the gap is gone: one landing above a gap is silently
+    /// preprocessed and never advances the tip.
+    pub(crate) async fn send_block(
+        &mut self,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        blobs: &[CacheArc<Blob>],
+        destination_next_height: Option<BlockHeight>,
+        max_catch_up: u64,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        let block = certificate.block();
+        let (chain_id, height) = (block.header.chain_id, block.header.height);
+
+        let next_height = if destination_next_height == Some(height) {
+            height
+        } else {
+            self.send_missing_blocks(chain_id, height, destination_next_height, max_catch_up)
+                .await?
+        };
+        // Not exactly at this block: either the gap was larger than one chunk, or the validator
+        // is already past it — a re-executed chain re-offers its whole history — and in both
+        // cases sending would be waste, so report the truth instead.
+        if next_height != height {
+            return Ok(next_height);
+        }
+        let info = self.send_confirmed_certificate(certificate, blobs).await?;
+        Ok(info.next_block_height)
+    }
+
+    /// Sends up to `max_blocks` of the blocks of `chain_id` the validator is missing below
+    /// `target_next_height`, returning the height it reports afterwards.
+    ///
+    /// Bounded so a validator that just joined converges over rounds instead of blocking the
+    /// caller once. Heights whose certificates are not in storage are skipped — a chain we merely
+    /// receive from is stored only at its message-bearing blocks, and the destination
+    /// preprocesses above such gaps.
+    pub(crate) async fn send_missing_blocks(
+        &mut self,
+        chain_id: ChainId,
+        target_next_height: BlockHeight,
+        destination_next_height: Option<BlockHeight>,
+        max_blocks: u64,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        let mut next_height = match destination_next_height {
+            Some(height) => height,
+            None => {
+                let query = ChainInfoQuery::new(chain_id);
+                self.remote_node
+                    .handle_chain_info_query(query)
+                    .await?
+                    .next_block_height
+            }
+        };
+        let last = target_next_height
+            .0
+            .min(next_height.0.saturating_add(max_blocks));
+        let heights = (next_height.0..last).map(BlockHeight).collect::<Vec<_>>();
+        for chunk in heights.chunks(self.certificate_upload_batch_size as usize) {
+            let certificates = self
+                .storage
+                .read_certificates_by_heights(chain_id, chunk)
+                .await?;
+            for certificate in certificates.into_iter().flatten() {
+                // The validator's own responses move the cursor, so skip anything it has since
+                // reported holding rather than re-sending it.
+                if certificate.block().header.height < next_height {
+                    continue;
+                }
+                let info = self.send_confirmed_certificate(&certificate, &[]).await?;
+                next_height = info.next_block_height;
+            }
+        }
+        Ok(next_height)
+    }
+
+    /// Sends one confirmed certificate, uploading blobs the validator reports missing.
+    ///
+    /// A missing *committee* (`EventsNotFound` for the epoch stream) is not recovered here: the
+    /// admin chain is a chain like any other, so its own export brings the destination up to
+    /// date, and this block succeeds on a later round. Replaying the admin chain from inside
+    /// another chain's push is how one export round used to stall on an unbounded foreign
+    /// history.
+    async fn send_confirmed_certificate(
+        &mut self,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        held: &[CacheArc<Blob>],
+    ) -> Result<Box<crate::data_types::ChainInfo>, chain_client::Error> {
+        let delivery = CrossChainMessageDelivery::NonBlocking;
+        let result = self
+            .remote_node
+            .handle_optimized_confirmed_certificate(certificate, delivery)
+            .await;
+        match result {
+            Err(NodeError::BlobsNotFound(blob_ids)) => {
+                self.remote_node
+                    .check_blobs_not_found(certificate, &blob_ids)?;
+                let blobs = self.resolve_blobs(&blob_ids, held).await?;
+                self.remote_node
+                    .node
+                    .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
+                    .await?;
+                Ok(self
+                    .remote_node
+                    .handle_confirmed_certificate(certificate.clone(), delivery)
+                    .await?)
+            }
+            result => Ok(result?),
+        }
+    }
+
+    /// Collects the given blobs, taking each from `held` if present and the rest from storage.
+    async fn resolve_blobs(
+        &self,
+        blob_ids: &[BlobId],
+        held: &[CacheArc<Blob>],
+    ) -> Result<Vec<CacheArc<Blob>>, chain_client::Error> {
+        let mut blobs = Vec::with_capacity(blob_ids.len());
+        let mut to_read = Vec::new();
+        for blob_id in blob_ids {
+            match held.iter().find(|blob| blob.id() == *blob_id) {
+                Some(blob) => blobs.push(blob.clone()),
+                None => to_read.push(*blob_id),
+            }
+        }
+        if to_read.is_empty() {
+            return Ok(blobs);
+        }
+        let read = self
+            .storage
+            .read_blobs(&to_read)
+            .await?
+            .into_iter()
+            .collect::<Option<Vec<_>>>();
+        blobs.extend(read.ok_or(NodeError::BlobsNotFound(to_read))?);
+        Ok(blobs)
     }
 }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -155,6 +155,16 @@ mod metrics {
         )
     });
 
+    /// Sends the destination actually answered, as opposed to attempts: `SEND_LATENCY` counts
+    /// every completion, failures included, so success rate needs its own counter.
+    pub static SENDS_SUCCEEDED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "block_export_sends_succeeded",
+            "Export sends acknowledged by the destination validator",
+            &["validator"],
+        )
+    });
+
     /// How many blocks the destination was behind when we pushed to it: zero whenever the block
     /// was contiguous there, and the size of the gap we had to fill otherwise.
     pub static DESTINATION_LAG: LazyLock<HistogramVec> = LazyLock::new(|| {
@@ -949,6 +959,10 @@ where
                 dest.failures = 0;
                 dest.retry_at = None;
                 dest.window = (dest.window + 1).min(self.config.max_in_flight_per_destination);
+                #[cfg(with_metrics)]
+                metrics::SENDS_SUCCEEDED
+                    .with_label_values(&[&dest.address])
+                    .inc();
             }
             SendOutcome::ChainScoped(_) => {}
             SendOutcome::DestinationScoped(error) => {
@@ -1206,8 +1220,13 @@ where
                 progress.heights.remove(chain_id);
             }
             // Same reason as `chains` above: `remove` never shrinks the table, and this one is
-            // sized by the same burst.
-            if progress.heights.capacity() > progress.heights.len().saturating_mul(4) {
+            // sized by the same burst. But this shrink runs under the mutex whose hold
+            // `MAX_FORGET_PER_SWEEP` exists to bound, so it must obey the same budget: only once
+            // the survivors fit in it — a burst that drains fully still gives its memory back at
+            // the tail, and one that plateaus keeps a table it needs anyway.
+            if progress.heights.len() <= MAX_FORGET_PER_SWEEP
+                && progress.heights.capacity() > progress.heights.len().saturating_mul(4)
+            {
                 progress.heights.shrink_to_fit();
             }
         }
@@ -1335,6 +1354,9 @@ where
                 .remove_label_values(&[address])
                 .ok();
             metrics::SEND_LATENCY.remove_label_values(&[address]).ok();
+            metrics::SENDS_SUCCEEDED
+                .remove_label_values(&[address])
+                .ok();
             metrics::DESTINATION_LAG
                 .remove_label_values(&[address])
                 .ok();

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -26,7 +26,7 @@ use futures::future;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
-    crypto::{CryptoHash, ValidatorPublicKey},
+    crypto::ValidatorPublicKey,
     data_types::{Blob, BlockHeight},
     identifiers::ChainId,
     time::{Duration, Instant},
@@ -38,11 +38,10 @@ use tokio::sync::mpsc;
 use tracing::{debug, instrument, warn};
 
 use crate::{
-    client::chain_client,
     local_node::LocalNodeClient,
     node::{ValidatorNode, ValidatorNodeProvider},
     remote_node::RemoteNode,
-    updater::confirmed_sender::{ConfirmedCertificateSender, LocalChainState},
+    updater::confirmed_sender::ConfirmedCertificateSender,
 };
 
 #[cfg(with_metrics)]
@@ -188,14 +187,16 @@ impl ChainExporter {
             committee,
             admin_chain_id,
         };
-        if self.blocks.send(block).is_err() {
-            // The task exits only when this sender is dropped, so it cannot be gone while we
-            // hold it.
-            warn!("Block export task stopped unexpectedly; blocks are no longer being exported");
-            return;
+        match self.blocks.send(block) {
+            Ok(()) => {
+                #[cfg(with_metrics)]
+                metrics::QUEUE_SIZE.inc();
+            }
+            // The task runs until this sender is dropped, so it cannot be gone while we hold it.
+            Err(_) => {
+                warn!("Block export task stopped unexpectedly; blocks are no longer being exported")
+            }
         }
-        #[cfg(with_metrics)]
-        metrics::QUEUE_SIZE.inc();
     }
 
     /// Returns how far each validator has been exported to, restricted to `committee` so that
@@ -222,7 +223,6 @@ impl ChainExporter {
 /// worker is dropped — so an idle chain costs neither a task nor a connection.
 pub fn spawn_chain_exporter<S, P>(
     setup: ChainExportSetup<S>,
-    storage: S,
     node_provider: Arc<P>,
     config: BlockExportConfig,
     own_public_key: Option<ValidatorPublicKey>,
@@ -240,11 +240,8 @@ where
 
     let task = ChainExportTask {
         chain_id: setup.chain_id,
-        storage,
         node_provider,
-        local_chain_state: LocalNodeChainState {
-            local_node: setup.local_node,
-        },
+        local_node: setup.local_node,
         config,
         own_public_key,
         destinations: HashMap::new(),
@@ -255,43 +252,9 @@ where
     ChainExporter { blocks, progress }
 }
 
-/// Answers chain-level queries through the local worker, which owns the chain state views.
-///
-/// The export task runs outside its worker's lock, so it must never load a chain state view
-/// itself — the worker may be executing on it, and two loads of the same chain race. Routing the
-/// queries through the worker is how the client answers them too.
-#[derive(Clone)]
-struct LocalNodeChainState<S: Storage> {
-    local_node: LocalNodeClient<S>,
-}
-
-impl<S> LocalChainState for LocalNodeChainState<S>
-where
-    S: Storage + Clone + 'static,
-{
-    async fn next_block_height(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<BlockHeight, chain_client::Error> {
-        Ok(self
-            .local_node
-            .chain_info(chain_id)
-            .await?
-            .next_block_height)
-    }
-
-    async fn block_hashes(
-        &self,
-        chain_id: ChainId,
-        heights: Vec<BlockHeight>,
-    ) -> Result<Vec<CryptoHash>, chain_client::Error> {
-        Ok(self.local_node.get_block_hashes(chain_id, heights).await?)
-    }
-}
-
 /// One destination validator, and what we believe it holds of this chain.
-struct Destination<S, N, L> {
-    sender: ConfirmedCertificateSender<S, N, L>,
+struct Destination<S: Storage, N> {
+    sender: ConfirmedCertificateSender<S, N>,
     address: String,
     /// The next height the validator needs, or `None` when we have to ask it — before the first
     /// push, and after any failed one.
@@ -303,29 +266,30 @@ struct Destination<S, N, L> {
 }
 
 /// The body of one chain's export task.
-struct ChainExportTask<S, P, L>
+struct ChainExportTask<S, P>
 where
+    S: Storage,
     P: ValidatorNodeProvider,
 {
     chain_id: ChainId,
-    storage: S,
     node_provider: Arc<P>,
-    local_chain_state: L,
+    /// Answers the chain-level queries the certificate partitions cannot, through the local
+    /// worker that owns the chain state views.
+    local_node: LocalNodeClient<S>,
     config: BlockExportConfig,
     own_public_key: Option<ValidatorPublicKey>,
-    destinations: HashMap<ValidatorPublicKey, Destination<S, P::Node, L>>,
+    destinations: HashMap<ValidatorPublicKey, Destination<S, P::Node>>,
     /// The highest height each validator has acknowledged. Seeded from what the worker had
     /// persisted, so a destination we meet for the first time — after a restart, or after the
     /// chain worker was dropped and reloaded — starts from there instead of being queried.
     progress: Arc<Mutex<BTreeMap<ValidatorPublicKey, BlockHeight>>>,
 }
 
-impl<S, P, L> ChainExportTask<S, P, L>
+impl<S, P> ChainExportTask<S, P>
 where
     S: Storage + Clone,
     P: ValidatorNodeProvider,
     P::Node: Clone,
-    L: LocalChainState + Clone,
 {
     /// Exports each block in turn, and returns when the chain worker has dropped its end.
     #[instrument(level = "debug", skip_all, fields(chain_id = %self.chain_id))]
@@ -417,12 +381,11 @@ where
                 continue;
             };
             let sender = ConfirmedCertificateSender::new(
-                self.storage.clone(),
                 RemoteNode {
                     public_key: validator,
                     node,
                 },
-                self.local_chain_state.clone(),
+                self.local_node.clone(),
                 block.admin_chain_id,
                 self.config.certificate_upload_batch_size,
             );
@@ -444,11 +407,10 @@ where
     }
 }
 
-impl<S, N, L> Destination<S, N, L>
+impl<S, N> Destination<S, N>
 where
     S: Storage + Clone,
     N: ValidatorNode + Clone,
-    L: LocalChainState + Clone,
 {
     /// Pushes the block, along with any earlier ones this validator is missing, and returns the
     /// validator's next block height afterwards — or `None` if it was skipped or failed.

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -73,9 +73,22 @@ mod metrics {
 
     use linera_base::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
-        register_histogram_vec, register_int_counter, register_int_gauge, register_int_gauge_vec,
+        register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+        register_int_gauge_vec,
     };
-    use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge, IntGaugeVec};
+    use prometheus::{Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
+
+    /// Sends refused for a reason about one chain rather than the destination — most often a
+    /// committee the destination has not learned yet. Self-healing, so a rising rate is the
+    /// signal, not the count: one that stays flat and non-zero means a destination is stuck on
+    /// some chain and nothing is repairing it.
+    pub static CHAIN_SCOPED_BACKOFFS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "block_export_chain_scoped_backoffs",
+            "Sends deferred because a destination cannot accept a particular chain yet",
+            &["validator"],
+        )
+    });
 
     /// Chains the queue is tracking: those with a destination still behind, plus recently
     /// converged ones inside the retention window. A destination that is down holds every chain
@@ -904,6 +917,10 @@ where
                             %chain_id, %validator, %error,
                             "Destination cannot accept this chain yet; backing the pair off",
                         );
+                        #[cfg(with_metrics)]
+                        metrics::CHAIN_SCOPED_BACKOFFS
+                            .with_label_values(&[&dest.address])
+                            .inc();
                         chain_dest.next_height = None;
                         back_off(
                             &mut chain_dest.failures,
@@ -1164,6 +1181,9 @@ where
                 .ok();
             metrics::SEND_LATENCY.remove_label_values(&[address]).ok();
             metrics::DESTINATION_LAG
+                .remove_label_values(&[address])
+                .ok();
+            metrics::CHAIN_SCOPED_BACKOFFS
                 .remove_label_values(&[address])
                 .ok();
         }
@@ -1486,6 +1506,12 @@ where
     /// date, and this block succeeds on a later round. Replaying the admin chain from inside
     /// another chain's push is how one export round used to stall on an unbounded foreign
     /// history.
+    ///
+    /// The pair retries indefinitely — the backoff caps at `max_retry_delay` — so it recovers
+    /// whenever the destination learns the epoch, from the admin chain's own export or from the
+    /// client, which pushes it on this same error. After a restart the admin chain re-enters
+    /// this queue's work-list only once it produces a block, so a quiet admin chain can leave a
+    /// pair deferred for a while; `CHAIN_SCOPED_BACKOFFS` is what makes that visible.
     async fn send_confirmed_certificate(
         &mut self,
         certificate: &CacheArc<ConfirmedBlockCertificate>,

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -338,6 +338,33 @@ struct ProgressMap {
     heights: HashMap<ChainId, Vec<(DestIndex, BlockHeight)>>,
 }
 
+impl ProgressMap {
+    /// Drops the given chains, and returns a burst's peak-sized table for the caller to free
+    /// *outside* the mutex.
+    ///
+    /// `remove` never shrinks, so a drained burst would otherwise pin its peak allocation
+    /// forever. The obvious `shrink_to_fit` is not usable here: it frees the peak-sized bucket
+    /// array in place, and this runs under the mutex every chain worker takes per executed block
+    /// — whose hold `MAX_FORGET_PER_SWEEP` exists to bound. Rebuilding the few survivors into a
+    /// fitted map costs within that budget; handing the old table back moves the
+    /// peak-proportional free off the lock.
+    fn forget_chains(
+        &mut self,
+        forgotten: &[ChainId],
+    ) -> Option<HashMap<ChainId, Vec<(DestIndex, BlockHeight)>>> {
+        for chain_id in forgotten {
+            self.heights.remove(chain_id);
+        }
+        if self.heights.len() <= MAX_FORGET_PER_SWEEP
+            && self.heights.capacity() > self.heights.len().saturating_mul(4)
+        {
+            let survivors = self.heights.drain().collect();
+            return Some(std::mem::replace(&mut self.heights, survivors));
+        }
+        None
+    }
+}
+
 type SharedProgress = Arc<Mutex<ProgressMap>>;
 
 /// The height after each chain's newest announced block. Written on every `export` call before
@@ -1022,9 +1049,23 @@ where
                         // converged pairs instead would cost a query per chain per destination
                         // forever, to catch something only a restore causes.
                         chain_dest.next_height = Some(*next_height);
-                        if advanced || previous.is_some_and(|n| *next_height < n) {
-                            chain_dest.failures = 0;
-                            chain_dest.retry_at = None;
+                        let regressed = previous.is_some_and(|n| *next_height < n);
+                        if advanced || regressed {
+                            // A regression is believed but backed off, not cleared: a real
+                            // restore pays one delay once, while a peer oscillating its
+                            // reported height would otherwise hold this pair in a zero-delay
+                            // re-send loop for as long as it keeps lying.
+                            if advanced {
+                                chain_dest.failures = 0;
+                                chain_dest.retry_at = None;
+                            } else {
+                                back_off(
+                                    &mut chain_dest.failures,
+                                    &mut chain_dest.retry_at,
+                                    now,
+                                    &self.config,
+                                );
+                            }
                             if let Ok(acked) = next_height.try_sub_one() {
                                 let mut progress = self
                                     .progress
@@ -1212,23 +1253,15 @@ where
             self.ticks_until_sweep -= 1;
         }
         if !forgotten.is_empty() {
-            let mut progress = self
+            let peak_table = self
                 .progress
                 .lock()
-                .expect("progress mutex is never poisoned");
-            for chain_id in &forgotten {
-                progress.heights.remove(chain_id);
-            }
-            // Same reason as `chains` above: `remove` never shrinks the table, and this one is
-            // sized by the same burst. But this shrink runs under the mutex whose hold
-            // `MAX_FORGET_PER_SWEEP` exists to bound, so it must obey the same budget: only once
-            // the survivors fit in it — a burst that drains fully still gives its memory back at
-            // the tail, and one that plateaus keeps a table it needs anyway.
-            if progress.heights.len() <= MAX_FORGET_PER_SWEEP
-                && progress.heights.capacity() > progress.heights.len().saturating_mul(4)
-            {
-                progress.heights.shrink_to_fit();
-            }
+                .expect("progress mutex is never poisoned")
+                .forget_chains(&forgotten);
+            // The free of a burst's peak-sized table happens here, after the guard above is
+            // gone — measured at milliseconds per gigabyte-scale table, which is fine for the
+            // queue task and was not fine under the mutex.
+            drop(peak_table);
         }
 
         #[cfg(with_metrics)]
@@ -1960,6 +1993,35 @@ mod tests {
             resumed.iter().all(|id| !first.contains(id)),
             "the drain restarted at the front of the backlog: {first:?} then {resumed:?}",
         );
+    }
+
+    /// A drained burst hands back its peak-sized table for freeing off the mutex; a live one
+    /// keeps its table.
+    ///
+    /// Pinned because the sweep's mutex-hold budget has been broken twice: once by never
+    /// shrinking at all, once by an in-place shrink whose free of the peak table ran under the
+    /// lock.
+    #[test]
+    fn forgetting_a_drained_burst_returns_its_table() {
+        let mut progress = ProgressMap::default();
+        let chains = test_chain_ids(MAX_FORGET_PER_SWEEP + 100);
+        for chain_id in &chains {
+            progress.heights.insert(*chain_id, Vec::new());
+        }
+        let peak_capacity = progress.heights.capacity();
+
+        // Still above the budget: the table must stay, however much was just forgotten.
+        // `capacity()` is derived from occupancy, so compare magnitudes, not exact values.
+        let (first, rest) = chains.split_at(50);
+        assert!(progress.forget_chains(first).is_none());
+        assert!(progress.heights.capacity() > peak_capacity / 2);
+
+        // Down to a handful of survivors: the peak table is handed back, not freed in place.
+        let (bulk, survivors) = rest.split_at(rest.len() - 10);
+        let old_table = progress.forget_chains(bulk);
+        assert!(old_table.is_some_and(|table| table.capacity() > peak_capacity / 2));
+        assert!(progress.heights.capacity() < peak_capacity / 4);
+        assert_eq!(progress.heights.len(), survivors.len());
     }
 
     /// Chain ids in the order `lagging` holds them, so a test can name "the front" of a backlog.

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -105,12 +105,16 @@ pub struct BlockExportConfig {
     /// How many certificates are read from storage and pushed per batch when catching a
     /// destination up.
     pub certificate_upload_batch_size: u64,
-    /// How long a destination is skipped after a failed push, doubling up to
-    /// `max_retry_delay` while it keeps failing.
+    /// How long a destination is skipped after a failed push, doubling up to `max_retry_delay`
+    /// while it keeps failing.
     ///
     /// A destination that is down must not stall export for the rest of the committee, and must
     /// not cost a full round trip on every block either. Skipping it leaves its cursor stale, so
     /// the first push that does go through queries it and fills in whatever it missed.
+    ///
+    /// This is a coarser layer than the transport's own per-request retries: those decide whether
+    /// one call is worth attempting again, this decides whether the destination is worth
+    /// attempting at all right now.
     pub retry_delay: Duration,
     /// The longest a failing destination is skipped for.
     pub max_retry_delay: Duration,
@@ -149,8 +153,9 @@ pub type ChainExporterFactory<S> = Arc<dyn Fn(ChainExportSetup<S>) -> ChainExpor
 struct ExportedBlock {
     certificate: CacheArc<ConfirmedBlockCertificate>,
     /// The block's required blobs, so that a destination missing them — which is always the case
-    /// for a blob this very block publishes — is served without a read from storage.
-    blobs: Vec<Arc<Blob>>,
+    /// for a blob this very block publishes — is served without a read from storage. Held as the
+    /// storage cache's pointers, so queued blocks share the allocations rather than copying them.
+    blobs: Vec<CacheArc<Blob>>,
     /// The chain's committee *after* the block was applied, so that a validator joining in this
     /// block is exported to immediately, including the admin-chain block that admitted it.
     committee: Arc<Committee>,
@@ -177,7 +182,7 @@ impl ChainExporter {
     pub(crate) fn export(
         &self,
         certificate: CacheArc<ConfirmedBlockCertificate>,
-        blobs: Vec<Arc<Blob>>,
+        blobs: Vec<CacheArc<Blob>>,
         committee: Arc<Committee>,
         admin_chain_id: ChainId,
     ) {
@@ -261,8 +266,9 @@ struct Destination<S: Storage, N> {
     next_height: Option<BlockHeight>,
     /// While this is in the future the validator is skipped; it failed recently.
     retry_at: Option<Instant>,
-    /// How long the next skip lasts, doubling for as long as pushes keep failing.
-    backoff: Duration,
+    /// How many pushes to this destination have failed in a row, which sets how long the next
+    /// skip lasts.
+    failures: u32,
 }
 
 /// The body of one chain's export task.
@@ -400,7 +406,7 @@ where
                         .get(&validator)
                         .map(|height| BlockHeight(height.0.saturating_add(1))),
                     retry_at: None,
-                    backoff: self.config.retry_delay,
+                    failures: 0,
                 },
             );
         }
@@ -441,20 +447,24 @@ where
             Ok(next_height) => {
                 self.next_height = Some(next_height);
                 self.retry_at = None;
-                self.backoff = config.retry_delay;
+                self.failures = 0;
                 Some(next_height)
             }
             Err(error) => {
+                let backoff = config
+                    .retry_delay
+                    .saturating_mul(1u32.checked_shl(self.failures).unwrap_or(u32::MAX))
+                    .min(config.max_retry_delay);
                 let height = block.certificate.block().header.height;
                 warn!(
-                    validator = %self.address, %height, %error, backoff = ?self.backoff,
+                    validator = %self.address, %height, %error, ?backoff,
                     "Failed to export block; will query the validator before the next push",
                 );
                 // Forget the cursor: the next push must ask what this validator actually has
                 // rather than assume the block we just failed to send arrived.
                 self.next_height = None;
-                self.retry_at = Some(now + self.backoff);
-                self.backoff = (self.backoff * 2).min(config.max_retry_delay);
+                self.retry_at = Some(now + backoff);
+                self.failures = self.failures.saturating_add(1);
                 None
             }
         }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -1,0 +1,511 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pushing executed blocks to the other validators in the committee.
+//!
+//! Each chain worker owns one export task. When the worker executes a block it hands the
+//! certificate and the block's blobs — both already in memory — to that task, which pushes them to
+//! every other validator in the chain's current committee. This is the validator-to-validator
+//! dissemination that makes each validator a complete replica: consensus itself only guarantees
+//! that a quorum holds any given block.
+//!
+//! One task per chain worker rather than one per process: thousands of chains through a single
+//! task would serialize them, and a per-chain task gets per-chain height ordering for free, since
+//! it finishes one block before taking the next off its queue.
+//!
+//! The queue is unbounded. Dropping a block would leave a gap in the destination that nothing ever
+//! repairs, which is the failure mode this design exists to remove; a queue that grows is a
+//! performance problem instead, and [`metrics::QUEUE_SIZE`] is there to see it.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::{Arc, Mutex},
+};
+
+use futures::future;
+#[cfg(with_metrics)]
+use linera_base::prometheus_util::MeasureLatency as _;
+use linera_base::{
+    crypto::{CryptoHash, ValidatorPublicKey},
+    data_types::{Blob, BlockHeight},
+    identifiers::ChainId,
+    time::{Duration, Instant},
+};
+use linera_chain::types::ConfirmedBlockCertificate;
+use linera_execution::committee::Committee;
+use linera_storage::{Arc as CacheArc, Storage};
+use tokio::sync::mpsc;
+use tracing::{debug, instrument, warn};
+
+use crate::{
+    client::chain_client,
+    local_node::LocalNodeClient,
+    node::{ValidatorNode, ValidatorNodeProvider},
+    remote_node::RemoteNode,
+    updater::confirmed_sender::{ConfirmedCertificateSender, LocalChainState},
+};
+
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use linera_base::prometheus_util::{
+        exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
+        register_histogram_vec, register_int_gauge,
+    };
+    use prometheus::{Histogram, HistogramVec, IntGauge};
+
+    /// Blocks waiting to be exported, across every chain worker in this process.
+    ///
+    /// The queue is unbounded, so this is how a chain that produces blocks faster than they can be
+    /// pushed becomes visible instead of silently losing them.
+    pub static QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_queue_size",
+            "Blocks queued for export across all chain workers",
+        )
+    });
+
+    /// Time from a block being queued to it having been pushed to every destination.
+    ///
+    /// This is the export cost per block, including the serialization and signature work that
+    /// shares a runtime thread with block execution on a single-threaded shard.
+    pub static EXPORT_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
+        register_histogram(
+            "block_export_latency",
+            "Time (ms) to export one block to every destination, including time spent queued",
+            exponential_bucket_latencies(60_000.0),
+        )
+    });
+
+    /// Time for one push to one destination, including any catch-up it triggered.
+    pub static SEND_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "block_export_send_latency",
+            "Time (ms) to push one block to one destination validator",
+            &["validator"],
+            exponential_bucket_latencies(60_000.0),
+        )
+    });
+
+    /// How many blocks the destination was behind when we pushed to it: zero whenever the block
+    /// was contiguous there, and the size of the gap we had to fill otherwise.
+    pub static DESTINATION_LAG: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "block_export_destination_lag",
+            "Blocks a destination validator was missing when a block was pushed to it",
+            &["validator"],
+            exponential_bucket_interval(1.0, 100_000.0),
+        )
+    });
+}
+
+/// Configuration for pushing executed blocks to the other committee validators.
+#[derive(Clone, Debug)]
+pub struct BlockExportConfig {
+    /// How many certificates are read from storage and pushed per batch when catching a
+    /// destination up.
+    pub certificate_upload_batch_size: u64,
+    /// How long a destination is skipped after a failed push, doubling up to
+    /// `max_retry_delay` while it keeps failing.
+    ///
+    /// A destination that is down must not stall export for the rest of the committee, and must
+    /// not cost a full round trip on every block either. Skipping it leaves its cursor stale, so
+    /// the first push that does go through queries it and fills in whatever it missed.
+    pub retry_delay: Duration,
+    /// The longest a failing destination is skipped for.
+    pub max_retry_delay: Duration,
+}
+
+impl Default for BlockExportConfig {
+    fn default() -> Self {
+        BlockExportConfig {
+            certificate_upload_batch_size: crate::client::DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
+            retry_delay: Duration::from_secs(1),
+            max_retry_delay: Duration::from_secs(60),
+        }
+    }
+}
+
+/// Everything the export task needs that only the chain worker can supply.
+pub struct ChainExportSetup<S: Storage> {
+    /// The chain whose blocks this task exports.
+    pub chain_id: ChainId,
+    /// Read access to the chains this process serves, used for the few chain-level queries that
+    /// the certificate partitions cannot answer — the admin chain's height, and block hashes for
+    /// certificates that predate the height index.
+    pub local_node: LocalNodeClient<S>,
+    /// The heights already exported to each validator, as last persisted by the worker.
+    pub exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
+}
+
+/// Creates the export task for one chain worker.
+///
+/// The transport is type-erased behind this alias: `linera-core` knows how to export a block, but
+/// only the server binary knows how to reach another validator, so it installs a factory that
+/// closes over its node provider.
+pub type ChainExporterFactory<S> = Arc<dyn Fn(ChainExportSetup<S>) -> ChainExporter + Send + Sync>;
+
+/// A block a chain worker has executed, on its way to the other validators.
+struct ExportedBlock {
+    certificate: CacheArc<ConfirmedBlockCertificate>,
+    /// The block's required blobs, so that a destination missing them — which is always the case
+    /// for a blob this very block publishes — is served without a read from storage.
+    blobs: Vec<Arc<Blob>>,
+    /// The chain's committee *after* the block was applied, so that a validator joining in this
+    /// block is exported to immediately, including the admin-chain block that admitted it.
+    committee: Arc<Committee>,
+    /// The chain carrying the epoch events, needed when a destination does not yet know the
+    /// committee that signed the certificate.
+    admin_chain_id: ChainId,
+}
+
+/// The chain worker's end of its export task.
+pub struct ChainExporter {
+    blocks: mpsc::UnboundedSender<ExportedBlock>,
+    /// The highest height each validator has acknowledged, written by the export task and folded
+    /// into the chain's `exported_heights` by the worker when it next saves.
+    ///
+    /// Progress travels this way rather than back through the worker so that the worker stays the
+    /// only writer of its own chain state, and so that export costs no extra database write.
+    progress: Arc<Mutex<BTreeMap<ValidatorPublicKey, BlockHeight>>>,
+}
+
+impl ChainExporter {
+    /// Queues a block for export, and returns without waiting for it to be sent.
+    ///
+    /// Never blocks and never drops: see the module documentation for why the queue is unbounded.
+    pub(crate) fn export(
+        &self,
+        certificate: CacheArc<ConfirmedBlockCertificate>,
+        blobs: Vec<Arc<Blob>>,
+        committee: Arc<Committee>,
+        admin_chain_id: ChainId,
+    ) {
+        let block = ExportedBlock {
+            certificate,
+            blobs,
+            committee,
+            admin_chain_id,
+        };
+        if self.blocks.send(block).is_err() {
+            // The task exits only when this sender is dropped, so it cannot be gone while we
+            // hold it.
+            warn!("Block export task stopped unexpectedly; blocks are no longer being exported");
+            return;
+        }
+        #[cfg(with_metrics)]
+        metrics::QUEUE_SIZE.inc();
+    }
+
+    /// Returns how far each validator has been exported to, restricted to `committee` so that
+    /// validators which have left it are pruned.
+    pub(crate) fn progress(
+        &self,
+        committee: &Committee,
+    ) -> BTreeMap<ValidatorPublicKey, BlockHeight> {
+        let progress = self
+            .progress
+            .lock()
+            .expect("progress mutex is never poisoned");
+        progress
+            .iter()
+            .filter(|(validator, _)| committee.validators().contains_key(*validator))
+            .map(|(validator, height)| (*validator, *height))
+            .collect()
+    }
+}
+
+/// Spawns the export task for one chain worker and returns the worker's end of it.
+///
+/// The task runs until the returned [`ChainExporter`] is dropped, which happens when the chain
+/// worker is dropped — so an idle chain costs neither a task nor a connection.
+pub fn spawn_chain_exporter<S, P>(
+    setup: ChainExportSetup<S>,
+    storage: S,
+    node_provider: Arc<P>,
+    config: BlockExportConfig,
+    own_public_key: Option<ValidatorPublicKey>,
+) -> ChainExporter
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    P: ValidatorNodeProvider + Send + Sync + 'static,
+    P::Node: Send + Sync,
+{
+    let (blocks, receiver) = mpsc::unbounded_channel();
+    // Seed the progress map with what the worker had already persisted, so that the first fold
+    // back into the chain state cannot regress it to nothing while the task has yet to send
+    // anything.
+    let progress = Arc::new(Mutex::new(setup.exported_heights.clone()));
+
+    let task = ChainExportTask {
+        chain_id: setup.chain_id,
+        storage,
+        node_provider,
+        local_chain_state: LocalNodeChainState {
+            local_node: setup.local_node,
+        },
+        config,
+        own_public_key,
+        destinations: HashMap::new(),
+        progress: progress.clone(),
+    };
+    linera_base::Task::spawn(task.run(receiver)).forget();
+
+    ChainExporter { blocks, progress }
+}
+
+/// Answers chain-level queries through the local worker, which owns the chain state views.
+///
+/// The export task runs outside its worker's lock, so it must never load a chain state view
+/// itself — the worker may be executing on it, and two loads of the same chain race. Routing the
+/// queries through the worker is how the client answers them too.
+#[derive(Clone)]
+struct LocalNodeChainState<S: Storage> {
+    local_node: LocalNodeClient<S>,
+}
+
+impl<S> LocalChainState for LocalNodeChainState<S>
+where
+    S: Storage + Clone + 'static,
+{
+    async fn next_block_height(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        Ok(self
+            .local_node
+            .chain_info(chain_id)
+            .await?
+            .next_block_height)
+    }
+
+    async fn block_hashes(
+        &self,
+        chain_id: ChainId,
+        heights: Vec<BlockHeight>,
+    ) -> Result<Vec<CryptoHash>, chain_client::Error> {
+        Ok(self.local_node.get_block_hashes(chain_id, heights).await?)
+    }
+}
+
+/// One destination validator, and what we believe it holds of this chain.
+struct Destination<S, N, L> {
+    sender: ConfirmedCertificateSender<S, N, L>,
+    address: String,
+    /// The next height the validator needs, or `None` when we have to ask it — before the first
+    /// push, and after any failed one.
+    next_height: Option<BlockHeight>,
+    /// While this is in the future the validator is skipped; it failed recently.
+    retry_at: Option<Instant>,
+    /// How long the next skip lasts, doubling for as long as pushes keep failing.
+    backoff: Duration,
+}
+
+/// The body of one chain's export task.
+struct ChainExportTask<S, P, L>
+where
+    P: ValidatorNodeProvider,
+{
+    chain_id: ChainId,
+    storage: S,
+    node_provider: Arc<P>,
+    local_chain_state: L,
+    config: BlockExportConfig,
+    own_public_key: Option<ValidatorPublicKey>,
+    destinations: HashMap<ValidatorPublicKey, Destination<S, P::Node, L>>,
+    /// The highest height each validator has acknowledged. Seeded from what the worker had
+    /// persisted, so a destination we meet for the first time — after a restart, or after the
+    /// chain worker was dropped and reloaded — starts from there instead of being queried.
+    progress: Arc<Mutex<BTreeMap<ValidatorPublicKey, BlockHeight>>>,
+}
+
+impl<S, P, L> ChainExportTask<S, P, L>
+where
+    S: Storage + Clone,
+    P: ValidatorNodeProvider,
+    P::Node: Clone,
+    L: LocalChainState + Clone,
+{
+    /// Exports each block in turn, and returns when the chain worker has dropped its end.
+    #[instrument(level = "debug", skip_all, fields(chain_id = %self.chain_id))]
+    async fn run(mut self, mut receiver: mpsc::UnboundedReceiver<ExportedBlock>) {
+        while let Some(block) = receiver.recv().await {
+            #[cfg(with_metrics)]
+            metrics::QUEUE_SIZE.dec();
+            #[cfg(with_metrics)]
+            let _latency = metrics::EXPORT_LATENCY.measure_latency();
+            self.export(block).await;
+        }
+        debug!("Chain worker dropped; stopping block export");
+    }
+
+    /// Pushes one block to every destination, concurrently, and records how far each got.
+    async fn export(&mut self, block: ExportedBlock) {
+        self.sync_destinations(&block);
+
+        // Push to every destination concurrently, but only move on to the next block once they
+        // have all answered: that is what gives each destination the blocks of this chain in
+        // height order.
+        let now = Instant::now();
+        let (config, block) = (&self.config, &block);
+        let results = future::join_all(self.destinations.iter_mut().map(
+            |(validator, destination)| async move {
+                (*validator, destination.send(block, now, config).await)
+            },
+        ))
+        .await;
+
+        // `next_height` is what the validator itself reported, so the recorded height is a fact
+        // rather than an assumption: a validator that could not close its gap reports the truth
+        // and keeps a low cursor here, and is queried again on the next block.
+        let mut progress = self
+            .progress
+            .lock()
+            .expect("progress mutex is never poisoned");
+        for (validator, next_height) in results {
+            if let Some(Ok(height)) = next_height.map(BlockHeight::try_sub_one) {
+                progress.insert(validator, height);
+            }
+        }
+    }
+
+    /// Brings the destination set in line with the block's committee: adds validators that joined,
+    /// drops those that left, and re-creates a node whose address changed.
+    fn sync_destinations(&mut self, block: &ExportedBlock) {
+        let committee = &block.committee;
+        self.destinations.retain(|validator, destination| {
+            committee
+                .validators()
+                .get(validator)
+                .is_some_and(|state| state.network_address == destination.address)
+        });
+
+        let missing = committee
+            .validator_addresses()
+            .filter(|(validator, _)| {
+                Some(*validator) != self.own_public_key
+                    && !self.destinations.contains_key(validator)
+            })
+            .map(|(validator, address)| (validator, address.to_owned()))
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            return;
+        }
+
+        let nodes = match self.node_provider.make_nodes_from_list(missing) {
+            Ok(nodes) => nodes.collect::<Vec<_>>(),
+            Err(error) => {
+                // Leaves the destinations we already have untouched, and tries again on the next
+                // block; a committee we cannot resolve at all is a configuration problem.
+                warn!(%error, "Cannot reach the committee to export blocks to");
+                return;
+            }
+        };
+
+        let acknowledged = self
+            .progress
+            .lock()
+            .expect("progress mutex is never poisoned")
+            .clone();
+        for (validator, node) in nodes {
+            let Some(address) = committee
+                .validators()
+                .get(&validator)
+                .map(|state| state.network_address.clone())
+            else {
+                continue;
+            };
+            let sender = ConfirmedCertificateSender::new(
+                self.storage.clone(),
+                RemoteNode {
+                    public_key: validator,
+                    node,
+                },
+                self.local_chain_state.clone(),
+                block.admin_chain_id,
+                self.config.certificate_upload_batch_size,
+            );
+            self.destinations.insert(
+                validator,
+                Destination {
+                    sender,
+                    address,
+                    // An acknowledged height was reported by the validator itself, so the block
+                    // after it is the one the validator needs next.
+                    next_height: acknowledged
+                        .get(&validator)
+                        .map(|height| BlockHeight(height.0.saturating_add(1))),
+                    retry_at: None,
+                    backoff: self.config.retry_delay,
+                },
+            );
+        }
+    }
+}
+
+impl<S, N, L> Destination<S, N, L>
+where
+    S: Storage + Clone,
+    N: ValidatorNode + Clone,
+    L: LocalChainState + Clone,
+{
+    /// Pushes the block, along with any earlier ones this validator is missing, and returns the
+    /// validator's next block height afterwards — or `None` if it was skipped or failed.
+    async fn send(
+        &mut self,
+        block: &ExportedBlock,
+        now: Instant,
+        config: &BlockExportConfig,
+    ) -> Option<BlockHeight> {
+        if self.retry_at.is_some_and(|retry_at| now < retry_at) {
+            return None;
+        }
+
+        #[cfg(with_metrics)]
+        let send_latency = metrics::SEND_LATENCY.with_label_values(&[&self.address]);
+        #[cfg(with_metrics)]
+        let _latency = send_latency.measure_latency();
+        #[cfg(with_metrics)]
+        metrics::DESTINATION_LAG
+            .with_label_values(&[&self.address])
+            .observe(self.lag(block) as f64);
+
+        match self
+            .sender
+            .send_block(&block.certificate, &block.blobs, self.next_height)
+            .await
+        {
+            Ok(next_height) => {
+                self.next_height = Some(next_height);
+                self.retry_at = None;
+                self.backoff = config.retry_delay;
+                Some(next_height)
+            }
+            Err(error) => {
+                let height = block.certificate.block().header.height;
+                warn!(
+                    validator = %self.address, %height, %error, backoff = ?self.backoff,
+                    "Failed to export block; will query the validator before the next push",
+                );
+                // Forget the cursor: the next push must ask what this validator actually has
+                // rather than assume the block we just failed to send arrived.
+                self.next_height = None;
+                self.retry_at = Some(now + self.backoff);
+                self.backoff = (self.backoff * 2).min(config.max_retry_delay);
+                None
+            }
+        }
+    }
+
+    /// How many blocks this validator is believed to be missing before the block being pushed.
+    #[cfg(with_metrics)]
+    fn lag(&self, block: &ExportedBlock) -> u64 {
+        let height = block.certificate.block().header.height;
+        match self.next_height {
+            Some(next_height) => height.0.saturating_sub(next_height.0),
+            // We have no cursor, so we are about to query; report the gap as unknown-but-nonzero.
+            None => 1,
+        }
+    }
+}

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -584,6 +584,7 @@ where
         ticks_until_sweep: TICKS_PER_CONVERGENCE_SWEEP,
         #[cfg(with_metrics)]
         ticks_until_census: 0,
+        drain_cursor: None,
         chains: HashMap::new(),
         destinations: BTreeMap::new(),
         dest_indices: BTreeMap::new(),
@@ -894,6 +895,8 @@ where
     /// Ticks until the next backlog census.
     #[cfg(with_metrics)]
     ticks_until_census: u32,
+    /// Which destination the queue-wide budget is offered to first, rotated every tick.
+    drain_cursor: Option<DestIndex>,
     chains: HashMap<ChainId, ChainRecord>,
     destinations: BTreeMap<DestIndex, DestState<P::Node>>,
     /// Every validator ever registered as a destination, and the index its per-chain state uses.
@@ -942,6 +945,36 @@ const TICKS_PER_CONVERGENCE_SWEEP: u32 = 25;
 #[cfg(with_metrics)]
 const TICKS_PER_BACKLOG_CENSUS: u32 = 300;
 
+/// Destinations in the order the queue-wide budget is offered to them, resuming past `cursor`
+/// and wrapping. Rotating matters because the budget is shared: served in index order every
+/// time, the first `max_in_flight_total / max_in_flight_per_destination` destinations absorb all
+/// of it and the rest never get a catch-up slot.
+fn rotated_order(indices: &[DestIndex], cursor: Option<DestIndex>) -> Vec<DestIndex> {
+    match cursor {
+        Some(at) => indices
+            .iter()
+            .copied()
+            .skip_while(|index| *index < at)
+            .chain(indices.iter().copied().take_while(|index| *index < at))
+            .collect(),
+        None => indices.to_vec(),
+    }
+}
+
+/// Where the next round starts: past the destination this one served first.
+fn next_drain_cursor(indices: &[DestIndex], served_first: Option<DestIndex>) -> Option<DestIndex> {
+    let first = served_first?;
+    indices.iter().copied().find(|index| *index > first)
+}
+
+/// The most (chain, destination) pairs one census walks. Each is a random lookup into the chain
+/// map plus a search of its cursors — measured at roughly half a microsecond per pair, so this
+/// caps the stall at about 25 ms however deep the backlog is. Past the cap the gauges are a
+/// floor rather than a total, which is the right trade for a number read off a dashboard:
+/// `block_export_lagging_pairs` is exact and free, and says how far past the cap we are.
+#[cfg(with_metrics)]
+const MAX_CENSUS_PAIRS: usize = 50_000;
+
 /// How many chains one sweep may forget, bounding how long it holds the progress mutex that every
 /// chain worker takes on every block.
 const MAX_FORGET_PER_SWEEP: usize = 4096;
@@ -977,6 +1010,14 @@ where
             .saturating_add(tick_delta);
         loop {
             let now = self.storage.clock().current_time();
+            // The storage clock is the wall clock in production, so it can step backwards (NTP,
+            // a restored snapshot). The deadline is a timestamp but the wait is real time, so a
+            // backward step of N seconds would otherwise suspend every tick-only duty — backoff
+            // expiry, drop repair, the committee scan — for N seconds. Never wait longer than
+            // one interval.
+            if next_tick.duration_since(now) > interval {
+                next_tick = now.saturating_add(tick_delta);
+            }
             if now >= next_tick {
                 self.tick(&mut jobs).await;
                 next_tick = self
@@ -1435,12 +1476,22 @@ where
                 .map(|dest| dest.in_flight)
                 .sum::<usize>(),
         );
-        for (index, dest) in &mut self.destinations {
+        // Resume where the last round stopped. The budget is queue-wide, so serving destinations
+        // in index order every time lets the first `total_window / window` of them absorb all of
+        // it — at a committee larger than that ratio (8 with the defaults) the rest would get no
+        // catch-up at all. Same starvation the per-chain cursor exists to prevent, one level up.
+        let indices = self.destinations.keys().copied().collect::<Vec<_>>();
+        let order = rotated_order(&indices, self.drain_cursor);
+        self.drain_cursor = next_drain_cursor(&indices, order.first().copied());
+        for index in order {
+            let Some(dest) = self.destinations.get_mut(&index) else {
+                continue;
+            };
             budget -= Self::drain_ready(
                 &mut self.chains,
                 &self.storage,
                 &self.config,
-                *index,
+                index,
                 dest,
                 jobs,
                 now,
@@ -1637,10 +1688,19 @@ where
     /// sweep at a million pairs, and the maximum is the tail a quantile would hide anyway.
     #[cfg(with_metrics)]
     fn publish_backlog(&self) {
+        // Shared across destinations so one enormous backlog cannot spend the whole budget and
+        // leave every later destination reporting zero.
+        let mut remaining = MAX_CENSUS_PAIRS;
         for (index, dest) in &self.destinations {
             let mut owed = 0u64;
             let mut worst = 0u64;
+            let per_destination = remaining / self.destinations.len().max(1);
+            let mut examined = 0usize;
             for chain_id in &dest.lagging {
+                if examined >= per_destination {
+                    break;
+                }
+                examined += 1;
                 let Some(record) = self.chains.get(chain_id) else {
                     continue;
                 };
@@ -1661,6 +1721,7 @@ where
             metrics::MAX_CHAIN_GAP
                 .with_label_values(&[&dest.address])
                 .set(worst as i64);
+            remaining = remaining.saturating_sub(examined);
         }
     }
 
@@ -2366,6 +2427,31 @@ mod tests {
             chain_client::Error::RemoteNodeError(NodeError::EventsNotFound(vec![]));
         assert!(is_chain_scoped(&events_missing));
         assert!(!is_local_scoped(&events_missing));
+    }
+
+    /// The queue-wide budget is offered to a different destination each round.
+    ///
+    /// It is shared across destinations, so serving them in index order every time lets the
+    /// first `max_in_flight_total / max_in_flight_per_destination` of them absorb all of it —
+    /// with the defaults that is eight, and every destination past the eighth in a larger
+    /// committee would get no catch-up at all.
+    #[test]
+    fn the_budget_is_offered_to_a_different_destination_each_round() {
+        let indices = (0..12 as DestIndex).collect::<Vec<_>>();
+        let mut cursor = None;
+        let mut first_served = Vec::new();
+
+        for _ in 0..12 {
+            let order = rotated_order(&indices, cursor);
+            first_served.push(order[0]);
+            cursor = next_drain_cursor(&indices, order.first().copied());
+        }
+
+        assert_eq!(
+            first_served,
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            "the same destinations kept first claim on the budget",
+        );
     }
 
     /// A drained burst hands back its peak-sized table for freeing off the mutex; a live one

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -355,7 +355,9 @@ impl ProgressMap {
         for chain_id in forgotten {
             self.heights.remove(chain_id);
         }
-        if self.heights.capacity() > self.heights.len().saturating_mul(4) {
+        if self.heights.len() <= MAX_FORGET_PER_SWEEP
+            && self.heights.capacity() > self.heights.len().saturating_mul(4)
+        {
             let survivors = self.heights.drain().collect();
             return Some(std::mem::replace(&mut self.heights, survivors));
         }
@@ -705,7 +707,12 @@ impl ChainDest {
         } else {
             return None;
         }
-        reported.try_sub_one().ok()
+        // Never acknowledge past our own tip. A destination legitimately runs ahead of us — the
+        // client broadcasts to everyone — but the height is *its* claim, and this one is merged
+        // into the chain's persisted `exported_heights` by maximum. An over-report would write a
+        // permanent "converged" marker that survives restarts, ending export to that pair for
+        // good and taking the regression check with it.
+        reported.min(tip).try_sub_one().ok()
     }
 }
 
@@ -2060,6 +2067,27 @@ mod tests {
         );
     }
 
+    /// A destination claiming a height above our own tip is acknowledged only up to that tip.
+    ///
+    /// The acknowledged height is merged into the chain's persisted `exported_heights` by
+    /// maximum, so believing an over-report would write a "converged" marker that outlives the
+    /// process and silently ends export to that pair. Being *ahead* is normal — the client
+    /// broadcasts to everyone — so the report cannot simply be rejected either.
+    #[test]
+    fn a_height_above_our_tip_is_acknowledged_only_up_to_it() {
+        let config = BlockExportConfig::default();
+        let tip = BlockHeight(100);
+        let mut dest = ChainDest::default();
+
+        let acked = dest.record_reached(BlockHeight(u64::MAX), tip, Instant::now(), &config);
+
+        assert_eq!(
+            acked,
+            Some(BlockHeight(99)),
+            "acknowledged a height we never exported",
+        );
+    }
+
     /// The regression counter has to be free: this is per (chain, destination), and a down peer
     /// holds one per tracked chain.
     #[test]
@@ -2076,24 +2104,38 @@ mod tests {
     #[test]
     fn forgetting_a_drained_burst_returns_its_table() {
         let mut progress = ProgressMap::default();
-        let chains = test_chain_ids(MAX_FORGET_PER_SWEEP + 100);
+        let chains = test_chain_ids(20_000);
         for chain_id in &chains {
             progress.heights.insert(*chain_id, Vec::new());
         }
         let peak_capacity = progress.heights.capacity();
 
-        // Still above the budget: the table must stay, however much was just forgotten.
-        // `capacity()` is derived from occupancy, so compare magnitudes, not exact values.
-        let (first, rest) = chains.split_at(50);
-        assert!(progress.forget_chains(first).is_none());
-        assert!(progress.heights.capacity() > peak_capacity / 2);
+        // Still holding more than one sweep's budget: no rebuild, however oversized the table.
+        // This is the case that separates the two halves of the guard — the table below is
+        // several times too big, so a capacity test on its own would rebuild it here, under the
+        // mutex, at a size the sweep's budget was written to exclude.
+        let keep = MAX_FORGET_PER_SWEEP + 1000;
+        let (bulk, _) = chains.split_at(chains.len() - keep);
+        assert!(
+            progress.forget_chains(bulk).is_none(),
+            "rebuilt a map still holding {} entries, past the {MAX_FORGET_PER_SWEEP} budget",
+            progress.heights.len(),
+        );
+        assert!(
+            progress.heights.capacity() > progress.heights.len().saturating_mul(4),
+            "the table has to be oversized here or the case proves nothing",
+        );
 
-        // Down to a handful of survivors: the peak table is handed back, not freed in place.
-        let (bulk, survivors) = rest.split_at(rest.len() - 10);
-        let old_table = progress.forget_chains(bulk);
-        assert!(old_table.is_some_and(|table| table.capacity() > peak_capacity / 2));
+        // Down to within the budget: the peak table is handed back, not freed in place.
+        let survivors = 10;
+        let within_budget = chains.len() - survivors;
+        let old_table = progress.forget_chains(&chains[chains.len() - keep..within_budget]);
+        assert!(
+            old_table.is_some_and(|table| table.capacity() > peak_capacity / 2),
+            "the peak-sized table was not handed back for freeing off the mutex",
+        );
         assert!(progress.heights.capacity() < peak_capacity / 4);
-        assert_eq!(progress.heights.len(), survivors.len());
+        assert_eq!(progress.heights.len(), survivors);
     }
 
     /// Chain ids in the order `lagging` holds them, so a test can name "the front" of a backlog.

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -685,6 +685,15 @@ impl ChainDest {
         now: Instant,
         config: &BlockExportConfig,
     ) -> Option<BlockHeight> {
+        // Clamped once, here, so the cursor, the counters and the acknowledgement all read the
+        // same height. A destination legitimately runs ahead of us — the client broadcasts to
+        // everyone — but the value is *its* claim, and storing a claim above our tip satisfies
+        // none of the "behind" predicates that schedule work, while satisfying every
+        // "converged" one. Since only a completed send can rewrite the cursor, and no send is
+        // ever scheduled for a pair that looks converged, an over-report would strand that pair
+        // for the life of the process. Clamped, it is self-correcting: the pair re-enters the
+        // work set as soon as our own tip passes the clamp.
+        let reported = reported.min(tip);
         let previous = self.next_height;
         let advanced = previous.is_none_or(|height| reported > height);
         let regressed = previous.is_some_and(|height| reported < height);
@@ -707,12 +716,7 @@ impl ChainDest {
         } else {
             return None;
         }
-        // Never acknowledge past our own tip. A destination legitimately runs ahead of us — the
-        // client broadcasts to everyone — but the height is *its* claim, and this one is merged
-        // into the chain's persisted `exported_heights` by maximum. An over-report would write a
-        // permanent "converged" marker that survives restarts, ending export to that pair for
-        // good and taking the regression check with it.
-        reported.min(tip).try_sub_one().ok()
+        reported.try_sub_one().ok()
     }
 }
 
@@ -2077,15 +2081,33 @@ mod tests {
     fn a_height_above_our_tip_is_acknowledged_only_up_to_it() {
         let config = BlockExportConfig::default();
         let tip = BlockHeight(100);
-        let mut dest = ChainDest::default();
 
-        let acked = dest.record_reached(BlockHeight(u64::MAX), tip, Instant::now(), &config);
-
+        // An over-report is clamped — in the acknowledgement AND in the stored cursor. Leaving
+        // the cursor raw satisfies every "converged" predicate and no "behind" one, and only a
+        // completed send can rewrite it, so the pair would never be scheduled again.
+        let mut liar = ChainDest::default();
+        let acked = liar.record_reached(BlockHeight(u64::MAX), tip, Instant::now(), &config);
         assert_eq!(
             acked,
             Some(BlockHeight(99)),
             "acknowledged a height we never exported",
         );
+        assert_eq!(
+            liar.next_height,
+            Some(tip),
+            "stored a cursor above our tip: the pair is now unschedulable and reads as converged",
+        );
+
+        // And an honest report below the tip is taken at its word, not rounded up to it —
+        // otherwise "always acknowledge tip - 1" would satisfy the clamp just as well.
+        let mut honest = ChainDest::default();
+        let acked = honest.record_reached(BlockHeight(40), tip, Instant::now(), &config);
+        assert_eq!(
+            acked,
+            Some(BlockHeight(39)),
+            "acknowledged more than the destination reported",
+        );
+        assert_eq!(honest.next_height, Some(BlockHeight(40)));
     }
 
     /// The regression counter has to be free: this is per (chain, destination), and a down peer

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -1691,10 +1691,17 @@ where
         // Shared across destinations so one enormous backlog cannot spend the whole budget and
         // leave every later destination reporting zero.
         let mut remaining = MAX_CENSUS_PAIRS;
+        let mut unvisited = self.destinations.len();
         for (index, dest) in &self.destinations {
             let mut owed = 0u64;
             let mut worst = 0u64;
-            let per_destination = remaining / self.destinations.len().max(1);
+            // Divided by the destinations still to come, not by all of them: dividing by the
+            // total while `remaining` shrinks gives each successive destination a smaller share
+            // than the last, so the ones late in the index order would under-report their
+            // backlog. This way a destination that needs less than its share leaves the surplus
+            // to the rest, and the last one may use whatever is left.
+            let per_destination = remaining / unvisited.max(1);
+            unvisited = unvisited.saturating_sub(1);
             let mut examined = 0usize;
             for chain_id in &dest.lagging {
                 if examined >= per_destination {

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -808,10 +808,24 @@ where
                 }
                 match &outcome {
                     SendOutcome::Reached(next_height) => {
-                        let advanced = chain_dest.next_height.is_none_or(|n| *next_height > n);
-                        if advanced {
-                            // Only ever forward: a stale response must not drag the cursor back.
-                            chain_dest.next_height = Some(*next_height);
+                        let previous = chain_dest.next_height;
+                        let advanced = previous.is_none_or(|n| *next_height > n);
+                        // The validator is authoritative about its own height, in both
+                        // directions: only one send per pair is ever in flight and stale
+                        // generations are filtered above, so this is not a race. One restored
+                        // from a backup reports a *lower* height, and refusing to believe it
+                        // would leave that gap unrepaired for good — we would think it caught
+                        // up and never send the blocks it lost.
+                        //
+                        // Untested: the in-process harness has no way to make a validator lose
+                        // state, so this direction rests on the argument above rather than on a
+                        // failing-first test. A regression is noticed only once a send happens,
+                        // which needs the chain's tip to be above the cursor. One that regresses while we
+                        // believe it fully converged waits for the chain's next block; probing
+                        // converged pairs instead would cost a query per chain per destination
+                        // forever, to catch something only a restore causes.
+                        chain_dest.next_height = Some(*next_height);
+                        if advanced || previous.is_some_and(|n| *next_height < n) {
                             chain_dest.failures = 0;
                             chain_dest.retry_at = None;
                             if let Ok(acked) = next_height.try_sub_one() {

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -38,6 +38,7 @@ use tokio::sync::mpsc;
 use tracing::{debug, instrument, warn};
 
 use crate::{
+    data_types::ChainInfoQuery,
     local_node::LocalNodeClient,
     node::{ValidatorNode, ValidatorNodeProvider},
     remote_node::RemoteNode,
@@ -138,6 +139,33 @@ pub struct BlockExportConfig {
     /// The bound is what a live block may have to wait behind, so it is deliberately small: the
     /// backfill rate is set by how often rounds happen, not by how much each one does.
     pub max_catch_up_blocks: u64,
+}
+
+impl BlockExportConfig {
+    /// Rejects values that would make export misbehave rather than merely perform badly.
+    ///
+    /// Checked once at startup so a typo fails the validator immediately, instead of surfacing
+    /// later as a panic mid-export, a task spinning a core, or gaps that are silently never
+    /// repaired.
+    pub fn check(&self) -> Result<(), String> {
+        if self.certificate_upload_batch_size == 0 {
+            // `slice::chunks(0)` panics.
+            return Err("block export batch size must be greater than zero".into());
+        }
+        if self.max_catch_up_blocks == 0 {
+            // Every gap would stay open forever, silently.
+            return Err("block export catch-up bound must be greater than zero".into());
+        }
+        if self.idle_catch_up_interval.is_zero() {
+            // The idle timer would fire continuously, turning the task into a busy loop.
+            return Err("block export idle interval must be greater than zero".into());
+        }
+        if self.retry_delay.is_zero() {
+            // A failing destination would be retried without pause.
+            return Err("block export retry delay must be greater than zero".into());
+        }
+        Ok(())
+    }
 }
 
 impl Default for BlockExportConfig {
@@ -273,21 +301,13 @@ where
         own_public_key,
         destinations: HashMap::new(),
         chain_next_height: BlockHeight::ZERO,
+        admin_chain_id: None,
         progress: progress.clone(),
     };
     linera_base::Task::spawn(task.run(receiver)).forget();
 
     ChainExporter { blocks, progress }
 }
-
-/// Consecutive failed pushes after which a destination's connection is rebuilt.
-///
-/// The transport may be relaying through one of several proxies, and a destination keeps whichever
-/// it was given. If that proxy dies, this destination would otherwise keep failing against it
-/// forever while the others stay healthy, so after a few failures the node is remade — which draws
-/// a fresh proxy from the rotation. The failure count and backoff are deliberately *not* reset, so
-/// a destination that is genuinely down still backs off rather than being hammered once per proxy.
-const REBUILD_AFTER_FAILURES: u32 = 3;
 
 /// One destination validator, and what we believe it holds of this chain.
 struct Destination<S: Storage, N> {
@@ -321,6 +341,9 @@ where
     /// be considered caught up. Used to keep catching a lagging destination up while the chain is
     /// idle, so that convergence does not depend on the chain producing more blocks.
     chain_next_height: BlockHeight,
+    /// The chain carrying the epoch events, learned from the first block exported. `None` until
+    /// then, which is also when there is nothing to catch anyone up on.
+    admin_chain_id: Option<ChainId>,
     /// The highest height each validator has acknowledged. Seeded from what the worker had
     /// persisted, so a destination we meet for the first time — after a restart, or after the
     /// chain worker was dropped and reloaded — starts from there instead of being queried.
@@ -358,12 +381,41 @@ where
         debug!("Chain worker dropped; stopping block export");
     }
 
-    /// Remakes the node of any destination that has failed repeatedly.
+    /// Brings the destination set in line with the chain's committee as the local worker sees it
+    /// right now, rather than as of the last block exported.
+    ///
+    /// Asked of the worker rather than read from the chain view directly: the worker owns that
+    /// view while it is running, and loading it here would race with it.
+    async fn sync_destinations_from_local_node(&mut self) {
+        let query = ChainInfoQuery::new(self.chain_id).with_committees();
+        let info = match self.local_node.handle_chain_info_query(query).await {
+            Ok(response) => response.info,
+            Err(error) => {
+                debug!(%error, "Cannot read the committee while catching up");
+                return;
+            }
+        };
+        let Some(committee) = info
+            .requested_committees
+            .and_then(|committees| committees.into_iter().next_back().map(|(_, c)| c))
+        else {
+            return;
+        };
+        let Some(admin_chain_id) = self.admin_chain_id else {
+            return;
+        };
+        self.sync_destinations_with(&committee, admin_chain_id);
+    }
+
+    /// Remakes the node of every destination whose last push failed.
     ///
     /// The transport may be relaying through one of several proxies and a destination keeps
-    /// whichever it was handed, so one that keeps failing may simply be pointed at a dead proxy.
-    /// Remaking it draws a fresh one. The failure count and backoff are deliberately kept, so a
-    /// validator that is itself down still backs off rather than being retried once per proxy.
+    /// whichever it was handed, so a failure may mean nothing worse than a dead proxy. Remaking
+    /// the node draws the next one from the rotation, so a bad proxy is stepped over on the very
+    /// next attempt instead of being retried; if the destination itself is down, the fresh proxy
+    /// fails too and the backoff below still applies. The failure count and backoff are kept
+    /// across the rebuild for exactly that reason — rotating proxies must not become a way to
+    /// hammer a validator that is simply offline.
     ///
     /// Runs before every catch-up round as well as on every new block: a destination that fell
     /// behind while the chain was idle would otherwise never get a second chance at a connection.
@@ -371,7 +423,7 @@ where
         let stuck = self
             .destinations
             .iter()
-            .filter(|(_, destination)| destination.failures >= REBUILD_AFTER_FAILURES)
+            .filter(|(_, destination)| destination.failures > 0)
             .map(|(validator, destination)| (*validator, destination.address.clone()))
             .collect::<Vec<_>>();
         if stuck.is_empty() {
@@ -395,6 +447,10 @@ where
     ///
     /// Runs only when nothing is queued, so live blocks always take priority over backfill.
     async fn catch_up_round(&mut self) {
+        // Pick up committee changes too. A validator admitted while this chain happens to be idle
+        // would otherwise never become a destination at all — `sync_destinations` runs off an
+        // exported block, and there is no next block to carry the new committee.
+        self.sync_destinations_from_local_node().await;
         self.refresh_stuck_destinations();
         let now = Instant::now();
         let (config, chain_id, target) = (&self.config, self.chain_id, self.chain_next_height);
@@ -459,7 +515,13 @@ where
     /// Brings the destination set in line with the block's committee: adds validators that joined,
     /// drops those that left, and re-creates a node whose address changed.
     fn sync_destinations(&mut self, block: &ExportedBlock) {
-        let committee = &block.committee;
+        self.admin_chain_id = Some(block.admin_chain_id);
+        self.sync_destinations_with(&block.committee, block.admin_chain_id);
+    }
+
+    /// Adds destinations for validators in `committee` we do not have, and drops those that have
+    /// left it or changed address.
+    fn sync_destinations_with(&mut self, committee: &Committee, admin_chain_id: ChainId) {
         self.destinations.retain(|validator, destination| {
             committee
                 .validators()
@@ -467,12 +529,12 @@ where
                 .is_some_and(|state| state.network_address == destination.address)
         });
 
-        // A destination that has failed repeatedly may be stuck behind a dead proxy, so rebuild
-        // its node alongside any validator we do not have yet.
+        // A destination whose last push failed may be stuck behind a dead proxy, so rebuild its
+        // node alongside any validator we do not have yet.
         let stuck = self
             .destinations
             .iter()
-            .filter(|(_, destination)| destination.failures >= REBUILD_AFTER_FAILURES)
+            .filter(|(_, destination)| destination.failures > 0)
             .map(|(validator, _)| *validator)
             .collect::<Vec<_>>();
 
@@ -517,8 +579,11 @@ where
                     node,
                 },
                 local_node: self.local_node.clone(),
-                admin_chain_id: block.admin_chain_id,
+                admin_chain_id,
                 certificate_upload_batch_size: self.config.certificate_upload_batch_size,
+                // Export replicates blocks; it does not take part in the destination's consensus.
+                sync_consensus_rounds: false,
+                max_admin_catch_up_blocks: Some(self.config.max_catch_up_blocks),
             };
             // Rebuilding a stuck destination keeps its failure count and retry time: only the
             // connection is replaced, so a validator that is itself down keeps backing off.
@@ -621,18 +686,19 @@ where
             .await;
         let outcome = self.record_outcome(result, target, now, config);
 
-        // A round can succeed and still advance nothing: storage need not hold the missing
+        // A round can *succeed* and still advance nothing: storage need not hold the missing
         // heights, since a chain we merely *receive* from is stored only at its message-bearing
         // blocks. Without backing off here the caller would call straight back in, and a
         // destination we can never finish catching up would spin the task at full tilt.
-        let advanced = match (previous, self.next_height) {
-            (Some(before), Some(after)) => after > before,
-            // We at least learned where it is, which is progress the first time round.
-            (None, Some(_)) => true,
-            _ => false,
-        };
-        if !advanced {
-            self.back_off(now, config);
+        //
+        // Only the success path needs this. A failed round has already been backed off inside
+        // `record_outcome`, and doing it again here would double-count the failure and escalate
+        // the delay twice as fast as configured.
+        if let Some(reached) = outcome {
+            let advanced = previous.is_none_or(|before| reached > before);
+            if !advanced {
+                self.back_off(now, config);
+            }
         }
         outcome
     }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -41,7 +41,7 @@ use crate::{
     local_node::LocalNodeClient,
     node::{ValidatorNode, ValidatorNodeProvider},
     remote_node::RemoteNode,
-    updater::confirmed_sender::ConfirmedCertificateSender,
+    updater::RemoteNodeUpdater,
 };
 
 #[cfg(with_metrics)]
@@ -259,7 +259,7 @@ where
 
 /// One destination validator, and what we believe it holds of this chain.
 struct Destination<S: Storage, N> {
-    sender: ConfirmedCertificateSender<S, N>,
+    updater: RemoteNodeUpdater<S, N>,
     address: String,
     /// The next height the validator needs, or `None` when we have to ask it — before the first
     /// push, and after any failed one.
@@ -293,9 +293,9 @@ where
 
 impl<S, P> ChainExportTask<S, P>
 where
-    S: Storage + Clone,
+    S: Storage + Clone + 'static,
     P: ValidatorNodeProvider,
-    P::Node: Clone,
+    P::Node: Clone + 'static,
 {
     /// Exports each block in turn, and returns when the chain worker has dropped its end.
     #[instrument(level = "debug", skip_all, fields(chain_id = %self.chain_id))]
@@ -386,19 +386,19 @@ where
             else {
                 continue;
             };
-            let sender = ConfirmedCertificateSender::new(
-                RemoteNode {
+            let updater = RemoteNodeUpdater {
+                remote_node: RemoteNode {
                     public_key: validator,
                     node,
                 },
-                self.local_node.clone(),
-                block.admin_chain_id,
-                self.config.certificate_upload_batch_size,
-            );
+                local_node: self.local_node.clone(),
+                admin_chain_id: block.admin_chain_id,
+                certificate_upload_batch_size: self.config.certificate_upload_batch_size,
+            };
             self.destinations.insert(
                 validator,
                 Destination {
-                    sender,
+                    updater,
                     address,
                     // An acknowledged height was reported by the validator itself, so the block
                     // after it is the one the validator needs next.
@@ -415,8 +415,8 @@ where
 
 impl<S, N> Destination<S, N>
 where
-    S: Storage + Clone,
-    N: ValidatorNode + Clone,
+    S: Storage + Clone + 'static,
+    N: ValidatorNode + Clone + 'static,
 {
     /// Pushes the block, along with any earlier ones this validator is missing, and returns the
     /// validator's next block height afterwards — or `None` if it was skipped or failed.
@@ -440,7 +440,7 @@ where
             .observe(self.lag(block) as f64);
 
         match self
-            .sender
+            .updater
             .send_block(&block.certificate, &block.blobs, self.next_height)
             .await
         {

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -3,29 +3,51 @@
 
 //! Pushing executed blocks to the other validators in the committee.
 //!
-//! Each chain worker owns one export task and hands it every block it executes — certificate and
-//! blobs, both already in memory. This is the dissemination that makes each validator a complete
-//! replica; consensus alone only guarantees that a quorum holds any given block.
+//! One queue task per server process. Chain workers hand it every block they execute —
+//! certificate and blobs, both already in memory — and it pushes them to the rest of the
+//! committee. This is the dissemination that makes each validator a complete replica; consensus
+//! alone only guarantees that a quorum holds any given block.
 //!
-//! One task per chain worker rather than per process: a single task would serialize thousands of
-//! chains, and a per-chain task gets height ordering for free.
+//! One task per *process* rather than per chain worker, for two reasons. Nothing on this path may
+//! touch a chain worker — a task that does resets the worker's keep-alive clock and keeps it
+//! resident forever — so everything here reads storage only. And destination state must be
+//! shared: with per-chain tasks, one unreachable validator is discovered, retried, and backed off
+//! independently by every chain, which at scale is thousands of connection attempts against a
+//! peer that may already be struggling. Here each destination has one connection, one backoff,
+//! and one AIMD window that all chains share: a success widens the window additively, a
+//! transport failure halves it, so the total in-flight load on a struggling peer shrinks
+//! exponentially while it struggles and recovers once it stops.
 //!
-//! The queue is unbounded, because dropping a block would leave a gap nothing repairs — the very
-//! failure this design removes. A growing queue is a performance problem instead; see
-//! [`metrics::QUEUE_SIZE`].
+//! Failures are scoped by what they say. A timeout or transport error is about the
+//! *destination*, so it halves the window and backs the destination off (and re-resolves its
+//! node, which rotates to the next proxy when the transport is relayed). An error like
+//! `EventsNotFound` is about one *chain* — the destination lacks the committee that signed the
+//! certificate — so it backs off only that chain-destination pair: the admin chain's own export
+//! is what will fix it, and must not be throttled by it.
+//!
+//! The queue is bounded, and a full queue drops the block rather than blocking the worker.
+//! Dropping is safe because it is *repaired*: the queue tracks each chain's tip against what
+//! every destination acknowledged, and closes any gap from storage during idle rounds. Per-chain
+//! height ordering is preserved by allowing at most one in-flight send per chain-destination
+//! pair.
+//!
+//! Chains converge and are forgotten: a record exists only while some destination is behind, so
+//! memory is bounded by lagging chains, not by every chain the process ever served. The
+//! work-list therefore covers chains seen since the process started — a validator that needs the
+//! full history of a chain that never produces blocks again is out of scope here.
 
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashMap, VecDeque},
     iter,
     sync::{Arc, Mutex},
 };
 
-use futures::future;
+use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt as _};
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{Blob, BlockHeight},
+    data_types::{Blob, BlockHeight, Epoch},
     identifiers::{BlobId, ChainId},
     time::{timer::timeout, Duration, Instant},
 };
@@ -48,24 +70,41 @@ mod metrics {
 
     use linera_base::prometheus_util::{
         exponential_bucket_interval, exponential_bucket_latencies, register_histogram,
-        register_histogram_vec, register_int_gauge,
+        register_histogram_vec, register_int_counter, register_int_gauge,
     };
-    use prometheus::{Histogram, HistogramVec, IntGauge};
+    use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge};
 
-    /// Blocks waiting to be exported, across every chain worker in this process. The queue is
-    /// unbounded, so this is how a chain producing faster than it can push becomes visible.
+    /// Blocks waiting in the export queue.
     pub static QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
         register_int_gauge(
             "block_export_queue_size",
-            "Blocks queued for export across all chain workers",
+            "Blocks queued for export in this process",
         )
     });
 
-    /// Time from a block being queued to it having been pushed to every destination.
+    /// Blob payload bytes held by queued blocks, since a block count alone hides the memory a
+    /// backlog of large blobs pins.
+    pub static QUEUE_BYTES: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_queue_bytes",
+            "Blob bytes held by blocks queued for export in this process",
+        )
+    });
+
+    /// Blocks dropped because the queue was full. Each is repaired by a later catch-up round, so
+    /// this counting up means latency, not loss.
+    pub static DROPPED_BLOCKS: LazyLock<IntCounter> = LazyLock::new(|| {
+        register_int_counter(
+            "block_export_dropped_blocks",
+            "Blocks dropped from a full export queue, to be re-sent from storage",
+        )
+    });
+
+    /// Time from a block being queued to its sends being scheduled.
     pub static EXPORT_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
         register_histogram(
             "block_export_latency",
-            "Time (ms) to export one block to every destination, including time spent queued",
+            "Time (ms) a block waits in the export queue before its sends are scheduled",
             exponential_bucket_latencies(60_000.0),
         )
     });
@@ -77,6 +116,16 @@ mod metrics {
             "Time (ms) to push one block to one destination validator",
             &["validator"],
             exponential_bucket_latencies(60_000.0),
+        )
+    });
+
+    /// How many concurrent sends each destination is currently allowed.
+    pub static DESTINATION_WINDOW: LazyLock<HistogramVec> = LazyLock::new(|| {
+        register_histogram_vec(
+            "block_export_destination_window",
+            "AIMD in-flight window per destination validator, sampled at each change",
+            &["validator"],
+            exponential_bucket_interval(1.0, 1_024.0),
         )
     });
 
@@ -95,16 +144,19 @@ mod metrics {
 /// Configuration for pushing executed blocks to the other committee validators.
 #[derive(Clone, Debug)]
 pub struct BlockExportConfig {
-    /// How many certificates are read from storage and pushed per batch when catching a
-    /// destination up.
+    /// How many certificates are read from storage per catch-up read.
     pub certificate_upload_batch_size: u64,
+    /// How many blocks the export queue holds before dropping new ones for catch-up to repair.
+    pub queue_size: usize,
+    /// The most concurrent sends one destination is ever allowed — the AIMD window's ceiling.
+    pub max_in_flight_per_destination: usize,
     /// How long a destination is skipped after a failed push, doubling up to `max_retry_delay`.
     /// Coarser than the transport's per-request retries: those decide whether one call is worth
     /// repeating, this decides whether the destination is worth attempting at all right now.
     pub retry_delay: Duration,
     /// The longest a failing destination is skipped for.
     pub max_retry_delay: Duration,
-    /// How long the task waits for a new block before spending a round catching up destinations
+    /// How long the queue waits for a new block before spending a round catching up destinations
     /// that are behind. With `max_catch_up_blocks` this sets the backfill rate, so tune them
     /// together.
     pub idle_catch_up_interval: Duration,
@@ -112,6 +164,10 @@ pub struct BlockExportConfig {
     /// bounds what a live block may wait behind, and a validator that just joined reports height
     /// 0, so its catch-up is otherwise arbitrarily large.
     pub max_catch_up_blocks: u64,
+    /// How long a converged chain's record is kept before being forgotten. Long enough for the
+    /// chain's worker to fold the final heights into `exported_heights` on its next save; after
+    /// it, a lost cursor costs one query to rebuild.
+    pub converged_chain_retention: Duration,
 }
 
 impl BlockExportConfig {
@@ -122,6 +178,14 @@ impl BlockExportConfig {
         if self.certificate_upload_batch_size == 0 {
             // `slice::chunks(0)` panics.
             return Err("block export batch size must be greater than zero".into());
+        }
+        if self.queue_size == 0 {
+            // Every block would be dropped and export would run on catch-up alone.
+            return Err("block export queue size must be greater than zero".into());
+        }
+        if self.max_in_flight_per_destination == 0 {
+            // No destination could ever be sent anything.
+            return Err("block export in-flight ceiling must be greater than zero".into());
         }
         if self.max_catch_up_blocks == 0 {
             // Every gap would stay open forever, silently.
@@ -143,6 +207,10 @@ impl BlockExportConfig {
             // The very first backoff would already exceed its own ceiling.
             return Err("block export retry delay must not exceed the max retry delay".into());
         }
+        if self.converged_chain_retention.is_zero() {
+            // The progress of a converged chain would be dropped before its worker folds it in.
+            return Err("block export converged-chain retention must be greater than zero".into());
+        }
         Ok(())
     }
 }
@@ -150,30 +218,17 @@ impl BlockExportConfig {
 impl Default for BlockExportConfig {
     fn default() -> Self {
         BlockExportConfig {
-            certificate_upload_batch_size: crate::client::DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
+            certificate_upload_batch_size: 100,
+            queue_size: 1024,
+            max_in_flight_per_destination: 8,
             retry_delay: Duration::from_secs(1),
             max_retry_delay: Duration::from_secs(60),
             idle_catch_up_interval: Duration::from_millis(200),
             max_catch_up_blocks: 200,
+            converged_chain_retention: Duration::from_secs(300),
         }
     }
 }
-
-/// Everything the export task needs that only the chain worker can supply.
-pub struct ChainExportSetup<S: Storage> {
-    /// The chain whose blocks this task exports.
-    pub chain_id: ChainId,
-    /// Read access to this validator's storage, for certificates and blobs during catch-up.
-    /// Deliberately not a local node: going through one loads chain workers, and an export task
-    /// that touches a chain worker resets its TTL and keeps it resident forever.
-    pub storage: S,
-    /// The heights already exported to each validator, as last persisted by the worker.
-    pub exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
-}
-
-/// Creates the export task for one chain worker. Type-erased because only the server binary knows
-/// how to reach another validator.
-pub type ChainExporterFactory<S> = Arc<dyn Fn(ChainExportSetup<S>) -> ChainExporter + Send + Sync>;
 
 /// A block a chain worker has executed, on its way to the other validators.
 struct ExportedBlock {
@@ -182,65 +237,100 @@ struct ExportedBlock {
     /// for a blob this very block publishes — is served without a read from storage. Held as the
     /// storage cache's pointers, so queued blocks share the allocations rather than copying them.
     blobs: Vec<CacheArc<Blob>>,
-    /// The chain's committee *after* the block was applied, so that a validator joining in this
-    /// block is exported to immediately.
+    /// The chain's epoch and committee *after* the block was applied, so that a validator joining
+    /// in this block is exported to immediately.
+    epoch: Epoch,
     committee: Arc<Committee>,
-    /// When the worker queued this block, so that `EXPORT_LATENCY` covers the wait as well as
-    /// the sending. The queue is where the delay shows up once export falls behind, which is
-    /// exactly when the metric is worth reading.
+    /// Blob payload bytes, counted at enqueue so the dequeue can decrement the same amount.
+    #[cfg(with_metrics)]
+    blob_bytes: i64,
     #[cfg(with_metrics)]
     queued_at: Instant,
 }
 
-/// The chain worker's end of its export task.
-pub struct ChainExporter {
-    blocks: mpsc::UnboundedSender<ExportedBlock>,
-    /// The highest height each validator has acknowledged, folded into the chain's
-    /// `exported_heights` by the worker on its next save. Travels this way so the worker stays the
-    /// only writer of its own chain state, and export costs no extra database write.
-    progress: Arc<Mutex<BTreeMap<ValidatorPublicKey, BlockHeight>>>,
+/// The chain workers' end of the export queue: hands blocks over and reads back progress.
+pub struct BlockExportHandle {
+    blocks: mpsc::Sender<ExportedBlock>,
+    progress: SharedProgress,
 }
 
-impl ChainExporter {
-    /// Queues a block for export, and returns without waiting for it to be sent.
-    ///
-    /// Never blocks and never drops: see the module documentation for why the queue is unbounded.
+impl Clone for BlockExportHandle {
+    fn clone(&self) -> Self {
+        BlockExportHandle {
+            blocks: self.blocks.clone(),
+            progress: self.progress.clone(),
+        }
+    }
+}
+
+/// The highest height each destination has acknowledged, per chain, written by the queue task
+/// and folded into each chain's `exported_heights` by its worker on save. Entries are removed
+/// when a chain converges, so this holds lagging chains only.
+type SharedProgress = Arc<Mutex<HashMap<ChainId, BTreeMap<ValidatorPublicKey, BlockHeight>>>>;
+
+impl BlockExportHandle {
+    /// Queues a block for export and returns immediately. A full queue drops the block — never
+    /// blocks the worker — and the queue's catch-up re-sends it from storage.
     pub(crate) fn export(
         &self,
         certificate: CacheArc<ConfirmedBlockCertificate>,
         blobs: Vec<CacheArc<Blob>>,
+        epoch: Epoch,
         committee: Arc<Committee>,
     ) {
+        #[cfg(with_metrics)]
+        let blob_bytes = blobs
+            .iter()
+            .map(|blob| blob.bytes().len() as i64)
+            .sum::<i64>();
         let block = ExportedBlock {
             certificate,
             blobs,
+            epoch,
             committee,
+            #[cfg(with_metrics)]
+            blob_bytes,
             #[cfg(with_metrics)]
             queued_at: Instant::now(),
         };
-        match self.blocks.send(block) {
+        match self.blocks.try_send(block) {
             Ok(()) => {
                 #[cfg(with_metrics)]
-                metrics::QUEUE_SIZE.inc();
+                {
+                    metrics::QUEUE_SIZE.inc();
+                    metrics::QUEUE_BYTES.add(blob_bytes);
+                }
             }
-            // The task runs until this sender is dropped, so it cannot be gone while we hold it.
-            Err(_) => {
-                warn!("Block export task stopped unexpectedly; blocks are no longer being exported")
+            Err(mpsc::error::TrySendError::Full(block)) => {
+                debug!(
+                    chain_id = %block.certificate.block().header.chain_id,
+                    height = %block.certificate.block().header.height,
+                    "Export queue full; dropping the block for catch-up to re-send",
+                );
+                #[cfg(with_metrics)]
+                metrics::DROPPED_BLOCKS.inc();
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!("Block export queue stopped unexpectedly; blocks are no longer exported");
             }
         }
     }
 
-    /// Returns how far each validator has been exported to, restricted to `committee` so that
-    /// validators which have left it are pruned.
+    /// Returns how far each validator has been exported to on `chain_id`, restricted to
+    /// `committee` so that validators which left it are pruned.
     pub(crate) fn progress(
         &self,
+        chain_id: ChainId,
         committee: &Committee,
     ) -> BTreeMap<ValidatorPublicKey, BlockHeight> {
         let progress = self
             .progress
             .lock()
             .expect("progress mutex is never poisoned");
-        progress
+        let Some(chain_progress) = progress.get(&chain_id) else {
+            return BTreeMap::new();
+        };
+        chain_progress
             .iter()
             .filter(|(validator, _)| committee.validators().contains_key(*validator))
             .map(|(validator, height)| (*validator, *height))
@@ -248,453 +338,598 @@ impl ChainExporter {
     }
 }
 
-/// Spawns the export task for one chain worker and returns the worker's end of it. The task runs
-/// until the returned [`ChainExporter`] is dropped with its worker, so an idle chain costs neither
-/// a task nor a connection.
-pub fn spawn_chain_exporter<S, P>(
-    setup: ChainExportSetup<S>,
+/// Spawns the process-wide export queue task and returns the handle chain workers push to.
+///
+/// The task runs until every clone of the returned handle is dropped, and reads only from
+/// `storage` — never through a chain worker, whose TTL a touch would reset.
+pub fn spawn_block_export_queue<S, P>(
+    storage: S,
     node_provider: Arc<P>,
     config: BlockExportConfig,
     own_public_key: Option<ValidatorPublicKey>,
-) -> ChainExporter
+) -> BlockExportHandle
 where
     S: Storage + Clone + Send + Sync + 'static,
     P: ValidatorNodeProvider + Send + Sync + 'static,
     P::Node: Send + Sync,
 {
-    let (blocks, receiver) = mpsc::unbounded_channel();
-    // Seed the progress map with what the worker had already persisted, so that the first fold
-    // back into the chain state cannot regress it to nothing while the task has yet to send
-    // anything.
-    let progress = Arc::new(Mutex::new(setup.exported_heights.clone()));
+    let (blocks, receiver) = mpsc::channel(config.queue_size);
+    let progress: SharedProgress = Arc::default();
 
-    let task = ChainExportTask {
-        chain_id: setup.chain_id,
+    let task = BlockExportQueue {
+        storage,
         node_provider,
-        storage: setup.storage,
         config,
         own_public_key,
+        latest_epoch: None,
+        committee: None,
+        chains: HashMap::new(),
         destinations: HashMap::new(),
-        chain_next_height: BlockHeight::ZERO,
         progress: progress.clone(),
     };
     linera_base::Task::spawn(task.run(receiver)).forget();
 
-    ChainExporter { blocks, progress }
+    BlockExportHandle { blocks, progress }
 }
 
-/// One destination validator, and what we believe it holds of this chain.
-struct Destination<S: Storage, N> {
-    sender: BlockSender<S, N>,
-    address: String,
-    /// The next height the validator needs, or `None` when we have to ask it — before the first
-    /// push, and after any failed one.
+/// What we know of one chain: its tip, and each destination's position below it. Kept while some
+/// destination is behind, and for a grace window after convergence so the chain's worker can
+/// still fold the final heights into its state; then forgotten.
+struct ChainRecord {
+    /// The height after the chain's last known block: what a destination must reach to be
+    /// caught up.
+    tip: BlockHeight,
+    /// When this chain last saw a block or a completed send, for the convergence sweep.
+    last_activity: Instant,
+    dests: BTreeMap<ValidatorPublicKey, ChainDest>,
+}
+
+/// One chain's cursor at one destination.
+#[derive(Default)]
+struct ChainDest {
+    /// The next height the destination needs, or `None` when we have to ask it — before the
+    /// first push, and after any failed one.
     next_height: Option<BlockHeight>,
-    /// While this is in the future the validator is skipped; it failed recently.
+    in_flight: bool,
+    /// Whether this chain already sits in the destination's ready list, to keep it there once.
+    queued: bool,
+    /// Backoff for *chain-scoped* failures — the destination is healthy but cannot accept this
+    /// chain yet, e.g. it lacks the committee and the admin chain's export has not reached it.
     retry_at: Option<Instant>,
-    /// How many pushes to this destination have failed in a row, which sets how long the next
-    /// skip lasts.
     failures: u32,
 }
 
-/// The body of one chain's export task.
-struct ChainExportTask<S, P>
+/// One destination validator: its connection and the health state every chain shares.
+struct DestState<N> {
+    node: N,
+    address: String,
+    /// Sends currently running against this destination, over all chains.
+    in_flight: usize,
+    /// How many concurrent sends the AIMD control currently allows: +1 per success up to the
+    /// configured ceiling, halved per transport failure down to 1.
+    window: usize,
+    /// Backoff for *destination-scoped* failures: transport errors and timeouts.
+    retry_at: Option<Instant>,
+    failures: u32,
+    /// Chains with work for this destination, drained as the window allows.
+    ready: VecDeque<ChainId>,
+}
+
+/// How one send ended, scoped to what the error tells us about.
+enum SendOutcome {
+    /// The validator answered; its reported next height.
+    Reached(BlockHeight),
+    /// The failure is about this chain on this destination, not about the destination.
+    ChainScoped(chain_client::Error),
+    /// The failure is about the destination itself.
+    DestinationScoped(chain_client::Error),
+}
+
+/// The body of the process-wide export queue task.
+struct BlockExportQueue<S, P>
 where
     S: Storage,
     P: ValidatorNodeProvider,
 {
-    chain_id: ChainId,
-    node_provider: Arc<P>,
     storage: S,
+    node_provider: Arc<P>,
     config: BlockExportConfig,
     own_public_key: Option<ValidatorPublicKey>,
-    destinations: HashMap<ValidatorPublicKey, Destination<S, P::Node>>,
-    /// The height after the last block handed to this task: how far a destination must reach to
-    /// be considered caught up. Used to keep catching a lagging destination up while the chain is
-    /// idle, so that convergence does not depend on the chain producing more blocks.
-    chain_next_height: BlockHeight,
-    /// The highest height each validator has acknowledged. Seeded from what the worker had
-    /// persisted, so a destination we meet for the first time — after a restart, or after the
-    /// chain worker was dropped and reloaded — starts from there instead of being queried.
-    progress: Arc<Mutex<BTreeMap<ValidatorPublicKey, BlockHeight>>>,
+    /// The newest committee seen, from exported blocks and from scanning storage forward. Used
+    /// for the destination set of every chain: a chain's own committee cannot announce a
+    /// newcomer, and current committee members need every chain regardless of its epoch.
+    latest_epoch: Option<Epoch>,
+    committee: Option<Arc<Committee>>,
+    chains: HashMap<ChainId, ChainRecord>,
+    destinations: HashMap<ValidatorPublicKey, DestState<P::Node>>,
+    progress: SharedProgress,
 }
 
-impl<S, P> ChainExportTask<S, P>
+impl<S, P> BlockExportQueue<S, P>
 where
-    S: Storage + Clone + 'static,
+    S: Storage + Clone + Send + Sync + 'static,
     P: ValidatorNodeProvider,
-    P::Node: Clone + 'static,
+    P::Node: Clone + Send + 'static,
 {
-    /// Exports each block in turn, and returns when the chain worker has dropped its end.
-    #[instrument(level = "debug", skip_all, fields(chain_id = %self.chain_id))]
-    async fn run(mut self, mut receiver: mpsc::UnboundedReceiver<ExportedBlock>) {
+    /// Exports blocks until every handle is dropped, interleaving catch-up while idle.
+    #[instrument(level = "debug", skip_all)]
+    async fn run(mut self, mut receiver: mpsc::Receiver<ExportedBlock>) {
+        let mut jobs = FuturesUnordered::new();
         loop {
-            match timeout(self.config.idle_catch_up_interval, receiver.recv()).await {
-                Ok(Some(block)) => {
-                    #[cfg(with_metrics)]
-                    metrics::QUEUE_SIZE.dec();
-                    #[cfg(with_metrics)]
-                    let queued_at = block.queued_at;
-                    self.export(block).await;
-                    #[cfg(with_metrics)]
-                    metrics::EXPORT_LATENCY
-                        .finish_measurement(queued_at.elapsed().as_secs_f64() * 1000.0);
+            if jobs.is_empty() {
+                match timeout(self.config.idle_catch_up_interval, receiver.recv()).await {
+                    Ok(Some(block)) => self.on_block(block, &mut jobs),
+                    Ok(None) => break,
+                    Err(_) => self.tick(&mut jobs).await,
                 }
-                // The chain worker dropped its end.
-                Ok(None) => break,
-                // Nothing arrived for a while: close more of a lagging destination's gap rather
-                // than waiting for a block the chain may never produce. One round per interval,
-                // so a destination that cannot be caught up trickles rather than spins.
-                Err(_) => self.catch_up_round().await,
+            } else {
+                tokio::select! {
+                    Some(done) = jobs.next() => self.on_done(done, &mut jobs),
+                    received = receiver.recv() => match received {
+                        Some(block) => self.on_block(block, &mut jobs),
+                        None => break,
+                    },
+                }
             }
         }
-        debug!("Chain worker dropped; stopping block export");
+        // The workers are gone; let in-flight sends finish rather than cutting them off.
+        while let Some(done) = jobs.next().await {
+            self.on_done(done, &mut jobs);
+        }
+        debug!("All block export handles dropped; stopping the export queue");
     }
 
-    /// Remakes the node of every destination whose last push failed, drawing the next proxy from
-    /// the rotation so a dead proxy is stepped over rather than retried. Keeps the failure count
-    /// and backoff, so this cannot become a way to hammer a validator that is simply offline.
-    fn refresh_stuck_destinations(&mut self) {
-        let stuck = self
-            .destinations
-            .iter()
-            .filter(|(_, destination)| destination.failures > 0)
-            .map(|(validator, destination)| (*validator, destination.address.clone()))
-            .collect::<Vec<_>>();
-        if stuck.is_empty() {
-            return;
+    /// Folds a fresh block in: advances the chain's tip and fans out to every destination that
+    /// can take it now; the rest catch up from storage when their turn comes.
+    fn on_block(&mut self, block: ExportedBlock, jobs: &mut FuturesUnordered<JobFuture>) {
+        #[cfg(with_metrics)]
+        {
+            metrics::QUEUE_SIZE.dec();
+            metrics::QUEUE_BYTES.sub(block.blob_bytes);
+            metrics::EXPORT_LATENCY
+                .finish_measurement(block.queued_at.elapsed().as_secs_f64() * 1000.0);
         }
-        // One at a time: a batch fails whole on the first bad address, and one unresolvable
-        // destination must not block reconnecting the others.
-        for (validator, address) in stuck {
+        let header = &block.certificate.block().header;
+        let (chain_id, height) = (header.chain_id, header.height);
+        if self.latest_epoch.is_none_or(|epoch| block.epoch > epoch) {
+            self.latest_epoch = Some(block.epoch);
+            self.committee = Some(block.committee.clone());
+        }
+        self.sync_destinations();
+
+        let now = Instant::now();
+        let tip = height.try_add_one().unwrap_or(BlockHeight::MAX);
+        let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
+            tip: BlockHeight::ZERO,
+            last_activity: now,
+            dests: BTreeMap::new(),
+        });
+        record.tip = record.tip.max(tip);
+        record.last_activity = now;
+        let validators = self.destinations.keys().copied().collect::<Vec<_>>();
+        for validator in validators {
+            let record = self.chains.get_mut(&chain_id).expect("inserted above");
+            let chain_dest = record.dests.entry(validator).or_default();
+            let dest = self
+                .destinations
+                .get_mut(&validator)
+                .expect("iterating destinations");
+            let contiguous = chain_dest.next_height == Some(height);
+            let can_send_now = !chain_dest.in_flight
+                && chain_dest.retry_at.is_none_or(|at| at <= now)
+                && dest.retry_at.is_none_or(|at| at <= now)
+                && dest.in_flight < dest.window;
+            if contiguous && can_send_now {
+                // The fast path: the block is already in memory and the destination is ready,
+                // so no storage read at all.
+                Self::spawn_job(
+                    jobs,
+                    &self.storage,
+                    &self.config,
+                    chain_id,
+                    validator,
+                    dest,
+                    chain_dest,
+                    record.tip,
+                    Some((block.certificate.clone(), block.blobs.clone())),
+                );
+            } else if !chain_dest.queued {
+                chain_dest.queued = true;
+                dest.ready.push_back(chain_id);
+                if can_send_now {
+                    Self::drain_ready(
+                        &mut self.chains,
+                        &self.storage,
+                        &self.config,
+                        validator,
+                        dest,
+                        jobs,
+                        now,
+                    );
+                }
+            }
+        }
+    }
+
+    /// Folds one finished send back into the destination's and the chain's state.
+    fn on_done(
+        &mut self,
+        (chain_id, validator, outcome): JobDone,
+        jobs: &mut FuturesUnordered<JobFuture>,
+    ) {
+        let now = Instant::now();
+        let Some(dest) = self.destinations.get_mut(&validator) else {
+            return; // The validator left the committee while its send was in flight.
+        };
+        dest.in_flight = dest.in_flight.saturating_sub(1);
+
+        if let Some(record) = self.chains.get_mut(&chain_id) {
+            record.last_activity = now;
+            if let Some(chain_dest) = record.dests.get_mut(&validator) {
+                chain_dest.in_flight = false;
+                match &outcome {
+                    SendOutcome::Reached(next_height) => {
+                        let advanced = chain_dest.next_height.is_none_or(|n| *next_height > n);
+                        chain_dest.next_height = Some(*next_height);
+                        if advanced {
+                            chain_dest.failures = 0;
+                            chain_dest.retry_at = None;
+                        } else if *next_height < record.tip {
+                            // Answered but moved nothing — a gap our storage cannot fill — so
+                            // back this pair off rather than spinning on it.
+                            back_off(
+                                &mut chain_dest.failures,
+                                &mut chain_dest.retry_at,
+                                now,
+                                &self.config,
+                            );
+                        }
+                        if let Ok(acked) = next_height.try_sub_one() {
+                            self.progress
+                                .lock()
+                                .expect("progress mutex is never poisoned")
+                                .entry(chain_id)
+                                .or_default()
+                                .insert(validator, acked);
+                        }
+                        dest.failures = 0;
+                        dest.retry_at = None;
+                        dest.window =
+                            (dest.window + 1).min(self.config.max_in_flight_per_destination);
+                    }
+                    SendOutcome::ChainScoped(error) => {
+                        debug!(
+                            %chain_id, %validator, %error,
+                            "Destination cannot accept this chain yet; backing the pair off",
+                        );
+                        chain_dest.next_height = None;
+                        back_off(
+                            &mut chain_dest.failures,
+                            &mut chain_dest.retry_at,
+                            now,
+                            &self.config,
+                        );
+                    }
+                    SendOutcome::DestinationScoped(error) => {
+                        warn!(
+                            validator = %dest.address, %chain_id, %error,
+                            "Failed to export to a validator; backing it off and re-resolving",
+                        );
+                        chain_dest.next_height = None;
+                        dest.window = (dest.window / 2).max(1);
+                        back_off(&mut dest.failures, &mut dest.retry_at, now, &self.config);
+                        // Re-resolve so a relayed transport draws the next proxy from the
+                        // rotation; the backoff above still applies if the validator itself is
+                        // the problem.
+                        match self
+                            .node_provider
+                            .make_nodes_from_list(iter::once((validator, dest.address.clone())))
+                        {
+                            Ok(mut nodes) => {
+                                if let Some((_, node)) = nodes.next() {
+                                    dest.node = node;
+                                }
+                            }
+                            Err(error) => {
+                                warn!(%validator, %error, "Cannot re-resolve a failing destination");
+                            }
+                        }
+                    }
+                }
+                #[cfg(with_metrics)]
+                metrics::DESTINATION_WINDOW
+                    .with_label_values(&[&dest.address])
+                    .observe(dest.window as f64);
+            }
+        }
+
+        let dest = self
+            .destinations
+            .get_mut(&validator)
+            .expect("checked above");
+        Self::drain_ready(
+            &mut self.chains,
+            &self.storage,
+            &self.config,
+            validator,
+            dest,
+            jobs,
+            now,
+        );
+    }
+
+    /// An idle moment: pick up committee changes from storage and requeue expired backoffs.
+    async fn tick(&mut self, jobs: &mut FuturesUnordered<JobFuture>) {
+        // Scan forward for committees this process has not seen via blocks — how a validator
+        // admitted while every chain is idle still becomes a destination.
+        let mut next = self
+            .latest_epoch
+            .map_or(0, |epoch| epoch.0.saturating_add(1));
+        while let Ok(Some(committee)) = self.storage.get_or_load_committee(Epoch(next)).await {
+            self.latest_epoch = Some(Epoch(next));
+            self.committee = Some(committee);
+            next = next.saturating_add(1);
+        }
+        self.sync_destinations();
+
+        // Forget chains that converged and stayed quiet past the retention window, so memory
+        // tracks recent and lagging chains rather than every chain ever seen. The grace window
+        // is what lets the chain's worker fold the final heights in before they vanish.
+        let now = Instant::now();
+        let retention = self.config.converged_chain_retention;
+        let progress = &self.progress;
+        self.chains.retain(|chain_id, record| {
+            let converged = !record.dests.is_empty()
+                && record.dests.values().all(|chain_dest| {
+                    !chain_dest.in_flight && chain_dest.next_height == Some(record.tip)
+                });
+            if converged && now.duration_since(record.last_activity) > retention {
+                progress
+                    .lock()
+                    .expect("progress mutex is never poisoned")
+                    .remove(chain_id);
+                false
+            } else {
+                true
+            }
+        });
+
+        // Requeue everything whose backoff expired and is still behind.
+        for (chain_id, record) in &mut self.chains {
+            for (validator, chain_dest) in &mut record.dests {
+                let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
+                if behind
+                    && !chain_dest.in_flight
+                    && !chain_dest.queued
+                    && chain_dest.retry_at.is_none_or(|at| at <= now)
+                {
+                    if let Some(dest) = self.destinations.get_mut(validator) {
+                        chain_dest.queued = true;
+                        dest.ready.push_back(*chain_id);
+                    }
+                }
+            }
+        }
+        let validators = self.destinations.keys().copied().collect::<Vec<_>>();
+        for validator in validators {
+            let dest = self
+                .destinations
+                .get_mut(&validator)
+                .expect("iterating destinations");
+            Self::drain_ready(
+                &mut self.chains,
+                &self.storage,
+                &self.config,
+                validator,
+                dest,
+                jobs,
+                now,
+            );
+        }
+    }
+
+    /// Brings the destination set in line with the latest committee: adds joiners, drops
+    /// leavers, and re-resolves a changed address.
+    fn sync_destinations(&mut self) {
+        let Some(committee) = &self.committee else {
+            return;
+        };
+        self.destinations.retain(|validator, dest| {
+            committee
+                .validators()
+                .get(validator)
+                .is_some_and(|state| state.network_address == dest.address)
+        });
+        for (validator, address) in committee.validator_addresses() {
+            if Some(validator) == self.own_public_key || self.destinations.contains_key(&validator)
+            {
+                continue;
+            }
+            // One at a time: a batch fails whole on the first bad address, and one unresolvable
+            // validator must not keep every other one out of the destination set.
             match self
                 .node_provider
                 .make_nodes_from_list(iter::once((validator, address)))
             {
-                Ok(nodes) => {
-                    if let (Some((_, node)), Some(destination)) = (
-                        nodes.into_iter().next(),
-                        self.destinations.get_mut(&validator),
-                    ) {
-                        destination.sender.remote_node.node = node;
+                Ok(mut nodes) => {
+                    if let Some((_, node)) = nodes.next() {
+                        self.destinations.insert(
+                            validator,
+                            DestState {
+                                node,
+                                address: address.to_owned(),
+                                in_flight: 0,
+                                window: self.config.max_in_flight_per_destination,
+                                retry_at: None,
+                                failures: 0,
+                                ready: VecDeque::new(),
+                            },
+                        );
                     }
                 }
                 Err(error) => {
-                    warn!(%validator, %error, "Cannot rebuild the connection to a lagging validator");
+                    warn!(
+                        %validator, %address, %error,
+                        "Cannot resolve a committee member to export blocks to; \
+                         continuing with the others",
+                    );
                 }
             }
         }
-    }
-
-    /// Pushes one bounded chunk of missing blocks to every destination that is behind.
-    ///
-    /// Runs only when nothing is queued, so live blocks always take priority over backfill.
-    async fn catch_up_round(&mut self) {
-        // The destination set stays as of the last exported block. That loses nothing: a chain's
-        // own committee only changes when the chain executes a block (`CreateCommittee` and
-        // `ProcessNewEpoch` both mutate it in the executing block), so there is no committee
-        // change for an idle chain to discover.
-        self.refresh_stuck_destinations();
-        let now = Instant::now();
-        let (config, chain_id, target) = (&self.config, self.chain_id, self.chain_next_height);
-        let results = future::join_all(
-            self.destinations
-                .iter_mut()
-                .filter(|(_, destination)| destination.is_behind(target) && destination.is_due(now))
-                .map(|(validator, destination)| async move {
-                    (
-                        *validator,
-                        destination.catch_up(chain_id, target, now, config).await,
-                    )
-                }),
-        )
-        .await;
-        self.record_progress(results);
-    }
-
-    /// Pushes one block to every destination, concurrently, and records how far each got.
-    async fn export(&mut self, block: ExportedBlock) {
-        self.chain_next_height = block
-            .certificate
-            .block()
-            .header
-            .height
-            .try_add_one()
-            .unwrap_or(BlockHeight::MAX);
-        self.sync_destinations(&block);
-
-        // Push to every destination concurrently, but only move on to the next block once they
-        // have all answered: that is what gives each destination the blocks of this chain in
-        // height order.
-        let now = Instant::now();
-        let (config, block) = (&self.config, &block);
-        let results = future::join_all(self.destinations.iter_mut().map(
-            |(validator, destination)| async move {
-                (*validator, destination.send(block, now, config).await)
-            },
-        ))
-        .await;
-
-        self.record_progress(results);
-    }
-
-    /// Records how far each destination acknowledged, for the worker to persist on its next save.
-    /// These are heights the validators reported themselves, so one that could not close its gap
-    /// keeps a low cursor and is picked up again next round.
-    fn record_progress(&self, results: Vec<(ValidatorPublicKey, Option<BlockHeight>)>) {
-        let mut progress = self
-            .progress
-            .lock()
-            .expect("progress mutex is never poisoned");
-        for (validator, next_height) in results {
-            if let Some(Ok(height)) = next_height.map(BlockHeight::try_sub_one) {
-                progress.insert(validator, height);
-            }
-        }
-    }
-
-    /// Brings the destination set in line with the block's committee: adds validators that joined,
-    /// drops those that left, and re-creates a node whose address changed.
-    fn sync_destinations(&mut self, block: &ExportedBlock) {
-        self.sync_destinations_with(&block.committee);
-    }
-
-    /// Adds destinations for validators in `committee` we do not have, and drops those that have
-    /// left it or changed address.
-    fn sync_destinations_with(&mut self, committee: &Committee) {
-        self.destinations.retain(|validator, destination| {
-            committee
-                .validators()
-                .get(validator)
-                .is_some_and(|state| state.network_address == destination.address)
+        // A validator that left takes its cursors with it.
+        self.chains.retain(|_, record| {
+            record
+                .dests
+                .retain(|validator, _| self.destinations.contains_key(validator));
+            true
         });
+    }
+}
 
-        // A destination whose last push failed may be stuck behind a dead proxy, so rebuild its
-        // node alongside any validator we do not have yet.
-        let stuck = self
-            .destinations
-            .iter()
-            .filter(|(_, destination)| destination.failures > 0)
-            .map(|(validator, _)| *validator)
-            .collect::<Vec<_>>();
+/// The result of one send job: which pair it was for, and how it went.
+type JobDone = (ChainId, ValidatorPublicKey, SendOutcome);
 
-        let missing = committee
-            .validator_addresses()
-            .filter(|(validator, _)| {
-                Some(*validator) != self.own_public_key
-                    && (!self.destinations.contains_key(validator) || stuck.contains(validator))
-            })
-            .map(|(validator, address)| (validator, address.to_owned()))
-            .collect::<Vec<_>>();
-        if missing.is_empty() {
+/// One send in flight, boxed so jobs from different call sites share a queue.
+#[cfg(not(web))]
+type JobFuture = futures::future::BoxFuture<'static, JobDone>;
+#[cfg(web)]
+type JobFuture = futures::future::LocalBoxFuture<'static, JobDone>;
+
+impl<S, P> BlockExportQueue<S, P>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    P: ValidatorNodeProvider,
+    P::Node: Clone + Send + 'static,
+{
+    /// Starts one send for `(chain_id, validator)`: the held block when contiguous, catch-up
+    /// from storage otherwise.
+    #[expect(clippy::too_many_arguments)]
+    fn spawn_job(
+        jobs: &mut FuturesUnordered<JobFuture>,
+        storage: &S,
+        config: &BlockExportConfig,
+        chain_id: ChainId,
+        validator: ValidatorPublicKey,
+        dest: &mut DestState<P::Node>,
+        chain_dest: &mut ChainDest,
+        target: BlockHeight,
+        live: Option<(CacheArc<ConfirmedBlockCertificate>, Vec<CacheArc<Blob>>)>,
+    ) {
+        chain_dest.in_flight = true;
+        chain_dest.queued = false;
+        dest.in_flight += 1;
+        let mut sender = BlockSender {
+            remote_node: RemoteNode {
+                public_key: validator,
+                node: dest.node.clone(),
+            },
+            storage: storage.clone(),
+            certificate_upload_batch_size: config.certificate_upload_batch_size,
+        };
+        let cursor = chain_dest.next_height;
+        let max_catch_up = config.max_catch_up_blocks;
+        #[cfg(with_metrics)]
+        let address = dest.address.clone();
+        let job = async move {
+            #[cfg(with_metrics)]
+            let send_latency = metrics::SEND_LATENCY.with_label_values(&[&address]);
+            #[cfg(with_metrics)]
+            let _latency = send_latency.measure_latency();
+            #[cfg(with_metrics)]
+            metrics::DESTINATION_LAG
+                .with_label_values(&[&address])
+                .observe(match cursor {
+                    Some(next) => target.0.saturating_sub(next.0) as f64,
+                    None => 1.0,
+                });
+            let result = match live {
+                Some((certificate, blobs)) => {
+                    sender
+                        .send_block(&certificate, &blobs, cursor, max_catch_up)
+                        .await
+                }
+                None => {
+                    sender
+                        .send_missing_blocks(chain_id, target, cursor, max_catch_up)
+                        .await
+                }
+            };
+            let outcome = match result {
+                Ok(next_height) => SendOutcome::Reached(next_height),
+                Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(error),
+                Err(error) => SendOutcome::DestinationScoped(error),
+            };
+            (chain_id, validator, outcome)
+        };
+        #[cfg(not(web))]
+        jobs.push(job.boxed());
+        #[cfg(web)]
+        jobs.push(job.boxed_local());
+    }
+
+    /// Starts catch-up sends from this destination's ready list until its window is full.
+    fn drain_ready(
+        chains: &mut HashMap<ChainId, ChainRecord>,
+        storage: &S,
+        config: &BlockExportConfig,
+        validator: ValidatorPublicKey,
+        dest: &mut DestState<P::Node>,
+        jobs: &mut FuturesUnordered<JobFuture>,
+        now: Instant,
+    ) {
+        if dest.retry_at.is_some_and(|at| at > now) {
             return;
         }
-
-        // One at a time: resolving as a batch fails the whole batch on the first bad address,
-        // which would stop this chain exporting to *any* validator, on every later block.
-        let nodes = missing
-            .into_iter()
-            .filter_map(|(validator, address)| {
-                match self
-                    .node_provider
-                    .make_nodes_from_list(iter::once((validator, address.clone())))
-                {
-                    Ok(nodes) => nodes.into_iter().next(),
-                    Err(error) => {
-                        warn!(
-                            %validator, %address, %error,
-                            "Cannot reach a committee member to export blocks to; \
-                             continuing with the others",
-                        );
-                        None
-                    }
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let acknowledged = self
-            .progress
-            .lock()
-            .expect("progress mutex is never poisoned")
-            .clone();
-        for (validator, node) in nodes {
-            let Some(address) = committee
-                .validators()
-                .get(&validator)
-                .map(|state| state.network_address.clone())
-            else {
+        while dest.in_flight < dest.window {
+            let Some(chain_id) = dest.ready.pop_front() else {
+                return;
+            };
+            let Some(record) = chains.get_mut(&chain_id) else {
+                continue; // Converged and dropped while queued.
+            };
+            let Some(chain_dest) = record.dests.get_mut(&validator) else {
                 continue;
             };
-            let sender = BlockSender {
-                remote_node: RemoteNode {
-                    public_key: validator,
-                    node,
-                },
-                storage: self.storage.clone(),
-                certificate_upload_batch_size: self.config.certificate_upload_batch_size,
-            };
-            // Rebuilding a stuck destination keeps its failure count and retry time: only the
-            // connection is replaced, so a validator that is itself down keeps backing off.
-            let previous = self.destinations.remove(&validator);
-            self.destinations.insert(
-                validator,
-                Destination {
-                    sender,
-                    address,
-                    // An acknowledged height was reported by the validator itself, so the block
-                    // after it is the one the validator needs next.
-                    next_height: acknowledged
-                        .get(&validator)
-                        .map(|height| BlockHeight(height.0.saturating_add(1))),
-                    retry_at: previous.as_ref().and_then(|d| d.retry_at),
-                    failures: previous.map_or(0, |d| d.failures),
-                },
+            chain_dest.queued = false;
+            let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
+            if chain_dest.in_flight || !behind || chain_dest.retry_at.is_some_and(|at| at > now) {
+                continue; // The tick that queued it has been overtaken; it requeues if needed.
+            }
+            Self::spawn_job(
+                jobs, storage, config, chain_id, validator, dest, chain_dest, record.tip, None,
             );
         }
     }
 }
 
-impl<S, N> Destination<S, N>
-where
-    S: Storage + Clone + 'static,
-    N: ValidatorNode + Clone + 'static,
-{
-    /// Pushes the block, along with any earlier ones this validator is missing, and returns the
-    /// validator's next block height afterwards — or `None` if it was skipped or failed.
-    async fn send(
-        &mut self,
-        block: &ExportedBlock,
-        now: Instant,
-        config: &BlockExportConfig,
-    ) -> Option<BlockHeight> {
-        if self.retry_at.is_some_and(|retry_at| now < retry_at) {
-            return None;
-        }
+/// Whether this failure is about one chain rather than about the destination. `EventsNotFound`
+/// is the destination lacking a committee — the admin chain's export fixes that, and must not be
+/// throttled by it; the others are gaps on our own side.
+fn is_chain_scoped(error: &chain_client::Error) -> bool {
+    matches!(
+        error,
+        chain_client::Error::RemoteNodeError(
+            NodeError::EventsNotFound(_)
+                | NodeError::BlobsNotFound(_)
+                | NodeError::InactiveChain(_)
+        ) | chain_client::Error::ReadCertificatesError(_)
+    )
+}
 
-        #[cfg(with_metrics)]
-        let send_latency = metrics::SEND_LATENCY.with_label_values(&[&self.address]);
-        #[cfg(with_metrics)]
-        let _latency = send_latency.measure_latency();
-        #[cfg(with_metrics)]
-        metrics::DESTINATION_LAG
-            .with_label_values(&[&self.address])
-            .observe(self.lag(block) as f64);
-
-        let height = block.certificate.block().header.height;
-        let result = self
-            .sender
-            .send_block(
-                &block.certificate,
-                &block.blobs,
-                self.next_height,
-                config.max_catch_up_blocks,
-            )
-            .await;
-        self.record_outcome(result, height, now, config)
-    }
-
-    /// Whether this destination is, as far as we know, below `target`. An unknown height counts
-    /// as behind: that is what a failed send leaves, and assuming otherwise strands it silently.
-    fn is_behind(&self, target: BlockHeight) -> bool {
-        self.next_height.is_none_or(|next| next < target)
-    }
-
-    /// Whether this destination's backoff, if any, has expired.
-    fn is_due(&self, now: Instant) -> bool {
-        self.retry_at.is_none_or(|retry_at| retry_at <= now)
-    }
-
-    /// Pushes one bounded chunk of the blocks this validator is missing below `target`, so one
-    /// that joined partway through a long chain converges without waiting for new blocks.
-    async fn catch_up(
-        &mut self,
-        chain_id: ChainId,
-        target: BlockHeight,
-        now: Instant,
-        config: &BlockExportConfig,
-    ) -> Option<BlockHeight> {
-        #[cfg(with_metrics)]
-        let send_latency = metrics::SEND_LATENCY.with_label_values(&[&self.address]);
-        #[cfg(with_metrics)]
-        let _latency = send_latency.measure_latency();
-
-        let previous = self.next_height;
-        let failures_before = self.failures;
-        let result = self
-            .sender
-            .send_missing_blocks(
-                chain_id,
-                target,
-                self.next_height,
-                config.max_catch_up_blocks,
-            )
-            .await;
-        let outcome = self.record_outcome(result, target, now, config);
-
-        // A round can succeed and advance nothing, since a chain we merely receive from is
-        // stored only at its message-bearing blocks; without backing off, a destination we can
-        // never finish would spin the task. Success only: `record_outcome` handles failures.
-        // Restore the pre-success failure count first — `record_outcome` just reset it, and a
-        // backoff computed from zero would never escalate past the base delay.
-        if let Some(reached) = outcome {
-            let advanced = previous.is_none_or(|before| reached > before);
-            if !advanced {
-                self.failures = failures_before;
-                self.back_off(now, config);
-            }
-        }
-        outcome
-    }
-
-    /// Folds the outcome of a push into this destination's cursor and backoff.
-    fn record_outcome(
-        &mut self,
-        result: Result<BlockHeight, crate::client::chain_client::Error>,
-        height: BlockHeight,
-        now: Instant,
-        config: &BlockExportConfig,
-    ) -> Option<BlockHeight> {
-        match result {
-            Ok(next_height) => {
-                self.next_height = Some(next_height);
-                self.retry_at = None;
-                self.failures = 0;
-                Some(next_height)
-            }
-            Err(error) => {
-                warn!(
-                    validator = %self.address, %height, %error,
-                    "Failed to export block; will query the validator before the next push",
-                );
-                // Forget the cursor: the next push must ask what this validator actually has
-                // rather than assume the block we just failed to send arrived.
-                self.next_height = None;
-                self.back_off(now, config);
-                None
-            }
-        }
-    }
-
-    /// Holds this destination off for a growing interval, capped by the configured maximum.
-    fn back_off(&mut self, now: Instant, config: &BlockExportConfig) {
-        let backoff = config
-            .retry_delay
-            .saturating_mul(1u32.checked_shl(self.failures).unwrap_or(u32::MAX))
-            .min(config.max_retry_delay);
-        self.retry_at = Some(now + backoff);
-        self.failures = self.failures.saturating_add(1);
-    }
-
-    /// How many blocks this validator is believed to be missing before the block being pushed.
-    #[cfg(with_metrics)]
-    fn lag(&self, block: &ExportedBlock) -> u64 {
-        let height = block.certificate.block().header.height;
-        match self.next_height {
-            Some(next_height) => height.0.saturating_sub(next_height.0),
-            // We have no cursor, so we are about to query; report the gap as unknown-but-nonzero.
-            None => 1,
-        }
-    }
+/// Escalating backoff shared by both scopes: doubles from `retry_delay` per consecutive failure,
+/// capped at `max_retry_delay`.
+fn back_off(
+    failures: &mut u32,
+    retry_at: &mut Option<Instant>,
+    now: Instant,
+    config: &BlockExportConfig,
+) {
+    let backoff = config
+        .retry_delay
+        .saturating_mul(1u32.checked_shl(*failures).unwrap_or(u32::MAX))
+        .min(config.max_retry_delay);
+    *retry_at = Some(now + backoff);
+    *failures = failures.saturating_add(1);
 }
 
 /// Sends this validator's blocks to one other validator, reading everything it needs from
@@ -871,6 +1106,14 @@ mod tests {
                 ..BlockExportConfig::default()
             },
             BlockExportConfig {
+                queue_size: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                max_in_flight_per_destination: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
                 max_catch_up_blocks: 0,
                 ..BlockExportConfig::default()
             },
@@ -891,9 +1134,41 @@ mod tests {
                 max_retry_delay: Duration::from_secs(60),
                 ..BlockExportConfig::default()
             },
+            BlockExportConfig {
+                converged_chain_retention: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
         ];
         for config in invalid {
             assert!(config.check().is_err(), "accepted: {config:?}");
         }
+    }
+
+    /// The backoff must escalate across consecutive failures — computing it from a reset counter
+    /// is how it once retried a hopeless destination at the base delay forever.
+    #[test]
+    fn back_off_escalates_and_caps() {
+        let config = BlockExportConfig {
+            retry_delay: Duration::from_millis(100),
+            max_retry_delay: Duration::from_millis(450),
+            ..BlockExportConfig::default()
+        };
+        let mut failures = 0;
+        let mut retry_at = None;
+        let now = Instant::now();
+        let mut delays = Vec::new();
+        for _ in 0..4 {
+            back_off(&mut failures, &mut retry_at, now, &config);
+            delays.push(retry_at.expect("set by back_off") - now);
+        }
+        assert_eq!(
+            delays,
+            [
+                Duration::from_millis(100),
+                Duration::from_millis(200),
+                Duration::from_millis(400),
+                Duration::from_millis(450),
+            ],
+        );
     }
 }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -19,6 +19,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
+    iter,
     sync::{Arc, Mutex},
 };
 
@@ -212,6 +213,11 @@ struct ExportedBlock {
     /// The chain carrying the epoch events, needed when a destination does not yet know the
     /// committee that signed the certificate.
     admin_chain_id: ChainId,
+    /// When the worker queued this block, so that `EXPORT_LATENCY` covers the wait as well as
+    /// the sending. The queue is where the delay shows up once export falls behind, which is
+    /// exactly when the metric is worth reading.
+    #[cfg(with_metrics)]
+    queued_at: Instant,
 }
 
 /// The chain worker's end of its export task.
@@ -241,6 +247,8 @@ impl ChainExporter {
             blobs,
             committee,
             admin_chain_id,
+            #[cfg(with_metrics)]
+            queued_at: Instant::now(),
         };
         match self.blocks.send(block) {
             Ok(()) => {
@@ -365,8 +373,11 @@ where
                     #[cfg(with_metrics)]
                     metrics::QUEUE_SIZE.dec();
                     #[cfg(with_metrics)]
-                    let _latency = metrics::EXPORT_LATENCY.measure_latency();
+                    let queued_at = block.queued_at;
                     self.export(block).await;
+                    #[cfg(with_metrics)]
+                    metrics::EXPORT_LATENCY
+                        .finish_measurement(queued_at.elapsed().as_secs_f64() * 1000.0);
                 }
                 // The chain worker dropped its end.
                 Ok(None) => break,
@@ -550,15 +561,29 @@ where
             return;
         }
 
-        let nodes = match self.node_provider.make_nodes_from_list(missing) {
-            Ok(nodes) => nodes.collect::<Vec<_>>(),
-            Err(error) => {
-                // Leaves the destinations we already have untouched, and tries again on the next
-                // block; a committee we cannot resolve at all is a configuration problem.
-                warn!(%error, "Cannot reach the committee to export blocks to");
-                return;
-            }
-        };
+        // One validator at a time, because resolving them as a batch fails the whole batch on the
+        // first bad address: a single malformed committee entry would then stop this chain
+        // exporting to *any* validator, and would keep doing so on every later block. The
+        // validators we can reach are worth reaching even when one of them is misconfigured.
+        let nodes = missing
+            .into_iter()
+            .filter_map(|(validator, address)| {
+                match self
+                    .node_provider
+                    .make_nodes_from_list(iter::once((validator, address.clone())))
+                {
+                    Ok(nodes) => nodes.into_iter().next(),
+                    Err(error) => {
+                        warn!(
+                            %validator, %address, %error,
+                            "Cannot reach a committee member to export blocks to; \
+                             continuing with the others",
+                        );
+                        None
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
 
         let acknowledged = self
             .progress

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -48,7 +48,7 @@ use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{Blob, BlockHeight, Epoch},
-    identifiers::{BlobId, ChainId, EventId, StreamId},
+    identifiers::{BlobId, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
 };
 use linera_chain::types::ConfirmedBlockCertificate;
@@ -314,13 +314,19 @@ impl BlockExportHandle {
         }
         let blob_bytes = blobs.iter().map(|blob| blob.bytes().len()).sum::<usize>();
         // The byte budget is enforced, not merely measured: a block count alone would let a few
-        // blob-heavy blocks pin memory far past the cache's own bounds.
-        let queued = self.queued_bytes.load(std::sync::atomic::Ordering::Relaxed);
-        if queued.saturating_add(blob_bytes) > self.queue_bytes_budget {
+        // blob-heavy blocks pin memory far past the cache's own bounds. Reserved *before* the
+        // send: incrementing after `try_send` would let the queue task's decrement run first and
+        // wrap the counter, spuriously exhausting the budget for every concurrent caller.
+        let prior = self
+            .queued_bytes
+            .fetch_add(blob_bytes, std::sync::atomic::Ordering::Relaxed);
+        if prior.saturating_add(blob_bytes) > self.queue_bytes_budget {
+            self.queued_bytes
+                .fetch_sub(blob_bytes, std::sync::atomic::Ordering::Relaxed);
             debug!(
                 chain_id = %certificate.block().header.chain_id,
                 height = %certificate.block().header.height,
-                queued, blob_bytes,
+                queued = prior, blob_bytes,
                 "Export queue byte budget exhausted; dropping the block for catch-up to re-send",
             );
             #[cfg(with_metrics)]
@@ -338,8 +344,6 @@ impl BlockExportHandle {
         };
         match self.blocks.try_send(block) {
             Ok(()) => {
-                self.queued_bytes
-                    .fetch_add(blob_bytes, std::sync::atomic::Ordering::Relaxed);
                 #[cfg(with_metrics)]
                 {
                     metrics::QUEUE_SIZE.inc();
@@ -347,6 +351,8 @@ impl BlockExportHandle {
                 }
             }
             Err(mpsc::error::TrySendError::Full(block)) => {
+                self.queued_bytes
+                    .fetch_sub(blob_bytes, std::sync::atomic::Ordering::Relaxed);
                 debug!(
                     chain_id = %block.certificate.block().header.chain_id,
                     height = %block.certificate.block().header.height,
@@ -356,6 +362,8 @@ impl BlockExportHandle {
                 metrics::DROPPED_BLOCKS.inc();
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.queued_bytes
+                    .fetch_sub(blob_bytes, std::sync::atomic::Ordering::Relaxed);
                 warn!("Block export queue stopped unexpectedly; blocks are no longer exported");
             }
         }
@@ -422,6 +430,7 @@ where
         chains: HashMap::new(),
         destinations: HashMap::new(),
         next_generation: 0,
+        announced_epoch: None,
         destinations_changed: false,
         queued_bytes: queued_bytes.clone(),
         progress: progress.clone(),
@@ -457,7 +466,10 @@ struct ChainDest {
     /// The next height the destination needs, or `None` when we have to ask it — before the
     /// first push, and after any failed one.
     next_height: Option<BlockHeight>,
-    in_flight: bool,
+    /// The destination generation of the send currently running for this pair, if any. Carrying
+    /// the generation is what stops a stale job's completion from clearing a *newer* job's flag
+    /// and breaking the one-send-per-pair ordering invariant.
+    in_flight: Option<u64>,
     /// Whether this chain already sits in the destination's ready list, to keep it there once.
     queued: bool,
     /// Backoff for *chain-scoped* failures — the destination is healthy but cannot accept this
@@ -521,6 +533,9 @@ where
     destinations: HashMap<ValidatorPublicKey, DestState<P::Node>>,
     /// The last destination generation handed out; never reused within this queue's lifetime.
     next_generation: u64,
+    /// The newest epoch any exported block has announced; the tick loads its committee when it
+    /// is ahead of `latest_epoch`.
+    announced_epoch: Option<Epoch>,
     /// Set when `sync_destinations` changed the set, so the per-record cursor fill runs once
     /// per change instead of once per tick.
     destinations_changed: bool,
@@ -585,7 +600,7 @@ where
             };
             match wake {
                 Wake::Done(done) => self.on_done(done, &mut jobs),
-                Wake::Block(Some(block)) => self.on_block(block, &mut jobs).await,
+                Wake::Block(Some(block)) => self.on_block(block, &mut jobs),
                 Wake::Block(None) => break,
                 Wake::Tick => {
                     self.tick(&mut jobs).await;
@@ -604,7 +619,7 @@ where
 
     /// Folds a fresh block in: advances the chain's tip and fans out to every destination that
     /// can take it now; the rest catch up from storage when their turn comes.
-    async fn on_block(&mut self, block: ExportedBlock, jobs: &mut FuturesUnordered<JobFuture>) {
+    fn on_block(&mut self, block: ExportedBlock, jobs: &mut FuturesUnordered<JobFuture>) {
         self.queued_bytes
             .fetch_sub(block.blob_bytes, std::sync::atomic::Ordering::Relaxed);
         #[cfg(with_metrics)]
@@ -616,22 +631,11 @@ where
         }
         let header = &block.certificate.block().header;
         let (chain_id, height) = (header.chain_id, header.height);
-        if self.latest_epoch.is_none_or(|epoch| block.epoch > epoch) {
-            // The block only carries the epoch; the committee itself comes from storage, where
-            // the chain that executed under it has already stored the event and blob.
-            match self.storage.get_or_load_committee(block.epoch).await {
-                Ok(Some(committee)) => {
-                    self.latest_epoch = Some(block.epoch);
-                    self.committee = Some(committee);
-                    self.committee_dirty = true;
-                }
-                Ok(None) => {
-                    debug!(epoch = %block.epoch, "Cannot load the committee for an exported block");
-                }
-                Err(error) => {
-                    debug!(%error, epoch = %block.epoch, "Cannot load a committee from storage");
-                }
-            }
+        // Only recorded here: loading the committee reads storage, and an await in this handler
+        // stalls every in-flight send — the tick's scan does the loading.
+        if block.epoch > self.announced_epoch.unwrap_or(Epoch(0)) || self.announced_epoch.is_none()
+        {
+            self.announced_epoch = Some(block.epoch);
         }
         // Per committee change, not per block: the rebuild walks every tracked chain.
         if self.committee_dirty || self.destinations.is_empty() {
@@ -668,7 +672,7 @@ where
                 .get_mut(&validator)
                 .expect("iterating destinations");
             let contiguous = chain_dest.next_height == Some(height);
-            let can_send_now = !chain_dest.in_flight
+            let can_send_now = chain_dest.in_flight.is_none()
                 && chain_dest.retry_at.is_none_or(|at| at <= now)
                 && dest.retry_at.is_none_or(|at| at <= now)
                 && dest.in_flight < dest.window;
@@ -722,7 +726,10 @@ where
                 .get_mut(&chain_id)
                 .and_then(|record| record.dests.get_mut(&validator))
             {
-                chain_dest.in_flight = false;
+                // Only the flag this very job set — the pair may since carry a newer job's.
+                if chain_dest.in_flight == Some(generation) {
+                    chain_dest.in_flight = None;
+                }
             }
             return;
         }
@@ -772,7 +779,9 @@ where
         if let Some(record) = self.chains.get_mut(&chain_id) {
             record.last_activity = now;
             if let Some(chain_dest) = record.dests.get_mut(&validator) {
-                chain_dest.in_flight = false;
+                if chain_dest.in_flight == Some(generation) {
+                    chain_dest.in_flight = None;
+                }
                 match &outcome {
                     SendOutcome::Reached(next_height) => {
                         let advanced = chain_dest.next_height.is_none_or(|n| *next_height > n);
@@ -833,7 +842,7 @@ where
             let tip = record.tip;
             if let Some(chain_dest) = record.dests.get_mut(&validator) {
                 let behind = chain_dest.next_height.is_none_or(|next| next < tip);
-                if behind && !chain_dest.queued && !chain_dest.in_flight {
+                if behind && !chain_dest.queued && chain_dest.in_flight.is_none() {
                     chain_dest.queued = true;
                     dest.ready.push_back(chain_id);
                 }
@@ -856,7 +865,10 @@ where
         // Occasionally scan storage for committees no block has carried — how a validator
         // admitted while every chain is idle still becomes a destination. On its own cadence
         // because the probe reads storage, and ticks now fire even under load.
-        if self.ticks_until_scan == 0 {
+        let announced_newer = self
+            .announced_epoch
+            .is_some_and(|epoch| self.latest_epoch.is_none_or(|latest| epoch > latest));
+        if self.ticks_until_scan == 0 || announced_newer {
             self.ticks_until_scan = TICKS_PER_COMMITTEE_SCAN;
             self.scan_committees().await;
         } else {
@@ -878,6 +890,12 @@ where
                 dests: BTreeMap::new(),
             });
             record.tip = record.tip.max(tip);
+            // A record born here — its block was dropped — must get its cursors immediately:
+            // the destination-change fill below cannot be relied on for it, and a record with no
+            // cursors is invisible to the requeue and immortal to the sweep.
+            for validator in self.destinations.keys() {
+                record.dests.entry(*validator).or_default();
+            }
         }
         // When the destination set changed, every destination gets a cursor on every tracked
         // chain, so a validator that joined after a chain's last block is still caught up on it.
@@ -905,7 +923,7 @@ where
                     // `>=`: a destination is routinely *ahead* of our tip — the client
                     // broadcasts to everyone — and ahead must count as done, not as never
                     // converging.
-                    !chain_dest.in_flight
+                    chain_dest.in_flight.is_none()
                         && chain_dest
                             .next_height
                             .is_some_and(|next| next >= record.tip)
@@ -933,7 +951,7 @@ where
             for (validator, chain_dest) in &mut record.dests {
                 let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
                 if behind
-                    && !chain_dest.in_flight
+                    && chain_dest.in_flight.is_none()
                     && !chain_dest.queued
                     && chain_dest.retry_at.is_none_or(|at| at <= now)
                 {
@@ -962,8 +980,9 @@ where
         }
     }
 
-    /// Scans storage forward for committees newer than any block has announced, probing the
-    /// epoch event directly so a missing next epoch — the steady state — stays silent.
+    /// Scans storage for committees newer than the one in use, by listing the admin chain's
+    /// epoch events from the frontier — one bulk read, immune to holes in the history, and
+    /// silent when nothing is new.
     async fn scan_committees(&mut self) {
         if self.admin_chain_id.is_none() {
             self.admin_chain_id = match self.storage.read_network_description().await {
@@ -978,38 +997,42 @@ where
         let Some(admin_chain_id) = self.admin_chain_id else {
             return;
         };
-        loop {
-            let next = self
-                .latest_epoch
-                .map_or(0, |epoch| epoch.0.saturating_add(1));
-            let event_present = if next == 0 {
-                // Epoch 0 comes from the genesis blob, not an event; only `get_or_load` knows.
-                Ok(true)
-            } else {
-                self.storage
-                    .read_event(EventId {
-                        chain_id: admin_chain_id,
-                        stream_id: StreamId::system(EPOCH_STREAM_NAME),
-                        index: next,
-                    })
-                    .await
-                    .map(|found| found.is_some())
-            };
-            match event_present {
-                Ok(true) => match self.storage.get_or_load_committee(Epoch(next)).await {
-                    Ok(Some(committee)) => {
-                        self.latest_epoch = Some(Epoch(next));
-                        self.committee = Some(committee);
-                        self.committee_dirty = true;
-                    }
-                    Ok(None) | Err(_) => return,
-                },
-                Ok(false) => return,
-                Err(error) => {
-                    debug!(%error, "Cannot probe for a new committee");
-                    return;
-                }
+        let start = self
+            .latest_epoch
+            .map_or(0, |epoch| epoch.0.saturating_add(1));
+        let newest = if start == 0 {
+            // Epoch 0 comes from the genesis blob, not an event.
+            Some(Epoch(0))
+        } else {
+            None
+        };
+        let newest = match self
+            .storage
+            .read_events_from_index(&admin_chain_id, &StreamId::system(EPOCH_STREAM_NAME), start)
+            .await
+        {
+            // A committee lists the full validator set, so only the newest loadable one matters.
+            Ok(events) => events
+                .into_iter()
+                .map(|event| Epoch(event.index))
+                .max()
+                .or(newest),
+            Err(error) => {
+                debug!(%error, "Cannot list epoch events to scan for committees");
+                return;
             }
+        };
+        let Some(epoch) = newest else {
+            return;
+        };
+        match self.storage.get_or_load_committee(epoch).await {
+            Ok(Some(committee)) => {
+                self.latest_epoch = Some(epoch);
+                self.committee = Some(committee);
+                self.committee_dirty = true;
+            }
+            Ok(None) => debug!(%epoch, "An epoch event exists but its committee cannot load"),
+            Err(error) => debug!(%error, %epoch, "Cannot load a committee from storage"),
         }
     }
 
@@ -1127,10 +1150,10 @@ where
         target: BlockHeight,
         live: Option<(CacheArc<ConfirmedBlockCertificate>, Vec<CacheArc<Blob>>)>,
     ) {
-        chain_dest.in_flight = true;
+        let generation = dest.generation;
+        chain_dest.in_flight = Some(generation);
         chain_dest.queued = false;
         dest.in_flight += 1;
-        let generation = dest.generation;
         let mut sender = BlockSender {
             remote_node: RemoteNode {
                 public_key: validator,
@@ -1205,7 +1228,10 @@ where
             };
             chain_dest.queued = false;
             let behind = chain_dest.next_height.is_none_or(|next| next < record.tip);
-            if chain_dest.in_flight || !behind || chain_dest.retry_at.is_some_and(|at| at > now) {
+            if chain_dest.in_flight.is_some()
+                || !behind
+                || chain_dest.retry_at.is_some_and(|at| at > now)
+            {
                 continue; // The tick that queued it has been overtaken; it requeues if needed.
             }
             Self::spawn_job(
@@ -1429,6 +1455,10 @@ mod tests {
             },
             BlockExportConfig {
                 queue_size: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                queue_bytes: 0,
                 ..BlockExportConfig::default()
             },
             BlockExportConfig {

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -431,6 +431,7 @@ where
         destinations: HashMap::new(),
         next_generation: 0,
         announced_epoch: None,
+        scan_attempted_for: None,
         destinations_changed: false,
         queued_bytes: queued_bytes.clone(),
         progress: progress.clone(),
@@ -458,6 +459,25 @@ struct ChainRecord {
     /// When this chain last saw a block or a completed send, for the convergence sweep.
     last_activity: Instant,
     dests: BTreeMap<ValidatorPublicKey, ChainDest>,
+}
+
+impl ChainRecord {
+    /// Starts a record with a cursor for every current destination.
+    ///
+    /// Seeding here rather than at the call sites is what makes the empty-cursor state
+    /// unrepresentable: a record with no cursors is invisible to the requeue loop and trivially
+    /// "converged" to the sweep, so such a chain would be abandoned in silence. One creation
+    /// path used to miss the seeding, and nothing in the suite could see it.
+    fn new<N>(now: Instant, destinations: &HashMap<ValidatorPublicKey, DestState<N>>) -> Self {
+        ChainRecord {
+            tip: BlockHeight::ZERO,
+            last_activity: now,
+            dests: destinations
+                .keys()
+                .map(|validator| (*validator, ChainDest::default()))
+                .collect(),
+        }
+    }
 }
 
 /// One chain's cursor at one destination.
@@ -536,6 +556,9 @@ where
     /// The newest epoch any exported block has announced; the tick loads its committee when it
     /// is ahead of `latest_epoch`.
     announced_epoch: Option<Epoch>,
+    /// The announcement the eager scan last acted on, so one that fails to load is retried on
+    /// the normal cadence rather than on every tick.
+    scan_attempted_for: Option<Epoch>,
     /// Set when `sync_destinations` changed the set, so the per-record cursor fill runs once
     /// per change instead of once per tick.
     destinations_changed: bool,
@@ -633,7 +656,9 @@ where
         let (chain_id, height) = (header.chain_id, header.height);
         // Only recorded here: loading the committee reads storage, and an await in this handler
         // stalls every in-flight send — the tick's scan does the loading.
-        if block.epoch > self.announced_epoch.unwrap_or(Epoch(0)) || self.announced_epoch.is_none()
+        if self
+            .announced_epoch
+            .is_none_or(|announced| block.epoch > announced)
         {
             self.announced_epoch = Some(block.epoch);
         }
@@ -644,11 +669,10 @@ where
 
         let now = Instant::now();
         let tip = height.try_add_one().unwrap_or(BlockHeight::MAX);
-        let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
-            tip: BlockHeight::ZERO,
-            last_activity: now,
-            dests: BTreeMap::new(),
-        });
+        let record = self
+            .chains
+            .entry(chain_id)
+            .or_insert_with(|| ChainRecord::new(now, &self.destinations));
         record.tip = record.tip.max(tip);
         record.last_activity = now;
         // Seed *missing* pairs from what the chain last persisted — on every block, not only at
@@ -865,11 +889,17 @@ where
         // Occasionally scan storage for committees no block has carried — how a validator
         // admitted while every chain is idle still becomes a destination. On its own cadence
         // because the probe reads storage, and ticks now fire even under load.
-        let announced_newer = self
-            .announced_epoch
-            .is_some_and(|epoch| self.latest_epoch.is_none_or(|latest| epoch > latest));
+        // Eagerly, but at most once per announced epoch: a committee that cannot be loaded
+        // leaves `latest_epoch` behind, and re-triggering on the same announcement would turn
+        // the throttled scan into a storage read every tick for as long as it stays unloadable.
+        // The cadence below still retries it.
+        let announced_newer = self.announced_epoch.is_some_and(|epoch| {
+            self.latest_epoch.is_none_or(|latest| epoch > latest)
+                && self.scan_attempted_for != Some(epoch)
+        });
         if self.ticks_until_scan == 0 || announced_newer {
             self.ticks_until_scan = TICKS_PER_COMMITTEE_SCAN;
+            self.scan_attempted_for = self.announced_epoch;
             self.scan_committees().await;
         } else {
             self.ticks_until_scan -= 1;
@@ -884,18 +914,11 @@ where
         // carry the truth.
         let tips = std::mem::take(&mut *self.tips.lock().expect("tips mutex is never poisoned"));
         for (chain_id, tip) in tips {
-            let record = self.chains.entry(chain_id).or_insert_with(|| ChainRecord {
-                tip: BlockHeight::ZERO,
-                last_activity: now,
-                dests: BTreeMap::new(),
-            });
+            let record = self
+                .chains
+                .entry(chain_id)
+                .or_insert_with(|| ChainRecord::new(now, &self.destinations));
             record.tip = record.tip.max(tip);
-            // A record born here — its block was dropped — must get its cursors immediately:
-            // the destination-change fill below cannot be relied on for it, and a record with no
-            // cursors is invisible to the requeue and immortal to the sweep.
-            for validator in self.destinations.keys() {
-                record.dests.entry(*validator).or_default();
-            }
         }
         // When the destination set changed, every destination gets a cursor on every tracked
         // chain, so a validator that joined after a chain's last block is still caught up on it.
@@ -1000,39 +1023,39 @@ where
         let start = self
             .latest_epoch
             .map_or(0, |epoch| epoch.0.saturating_add(1));
-        let newest = if start == 0 {
-            // Epoch 0 comes from the genesis blob, not an event.
-            Some(Epoch(0))
-        } else {
-            None
-        };
-        let newest = match self
+        // Epoch 0 comes from the genesis blob, not an event, so it is never in the list.
+        let genesis = (start == 0).then_some(Epoch(0));
+        let mut candidates = match self
             .storage
             .read_events_from_index(&admin_chain_id, &StreamId::system(EPOCH_STREAM_NAME), start)
             .await
         {
-            // A committee lists the full validator set, so only the newest loadable one matters.
             Ok(events) => events
                 .into_iter()
                 .map(|event| Epoch(event.index))
-                .max()
-                .or(newest),
+                .chain(genesis)
+                .collect::<Vec<_>>(),
             Err(error) => {
                 debug!(%error, "Cannot list epoch events to scan for committees");
                 return;
             }
         };
-        let Some(epoch) = newest else {
-            return;
-        };
-        match self.storage.get_or_load_committee(epoch).await {
-            Ok(Some(committee)) => {
-                self.latest_epoch = Some(epoch);
-                self.committee = Some(committee);
-                self.committee_dirty = true;
+        // Newest first, and stop at the first that loads: a committee lists the full validator
+        // set, so the newest usable one subsumes the rest. Trying only the newest would stall
+        // the whole scan whenever its blob happens to be missing while an older — but still
+        // newer than ours — one is right there.
+        candidates.sort_unstable_by(|a, b| b.cmp(a));
+        for epoch in candidates {
+            match self.storage.get_or_load_committee(epoch).await {
+                Ok(Some(committee)) => {
+                    self.latest_epoch = Some(epoch);
+                    self.committee = Some(committee);
+                    self.committee_dirty = true;
+                    return;
+                }
+                Ok(None) => debug!(%epoch, "An epoch event exists but its committee cannot load"),
+                Err(error) => debug!(%error, %epoch, "Cannot load a committee from storage"),
             }
-            Ok(None) => debug!(%epoch, "An epoch event exists but its committee cannot load"),
-            Err(error) => debug!(%error, %epoch, "Cannot load a committee from storage"),
         }
     }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -135,6 +135,14 @@ impl BlockExportConfig {
             // A failing destination would be retried without pause.
             return Err("block export retry delay must be greater than zero".into());
         }
+        if self.max_retry_delay.is_zero() {
+            // The cap would clamp every computed backoff to zero, same busy retry as above.
+            return Err("block export max retry delay must be greater than zero".into());
+        }
+        if self.retry_delay > self.max_retry_delay {
+            // The very first backoff would already exceed its own ceiling.
+            return Err("block export retry delay must not exceed the max retry delay".into());
+        }
         Ok(())
     }
 }
@@ -844,5 +852,48 @@ where
             .collect::<Option<Vec<_>>>();
         blobs.extend(read.ok_or(NodeError::BlobsNotFound(to_read))?);
         Ok(blobs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every rejection in `check()` guards a distinct failure mode, so each invalid field must be
+    /// caught on its own — including `max_retry_delay`, whose zero used to slip through and turn
+    /// backoff into a busy retry.
+    #[test]
+    fn config_check_rejects_each_zero_knob() {
+        assert!(BlockExportConfig::default().check().is_ok());
+        let invalid = [
+            BlockExportConfig {
+                certificate_upload_batch_size: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                max_catch_up_blocks: 0,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                idle_catch_up_interval: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                retry_delay: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                max_retry_delay: Duration::ZERO,
+                ..BlockExportConfig::default()
+            },
+            BlockExportConfig {
+                retry_delay: Duration::from_secs(120),
+                max_retry_delay: Duration::from_secs(60),
+                ..BlockExportConfig::default()
+            },
+        ];
+        for config in invalid {
+            assert!(config.check().is_err(), "accepted: {config:?}");
+        }
     }
 }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -29,7 +29,7 @@ use linera_base::{
     crypto::ValidatorPublicKey,
     data_types::{Blob, BlockHeight},
     identifiers::ChainId,
-    time::{Duration, Instant},
+    time::{timer::timeout, Duration, Instant},
 };
 use linera_chain::types::ConfirmedBlockCertificate;
 use linera_execution::committee::Committee;
@@ -118,6 +118,20 @@ pub struct BlockExportConfig {
     pub retry_delay: Duration,
     /// The longest a failing destination is skipped for.
     pub max_retry_delay: Duration,
+    /// How long the task waits for a new block before spending a round on catching up whichever
+    /// destinations are behind.
+    ///
+    /// Live blocks always win: catching up only happens when nothing has arrived for this long,
+    /// and only one round per interval, so it can never crowd out export or spin.
+    pub idle_catch_up_interval: Duration,
+    /// How many missing blocks are pushed to one destination in a single round.
+    ///
+    /// A validator that has just joined the committee knows nothing of a chain and reports height
+    /// 0, so on a chain with a long history the catch-up is arbitrarily large. Doing it in bounded
+    /// rounds keeps one far-behind destination from holding up every other destination and every
+    /// later block of the chain; the remainder is picked up on subsequent rounds, including while
+    /// the chain is idle.
+    pub max_catch_up_blocks: u64,
 }
 
 impl Default for BlockExportConfig {
@@ -126,6 +140,8 @@ impl Default for BlockExportConfig {
             certificate_upload_batch_size: crate::client::DEFAULT_CERTIFICATE_UPLOAD_BATCH_SIZE,
             retry_delay: Duration::from_secs(1),
             max_retry_delay: Duration::from_secs(60),
+            idle_catch_up_interval: Duration::from_secs(1),
+            max_catch_up_blocks: 1_000,
         }
     }
 }
@@ -250,6 +266,7 @@ where
         config,
         own_public_key,
         destinations: HashMap::new(),
+        chain_next_height: BlockHeight::ZERO,
         progress: progress.clone(),
     };
     linera_base::Task::spawn(task.run(receiver)).forget();
@@ -294,6 +311,10 @@ where
     config: BlockExportConfig,
     own_public_key: Option<ValidatorPublicKey>,
     destinations: HashMap<ValidatorPublicKey, Destination<S, P::Node>>,
+    /// The height after the last block handed to this task: how far a destination must reach to
+    /// be considered caught up. Used to keep catching a lagging destination up while the chain is
+    /// idle, so that convergence does not depend on the chain producing more blocks.
+    chain_next_height: BlockHeight,
     /// The highest height each validator has acknowledged. Seeded from what the worker had
     /// persisted, so a destination we meet for the first time — after a restart, or after the
     /// chain worker was dropped and reloaded — starts from there instead of being queried.
@@ -309,18 +330,92 @@ where
     /// Exports each block in turn, and returns when the chain worker has dropped its end.
     #[instrument(level = "debug", skip_all, fields(chain_id = %self.chain_id))]
     async fn run(mut self, mut receiver: mpsc::UnboundedReceiver<ExportedBlock>) {
-        while let Some(block) = receiver.recv().await {
-            #[cfg(with_metrics)]
-            metrics::QUEUE_SIZE.dec();
-            #[cfg(with_metrics)]
-            let _latency = metrics::EXPORT_LATENCY.measure_latency();
-            self.export(block).await;
+        loop {
+            match timeout(self.config.idle_catch_up_interval, receiver.recv()).await {
+                Ok(Some(block)) => {
+                    #[cfg(with_metrics)]
+                    metrics::QUEUE_SIZE.dec();
+                    #[cfg(with_metrics)]
+                    let _latency = metrics::EXPORT_LATENCY.measure_latency();
+                    self.export(block).await;
+                }
+                // The chain worker dropped its end.
+                Ok(None) => break,
+                // Nothing arrived for a while. If a destination is still behind — a validator
+                // that joined the committee partway through a long chain, say — close some more
+                // of its gap rather than waiting for the chain to produce another block, which
+                // it may never do. At most one round per interval, so a destination that cannot
+                // be caught up costs a bounded trickle rather than a spin.
+                Err(_) => self.catch_up_round().await,
+            }
         }
         debug!("Chain worker dropped; stopping block export");
     }
 
+    /// Remakes the node of any destination that has failed repeatedly.
+    ///
+    /// The transport may be relaying through one of several proxies and a destination keeps
+    /// whichever it was handed, so one that keeps failing may simply be pointed at a dead proxy.
+    /// Remaking it draws a fresh one. The failure count and backoff are deliberately kept, so a
+    /// validator that is itself down still backs off rather than being retried once per proxy.
+    ///
+    /// Runs before every catch-up round as well as on every new block: a destination that fell
+    /// behind while the chain was idle would otherwise never get a second chance at a connection.
+    fn refresh_stuck_destinations(&mut self) {
+        let stuck = self
+            .destinations
+            .iter()
+            .filter(|(_, destination)| destination.failures >= REBUILD_AFTER_FAILURES)
+            .map(|(validator, destination)| (*validator, destination.address.clone()))
+            .collect::<Vec<_>>();
+        if stuck.is_empty() {
+            return;
+        }
+        let nodes = match self.node_provider.make_nodes_from_list(stuck) {
+            Ok(nodes) => nodes.collect::<Vec<_>>(),
+            Err(error) => {
+                warn!(%error, "Cannot rebuild connections to lagging validators");
+                return;
+            }
+        };
+        for (validator, node) in nodes {
+            if let Some(destination) = self.destinations.get_mut(&validator) {
+                destination.updater.remote_node.node = node;
+            }
+        }
+    }
+
+    /// Pushes one bounded chunk of missing blocks to every destination that is behind.
+    ///
+    /// Runs only when nothing is queued, so live blocks always take priority over backfill.
+    async fn catch_up_round(&mut self) {
+        self.refresh_stuck_destinations();
+        let now = Instant::now();
+        let (config, chain_id, target) = (&self.config, self.chain_id, self.chain_next_height);
+        let results = future::join_all(
+            self.destinations
+                .iter_mut()
+                .filter(|(_, destination)| destination.is_behind(target) && destination.is_due(now))
+                .map(|(validator, destination)| async move {
+                    (
+                        *validator,
+                        destination.catch_up(chain_id, target, now, config).await,
+                    )
+                }),
+        )
+        .await;
+        self.record_progress(results);
+    }
+
     /// Pushes one block to every destination, concurrently, and records how far each got.
     async fn export(&mut self, block: ExportedBlock) {
+        self.chain_next_height = block
+            .certificate
+            .block()
+            .header
+            .height
+            .try_add_one()
+            .unwrap_or(BlockHeight::MAX);
         self.sync_destinations(&block);
 
         // Push to every destination concurrently, but only move on to the next block once they
@@ -335,9 +430,15 @@ where
         ))
         .await;
 
-        // `next_height` is what the validator itself reported, so the recorded height is a fact
-        // rather than an assumption: a validator that could not close its gap reports the truth
-        // and keeps a low cursor here, and is queried again on the next block.
+        self.record_progress(results);
+    }
+
+    /// Records how far each destination acknowledged, for the worker to persist on its next save.
+    ///
+    /// The heights are what the validators themselves reported, so they are facts rather than
+    /// assumptions: one that could not close its gap keeps a low cursor here and is picked up
+    /// again next round.
+    fn record_progress(&self, results: Vec<(ValidatorPublicKey, Option<BlockHeight>)>) {
         let mut progress = self
             .progress
             .lock()
@@ -460,11 +561,85 @@ where
             .with_label_values(&[&self.address])
             .observe(self.lag(block) as f64);
 
-        match self
+        let height = block.certificate.block().header.height;
+        let result = self
             .updater
-            .send_block(&block.certificate, &block.blobs, self.next_height)
-            .await
-        {
+            .send_block(
+                &block.certificate,
+                &block.blobs,
+                self.next_height,
+                config.max_catch_up_blocks,
+            )
+            .await;
+        self.record_outcome(result, height, now, config)
+    }
+
+    /// Whether this destination is, as far as we know, below `target`.
+    ///
+    /// An unknown height counts as behind: it is what a failed send leaves behind, and assuming
+    /// such a destination is up to date is how one silently stops being exported to.
+    fn is_behind(&self, target: BlockHeight) -> bool {
+        self.next_height.is_none_or(|next| next < target)
+    }
+
+    /// Whether this destination's backoff, if any, has expired.
+    fn is_due(&self, now: Instant) -> bool {
+        self.retry_at.is_none_or(|retry_at| retry_at <= now)
+    }
+
+    /// Pushes one bounded chunk of the blocks this validator is missing below `target`.
+    ///
+    /// Used while nothing is queued, so that a validator which joined partway through a long chain
+    /// converges without waiting for the chain to produce more blocks.
+    async fn catch_up(
+        &mut self,
+        chain_id: ChainId,
+        target: BlockHeight,
+        now: Instant,
+        config: &BlockExportConfig,
+    ) -> Option<BlockHeight> {
+        #[cfg(with_metrics)]
+        let send_latency = metrics::SEND_LATENCY.with_label_values(&[&self.address]);
+        #[cfg(with_metrics)]
+        let _latency = send_latency.measure_latency();
+
+        let previous = self.next_height;
+        let result = self
+            .updater
+            .send_missing_blocks(
+                chain_id,
+                target,
+                self.next_height,
+                config.max_catch_up_blocks,
+            )
+            .await;
+        let outcome = self.record_outcome(result, target, now, config);
+
+        // A round can succeed and still advance nothing: storage need not hold the missing
+        // heights, since a chain we merely *receive* from is stored only at its message-bearing
+        // blocks. Without backing off here the caller would call straight back in, and a
+        // destination we can never finish catching up would spin the task at full tilt.
+        let advanced = match (previous, self.next_height) {
+            (Some(before), Some(after)) => after > before,
+            // We at least learned where it is, which is progress the first time round.
+            (None, Some(_)) => true,
+            _ => false,
+        };
+        if !advanced {
+            self.back_off(now, config);
+        }
+        outcome
+    }
+
+    /// Folds the outcome of a push into this destination's cursor and backoff.
+    fn record_outcome(
+        &mut self,
+        result: Result<BlockHeight, crate::client::chain_client::Error>,
+        height: BlockHeight,
+        now: Instant,
+        config: &BlockExportConfig,
+    ) -> Option<BlockHeight> {
+        match result {
             Ok(next_height) => {
                 self.next_height = Some(next_height);
                 self.retry_at = None;
@@ -472,23 +647,27 @@ where
                 Some(next_height)
             }
             Err(error) => {
-                let backoff = config
-                    .retry_delay
-                    .saturating_mul(1u32.checked_shl(self.failures).unwrap_or(u32::MAX))
-                    .min(config.max_retry_delay);
-                let height = block.certificate.block().header.height;
                 warn!(
-                    validator = %self.address, %height, %error, ?backoff,
+                    validator = %self.address, %height, %error,
                     "Failed to export block; will query the validator before the next push",
                 );
                 // Forget the cursor: the next push must ask what this validator actually has
                 // rather than assume the block we just failed to send arrived.
                 self.next_height = None;
-                self.retry_at = Some(now + backoff);
-                self.failures = self.failures.saturating_add(1);
+                self.back_off(now, config);
                 None
             }
         }
+    }
+
+    /// Holds this destination off for a growing interval, capped by the configured maximum.
+    fn back_off(&mut self, now: Instant, config: &BlockExportConfig) {
+        let backoff = config
+            .retry_delay
+            .saturating_mul(1u32.checked_shl(self.failures).unwrap_or(u32::MAX))
+            .min(config.max_retry_delay);
+        self.retry_at = Some(now + backoff);
+        self.failures = self.failures.saturating_add(1);
     }
 
     /// How many blocks this validator is believed to be missing before the block being pushed.

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -3,19 +3,16 @@
 
 //! Pushing executed blocks to the other validators in the committee.
 //!
-//! Each chain worker owns one export task. When the worker executes a block it hands the
-//! certificate and the block's blobs — both already in memory — to that task, which pushes them to
-//! every other validator in the chain's current committee. This is the validator-to-validator
-//! dissemination that makes each validator a complete replica: consensus itself only guarantees
-//! that a quorum holds any given block.
+//! Each chain worker owns one export task and hands it every block it executes — certificate and
+//! blobs, both already in memory. This is the dissemination that makes each validator a complete
+//! replica; consensus alone only guarantees that a quorum holds any given block.
 //!
-//! One task per chain worker rather than one per process: thousands of chains through a single
-//! task would serialize them, and a per-chain task gets per-chain height ordering for free, since
-//! it finishes one block before taking the next off its queue.
+//! One task per chain worker rather than per process: a single task would serialize thousands of
+//! chains, and a per-chain task gets height ordering for free.
 //!
-//! The queue is unbounded. Dropping a block would leave a gap in the destination that nothing ever
-//! repairs, which is the failure mode this design exists to remove; a queue that grows is a
-//! performance problem instead, and [`metrics::QUEUE_SIZE`] is there to see it.
+//! The queue is unbounded, because dropping a block would leave a gap nothing repairs — the very
+//! failure this design removes. A growing queue is a performance problem instead; see
+//! [`metrics::QUEUE_SIZE`].
 
 use std::{
     collections::{BTreeMap, HashMap},
@@ -56,10 +53,8 @@ mod metrics {
     };
     use prometheus::{Histogram, HistogramVec, IntGauge};
 
-    /// Blocks waiting to be exported, across every chain worker in this process.
-    ///
-    /// The queue is unbounded, so this is how a chain that produces blocks faster than they can be
-    /// pushed becomes visible instead of silently losing them.
+    /// Blocks waiting to be exported, across every chain worker in this process. The queue is
+    /// unbounded, so this is how a chain producing faster than it can push becomes visible.
     pub static QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
         register_int_gauge(
             "block_export_queue_size",
@@ -68,9 +63,6 @@ mod metrics {
     });
 
     /// Time from a block being queued to it having been pushed to every destination.
-    ///
-    /// This is the export cost per block, including the serialization and signature work that
-    /// shares a runtime thread with block execution on a single-threaded shard.
     pub static EXPORT_LATENCY: LazyLock<Histogram> = LazyLock::new(|| {
         register_histogram(
             "block_export_latency",
@@ -107,47 +99,26 @@ pub struct BlockExportConfig {
     /// How many certificates are read from storage and pushed per batch when catching a
     /// destination up.
     pub certificate_upload_batch_size: u64,
-    /// How long a destination is skipped after a failed push, doubling up to `max_retry_delay`
-    /// while it keeps failing.
-    ///
-    /// A destination that is down must not stall export for the rest of the committee, and must
-    /// not cost a full round trip on every block either. Skipping it leaves its cursor stale, so
-    /// the first push that does go through queries it and fills in whatever it missed.
-    ///
-    /// This is a coarser layer than the transport's own per-request retries: those decide whether
-    /// one call is worth attempting again, this decides whether the destination is worth
-    /// attempting at all right now.
+    /// How long a destination is skipped after a failed push, doubling up to `max_retry_delay`.
+    /// Coarser than the transport's per-request retries: those decide whether one call is worth
+    /// repeating, this decides whether the destination is worth attempting at all right now.
     pub retry_delay: Duration,
     /// The longest a failing destination is skipped for.
     pub max_retry_delay: Duration,
-    /// How long the task waits for a new block before spending a round on catching up whichever
-    /// destinations are behind.
-    ///
-    /// Live blocks always win: catching up only happens when nothing has arrived for this long,
-    /// and only one round per interval, so it can never crowd out export or spin. Together with
-    /// `max_catch_up_blocks` this sets the backfill rate — blocks per interval — so the two should
-    /// be tuned as a pair; a shorter interval with a proportionally smaller bound keeps the same
-    /// throughput while returning to live blocks sooner.
+    /// How long the task waits for a new block before spending a round catching up destinations
+    /// that are behind. With `max_catch_up_blocks` this sets the backfill rate, so tune them
+    /// together.
     pub idle_catch_up_interval: Duration,
-    /// How many missing blocks are pushed to one destination in a single round.
-    ///
-    /// A validator that has just joined the committee knows nothing of a chain and reports height
-    /// 0, so on a chain with a long history the catch-up is arbitrarily large. Doing it in bounded
-    /// rounds keeps one far-behind destination from holding up every other destination and every
-    /// later block of the chain; the remainder is picked up on subsequent rounds, including while
-    /// the chain is idle.
-    ///
-    /// The bound is what a live block may have to wait behind, so it is deliberately small: the
-    /// backfill rate is set by how often rounds happen, not by how much each one does.
+    /// How many missing blocks are pushed to one destination per round. Deliberately small: it
+    /// bounds what a live block may wait behind, and a validator that just joined reports height
+    /// 0, so its catch-up is otherwise arbitrarily large.
     pub max_catch_up_blocks: u64,
 }
 
 impl BlockExportConfig {
-    /// Rejects values that would make export misbehave rather than merely perform badly.
-    ///
-    /// Checked once at startup so a typo fails the validator immediately, instead of surfacing
-    /// later as a panic mid-export, a task spinning a core, or gaps that are silently never
-    /// repaired.
+    /// Rejects values that would make export misbehave rather than merely perform badly. Checked
+    /// at startup, so a typo fails fast instead of surfacing as a panic, a spinning task, or gaps
+    /// that are never repaired.
     pub fn check(&self) -> Result<(), String> {
         if self.certificate_upload_batch_size == 0 {
             // `slice::chunks(0)` panics.
@@ -193,11 +164,8 @@ pub struct ChainExportSetup<S: Storage> {
     pub exported_heights: BTreeMap<ValidatorPublicKey, BlockHeight>,
 }
 
-/// Creates the export task for one chain worker.
-///
-/// The transport is type-erased behind this alias: `linera-core` knows how to export a block, but
-/// only the server binary knows how to reach another validator, so it installs a factory that
-/// closes over its node provider.
+/// Creates the export task for one chain worker. Type-erased because only the server binary knows
+/// how to reach another validator.
 pub type ChainExporterFactory<S> = Arc<dyn Fn(ChainExportSetup<S>) -> ChainExporter + Send + Sync>;
 
 /// A block a chain worker has executed, on its way to the other validators.
@@ -223,11 +191,9 @@ struct ExportedBlock {
 /// The chain worker's end of its export task.
 pub struct ChainExporter {
     blocks: mpsc::UnboundedSender<ExportedBlock>,
-    /// The highest height each validator has acknowledged, written by the export task and folded
-    /// into the chain's `exported_heights` by the worker when it next saves.
-    ///
-    /// Progress travels this way rather than back through the worker so that the worker stays the
-    /// only writer of its own chain state, and so that export costs no extra database write.
+    /// The highest height each validator has acknowledged, folded into the chain's
+    /// `exported_heights` by the worker on its next save. Travels this way so the worker stays the
+    /// only writer of its own chain state, and export costs no extra database write.
     progress: Arc<Mutex<BTreeMap<ValidatorPublicKey, BlockHeight>>>,
 }
 
@@ -280,10 +246,9 @@ impl ChainExporter {
     }
 }
 
-/// Spawns the export task for one chain worker and returns the worker's end of it.
-///
-/// The task runs until the returned [`ChainExporter`] is dropped, which happens when the chain
-/// worker is dropped — so an idle chain costs neither a task nor a connection.
+/// Spawns the export task for one chain worker and returns the worker's end of it. The task runs
+/// until the returned [`ChainExporter`] is dropped with its worker, so an idle chain costs neither
+/// a task nor a connection.
 pub fn spawn_chain_exporter<S, P>(
     setup: ChainExportSetup<S>,
     node_provider: Arc<P>,
@@ -381,22 +346,17 @@ where
                 }
                 // The chain worker dropped its end.
                 Ok(None) => break,
-                // Nothing arrived for a while. If a destination is still behind — a validator
-                // that joined the committee partway through a long chain, say — close some more
-                // of its gap rather than waiting for the chain to produce another block, which
-                // it may never do. At most one round per interval, so a destination that cannot
-                // be caught up costs a bounded trickle rather than a spin.
+                // Nothing arrived for a while: close more of a lagging destination's gap rather
+                // than waiting for a block the chain may never produce. One round per interval,
+                // so a destination that cannot be caught up trickles rather than spins.
                 Err(_) => self.catch_up_round().await,
             }
         }
         debug!("Chain worker dropped; stopping block export");
     }
 
-    /// Brings the destination set in line with the chain's committee as the local worker sees it
-    /// right now, rather than as of the last block exported.
-    ///
-    /// Asked of the worker rather than read from the chain view directly: the worker owns that
-    /// view while it is running, and loading it here would race with it.
+    /// Brings the destination set in line with the committee as the worker sees it now. Asked of
+    /// the worker rather than read from the chain view, which the worker owns while running.
     async fn sync_destinations_from_local_node(&mut self) {
         let query = ChainInfoQuery::new(self.chain_id).with_committees();
         let info = match self.local_node.handle_chain_info_query(query).await {
@@ -418,18 +378,9 @@ where
         self.sync_destinations_with(&committee, admin_chain_id);
     }
 
-    /// Remakes the node of every destination whose last push failed.
-    ///
-    /// The transport may be relaying through one of several proxies and a destination keeps
-    /// whichever it was handed, so a failure may mean nothing worse than a dead proxy. Remaking
-    /// the node draws the next one from the rotation, so a bad proxy is stepped over on the very
-    /// next attempt instead of being retried; if the destination itself is down, the fresh proxy
-    /// fails too and the backoff below still applies. The failure count and backoff are kept
-    /// across the rebuild for exactly that reason — rotating proxies must not become a way to
-    /// hammer a validator that is simply offline.
-    ///
-    /// Runs before every catch-up round as well as on every new block: a destination that fell
-    /// behind while the chain was idle would otherwise never get a second chance at a connection.
+    /// Remakes the node of every destination whose last push failed, drawing the next proxy from
+    /// the rotation so a dead proxy is stepped over rather than retried. Keeps the failure count
+    /// and backoff, so this cannot become a way to hammer a validator that is simply offline.
     fn refresh_stuck_destinations(&mut self) {
         let stuck = self
             .destinations
@@ -507,10 +458,8 @@ where
     }
 
     /// Records how far each destination acknowledged, for the worker to persist on its next save.
-    ///
-    /// The heights are what the validators themselves reported, so they are facts rather than
-    /// assumptions: one that could not close its gap keeps a low cursor here and is picked up
-    /// again next round.
+    /// These are heights the validators reported themselves, so one that could not close its gap
+    /// keeps a low cursor and is picked up again next round.
     fn record_progress(&self, results: Vec<(ValidatorPublicKey, Option<BlockHeight>)>) {
         let mut progress = self
             .progress
@@ -561,10 +510,8 @@ where
             return;
         }
 
-        // One validator at a time, because resolving them as a batch fails the whole batch on the
-        // first bad address: a single malformed committee entry would then stop this chain
-        // exporting to *any* validator, and would keep doing so on every later block. The
-        // validators we can reach are worth reaching even when one of them is misconfigured.
+        // One at a time: resolving as a batch fails the whole batch on the first bad address,
+        // which would stop this chain exporting to *any* validator, on every later block.
         let nodes = missing
             .into_iter()
             .filter_map(|(validator, address)| {
@@ -670,10 +617,8 @@ where
         self.record_outcome(result, height, now, config)
     }
 
-    /// Whether this destination is, as far as we know, below `target`.
-    ///
-    /// An unknown height counts as behind: it is what a failed send leaves behind, and assuming
-    /// such a destination is up to date is how one silently stops being exported to.
+    /// Whether this destination is, as far as we know, below `target`. An unknown height counts
+    /// as behind: that is what a failed send leaves, and assuming otherwise strands it silently.
     fn is_behind(&self, target: BlockHeight) -> bool {
         self.next_height.is_none_or(|next| next < target)
     }
@@ -683,10 +628,8 @@ where
         self.retry_at.is_none_or(|retry_at| retry_at <= now)
     }
 
-    /// Pushes one bounded chunk of the blocks this validator is missing below `target`.
-    ///
-    /// Used while nothing is queued, so that a validator which joined partway through a long chain
-    /// converges without waiting for the chain to produce more blocks.
+    /// Pushes one bounded chunk of the blocks this validator is missing below `target`, so one
+    /// that joined partway through a long chain converges without waiting for new blocks.
     async fn catch_up(
         &mut self,
         chain_id: ChainId,
@@ -711,14 +654,9 @@ where
             .await;
         let outcome = self.record_outcome(result, target, now, config);
 
-        // A round can *succeed* and still advance nothing: storage need not hold the missing
-        // heights, since a chain we merely *receive* from is stored only at its message-bearing
-        // blocks. Without backing off here the caller would call straight back in, and a
-        // destination we can never finish catching up would spin the task at full tilt.
-        //
-        // Only the success path needs this. A failed round has already been backed off inside
-        // `record_outcome`, and doing it again here would double-count the failure and escalate
-        // the delay twice as fast as configured.
+        // A round can succeed and advance nothing, since a chain we merely receive from is
+        // stored only at its message-bearing blocks; without backing off, a destination we can
+        // never finish would spin the task. Success only: `record_outcome` handles failures.
         if let Some(reached) = outcome {
             let advanced = previous.is_none_or(|before| reached > before);
             if !advanced {

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -257,6 +257,15 @@ where
     ChainExporter { blocks, progress }
 }
 
+/// Consecutive failed pushes after which a destination's connection is rebuilt.
+///
+/// The transport may be relaying through one of several proxies, and a destination keeps whichever
+/// it was given. If that proxy dies, this destination would otherwise keep failing against it
+/// forever while the others stay healthy, so after a few failures the node is remade — which draws
+/// a fresh proxy from the rotation. The failure count and backoff are deliberately *not* reset, so
+/// a destination that is genuinely down still backs off rather than being hammered once per proxy.
+const REBUILD_AFTER_FAILURES: u32 = 3;
+
 /// One destination validator, and what we believe it holds of this chain.
 struct Destination<S: Storage, N> {
     updater: RemoteNodeUpdater<S, N>,
@@ -351,11 +360,20 @@ where
                 .is_some_and(|state| state.network_address == destination.address)
         });
 
+        // A destination that has failed repeatedly may be stuck behind a dead proxy, so rebuild
+        // its node alongside any validator we do not have yet.
+        let stuck = self
+            .destinations
+            .iter()
+            .filter(|(_, destination)| destination.failures >= REBUILD_AFTER_FAILURES)
+            .map(|(validator, _)| *validator)
+            .collect::<Vec<_>>();
+
         let missing = committee
             .validator_addresses()
             .filter(|(validator, _)| {
                 Some(*validator) != self.own_public_key
-                    && !self.destinations.contains_key(validator)
+                    && (!self.destinations.contains_key(validator) || stuck.contains(validator))
             })
             .map(|(validator, address)| (validator, address.to_owned()))
             .collect::<Vec<_>>();
@@ -395,6 +413,9 @@ where
                 admin_chain_id: block.admin_chain_id,
                 certificate_upload_batch_size: self.config.certificate_upload_batch_size,
             };
+            // Rebuilding a stuck destination keeps its failure count and retry time: only the
+            // connection is replaced, so a validator that is itself down keeps backing off.
+            let previous = self.destinations.remove(&validator);
             self.destinations.insert(
                 validator,
                 Destination {
@@ -405,8 +426,8 @@ where
                     next_height: acknowledged
                         .get(&validator)
                         .map(|height| BlockHeight(height.0.saturating_add(1))),
-                    retry_at: None,
-                    failures: 0,
+                    retry_at: previous.as_ref().and_then(|d| d.retry_at),
+                    failures: previous.map_or(0, |d| d.failures),
                 },
             );
         }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -50,13 +50,13 @@ use futures::{stream::FuturesUnordered, FutureExt as _, StreamExt as _};
 use linera_base::prometheus_util::MeasureLatency as _;
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{Blob, BlockHeight, Epoch},
+    data_types::{Blob, BlockHeight, Epoch, TimeDelta, Timestamp},
     identifiers::{BlobId, ChainId, StreamId},
-    time::{timer::timeout, Duration, Instant},
+    time::{timer::timeout, Duration},
 };
 use linera_chain::types::ConfirmedBlockCertificate;
 use linera_execution::{committee::Committee, system::EPOCH_STREAM_NAME};
-use linera_storage::{Arc as CacheArc, Storage};
+use linera_storage::{Arc as CacheArc, Clock as _, Storage};
 use tokio::sync::mpsc;
 use tracing::{debug, instrument, warn};
 
@@ -155,6 +155,33 @@ mod metrics {
         )
     });
 
+    /// Destinations currently resolved. Zero with export enabled means the committee could not
+    /// be loaded or no address resolved — on a dashboard that is otherwise indistinguishable
+    /// from a healthy validator with nothing to send.
+    pub static DESTINATIONS: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_destinations",
+            "Committee members this validator is currently exporting to",
+        )
+    });
+
+    /// Lagging (chain, destination) *pairs*, which is what the queue's memory tracks — a chain
+    /// behind on ten destinations costs ten times one behind on one.
+    pub static LAGGING_PAIRS: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_lagging_pairs",
+            "Chain-destination pairs currently behind, summed over destinations",
+        )
+    });
+
+    /// The queue-wide in-flight budget, halved whenever our own storage fails a read.
+    pub static TOTAL_WINDOW: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_total_window",
+            "Concurrent sends allowed across all destinations (AIMD on local storage failures)",
+        )
+    });
+
     /// Sends the destination actually answered, as opposed to attempts: `SEND_LATENCY` counts
     /// every completion, failures included, so success rate needs its own counter.
     pub static SENDS_SUCCEEDED: LazyLock<IntCounterVec> = LazyLock::new(|| {
@@ -191,6 +218,11 @@ pub struct BlockExportConfig {
     pub queue_bytes: usize,
     /// The most concurrent sends one destination is ever allowed — the AIMD window's ceiling.
     pub max_in_flight_per_destination: usize,
+    /// The most concurrent sends across *all* destinations. Each one can be reading up to
+    /// `max_catch_up_blocks` certificates, so without this the aggregate read concurrency is
+    /// the per-destination window times the committee size, and nothing shrinks it when our own
+    /// storage is the bottleneck.
+    pub max_in_flight_total: usize,
     /// How long a destination is skipped after a failed push, doubling up to `max_retry_delay`.
     /// Coarser than the transport's per-request retries: those decide whether one call is worth
     /// repeating, this decides whether the destination is worth attempting at all right now.
@@ -232,6 +264,18 @@ impl BlockExportConfig {
             // No destination could ever be sent anything.
             return Err("block export in-flight ceiling must be greater than zero".into());
         }
+        if self.max_in_flight_total == 0 {
+            // The queue-wide budget would admit nothing, so no send would ever start.
+            return Err("block export total in-flight budget must be greater than zero".into());
+        }
+        if self.max_in_flight_total < self.max_in_flight_per_destination {
+            // One destination could never reach its own ceiling, and the AIMD window would
+            // advertise a capacity the queue refuses to grant.
+            return Err(
+                "block export total in-flight budget must be at least the per-destination ceiling"
+                    .into(),
+            );
+        }
         if self.max_catch_up_blocks == 0 {
             // Every gap would stay open forever, silently.
             return Err("block export catch-up bound must be greater than zero".into());
@@ -267,6 +311,7 @@ impl Default for BlockExportConfig {
             queue_size: 1024,
             queue_bytes: 256 * 1024 * 1024,
             max_in_flight_per_destination: 8,
+            max_in_flight_total: 64,
             retry_delay: Duration::from_secs(1),
             max_retry_delay: Duration::from_secs(60),
             idle_catch_up_interval: Duration::from_millis(200),
@@ -293,7 +338,9 @@ struct ExportedBlock {
     /// byte budget.
     blob_bytes: usize,
     #[cfg(with_metrics)]
-    queued_at: Instant,
+    /// Wall clock, not the storage clock: this only feeds the queue-latency histogram, and a
+    /// simulated clock would report time that no operator waited.
+    queued_at: linera_base::time::Instant,
 }
 
 /// The chain workers' end of the export queue: hands blocks over and reads back progress.
@@ -420,7 +467,7 @@ impl BlockExportHandle {
             exported_heights,
             blob_bytes,
             #[cfg(with_metrics)]
-            queued_at: Instant::now(),
+            queued_at: linera_base::time::Instant::now(),
         };
         match self.blocks.try_send(block) {
             Ok(()) => {
@@ -501,6 +548,7 @@ where
     let tips: SharedTips = Arc::default();
     let queued_bytes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let queue_bytes_budget = config.queue_bytes;
+    let max_in_flight_total = config.max_in_flight_total;
 
     let task = BlockExportQueue {
         storage,
@@ -517,6 +565,7 @@ where
         destinations: BTreeMap::new(),
         dest_indices: BTreeMap::new(),
         next_generation: 0,
+        total_window: max_in_flight_total,
         announced_epoch: None,
         scan_attempted_for: None,
         destinations_changed: false,
@@ -544,7 +593,7 @@ struct ChainRecord {
     /// caught up.
     tip: BlockHeight,
     /// When this chain last saw a block or a completed send, for the convergence sweep.
-    last_activity: Instant,
+    last_activity: Timestamp,
     /// Sorted by index, so lookups binary-search integers. A flat vector rather than a map
     /// because this is allocated per tracked chain: a `BTreeMap` pays for an eleven-slot leaf
     /// whatever the committee size.
@@ -559,7 +608,7 @@ impl ChainRecord {
     /// "converged" to the sweep, so such a chain would be abandoned in silence. One creation
     /// path used to miss the seeding, and nothing in the suite could see it.
     fn new<N>(
-        now: Instant,
+        now: Timestamp,
         destinations: &BTreeMap<DestIndex, DestState<N>>,
         exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
     ) -> Self {
@@ -659,7 +708,7 @@ struct ChainDest {
     in_flight: Option<u64>,
     /// Backoff for *chain-scoped* failures — the destination is healthy but cannot accept this
     /// chain yet, e.g. it lacks the committee and the admin chain's export has not reached it.
-    retry_at: Option<Instant>,
+    retry_at: Option<Timestamp>,
     failures: u32,
     /// How many times this destination has reported a *lower* height than it had. Counted apart
     /// from `failures` because an advance clears those, and a peer alternating advance with
@@ -682,7 +731,7 @@ impl ChainDest {
         &mut self,
         reported: BlockHeight,
         tip: BlockHeight,
-        now: Instant,
+        now: Timestamp,
         config: &BlockExportConfig,
     ) -> Option<BlockHeight> {
         // Clamped once, here, so the cursor, the counters and the acknowledgement all read the
@@ -706,7 +755,7 @@ impl ChainDest {
             // restore regresses once and pays one delay, an oscillating peer pays double each
             // time it lies.
             let attempt = self.failures.max(self.regressions);
-            self.retry_at = Some(now + backoff_delay(attempt, config));
+            self.retry_at = Some(now.saturating_add(backoff_delay(attempt, config)));
             self.regressions = self.regressions.saturating_add(1);
         } else if reported < tip {
             // Answered but moved nothing — a gap our storage cannot fill — so back this pair
@@ -735,7 +784,7 @@ struct DestState<N> {
     /// configured ceiling, halved per transport failure down to 1.
     window: usize,
     /// Backoff for *destination-scoped* failures: transport errors and timeouts.
-    retry_at: Option<Instant>,
+    retry_at: Option<Timestamp>,
     failures: u32,
     /// Chains this destination is behind on, maintained as pairs fall behind and converge
     /// rather than rediscovered by scanning every chain each tick — that scan was O(tracked
@@ -791,6 +840,8 @@ enum SendOutcome {
     ChainScoped(Box<chain_client::Error>),
     /// The failure is about the destination itself.
     DestinationScoped(Box<chain_client::Error>),
+    /// Our own storage failed. Nobody's health signal but ours.
+    LocalScoped(Box<chain_client::Error>),
 }
 
 /// The body of the process-wide export queue task.
@@ -825,6 +876,11 @@ where
     dest_indices: BTreeMap<ValidatorPublicKey, DestIndex>,
     /// The last destination generation handed out; never reused within this queue's lifetime.
     next_generation: u64,
+    /// Concurrent sends allowed across all destinations right now: halved when our own storage
+    /// fails a read, restored one slot per success up to `max_in_flight_total`. A destination's
+    /// own window bounds what one peer can consume; this bounds what the queue as a whole asks
+    /// of storage.
+    total_window: usize,
     /// The newest epoch any exported block has announced; the tick loads its committee when it
     /// is ahead of `latest_epoch`.
     announced_epoch: Option<Epoch>,
@@ -882,12 +938,21 @@ where
         // would die every tick-only duty (drop repair, backoff expiry, the committee scan, the
         // convergence sweep).
         let interval = self.config.idle_catch_up_interval;
-        let mut next_tick = Instant::now() + interval;
+        let tick_delta = TimeDelta::from_micros(interval.as_micros() as u64);
+        let mut next_tick = self
+            .storage
+            .clock()
+            .current_time()
+            .saturating_add(tick_delta);
         loop {
-            let now = Instant::now();
+            let now = self.storage.clock().current_time();
             if now >= next_tick {
                 self.tick(&mut jobs).await;
-                next_tick = Instant::now() + interval;
+                next_tick = self
+                    .storage
+                    .clock()
+                    .current_time()
+                    .saturating_add(tick_delta);
                 continue;
             }
             let until_tick = next_tick.duration_since(now);
@@ -902,7 +967,7 @@ where
                 futures::select_biased! {
                     done = jobs.next() => Wake::Done(done.expect("jobs is not empty")),
                     received = receiver.recv().fuse() => Wake::Block(received),
-                    _ = linera_base::time::timer::sleep(until_tick).fuse() => Wake::Tick,
+                    _ = self.storage.clock().sleep_for(until_tick).fuse() => Wake::Tick,
                 }
             };
             match wake {
@@ -911,7 +976,11 @@ where
                 Wake::Block(None) => break,
                 Wake::Tick => {
                     self.tick(&mut jobs).await;
-                    next_tick = Instant::now() + interval;
+                    next_tick = self
+                        .storage
+                        .clock()
+                        .current_time()
+                        .saturating_add(tick_delta);
                 }
             }
         }
@@ -953,7 +1022,7 @@ where
             self.sync_destinations();
         }
 
-        let now = Instant::now();
+        let now = self.storage.clock().current_time();
         let tip = height.try_add_one().unwrap_or(BlockHeight::MAX);
         let record = self
             .chains
@@ -964,6 +1033,7 @@ where
         record.seed_missing_cursors(&self.destinations, &block.exported_heights);
         let indices = self.destinations.keys().copied().collect::<Vec<_>>();
         for index in indices {
+            let budget = self.budget_remaining();
             let record = self.chains.get_mut(&chain_id).expect("inserted above");
             let record_tip = record.tip;
             let chain_dest = record.dest_entry(index);
@@ -1001,6 +1071,7 @@ where
                         dest,
                         jobs,
                         now,
+                        budget,
                     );
                 }
             }
@@ -1013,7 +1084,7 @@ where
         (chain_id, index, generation, outcome): JobDone,
         jobs: &mut FuturesUnordered<JobFuture>,
     ) {
-        let now = Instant::now();
+        let now = self.storage.clock().current_time();
         let Some(dest) = self.destinations.get_mut(&index) else {
             return; // The validator left the committee while its send was in flight.
         };
@@ -1043,12 +1114,26 @@ where
                 dest.failures = 0;
                 dest.retry_at = None;
                 dest.window = (dest.window + 1).min(self.config.max_in_flight_per_destination);
+                self.total_window = (self.total_window + 1).min(self.config.max_in_flight_total);
                 #[cfg(with_metrics)]
                 metrics::SENDS_SUCCEEDED
                     .with_label_values(&[&dest.address])
                     .inc();
             }
             SendOutcome::ChainScoped(_) => {}
+            SendOutcome::LocalScoped(error) => {
+                // Our storage, not the peer: leave the destination's window alone and halve the
+                // queue's own budget, so the pressure is relieved across every destination
+                // rather than one pair at a time while the rest keep reading.
+                warn!(
+                    %chain_id, %error,
+                    "Export could not read from local storage; halving the queue's total \
+                     in-flight budget",
+                );
+                self.total_window = (self.total_window / 2).max(1);
+                #[cfg(with_metrics)]
+                metrics::TOTAL_WINDOW.set(self.total_window as i64);
+            }
             SendOutcome::DestinationScoped(error) => {
                 warn!(
                     validator = %dest.address, %chain_id, %error,
@@ -1103,6 +1188,16 @@ where
                             }
                         }
                     }
+                    SendOutcome::LocalScoped(_) => {
+                        // The global budget already shrank; back the pair off too so the same
+                        // unreadable range is not retried immediately.
+                        back_off(
+                            &mut chain_dest.failures,
+                            &mut chain_dest.retry_at,
+                            now,
+                            &self.config,
+                        );
+                    }
                     SendOutcome::ChainScoped(error) => {
                         debug!(
                             %chain_id, %validator, %error,
@@ -1132,6 +1227,7 @@ where
         }
         // A pair that advanced but is still behind continues on the next free slot rather than
         // waiting for a tick — multi-round catch-up must not depend on a process-wide lull.
+        let budget = self.budget_remaining();
         let dest = self.destinations.get_mut(&index).expect("checked above");
         if let Some(record) = self.chains.get_mut(&chain_id) {
             let tip = record.tip;
@@ -1153,12 +1249,13 @@ where
             dest,
             jobs,
             now,
+            budget,
         );
     }
 
     /// An idle moment: pick up committee changes from storage and requeue expired backoffs.
     async fn tick(&mut self, jobs: &mut FuturesUnordered<JobFuture>) {
-        let now = Instant::now();
+        let now = self.storage.clock().current_time();
         // Occasionally scan storage for committees no block has carried — how a validator
         // admitted while every chain is idle still becomes a destination. On its own cadence
         // because the probe reads storage, and ticks now fire even under load.
@@ -1280,13 +1377,29 @@ where
         }
 
         #[cfg(with_metrics)]
-        metrics::TRACKED_CHAINS.set(self.chains.len() as i64);
+        {
+            metrics::TRACKED_CHAINS.set(self.chains.len() as i64);
+            metrics::DESTINATIONS.set(self.destinations.len() as i64);
+            let lagging_pairs = self
+                .destinations
+                .values()
+                .map(|dest| dest.lagging.len())
+                .sum::<usize>();
+            metrics::LAGGING_PAIRS.set(lagging_pairs as i64);
+            metrics::TOTAL_WINDOW.set(self.total_window as i64);
+        }
 
         // No requeue scan: each destination's `lagging` set already *is* the list of chains it
         // owes work on, kept current as pairs fall behind and converge. Draining it is
         // proportional to the work available, not to how much state the process is holding.
+        let mut budget = self.total_window.saturating_sub(
+            self.destinations
+                .values()
+                .map(|dest| dest.in_flight)
+                .sum::<usize>(),
+        );
         for (index, dest) in &mut self.destinations {
-            Self::drain_ready(
+            budget -= Self::drain_ready(
                 &mut self.chains,
                 &self.storage,
                 &self.config,
@@ -1294,6 +1407,7 @@ where
                 dest,
                 jobs,
                 now,
+                budget,
             );
         }
     }
@@ -1471,6 +1585,17 @@ where
         }
     }
 
+    /// Sends the queue-wide budget still allows, summed from the destinations rather than
+    /// tracked in a counter that could drift out of step with them.
+    fn budget_remaining(&self) -> usize {
+        let in_flight = self
+            .destinations
+            .values()
+            .map(|dest| dest.in_flight)
+            .sum::<usize>();
+        self.total_window.saturating_sub(in_flight)
+    }
+
     /// The index `validator`'s per-chain state is keyed by, registering it on first sight.
     ///
     /// Published to the handles under the progress mutex, because the chain workers read that
@@ -1561,6 +1686,7 @@ where
             };
             let outcome = match result {
                 Ok(next_height) => SendOutcome::Reached(next_height),
+                Err(error) if is_local_scoped(&error) => SendOutcome::LocalScoped(Box::new(error)),
                 Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(Box::new(error)),
                 Err(error) => SendOutcome::DestinationScoped(Box::new(error)),
             };
@@ -1573,6 +1699,7 @@ where
     }
 
     /// Starts catch-up sends from this destination's ready list until its window is full.
+    #[expect(clippy::too_many_arguments)]
     fn drain_ready(
         chains: &mut HashMap<ChainId, ChainRecord>,
         storage: &S,
@@ -1580,10 +1707,12 @@ where
         index: DestIndex,
         dest: &mut DestState<P::Node>,
         jobs: &mut FuturesUnordered<JobFuture>,
-        now: Instant,
-    ) {
-        if dest.retry_at.is_some_and(|at| at > now) || dest.in_flight >= dest.window {
-            return;
+        now: Timestamp,
+        budget: usize,
+    ) -> usize {
+        if dest.retry_at.is_some_and(|at| at > now) || dest.in_flight >= dest.window || budget == 0
+        {
+            return 0;
         }
         // Only as far as the window allows, so the cost is the sends we are about to make and
         // not the size of the backlog. Entries stay in `lagging` until they converge: one that
@@ -1597,7 +1726,7 @@ where
         let mut stale = Vec::new();
         let mut last_visited = None;
         for chain_id in ordered {
-            if dest.in_flight + spawn.len() >= dest.window {
+            if dest.in_flight + spawn.len() >= dest.window || spawn.len() >= budget {
                 break;
             }
             last_visited = Some(chain_id);
@@ -1622,6 +1751,7 @@ where
         for chain_id in stale {
             dest.lagging.remove(&chain_id);
         }
+        let spawned = spawn.len();
         for chain_id in spawn {
             let Some(record) = chains.get_mut(&chain_id) else {
                 continue;
@@ -1634,6 +1764,7 @@ where
                 jobs, storage, config, chain_id, index, dest, chain_dest, tip, None,
             );
         }
+        spawned
     }
 }
 
@@ -1647,10 +1778,19 @@ fn is_chain_scoped(error: &chain_client::Error) -> bool {
             NodeError::EventsNotFound(_)
                 | NodeError::BlobsNotFound(_)
                 | NodeError::InactiveChain(_)
-        ) | chain_client::Error::ReadCertificatesError(_)
-            // Our own storage failing to read is nobody's health signal; halving the
-            // destination's window for it would punish the wrong side.
-            | chain_client::Error::ViewError(_)
+        )
+    )
+}
+
+/// Whether this failure is our own storage rather than anything about the destination.
+///
+/// Halving the destination's window for it would punish the wrong side, but backing off only the
+/// one pair leaves every other pair reading at full rate — so the control loop cannot see the
+/// bottleneck it is creating. These shrink the queue's *global* budget instead.
+fn is_local_scoped(error: &chain_client::Error) -> bool {
+    matches!(
+        error,
+        chain_client::Error::ReadCertificatesError(_) | chain_client::Error::ViewError(_)
     )
 }
 
@@ -1658,20 +1798,21 @@ fn is_chain_scoped(error: &chain_client::Error) -> bool {
 /// capped at `max_retry_delay`.
 fn back_off(
     failures: &mut u32,
-    retry_at: &mut Option<Instant>,
-    now: Instant,
+    retry_at: &mut Option<Timestamp>,
+    now: Timestamp,
     config: &BlockExportConfig,
 ) {
-    *retry_at = Some(now + backoff_delay(*failures, config));
+    *retry_at = Some(now.saturating_add(backoff_delay(*failures, config)));
     *failures = failures.saturating_add(1);
 }
 
 /// The delay after `attempt` consecutive failures: doubles per attempt, capped.
-fn backoff_delay(attempt: u32, config: &BlockExportConfig) -> linera_base::time::Duration {
-    config
+fn backoff_delay(attempt: u32, config: &BlockExportConfig) -> TimeDelta {
+    let delay = config
         .retry_delay
         .saturating_mul(1u32.checked_shl(attempt).unwrap_or(u32::MAX))
-        .min(config.max_retry_delay)
+        .min(config.max_retry_delay);
+    TimeDelta::from_micros(delay.as_micros() as u64)
 }
 
 /// Sends this validator's blocks to one other validator, reading everything it needs from
@@ -1919,7 +2060,7 @@ mod tests {
         let destinations = test_destinations([validator, other]);
         let exported = [(validator, BlockHeight(41))].into_iter().collect();
 
-        let record = ChainRecord::new(Instant::now(), &destinations, &exported);
+        let record = ChainRecord::new(Timestamp::now(), &destinations, &exported);
 
         assert_eq!(
             record.dest(0).unwrap().next_height,
@@ -1946,7 +2087,7 @@ mod tests {
         let exported: BTreeMap<_, _> = [(validator, BlockHeight(7))].into_iter().collect();
 
         // As the tick builds it: no heights to hand over, so the cursor starts unset.
-        let mut record = ChainRecord::new(Instant::now(), &destinations, &BTreeMap::new());
+        let mut record = ChainRecord::new(Timestamp::now(), &destinations, &BTreeMap::new());
         assert_eq!(record.dest(0).unwrap().next_height, None);
 
         // The fill `on_block` performs once a block for that chain arrives.
@@ -2028,7 +2169,7 @@ mod tests {
             max_retry_delay: Duration::from_secs(60),
             ..BlockExportConfig::default()
         };
-        let now = Instant::now();
+        let now = Timestamp::now();
         let tip = BlockHeight(100);
 
         // A genuine restore: one regression, then it advances from there for good.
@@ -2040,7 +2181,10 @@ mod tests {
             .record_reached(BlockHeight(10), tip, now, &config)
             .is_some());
         let restore_penalty = restored.retry_at.expect("a regression backs the pair off");
-        assert_eq!(restore_penalty, now + Duration::from_millis(100));
+        assert_eq!(
+            restore_penalty,
+            now.saturating_add(TimeDelta::from_millis(100))
+        );
         restored.record_reached(BlockHeight(20), tip, now, &config);
         assert_eq!(
             restored.retry_at, None,
@@ -2056,16 +2200,20 @@ mod tests {
         let mut penalties = Vec::new();
         for round in 0..4 {
             liar.record_reached(BlockHeight(10), tip, now, &config);
-            penalties.push(liar.retry_at.expect("a regression backs the pair off") - now);
+            penalties.push(
+                liar.retry_at
+                    .expect("a regression backs the pair off")
+                    .delta_since(now),
+            );
             liar.record_reached(BlockHeight(50 + round), tip, now, &config);
         }
         assert_eq!(
             penalties,
             vec![
-                Duration::from_millis(100),
-                Duration::from_millis(200),
-                Duration::from_millis(400),
-                Duration::from_millis(800),
+                TimeDelta::from_millis(100),
+                TimeDelta::from_millis(200),
+                TimeDelta::from_millis(400),
+                TimeDelta::from_millis(800),
             ],
             "an advance between regressions reset the penalty",
         );
@@ -2086,7 +2234,7 @@ mod tests {
         // the cursor raw satisfies every "converged" predicate and no "behind" one, and only a
         // completed send can rewrite it, so the pair would never be scheduled again.
         let mut liar = ChainDest::default();
-        let acked = liar.record_reached(BlockHeight(u64::MAX), tip, Instant::now(), &config);
+        let acked = liar.record_reached(BlockHeight(u64::MAX), tip, Timestamp::now(), &config);
         assert_eq!(
             acked,
             Some(BlockHeight(99)),
@@ -2101,7 +2249,7 @@ mod tests {
         // And an honest report below the tip is taken at its word, not rounded up to it —
         // otherwise "always acknowledge tip - 1" would satisfy the clamp just as well.
         let mut honest = ChainDest::default();
-        let acked = honest.record_reached(BlockHeight(40), tip, Instant::now(), &config);
+        let acked = honest.record_reached(BlockHeight(40), tip, Timestamp::now(), &config);
         assert_eq!(
             acked,
             Some(BlockHeight(39)),
@@ -2115,6 +2263,30 @@ mod tests {
     #[test]
     fn the_regression_counter_costs_no_memory() {
         assert_eq!(size_of::<ChainDest>(), 56);
+    }
+
+    /// Our own storage failing is not the destination's fault, and not one pair's problem
+    /// either: it shrinks the queue-wide budget, leaving the peer's window alone.
+    ///
+    /// Classifying it per-pair (as `ChainScoped` did) backs off one pair at a time while every
+    /// other pair keeps reading at full rate, so the control loop cannot see the bottleneck it
+    /// is creating.
+    #[test]
+    fn local_storage_errors_are_neither_chain_nor_destination_scoped() {
+        let view_error = chain_client::Error::ViewError(linera_views::ViewError::NotFound(
+            "storage is unhappy".to_owned(),
+        ));
+        assert!(is_local_scoped(&view_error));
+        assert!(
+            !is_chain_scoped(&view_error),
+            "a storage failure would back off one pair and leave the budget untouched",
+        );
+
+        // A destination genuinely lacking the chain's events stays chain-scoped.
+        let events_missing =
+            chain_client::Error::RemoteNodeError(NodeError::EventsNotFound(vec![]));
+        assert!(is_chain_scoped(&events_missing));
+        assert!(!is_local_scoped(&events_missing));
     }
 
     /// A drained burst hands back its peak-sized table for freeing off the mutex; a live one
@@ -2212,19 +2384,19 @@ mod tests {
         };
         let mut failures = 0;
         let mut retry_at = None;
-        let now = Instant::now();
+        let now = Timestamp::now();
         let mut delays = Vec::new();
         for _ in 0..4 {
             back_off(&mut failures, &mut retry_at, now, &config);
-            delays.push(retry_at.expect("set by back_off") - now);
+            delays.push(retry_at.expect("set by back_off").delta_since(now));
         }
         assert_eq!(
             delays,
             [
-                Duration::from_millis(100),
-                Duration::from_millis(200),
-                Duration::from_millis(400),
-                Duration::from_millis(450),
+                TimeDelta::from_millis(100),
+                TimeDelta::from_millis(200),
+                TimeDelta::from_millis(400),
+                TimeDelta::from_millis(450),
             ],
         );
     }

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -32,7 +32,10 @@
 //! pair.
 //!
 //! Chains converge and are forgotten: a record exists only while some destination is behind, so
-//! memory is bounded by lagging chains, not by every chain the process ever served. The
+//! memory is bounded by lagging chains, not by every chain the process ever served. Note what
+//! that means during an outage — a destination that is down keeps every chain that produced a
+//! block while it was gone, because that set *is* the work-list its catch-up needs. That is
+//! bounded by the chains that were active, and [`metrics::TRACKED_CHAINS`] exposes it. The
 //! work-list therefore covers chains seen since the process started — a validator that needs the
 //! full history of a chain that never produces blocks again is out of scope here.
 
@@ -73,6 +76,17 @@ mod metrics {
         register_histogram_vec, register_int_counter, register_int_gauge, register_int_gauge_vec,
     };
     use prometheus::{Histogram, HistogramVec, IntCounter, IntGauge, IntGaugeVec};
+
+    /// Chains the queue is tracking: those with a destination still behind, plus recently
+    /// converged ones inside the retention window. A destination that is down holds every chain
+    /// that produced a block during the outage here — that is the work-list its catch-up needs,
+    /// and this is how an operator sees it growing.
+    pub static TRACKED_CHAINS: LazyLock<IntGauge> = LazyLock::new(|| {
+        register_int_gauge(
+            "block_export_tracked_chains",
+            "Chains the export queue is tracking for catch-up",
+        )
+    });
 
     /// Blocks waiting in the export queue.
     pub static QUEUE_SIZE: LazyLock<IntGauge> = LazyLock::new(|| {
@@ -499,6 +513,34 @@ impl ChainRecord {
     }
 }
 
+impl ChainRecord {
+    /// Fills in every cursor this record does not have from the chain's persisted heights.
+    ///
+    /// Applied on every block rather than at record creation, and idempotent. Tying the seeding
+    /// to creation has failed twice — the tick creates records too, from a tip announced before
+    /// its block was dequeued, and it has no heights to seed with; an `or_insert` then cannot
+    /// correct a cursor that already exists as `None`.
+    ///
+    /// Safe for a cursor a failure cleared, too: the persisted height is a lower bound, so the
+    /// worst case is re-offering blocks the destination already holds, and its reply corrects
+    /// the cursor in either direction.
+    fn seed_missing_cursors<N>(
+        &mut self,
+        destinations: &HashMap<ValidatorPublicKey, DestState<N>>,
+        exported_heights: &BTreeMap<ValidatorPublicKey, BlockHeight>,
+    ) {
+        for validator in destinations.keys() {
+            let seed = exported_heights
+                .get(validator)
+                .and_then(|height| height.try_add_one().ok());
+            let chain_dest = self.dests.entry(*validator).or_default();
+            if chain_dest.next_height.is_none() && chain_dest.in_flight.is_none() {
+                chain_dest.next_height = seed;
+            }
+        }
+    }
+}
+
 /// One chain's cursor at one destination.
 #[derive(Default)]
 struct ChainDest {
@@ -696,17 +738,7 @@ where
             .or_insert_with(|| ChainRecord::new(now, &self.destinations, &block.exported_heights));
         record.tip = record.tip.max(tip);
         record.last_activity = now;
-        // A destination that joined after this record did still needs a cursor, and the chain's
-        // persisted height is a better start than none.
-        for validator in self.destinations.keys() {
-            record.dests.entry(*validator).or_insert_with(|| ChainDest {
-                next_height: block
-                    .exported_heights
-                    .get(validator)
-                    .and_then(|height| height.try_add_one().ok()),
-                ..ChainDest::default()
-            });
-        }
+        record.seed_missing_cursors(&self.destinations, &block.exported_heights);
         let validators = self.destinations.keys().copied().collect::<Vec<_>>();
         for validator in validators {
             let record = self.chains.get_mut(&chain_id).expect("inserted above");
@@ -1002,6 +1034,9 @@ where
                 progress.remove(chain_id);
             }
         }
+
+        #[cfg(with_metrics)]
+        metrics::TRACKED_CHAINS.set(self.chains.len() as i64);
 
         // Requeue everything whose backoff expired and is still behind.
         for (chain_id, record) in &mut self.chains {
@@ -1599,6 +1634,33 @@ mod tests {
         assert_eq!(
             record.dests[&other].next_height, None,
             "a destination with nothing persisted must be queried, not assumed",
+        );
+    }
+
+    /// A cursor already present as `None` — the state a tick-created record starts in — is still
+    /// seeded from the persisted heights.
+    ///
+    /// The seeding has regressed three times, each time because it was tied to record *creation*
+    /// while a second path also creates records. This pins the property that actually matters:
+    /// after the fill, a missing cursor is seeded no matter who made the record.
+    #[test]
+    fn a_cursor_left_unset_is_still_seeded() {
+        let validator = ValidatorPublicKey::test_key(1);
+        let destinations: HashMap<ValidatorPublicKey, DestState<()>> =
+            [(validator, test_dest_state())].into_iter().collect();
+        let exported: BTreeMap<_, _> = [(validator, BlockHeight(7))].into_iter().collect();
+
+        // As the tick builds it: no heights to hand over, so the cursor starts unset.
+        let mut record = ChainRecord::new(Instant::now(), &destinations, &BTreeMap::new());
+        assert_eq!(record.dests[&validator].next_height, None);
+
+        // The fill `on_block` performs once a block for that chain arrives.
+        record.seed_missing_cursors(&destinations, &exported);
+
+        assert_eq!(
+            record.dests[&validator].next_height,
+            Some(BlockHeight(8)),
+            "a record the tick created must still pick up the persisted cursor",
         );
     }
 

--- a/linera-core/src/chain_worker/export.rs
+++ b/linera-core/src/chain_worker/export.rs
@@ -456,9 +456,9 @@ enum SendOutcome {
     /// The validator answered; its reported next height.
     Reached(BlockHeight),
     /// The failure is about this chain on this destination, not about the destination.
-    ChainScoped(chain_client::Error),
+    ChainScoped(Box<chain_client::Error>),
     /// The failure is about the destination itself.
-    DestinationScoped(chain_client::Error),
+    DestinationScoped(Box<chain_client::Error>),
 }
 
 /// The body of the process-wide export queue task.
@@ -1088,8 +1088,8 @@ where
             };
             let outcome = match result {
                 Ok(next_height) => SendOutcome::Reached(next_height),
-                Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(error),
-                Err(error) => SendOutcome::DestinationScoped(error),
+                Err(error) if is_chain_scoped(&error) => SendOutcome::ChainScoped(Box::new(error)),
+                Err(error) => SendOutcome::DestinationScoped(Box::new(error)),
             };
             (chain_id, validator, generation, outcome)
         };

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -15,9 +15,6 @@ pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::state::{BlockOutcome, CrossChainUpdateResult, EventSubscriptionsResult};
 pub use self::{
     config::ChainWorkerConfig,
-    export::{
-        spawn_chain_exporter, BlockExportConfig, ChainExportSetup, ChainExporter,
-        ChainExporterFactory,
-    },
+    export::{spawn_block_export_queue, BlockExportConfig, BlockExportHandle},
     state::ProcessConfirmedBlockMode,
 };

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -5,6 +5,7 @@
 
 mod config;
 mod delivery_notifier;
+pub(crate) mod export;
 pub(crate) mod handle;
 pub(crate) mod state;
 
@@ -12,4 +13,11 @@ pub(super) use self::delivery_notifier::DeliveryNotifier;
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
 pub(crate) use self::state::{BlockOutcome, CrossChainUpdateResult, EventSubscriptionsResult};
-pub use self::{config::ChainWorkerConfig, state::ProcessConfirmedBlockMode};
+pub use self::{
+    config::ChainWorkerConfig,
+    export::{
+        spawn_chain_exporter, BlockExportConfig, ChainExportSetup, ChainExporter,
+        ChainExporterFactory,
+    },
+    state::ProcessConfirmedBlockMode,
+};

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1212,10 +1212,12 @@ where
             })),
         };
 
+        // Through the cache rather than `Arc::new`: these blobs are already in storage's cache
+        // in the common case, and the cache is what keeps one allocation per blob content.
         let blobs = published_blobs
             .into_iter()
             .chain(read_blobs.into_values())
-            .map(Arc::new)
+            .map(|blob| self.storage.cache_blob(blob))
             .collect();
         exporter.export(
             certificate.clone(),

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -132,6 +132,9 @@ where
     poisoned: bool,
     /// The process-wide export queue, if the server enabled block export.
     block_export: Option<BlockExportHandle>,
+    /// When export progress was last folded into `exported_heights`, to bound the register
+    /// rewrites on an active chain.
+    last_exported_heights_fold: Option<linera_base::time::Instant>,
 }
 
 /// The result of processing a cross-chain update.
@@ -212,6 +215,7 @@ where
             knows_chain_is_active: false,
             poisoned: false,
             block_export,
+            last_exported_heights_fold: None,
         })
     }
 
@@ -1021,8 +1025,17 @@ where
         tip: ChainTipState,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
-        // Hold the certificate behind the storage cache's shared pointer.
-        let certificate = self.storage.cache_certificate(certificate);
+        // Cached only when export is on: the queue holds the shared pointer, and inserting on
+        // every executed block would otherwise churn the dedup cache for nothing.
+        let (cached, plain) = if self.block_export.is_some() {
+            (Some(self.storage.cache_certificate(certificate)), None)
+        } else {
+            (None, Some(certificate))
+        };
+        let certificate = cached
+            .as_deref()
+            .or(plain.as_ref())
+            .expect("exactly one of the two is set");
         let block_hash = certificate.hash();
         let block = certificate.block();
         let chain_id = block.header.chain_id;
@@ -1114,7 +1127,7 @@ where
                 tracked.as_deref().map(|h| h.inner()),
             )
             .await?;
-        self.export_block(&certificate, published_blobs, blobs)
+        self.export_block(cached.as_ref(), published_blobs, blobs)
             .await;
         let mut actions = self.create_network_actions(None).await?;
         trace!("Processed confirmed block {height}");
@@ -1160,11 +1173,13 @@ where
     /// consensus, so a problem here is logged and the block stands.
     async fn export_block(
         &mut self,
-        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        certificate: Option<&CacheArc<ConfirmedBlockCertificate>>,
         published_blobs: Vec<Blob>,
         read_blobs: BTreeMap<BlobId, Blob>,
     ) {
-        let Some(export) = self.block_export.clone() else {
+        // The certificate is cached exactly when export is enabled, so both are `Some` or
+        // neither is.
+        let (Some(export), Some(certificate)) = (self.block_export.clone(), certificate) else {
             return;
         };
         // The committee *after* applying the block: a validator that this very block admits has to
@@ -1204,7 +1219,18 @@ where
             }
         }
         if **self.chain.exported_heights.get() != merged {
-            self.chain.exported_heights.set(merged.into());
+            // Rewrites of an already-populated register are throttled: it is re-serialized
+            // whole, changes on every block of an active chain, and is a lower bound by design.
+            // The first real content is never held back.
+            let now = linera_base::time::Instant::now();
+            let throttled = !self.chain.exported_heights.get().is_empty()
+                && self.last_exported_heights_fold.is_some_and(|last| {
+                    now.duration_since(last) < self.config.exported_heights_fold_interval
+                });
+            if !throttled {
+                self.last_exported_heights_fold = Some(now);
+                self.chain.exported_heights.set(merged.into());
+            }
         }
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1021,9 +1021,7 @@ where
         tip: ChainTipState,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
-        // Hold the certificate behind the storage cache's shared pointer rather than unwrapping
-        // the block out of it: the export task pushes this very certificate, so it never has to
-        // read the block back from storage.
+        // Hold the certificate behind the storage cache's shared pointer.
         let certificate = self.storage.cache_certificate(certificate);
         let block_hash = certificate.hash();
         let block = certificate.block();
@@ -1190,7 +1188,6 @@ where
             certificate.clone(),
             blobs,
             epoch,
-            committee.clone(),
             (**self.chain.exported_heights.get()).clone(),
         );
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1221,7 +1221,10 @@ where
         if **self.chain.exported_heights.get() != merged {
             // Rewrites of an already-populated register are throttled: it is re-serialized
             // whole, changes on every block of an active chain, and is a lower bound by design.
-            // The first real content is never held back.
+            // The first real content is never held back. The tail of a burst may therefore
+            // never be folded at all — there is no later save to carry it — which is accepted:
+            // the cost is one query per destination when the cursor is rebuilt, and the
+            // alternative is a full register write per block.
             let now = linera_base::time::Instant::now();
             let throttled = !self.chain.exported_heights.get().is_empty()
                 && self.last_exported_heights_fold.is_some_and(|last| {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1186,7 +1186,13 @@ where
             .chain(read_blobs.into_values())
             .map(|blob| self.storage.cache_blob(blob))
             .collect();
-        export.export(certificate.clone(), blobs, epoch, committee.clone());
+        export.export(
+            certificate.clone(),
+            blobs,
+            epoch,
+            committee.clone(),
+            (**self.chain.exported_heights.get()).clone(),
+        );
 
         // Fold in what the queue has recorded so far — which never includes the block we just
         // queued. Merged by maximum: the queue drops a chain's progress once it converges, and an

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1168,16 +1168,10 @@ where
         ))
     }
 
-    /// Hands the block just executed to this chain's export task, which pushes it to the other
-    /// validators in the committee, and folds the task's progress into the chain state so that
-    /// the save that follows persists it.
-    ///
-    /// Returns as soon as the block is queued: the pushes themselves happen on the export task,
-    /// off the block-execution path. Does nothing if the server did not enable block export.
-    ///
-    /// Never fails the block. Export is replication, not consensus: a block we cannot export is
-    /// still a block this validator has executed and committed, so a problem here is logged and
-    /// the block stands.
+    /// Queues the block just executed for export and folds the task's progress into the chain
+    /// state, for the save that follows to persist. Returns as soon as it is queued, and does
+    /// nothing if export is disabled. Never fails the block: export is replication, not
+    /// consensus, so a problem here is logged and the block stands.
     async fn export_block(
         &mut self,
         certificate: &CacheArc<ConfirmedBlockCertificate>,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -55,7 +55,6 @@ use crate::{
     },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
-    local_node::LocalNodeClient,
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
 
@@ -135,9 +134,6 @@ where
     poisoned: bool,
     /// Creates this chain's export task, if the server enabled block export.
     export_factory: Option<ChainExporterFactory<StorageClient>>,
-    /// Read access to this process's chains, which the export task needs for the few chain-level
-    /// queries it cannot answer from the certificate partitions.
-    local_node: LocalNodeClient<StorageClient>,
     /// This chain's export task, spawned the first time the chain executes a block so that
     /// chains we only ever receive from cost nothing.
     exporter: Option<ChainExporter>,
@@ -204,7 +200,6 @@ where
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
         service_runtime_task: Option<web_thread_pool::Task<()>>,
         export_factory: Option<ChainExporterFactory<StorageClient>>,
-        local_node: LocalNodeClient<StorageClient>,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
@@ -222,7 +217,6 @@ where
             knows_chain_is_active: false,
             poisoned: false,
             export_factory,
-            local_node,
             exporter: None,
         })
     }
@@ -1182,7 +1176,7 @@ where
             return;
         };
         // The committee *after* applying the block: a validator that this very block admits has to
-        // be exported to from now on, starting with the admin-chain block that admitted it.
+        // be exported to from now on.
         let committee = match self.chain.current_committee().await {
             Ok((_, committee)) => committee,
             Err(error) => {
@@ -1190,18 +1184,12 @@ where
                 return;
             }
         };
-        let Some(admin_chain_id) = *self.chain.execution_state.system.admin_chain_id.get() else {
-            // An active chain always knows its admin chain, and `current_committee` above has
-            // already established that this one is active.
-            warn!("Not exporting a block of a chain that has no admin chain");
-            return;
-        };
 
         let exporter = match &self.exporter {
             Some(exporter) => exporter,
             None => self.exporter.insert(export_factory(ChainExportSetup {
                 chain_id: self.chain.chain_id(),
-                local_node: self.local_node.clone(),
+                storage: self.storage.clone(),
                 exported_heights: self.chain.exported_heights.get().clone().into(),
             })),
         };
@@ -1213,12 +1201,7 @@ where
             .chain(read_blobs.into_values())
             .map(|blob| self.storage.cache_blob(blob))
             .collect();
-        exporter.export(
-            certificate.clone(),
-            blobs,
-            committee.clone(),
-            admin_chain_id,
-        );
+        exporter.export(certificate.clone(), blobs, committee.clone());
 
         // Record what the task has acknowledged so far — which never includes the block we just
         // queued, and after a stall may not have moved at all. Only mark the register dirty when

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -48,9 +48,14 @@ use tokio::sync::oneshot;
 use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
-    chain_worker::{handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier},
+    chain_worker::{
+        export::{ChainExportSetup, ChainExporter, ChainExporterFactory},
+        handle::AtomicTimestamp,
+        ChainWorkerConfig, DeliveryNotifier,
+    },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    local_node::LocalNodeClient,
     worker::{BatchRequest, NetworkActions, Notification, Reason, WorkerError},
 };
 
@@ -128,6 +133,14 @@ where
     /// Set to `true` if a database `save` failure has left storage potentially
     /// inconsistent.
     poisoned: bool,
+    /// Creates this chain's export task, if the server enabled block export.
+    export_factory: Option<ChainExporterFactory<StorageClient>>,
+    /// Read access to this process's chains, which the export task needs for the few chain-level
+    /// queries it cannot answer from the certificate partitions.
+    local_node: LocalNodeClient<StorageClient>,
+    /// This chain's export task, spawned the first time the chain executes a block so that
+    /// chains we only ever receive from cost nothing.
+    exporter: Option<ChainExporter>,
 }
 
 /// The result of processing a cross-chain update.
@@ -190,6 +203,8 @@ where
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
         service_runtime_task: Option<web_thread_pool::Task<()>>,
+        export_factory: Option<ChainExporterFactory<StorageClient>>,
+        local_node: LocalNodeClient<StorageClient>,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
@@ -206,6 +221,9 @@ where
             delivery_notifier,
             knows_chain_is_active: false,
             poisoned: false,
+            export_factory,
+            local_node,
+            exporter: None,
         })
     }
 
@@ -1015,6 +1033,10 @@ where
         tip: ChainTipState,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions, BlockOutcome), WorkerError> {
+        // Hold the certificate behind the storage cache's shared pointer rather than unwrapping
+        // the block out of it: the export task pushes this very certificate, so it never has to
+        // read the block back from storage.
+        let certificate = self.storage.cache_certificate(certificate);
         let block_hash = certificate.hash();
         let block = certificate.block();
         let chain_id = block.header.chain_id;
@@ -1073,7 +1095,7 @@ where
                         .clone_with_base_key(ctx.base_key().bytes.clone())
                 })
                 .await;
-            certificate.into_value()
+            Cow::Borrowed(certificate.value())
         } else {
             let oracle_responses = Some(block.body.oracle_responses.clone());
             let (proposed_block, outcome) = block.clone().into_proposal();
@@ -1096,7 +1118,7 @@ where
                 ))
                 .into());
             }
-            ConfirmedBlock::new(Block::new(proposed_block, verified))
+            Cow::Owned(ConfirmedBlock::new(Block::new(proposed_block, verified)))
         };
 
         let event_streams = chain
@@ -1106,6 +1128,8 @@ where
                 tracked.as_deref().map(|h| h.inner()),
             )
             .await?;
+        self.export_block(&certificate, published_blobs, blobs)
+            .await;
         let mut actions = self.create_network_actions(None).await?;
         trace!("Processed confirmed block {height}");
         let hash = confirmed_block.inner().hash();
@@ -1129,8 +1153,10 @@ where
         }
         self.save().await?;
 
-        self.block_values
-            .insert_hashed(Cow::Owned(confirmed_block.into_inner()));
+        self.block_values.insert_hashed(match confirmed_block {
+            Cow::Borrowed(block) => Cow::Borrowed(block.inner()),
+            Cow::Owned(block) => Cow::Owned(block.into_inner()),
+        });
 
         self.register_delivery_notifier(height, &actions, notify_when_messages_are_delivered)
             .await;
@@ -1140,6 +1166,71 @@ where
             actions,
             BlockOutcome::Processed,
         ))
+    }
+
+    /// Hands the block just executed to this chain's export task, which pushes it to the other
+    /// validators in the committee, and folds the task's progress into the chain state so that
+    /// the save that follows persists it.
+    ///
+    /// Returns as soon as the block is queued: the pushes themselves happen on the export task,
+    /// off the block-execution path. Does nothing if the server did not enable block export.
+    ///
+    /// Never fails the block. Export is replication, not consensus: a block we cannot export is
+    /// still a block this validator has executed and committed, so a problem here is logged and
+    /// the block stands.
+    async fn export_block(
+        &mut self,
+        certificate: &CacheArc<ConfirmedBlockCertificate>,
+        published_blobs: Vec<Blob>,
+        read_blobs: BTreeMap<BlobId, Blob>,
+    ) {
+        let Some(export_factory) = self.export_factory.clone() else {
+            return;
+        };
+        // The committee *after* applying the block: a validator that this very block admits has to
+        // be exported to from now on, starting with the admin-chain block that admitted it.
+        let committee = match self.chain.current_committee().await {
+            Ok((_, committee)) => committee,
+            Err(error) => {
+                warn!(%error, "Not exporting a block of a chain with no current committee");
+                return;
+            }
+        };
+        let Some(admin_chain_id) = *self.chain.execution_state.system.admin_chain_id.get() else {
+            // An active chain always knows its admin chain, and `current_committee` above has
+            // already established that this one is active.
+            warn!("Not exporting a block of a chain that has no admin chain");
+            return;
+        };
+
+        let exporter = match &self.exporter {
+            Some(exporter) => exporter,
+            None => self.exporter.insert(export_factory(ChainExportSetup {
+                chain_id: self.chain.chain_id(),
+                local_node: self.local_node.clone(),
+                exported_heights: self.chain.exported_heights.get().clone().into(),
+            })),
+        };
+
+        let blobs = published_blobs
+            .into_iter()
+            .chain(read_blobs.into_values())
+            .map(Arc::new)
+            .collect();
+        exporter.export(
+            certificate.clone(),
+            blobs,
+            committee.clone(),
+            admin_chain_id,
+        );
+
+        // Record what the task has acknowledged so far — which never includes the block we just
+        // queued, and after a stall may not have moved at all. Only mark the register dirty when
+        // it actually changed, so a stalled export costs no writes.
+        let progress = exporter.progress(&committee);
+        if **self.chain.exported_heights.get() != progress {
+            self.chain.exported_heights.set(progress.into());
+        }
     }
 
     /// Schedules a notification for when cross-chain messages are delivered up to the given

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -49,9 +49,7 @@ use tracing::{debug, info, instrument, trace, warn};
 
 use crate::{
     chain_worker::{
-        export::{ChainExportSetup, ChainExporter, ChainExporterFactory},
-        handle::AtomicTimestamp,
-        ChainWorkerConfig, DeliveryNotifier,
+        export::BlockExportHandle, handle::AtomicTimestamp, ChainWorkerConfig, DeliveryNotifier,
     },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -132,11 +130,8 @@ where
     /// Set to `true` if a database `save` failure has left storage potentially
     /// inconsistent.
     poisoned: bool,
-    /// Creates this chain's export task, if the server enabled block export.
-    export_factory: Option<ChainExporterFactory<StorageClient>>,
-    /// This chain's export task, spawned the first time the chain executes a block so that
-    /// chains we only ever receive from cost nothing.
-    exporter: Option<ChainExporter>,
+    /// The process-wide export queue, if the server enabled block export.
+    block_export: Option<BlockExportHandle>,
 }
 
 /// The result of processing a cross-chain update.
@@ -199,7 +194,7 @@ where
         chain_id: ChainId,
         service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
         service_runtime_task: Option<web_thread_pool::Task<()>>,
-        export_factory: Option<ChainExporterFactory<StorageClient>>,
+        block_export: Option<BlockExportHandle>,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
@@ -216,8 +211,7 @@ where
             delivery_notifier,
             knows_chain_is_active: false,
             poisoned: false,
-            export_factory,
-            exporter: None,
+            block_export,
         })
     }
 
@@ -1162,7 +1156,7 @@ where
         ))
     }
 
-    /// Queues the block just executed for export and folds the task's progress into the chain
+    /// Queues the block just executed for export and folds the queue's progress into the chain
     /// state, for the save that follows to persist. Returns as soon as it is queued, and does
     /// nothing if export is disabled. Never fails the block: export is replication, not
     /// consensus, so a problem here is logged and the block stands.
@@ -1172,26 +1166,17 @@ where
         published_blobs: Vec<Blob>,
         read_blobs: BTreeMap<BlobId, Blob>,
     ) {
-        let Some(export_factory) = self.export_factory.clone() else {
+        let Some(export) = self.block_export.clone() else {
             return;
         };
         // The committee *after* applying the block: a validator that this very block admits has to
         // be exported to from now on.
-        let committee = match self.chain.current_committee().await {
-            Ok((_, committee)) => committee,
+        let (epoch, committee) = match self.chain.current_committee().await {
+            Ok((epoch, committee)) => (epoch, committee),
             Err(error) => {
                 warn!(%error, "Not exporting a block of a chain with no current committee");
                 return;
             }
-        };
-
-        let exporter = match &self.exporter {
-            Some(exporter) => exporter,
-            None => self.exporter.insert(export_factory(ChainExportSetup {
-                chain_id: self.chain.chain_id(),
-                storage: self.storage.clone(),
-                exported_heights: self.chain.exported_heights.get().clone().into(),
-            })),
         };
 
         // Through the cache rather than `Arc::new`: these blobs are already in storage's cache
@@ -1201,14 +1186,22 @@ where
             .chain(read_blobs.into_values())
             .map(|blob| self.storage.cache_blob(blob))
             .collect();
-        exporter.export(certificate.clone(), blobs, committee.clone());
+        export.export(certificate.clone(), blobs, epoch, committee.clone());
 
-        // Record what the task has acknowledged so far — which never includes the block we just
-        // queued, and after a stall may not have moved at all. Only mark the register dirty when
-        // it actually changed, so a stalled export costs no writes.
-        let progress = exporter.progress(&committee);
-        if **self.chain.exported_heights.get() != progress {
-            self.chain.exported_heights.set(progress.into());
+        // Fold in what the queue has recorded so far — which never includes the block we just
+        // queued. Merged by maximum: the queue drops a chain's progress once it converges, and an
+        // empty read must not regress what an earlier save persisted.
+        let acknowledged = export.progress(self.chain.chain_id(), &committee);
+        let mut merged = std::collections::BTreeMap::new();
+        for validator in committee.validators().keys() {
+            let previous = self.chain.exported_heights.get().get(validator).copied();
+            let reported = acknowledged.get(validator).copied();
+            if let Some(height) = previous.max(reported) {
+                merged.insert(*validator, height);
+            }
+        }
+        if **self.chain.exported_heights.get() != merged {
+            self.chain.exported_heights.set(merged.into());
         }
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1310,8 +1310,6 @@ impl<Env: Environment> Client<Env> {
             local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
             certificate_upload_batch_size: self.options.certificate_upload_batch_size,
-            sync_consensus_rounds: true,
-            max_admin_catch_up_blocks: None,
         }
     }
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1304,12 +1304,14 @@ impl<Env: Environment> Client<Env> {
     fn remote_node_updater(
         &self,
         remote_node: RemoteNode<Env::ValidatorNode>,
-    ) -> RemoteNodeUpdater<Env> {
+    ) -> RemoteNodeUpdater<Env::Storage, Env::ValidatorNode> {
         RemoteNodeUpdater {
             remote_node,
             local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
             certificate_upload_batch_size: self.options.certificate_upload_batch_size,
+            sync_consensus_rounds: true,
+            max_admin_catch_up_blocks: None,
         }
     }
 

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -10,7 +10,10 @@
 #![allow(async_fn_in_trait)]
 
 mod chain_worker;
-pub use chain_worker::{ChainWorkerConfig, ProcessConfirmedBlockMode};
+pub use chain_worker::{
+    spawn_chain_exporter, BlockExportConfig, ChainExportSetup, ChainExporter, ChainExporterFactory,
+    ChainWorkerConfig, ProcessConfirmedBlockMode,
+};
 /// The high-level client for interacting with chains and validators.
 pub mod client;
 pub use client::Client;

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -11,8 +11,8 @@
 
 mod chain_worker;
 pub use chain_worker::{
-    spawn_chain_exporter, BlockExportConfig, ChainExportSetup, ChainExporter, ChainExporterFactory,
-    ChainWorkerConfig, ProcessConfirmedBlockMode,
+    spawn_block_export_queue, BlockExportConfig, BlockExportHandle, ChainWorkerConfig,
+    ProcessConfirmedBlockMode,
 };
 /// The high-level client for interacting with chains and validators.
 pub mod client;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4688,6 +4688,10 @@ where
     // Three peers, one down, so exactly two are ever recorded. Which one is down is deliberately
     // not asserted: `set_fault_type` indexes creation order, the committee map is keyed by public
     // key, and the count is the property that matters.
+    // A block per iteration, because `exported_heights` is only folded while a block is being
+    // processed: progress acknowledged after the last block has nothing to write it. The clock
+    // advance is what lets the export tick run at all — it reads the storage clock, so under the
+    // test clock it only moves when the test moves it.
     let mut exported = BTreeMap::new();
     for _ in 0..40 {
         exported = builder.exported_heights(0, chain_id).await;
@@ -4698,6 +4702,14 @@ where
             .clock()
             .add(linera_base::data_types::TimeDelta::from_millis(100));
         linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
     }
     assert_eq!(
         exported.len(),

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2651,8 +2651,6 @@ where
         local_node: LocalNodeClient::new(state),
         admin_chain_id: builder.admin_chain_id(),
         certificate_upload_batch_size: 100,
-        sync_consensus_rounds: true,
-        max_admin_catch_up_blocks: None,
     };
     let submit = |proposal| {
         let (clock_skew_sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
@@ -4717,10 +4715,7 @@ async fn test_catch_up_sends_at_most_the_bound_per_round<B>(
 where
     B: StorageBuilder,
 {
-    use crate::{
-        local_node::LocalNodeClient, remote_node::RemoteNode, updater::RemoteNodeUpdater,
-        worker::WorkerState, ChainWorkerConfig,
-    };
+    use crate::remote_node::RemoteNode;
 
     /// Small enough that the backlog below needs several rounds, and not a divisor of it, so a
     /// final short round is exercised too.
@@ -4750,24 +4745,16 @@ where
     builder.set_fault_type([3], FaultType::Honest);
     assert_eq!(builder.next_block_height(3, chain_id).await, BlockHeight(0));
 
-    // Drive the updater the way an export round does: at validator 3, reading the blocks out of a
-    // local node that has them (validator 0 stayed online throughout).
+    // Drive the sender the way an export round does: at validator 3, reading the blocks out of
+    // validator 0's storage (it stayed online throughout).
     let node = builder.node(3);
-    let state = WorkerState::new(
-        builder.validator_storage(0),
-        ChainWorkerConfig::default(),
-        None,
-    );
-    let mut updater = RemoteNodeUpdater {
+    let mut sender_task = crate::chain_worker::export::BlockSender {
         remote_node: RemoteNode {
             public_key: node.name(),
             node,
         },
-        local_node: LocalNodeClient::new(state),
-        admin_chain_id: builder.admin_chain_id(),
+        storage: builder.validator_storage(0),
         certificate_upload_batch_size: 100,
-        sync_consensus_rounds: false,
-        max_admin_catch_up_blocks: Some(MAX_CATCH_UP_BLOCKS),
     };
 
     // Round by round: each one advances by exactly the bound until the last, which sends only the
@@ -4777,7 +4764,7 @@ where
     while reached != Some(target) {
         let before = reached;
         reached = Some(
-            updater
+            sender_task
                 .send_missing_blocks(chain_id, target, reached, MAX_CATCH_UP_BLOCKS)
                 .await?,
         );
@@ -4865,103 +4852,6 @@ where
     );
 }
 
-/// `max_admin_catch_up_blocks` bounds the admin-chain replay, and leaving it unset does not.
-///
-/// Export bounds it because `update_admin_chain` runs inside one export round; the client must
-/// not, since it is blocking on one certificate. Both branches are asserted, because the bounded
-/// one is a behaviour change that must not leak into the client's path.
-#[test_case(MemoryStorageBuilder::default(); "memory")]
-#[test_log::test(tokio::test)]
-async fn test_admin_chain_catch_up_is_bounded_only_for_export<B>(
-    storage_builder: B,
-) -> anyhow::Result<()>
-where
-    B: StorageBuilder,
-{
-    use crate::{
-        local_node::LocalNodeClient, remote_node::RemoteNode, updater::RemoteNodeUpdater,
-        worker::WorkerState, ChainWorkerConfig,
-    };
-
-    const MAX_ADMIN_CATCH_UP_BLOCKS: u64 = 2;
-    const BACKLOG: usize = 7;
-
-    let signer = InMemorySigner::new(None);
-    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
-    // Root chain 0 is the admin chain, so these blocks land on the chain the bound governs.
-    let admin = builder.add_root_chain(0, Amount::from_tokens(4)).await?;
-    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
-    let admin_chain_id = builder.admin_chain_id();
-    assert_eq!(admin.chain_id(), admin_chain_id);
-
-    builder.set_fault_type([3], FaultType::Offline);
-    for _ in 0..BACKLOG {
-        admin
-            .transfer_to_account(
-                AccountOwner::CHAIN,
-                Amount::from_millis(1),
-                Account::chain(recipient.chain_id()),
-            )
-            .await
-            .unwrap_ok_committed();
-    }
-    let tip = admin.chain_info().await?.next_block_height;
-    assert_eq!(tip, BlockHeight(BACKLOG as u64));
-    builder.set_fault_type([3], FaultType::Honest);
-    assert_eq!(
-        builder.next_block_height(3, admin_chain_id).await,
-        BlockHeight(0)
-    );
-
-    let make_updater = |builder: &mut TestBuilder<B>, max_admin_catch_up_blocks, storage| {
-        let node = builder.node(3);
-        RemoteNodeUpdater {
-            remote_node: RemoteNode {
-                public_key: node.name(),
-                node,
-            },
-            local_node: LocalNodeClient::new(WorkerState::new(
-                storage,
-                ChainWorkerConfig::default(),
-                None,
-            )),
-            admin_chain_id,
-            certificate_upload_batch_size: 100,
-            sync_consensus_rounds: false,
-            max_admin_catch_up_blocks,
-        }
-    };
-
-    // Export's path: one call moves the admin chain forward by the bound and no further, so the
-    // export round it runs inside stays short.
-    let storage = builder.validator_storage(0);
-    let mut bounded = make_updater(&mut builder, Some(MAX_ADMIN_CATCH_UP_BLOCKS), storage);
-    bounded.update_admin_chain().await?;
-    assert_eq!(
-        builder.next_block_height(3, admin_chain_id).await,
-        BlockHeight(MAX_ADMIN_CATCH_UP_BLOCKS),
-        "a bounded admin catch-up should send exactly {MAX_ADMIN_CATCH_UP_BLOCKS} blocks",
-    );
-
-    // Repeating it keeps making progress rather than re-sending the same prefix forever.
-    bounded.update_admin_chain().await?;
-    assert_eq!(
-        builder.next_block_height(3, admin_chain_id).await,
-        BlockHeight(2 * MAX_ADMIN_CATCH_UP_BLOCKS),
-    );
-
-    // The client's path, unchanged: one call catches the whole chain up.
-    let storage = builder.validator_storage(0);
-    let mut unbounded = make_updater(&mut builder, None, storage);
-    unbounded.update_admin_chain().await?;
-    assert_eq!(
-        builder.next_block_height(3, admin_chain_id).await,
-        tip,
-        "an unbounded admin catch-up should not stop short",
-    );
-    Ok(())
-}
-
 /// A block the destination already has is not sent again.
 ///
 /// `reset_and_reexecute_chain` replays a chain's whole history, and without the guard every block
@@ -4975,10 +4865,7 @@ async fn test_send_block_skips_a_block_the_destination_already_has<B>(
 where
     B: StorageBuilder,
 {
-    use crate::{
-        local_node::LocalNodeClient, remote_node::RemoteNode, updater::RemoteNodeUpdater,
-        worker::WorkerState, ChainWorkerConfig,
-    };
+    use crate::remote_node::RemoteNode;
 
     let signer = InMemorySigner::new(None);
     let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
@@ -5017,24 +4904,17 @@ where
     // From here the destination answers nothing at all, so reaching for it is an error.
     builder.set_fault_type([3], FaultType::Offline);
     let node = builder.node(3);
-    let mut updater = RemoteNodeUpdater {
+    let mut sender_task = crate::chain_worker::export::BlockSender {
         remote_node: RemoteNode {
             public_key: node.name(),
             node,
         },
-        local_node: LocalNodeClient::new(WorkerState::new(
-            storage,
-            ChainWorkerConfig::default(),
-            None,
-        )),
-        admin_chain_id: builder.admin_chain_id(),
+        storage,
         certificate_upload_batch_size: 100,
-        sync_consensus_rounds: false,
-        max_admin_catch_up_blocks: Some(100),
     };
 
     // Re-offer an old block, exactly as a re-execution would.
-    let reached = updater
+    let reached = sender_task
         .send_block(&certificate, &[], Some(tip), 100)
         .await?;
     assert_eq!(
@@ -5042,4 +4922,50 @@ where
         "the destination's height must be reported back"
     );
     Ok(())
+}
+
+/// A chain worker expires at its TTL even while block export is enabled.
+///
+/// The export machinery must never touch its own chain worker: a periodic touch resets the
+/// keep-alive clock, and a worker that is touched forever is resident forever — on a validator
+/// with many chains, that is unbounded memory growth and the TTL flag is a no-op.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_chain_workers_expire_while_export_is_enabled<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    const TTL: linera_base::time::Duration = linera_base::time::Duration::from_millis(500);
+
+    let signer = InMemorySigner::new(None);
+    let mut builder =
+        TestBuilder::new_with_block_export_and_ttl(storage_builder, 4, 0, signer, TTL).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    sender
+        .transfer_to_account(
+            AccountOwner::CHAIN,
+            Amount::from_millis(1),
+            Account::chain(recipient.chain_id()),
+        )
+        .await
+        .unwrap_ok_committed();
+    assert!(builder.resident_chain_workers(0).await > 0);
+
+    // From here nothing touches any chain. Every worker must be gone within a few TTLs;
+    // the generous deadline keeps slow CI from flaking, not the assertion from biting.
+    for _ in 0..100 {
+        if builder.resident_chain_workers(0).await == 0 {
+            return Ok(());
+        }
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+    }
+    panic!(
+        "{} chain workers still resident 10s after the last activity, with a TTL of 500ms — \
+         something in the export path is touching them",
+        builder.resident_chain_workers(0).await,
+    );
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2596,7 +2596,6 @@ where
     use crate::{
         local_node::LocalNodeClient,
         remote_node::RemoteNode,
-        test_utils::NodeProvider,
         updater::{CommunicateAction, RemoteNodeUpdater},
         worker::WorkerState,
         ChainWorkerConfig,
@@ -2644,16 +2643,17 @@ where
         None,
     );
     let node = builder.node(1);
-    let mut updater =
-        RemoteNodeUpdater::<crate::environment::Impl<B::Storage, NodeProvider<B::Storage>>> {
-            remote_node: RemoteNode {
-                public_key: node.name(),
-                node,
-            },
-            local_node: LocalNodeClient::new(state),
-            admin_chain_id: builder.admin_chain_id(),
-            certificate_upload_batch_size: 100,
-        };
+    let mut updater = RemoteNodeUpdater {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        local_node: LocalNodeClient::new(state),
+        admin_chain_id: builder.admin_chain_id(),
+        certificate_upload_batch_size: 100,
+        sync_consensus_rounds: true,
+        max_admin_catch_up_blocks: None,
+    };
     let submit = |proposal| {
         let (clock_skew_sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
         CommunicateAction::SubmitBlock {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4510,3 +4510,87 @@ where
 
     Ok(())
 }
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[test_log::test(tokio::test)]
+async fn test_blocks_are_exported_to_the_committee<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Each save folds in whatever the export task has acknowledged *so far*, so the recorded
+    // heights necessarily trail the tip: the block being saved has only just been queued. Keep
+    // producing blocks until the exports of the earlier ones have been folded in.
+    let mut exported = BTreeMap::new();
+    for _ in 0..10 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+        exported = builder.exported_heights(0, chain_id).await;
+        if exported.len() == 3 && exported.values().all(|height| *height >= BlockHeight(1)) {
+            break;
+        }
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(50)).await;
+    }
+
+    // One entry per *other* committee member: a validator never exports to itself.
+    assert_eq!(
+        exported.len(),
+        3,
+        "expected the first validator to have exported to the three others, got {exported:?}"
+    );
+    assert!(
+        exported.values().all(|height| *height >= BlockHeight(1)),
+        "expected every destination to have acknowledged at least height 1, got {exported:?}"
+    );
+
+    // The destinations really do hold the chain, and the exporter's cursors agree with them.
+    let tip = sender.chain_info().await?.next_block_height;
+    for index in 0..4 {
+        assert_eq!(builder.next_block_height(index, chain_id).await, tip);
+    }
+    Ok(())
+}
+
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_blocks_are_not_exported_without_the_flag<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+
+    for _ in 0..3 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+
+    assert!(
+        builder
+            .exported_heights(0, sender.chain_id())
+            .await
+            .is_empty(),
+        "block export must stay off unless the server asks for it",
+    );
+    Ok(())
+}

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4813,6 +4813,9 @@ where
         signer,
         crate::BlockExportConfig {
             max_catch_up_blocks: MAX_CATCH_UP_BLOCKS,
+            // A queue this small drops blocks under the burst below, so this also covers the
+            // drop-and-repair path: anything dropped must come back through catch-up.
+            queue_size: 2,
             ..TestBuilder::<B>::test_block_export_config()
         },
     )

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4539,7 +4539,10 @@ where
         if exported.len() == 3 && exported.values().all(|height| *height >= BlockHeight(1)) {
             break;
         }
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(50)).await;
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(50));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
     }
 
     // One entry per *other* committee member: a validator never exports to itself.
@@ -4639,7 +4642,10 @@ where
         if builder.next_block_height(3, chain_id).await == tip {
             return Ok(());
         }
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
     }
     panic!(
         "export did not catch the lagging validator up to {tip} while idle; it is at {}",
@@ -4688,7 +4694,10 @@ where
         if exported.len() >= 2 {
             break;
         }
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
     }
     assert_eq!(
         exported.len(),
@@ -4846,7 +4855,10 @@ where
         if builder.next_block_height(3, chain_id).await == tip {
             return Ok(());
         }
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
     }
     panic!(
         "export did not drain a backlog of {BACKLOG} in rounds of {MAX_CATCH_UP_BLOCKS}; it \
@@ -4964,7 +4976,10 @@ where
         if builder.resident_chain_workers(0).await == 0 {
             return Ok(());
         }
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+        builder
+            .clock()
+            .add(linera_base::data_types::TimeDelta::from_millis(100));
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
     }
     panic!(
         "{} chain workers still resident 10s after the last activity, with a TTL of 500ms — \

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4594,3 +4594,120 @@ where
     );
     Ok(())
 }
+
+/// A validator that missed blocks is caught up by export alone, while the chain is idle.
+///
+/// This isolates the mechanism deliberately. One validator is offline while the chain produces
+/// blocks, then comes back — and then *nothing else happens*: no further blocks, and the client is
+/// never asked to do anything, so it has no reason to talk to that validator. The only thing that
+/// can close the gap is the export tasks noticing a lagging destination with an empty queue. That
+/// is the same path a validator joining a long-lived chain takes, where it reports height 0 and
+/// has to be replayed the whole history.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_export_catches_a_lagging_validator_up_while_idle<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Validator 3 misses everything below. The other three still form a quorum, so the chain
+    // advances without it.
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..5 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    assert!(tip >= BlockHeight(5));
+
+    // Bring it back and then do nothing at all: no new blocks, no client activity. Anything that
+    // happens from here is export catching up on its own. (Its height can only be read once it is
+    // reachable again — an offline validator answers no queries.)
+    builder.set_fault_type([3], FaultType::Honest);
+    assert!(
+        builder.next_block_height(3, chain_id).await < tip,
+        "the validator that was offline should start out behind",
+    );
+    for _ in 0..60 {
+        if builder.next_block_height(3, chain_id).await == tip {
+            return Ok(());
+        }
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+    }
+    panic!(
+        "export did not catch the lagging validator up to {tip} while idle; it is at {}",
+        builder.next_block_height(3, chain_id).await,
+    );
+}
+
+/// A destination that is unreachable must not stall export to the rest of the committee.
+///
+/// The failing validator is the one this asserts *around*: the others still receive every block,
+/// and the exporter records progress only for them, so one dead peer degrades to a gap in
+/// `exported_heights` rather than to a stalled chain.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_export_survives_an_unreachable_destination<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Take one validator away. Its own exporter stops too, which is why the assertions below are
+    // all made from validator 0's point of view.
+    builder.set_fault_type([3], FaultType::Offline);
+
+    for _ in 0..6 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+
+    // Validator 0 has three peers and one of them is down, so exactly two should ever be
+    // recorded: export keeps flowing to the reachable ones, and the dead one is simply absent
+    // rather than taking the chain's export down with it. Identifying *which* peer is down is
+    // deliberately avoided — `set_fault_type` indexes creation order while the committee map is
+    // ordered by public key, and the count is the property that matters anyway.
+    let mut exported = BTreeMap::new();
+    for _ in 0..40 {
+        exported = builder.exported_heights(0, chain_id).await;
+        if exported.len() >= 2 {
+            break;
+        }
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+    }
+    assert_eq!(
+        exported.len(),
+        2,
+        "expected the two reachable peers to be exported to, and only those; got {exported:?}",
+    );
+    assert!(
+        exported.values().all(|height| *height >= BlockHeight(1)),
+        "reachable peers should have acknowledged real progress; got {exported:?}",
+    );
+    Ok(())
+}

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4813,8 +4813,8 @@ where
         signer,
         crate::BlockExportConfig {
             max_catch_up_blocks: MAX_CATCH_UP_BLOCKS,
-            // A queue this small drops blocks under the burst below, so this also covers the
-            // drop-and-repair path: anything dropped must come back through catch-up.
+            // The smallest queue the config accepts, so the bound is exercised; the sequential
+            // burst never outruns the in-process task, so no block is actually dropped here.
             queue_size: 2,
             ..TestBuilder::<B>::test_block_export_config()
         },

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4542,7 +4542,7 @@ where
         builder
             .clock()
             .add(linera_base::data_types::TimeDelta::from_millis(50));
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(50)).await;
     }
 
     // One entry per *other* committee member: a validator never exports to itself.
@@ -4645,7 +4645,7 @@ where
         builder
             .clock()
             .add(linera_base::data_types::TimeDelta::from_millis(100));
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
     }
     panic!(
         "export did not catch the lagging validator up to {tip} while idle; it is at {}",
@@ -4697,7 +4697,7 @@ where
         builder
             .clock()
             .add(linera_base::data_types::TimeDelta::from_millis(100));
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
     }
     assert_eq!(
         exported.len(),
@@ -4858,7 +4858,7 @@ where
         builder
             .clock()
             .add(linera_base::data_types::TimeDelta::from_millis(100));
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
     }
     panic!(
         "export did not drain a backlog of {BACKLOG} in rounds of {MAX_CATCH_UP_BLOCKS}; it \
@@ -4979,7 +4979,7 @@ where
         builder
             .clock()
             .add(linera_base::data_types::TimeDelta::from_millis(100));
-        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(20)).await;
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
     }
     panic!(
         "{} chain workers still resident 10s after the last activity, with a TTL of 500ms — \

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4711,3 +4711,267 @@ where
     );
     Ok(())
 }
+
+/// One catch-up round sends at most `max_catch_up_blocks`, and the next round picks up where it
+/// left off.
+///
+/// This is the arithmetic the bound exists for, asserted directly rather than through the export
+/// loop's timing: a round is capped, and capping it does not lose the remainder. A test that only
+/// checked eventual convergence would pass just as well with the bound ignored entirely, since
+/// ignoring it converges in one round.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_catch_up_sends_at_most_the_bound_per_round<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::{
+        local_node::LocalNodeClient, remote_node::RemoteNode, updater::RemoteNodeUpdater,
+        worker::WorkerState, ChainWorkerConfig,
+    };
+
+    /// Small enough that the backlog below needs several rounds, and not a divisor of it, so a
+    /// final short round is exercised too.
+    const MAX_CATCH_UP_BLOCKS: u64 = 3;
+    const BACKLOG: usize = 11;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Validator 3 misses the whole backlog. The other three still form a quorum.
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..BACKLOG {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let target = sender.chain_info().await?.next_block_height;
+    assert_eq!(target, BlockHeight(BACKLOG as u64));
+    builder.set_fault_type([3], FaultType::Honest);
+    assert_eq!(builder.next_block_height(3, chain_id).await, BlockHeight(0));
+
+    // Drive the updater the way an export round does: at validator 3, reading the blocks out of a
+    // local node that has them (validator 0 stayed online throughout).
+    let node = builder.node(3);
+    let state = WorkerState::new(
+        builder.validator_storage(0),
+        ChainWorkerConfig::default(),
+        None,
+    );
+    let mut updater = RemoteNodeUpdater {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        local_node: LocalNodeClient::new(state),
+        admin_chain_id: builder.admin_chain_id(),
+        certificate_upload_batch_size: 100,
+        sync_consensus_rounds: false,
+        max_admin_catch_up_blocks: Some(MAX_CATCH_UP_BLOCKS),
+    };
+
+    // Round by round: each one advances by exactly the bound until the last, which sends only the
+    // remainder and stops at the target rather than overshooting.
+    let mut reached = None;
+    let mut rounds = 0;
+    while reached != Some(target) {
+        let before = reached;
+        reached = Some(
+            updater
+                .send_missing_blocks(chain_id, target, reached, MAX_CATCH_UP_BLOCKS)
+                .await?,
+        );
+        rounds += 1;
+        let expected = target.min(BlockHeight(
+            before.unwrap_or(BlockHeight(0)).0 + MAX_CATCH_UP_BLOCKS,
+        ));
+        assert_eq!(
+            reached,
+            Some(expected),
+            "round {rounds} starting at {before:?} should have reached {expected}",
+        );
+        assert_eq!(
+            builder.next_block_height(3, chain_id).await,
+            expected,
+            "the validator itself should be at {expected} after round {rounds}",
+        );
+        assert!(rounds <= BACKLOG, "catch-up is not converging");
+    }
+    // 11 blocks in chunks of 3: three full rounds and a remainder of two.
+    assert_eq!(rounds, 4);
+    Ok(())
+}
+
+/// A validator behind by more blocks than one round may send is still caught up, over several
+/// rounds, by the idle export loop alone.
+///
+/// The bound is what keeps a freshly-joined validator's backfill from monopolising a chain's
+/// export, so the thing that must not happen is for it to also stop the backfill short. Here the
+/// backlog is several times the bound and nothing else is running: no new blocks, no client
+/// traffic. Only the export loop repeating bounded rounds can close the gap.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_export_catches_up_a_backlog_larger_than_the_bound<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    const MAX_CATCH_UP_BLOCKS: u64 = 2;
+    const BACKLOG: usize = 9;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new_with_block_export_config(
+        storage_builder,
+        4,
+        0,
+        signer,
+        crate::BlockExportConfig {
+            max_catch_up_blocks: MAX_CATCH_UP_BLOCKS,
+            ..TestBuilder::<B>::test_block_export_config()
+        },
+    )
+    .await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..BACKLOG {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    assert_eq!(tip, BlockHeight(BACKLOG as u64));
+
+    // Back online, then idle. Everything from here is the export loop's doing.
+    builder.set_fault_type([3], FaultType::Honest);
+    assert!(builder.next_block_height(3, chain_id).await < tip);
+
+    for _ in 0..100 {
+        if builder.next_block_height(3, chain_id).await == tip {
+            return Ok(());
+        }
+        linera_base::time::timer::sleep(linera_base::time::Duration::from_millis(100)).await;
+    }
+    panic!(
+        "export did not drain a backlog of {BACKLOG} in rounds of {MAX_CATCH_UP_BLOCKS}; it \
+         stopped at {} of {tip}",
+        builder.next_block_height(3, chain_id).await,
+    );
+}
+
+/// `max_admin_catch_up_blocks` bounds the admin-chain replay, and leaving it unset does not.
+///
+/// Export sets it because `update_admin_chain` runs *inside* one export round: replaying a long
+/// admin chain there would stall that chain's export behind an unrelated backfill. The client
+/// leaves it unset, because it is blocking on this one certificate being accepted and must not
+/// give up partway. Both branches are asserted here, since the bounded one is a behaviour change
+/// that must not leak into the client's path.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_admin_chain_catch_up_is_bounded_only_for_export<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::{
+        local_node::LocalNodeClient, remote_node::RemoteNode, updater::RemoteNodeUpdater,
+        worker::WorkerState, ChainWorkerConfig,
+    };
+
+    const MAX_ADMIN_CATCH_UP_BLOCKS: u64 = 2;
+    const BACKLOG: usize = 7;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    // Root chain 0 is the admin chain, so these blocks land on the chain the bound governs.
+    let admin = builder.add_root_chain(0, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let admin_chain_id = builder.admin_chain_id();
+    assert_eq!(admin.chain_id(), admin_chain_id);
+
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..BACKLOG {
+        admin
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = admin.chain_info().await?.next_block_height;
+    assert_eq!(tip, BlockHeight(BACKLOG as u64));
+    builder.set_fault_type([3], FaultType::Honest);
+    assert_eq!(
+        builder.next_block_height(3, admin_chain_id).await,
+        BlockHeight(0)
+    );
+
+    let make_updater = |builder: &mut TestBuilder<B>, max_admin_catch_up_blocks, storage| {
+        let node = builder.node(3);
+        RemoteNodeUpdater {
+            remote_node: RemoteNode {
+                public_key: node.name(),
+                node,
+            },
+            local_node: LocalNodeClient::new(WorkerState::new(
+                storage,
+                ChainWorkerConfig::default(),
+                None,
+            )),
+            admin_chain_id,
+            certificate_upload_batch_size: 100,
+            sync_consensus_rounds: false,
+            max_admin_catch_up_blocks,
+        }
+    };
+
+    // Export's path: one call moves the admin chain forward by the bound and no further, so the
+    // export round it runs inside stays short.
+    let storage = builder.validator_storage(0);
+    let mut bounded = make_updater(&mut builder, Some(MAX_ADMIN_CATCH_UP_BLOCKS), storage);
+    bounded.update_admin_chain().await?;
+    assert_eq!(
+        builder.next_block_height(3, admin_chain_id).await,
+        BlockHeight(MAX_ADMIN_CATCH_UP_BLOCKS),
+        "a bounded admin catch-up should send exactly {MAX_ADMIN_CATCH_UP_BLOCKS} blocks",
+    );
+
+    // Repeating it keeps making progress rather than re-sending the same prefix forever.
+    bounded.update_admin_chain().await?;
+    assert_eq!(
+        builder.next_block_height(3, admin_chain_id).await,
+        BlockHeight(2 * MAX_ADMIN_CATCH_UP_BLOCKS),
+    );
+
+    // The client's path, unchanged: one call catches the whole chain up.
+    let storage = builder.validator_storage(0);
+    let mut unbounded = make_updater(&mut builder, None, storage);
+    unbounded.update_admin_chain().await?;
+    assert_eq!(
+        builder.next_block_height(3, admin_chain_id).await,
+        tip,
+        "an unbounded admin catch-up should not stop short",
+    );
+    Ok(())
+}

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4972,3 +4972,66 @@ where
         builder.resident_chain_workers(0).await,
     );
 }
+
+/// A validator that has fallen behind its cursor reports its own height, which is what lets the
+/// queue notice a regression.
+///
+/// A validator restored from a backup is *behind* where we last saw it. The queue's cursor is
+/// only corrected because a send above that cursor comes back carrying the validator's real
+/// height rather than the one we assumed — this asserts that reporting, which
+/// `on_done` then follows downwards.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_send_block_reports_the_destinations_own_height<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::remote_node::RemoteNode;
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    // Validator 3 misses everything, so its real height stays far below the others'.
+    builder.set_fault_type([3], FaultType::Offline);
+    for _ in 0..4 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    builder.set_fault_type([3], FaultType::Honest);
+    assert_eq!(builder.next_block_height(3, chain_id).await, BlockHeight(0));
+
+    let storage = builder.validator_storage(0);
+    let node = builder.node(3);
+    let mut sender_task = crate::chain_worker::export::BlockSender {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        storage,
+        certificate_upload_batch_size: 100,
+    };
+
+    // Ask with no cursor at all — the state a failed send leaves behind. One bounded round must
+    // come back with what the validator actually holds, so the queue can act on the truth.
+    let reached = sender_task
+        .send_missing_blocks(chain_id, tip, None, 2)
+        .await?;
+    assert_eq!(
+        reached,
+        BlockHeight(2),
+        "a bounded round must report the validator's own height afterwards",
+    );
+    Ok(())
+}

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4975,3 +4975,90 @@ where
     );
     Ok(())
 }
+
+/// A block the destination already has is not sent again.
+///
+/// The guard matters because re-execution replays history: `reset_and_reexecute_chain` pushes
+/// every block of the chain back through the worker, and each one reaches export with the
+/// destination already far ahead of it. Without the check those all go out — the catch-up finds
+/// nothing to do and returns the destination's own height, which is not *below* the block, so the
+/// send proceeds — costing a serialization and a signature verification per block per validator.
+///
+/// Taking the destination offline is what makes this observable: skipping it succeeds precisely
+/// because nothing is sent, whereas any attempt to contact it fails.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[test_log::test(tokio::test)]
+async fn test_send_block_skips_a_block_the_destination_already_has<B>(
+    storage_builder: B,
+) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use crate::{
+        local_node::LocalNodeClient, remote_node::RemoteNode, updater::RemoteNodeUpdater,
+        worker::WorkerState, ChainWorkerConfig,
+    };
+
+    let signer = InMemorySigner::new(None);
+    let mut builder = TestBuilder::new(storage_builder, 4, 0, signer).await?;
+    let sender = builder.add_root_chain(1, Amount::from_tokens(4)).await?;
+    let recipient = builder.add_root_chain(2, Amount::ZERO).await?;
+    let chain_id = sender.chain_id();
+
+    for _ in 0..4 {
+        sender
+            .transfer_to_account(
+                AccountOwner::CHAIN,
+                Amount::from_millis(1),
+                Account::chain(recipient.chain_id()),
+            )
+            .await
+            .unwrap_ok_committed();
+    }
+    let tip = sender.chain_info().await?.next_block_height;
+    assert_eq!(tip, BlockHeight(4));
+    // Every validator followed along, so validator 3 is fully caught up.
+    assert_eq!(builder.next_block_height(3, chain_id).await, tip);
+
+    let storage = builder.validator_storage(0);
+    let hash = storage
+        .read_certificate_hashes_by_heights(chain_id, &[BlockHeight(0)])
+        .await?
+        .into_iter()
+        .next()
+        .flatten()
+        .expect("the chain has a block at height 0");
+    let certificate = storage
+        .read_certificate(hash)
+        .await?
+        .expect("the certificate at height 0 is in storage");
+
+    // From here the destination answers nothing at all, so reaching for it is an error.
+    builder.set_fault_type([3], FaultType::Offline);
+    let node = builder.node(3);
+    let mut updater = RemoteNodeUpdater {
+        remote_node: RemoteNode {
+            public_key: node.name(),
+            node,
+        },
+        local_node: LocalNodeClient::new(WorkerState::new(
+            storage,
+            ChainWorkerConfig::default(),
+            None,
+        )),
+        admin_chain_id: builder.admin_chain_id(),
+        certificate_upload_batch_size: 100,
+        sync_consensus_rounds: false,
+        max_admin_catch_up_blocks: Some(100),
+    };
+
+    // Re-offer an old block, exactly as a re-execution would.
+    let reached = updater
+        .send_block(&certificate, &[], Some(tip), 100)
+        .await?;
+    assert_eq!(
+        reached, tip,
+        "the destination's height must be reported back"
+    );
+    Ok(())
+}

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4565,7 +4565,7 @@ where
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[test_log::test(tokio::test)]
-async fn test_blocks_are_not_exported_without_the_flag<B>(storage_builder: B) -> anyhow::Result<()>
+async fn test_blocks_are_not_exported_by_default<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
 {
@@ -4590,7 +4590,7 @@ where
             .exported_heights(0, sender.chain_id())
             .await
             .is_empty(),
-        "block export must stay off unless the server asks for it",
+        "block export must stay off unless a chain exporter factory is installed",
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -4597,12 +4597,8 @@ where
 
 /// A validator that missed blocks is caught up by export alone, while the chain is idle.
 ///
-/// This isolates the mechanism deliberately. One validator is offline while the chain produces
-/// blocks, then comes back — and then *nothing else happens*: no further blocks, and the client is
-/// never asked to do anything, so it has no reason to talk to that validator. The only thing that
-/// can close the gap is the export tasks noticing a lagging destination with an empty queue. That
-/// is the same path a validator joining a long-lived chain takes, where it reports height 0 and
-/// has to be replayed the whole history.
+/// After the validator comes back, *nothing else happens* — no blocks, no client traffic — so the
+/// only thing that can close the gap is the export task noticing a lagging destination.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[test_log::test(tokio::test)]
 async fn test_export_catches_a_lagging_validator_up_while_idle<B>(
@@ -4655,9 +4651,7 @@ where
 
 /// A destination that is unreachable must not stall export to the rest of the committee.
 ///
-/// The failing validator is the one this asserts *around*: the others still receive every block,
-/// and the exporter records progress only for them, so one dead peer degrades to a gap in
-/// `exported_heights` rather than to a stalled chain.
+/// One dead peer must degrade to a gap in `exported_heights`, not to a stalled chain.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[test_log::test(tokio::test)]
 async fn test_export_survives_an_unreachable_destination<B>(
@@ -4687,11 +4681,9 @@ where
             .unwrap_ok_committed();
     }
 
-    // Validator 0 has three peers and one of them is down, so exactly two should ever be
-    // recorded: export keeps flowing to the reachable ones, and the dead one is simply absent
-    // rather than taking the chain's export down with it. Identifying *which* peer is down is
-    // deliberately avoided — `set_fault_type` indexes creation order while the committee map is
-    // ordered by public key, and the count is the property that matters anyway.
+    // Three peers, one down, so exactly two are ever recorded. Which one is down is deliberately
+    // not asserted: `set_fault_type` indexes creation order, the committee map is keyed by public
+    // key, and the count is the property that matters.
     let mut exported = BTreeMap::new();
     for _ in 0..40 {
         exported = builder.exported_heights(0, chain_id).await;
@@ -4715,10 +4707,8 @@ where
 /// One catch-up round sends at most `max_catch_up_blocks`, and the next round picks up where it
 /// left off.
 ///
-/// This is the arithmetic the bound exists for, asserted directly rather than through the export
-/// loop's timing: a round is capped, and capping it does not lose the remainder. A test that only
-/// checked eventual convergence would pass just as well with the bound ignored entirely, since
-/// ignoring it converges in one round.
+/// Asserted directly rather than through the export loop's timing, because a convergence-only
+/// test passes just as well with the bound ignored — ignoring it converges in one round.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[test_log::test(tokio::test)]
 async fn test_catch_up_sends_at_most_the_bound_per_round<B>(
@@ -4815,10 +4805,8 @@ where
 /// A validator behind by more blocks than one round may send is still caught up, over several
 /// rounds, by the idle export loop alone.
 ///
-/// The bound is what keeps a freshly-joined validator's backfill from monopolising a chain's
-/// export, so the thing that must not happen is for it to also stop the backfill short. Here the
-/// backlog is several times the bound and nothing else is running: no new blocks, no client
-/// traffic. Only the export loop repeating bounded rounds can close the gap.
+/// The bound must not also stop the backfill short. The backlog is several times the bound and
+/// nothing else is running, so only the export loop repeating rounds can close the gap.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[test_log::test(tokio::test)]
 async fn test_export_catches_up_a_backlog_larger_than_the_bound<B>(
@@ -4879,11 +4867,9 @@ where
 
 /// `max_admin_catch_up_blocks` bounds the admin-chain replay, and leaving it unset does not.
 ///
-/// Export sets it because `update_admin_chain` runs *inside* one export round: replaying a long
-/// admin chain there would stall that chain's export behind an unrelated backfill. The client
-/// leaves it unset, because it is blocking on this one certificate being accepted and must not
-/// give up partway. Both branches are asserted here, since the bounded one is a behaviour change
-/// that must not leak into the client's path.
+/// Export bounds it because `update_admin_chain` runs inside one export round; the client must
+/// not, since it is blocking on one certificate. Both branches are asserted, because the bounded
+/// one is a behaviour change that must not leak into the client's path.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[test_log::test(tokio::test)]
 async fn test_admin_chain_catch_up_is_bounded_only_for_export<B>(
@@ -4978,14 +4964,9 @@ where
 
 /// A block the destination already has is not sent again.
 ///
-/// The guard matters because re-execution replays history: `reset_and_reexecute_chain` pushes
-/// every block of the chain back through the worker, and each one reaches export with the
-/// destination already far ahead of it. Without the check those all go out — the catch-up finds
-/// nothing to do and returns the destination's own height, which is not *below* the block, so the
-/// send proceeds — costing a serialization and a signature verification per block per validator.
-///
-/// Taking the destination offline is what makes this observable: skipping it succeeds precisely
-/// because nothing is sent, whereas any attempt to contact it fails.
+/// `reset_and_reexecute_chain` replays a chain's whole history, and without the guard every block
+/// goes back out. Taking the destination offline is what makes it observable: skipping succeeds
+/// precisely because nothing is sent.
 #[test_case(MemoryStorageBuilder::default(); "memory")]
 #[test_log::test(tokio::test)]
 async fn test_send_block_skips_a_block_the_destination_already_has<B>(

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1015,8 +1015,8 @@ where
             let storage = storage_builder.build().await?;
             let config = ChainWorkerConfig {
                 nickname: format!("Node {i}"),
-                // A chain worker owns its export task, so without a TTL it is dropped — with the
-                // task — as soon as the request that loaded it returns.
+                // Export folds progress into the chain state when the worker next saves, so
+                // give workers a lifetime instead of dropping them after every request.
                 ttl: chain_worker_ttl
                     .or_else(|| block_export.is_some().then(|| Duration::from_secs(60))),
                 ..ChainWorkerConfig::default()

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -898,6 +898,12 @@ impl<B> TestBuilder<B>
 where
     B: StorageBuilder,
 {
+    /// The simulated clock every storage here shares, so a test can drive the export queue's
+    /// tick in virtual time instead of sleeping through it.
+    pub fn clock(&self) -> &TestClock {
+        self.storage_builder.clock()
+    }
+
     /// Creates a test setup with `count` validators, `with_faulty_validators` of which are faulty.
     pub async fn new(
         storage_builder: B,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -905,7 +905,15 @@ where
         with_faulty_validators: usize,
         signer: TestSigner,
     ) -> Result<Self, anyhow::Error> {
-        Self::build(storage_builder, count, with_faulty_validators, signer, None).await
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            None,
+            None,
+        )
+        .await
     }
 
     /// Creates a test setup like [`TestBuilder::new`], in which every validator also pushes the
@@ -922,6 +930,27 @@ where
             with_faulty_validators,
             signer,
             Some(Self::test_block_export_config()),
+            None,
+        )
+        .await
+    }
+
+    /// Creates a test setup like [`TestBuilder::new_with_block_export`] with an explicit chain
+    /// worker TTL, for asserting that workers expire even while export is enabled.
+    pub async fn new_with_block_export_and_ttl(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+        chain_worker_ttl: Duration,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            Some(Self::test_block_export_config()),
+            Some(chain_worker_ttl),
         )
         .await
     }
@@ -942,6 +971,7 @@ where
             with_faulty_validators,
             signer,
             Some(config),
+            None,
         )
         .await
     }
@@ -962,6 +992,7 @@ where
         with_faulty_validators: usize,
         mut signer: TestSigner,
         block_export: Option<crate::BlockExportConfig>,
+        chain_worker_ttl: Option<Duration>,
     ) -> Result<Self, anyhow::Error> {
         let mut validators = Vec::new();
         for _ in 0..count {
@@ -986,7 +1017,8 @@ where
                 nickname: format!("Node {i}"),
                 // A chain worker owns its export task, so without a TTL it is dropped — with the
                 // task — as soon as the request that loaded it returns.
-                ttl: block_export.is_some().then(|| Duration::from_secs(60)),
+                ttl: chain_worker_ttl
+                    .or_else(|| block_export.is_some().then(|| Duration::from_secs(60))),
                 ..ChainWorkerConfig::default()
             }
             .with_key_pair(Some(validator_keypair.secret_key));
@@ -1334,6 +1366,13 @@ where
         let guard = validator.client.lock().await;
         let chain = guard.state.chain_state_view(chain_id).await.unwrap();
         chain.exported_heights.get().clone().into()
+    }
+
+    /// Returns how many chain workers the validator at `index` currently has resident.
+    pub async fn resident_chain_workers(&self, index: usize) -> usize {
+        let validator = self.node_provider.all_nodes()[index].clone();
+        let guard = validator.client.lock().await;
+        guard.state.resident_chain_worker_count()
     }
 
     /// Returns the next block height the validator at `index` has for the given chain.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -984,10 +984,8 @@ where
             let storage = storage_builder.build().await?;
             let config = ChainWorkerConfig {
                 nickname: format!("Node {i}"),
-                // A chain worker owns its export task, so it has to outlive a single request for
-                // the task to accumulate anything. Without a TTL no keep-alive task is spawned
-                // and the worker — and its export task — is dropped as soon as the request that
-                // loaded it returns.
+                // A chain worker owns its export task, so without a TTL it is dropped — with the
+                // task — as soon as the request that loaded it returns.
                 ttl: block_export.is_some().then(|| Duration::from_secs(60)),
                 ..ChainWorkerConfig::default()
             }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -900,10 +900,38 @@ where
 {
     /// Creates a test setup with `count` validators, `with_faulty_validators` of which are faulty.
     pub async fn new(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            false,
+        )
+        .await
+    }
+
+    /// Creates a test setup like [`TestBuilder::new`], in which every validator also pushes the
+    /// blocks it executes to the rest of the committee.
+    pub async fn new_with_block_export(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(storage_builder, count, with_faulty_validators, signer, true).await
+    }
+
+    async fn build(
         mut storage_builder: B,
         count: usize,
         with_faulty_validators: usize,
         mut signer: TestSigner,
+        block_export: bool,
     ) -> Result<Self, anyhow::Error> {
         let mut validators = Vec::new();
         for _ in 0..count {
@@ -916,7 +944,9 @@ where
             .map(|(validating, account)| (validating.public_key, *account))
             .collect::<Vec<_>>();
         let initial_committee = Committee::make_simple(for_committee);
-        let mut validator_clients = Vec::new();
+        // Created up front and filled in below, so that each validator's export tasks can resolve
+        // the others through it even though those clients do not exist yet.
+        let node_provider = NodeProvider(Arc::new(std::sync::Mutex::new(Vec::new())));
         let mut validator_storages = HashMap::new();
         let mut faulty_validators = HashSet::new();
         for (i, (validator_keypair, _account_public_key)) in validators.into_iter().enumerate() {
@@ -924,16 +954,34 @@ where
             let storage = storage_builder.build().await?;
             let config = ChainWorkerConfig {
                 nickname: format!("Node {i}"),
+                // A chain worker owns its export task, so it has to outlive a single request for
+                // the task to accumulate anything. Without a TTL no keep-alive task is spawned
+                // and the worker — and its export task — is dropped as soon as the request that
+                // loaded it returns.
+                ttl: block_export.then(|| Duration::from_secs(60)),
                 ..ChainWorkerConfig::default()
             }
             .with_key_pair(Some(validator_keypair.secret_key));
-            let state = WorkerState::new(storage.clone(), config, None);
+            let mut state = WorkerState::new(storage.clone(), config, None);
+            if block_export {
+                let node_provider = Arc::new(node_provider.clone());
+                let storage = storage.clone();
+                state = state.with_chain_exporter_factory(Arc::new(move |setup| {
+                    crate::spawn_chain_exporter(
+                        setup,
+                        storage.clone(),
+                        node_provider.clone(),
+                        crate::BlockExportConfig::default(),
+                        Some(validator_public_key),
+                    )
+                }));
+            }
             let mut validator = LocalValidatorClient::new(validator_public_key, state);
             if i < with_faulty_validators {
                 faulty_validators.insert(validator_public_key);
                 validator.set_fault_type(FaultType::NoChains);
             }
-            validator_clients.push(validator);
+            node_provider.0.lock().unwrap().push(validator);
             validator_storages.insert(validator_public_key, storage);
         }
         tracing::info!(
@@ -946,7 +994,7 @@ where
             admin_description: None,
             network_description: None,
             genesis_storage_builder: GenesisStorageBuilder::default(),
-            node_provider: NodeProvider::from_iter(validator_clients),
+            node_provider,
             validator_storages,
             chain_client_storages: Vec::new(),
             chain_owners: BTreeMap::new(),
@@ -1240,6 +1288,29 @@ where
             }
         }
         assert!(count >= target_count);
+    }
+
+    /// Returns how far the validator at `index` believes it has exported the given chain to each
+    /// of the other validators.
+    pub async fn exported_heights(
+        &self,
+        index: usize,
+        chain_id: ChainId,
+    ) -> BTreeMap<ValidatorPublicKey, BlockHeight> {
+        let validator = self.node_provider.all_nodes()[index].clone();
+        let guard = validator.client.lock().await;
+        let chain = guard.state.chain_state_view(chain_id).await.unwrap();
+        chain.exported_heights.get().clone().into()
+    }
+
+    /// Returns the next block height the validator at `index` has for the given chain.
+    pub async fn next_block_height(&self, index: usize, chain_id: ChainId) -> BlockHeight {
+        let validator = self.node_provider.all_nodes()[index].clone();
+        let response = validator
+            .handle_chain_info_query(ChainInfoQuery::new(chain_id))
+            .await
+            .unwrap();
+        response.info.next_block_height
     }
 
     /// Panics if any validator has a nonempty outbox for the given chain.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -969,7 +969,13 @@ where
                     crate::spawn_chain_exporter(
                         setup,
                         node_provider.clone(),
-                        crate::BlockExportConfig::default(),
+                        // Production backoff is measured in seconds, which would make every
+                        // test that exercises a failing destination wait it out.
+                        crate::BlockExportConfig {
+                            retry_delay: Duration::from_millis(20),
+                            max_retry_delay: Duration::from_millis(200),
+                            ..crate::BlockExportConfig::default()
+                        },
                         Some(validator_public_key),
                     )
                 }));

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1024,15 +1024,13 @@ where
             .with_key_pair(Some(validator_keypair.secret_key));
             let mut state = WorkerState::new(storage.clone(), config, None);
             if let Some(export_config) = block_export.clone() {
-                let node_provider = Arc::new(node_provider.clone());
-                state = state.with_chain_exporter_factory(Arc::new(move |setup| {
-                    crate::spawn_chain_exporter(
-                        setup,
-                        node_provider.clone(),
-                        export_config.clone(),
-                        Some(validator_public_key),
-                    )
-                }));
+                let handle = crate::spawn_block_export_queue(
+                    storage.clone(),
+                    Arc::new(node_provider.clone()),
+                    export_config,
+                    Some(validator_public_key),
+                );
+                state = state.with_block_export(handle);
             }
             let mut validator = LocalValidatorClient::new(validator_public_key, state);
             if i < with_faulty_validators {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -965,11 +965,9 @@ where
             let mut state = WorkerState::new(storage.clone(), config, None);
             if block_export {
                 let node_provider = Arc::new(node_provider.clone());
-                let storage = storage.clone();
                 state = state.with_chain_exporter_factory(Arc::new(move |setup| {
                     crate::spawn_chain_exporter(
                         setup,
-                        storage.clone(),
                         node_provider.clone(),
                         crate::BlockExportConfig::default(),
                         Some(validator_public_key),

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -905,14 +905,7 @@ where
         with_faulty_validators: usize,
         signer: TestSigner,
     ) -> Result<Self, anyhow::Error> {
-        Self::build(
-            storage_builder,
-            count,
-            with_faulty_validators,
-            signer,
-            false,
-        )
-        .await
+        Self::build(storage_builder, count, with_faulty_validators, signer, None).await
     }
 
     /// Creates a test setup like [`TestBuilder::new`], in which every validator also pushes the
@@ -923,7 +916,44 @@ where
         with_faulty_validators: usize,
         signer: TestSigner,
     ) -> Result<Self, anyhow::Error> {
-        Self::build(storage_builder, count, with_faulty_validators, signer, true).await
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            Some(Self::test_block_export_config()),
+        )
+        .await
+    }
+
+    /// Creates a test setup like [`TestBuilder::new_with_block_export`], with the export tuned by
+    /// the caller. Used to shrink `max_catch_up_blocks` far below its default so that a backlog a
+    /// test can actually produce still takes several rounds to drain.
+    pub async fn new_with_block_export_config(
+        storage_builder: B,
+        count: usize,
+        with_faulty_validators: usize,
+        signer: TestSigner,
+        config: crate::BlockExportConfig,
+    ) -> Result<Self, anyhow::Error> {
+        Self::build(
+            storage_builder,
+            count,
+            with_faulty_validators,
+            signer,
+            Some(config),
+        )
+        .await
+    }
+
+    /// The export settings the block-export tests run with: production backoff is measured in
+    /// seconds, which would make every test that exercises a failing destination wait it out.
+    pub fn test_block_export_config() -> crate::BlockExportConfig {
+        crate::BlockExportConfig {
+            retry_delay: Duration::from_millis(20),
+            max_retry_delay: Duration::from_millis(200),
+            ..crate::BlockExportConfig::default()
+        }
     }
 
     async fn build(
@@ -931,7 +961,7 @@ where
         count: usize,
         with_faulty_validators: usize,
         mut signer: TestSigner,
-        block_export: bool,
+        block_export: Option<crate::BlockExportConfig>,
     ) -> Result<Self, anyhow::Error> {
         let mut validators = Vec::new();
         for _ in 0..count {
@@ -958,24 +988,18 @@ where
                 // the task to accumulate anything. Without a TTL no keep-alive task is spawned
                 // and the worker — and its export task — is dropped as soon as the request that
                 // loaded it returns.
-                ttl: block_export.then(|| Duration::from_secs(60)),
+                ttl: block_export.is_some().then(|| Duration::from_secs(60)),
                 ..ChainWorkerConfig::default()
             }
             .with_key_pair(Some(validator_keypair.secret_key));
             let mut state = WorkerState::new(storage.clone(), config, None);
-            if block_export {
+            if let Some(export_config) = block_export.clone() {
                 let node_provider = Arc::new(node_provider.clone());
                 state = state.with_chain_exporter_factory(Arc::new(move |setup| {
                     crate::spawn_chain_exporter(
                         setup,
                         node_provider.clone(),
-                        // Production backoff is measured in seconds, which would make every
-                        // test that exercises a failing destination wait it out.
-                        crate::BlockExportConfig {
-                            retry_delay: Duration::from_millis(20),
-                            max_retry_delay: Duration::from_millis(200),
-                            ..crate::BlockExportConfig::default()
-                        },
+                        export_config.clone(),
                         Some(validator_public_key),
                     )
                 }));
@@ -1149,6 +1173,13 @@ where
     /// Returns a clone of the node provider backing this test setup.
     pub fn make_node_provider(&self) -> NodeProvider<B::Storage> {
         self.node_provider.clone()
+    }
+
+    /// Returns the storage of the validator at `index`, which holds every block that validator
+    /// has processed.
+    pub fn validator_storage(&mut self, index: usize) -> B::Storage {
+        let public_key = self.node(index).public_key;
+        self.validator_storages.get(&public_key).unwrap().clone()
     }
 
     /// Returns a clone of the validator client at the given index.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -1016,9 +1016,11 @@ where
             let config = ChainWorkerConfig {
                 nickname: format!("Node {i}"),
                 // Export folds progress into the chain state when the worker next saves, so
-                // give workers a lifetime instead of dropping them after every request.
+                // give workers a lifetime instead of dropping them after every request, and fold
+                // unthrottled so assertions see progress as it happens.
                 ttl: chain_worker_ttl
                     .or_else(|| block_export.is_some().then(|| Duration::from_secs(60))),
+                exported_heights_fold_interval: Duration::ZERO,
                 ..ChainWorkerConfig::default()
             }
             .with_key_pair(Some(validator_keypair.secret_key));

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -893,6 +893,16 @@ where
         let block = certificate.block();
         let (chain_id, height) = (block.header.chain_id, block.header.height);
 
+        // The destination is already past this block, so it has nothing to learn from it. Without
+        // this the block would be sent anyway: the catch-up below finds an empty range and returns
+        // the destination's own height, which is not *below* the block, so the send goes ahead.
+        // That costs a serialization and a signature verification per destination for nothing —
+        // and re-executing a chain (`reset_and_reexecute_chain`) re-queues its entire history, so
+        // the waste would be the whole chain times the committee rather than a stray block.
+        if destination_next_height.is_some_and(|next| next > height) {
+            return Ok(destination_next_height.expect("just checked that it is set"));
+        }
+
         let next_height = if destination_next_height == Some(height) {
             height
         } else {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -795,7 +795,7 @@ where
         }
     }
 
-    pub(crate) async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
+    async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
         let admin_chain_id = self.admin_chain_id;
         let target = local_admin_info.next_block_height;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -938,7 +938,7 @@ where
         Ok(blobs)
     }
 
-    async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
+    pub(crate) async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
         let admin_chain_id = self.admin_chain_id;
         let target = local_admin_info.next_block_height;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -12,7 +12,7 @@ use std::{
 use futures::{future, Future, StreamExt};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{BlockHeight, Round, TimeDelta},
+    data_types::{Blob, BlockHeight, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, BlobType, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
@@ -31,7 +31,6 @@ use tracing::{instrument, Level};
 use crate::{
     client::chain_client,
     data_types::{ChainInfo, ChainInfoQuery},
-    environment::Environment,
     local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
@@ -137,17 +136,17 @@ impl CommunicateAction {
 /// node must not mutate the client's own state. When a validator turns out to be *ahead* of the
 /// local node, the updater signals that with [`chain_client::Error::LocalNodeLagging`] and lets
 /// the caller decide whether to pull the missing state.
-pub struct RemoteNodeUpdater<Env>
+pub struct RemoteNodeUpdater<S, N>
 where
-    Env: Environment,
+    S: Storage,
 {
-    pub remote_node: RemoteNode<Env::ValidatorNode>,
-    pub local_node: LocalNodeClient<Env::Storage>,
+    pub remote_node: RemoteNode<N>,
+    pub local_node: LocalNodeClient<S>,
     pub admin_chain_id: ChainId,
     pub certificate_upload_batch_size: u64,
 }
 
-impl<Env: Environment> Clone for RemoteNodeUpdater<Env> {
+impl<S: Storage + Clone, N: Clone> Clone for RemoteNodeUpdater<S, N> {
     fn clone(&self) -> Self {
         RemoteNodeUpdater {
             remote_node: self.remote_node.clone(),
@@ -335,9 +334,10 @@ where
     })
 }
 
-impl<Env> RemoteNodeUpdater<Env>
+impl<S, N> RemoteNodeUpdater<S, N>
 where
-    Env: Environment + 'static,
+    S: Storage + Clone + 'static,
+    N: ValidatorNode + Clone + 'static,
 {
     /// Logs a warning if the error is not an expected part of the protocol flow.
     fn warn_if_unexpected(&self, err: &NodeError) {
@@ -354,9 +354,15 @@ where
         level = "trace", skip_all, err(level = Level::DEBUG),
         fields(chain_id = %certificate.block().header.chain_id)
     )]
+    /// Sends a single confirmed certificate, uploading its missing dependencies and retrying.
+    ///
+    /// Blobs the validator reports missing are taken from `held` when present there, and read from
+    /// storage otherwise. Callers that already hold the block's blobs in memory pass them so that
+    /// publishing a blob — where the validator is missing it by definition — costs no read.
     async fn send_confirmed_certificate(
         &mut self,
         certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
+        held: &[CacheArc<Blob>],
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self
@@ -384,12 +390,10 @@ where
                     // The validator is missing the blobs required by the certificate.
                     self.remote_node
                         .check_blobs_not_found(certificate, &blob_ids)?;
-                    // The certificate is confirmed, so the blobs must be in storage.
-                    let maybe_blobs = self.local_node.read_blobs_from_storage(&blob_ids).await?;
-                    let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
+                    let blobs = self.resolve_blobs(&blob_ids, held).await?;
                     self.remote_node
                         .node
-                        .upload_blobs(blobs.into_iter().map(|b| b.into_std()).collect())
+                        .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
                         .await?;
                     sent_blobs = true;
                 }
@@ -792,6 +796,82 @@ where
         }
     }
 
+    /// Pushes a block the caller already holds to the validator, preceded by whichever earlier
+    /// blocks of the same chain it is still missing, and returns its next block height afterwards.
+    ///
+    /// `certificate` and `blobs` are a block the caller holds in memory — the block a chain worker
+    /// has just executed — so the common case costs a single request and no read from storage.
+    ///
+    /// `destination_next_height` is the height we believe the validator to be at. When it is
+    /// exactly this block's height the block is contiguous there and is sent with no preceding
+    /// query. Otherwise — a gap, a first send, or a send that previously failed — the validator is
+    /// queried first and the missing earlier blocks are read from storage and sent before it.
+    /// Guessing "contiguous" wrongly is what must be avoided: a block landing above a gap is
+    /// silently preprocessed and never advances the tip, whereas re-sending a block the validator
+    /// already has costs it an integer comparison.
+    ///
+    /// The returned height is the validator's own, rather than an assumed `height + 1`, so a
+    /// validator that could not close its gap reports the truth and is queried again next time.
+    pub async fn send_block(
+        &mut self,
+        certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
+        blobs: &[CacheArc<Blob>],
+        destination_next_height: Option<BlockHeight>,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        let block = certificate.block();
+        let (chain_id, height) = (block.header.chain_id, block.header.height);
+        let delivery = CrossChainMessageDelivery::NonBlocking;
+
+        if destination_next_height != Some(height) {
+            let query = ChainInfoQuery::new(chain_id);
+            let info = self.remote_node.handle_chain_info_query(query).await?;
+            let heights = (info.next_block_height.0..height.0)
+                .map(BlockHeight)
+                .collect::<Vec<_>>();
+            let batch_size = self.certificate_upload_batch_size as usize;
+            for chunk in heights.chunks(batch_size) {
+                let certificates = self
+                    .read_certificates_for_heights(chain_id, chunk.to_vec())
+                    .await?;
+                for certificate in certificates {
+                    self.send_confirmed_certificate(&certificate, &[], delivery)
+                        .await?;
+                }
+            }
+        }
+
+        let info = self
+            .send_confirmed_certificate(certificate, blobs, delivery)
+            .await?;
+        Ok(info.next_block_height)
+    }
+
+    /// Collects the given blobs, taking each from `held` if it is there and reading the rest from
+    /// storage.
+    ///
+    /// The certificate is confirmed, so every blob it requires must be available; one that is in
+    /// neither place is reported back as still missing.
+    async fn resolve_blobs(
+        &self,
+        blob_ids: &[BlobId],
+        held: &[CacheArc<Blob>],
+    ) -> Result<Vec<CacheArc<Blob>>, chain_client::Error> {
+        let mut blobs = Vec::with_capacity(blob_ids.len());
+        let mut to_read = Vec::new();
+        for blob_id in blob_ids {
+            match held.iter().find(|blob| blob.id() == *blob_id) {
+                Some(blob) => blobs.push(blob.clone()),
+                None => to_read.push(*blob_id),
+            }
+        }
+        if to_read.is_empty() {
+            return Ok(blobs);
+        }
+        let read = self.local_node.read_blobs_from_storage(&to_read).await?;
+        blobs.extend(read.ok_or(NodeError::BlobsNotFound(to_read))?);
+        Ok(blobs)
+    }
+
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
         Box::pin(self.send_chain_information(
@@ -925,7 +1005,7 @@ where
 
         // Optimistically try sending just the last certificate
         let info = match self
-            .send_confirmed_certificate(&certificate, delivery)
+            .send_confirmed_certificate(&certificate, &[], delivery)
             .await
         {
             Ok(info) => info,
@@ -955,7 +1035,7 @@ where
                 .await?;
 
             for certificate in certificates {
-                self.send_confirmed_certificate(&certificate, delivery)
+                self.send_confirmed_certificate(&certificate, &[], delivery)
                     .await?;
             }
         }
@@ -1194,7 +1274,7 @@ where
                 // Send each certificate
                 for certificate in certificates {
                     updater
-                        .send_confirmed_certificate(&certificate, delivery)
+                        .send_confirmed_certificate(&certificate, &[], delivery)
                         .await?;
                 }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -12,7 +12,7 @@ use std::{
 use futures::{future, Future, StreamExt};
 use linera_base::{
     crypto::ValidatorPublicKey,
-    data_types::{Blob, BlockHeight, Round, TimeDelta},
+    data_types::{BlockHeight, Round, TimeDelta},
     ensure,
     identifiers::{BlobId, BlobType, ChainId, StreamId},
     time::{timer::timeout, Duration, Instant},
@@ -144,14 +144,6 @@ where
     pub local_node: LocalNodeClient<S>,
     pub admin_chain_id: ChainId,
     pub certificate_upload_batch_size: u64,
-    /// Whether to also bring the remote node's *consensus round* up to ours once its height
-    /// matches. The client wants this; export does not — pushing consensus evidence is taking
-    /// part in consensus rather than replicating it, so export only ever moves heights.
-    pub sync_consensus_rounds: bool,
-    /// Caps the admin-chain blocks replayed when a destination does not know the committee that
-    /// signed a certificate. `None` replays as far as needed, which is what the client wants;
-    /// export bounds it because the replay happens inside one export round.
-    pub max_admin_catch_up_blocks: Option<u64>,
 }
 
 impl<S: Storage + Clone, N: Clone> Clone for RemoteNodeUpdater<S, N> {
@@ -161,8 +153,6 @@ impl<S: Storage + Clone, N: Clone> Clone for RemoteNodeUpdater<S, N> {
             local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
             certificate_upload_batch_size: self.certificate_upload_batch_size,
-            sync_consensus_rounds: self.sync_consensus_rounds,
-            max_admin_catch_up_blocks: self.max_admin_catch_up_blocks,
         }
     }
 }
@@ -365,12 +355,9 @@ where
         fields(chain_id = %certificate.block().header.chain_id)
     )]
     /// Sends a single confirmed certificate, uploading its missing dependencies and retrying.
-    /// Missing blobs come from `held` when present and from storage otherwise, so a caller that
-    /// already holds them — publishing a blob, say — costs no read.
     async fn send_confirmed_certificate(
         &mut self,
         certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
-        held: &[CacheArc<Blob>],
         delivery: CrossChainMessageDelivery,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let mut result = self
@@ -398,7 +385,11 @@ where
                     // The validator is missing the blobs required by the certificate.
                     self.remote_node
                         .check_blobs_not_found(certificate, &blob_ids)?;
-                    let blobs = self.resolve_blobs(&blob_ids, held).await?;
+                    let blobs = self
+                        .local_node
+                        .read_blobs_from_storage(&blob_ids)
+                        .await?
+                        .ok_or(NodeError::BlobsNotFound(blob_ids))?;
                     self.remote_node
                         .node
                         .upload_blobs(blobs.into_iter().map(CacheArc::into_std).collect())
@@ -804,125 +795,10 @@ where
         }
     }
 
-    /// Sends up to `max_blocks` of the blocks of `chain_id` the validator is missing below
-    /// `target_next_height`, returning the height it reports afterwards. Bounded so a validator
-    /// that just joined converges over rounds instead of blocking every other destination once.
-    /// `destination_next_height` is what we believe it holds; `None` or a stale value costs one
-    /// [`ChainInfoQuery`] to establish the truth.
-    pub async fn send_missing_blocks(
-        &mut self,
-        chain_id: ChainId,
-        target_next_height: BlockHeight,
-        destination_next_height: Option<BlockHeight>,
-        max_blocks: u64,
-    ) -> Result<BlockHeight, chain_client::Error> {
-        let delivery = CrossChainMessageDelivery::NonBlocking;
-        let mut next_height = match destination_next_height {
-            Some(height) => height,
-            None => {
-                let query = ChainInfoQuery::new(chain_id);
-                self.remote_node
-                    .handle_chain_info_query(query)
-                    .await?
-                    .next_block_height
-            }
-        };
-
-        let last = target_next_height
-            .0
-            .min(next_height.0.saturating_add(max_blocks));
-        let heights = (next_height.0..last).map(BlockHeight).collect::<Vec<_>>();
-        let batch_size = self.certificate_upload_batch_size as usize;
-        for chunk in heights.chunks(batch_size) {
-            let certificates = self
-                .read_certificates_for_heights(chain_id, chunk.to_vec())
-                .await?;
-            for certificate in certificates {
-                let info = self
-                    .send_confirmed_certificate(&certificate, &[], delivery)
-                    .await?;
-                next_height = info.next_block_height;
-            }
-        }
-        Ok(next_height)
-    }
-
-    /// Pushes a block the caller already holds, first closing up to `max_catch_up` of any gap
-    /// below it, and returns the height the validator reports afterwards.
-    ///
-    /// The held block is sent only once the gap is gone: one landing above a gap is silently
-    /// preprocessed and never advances the tip. The returned height is the validator's own rather
-    /// than an assumed `height + 1`, so one that could not close its gap reports the truth.
-    pub async fn send_block(
-        &mut self,
-        certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
-        blobs: &[CacheArc<Blob>],
-        destination_next_height: Option<BlockHeight>,
-        max_catch_up: u64,
-    ) -> Result<BlockHeight, chain_client::Error> {
-        let block = certificate.block();
-        let (chain_id, height) = (block.header.chain_id, block.header.height);
-
-        // Already past this block. Without the check it is sent anyway: the catch-up below finds
-        // an empty range and returns the destination's own height, which is not *below* the
-        // block. `reset_and_reexecute_chain` re-queues a whole chain, so this is not marginal.
-        if destination_next_height.is_some_and(|next| next > height) {
-            return Ok(destination_next_height.expect("just checked that it is set"));
-        }
-
-        let next_height = if destination_next_height == Some(height) {
-            height
-        } else {
-            self.send_missing_blocks(chain_id, height, destination_next_height, max_catch_up)
-                .await?
-        };
-
-        // Still below this block: the gap was larger than one chunk, so leave the rest for the
-        // next round rather than sending a block that would only be preprocessed.
-        if next_height < height {
-            return Ok(next_height);
-        }
-
-        let info = self
-            .send_confirmed_certificate(certificate, blobs, CrossChainMessageDelivery::NonBlocking)
-            .await?;
-        Ok(info.next_block_height)
-    }
-
-    /// Collects the given blobs, taking each from `held` if present and the rest from storage.
-    /// The certificate is confirmed, so one found in neither place is reported still missing.
-    async fn resolve_blobs(
-        &self,
-        blob_ids: &[BlobId],
-        held: &[CacheArc<Blob>],
-    ) -> Result<Vec<CacheArc<Blob>>, chain_client::Error> {
-        let mut blobs = Vec::with_capacity(blob_ids.len());
-        let mut to_read = Vec::new();
-        for blob_id in blob_ids {
-            match held.iter().find(|blob| blob.id() == *blob_id) {
-                Some(blob) => blobs.push(blob.clone()),
-                None => to_read.push(*blob_id),
-            }
-        }
-        if to_read.is_empty() {
-            return Ok(blobs);
-        }
-        let read = self.local_node.read_blobs_from_storage(&to_read).await?;
-        blobs.extend(read.ok_or(NodeError::BlobsNotFound(to_read))?);
-        Ok(blobs)
-    }
-
     pub(crate) async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
         let admin_chain_id = self.admin_chain_id;
         let target = local_admin_info.next_block_height;
-        // Bounded for block export: this runs inside one export round, so replaying an entire
-        // admin chain here would stall that chain's whole export. Unbounded for the client, which
-        // is waiting on this one certificate being accepted.
-        if let Some(max_blocks) = self.max_admin_catch_up_blocks {
-            Box::pin(self.send_missing_blocks(admin_chain_id, target, None, max_blocks)).await?;
-            return Ok(());
-        }
         Box::pin(self.send_chain_information(
             admin_chain_id,
             target,
@@ -995,12 +871,7 @@ where
 
         // Phase 2: Round synchronization (if needed)
         // Height synchronization is complete. Now check if we need to synchronize
-        // the consensus round at this height. Consumers that only replicate blocks — block
-        // export — stop here: everything above this point moves heights, everything below it
-        // takes part in consensus.
-        if !self.sync_consensus_rounds {
-            return Ok(());
-        }
+        // the consensus round at this height.
         let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
         let query = ChainInfoQuery::new(chain_id).with_manager_values();
         let local_info = match self.local_node.handle_chain_info_query(query).await {
@@ -1059,7 +930,7 @@ where
 
         // Optimistically try sending just the last certificate
         let info = match self
-            .send_confirmed_certificate(&certificate, &[], delivery)
+            .send_confirmed_certificate(&certificate, delivery)
             .await
         {
             Ok(info) => info,
@@ -1089,7 +960,7 @@ where
                 .await?;
 
             for certificate in certificates {
-                self.send_confirmed_certificate(&certificate, &[], delivery)
+                self.send_confirmed_certificate(&certificate, delivery)
                     .await?;
             }
         }
@@ -1328,7 +1199,7 @@ where
                 // Send each certificate
                 for certificate in certificates {
                     updater
-                        .send_confirmed_certificate(&certificate, &[], delivery)
+                        .send_confirmed_certificate(&certificate, delivery)
                         .await?;
                 }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -144,6 +144,25 @@ where
     pub local_node: LocalNodeClient<S>,
     pub admin_chain_id: ChainId,
     pub certificate_upload_batch_size: u64,
+    /// Whether to also bring the remote node's *consensus round* up to ours once its height
+    /// matches, by pushing the proposal, locking certificate or timeout certificate that
+    /// justifies the later round.
+    ///
+    /// The client wants this: it is trying to drive a chain forward. Block export does not — its
+    /// job is to make another validator hold the blocks we hold, and pushing consensus evidence
+    /// on top of that is participation in consensus rather than replication of it. Export
+    /// therefore leaves this off and only ever moves heights.
+    pub sync_consensus_rounds: bool,
+    /// Caps how many admin-chain blocks are replayed in one go when a destination turns out not
+    /// to know the committee that signed a certificate.
+    ///
+    /// `None` replays as far as needed, which is what the client wants: it is trying to get one
+    /// certificate accepted and will wait. Block export sets a bound, because that replay happens
+    /// inside a single export round — a validator admitted to a network with a long admin-chain
+    /// history would otherwise hold up every other destination, and every later block of the
+    /// chain being exported, for as long as the whole replay takes. Bounded, it converges over
+    /// rounds instead, exactly like the per-chain catch-up.
+    pub max_admin_catch_up_blocks: Option<u64>,
 }
 
 impl<S: Storage + Clone, N: Clone> Clone for RemoteNodeUpdater<S, N> {
@@ -153,6 +172,8 @@ impl<S: Storage + Clone, N: Clone> Clone for RemoteNodeUpdater<S, N> {
             local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
             certificate_upload_batch_size: self.certificate_upload_batch_size,
+            sync_consensus_rounds: self.sync_consensus_rounds,
+            max_admin_catch_up_blocks: self.max_admin_catch_up_blocks,
         }
     }
 }
@@ -919,9 +940,18 @@ where
 
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
         let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
+        let admin_chain_id = self.admin_chain_id;
+        let target = local_admin_info.next_block_height;
+        // Bounded for block export: this runs inside one export round, so replaying an entire
+        // admin chain here would stall that chain's whole export. Unbounded for the client, which
+        // is waiting on this one certificate being accepted.
+        if let Some(max_blocks) = self.max_admin_catch_up_blocks {
+            Box::pin(self.send_missing_blocks(admin_chain_id, target, None, max_blocks)).await?;
+            return Ok(());
+        }
         Box::pin(self.send_chain_information(
-            self.admin_chain_id,
-            local_admin_info.next_block_height,
+            admin_chain_id,
+            target,
             CrossChainMessageDelivery::NonBlocking,
             None,
         ))
@@ -991,7 +1021,12 @@ where
 
         // Phase 2: Round synchronization (if needed)
         // Height synchronization is complete. Now check if we need to synchronize
-        // the consensus round at this height.
+        // the consensus round at this height. Consumers that only replicate blocks — block
+        // export — stop here: everything above this point moves heights, everything below it
+        // takes part in consensus.
+        if !self.sync_consensus_rounds {
+            return Ok(());
+        }
         let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
         let query = ChainInfoQuery::new(chain_id).with_manager_values();
         let local_info = match self.local_node.handle_chain_info_query(query).await {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -145,23 +145,12 @@ where
     pub admin_chain_id: ChainId,
     pub certificate_upload_batch_size: u64,
     /// Whether to also bring the remote node's *consensus round* up to ours once its height
-    /// matches, by pushing the proposal, locking certificate or timeout certificate that
-    /// justifies the later round.
-    ///
-    /// The client wants this: it is trying to drive a chain forward. Block export does not — its
-    /// job is to make another validator hold the blocks we hold, and pushing consensus evidence
-    /// on top of that is participation in consensus rather than replication of it. Export
-    /// therefore leaves this off and only ever moves heights.
+    /// matches. The client wants this; export does not — pushing consensus evidence is taking
+    /// part in consensus rather than replicating it, so export only ever moves heights.
     pub sync_consensus_rounds: bool,
-    /// Caps how many admin-chain blocks are replayed in one go when a destination turns out not
-    /// to know the committee that signed a certificate.
-    ///
-    /// `None` replays as far as needed, which is what the client wants: it is trying to get one
-    /// certificate accepted and will wait. Block export sets a bound, because that replay happens
-    /// inside a single export round — a validator admitted to a network with a long admin-chain
-    /// history would otherwise hold up every other destination, and every later block of the
-    /// chain being exported, for as long as the whole replay takes. Bounded, it converges over
-    /// rounds instead, exactly like the per-chain catch-up.
+    /// Caps the admin-chain blocks replayed when a destination does not know the committee that
+    /// signed a certificate. `None` replays as far as needed, which is what the client wants;
+    /// export bounds it because the replay happens inside one export round.
     pub max_admin_catch_up_blocks: Option<u64>,
 }
 
@@ -376,10 +365,8 @@ where
         fields(chain_id = %certificate.block().header.chain_id)
     )]
     /// Sends a single confirmed certificate, uploading its missing dependencies and retrying.
-    ///
-    /// Blobs the validator reports missing are taken from `held` when present there, and read from
-    /// storage otherwise. Callers that already hold the block's blobs in memory pass them so that
-    /// publishing a blob — where the validator is missing it by definition — costs no read.
+    /// Missing blobs come from `held` when present and from storage otherwise, so a caller that
+    /// already holds them — publishing a blob, say — costs no read.
     async fn send_confirmed_certificate(
         &mut self,
         certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
@@ -817,19 +804,11 @@ where
         }
     }
 
-    /// Sends the validator the blocks of `chain_id` it is missing below `target_next_height`,
-    /// at most `max_blocks` of them, and returns the height it reports afterwards.
-    ///
-    /// Bounded on purpose. A validator that has just joined the committee knows nothing of a chain
-    /// and reports height 0, so an unbounded catch-up on a chain with a long history would occupy
-    /// the caller for as long as it takes to replay all of it — during which every other
-    /// destination, and every later block of this chain, waits. Sending a bounded chunk lets the
-    /// caller come back to it, so a far-behind validator converges over several rounds instead of
-    /// blocking everything once.
-    ///
-    /// `destination_next_height` is what we believe the validator holds. `None`, or a value that
-    /// disagrees with reality, costs one [`ChainInfoQuery`] to establish the truth — which is also
-    /// what discovers that a new validator is at 0.
+    /// Sends up to `max_blocks` of the blocks of `chain_id` the validator is missing below
+    /// `target_next_height`, returning the height it reports afterwards. Bounded so a validator
+    /// that just joined converges over rounds instead of blocking every other destination once.
+    /// `destination_next_height` is what we believe it holds; `None` or a stale value costs one
+    /// [`ChainInfoQuery`] to establish the truth.
     pub async fn send_missing_blocks(
         &mut self,
         chain_id: ChainId,
@@ -868,21 +847,12 @@ where
         Ok(next_height)
     }
 
-    /// Pushes a block the caller already holds to the validator, first closing up to `max_catch_up`
-    /// of any gap below it, and returns the height the validator reports afterwards.
+    /// Pushes a block the caller already holds, first closing up to `max_catch_up` of any gap
+    /// below it, and returns the height the validator reports afterwards.
     ///
-    /// `certificate` and `blobs` are a block the caller holds in memory — the block a chain worker
-    /// has just executed — so when the validator is already contiguous this costs a single request
-    /// and no read from storage.
-    ///
-    /// `destination_next_height` is the height we believe the validator to be at. When it is
-    /// exactly this block's height the block is contiguous there and is sent with no preceding
-    /// query. Otherwise the validator is queried and the gap is closed, up to `max_catch_up`
-    /// blocks; the held block is sent only once the gap is gone, since a block landing above a gap
-    /// is silently preprocessed and never advances the tip.
-    ///
-    /// The returned height is the validator's own, rather than an assumed `height + 1`, so a
-    /// validator that could not close its gap reports the truth and is queried again next time.
+    /// The held block is sent only once the gap is gone: one landing above a gap is silently
+    /// preprocessed and never advances the tip. The returned height is the validator's own rather
+    /// than an assumed `height + 1`, so one that could not close its gap reports the truth.
     pub async fn send_block(
         &mut self,
         certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
@@ -893,12 +863,9 @@ where
         let block = certificate.block();
         let (chain_id, height) = (block.header.chain_id, block.header.height);
 
-        // The destination is already past this block, so it has nothing to learn from it. Without
-        // this the block would be sent anyway: the catch-up below finds an empty range and returns
-        // the destination's own height, which is not *below* the block, so the send goes ahead.
-        // That costs a serialization and a signature verification per destination for nothing —
-        // and re-executing a chain (`reset_and_reexecute_chain`) re-queues its entire history, so
-        // the waste would be the whole chain times the committee rather than a stray block.
+        // Already past this block. Without the check it is sent anyway: the catch-up below finds
+        // an empty range and returns the destination's own height, which is not *below* the
+        // block. `reset_and_reexecute_chain` re-queues a whole chain, so this is not marginal.
         if destination_next_height.is_some_and(|next| next > height) {
             return Ok(destination_next_height.expect("just checked that it is set"));
         }
@@ -922,11 +889,8 @@ where
         Ok(info.next_block_height)
     }
 
-    /// Collects the given blobs, taking each from `held` if it is there and reading the rest from
-    /// storage.
-    ///
-    /// The certificate is confirmed, so every blob it requires must be available; one that is in
-    /// neither place is reported back as still missing.
+    /// Collects the given blobs, taking each from `held` if present and the rest from storage.
+    /// The certificate is confirmed, so one found in neither place is reported still missing.
     async fn resolve_blobs(
         &self,
         blob_ids: &[BlobId],

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -796,19 +796,69 @@ where
         }
     }
 
-    /// Pushes a block the caller already holds to the validator, preceded by whichever earlier
-    /// blocks of the same chain it is still missing, and returns its next block height afterwards.
+    /// Sends the validator the blocks of `chain_id` it is missing below `target_next_height`,
+    /// at most `max_blocks` of them, and returns the height it reports afterwards.
+    ///
+    /// Bounded on purpose. A validator that has just joined the committee knows nothing of a chain
+    /// and reports height 0, so an unbounded catch-up on a chain with a long history would occupy
+    /// the caller for as long as it takes to replay all of it — during which every other
+    /// destination, and every later block of this chain, waits. Sending a bounded chunk lets the
+    /// caller come back to it, so a far-behind validator converges over several rounds instead of
+    /// blocking everything once.
+    ///
+    /// `destination_next_height` is what we believe the validator holds. `None`, or a value that
+    /// disagrees with reality, costs one [`ChainInfoQuery`] to establish the truth — which is also
+    /// what discovers that a new validator is at 0.
+    pub async fn send_missing_blocks(
+        &mut self,
+        chain_id: ChainId,
+        target_next_height: BlockHeight,
+        destination_next_height: Option<BlockHeight>,
+        max_blocks: u64,
+    ) -> Result<BlockHeight, chain_client::Error> {
+        let delivery = CrossChainMessageDelivery::NonBlocking;
+        let mut next_height = match destination_next_height {
+            Some(height) => height,
+            None => {
+                let query = ChainInfoQuery::new(chain_id);
+                self.remote_node
+                    .handle_chain_info_query(query)
+                    .await?
+                    .next_block_height
+            }
+        };
+
+        let last = target_next_height
+            .0
+            .min(next_height.0.saturating_add(max_blocks));
+        let heights = (next_height.0..last).map(BlockHeight).collect::<Vec<_>>();
+        let batch_size = self.certificate_upload_batch_size as usize;
+        for chunk in heights.chunks(batch_size) {
+            let certificates = self
+                .read_certificates_for_heights(chain_id, chunk.to_vec())
+                .await?;
+            for certificate in certificates {
+                let info = self
+                    .send_confirmed_certificate(&certificate, &[], delivery)
+                    .await?;
+                next_height = info.next_block_height;
+            }
+        }
+        Ok(next_height)
+    }
+
+    /// Pushes a block the caller already holds to the validator, first closing up to `max_catch_up`
+    /// of any gap below it, and returns the height the validator reports afterwards.
     ///
     /// `certificate` and `blobs` are a block the caller holds in memory — the block a chain worker
-    /// has just executed — so the common case costs a single request and no read from storage.
+    /// has just executed — so when the validator is already contiguous this costs a single request
+    /// and no read from storage.
     ///
     /// `destination_next_height` is the height we believe the validator to be at. When it is
     /// exactly this block's height the block is contiguous there and is sent with no preceding
-    /// query. Otherwise — a gap, a first send, or a send that previously failed — the validator is
-    /// queried first and the missing earlier blocks are read from storage and sent before it.
-    /// Guessing "contiguous" wrongly is what must be avoided: a block landing above a gap is
-    /// silently preprocessed and never advances the tip, whereas re-sending a block the validator
-    /// already has costs it an integer comparison.
+    /// query. Otherwise the validator is queried and the gap is closed, up to `max_catch_up`
+    /// blocks; the held block is sent only once the gap is gone, since a block landing above a gap
+    /// is silently preprocessed and never advances the tip.
     ///
     /// The returned height is the validator's own, rather than an assumed `height + 1`, so a
     /// validator that could not close its gap reports the truth and is queried again next time.
@@ -817,31 +867,26 @@ where
         certificate: &CacheArc<GenericCertificate<ConfirmedBlock>>,
         blobs: &[CacheArc<Blob>],
         destination_next_height: Option<BlockHeight>,
+        max_catch_up: u64,
     ) -> Result<BlockHeight, chain_client::Error> {
         let block = certificate.block();
         let (chain_id, height) = (block.header.chain_id, block.header.height);
-        let delivery = CrossChainMessageDelivery::NonBlocking;
 
-        if destination_next_height != Some(height) {
-            let query = ChainInfoQuery::new(chain_id);
-            let info = self.remote_node.handle_chain_info_query(query).await?;
-            let heights = (info.next_block_height.0..height.0)
-                .map(BlockHeight)
-                .collect::<Vec<_>>();
-            let batch_size = self.certificate_upload_batch_size as usize;
-            for chunk in heights.chunks(batch_size) {
-                let certificates = self
-                    .read_certificates_for_heights(chain_id, chunk.to_vec())
-                    .await?;
-                for certificate in certificates {
-                    self.send_confirmed_certificate(&certificate, &[], delivery)
-                        .await?;
-                }
-            }
+        let next_height = if destination_next_height == Some(height) {
+            height
+        } else {
+            self.send_missing_blocks(chain_id, height, destination_next_height, max_catch_up)
+                .await?
+        };
+
+        // Still below this block: the gap was larger than one chunk, so leave the rest for the
+        // next round rather than sending a block that would only be preprocessed.
+        if next_height < height {
+            return Ok(next_height);
         }
 
         let info = self
-            .send_confirmed_certificate(certificate, blobs, delivery)
+            .send_confirmed_certificate(certificate, blobs, CrossChainMessageDelivery::NonBlocking)
             .await?;
         Ok(info.next_block_height)
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -64,7 +64,7 @@ impl<S: Storage> std::ops::Deref for ChainStateViewReadGuard<S> {
 pub(crate) use crate::chain_worker::EventSubscriptionsResult;
 use crate::{
     chain_worker::{
-        handle, state::ChainWorkerState, BlockOutcome, ChainExporterFactory, ChainWorkerConfig,
+        handle, state::ChainWorkerState, BlockExportHandle, BlockOutcome, ChainWorkerConfig,
         CrossChainUpdateResult, DeliveryNotifier, ProcessConfirmedBlockMode,
     },
     client::{ChainModes, ListeningMode},
@@ -722,7 +722,7 @@ pub struct WorkerState<StorageClient: Storage> {
     /// Creates each chain worker's block-export task. The server binary installs this, since it
     /// is the only layer that knows how to reach another validator; without it, executed blocks
     /// are not pushed to the rest of the committee.
-    chain_exporter_factory: Option<ChainExporterFactory<StorageClient>>,
+    block_export: Option<BlockExportHandle>,
 }
 
 /// Dispatcher for outbound cross-chain requests that handles the source-shard-to-
@@ -744,7 +744,7 @@ where
             chain_workers: self.chain_workers.clone(),
             chain_batches: self.chain_batches.clone(),
             outbound_cross_chain_sender: self.outbound_cross_chain_sender.clone(),
-            chain_exporter_factory: self.chain_exporter_factory.clone(),
+            block_export: self.block_export.clone(),
         }
     }
 }
@@ -892,18 +892,15 @@ where
             #[cfg_attr(web, expect(clippy::arc_with_non_send_sync))]
             chain_batches: Arc::new(papaya::HashMap::new()),
             outbound_cross_chain_sender: None,
-            chain_exporter_factory: None,
+            block_export: None,
         }
     }
 
-    /// Installs the factory that creates each chain worker's block-export task. Must be called
-    /// before any chain worker is created: workers capture the factory as they load, so one
-    /// created earlier would never export.
-    pub fn with_chain_exporter_factory(
-        mut self,
-        factory: ChainExporterFactory<StorageClient>,
-    ) -> Self {
-        self.chain_exporter_factory = Some(factory);
+    /// Installs the process-wide block export queue. Must be called before any chain worker is
+    /// created: workers capture the handle as they load, so one created earlier would never
+    /// export.
+    pub fn with_block_export(mut self, handle: BlockExportHandle) -> Self {
+        self.block_export = Some(handle);
         self
     }
 
@@ -1300,7 +1297,7 @@ where
             chain_id,
             service_runtime_endpoint,
             service_runtime_task,
-            self.chain_exporter_factory.clone(),
+            self.block_export.clone(),
         )
         .await?;
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -897,11 +897,9 @@ where
         }
     }
 
-    /// Installs the factory that creates each chain worker's block-export task, so that the
-    /// blocks this worker executes are pushed to the other validators in the committee.
-    ///
-    /// Must be called before any chain worker is created: workers capture the factory as they are
-    /// loaded, so one created earlier would never export.
+    /// Installs the factory that creates each chain worker's block-export task. Must be called
+    /// before any chain worker is created: workers capture the factory as they load, so one
+    /// created earlier would never export.
     pub fn with_chain_exporter_factory(
         mut self,
         factory: ChainExporterFactory<StorageClient>,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -69,7 +69,6 @@ use crate::{
     },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
-    local_node::LocalNodeClient,
     notifier::Notifier,
 };
 
@@ -1112,6 +1111,19 @@ where
         .forget();
     }
 
+    /// Returns how many chain workers are currently resident in memory. Used to assert that
+    /// workers expire at their TTL — a task that keeps touching one holds it forever.
+    #[cfg(with_testing)]
+    pub fn resident_chain_worker_count(&self) -> usize {
+        self.chain_workers
+            .pin()
+            .iter()
+            .filter(
+                |(_, future)| matches!(future.peek(), Some(Ok(weak)) if weak.strong_count() > 0),
+            )
+            .count()
+    }
+
     /// Evicts a poisoned chain worker from the cache, but only if the entry still
     /// points to the same instance. This avoids removing a fresh replacement that
     /// another task may have already loaded.
@@ -1289,7 +1301,6 @@ where
             service_runtime_endpoint,
             service_runtime_task,
             self.chain_exporter_factory.clone(),
-            LocalNodeClient::new(self.clone()),
         )
         .await?;
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -64,11 +64,12 @@ impl<S: Storage> std::ops::Deref for ChainStateViewReadGuard<S> {
 pub(crate) use crate::chain_worker::EventSubscriptionsResult;
 use crate::{
     chain_worker::{
-        handle, state::ChainWorkerState, BlockOutcome, ChainWorkerConfig, CrossChainUpdateResult,
-        DeliveryNotifier, ProcessConfirmedBlockMode,
+        handle, state::ChainWorkerState, BlockOutcome, ChainExporterFactory, ChainWorkerConfig,
+        CrossChainUpdateResult, DeliveryNotifier, ProcessConfirmedBlockMode,
     },
     client::{ChainModes, ListeningMode},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    local_node::LocalNodeClient,
     notifier::Notifier,
 };
 
@@ -719,6 +720,10 @@ pub struct WorkerState<StorageClient: Storage> {
     /// corrupted chain. The RPC server layer installs this; without it, we fall
     /// back to dispatching locally through `handle_cross_chain_request`.
     outbound_cross_chain_sender: Option<OutboundCrossChainSender>,
+    /// Creates each chain worker's block-export task. The server binary installs this, since it
+    /// is the only layer that knows how to reach another validator; without it, executed blocks
+    /// are not pushed to the rest of the committee.
+    chain_exporter_factory: Option<ChainExporterFactory<StorageClient>>,
 }
 
 /// Dispatcher for outbound cross-chain requests that handles the source-shard-to-
@@ -740,6 +745,7 @@ where
             chain_workers: self.chain_workers.clone(),
             chain_batches: self.chain_batches.clone(),
             outbound_cross_chain_sender: self.outbound_cross_chain_sender.clone(),
+            chain_exporter_factory: self.chain_exporter_factory.clone(),
         }
     }
 }
@@ -887,7 +893,21 @@ where
             #[cfg_attr(web, expect(clippy::arc_with_non_send_sync))]
             chain_batches: Arc::new(papaya::HashMap::new()),
             outbound_cross_chain_sender: None,
+            chain_exporter_factory: None,
         }
+    }
+
+    /// Installs the factory that creates each chain worker's block-export task, so that the
+    /// blocks this worker executes are pushed to the other validators in the committee.
+    ///
+    /// Must be called before any chain worker is created: workers capture the factory as they are
+    /// loaded, so one created earlier would never export.
+    pub fn with_chain_exporter_factory(
+        mut self,
+        factory: ChainExporterFactory<StorageClient>,
+    ) -> Self {
+        self.chain_exporter_factory = Some(factory);
+        self
     }
 
     /// Installs a shard-routing dispatcher used for outbound cross-chain requests
@@ -1270,6 +1290,8 @@ where
             chain_id,
             service_runtime_endpoint,
             service_runtime_task,
+            self.chain_exporter_factory.clone(),
+            LocalNodeClient::new(self.clone()),
         )
         .await?;
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -719,9 +719,8 @@ pub struct WorkerState<StorageClient: Storage> {
     /// corrupted chain. The RPC server layer installs this; without it, we fall
     /// back to dispatching locally through `handle_cross_chain_request`.
     outbound_cross_chain_sender: Option<OutboundCrossChainSender>,
-    /// Creates each chain worker's block-export task. The server binary installs this, since it
-    /// is the only layer that knows how to reach another validator; without it, executed blocks
-    /// are not pushed to the rest of the committee.
+    /// The process-wide export queue, installed by the server binary — the only layer that
+    /// knows how to reach another validator. `None` means blocks are not exported.
     block_export: Option<BlockExportHandle>,
 }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -10,6 +10,57 @@ service NotifierService {
   rpc NotifyBatch(NotificationBatch) returns (google.protobuf.Empty);
 }
 
+// A service run by the proxy which forwards a shard's requests to another validator.
+//
+// Shards must not have a route to the internet: they hold the validator's secret key, so the
+// proxy is the only component that opens outbound connections. A shard exporting a block it has
+// just executed sends each request here instead, naming the validator it is meant for, and the
+// proxy performs it on the shard's behalf and returns the answer.
+//
+// Deliberately limited to the operations block export needs, so that reaching this service does
+// not confer the ability to make the proxy issue arbitrary requests to arbitrary validators.
+service ValidatorRelay {
+  // Forward a lite certificate to another validator.
+  rpc RelayLiteCertificate(RelayLiteCertificateRequest) returns (ChainInfoResult);
+
+  // Forward a confirmed certificate to another validator.
+  rpc RelayConfirmedCertificate(RelayConfirmedCertificateRequest) returns (ChainInfoResult);
+
+  // Ask another validator for the state of a chain.
+  rpc RelayChainInfoQuery(RelayChainInfoQueryRequest) returns (ChainInfoResult);
+
+  // Upload a blob to another validator.
+  rpc RelayUploadBlob(RelayUploadBlobRequest) returns (BlobId);
+}
+
+// A lite certificate, and the validator it is for.
+message RelayLiteCertificateRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  LiteCertificate inner = 2;
+}
+
+// A confirmed certificate, and the validator it is for.
+message RelayConfirmedCertificateRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  HandleConfirmedCertificateRequest inner = 2;
+}
+
+// A chain info query, and the validator it is for.
+message RelayChainInfoQueryRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  ChainInfoQuery inner = 2;
+}
+
+// A blob, and the validator it is for.
+message RelayUploadBlobRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  BlobContent inner = 2;
+}
+
 // Interface provided by each physical shard (aka "worker") of a validator or a local node.
 // * All commands return either the current chain info or an error.
 // * Repeating commands produces no changes and returns no error.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -12,13 +12,10 @@ service NotifierService {
 
 // A service run by the proxy which forwards a shard's requests to another validator.
 //
-// Shards must not have a route to the internet: they hold the validator's secret key, so the
-// proxy is the only component that opens outbound connections. A shard exporting a block it has
-// just executed sends each request here instead, naming the validator it is meant for, and the
-// proxy performs it on the shard's behalf and returns the answer.
-//
-// Deliberately limited to the operations block export needs, so that reaching this service does
-// not confer the ability to make the proxy issue arbitrary requests to arbitrary validators.
+// Shards hold the validator's secret key, so the proxy is the only component that opens outbound
+// connections. A shard names the validator its request is meant for and the proxy performs it.
+// Limited to the operations block export needs, so reaching this service does not confer the
+// ability to make the proxy issue arbitrary requests.
 service ValidatorRelay {
   // Forward a lite certificate to another validator.
   rpc RelayLiteCertificate(RelayLiteCertificateRequest) returns (ChainInfoResult);

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -6,6 +6,7 @@ mod conversions;
 mod node_provider;
 /// A pool of reusable gRPC transport channels.
 pub mod pool;
+mod relay;
 #[cfg(with_server)]
 mod server;
 /// Transport-level configuration and channel construction for gRPC.
@@ -14,6 +15,7 @@ pub mod transport;
 pub use client::*;
 pub use conversions::*;
 pub use node_provider::*;
+pub use relay::{RelayClient, RelayNodeProvider};
 #[cfg(with_server)]
 pub use server::*;
 

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -1,0 +1,329 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reaching other validators through this validator's own proxy.
+//!
+//! Shards must not have a route to the internet: they hold the validator's secret key, so the
+//! proxy is the only component that should open outbound connections. A shard that needs to talk
+//! to another validator — which today means a chain worker exporting a block it has just executed
+//! — sends its request to the proxy's existing internal port instead, naming the validator it is
+//! meant for, and the proxy performs it and returns the answer.
+//!
+//! [`RelayClient`] therefore implements [`ValidatorNode`] only for the operations block export
+//! uses. Everything else is refused rather than silently doing something else, because a caller
+//! reaching for them through a relay is a mistake, not a fallback.
+//!
+//! Retries are deliberately absent: the caller (the chain worker's export task) already backs off
+//! per destination, and a second layer of retries underneath it would multiply the delays it is
+//! trying to control.
+
+use std::{collections::BTreeMap, str::FromStr as _};
+
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::{BlobContent, BlockHeight, NetworkDescription},
+    identifiers::{BlobId, ChainId, StreamId},
+};
+use linera_chain::{data_types, types};
+use linera_core::node::{
+    BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
+    ValidatorNodeProvider,
+};
+use linera_version::VersionInfo;
+use tonic::Request;
+use tracing::{debug, instrument, Level};
+
+use super::{
+    api::{self, validator_relay_client::ValidatorRelayClient},
+    pool::GrpcConnectionPool,
+    transport, GrpcError,
+};
+use crate::{
+    config::ValidatorPublicNetworkConfig, node_provider::NodeOptions,
+    HandleConfirmedCertificateRequest, HandleLiteCertRequest,
+};
+
+/// Refuses an operation that the relay deliberately does not carry.
+fn unsupported(operation: &str) -> NodeError {
+    NodeError::GrpcError {
+        error: format!(
+            "{operation} is not available through the validator relay, which only carries the \
+             requests needed to export blocks"
+        ),
+    }
+}
+
+/// A validator reached through this validator's proxy.
+#[derive(Clone)]
+pub struct RelayClient {
+    /// The public address of the validator this client talks to. Sent with every request so the
+    /// proxy knows where to forward it, and reported by [`ValidatorNode::address`] so that logs
+    /// and metrics name the destination rather than the relay.
+    destination: String,
+    client: ValidatorRelayClient<transport::Channel>,
+}
+
+impl RelayClient {
+    /// Turns the proxy's answer into the chain info the caller expects.
+    fn try_into_chain_info(
+        result: api::ChainInfoResult,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = result.inner.ok_or_else(|| NodeError::GrpcError {
+            error: "missing body from response".to_string(),
+        })?;
+        match inner {
+            api::chain_info_result::Inner::ChainInfoResponse(response) => {
+                Ok(response.try_into().map_err(|error| NodeError::GrpcError {
+                    error: format!("failed to unmarshal response: {error}"),
+                })?)
+            }
+            api::chain_info_result::Inner::Error(error) => Err(bcs::from_bytes(&error).map_err(
+                |error| NodeError::GrpcError {
+                    error: format!("failed to unmarshal error message: {error}"),
+                },
+            )?),
+        }
+    }
+}
+
+impl ValidatorNode for RelayClient {
+    type NotificationStream = NotificationStream;
+
+    fn address(&self) -> String {
+        self.destination.clone()
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn handle_lite_certificate(
+        &self,
+        certificate: types::LiteCertificate<'_>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = HandleLiteCertRequest {
+            certificate,
+            wait_for_outgoing_messages: delivery.wait_for_outgoing_messages(),
+        };
+        let request = api::RelayLiteCertificateRequest {
+            destination: self.destination.clone(),
+            inner: Some(inner.try_into()?),
+        };
+        debug!(handler = "relay_lite_certificate", "sending gRPC request");
+        let result = self
+            .client
+            .clone()
+            .relay_lite_certificate(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn handle_confirmed_certificate(
+        &self,
+        certificate: linera_storage::Arc<types::GenericCertificate<types::ConfirmedBlock>>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = HandleConfirmedCertificateRequest {
+            certificate: linera_storage::Arc::unwrap_or_clone(certificate),
+            wait_for_outgoing_messages: delivery.wait_for_outgoing_messages(),
+        };
+        let request = api::RelayConfirmedCertificateRequest {
+            destination: self.destination.clone(),
+            inner: Some(inner.try_into()?),
+        };
+        debug!(
+            handler = "relay_confirmed_certificate",
+            "sending gRPC request"
+        );
+        let result = self
+            .client
+            .clone()
+            .relay_confirmed_certificate(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn handle_chain_info_query(
+        &self,
+        query: linera_core::data_types::ChainInfoQuery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let request = api::RelayChainInfoQueryRequest {
+            destination: self.destination.clone(),
+            inner: Some(query.try_into()?),
+        };
+        debug!(handler = "relay_chain_info_query", "sending gRPC request");
+        let result = self
+            .client
+            .clone()
+            .relay_chain_info_query(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip(self), err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        let request = api::RelayUploadBlobRequest {
+            destination: self.destination.clone(),
+            inner: Some(content.try_into()?),
+        };
+        debug!(handler = "relay_upload_blob", "sending gRPC request");
+        let blob_id = self
+            .client
+            .clone()
+            .relay_upload_blob(Request::new(request))
+            .await?
+            .into_inner();
+        Ok(blob_id.try_into()?)
+    }
+
+    async fn handle_block_proposal(
+        &self,
+        _proposal: data_types::BlockProposal,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_block_proposal"))
+    }
+
+    async fn handle_validated_certificate(
+        &self,
+        _certificate: types::GenericCertificate<types::ValidatedBlock>,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_validated_certificate"))
+    }
+
+    async fn handle_timeout_certificate(
+        &self,
+        _certificate: types::GenericCertificate<types::Timeout>,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_timeout_certificate"))
+    }
+
+    async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
+        Err(unsupported("get_version_info"))
+    }
+
+    async fn get_network_description(&self) -> Result<NetworkDescription, NodeError> {
+        Err(unsupported("get_network_description"))
+    }
+
+    async fn subscribe(
+        &self,
+        _chains: Vec<ChainId>,
+    ) -> Result<Self::NotificationStream, NodeError> {
+        Err(unsupported("subscribe"))
+    }
+
+    async fn download_blob(&self, _blob_id: BlobId) -> Result<BlobContent, NodeError> {
+        Err(unsupported("download_blob"))
+    }
+
+    async fn download_blobs(&self, _blob_ids: Vec<BlobId>) -> Result<BlobStream, NodeError> {
+        Err(unsupported("download_blobs"))
+    }
+
+    async fn download_pending_blob(
+        &self,
+        _chain_id: ChainId,
+        _blob_id: BlobId,
+    ) -> Result<BlobContent, NodeError> {
+        Err(unsupported("download_pending_blob"))
+    }
+
+    async fn handle_pending_blob(
+        &self,
+        _chain_id: ChainId,
+        _blob: BlobContent,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_pending_blob"))
+    }
+
+    async fn download_certificate(
+        &self,
+        _hash: CryptoHash,
+    ) -> Result<types::ConfirmedBlockCertificate, NodeError> {
+        Err(unsupported("download_certificate"))
+    }
+
+    async fn download_certificates(
+        &self,
+        _hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<types::ConfirmedBlockCertificate>, NodeError> {
+        Err(unsupported("download_certificates"))
+    }
+
+    async fn blob_last_used_by(&self, _blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+        Err(unsupported("blob_last_used_by"))
+    }
+
+    async fn missing_blob_ids(&self, _blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
+        Err(unsupported("missing_blob_ids"))
+    }
+
+    async fn blob_last_used_by_certificate(
+        &self,
+        _blob_id: BlobId,
+    ) -> Result<types::ConfirmedBlockCertificate, NodeError> {
+        Err(unsupported("blob_last_used_by_certificate"))
+    }
+
+    async fn download_certificates_by_heights(
+        &self,
+        _chain_id: ChainId,
+        _heights: Vec<BlockHeight>,
+    ) -> Result<Vec<types::ConfirmedBlockCertificate>, NodeError> {
+        Err(unsupported("download_certificates_by_heights"))
+    }
+
+    async fn previous_event_blocks(
+        &self,
+        _chain_id: ChainId,
+        _stream_ids: Vec<StreamId>,
+    ) -> Result<BTreeMap<StreamId, (BlockHeight, CryptoHash)>, NodeError> {
+        Err(unsupported("previous_event_blocks"))
+    }
+}
+
+/// A node provider that reaches every validator through this validator's own proxy.
+#[derive(Clone)]
+pub struct RelayNodeProvider {
+    /// The internal address of this validator's proxy — the same one shards already send
+    /// notifications to.
+    relay_address: String,
+    pool: GrpcConnectionPool,
+}
+
+impl RelayNodeProvider {
+    /// Creates a provider that relays through the proxy listening at `relay_address`.
+    pub fn new(relay_address: String, options: NodeOptions) -> Self {
+        Self {
+            relay_address,
+            pool: GrpcConnectionPool::new(transport::Options::from(&options)),
+        }
+    }
+}
+
+impl ValidatorNodeProvider for RelayNodeProvider {
+    type Node = RelayClient;
+
+    fn make_node(&self, address: &str) -> Result<Self::Node, NodeError> {
+        // Parsed even though the proxy is the one that dials it, so that a malformed committee
+        // entry is rejected here rather than on every request.
+        let network = ValidatorPublicNetworkConfig::from_str(address).map_err(|_| {
+            NodeError::CannotResolveValidatorAddress {
+                address: address.to_string(),
+            }
+        })?;
+        let channel =
+            self.pool
+                .channel(self.relay_address.clone())
+                .map_err(|error: GrpcError| NodeError::GrpcError {
+                    error: format!("error creating channel to the relay: {error}"),
+                })?;
+        Ok(RelayClient {
+            destination: network.http_address(),
+            client: ValidatorRelayClient::new(channel),
+        })
+    }
+}

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -17,7 +17,14 @@
 //! per destination, and a second layer of retries underneath it would multiply the delays it is
 //! trying to control.
 
-use std::{collections::BTreeMap, str::FromStr as _};
+use std::{
+    collections::BTreeMap,
+    str::FromStr as _,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
 
 use linera_base::{
     crypto::CryptoHash,
@@ -288,22 +295,43 @@ impl ValidatorNode for RelayClient {
     }
 }
 
-/// A node provider that reaches every validator through this validator's own proxy.
+/// A node provider that reaches every validator through this validator's own proxies.
 #[derive(Clone)]
 pub struct RelayNodeProvider {
-    /// The internal address of this validator's proxy — the same one shards already send
-    /// notifications to.
-    relay_address: String,
+    /// The internal addresses of this validator's proxies — the same ones the shards already
+    /// send notifications to.
+    relay_addresses: Vec<String>,
+    /// Round-robin cursor over `relay_addresses`.
+    ///
+    /// Each request goes through exactly one proxy — relaying a block through more than one
+    /// would only duplicate it — but successive nodes are handed different proxies, so export
+    /// egress is spread rather than landing entirely on one. Shared across clones so that every
+    /// chain worker in the process draws from the same rotation.
+    next: Arc<AtomicUsize>,
     pool: GrpcConnectionPool,
 }
 
 impl RelayNodeProvider {
-    /// Creates a provider that relays through the proxy listening at `relay_address`.
-    pub fn new(relay_address: String, options: NodeOptions) -> Self {
+    /// Creates a provider that relays through the given proxies, in rotation.
+    ///
+    /// Panics if `relay_addresses` is empty: with no proxy to relay through there is no way to
+    /// reach another validator, and a shard must not open the connection itself.
+    pub fn new(relay_addresses: Vec<String>, options: NodeOptions) -> Self {
+        assert!(
+            !relay_addresses.is_empty(),
+            "relaying to other validators needs at least one proxy",
+        );
         Self {
-            relay_address,
+            relay_addresses,
+            next: Arc::new(AtomicUsize::new(0)),
             pool: GrpcConnectionPool::new(transport::Options::from(&options)),
         }
+    }
+
+    /// Returns the next proxy in the rotation.
+    fn next_relay(&self) -> &str {
+        let index = self.next.fetch_add(1, Ordering::Relaxed) % self.relay_addresses.len();
+        &self.relay_addresses[index]
     }
 }
 
@@ -318,12 +346,13 @@ impl ValidatorNodeProvider for RelayNodeProvider {
                 address: address.to_string(),
             }
         })?;
-        let channel =
-            self.pool
-                .channel(self.relay_address.clone())
-                .map_err(|error: GrpcError| NodeError::GrpcError {
-                    error: format!("error creating channel to the relay: {error}"),
-                })?;
+        let relay = self.next_relay();
+        let channel = self
+            .pool
+            .channel(relay.to_owned())
+            .map_err(|error: GrpcError| NodeError::GrpcError {
+                error: format!("error creating channel to the relay {relay}: {error}"),
+            })?;
         Ok(RelayClient {
             destination: address.to_owned(),
             address: network.http_address(),

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -38,7 +38,7 @@ use tracing::{debug, instrument, Level};
 use super::{
     api::{self, validator_relay_client::ValidatorRelayClient},
     pool::GrpcConnectionPool,
-    transport, GrpcError,
+    transport, GrpcError, GRPC_MAX_MESSAGE_SIZE,
 };
 use crate::{
     config::ValidatorPublicNetworkConfig, node_provider::NodeOptions,
@@ -347,7 +347,9 @@ impl ValidatorNodeProvider for RelayNodeProvider {
         Ok(RelayClient {
             destination: address.to_owned(),
             address: network.http_address(),
-            client: ValidatorRelayClient::new(channel),
+            client: ValidatorRelayClient::new(channel)
+                .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+                .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE),
         })
     }
 }

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -3,19 +3,14 @@
 
 //! Reaching other validators through this validator's own proxy.
 //!
-//! Shards must not have a route to the internet: they hold the validator's secret key, so the
-//! proxy is the only component that should open outbound connections. A shard that needs to talk
-//! to another validator — which today means a chain worker exporting a block it has just executed
-//! — sends its request to the proxy's existing internal port instead, naming the validator it is
-//! meant for, and the proxy performs it and returns the answer.
+//! Shards hold the validator's secret key, so the proxy is the only component that should open
+//! outbound connections. A shard needing another validator — today, a chain worker exporting a
+//! block — sends its request to the proxy's existing internal port naming the intended validator,
+//! and the proxy performs it and returns the answer.
 //!
 //! [`RelayClient`] therefore implements [`ValidatorNode`] only for the operations block export
-//! uses. Everything else is refused rather than silently doing something else, because a caller
-//! reaching for them through a relay is a mistake, not a fallback.
-//!
-//! Retries are deliberately absent: the caller (the chain worker's export task) already backs off
-//! per destination, and a second layer of retries underneath it would multiply the delays it is
-//! trying to control.
+//! uses; the rest are refused rather than silently doing something else. Retries are absent by
+//! design, since the export task already backs off per destination.
 
 use std::{
     collections::BTreeMap,
@@ -63,10 +58,9 @@ fn unsupported(operation: &str) -> NodeError {
 /// A validator reached through this validator's proxy.
 #[derive(Clone)]
 pub struct RelayClient {
-    /// The destination validator's address exactly as the committee spells it, e.g.
-    /// `grpc:host:port`. Sent with every request so the proxy knows where to forward it, and kept
-    /// in the committee's own form so the proxy resolves it the same way any other consumer of
-    /// the committee would.
+    /// The destination validator's address as the committee spells it, e.g. `grpc:host:port`.
+    /// Kept in the committee's own form so the proxy resolves it the way any other consumer
+    /// would.
     destination: String,
     /// The same validator as a URL, used only to name it in logs and metrics.
     address: String,
@@ -87,11 +81,9 @@ impl RelayClient {
                     error: format!("failed to unmarshal response: {error}"),
                 })?)
             }
-            // bincode, matching the encoding the validator used and this field's own note in
-            // the proto. Decoding it correctly is load-bearing rather than cosmetic: the
-            // recovery paths dispatch on the *variant* — `EventsNotFound` pushes the admin
-            // chain, `BlobsNotFound` uploads blobs — so a mangled error silently disables them
-            // and leaves the destination stuck forever.
+            // bincode, matching what the validator used. Load-bearing: the recovery paths
+            // dispatch on the *variant* — `EventsNotFound` pushes the admin chain,
+            // `BlobsNotFound` uploads blobs — so a mangled error silently disables them.
             api::chain_info_result::Inner::Error(error) => Err(bincode::deserialize(&error)
                 .map_err(|error| NodeError::GrpcError {
                     error: format!("failed to unmarshal error message: {error}"),
@@ -305,21 +297,16 @@ pub struct RelayNodeProvider {
     /// The internal addresses of this validator's proxies — the same ones the shards already
     /// send notifications to.
     relay_addresses: Vec<String>,
-    /// Round-robin cursor over `relay_addresses`.
-    ///
-    /// Each request goes through exactly one proxy — relaying a block through more than one
-    /// would only duplicate it — but successive nodes are handed different proxies, so export
-    /// egress is spread rather than landing entirely on one. Shared across clones so that every
-    /// chain worker in the process draws from the same rotation.
+    /// Round-robin cursor over `relay_addresses`. Each request goes through exactly one proxy,
+    /// but successive nodes draw different ones so egress is spread. Shared across clones, so
+    /// every chain worker in the process uses one rotation.
     next: Arc<AtomicUsize>,
     pool: GrpcConnectionPool,
 }
 
 impl RelayNodeProvider {
-    /// Creates a provider that relays through the given proxies, in rotation.
-    ///
-    /// Panics if `relay_addresses` is empty: with no proxy to relay through there is no way to
-    /// reach another validator, and a shard must not open the connection itself.
+    /// Creates a provider that relays through the given proxies, in rotation. Panics if
+    /// `relay_addresses` is empty: a shard must not open the connection itself.
     pub fn new(relay_addresses: Vec<String>, options: NodeOptions) -> Self {
         assert!(
             !relay_addresses.is_empty(),

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -56,10 +56,13 @@ fn unsupported(operation: &str) -> NodeError {
 /// A validator reached through this validator's proxy.
 #[derive(Clone)]
 pub struct RelayClient {
-    /// The public address of the validator this client talks to. Sent with every request so the
-    /// proxy knows where to forward it, and reported by [`ValidatorNode::address`] so that logs
-    /// and metrics name the destination rather than the relay.
+    /// The destination validator's address exactly as the committee spells it, e.g.
+    /// `grpc:host:port`. Sent with every request so the proxy knows where to forward it, and kept
+    /// in the committee's own form so the proxy resolves it the same way any other consumer of
+    /// the committee would.
     destination: String,
+    /// The same validator as a URL, used only to name it in logs and metrics.
+    address: String,
     client: ValidatorRelayClient<transport::Channel>,
 }
 
@@ -90,10 +93,10 @@ impl ValidatorNode for RelayClient {
     type NotificationStream = NotificationStream;
 
     fn address(&self) -> String {
-        self.destination.clone()
+        self.address.clone()
     }
 
-    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
     async fn handle_lite_certificate(
         &self,
         certificate: types::LiteCertificate<'_>,
@@ -117,7 +120,7 @@ impl ValidatorNode for RelayClient {
         Self::try_into_chain_info(result)
     }
 
-    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
     async fn handle_confirmed_certificate(
         &self,
         certificate: linera_storage::Arc<types::GenericCertificate<types::ConfirmedBlock>>,
@@ -144,7 +147,7 @@ impl ValidatorNode for RelayClient {
         Self::try_into_chain_info(result)
     }
 
-    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
     async fn handle_chain_info_query(
         &self,
         query: linera_core::data_types::ChainInfoQuery,
@@ -163,7 +166,7 @@ impl ValidatorNode for RelayClient {
         Self::try_into_chain_info(result)
     }
 
-    #[instrument(target = "relay_client", skip(self), err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip(self), err(level = Level::DEBUG), fields(destination = self.address))]
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
         let request = api::RelayUploadBlobRequest {
             destination: self.destination.clone(),
@@ -322,7 +325,8 @@ impl ValidatorNodeProvider for RelayNodeProvider {
                     error: format!("error creating channel to the relay: {error}"),
                 })?;
         Ok(RelayClient {
-            destination: network.http_address(),
+            destination: address.to_owned(),
+            address: network.http_address(),
             client: ValidatorRelayClient::new(channel),
         })
     }

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -87,11 +87,15 @@ impl RelayClient {
                     error: format!("failed to unmarshal response: {error}"),
                 })?)
             }
-            api::chain_info_result::Inner::Error(error) => Err(bcs::from_bytes(&error).map_err(
-                |error| NodeError::GrpcError {
+            // bincode, matching the encoding the validator used and this field's own note in
+            // the proto. Decoding it correctly is load-bearing rather than cosmetic: the
+            // recovery paths dispatch on the *variant* — `EventsNotFound` pushes the admin
+            // chain, `BlobsNotFound` uploads blobs — so a mangled error silently disables them
+            // and leaves the destination stuck forever.
+            api::chain_info_result::Inner::Error(error) => Err(bincode::deserialize(&error)
+                .map_err(|error| NodeError::GrpcError {
                     error: format!("failed to unmarshal error message: {error}"),
-                },
-            )?),
+                })?),
         }
     }
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -449,7 +449,8 @@ type ChainStateExtendedView {
 	"""
 	The height of the highest block of this chain that has been pushed to each of the other
 	committee validators. A validator with no entry has not been exported to yet, and is
-	queried before the first push.
+	queried before the first push. Validators that leave the committee are pruned, so this
+	stays bounded by the committee size.
 	"""
 	exportedHeights: JSONObject!
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -447,10 +447,8 @@ type ChainStateExtendedView {
 	"""
 	outboxIndexTrackedHash: CryptoHash
 	"""
-	The height of the highest block of this chain that has been pushed to each of the other
-	committee validators. A validator with no entry has not been exported to yet, and is
-	queried before the first push. Validators that leave the committee are pruned, so this
-	stays bounded by the committee size.
+	The highest block of this chain pushed to each other committee validator. A validator with
+	no entry is queried before its first push; ones that leave the committee are pruned.
 	"""
 	exportedHeights: JSONObject!
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -446,6 +446,12 @@ type ChainStateExtendedView {
 	that tracks all chains and never filters.
 	"""
 	outboxIndexTrackedHash: CryptoHash
+	"""
+	The height of the highest block of this chain that has been pushed to each of the other
+	committee validators. A validator with no entry has not been exported to yet, and is
+	queried before the first push.
+	"""
+	exportedHeights: JSONObject!
 }
 
 """

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -153,6 +153,7 @@ pub async fn handle_net_up_service(
         block_exporter_port,
     );
     let config = LocalNetConfig {
+        export_blocks_to_committee: false,
         network,
         database,
         testing_prng_seed,

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -153,6 +153,7 @@ pub async fn handle_net_up_service(
         block_exporter_port,
     );
     let config = LocalNetConfig {
+        block_export_transport: crate::config::BlockExportTransport::Relay,
         export_blocks_to_committee: false,
         network,
         database,

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -1086,10 +1086,8 @@ impl LocalNet {
 
 #[cfg(with_testing)]
 impl LocalNet {
-    /// Kills one proxy of the given validator, leaving its other proxies and shards running.
-    ///
-    /// Used to check that traffic which was relayed through that proxy moves to another one
-    /// rather than being stranded.
+    /// Kills one proxy of the given validator, leaving its other proxies and shards running, to
+    /// check that traffic relayed through it moves to another rather than being stranded.
     pub async fn kill_proxy(&mut self, validator: usize, proxy_id: usize) -> Result<()> {
         self.running_validators
             .get_mut(&validator)

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -547,7 +547,8 @@ impl LocalNet {
         test_offset_port() + 1000 + validator * self.num_proxies + proxy_id + 1
     }
 
-    fn shard_metrics_port(&self, validator: usize, shard: usize) -> usize {
+    /// Returns the metrics port of the given shard of the given validator.
+    pub fn shard_metrics_port(&self, validator: usize, shard: usize) -> usize {
         test_offset_port() + 2000 + validator * self.num_shards + shard + 1
     }
 

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -224,6 +224,9 @@ pub struct LocalNetConfig {
     pub path_provider: PathProvider,
     /// The setup describing how block exporters are run or reached.
     pub block_exporters: ExportersSetup,
+    /// Whether the validators push each block they execute to the rest of the committee,
+    /// through their own proxies.
+    pub export_blocks_to_committee: bool,
 }
 
 /// The setup for the block exporters.
@@ -268,6 +271,7 @@ pub struct LocalNet {
     cross_chain_config: CrossChainConfig,
     path_provider: PathProvider,
     block_exporters: ExportersSetup,
+    export_blocks_to_committee: bool,
 }
 
 /// The name of the environment variable that allows specifying additional arguments to be passed
@@ -378,6 +382,7 @@ impl LocalNetConfig {
             path_provider,
             block_exporters: ExportersSetup::Local(vec![]),
             http_request_allow_list: Some(vec!["localhost".to_string()]),
+            export_blocks_to_committee: false,
         }
     }
 }
@@ -399,6 +404,7 @@ impl LineraNetConfig for LocalNetConfig {
             self.cross_chain_config,
             self.path_provider,
             self.block_exporters,
+            self.export_blocks_to_committee,
         );
         let client = net.make_client().await;
         ensure!(
@@ -473,6 +479,7 @@ impl LocalNet {
         cross_chain_config: CrossChainConfig,
         path_provider: PathProvider,
         block_exporters: ExportersSetup,
+        export_blocks_to_committee: bool,
     ) -> Self {
         Self {
             network,
@@ -489,6 +496,7 @@ impl LocalNet {
             cross_chain_config,
             path_provider,
             block_exporters,
+            export_blocks_to_committee,
         }
     }
 
@@ -518,7 +526,8 @@ impl LocalNet {
         test_offset_port() + 2000 + validator * self.num_shards + shard + 1
     }
 
-    fn proxy_metrics_port(&self, validator: usize, proxy_id: usize) -> usize {
+    /// Returns the metrics port of the given proxy of the given validator.
+    pub fn proxy_metrics_port(&self, validator: usize, proxy_id: usize) -> usize {
         test_offset_port() + 3000 + validator * self.num_proxies + proxy_id + 1
     }
 
@@ -949,6 +958,9 @@ impl LocalNet {
             .args(["--server", &format!("server_{validator}.json")])
             .args(["--shard", &shard.to_string()])
             .args(self.cross_chain_config.to_args());
+        if self.export_blocks_to_committee {
+            command.arg("--export-blocks-to-committee");
+        }
         let child = command.spawn_into()?;
 
         let port = self.shard_port(validator, shard);

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -532,7 +532,8 @@ impl LocalNet {
         test_offset_port() + validator * self.num_shards + shard + 1
     }
 
-    fn proxy_internal_port(&self, validator: usize, proxy_id: usize) -> usize {
+    /// Returns the internal port of the given proxy, which its own shards use to reach it.
+    pub fn proxy_internal_port(&self, validator: usize, proxy_id: usize) -> usize {
         test_offset_port() + 1000 + validator * self.num_proxies + proxy_id + 1
     }
 

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -336,10 +336,10 @@ impl Validator {
             "no proxy {proxy_id} to kill; this validator runs {}",
             self.proxies.len()
         );
-        self.proxies[proxy_id]
-            .kill()
-            .await
-            .context("killing validator proxy")
+        // Removed rather than killed in place, as `terminate_server` does: `terminate()` later
+        // kills whatever remains in the vec, and must not have to reason about dead entries.
+        let mut proxy = self.proxies.remove(proxy_id);
+        proxy.kill().await.context("killing validator proxy")
     }
 
     fn add_server(&mut self, server: Child) {

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -16,6 +16,7 @@ use anyhow::{anyhow, bail, ensure, Context, Result};
 #[cfg(with_testing)]
 use async_lock::RwLock;
 use async_trait::async_trait;
+use clap::ValueEnum as _;
 use linera_base::{
     command::{resolve_binary, CommandExt},
     data_types::Amount,
@@ -42,6 +43,7 @@ use crate::{
     cli_wrappers::{
         ClientWrapper, LineraNet, LineraNetConfig, Network, NetworkConfig, OnClientDrop,
     },
+    config::BlockExportTransport,
     storage::{InnerStorageConfig, StorageConfig},
     util::ChildExt,
 };
@@ -227,6 +229,9 @@ pub struct LocalNetConfig {
     /// Whether the validators push each block they execute to the rest of the committee,
     /// through their own proxies.
     pub export_blocks_to_committee: bool,
+    /// How exporting validators reach the others: through their own proxy, or straight from the
+    /// shards.
+    pub block_export_transport: BlockExportTransport,
 }
 
 /// The setup for the block exporters.
@@ -272,6 +277,7 @@ pub struct LocalNet {
     path_provider: PathProvider,
     block_exporters: ExportersSetup,
     export_blocks_to_committee: bool,
+    block_export_transport: BlockExportTransport,
 }
 
 /// The name of the environment variable that allows specifying additional arguments to be passed
@@ -397,6 +403,7 @@ impl LocalNetConfig {
             block_exporters: ExportersSetup::Local(vec![]),
             http_request_allow_list: Some(vec!["localhost".to_string()]),
             export_blocks_to_committee: false,
+            block_export_transport: BlockExportTransport::Relay,
         }
     }
 }
@@ -419,6 +426,7 @@ impl LineraNetConfig for LocalNetConfig {
             self.path_provider,
             self.block_exporters,
             self.export_blocks_to_committee,
+            self.block_export_transport,
         );
         let client = net.make_client().await;
         ensure!(
@@ -494,6 +502,7 @@ impl LocalNet {
         path_provider: PathProvider,
         block_exporters: ExportersSetup,
         export_blocks_to_committee: bool,
+        block_export_transport: BlockExportTransport,
     ) -> Self {
         Self {
             network,
@@ -511,6 +520,7 @@ impl LocalNet {
             path_provider,
             block_exporters,
             export_blocks_to_committee,
+            block_export_transport,
         }
     }
 
@@ -975,6 +985,13 @@ impl LocalNet {
             .args(self.cross_chain_config.to_args());
         if self.export_blocks_to_committee {
             command.arg("--export-blocks-to-committee");
+            command.args([
+                "--block-export-transport",
+                self.block_export_transport
+                    .to_possible_value()
+                    .expect("every transport is a selectable value")
+                    .get_name(),
+            ]);
         }
         let child = command.spawn_into()?;
 

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -322,6 +322,20 @@ impl Validator {
         self.proxies.push(proxy)
     }
 
+    /// Kills one of this validator's proxies, leaving the rest running.
+    #[cfg(with_testing)]
+    async fn kill_proxy(&mut self, proxy_id: usize) -> Result<()> {
+        ensure!(
+            proxy_id < self.proxies.len(),
+            "no proxy {proxy_id} to kill; this validator runs {}",
+            self.proxies.len()
+        );
+        self.proxies[proxy_id]
+            .kill()
+            .await
+            .context("killing validator proxy")
+    }
+
     fn add_server(&mut self, server: Child) {
         self.servers.push(server)
     }
@@ -1054,6 +1068,18 @@ impl LocalNet {
 
 #[cfg(with_testing)]
 impl LocalNet {
+    /// Kills one proxy of the given validator, leaving its other proxies and shards running.
+    ///
+    /// Used to check that traffic which was relayed through that proxy moves to another one
+    /// rather than being stranded.
+    pub async fn kill_proxy(&mut self, validator: usize, proxy_id: usize) -> Result<()> {
+        self.running_validators
+            .get_mut(&validator)
+            .context("no such validator")?
+            .kill_proxy(proxy_id)
+            .await
+    }
+
     /// Returns the validating key and an account key of the validator.
     pub fn validator_keys(&self, validator: usize) -> Option<&(String, String)> {
         self.validator_keys.get(&validator)

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -8,13 +8,9 @@ pub use linera_exporter::config::{
 
 /// How a shard reaches the other validators when exporting the blocks it executes.
 ///
-/// The choice is a trade-off between this validator's own proxy load and keeping shards off the
-/// internet, and it is deliberately an operator's call: the cost of relaying every exported block
-/// through the proxy is not something we can predict from the code.
-///
-/// Note that neither setting changes what the *receiving* validator's proxy has to absorb — it
-/// serves the same requests either way. Relaying does, however, concentrate them: a peer sees
-/// connections from this validator's handful of proxies rather than from every one of its shards.
+/// A trade-off between this validator's own proxy load and keeping shards off the internet, left
+/// to the operator because relaying's cost is not predictable from the code. Neither setting
+/// changes what the *receiving* proxy absorbs, though relaying does concentrate the connections.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
 pub enum BlockExportTransport {
     /// Send through this validator's own proxy, which forwards to the destination. Shards need no

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -5,3 +5,23 @@ pub use linera_exporter::config::{
     BlockExporterConfig, Destination, DestinationConfig, DestinationId, DestinationKind,
     LimitsConfig,
 };
+
+/// How a shard reaches the other validators when exporting the blocks it executes.
+///
+/// The choice is a trade-off between this validator's own proxy load and keeping shards off the
+/// internet, and it is deliberately an operator's call: the cost of relaying every exported block
+/// through the proxy is not something we can predict from the code.
+///
+/// Note that neither setting changes what the *receiving* validator's proxy has to absorb — it
+/// serves the same requests either way. Relaying does, however, concentrate them: a peer sees
+/// connections from this validator's handful of proxies rather than from every one of its shards.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum BlockExportTransport {
+    /// Send through this validator's own proxy, which forwards to the destination. Shards need no
+    /// outbound access, which matters because a shard holds the validator secret key.
+    Relay,
+    /// Send straight from the shard to the destination validator's public endpoint. Takes the
+    /// sending proxy out of the path entirely, at the cost of giving shards — which hold the
+    /// validator secret key — outbound access to the other validators.
+    Direct,
+}

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::Debug,
     marker::PhantomData,
     net::SocketAddr,
+    str::FromStr as _,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -31,12 +32,17 @@ use linera_rpc::propagation::get_traffic_type_from_request;
 #[cfg(feature = "opentelemetry")]
 use linera_rpc::propagation::OtelContextLayer;
 use linera_rpc::{
-    config::{ProxyConfig, ShardConfig, TlsConfig, ValidatorInternalNetworkConfig},
+    config::{
+        ProxyConfig, ShardConfig, TlsConfig, ValidatorInternalNetworkConfig,
+        ValidatorPublicNetworkConfig,
+    },
     grpc::{
         api::{
             self,
             notifier_service_server::{NotifierService, NotifierServiceServer},
+            validator_node_client::ValidatorNodeClient,
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
+            validator_relay_server::{ValidatorRelay, ValidatorRelayServer},
             validator_worker_client::ValidatorWorkerClient,
             BlobContent, BlobId, BlobIds, BlockProposal, Certificate, CertificatesBatchRequest,
             CertificatesBatchResponse, ChainInfoResult, CryptoHash, HandlePendingBlobRequest,
@@ -201,6 +207,10 @@ pub struct GrpcProxy<S>(Arc<GrpcProxyInner<S>>);
 struct GrpcProxyInner<S> {
     internal_config: ValidatorInternalNetworkConfig,
     worker_connection_pool: GrpcConnectionPool,
+    /// Connections to the other validators, used to carry requests on behalf of this validator's
+    /// shards, which have no route to the internet of their own. Pooled, so a peer costs one
+    /// connection for the whole process rather than one per shard.
+    peer_connection_pool: GrpcConnectionPool,
     notifier: ChannelNotifier<Result<Notification, Status>>,
     tls: TlsConfig,
     storage: S,
@@ -222,6 +232,9 @@ where
         Self(Arc::new(GrpcProxyInner {
             internal_config,
             worker_connection_pool: GrpcConnectionPool::default()
+                .with_connect_timeout(connect_timeout)
+                .with_timeout(timeout),
+            peer_connection_pool: GrpcConnectionPool::default()
                 .with_connect_timeout(connect_timeout)
                 .with_timeout(timeout),
             notifier: ChannelNotifier::default(),
@@ -247,6 +260,30 @@ where
 
     fn as_notifier_service(&self) -> NotifierServiceServer<Self> {
         NotifierServiceServer::new(self.clone())
+    }
+
+    fn as_validator_relay(&self) -> ValidatorRelayServer<Self> {
+        ValidatorRelayServer::new(self.clone())
+            .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+    }
+
+    /// Returns a client for the validator a relayed request names.
+    ///
+    /// Relayed requests are forwarded as they arrived, without being decoded into their Rust
+    /// types and re-encoded: the proxy is carrying the shard's request, not making its own.
+    fn peer(&self, destination: &str) -> Result<ValidatorNodeClient<Channel>, Status> {
+        let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
+            Status::invalid_argument(format!("invalid destination validator: {destination}"))
+        })?;
+        let channel = self
+            .0
+            .peer_connection_pool
+            .channel(network.http_address())
+            .map_err(|error| Status::unavailable(format!("cannot reach {destination}: {error}")))?;
+        Ok(ValidatorNodeClient::new(channel)
+            .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE))
     }
 
     fn public_address(&self) -> SocketAddr {
@@ -319,6 +356,7 @@ where
         let internal_server = join_set.spawn_task(
             Server::builder()
                 .add_service(self.as_notifier_service())
+                .add_service(self.as_validator_relay())
                 .serve(self.internal_address())
                 .in_current_span(),
         );
@@ -955,6 +993,79 @@ where
         let cert_hash = self.blob_last_used_by(request).await?;
         let request = Request::new(cert_hash.into_inner());
         self.download_certificate(request).await
+    }
+}
+
+/// Performs, on behalf of this validator's shards, the requests they need to send to other
+/// validators.
+///
+/// Shards hold the validator's secret key and so must not be able to open outbound connections;
+/// the proxy is the one component that may. Each method here dials the validator named in the
+/// request and returns its answer verbatim, so that the shard sees exactly what it would have
+/// seen had it made the call itself — including the peer's errors, which the export logic
+/// depends on to decide what to send next.
+///
+/// Served only on the internal listener, and deliberately limited to the four requests block
+/// export makes.
+#[async_trait]
+impl<S> ValidatorRelay for GrpcProxy<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    #[instrument(skip_all, err(Display), fields(method = "relay_lite_certificate"))]
+    async fn relay_lite_certificate(
+        &self,
+        request: Request<api::RelayLiteCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing lite certificate"))?;
+        self.peer(&request.destination)?
+            .handle_lite_certificate(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_confirmed_certificate"))]
+    async fn relay_confirmed_certificate(
+        &self,
+        request: Request<api::RelayConfirmedCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing confirmed certificate"))?;
+        self.peer(&request.destination)?
+            .handle_confirmed_certificate(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_chain_info_query"))]
+    async fn relay_chain_info_query(
+        &self,
+        request: Request<api::RelayChainInfoQueryRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing chain info query"))?;
+        self.peer(&request.destination)?
+            .handle_chain_info_query(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_upload_blob"))]
+    async fn relay_upload_blob(
+        &self,
+        request: Request<api::RelayUploadBlobRequest>,
+    ) -> Result<Response<api::BlobId>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing blob"))?;
+        self.peer(&request.destination)?
+            .upload_blob(Request::new(inner))
+            .await
     }
 }
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -88,6 +88,18 @@ mod metrics {
             linear_bucket_interval(1.0, 50.0, 5000.0),
         )
     });
+    /// Requests this proxy has carried to another validator on behalf of one of its shards.
+    ///
+    /// Shards have no route to the internet, so this counting up is what shows that
+    /// validator-to-validator traffic is flowing, and through the relay rather than around it.
+    pub static RELAYED_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "proxy_relayed_request_count",
+            "Requests forwarded to another validator on behalf of a shard",
+            &[METHOD_NAME_LABEL],
+        )
+    });
+
     pub static PROXY_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
             "proxy_request_count",
@@ -272,7 +284,15 @@ where
     ///
     /// Relayed requests are forwarded as they arrived, without being decoded into their Rust
     /// types and re-encoded: the proxy is carrying the shard's request, not making its own.
-    fn peer(&self, destination: &str) -> Result<ValidatorNodeClient<Channel>, Status> {
+    fn peer(
+        &self,
+        destination: &str,
+        #[cfg_attr(not(with_metrics), allow(unused_variables))] method: &str,
+    ) -> Result<ValidatorNodeClient<Channel>, Status> {
+        #[cfg(with_metrics)]
+        metrics::RELAYED_REQUEST_COUNT
+            .with_label_values(&[method])
+            .inc();
         let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
             Status::invalid_argument(format!("invalid destination validator: {destination}"))
         })?;
@@ -1021,7 +1041,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing lite certificate"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_lite_certificate")?
             .handle_lite_certificate(Request::new(inner))
             .await
     }
@@ -1035,7 +1055,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing confirmed certificate"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_confirmed_certificate")?
             .handle_confirmed_certificate(Request::new(inner))
             .await
     }
@@ -1049,7 +1069,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing chain info query"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_chain_info_query")?
             .handle_chain_info_query(Request::new(inner))
             .await
     }
@@ -1063,7 +1083,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing blob"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_upload_blob")?
             .upload_blob(Request::new(inner))
             .await
     }

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -5,6 +5,7 @@
 #![allow(unknown_lints)]
 
 use std::{
+    collections::HashSet,
     fmt::Debug,
     marker::PhantomData,
     net::SocketAddr,
@@ -17,7 +18,10 @@ use std::{
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
-use linera_base::{data_types::BlockHeight, identifiers::ChainId};
+use linera_base::{
+    data_types::{BlockHeight, Epoch},
+    identifiers::ChainId,
+};
 use linera_chain::types::{ConfirmedBlock, LiteCertificate as ChainLiteCertificate};
 use linera_core::{
     data_types::{CertificatesByHeightRequest, ChainInfo, ChainInfoQuery},
@@ -227,6 +231,22 @@ struct GrpcProxyInner<S> {
     tls: TlsConfig,
     storage: S,
     id: usize,
+    /// The validator addresses this proxy is willing to relay to, and the next epoch it has yet
+    /// to learn about.
+    ///
+    /// Relaying exists so that shards — which hold the validator secret key — never open outbound
+    /// connections themselves. That is only worth anything if the proxy will not dial wherever it
+    /// is told: without this, anything able to reach the internal port could use the proxy to
+    /// reach an arbitrary host. Membership of some committee is the right test, because those are
+    /// exactly the validators block export has any business talking to.
+    relay_destinations: Arc<tokio::sync::RwLock<RelayDestinations>>,
+}
+
+/// Committee members seen so far, and how far the epochs have been scanned.
+#[derive(Default)]
+struct RelayDestinations {
+    addresses: HashSet<String>,
+    next_epoch: u32,
 }
 
 impl<S> GrpcProxy<S>
@@ -253,6 +273,7 @@ where
             tls,
             storage,
             id,
+            relay_destinations: Arc::default(),
         }))
     }
 
@@ -280,22 +301,65 @@ where
             .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE)
     }
 
+    /// Whether this proxy will relay to `address`, i.e. whether it belongs to a validator in any
+    /// committee this proxy can see.
+    ///
+    /// Epochs are scanned forward from wherever the last scan stopped, so a validator admitted
+    /// after startup is picked up on the first request naming it, and the scan is not repeated for
+    /// addresses already known.
+    async fn is_relay_destination(&self, address: &str) -> bool {
+        if self
+            .0
+            .relay_destinations
+            .read()
+            .await
+            .addresses
+            .contains(address)
+        {
+            return true;
+        }
+        let mut destinations = self.0.relay_destinations.write().await;
+        // Another task may have refreshed while we waited for the lock.
+        if destinations.addresses.contains(address) {
+            return true;
+        }
+        while let Ok(Some(committee)) = self
+            .0
+            .storage
+            .get_or_load_committee(Epoch(destinations.next_epoch))
+            .await
+        {
+            for (_, validator_address) in committee.validator_addresses() {
+                destinations.addresses.insert(validator_address.to_owned());
+            }
+            destinations.next_epoch += 1;
+        }
+        destinations.addresses.contains(address)
+    }
+
     /// Returns a client for the validator a relayed request names.
     ///
     /// Relayed requests are forwarded as they arrived, without being decoded into their Rust
     /// types and re-encoded: the proxy is carrying the shard's request, not making its own.
-    fn peer(
+    async fn peer(
         &self,
         destination: &str,
         #[cfg_attr(not(with_metrics), allow(unused_variables))] method: &str,
     ) -> Result<ValidatorNodeClient<Channel>, Status> {
+        let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
+            Status::invalid_argument(format!("invalid destination validator: {destination}"))
+        })?;
+        if !self.is_relay_destination(destination).await {
+            return Err(Status::permission_denied(format!(
+                "refusing to relay to {destination}: not a member of any known committee"
+            )));
+        }
+        // Counted only once the destination is accepted, so the metric measures relayed traffic
+        // rather than rejected attempts.
         #[cfg(with_metrics)]
         metrics::RELAYED_REQUEST_COUNT
             .with_label_values(&[method])
             .inc();
-        let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
-            Status::invalid_argument(format!("invalid destination validator: {destination}"))
-        })?;
         let channel = self
             .0
             .peer_connection_pool
@@ -1041,7 +1105,8 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing lite certificate"))?;
-        self.peer(&request.destination, "relay_lite_certificate")?
+        self.peer(&request.destination, "relay_lite_certificate")
+            .await?
             .handle_lite_certificate(Request::new(inner))
             .await
     }
@@ -1055,7 +1120,8 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing confirmed certificate"))?;
-        self.peer(&request.destination, "relay_confirmed_certificate")?
+        self.peer(&request.destination, "relay_confirmed_certificate")
+            .await?
             .handle_confirmed_certificate(Request::new(inner))
             .await
     }
@@ -1069,7 +1135,8 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing chain info query"))?;
-        self.peer(&request.destination, "relay_chain_info_query")?
+        self.peer(&request.destination, "relay_chain_info_query")
+            .await?
             .handle_chain_info_query(Request::new(inner))
             .await
     }
@@ -1083,7 +1150,8 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing blob"))?;
-        self.peer(&request.destination, "relay_upload_blob")?
+        self.peer(&request.destination, "relay_upload_blob")
+            .await?
             .upload_blob(Request::new(inner))
             .await
     }

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -350,19 +350,31 @@ where
             scanned_to = 1;
         }
         for event in events {
-            if let Some(committee) = self
+            let loaded = match self
                 .0
                 .storage
                 .get_or_load_committee(Epoch(event.index))
                 .await?
             {
-                found.extend(
-                    committee
-                        .validator_addresses()
-                        .map(|(_, address)| address.to_owned()),
-                );
-            }
-            scanned_to = scanned_to.max(event.index.saturating_add(1));
+                Some(committee) => {
+                    found.extend(
+                        committee
+                            .validator_addresses()
+                            .map(|(_, address)| address.to_owned()),
+                    );
+                    true
+                }
+                None => false,
+            };
+            // The frontier moves past an epoch we could not load — any validator still in the
+            // committee reappears in a later one, so its members are not lost — except when it
+            // is the newest we know of: there is no later committee to carry them, so leave the
+            // frontier on it and pick it up when it becomes loadable.
+            scanned_to = if loaded {
+                scanned_to.max(event.index.saturating_add(1))
+            } else {
+                scanned_to.max(event.index)
+            };
         }
 
         let mut destinations = self.0.relay_destinations.write().await;

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -339,15 +339,17 @@ where
         let mut found = Vec::new();
         let mut scanned_to = start;
         if start == 0 {
-            // Epoch 0 comes from the genesis blob, not an event.
+            // Epoch 0 comes from the genesis blob, not an event. The frontier only moves past it
+            // once it has actually loaded: on a network that has never changed epochs it is the
+            // only committee there is, so burning past it would refuse every validator forever.
             if let Some(committee) = self.0.storage.get_or_load_committee(Epoch(0)).await? {
                 found.extend(
                     committee
                         .validator_addresses()
                         .map(|(_, address)| address.to_owned()),
                 );
+                scanned_to = 1;
             }
-            scanned_to = 1;
         }
         for event in events {
             let loaded = match self

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -93,9 +93,7 @@ mod metrics {
         )
     });
     /// Requests this proxy has carried to another validator on behalf of one of its shards.
-    ///
-    /// Shards have no route to the internet, so this counting up is what shows that
-    /// validator-to-validator traffic is flowing, and through the relay rather than around it.
+    /// Shards have no internet route, so this is what shows the traffic goes through the relay.
     pub static RELAYED_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
             "proxy_relayed_request_count",
@@ -231,14 +229,9 @@ struct GrpcProxyInner<S> {
     tls: TlsConfig,
     storage: S,
     id: usize,
-    /// The validator addresses this proxy is willing to relay to, and the next epoch it has yet
-    /// to learn about.
-    ///
-    /// Relaying exists so that shards — which hold the validator secret key — never open outbound
-    /// connections themselves. That is only worth anything if the proxy will not dial wherever it
-    /// is told: without this, anything able to reach the internal port could use the proxy to
-    /// reach an arbitrary host. Membership of some committee is the right test, because those are
-    /// exactly the validators block export has any business talking to.
+    /// The validator addresses this proxy will relay to, and the next epoch it has yet to learn.
+    /// Without this, anything able to reach the internal port could use the proxy to dial an
+    /// arbitrary host, defeating the point of keeping shards off the internet.
     relay_destinations: Arc<tokio::sync::RwLock<RelayDestinations>>,
 }
 
@@ -302,11 +295,8 @@ where
     }
 
     /// Whether this proxy will relay to `address`, i.e. whether it belongs to a validator in any
-    /// committee this proxy can see.
-    ///
-    /// Epochs are scanned forward from wherever the last scan stopped, so a validator admitted
-    /// after startup is picked up on the first request naming it, and the scan is not repeated for
-    /// addresses already known.
+    /// committee it can see. Epochs are scanned forward from the last scan, so a validator
+    /// admitted after startup is picked up on the first request naming it.
     async fn is_relay_destination(&self, address: &str) -> bool {
         if self
             .0
@@ -337,10 +327,8 @@ where
         destinations.addresses.contains(address)
     }
 
-    /// Returns a client for the validator a relayed request names.
-    ///
-    /// Relayed requests are forwarded as they arrived, without being decoded into their Rust
-    /// types and re-encoded: the proxy is carrying the shard's request, not making its own.
+    /// Returns a client for the validator a relayed request names. Requests are forwarded as they
+    /// arrived, without decoding into Rust types: the proxy carries the shard's request.
     async fn peer(
         &self,
         destination: &str,
@@ -1080,17 +1068,9 @@ where
     }
 }
 
-/// Performs, on behalf of this validator's shards, the requests they need to send to other
-/// validators.
-///
-/// Shards hold the validator's secret key and so must not be able to open outbound connections;
-/// the proxy is the one component that may. Each method here dials the validator named in the
-/// request and returns its answer verbatim, so that the shard sees exactly what it would have
-/// seen had it made the call itself — including the peer's errors, which the export logic
-/// depends on to decide what to send next.
-///
-/// Served only on the internal listener, and deliberately limited to the four requests block
-/// export makes.
+/// Performs, on behalf of this validator's shards, the requests they must send to other
+/// validators, returning each answer verbatim — including the peer's errors, which export depends
+/// on. Served only on the internal listener, limited to the four requests block export makes.
 #[async_trait]
 impl<S> ValidatorRelay for GrpcProxy<S>
 where

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -297,34 +297,58 @@ where
     /// Whether this proxy will relay to `address`, i.e. whether it belongs to a validator in any
     /// committee it can see. Epochs are scanned forward from the last scan, so a validator
     /// admitted after startup is picked up on the first request naming it.
-    async fn is_relay_destination(&self, address: &str) -> bool {
-        if self
-            .0
-            .relay_destinations
-            .read()
-            .await
-            .addresses
-            .contains(address)
-        {
-            return true;
+    ///
+    /// `Err` means the scan itself failed and says nothing about the address, so the caller must
+    /// answer "try again", not "refused".
+    async fn is_relay_destination(&self, address: &str) -> Result<bool, ViewError> {
+        // How many epochs past the last loadable one to probe. An epoch can be temporarily
+        // unloadable (incomplete admin history) while later ones are present; without a probe the
+        // scan would stop at the hole forever, hiding every later committee.
+        const EPOCH_LOOKAHEAD: u32 = 8;
+
+        let (known, mut next_epoch) = {
+            let destinations = self.0.relay_destinations.read().await;
+            (
+                destinations.addresses.contains(address),
+                destinations.next_epoch,
+            )
+        };
+        if known {
+            return Ok(true);
         }
-        let mut destinations = self.0.relay_destinations.write().await;
-        // Another task may have refreshed while we waited for the lock.
-        if destinations.addresses.contains(address) {
-            return true;
-        }
-        while let Ok(Some(committee)) = self
-            .0
-            .storage
-            .get_or_load_committee(Epoch(destinations.next_epoch))
-            .await
-        {
-            for (_, validator_address) in committee.validator_addresses() {
-                destinations.addresses.insert(validator_address.to_owned());
+
+        // Scan outside any lock: `get_or_load_committee` reads storage, and holding the write
+        // lock across that would stall every concurrent `peer()` call, cached ones included.
+        let mut found = Vec::new();
+        let mut probe = next_epoch;
+        let mut contiguous = true;
+        while probe < next_epoch.saturating_add(EPOCH_LOOKAHEAD).max(next_epoch) {
+            match self.0.storage.get_or_load_committee(Epoch(probe)).await? {
+                Some(committee) => {
+                    found.extend(
+                        committee
+                            .validator_addresses()
+                            .map(|(_, address)| address.to_owned()),
+                    );
+                    if contiguous {
+                        // Everything up to here loaded, so the scan need never revisit it.
+                        next_epoch = probe + 1;
+                    }
+                    probe += 1;
+                }
+                // Not loadable (yet). Do not advance `next_epoch` past it — it may load later —
+                // but keep probing a bounded window so a hole cannot hide committees beyond it.
+                None => {
+                    contiguous = false;
+                    probe += 1;
+                }
             }
-            destinations.next_epoch += 1;
         }
-        destinations.addresses.contains(address)
+
+        let mut destinations = self.0.relay_destinations.write().await;
+        destinations.addresses.extend(found);
+        destinations.next_epoch = destinations.next_epoch.max(next_epoch);
+        Ok(destinations.addresses.contains(address))
     }
 
     /// Returns a client for the validator a relayed request names. Requests are forwarded as they
@@ -337,10 +361,20 @@ where
         let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
             Status::invalid_argument(format!("invalid destination validator: {destination}"))
         })?;
-        if !self.is_relay_destination(destination).await {
-            return Err(Status::permission_denied(format!(
-                "refusing to relay to {destination}: not a member of any known committee"
-            )));
+        match self.is_relay_destination(destination).await {
+            Ok(true) => {}
+            Ok(false) => {
+                return Err(Status::permission_denied(format!(
+                    "refusing to relay to {destination}: not a member of any known committee"
+                )));
+            }
+            // A scan failure says nothing about the destination; refusing here would disguise a
+            // storage problem as an authorization decision.
+            Err(error) => {
+                return Err(Status::unavailable(format!(
+                    "cannot verify the relay destination {destination} right now: {error}"
+                )));
+            }
         }
         // Counted only once the destination is accepted, so the metric measures relayed traffic
         // rather than rejected attempts.

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt as _};
 use linera_base::{
     data_types::{BlockHeight, Epoch},
-    identifiers::ChainId,
+    identifiers::{ChainId, StreamId},
 };
 use linera_chain::types::{ConfirmedBlock, LiteCertificate as ChainLiteCertificate};
 use linera_core::{
@@ -29,6 +29,7 @@ use linera_core::{
     notifier::ChannelNotifier,
     JoinSetExt as _,
 };
+use linera_execution::system::EPOCH_STREAM_NAME;
 #[cfg(with_metrics)]
 use linera_metrics::monitoring_server;
 #[cfg(all(with_metrics, feature = "opentelemetry"))]
@@ -240,6 +241,8 @@ struct GrpcProxyInner<S> {
 struct RelayDestinations {
     addresses: HashSet<String>,
     next_epoch: u32,
+    /// Resolved from the network description once and cached.
+    admin_chain_id: Option<ChainId>,
 }
 
 impl<S> GrpcProxy<S>
@@ -301,49 +304,69 @@ where
     /// `Err` means the scan itself failed and says nothing about the address, so the caller must
     /// answer "try again", not "refused".
     async fn is_relay_destination(&self, address: &str) -> Result<bool, ViewError> {
-        // The scan stops after this many consecutive unloadable epochs. A committee lists the
-        // *full* validator set, so an unloadable epoch can be skipped permanently — anyone still
-        // in the committee appears in a later, loadable one — and only the frontier (the trailing
-        // run of misses) is re-probed on later requests.
-        const EPOCH_MISS_RUN: u32 = 8;
-        // The most epochs one request scans; the frontier persists, so a scan interrupted by
-        // this cap resumes on the next request instead of doing unbounded work in a gRPC handler.
-        const MAX_EPOCHS_PER_SCAN: u32 = 64;
-
-        let (known, start) = {
+        let (known, start, admin_chain_id) = {
             let destinations = self.0.relay_destinations.read().await;
             (
                 destinations.addresses.contains(address),
                 destinations.next_epoch,
+                destinations.admin_chain_id,
             )
         };
         if known {
             return Ok(true);
         }
+        let admin_chain_id = match admin_chain_id {
+            Some(admin_chain_id) => admin_chain_id,
+            None => match self.0.storage.read_network_description().await? {
+                Some(description) => description.admin_chain_id,
+                None => return Ok(false),
+            },
+        };
 
-        // Scan outside any lock: `get_or_load_committee` reads storage, and holding the write
-        // lock across that would stall every concurrent `peer()` call, cached ones included.
+        // The events are listed in one bulk read from the frontier, outside any lock — so holes
+        // in the admin history are simply absent from the list rather than wedging a probe, and
+        // termination is the end of the list, not a heuristic. A committee lists the full
+        // validator set, so an epoch that stays unloadable is covered by any later one.
+        let events = self
+            .0
+            .storage
+            .read_events_from_index(
+                &admin_chain_id,
+                &StreamId::system(EPOCH_STREAM_NAME),
+                start.max(1),
+            )
+            .await?;
         let mut found = Vec::new();
-        let mut probe = start;
-        let mut misses = 0;
-        while misses < EPOCH_MISS_RUN && probe.saturating_sub(start) < MAX_EPOCHS_PER_SCAN {
-            match self.0.storage.get_or_load_committee(Epoch(probe)).await? {
-                Some(committee) => {
-                    found.extend(
-                        committee
-                            .validator_addresses()
-                            .map(|(_, address)| address.to_owned()),
-                    );
-                    misses = 0;
-                }
-                None => misses += 1,
+        let mut scanned_to = start;
+        if start == 0 {
+            // Epoch 0 comes from the genesis blob, not an event.
+            if let Some(committee) = self.0.storage.get_or_load_committee(Epoch(0)).await? {
+                found.extend(
+                    committee
+                        .validator_addresses()
+                        .map(|(_, address)| address.to_owned()),
+                );
             }
-            probe = probe.saturating_add(1);
+            scanned_to = 1;
         }
-        // Resume after everything decided; only the trailing miss-run is ever revisited.
-        let scanned_to = probe - misses;
+        for event in events {
+            if let Some(committee) = self
+                .0
+                .storage
+                .get_or_load_committee(Epoch(event.index))
+                .await?
+            {
+                found.extend(
+                    committee
+                        .validator_addresses()
+                        .map(|(_, address)| address.to_owned()),
+                );
+            }
+            scanned_to = scanned_to.max(event.index.saturating_add(1));
+        }
 
         let mut destinations = self.0.relay_destinations.write().await;
+        destinations.admin_chain_id = Some(admin_chain_id);
         destinations.addresses.extend(found);
         destinations.next_epoch = destinations.next_epoch.max(scanned_to);
         Ok(destinations.addresses.contains(address))

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -301,12 +301,16 @@ where
     /// `Err` means the scan itself failed and says nothing about the address, so the caller must
     /// answer "try again", not "refused".
     async fn is_relay_destination(&self, address: &str) -> Result<bool, ViewError> {
-        // How many epochs past the last loadable one to probe. An epoch can be temporarily
-        // unloadable (incomplete admin history) while later ones are present; without a probe the
-        // scan would stop at the hole forever, hiding every later committee.
-        const EPOCH_LOOKAHEAD: u32 = 8;
+        // The scan stops after this many consecutive unloadable epochs. A committee lists the
+        // *full* validator set, so an unloadable epoch can be skipped permanently — anyone still
+        // in the committee appears in a later, loadable one — and only the frontier (the trailing
+        // run of misses) is re-probed on later requests.
+        const EPOCH_MISS_RUN: u32 = 8;
+        // The most epochs one request scans; the frontier persists, so a scan interrupted by
+        // this cap resumes on the next request instead of doing unbounded work in a gRPC handler.
+        const MAX_EPOCHS_PER_SCAN: u32 = 64;
 
-        let (known, mut next_epoch) = {
+        let (known, start) = {
             let destinations = self.0.relay_destinations.read().await;
             (
                 destinations.addresses.contains(address),
@@ -320,9 +324,9 @@ where
         // Scan outside any lock: `get_or_load_committee` reads storage, and holding the write
         // lock across that would stall every concurrent `peer()` call, cached ones included.
         let mut found = Vec::new();
-        let mut probe = next_epoch;
-        let mut contiguous = true;
-        while probe < next_epoch.saturating_add(EPOCH_LOOKAHEAD).max(next_epoch) {
+        let mut probe = start;
+        let mut misses = 0;
+        while misses < EPOCH_MISS_RUN && probe.saturating_sub(start) < MAX_EPOCHS_PER_SCAN {
             match self.0.storage.get_or_load_committee(Epoch(probe)).await? {
                 Some(committee) => {
                     found.extend(
@@ -330,24 +334,18 @@ where
                             .validator_addresses()
                             .map(|(_, address)| address.to_owned()),
                     );
-                    if contiguous {
-                        // Everything up to here loaded, so the scan need never revisit it.
-                        next_epoch = probe + 1;
-                    }
-                    probe += 1;
+                    misses = 0;
                 }
-                // Not loadable (yet). Do not advance `next_epoch` past it — it may load later —
-                // but keep probing a bounded window so a hole cannot hide committees beyond it.
-                None => {
-                    contiguous = false;
-                    probe += 1;
-                }
+                None => misses += 1,
             }
+            probe = probe.saturating_add(1);
         }
+        // Resume after everything decided; only the trailing miss-run is ever revisited.
+        let scanned_to = probe - misses;
 
         let mut destinations = self.0.relay_destinations.write().await;
         destinations.addresses.extend(found);
-        destinations.next_epoch = destinations.next_epoch.max(next_epoch);
+        destinations.next_epoch = destinations.next_epoch.max(scanned_to);
         Ok(destinations.addresses.contains(address))
     }
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -134,16 +134,24 @@ impl ServerContext {
         S: Storage + Clone + Send + Sync + 'static,
     {
         let internal_network = &self.server_config.internal_network;
-        let relay_address = internal_network
+        // All of this validator's proxies, rotated over by the provider: each export leaves
+        // through exactly one of them, but successive destinations draw different ones so the
+        // egress is spread rather than landing entirely on the first.
+        let relay_addresses = internal_network
             .proxies
-            .first()
-            .expect("a validator always has at least one proxy")
-            .internal_address(&internal_network.protocol);
+            .iter()
+            .map(|proxy| proxy.internal_address(&internal_network.protocol))
+            .collect::<Vec<_>>();
+        assert!(
+            !relay_addresses.is_empty(),
+            "exporting blocks to the committee needs at least one proxy to relay through, but \
+             this validator's internal network configures none",
+        );
         // `NodeOptions::default()` leaves every timeout at zero, which the transport turns into
         // a deadline that has already passed; these are the values the block exporter used for
         // the same validator-to-validator traffic.
         let node_provider = Arc::new(grpc::RelayNodeProvider::new(
-            relay_address,
+            relay_addresses,
             linera_rpc::NodeOptions {
                 send_timeout: linera_base::time::Duration::from_secs(4),
                 recv_timeout: linera_base::time::Duration::from_secs(4),

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -131,11 +131,8 @@ impl ServerContext {
         (state, shard_id, shard.clone())
     }
 
-    /// Builds the factory that gives each chain worker its export task.
-    ///
-    /// The provider is built once and shared across chain workers, so a peer costs one pooled
-    /// connection rather than one per chain. Which provider depends on
-    /// [`BlockExportTransport`]; see there for the trade-off.
+    /// Builds the factory that gives each chain worker its export task. The provider is built
+    /// once and shared, so a peer costs one pooled connection rather than one per chain.
     fn chain_exporter_factory<S>(
         &self,
         export_config: BlockExportConfig,
@@ -146,13 +143,9 @@ impl ServerContext {
         S: Storage + Clone + Send + Sync + 'static,
     {
         let own_public_key = self.server_config.validator_secret.public();
-        // Both arms are handed the destination's committee address and differ only in who dials
-        // it, so the export task itself is identical either way.
-        //
-        // In neither arm do the retry fields of `node_options` take effect: the relay pool drops
-        // them, and the direct provider is given them as zero. Retrying is the export task's job,
-        // and it backs off per destination — a second retry loop underneath would multiply the
-        // delay before a failing validator is set aside.
+        // Both arms get the destination's committee address and differ only in who dials it. In
+        // neither do the retry fields of `node_options` take effect — the relay pool drops them,
+        // the direct provider gets zeros — because retrying is the export task's job.
         match transport {
             BlockExportTransport::Relay => {
                 let internal_network = &self.server_config.internal_network;
@@ -578,10 +571,8 @@ enum ServerCommand {
         #[arg(long, value_delimiter = ',')]
         recovery_whitelist: Option<Vec<ChainId>>,
 
-        /// Push each block this validator executes to the other validators in the committee, so
-        /// that every validator ends up holding every chain rather than only the quorum that
-        /// signed each block. The pushes go out through this validator's proxy; shards never
-        /// connect to another validator themselves.
+        /// Push each block this validator executes to the other committee validators, so every
+        /// validator holds every chain rather than only the quorum that signed each block.
         #[arg(
             long,
             default_value_t = false,
@@ -820,11 +811,9 @@ async fn run(options: ServerOptions) {
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
                 block_export_config: export_blocks_to_committee.then(|| {
-                    // A chain's export task lives inside its chain worker, so it is dropped when
-                    // the worker expires. A backoff longer than that TTL would never elapse: the
-                    // task would be gone before the destination came up for retry, and that
-                    // destination would then only be reconsidered if the chain produced another
-                    // block — exactly what the idle catch-up exists to avoid depending on.
+                    // The export task dies with its chain worker, so a backoff longer than the
+                    // worker TTL would never elapse — the destination would then only be
+                    // reconsidered if the chain produced another block.
                     let max_retry_delay = block_export_max_retry_delay.min(chain_worker_ttl);
                     if max_retry_delay != block_export_max_retry_delay {
                         warn!(

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -57,7 +57,7 @@ use linera_storage::Storage;
 use serde::Deserialize;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 struct ServerContext {
     server_config: ValidatorServerConfig,
@@ -766,12 +766,27 @@ async fn run(options: ServerOptions) {
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
                 block_export_config: export_blocks_to_committee.then(|| {
+                    // A chain's export task lives inside its chain worker, so it is dropped when
+                    // the worker expires. A backoff longer than that TTL would never elapse: the
+                    // task would be gone before the destination came up for retry, and that
+                    // destination would then only be reconsidered if the chain produced another
+                    // block — exactly what the idle catch-up exists to avoid depending on.
+                    let max_retry_delay = block_export_max_retry_delay.min(chain_worker_ttl);
+                    if max_retry_delay != block_export_max_retry_delay {
+                        warn!(
+                            ?block_export_max_retry_delay,
+                            ?chain_worker_ttl,
+                            ?max_retry_delay,
+                            "capping the block-export retry ceiling at the chain worker TTL, \
+                             beyond which the export task no longer exists to retry",
+                        );
+                    }
                     let config = BlockExportConfig {
                         certificate_upload_batch_size: block_export_batch_size,
                         max_catch_up_blocks: block_export_max_catch_up_blocks,
                         idle_catch_up_interval: block_export_idle_interval,
                         retry_delay: block_export_retry_delay,
-                        max_retry_delay: block_export_max_retry_delay,
+                        max_retry_delay,
                     };
                     config.check().expect("invalid block export configuration");
                     config

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -46,7 +46,7 @@ use linera_rpc::{
         ShardConfig, ShardId, TlsConfig, ValidatorInternalNetworkConfig,
         ValidatorPublicNetworkConfig,
     },
-    grpc, simple,
+    grpc, simple, NodeOptions,
 };
 use linera_sdk::linera_base_types::{AccountSecretKey, ValidatorKeypair};
 use linera_service::{
@@ -76,6 +76,8 @@ struct ServerContext {
     recovery_whitelist: Option<HashSet<ChainId>>,
     /// How to push executed blocks to the other committee validators, or `None` to not push them.
     block_export_config: Option<BlockExportConfig>,
+    /// The transport options for the connections block export makes to this validator's proxies.
+    block_export_node_options: NodeOptions,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -117,7 +119,9 @@ impl ServerContext {
         };
         let mut state = WorkerState::new(storage, config, None);
         if let Some(export_config) = self.block_export_config.clone() {
-            state = state.with_chain_exporter_factory(self.chain_exporter_factory(export_config));
+            state = state.with_chain_exporter_factory(
+                self.chain_exporter_factory(export_config, self.block_export_node_options),
+            );
         }
         (state, shard_id, shard.clone())
     }
@@ -129,7 +133,11 @@ impl ServerContext {
     /// addressed at the same internal endpoint the shards already send their notifications to,
     /// and the provider is shared across chain workers so a peer costs one pooled connection
     /// rather than one per chain.
-    fn chain_exporter_factory<S>(&self, export_config: BlockExportConfig) -> ChainExporterFactory<S>
+    fn chain_exporter_factory<S>(
+        &self,
+        export_config: BlockExportConfig,
+        node_options: NodeOptions,
+    ) -> ChainExporterFactory<S>
     where
         S: Storage + Clone + Send + Sync + 'static,
     {
@@ -147,19 +155,11 @@ impl ServerContext {
             "exporting blocks to the committee needs at least one proxy to relay through, but \
              this validator's internal network configures none",
         );
-        // `NodeOptions::default()` leaves every timeout at zero, which the transport turns into
-        // a deadline that has already passed; these are the values the block exporter used for
-        // the same validator-to-validator traffic.
-        let node_provider = Arc::new(grpc::RelayNodeProvider::new(
-            relay_addresses,
-            linera_rpc::NodeOptions {
-                send_timeout: linera_base::time::Duration::from_secs(4),
-                recv_timeout: linera_base::time::Duration::from_secs(4),
-                retry_delay: linera_base::time::Duration::from_secs(1),
-                max_retries: 10,
-                ..linera_rpc::NodeOptions::default()
-            },
-        ));
+        // Only the two timeouts in `node_options` reach the wire: the relay pool is built from
+        // `transport::Options`, which drops the retry fields. That is deliberate — retrying is the
+        // export task's job, and it backs off per destination, so a second retry loop underneath
+        // would multiply the delay before a failing validator is set aside.
+        let node_provider = Arc::new(grpc::RelayNodeProvider::new(relay_addresses, node_options));
         let own_public_key = self.server_config.validator_secret.public();
         Arc::new(move |setup| {
             spawn_chain_exporter(
@@ -601,6 +601,22 @@ enum ServerCommand {
         )]
         block_export_max_retry_delay: Duration,
 
+        /// How long block export waits to open a connection to one of this validator's proxies.
+        #[arg(
+            long = "block-export-send-timeout-ms",
+            default_value = "4000",
+            value_parser = util::parse_millis
+        )]
+        block_export_send_timeout: Duration,
+
+        /// How long block export waits for a proxy to answer a relayed request.
+        #[arg(
+            long = "block-export-recv-timeout-ms",
+            default_value = "4000",
+            value_parser = util::parse_millis
+        )]
+        block_export_recv_timeout: Duration,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -743,6 +759,8 @@ async fn run(options: ServerOptions) {
             block_export_idle_interval,
             block_export_retry_delay,
             block_export_max_retry_delay,
+            block_export_send_timeout,
+            block_export_recv_timeout,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -791,6 +809,11 @@ async fn run(options: ServerOptions) {
                     config.check().expect("invalid block export configuration");
                     config
                 }),
+                block_export_node_options: NodeOptions {
+                    send_timeout: block_export_send_timeout,
+                    recv_timeout: block_export_recv_timeout,
+                    ..NodeOptions::default()
+                },
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -603,6 +603,11 @@ enum ServerCommand {
         #[arg(long, default_value_t = BlockExportConfig::default().queue_size)]
         block_export_queue_size: usize,
 
+        /// The most blob payload bytes queued blocks may pin; past it blocks are dropped for
+        /// catch-up to re-send from storage.
+        #[arg(long, default_value_t = BlockExportConfig::default().queue_bytes)]
+        block_export_queue_bytes: usize,
+
         /// The most concurrent sends to one destination validator. Export backs off from this
         /// ceiling on its own when a destination slows down or fails.
         #[arg(long, default_value_t = BlockExportConfig::default().max_in_flight_per_destination)]
@@ -799,6 +804,7 @@ async fn run(options: ServerOptions) {
             block_export_batch_size,
             block_export_max_catch_up_blocks,
             block_export_queue_size,
+            block_export_queue_bytes,
             block_export_max_in_flight,
             block_export_converged_retention,
             block_export_idle_interval,
@@ -832,6 +838,7 @@ async fn run(options: ServerOptions) {
                     let config = BlockExportConfig {
                         certificate_upload_batch_size: block_export_batch_size,
                         queue_size: block_export_queue_size,
+                        queue_bytes: block_export_queue_bytes,
                         max_in_flight_per_destination: block_export_max_in_flight,
                         max_catch_up_blocks: block_export_max_catch_up_blocks,
                         idle_catch_up_interval: block_export_idle_interval,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -33,7 +33,7 @@ use linera_base::{
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
 use linera_core::{
-    spawn_chain_exporter, worker::WorkerState, BlockExportConfig, ChainExporterFactory,
+    spawn_block_export_queue, worker::WorkerState, BlockExportConfig, BlockExportHandle,
     ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 use linera_execution::{WasmRuntime, WithWasmDefault};
@@ -91,6 +91,7 @@ impl ServerContext {
         local_ip_addr: &str,
         shard_id: ShardId,
         storage: S,
+        block_export: Option<BlockExportHandle>,
     ) -> (WorkerState<S>, ShardId, ShardConfig)
     where
         S: Storage + Clone + Send + Sync + 'static,
@@ -121,32 +122,26 @@ impl ServerContext {
             ..ChainWorkerConfig::default()
         };
         let mut state = WorkerState::new(storage, config, None);
-        if let Some(export_config) = self.block_export_config.clone() {
-            state = state.with_chain_exporter_factory(self.chain_exporter_factory(
-                export_config,
-                self.block_export_node_options,
-                self.block_export_transport,
-            ));
+        if let Some(handle) = block_export {
+            state = state.with_block_export(handle);
         }
         (state, shard_id, shard.clone())
     }
 
-    /// Builds the factory that gives each chain worker its export task. The provider is built
-    /// once and shared, so a peer costs one pooled connection rather than one per chain.
-    fn chain_exporter_factory<S>(
-        &self,
-        export_config: BlockExportConfig,
-        node_options: NodeOptions,
-        transport: BlockExportTransport,
-    ) -> ChainExporterFactory<S>
+    /// Spawns the process-wide block export queue, if export is enabled. One per process: every
+    /// shard in it hands blocks to the same queue, so a peer costs one connection pool and one
+    /// rate-limit window rather than one per shard.
+    fn spawn_block_export<S>(&self, storage: S) -> Option<BlockExportHandle>
     where
         S: Storage + Clone + Send + Sync + 'static,
     {
+        let export_config = self.block_export_config.clone()?;
         let own_public_key = self.server_config.validator_secret.public();
+        let node_options = self.block_export_node_options;
         // Both arms get the destination's committee address and differ only in who dials it. In
         // neither do the retry fields of `node_options` take effect — the relay pool drops them,
-        // the direct provider gets zeros — because retrying is the export task's job.
-        match transport {
+        // the direct provider gets zeros — because retrying is the export queue's job.
+        let handle = match self.block_export_transport {
             BlockExportTransport::Relay => {
                 let internal_network = &self.server_config.internal_network;
                 // All of this validator's proxies, rotated over by the provider: each export
@@ -163,29 +158,21 @@ impl ServerContext {
                      validator's internal network configures none; use \
                      `--block-export-transport direct` to send without a proxy",
                 );
-                let node_provider =
-                    Arc::new(grpc::RelayNodeProvider::new(relay_addresses, node_options));
-                Arc::new(move |setup| {
-                    spawn_chain_exporter(
-                        setup,
-                        node_provider.clone(),
-                        export_config.clone(),
-                        Some(own_public_key),
-                    )
-                })
+                spawn_block_export_queue(
+                    storage,
+                    Arc::new(grpc::RelayNodeProvider::new(relay_addresses, node_options)),
+                    export_config,
+                    Some(own_public_key),
+                )
             }
-            BlockExportTransport::Direct => {
-                let node_provider = Arc::new(linera_rpc::NodeProvider::new(node_options));
-                Arc::new(move |setup| {
-                    spawn_chain_exporter(
-                        setup,
-                        node_provider.clone(),
-                        export_config.clone(),
-                        Some(own_public_key),
-                    )
-                })
-            }
-        }
+            BlockExportTransport::Direct => spawn_block_export_queue(
+                storage,
+                Arc::new(linera_rpc::NodeProvider::new(node_options)),
+                export_config,
+                Some(own_public_key),
+            ),
+        };
+        Some(handle)
     }
 
     #[cfg_attr(not(with_metrics), allow(unused_variables))]
@@ -328,17 +315,27 @@ impl Runnable for ServerContext {
         #[cfg(not(with_metrics))]
         let enable_memory_profiling = false;
 
+        // One export queue per process, shared by every shard this process runs.
+        let block_export = self.spawn_block_export(storage.clone());
+
         // Run the server
         let states = match self.shard {
             Some(shard) => {
                 info!("Running shard number {}", shard);
-                vec![self.make_shard_state(&listen_address, shard, storage)]
+                vec![self.make_shard_state(&listen_address, shard, storage, block_export)]
             }
             None => {
                 info!("Running all shards");
                 let num_shards = self.server_config.internal_network.shards.len();
                 (0..num_shards)
-                    .map(|shard| self.make_shard_state(&listen_address, shard, storage.clone()))
+                    .map(|shard| {
+                        self.make_shard_state(
+                            &listen_address,
+                            shard,
+                            storage.clone(),
+                            block_export.clone(),
+                        )
+                    })
                     .collect()
             }
         };
@@ -601,6 +598,24 @@ enum ServerCommand {
         #[arg(long, default_value_t = BlockExportConfig::default().max_catch_up_blocks)]
         block_export_max_catch_up_blocks: u64,
 
+        /// How many blocks the export queue holds; a full queue drops blocks for catch-up to
+        /// re-send from storage.
+        #[arg(long, default_value_t = BlockExportConfig::default().queue_size)]
+        block_export_queue_size: usize,
+
+        /// The most concurrent sends to one destination validator. Export backs off from this
+        /// ceiling on its own when a destination slows down or fails.
+        #[arg(long, default_value_t = BlockExportConfig::default().max_in_flight_per_destination)]
+        block_export_max_in_flight: usize,
+
+        /// How long export remembers a fully caught-up chain before dropping its bookkeeping.
+        #[arg(
+            long = "block-export-converged-retention-ms",
+            default_value = "300000",
+            value_parser = util::parse_millis
+        )]
+        block_export_converged_retention: Duration,
+
         /// How long block export waits for a new block before spending a round backfilling
         /// validators that are behind. With the catch-up bound, this sets the backfill rate.
         #[arg(
@@ -783,6 +798,9 @@ async fn run(options: ServerOptions) {
             block_export_transport,
             block_export_batch_size,
             block_export_max_catch_up_blocks,
+            block_export_queue_size,
+            block_export_max_in_flight,
+            block_export_converged_retention,
             block_export_idle_interval,
             block_export_retry_delay,
             block_export_max_retry_delay,
@@ -813,10 +831,13 @@ async fn run(options: ServerOptions) {
                 block_export_config: export_blocks_to_committee.then(|| {
                     let config = BlockExportConfig {
                         certificate_upload_batch_size: block_export_batch_size,
+                        queue_size: block_export_queue_size,
+                        max_in_flight_per_destination: block_export_max_in_flight,
                         max_catch_up_blocks: block_export_max_catch_up_blocks,
                         idle_catch_up_interval: block_export_idle_interval,
                         retry_delay: block_export_retry_delay,
                         max_retry_delay: block_export_max_retry_delay,
+                        converged_chain_retention: block_export_converged_retention,
                     };
                     config.check().expect("invalid block export configuration");
                     config

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -33,8 +33,7 @@ use linera_base::{
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
 use linera_core::{
-    spawn_chain_exporter, worker::WorkerState, BlockExportConfig, ChainExporterFactory,
-    ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    worker::WorkerState, ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 use linera_execution::{WasmRuntime, WithWasmDefault};
 #[cfg(with_metrics)]
@@ -74,12 +73,6 @@ struct ServerContext {
     allow_revert_confirm: bool,
     reset_on_corrupted_chain_state_mins: Option<u64>,
     recovery_whitelist: Option<HashSet<ChainId>>,
-    /// How to push executed blocks to the other committee validators, or `None` to not push them
-    /// at all.
-    block_export_config: Option<BlockExportConfig>,
-    /// Shared by every chain worker in this process, so that the connections to the other
-    /// validators are pooled per validator rather than per chain.
-    node_provider: Arc<linera_rpc::NodeProvider>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -119,37 +112,8 @@ impl ServerContext {
             cross_chain_message_chunk_limit: self.cross_chain_message_chunk_limit,
             ..ChainWorkerConfig::default()
         };
-        let mut state = WorkerState::new(storage.clone(), config, None);
-        if let Some(export_config) = self.block_export_config.clone() {
-            state = state
-                .with_chain_exporter_factory(self.chain_exporter_factory(storage, export_config));
-        }
+        let state = WorkerState::new(storage, config, None);
         (state, shard_id, shard.clone())
-    }
-
-    /// Builds the factory that gives each chain worker its export task.
-    ///
-    /// The node provider is shared across every chain worker of the process, so that a validator
-    /// costs one pooled connection rather than one per chain.
-    fn chain_exporter_factory<S>(
-        &self,
-        storage: S,
-        export_config: BlockExportConfig,
-    ) -> ChainExporterFactory<S>
-    where
-        S: Storage + Clone + Send + Sync + 'static,
-    {
-        let node_provider = self.node_provider.clone();
-        let own_public_key = self.server_config.validator_secret.public();
-        Arc::new(move |setup| {
-            spawn_chain_exporter(
-                setup,
-                storage.clone(),
-                node_provider.clone(),
-                export_config.clone(),
-                Some(own_public_key),
-            )
-        })
     }
 
     #[cfg_attr(not(with_metrics), allow(unused_variables))]
@@ -535,22 +499,6 @@ enum ServerCommand {
         #[arg(long, value_delimiter = ',')]
         recovery_whitelist: Option<Vec<ChainId>>,
 
-        /// Push each block this validator executes to the other validators in the committee, so
-        /// that every validator ends up holding every chain rather than only the quorum that
-        /// signed each block.
-        #[arg(
-            long,
-            default_value_t = false,
-            env = "LINERA_EXPORT_BLOCKS_TO_COMMITTEE"
-        )]
-        export_blocks_to_committee: bool,
-
-        /// How many certificates are read from storage and pushed per batch when a block export
-        /// has to catch a lagging validator up. Only used with
-        /// `--export-blocks-to-committee`.
-        #[arg(long, default_value_t = BlockExportConfig::default().certificate_upload_batch_size)]
-        block_export_batch_size: u64,
-
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -687,19 +635,12 @@ async fn run(options: ServerOptions) {
             allow_revert_confirm,
             reset_on_corrupted_chain_state_mins,
             recovery_whitelist,
-            export_blocks_to_committee,
-            block_export_batch_size,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
 
             let server_config: ValidatorServerConfig =
                 util::read_json(&server_config_path).expect("Failed to read server config");
-
-            let block_export_config = export_blocks_to_committee.then(|| BlockExportConfig {
-                certificate_upload_batch_size: block_export_batch_size,
-                ..BlockExportConfig::default()
-            });
 
             let job = ServerContext {
                 server_config,
@@ -716,10 +657,6 @@ async fn run(options: ServerOptions) {
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
-                block_export_config,
-                node_provider: Arc::new(linera_rpc::NodeProvider::new(
-                    linera_rpc::NodeOptions::default(),
-                )),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -33,7 +33,8 @@ use linera_base::{
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
 use linera_core::{
-    worker::WorkerState, ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    spawn_chain_exporter, worker::WorkerState, BlockExportConfig, ChainExporterFactory,
+    ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 use linera_execution::{WasmRuntime, WithWasmDefault};
 #[cfg(with_metrics)]
@@ -73,6 +74,8 @@ struct ServerContext {
     allow_revert_confirm: bool,
     reset_on_corrupted_chain_state_mins: Option<u64>,
     recovery_whitelist: Option<HashSet<ChainId>>,
+    /// How to push executed blocks to the other committee validators, or `None` to not push them.
+    block_export_config: Option<BlockExportConfig>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -112,8 +115,43 @@ impl ServerContext {
             cross_chain_message_chunk_limit: self.cross_chain_message_chunk_limit,
             ..ChainWorkerConfig::default()
         };
-        let state = WorkerState::new(storage, config, None);
+        let mut state = WorkerState::new(storage, config, None);
+        if let Some(export_config) = self.block_export_config.clone() {
+            state = state.with_chain_exporter_factory(self.chain_exporter_factory(export_config));
+        }
         (state, shard_id, shard.clone())
+    }
+
+    /// Builds the factory that gives each chain worker its export task.
+    ///
+    /// Every validator is reached through this validator's own proxy: a shard holds the validator
+    /// secret key, so it must not be able to open outbound connections itself. The proxy is
+    /// addressed at the same internal endpoint the shards already send their notifications to,
+    /// and the provider is shared across chain workers so a peer costs one pooled connection
+    /// rather than one per chain.
+    fn chain_exporter_factory<S>(&self, export_config: BlockExportConfig) -> ChainExporterFactory<S>
+    where
+        S: Storage + Clone + Send + Sync + 'static,
+    {
+        let internal_network = &self.server_config.internal_network;
+        let relay_address = internal_network
+            .proxies
+            .first()
+            .expect("a validator always has at least one proxy")
+            .internal_address(&internal_network.protocol);
+        let node_provider = Arc::new(grpc::RelayNodeProvider::new(
+            relay_address,
+            linera_rpc::NodeOptions::default(),
+        ));
+        let own_public_key = self.server_config.validator_secret.public();
+        Arc::new(move |setup| {
+            spawn_chain_exporter(
+                setup,
+                node_provider.clone(),
+                export_config.clone(),
+                Some(own_public_key),
+            )
+        })
     }
 
     #[cfg_attr(not(with_metrics), allow(unused_variables))]
@@ -499,6 +537,22 @@ enum ServerCommand {
         #[arg(long, value_delimiter = ',')]
         recovery_whitelist: Option<Vec<ChainId>>,
 
+        /// Push each block this validator executes to the other validators in the committee, so
+        /// that every validator ends up holding every chain rather than only the quorum that
+        /// signed each block. The pushes go out through this validator's proxy; shards never
+        /// connect to another validator themselves.
+        #[arg(
+            long,
+            default_value_t = false,
+            env = "LINERA_EXPORT_BLOCKS_TO_COMMITTEE"
+        )]
+        export_blocks_to_committee: bool,
+
+        /// How many certificates are read from storage and pushed per batch when a block export
+        /// has to catch a lagging validator up. Only used with `--export-blocks-to-committee`.
+        #[arg(long, default_value_t = BlockExportConfig::default().certificate_upload_batch_size)]
+        block_export_batch_size: u64,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -635,6 +689,8 @@ async fn run(options: ServerOptions) {
             allow_revert_confirm,
             reset_on_corrupted_chain_state_mins,
             recovery_whitelist,
+            export_blocks_to_committee,
+            block_export_batch_size,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -657,6 +713,10 @@ async fn run(options: ServerOptions) {
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
+                block_export_config: export_blocks_to_committee.then(|| BlockExportConfig {
+                    certificate_upload_batch_size: block_export_batch_size,
+                    ..BlockExportConfig::default()
+                }),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -58,7 +58,7 @@ use linera_storage::Storage;
 use serde::Deserialize;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 struct ServerContext {
     server_config: ValidatorServerConfig,
@@ -811,25 +811,12 @@ async fn run(options: ServerOptions) {
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
                 block_export_config: export_blocks_to_committee.then(|| {
-                    // The export task dies with its chain worker, so a backoff longer than the
-                    // worker TTL would never elapse — the destination would then only be
-                    // reconsidered if the chain produced another block.
-                    let max_retry_delay = block_export_max_retry_delay.min(chain_worker_ttl);
-                    if max_retry_delay != block_export_max_retry_delay {
-                        warn!(
-                            ?block_export_max_retry_delay,
-                            ?chain_worker_ttl,
-                            ?max_retry_delay,
-                            "capping the block-export retry ceiling at the chain worker TTL, \
-                             beyond which the export task no longer exists to retry",
-                        );
-                    }
                     let config = BlockExportConfig {
                         certificate_upload_batch_size: block_export_batch_size,
                         max_catch_up_blocks: block_export_max_catch_up_blocks,
                         idle_catch_up_interval: block_export_idle_interval,
                         retry_delay: block_export_retry_delay,
-                        max_retry_delay,
+                        max_retry_delay: block_export_max_retry_delay,
                     };
                     config.check().expect("invalid block export configuration");
                     config

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -33,7 +33,8 @@ use linera_base::{
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
 use linera_core::{
-    worker::WorkerState, ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    spawn_chain_exporter, worker::WorkerState, BlockExportConfig, ChainExporterFactory,
+    ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 use linera_execution::{WasmRuntime, WithWasmDefault};
 #[cfg(with_metrics)]
@@ -73,6 +74,12 @@ struct ServerContext {
     allow_revert_confirm: bool,
     reset_on_corrupted_chain_state_mins: Option<u64>,
     recovery_whitelist: Option<HashSet<ChainId>>,
+    /// How to push executed blocks to the other committee validators, or `None` to not push them
+    /// at all.
+    block_export_config: Option<BlockExportConfig>,
+    /// Shared by every chain worker in this process, so that the connections to the other
+    /// validators are pooled per validator rather than per chain.
+    node_provider: Arc<linera_rpc::NodeProvider>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -112,8 +119,37 @@ impl ServerContext {
             cross_chain_message_chunk_limit: self.cross_chain_message_chunk_limit,
             ..ChainWorkerConfig::default()
         };
-        let state = WorkerState::new(storage, config, None);
+        let mut state = WorkerState::new(storage.clone(), config, None);
+        if let Some(export_config) = self.block_export_config.clone() {
+            state = state
+                .with_chain_exporter_factory(self.chain_exporter_factory(storage, export_config));
+        }
         (state, shard_id, shard.clone())
+    }
+
+    /// Builds the factory that gives each chain worker its export task.
+    ///
+    /// The node provider is shared across every chain worker of the process, so that a validator
+    /// costs one pooled connection rather than one per chain.
+    fn chain_exporter_factory<S>(
+        &self,
+        storage: S,
+        export_config: BlockExportConfig,
+    ) -> ChainExporterFactory<S>
+    where
+        S: Storage + Clone + Send + Sync + 'static,
+    {
+        let node_provider = self.node_provider.clone();
+        let own_public_key = self.server_config.validator_secret.public();
+        Arc::new(move |setup| {
+            spawn_chain_exporter(
+                setup,
+                storage.clone(),
+                node_provider.clone(),
+                export_config.clone(),
+                Some(own_public_key),
+            )
+        })
     }
 
     #[cfg_attr(not(with_metrics), allow(unused_variables))]
@@ -499,6 +535,22 @@ enum ServerCommand {
         #[arg(long, value_delimiter = ',')]
         recovery_whitelist: Option<Vec<ChainId>>,
 
+        /// Push each block this validator executes to the other validators in the committee, so
+        /// that every validator ends up holding every chain rather than only the quorum that
+        /// signed each block.
+        #[arg(
+            long,
+            default_value_t = false,
+            env = "LINERA_EXPORT_BLOCKS_TO_COMMITTEE"
+        )]
+        export_blocks_to_committee: bool,
+
+        /// How many certificates are read from storage and pushed per batch when a block export
+        /// has to catch a lagging validator up. Only used with
+        /// `--export-blocks-to-committee`.
+        #[arg(long, default_value_t = BlockExportConfig::default().certificate_upload_batch_size)]
+        block_export_batch_size: u64,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -635,12 +687,19 @@ async fn run(options: ServerOptions) {
             allow_revert_confirm,
             reset_on_corrupted_chain_state_mins,
             recovery_whitelist,
+            export_blocks_to_committee,
+            block_export_batch_size,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
 
             let server_config: ValidatorServerConfig =
                 util::read_json(&server_config_path).expect("Failed to read server config");
+
+            let block_export_config = export_blocks_to_committee.then(|| BlockExportConfig {
+                certificate_upload_batch_size: block_export_batch_size,
+                ..BlockExportConfig::default()
+            });
 
             let job = ServerContext {
                 server_config,
@@ -657,6 +716,10 @@ async fn run(options: ServerOptions) {
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
+                block_export_config,
+                node_provider: Arc::new(linera_rpc::NodeProvider::new(
+                    linera_rpc::NodeOptions::default(),
+                )),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -613,6 +613,12 @@ enum ServerCommand {
         #[arg(long, default_value_t = BlockExportConfig::default().max_in_flight_per_destination)]
         block_export_max_in_flight: usize,
 
+        /// The most concurrent sends across all destinations. Each one can read up to
+        /// `--block-export-max-catch-up-blocks` certificates, so this is what bounds the load
+        /// catch-up puts on storage; export halves it whenever a read fails.
+        #[arg(long, default_value_t = BlockExportConfig::default().max_in_flight_total)]
+        block_export_max_in_flight_total: usize,
+
         /// How long export remembers a fully caught-up chain before dropping its bookkeeping.
         #[arg(
             long = "block-export-converged-retention-ms",
@@ -806,6 +812,7 @@ async fn run(options: ServerOptions) {
             block_export_queue_size,
             block_export_queue_bytes,
             block_export_max_in_flight,
+            block_export_max_in_flight_total,
             block_export_converged_retention,
             block_export_idle_interval,
             block_export_retry_delay,
@@ -840,6 +847,7 @@ async fn run(options: ServerOptions) {
                         queue_size: block_export_queue_size,
                         queue_bytes: block_export_queue_bytes,
                         max_in_flight_per_destination: block_export_max_in_flight,
+                        max_in_flight_total: block_export_max_in_flight_total,
                         max_catch_up_blocks: block_export_max_catch_up_blocks,
                         idle_catch_up_interval: block_export_idle_interval,
                         retry_delay: block_export_retry_delay,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -765,12 +765,16 @@ async fn run(options: ServerOptions) {
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
-                block_export_config: export_blocks_to_committee.then(|| BlockExportConfig {
-                    certificate_upload_batch_size: block_export_batch_size,
-                    max_catch_up_blocks: block_export_max_catch_up_blocks,
-                    idle_catch_up_interval: block_export_idle_interval,
-                    retry_delay: block_export_retry_delay,
-                    max_retry_delay: block_export_max_retry_delay,
+                block_export_config: export_blocks_to_committee.then(|| {
+                    let config = BlockExportConfig {
+                        certificate_upload_batch_size: block_export_batch_size,
+                        max_catch_up_blocks: block_export_max_catch_up_blocks,
+                        idle_catch_up_interval: block_export_idle_interval,
+                        retry_delay: block_export_retry_delay,
+                        max_retry_delay: block_export_max_retry_delay,
+                    };
+                    config.check().expect("invalid block export configuration");
+                    config
                 }),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -50,6 +50,7 @@ use linera_rpc::{
 };
 use linera_sdk::linera_base_types::{AccountSecretKey, ValidatorKeypair};
 use linera_service::{
+    config::BlockExportTransport,
     storage::{AssertStorageV1, CommonStorageOptions, Runnable, StorageConfig},
     util,
 };
@@ -76,8 +77,10 @@ struct ServerContext {
     recovery_whitelist: Option<HashSet<ChainId>>,
     /// How to push executed blocks to the other committee validators, or `None` to not push them.
     block_export_config: Option<BlockExportConfig>,
-    /// The transport options for the connections block export makes to this validator's proxies.
+    /// The transport options for the connections block export makes.
     block_export_node_options: NodeOptions,
+    /// How block export reaches the other validators.
+    block_export_transport: BlockExportTransport,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -119,56 +122,77 @@ impl ServerContext {
         };
         let mut state = WorkerState::new(storage, config, None);
         if let Some(export_config) = self.block_export_config.clone() {
-            state = state.with_chain_exporter_factory(
-                self.chain_exporter_factory(export_config, self.block_export_node_options),
-            );
+            state = state.with_chain_exporter_factory(self.chain_exporter_factory(
+                export_config,
+                self.block_export_node_options,
+                self.block_export_transport,
+            ));
         }
         (state, shard_id, shard.clone())
     }
 
     /// Builds the factory that gives each chain worker its export task.
     ///
-    /// Every validator is reached through this validator's own proxy: a shard holds the validator
-    /// secret key, so it must not be able to open outbound connections itself. The proxy is
-    /// addressed at the same internal endpoint the shards already send their notifications to,
-    /// and the provider is shared across chain workers so a peer costs one pooled connection
-    /// rather than one per chain.
+    /// The provider is built once and shared across chain workers, so a peer costs one pooled
+    /// connection rather than one per chain. Which provider depends on
+    /// [`BlockExportTransport`]; see there for the trade-off.
     fn chain_exporter_factory<S>(
         &self,
         export_config: BlockExportConfig,
         node_options: NodeOptions,
+        transport: BlockExportTransport,
     ) -> ChainExporterFactory<S>
     where
         S: Storage + Clone + Send + Sync + 'static,
     {
-        let internal_network = &self.server_config.internal_network;
-        // All of this validator's proxies, rotated over by the provider: each export leaves
-        // through exactly one of them, but successive destinations draw different ones so the
-        // egress is spread rather than landing entirely on the first.
-        let relay_addresses = internal_network
-            .proxies
-            .iter()
-            .map(|proxy| proxy.internal_address(&internal_network.protocol))
-            .collect::<Vec<_>>();
-        assert!(
-            !relay_addresses.is_empty(),
-            "exporting blocks to the committee needs at least one proxy to relay through, but \
-             this validator's internal network configures none",
-        );
-        // Only the two timeouts in `node_options` reach the wire: the relay pool is built from
-        // `transport::Options`, which drops the retry fields. That is deliberate — retrying is the
-        // export task's job, and it backs off per destination, so a second retry loop underneath
-        // would multiply the delay before a failing validator is set aside.
-        let node_provider = Arc::new(grpc::RelayNodeProvider::new(relay_addresses, node_options));
         let own_public_key = self.server_config.validator_secret.public();
-        Arc::new(move |setup| {
-            spawn_chain_exporter(
-                setup,
-                node_provider.clone(),
-                export_config.clone(),
-                Some(own_public_key),
-            )
-        })
+        // Both arms are handed the destination's committee address and differ only in who dials
+        // it, so the export task itself is identical either way.
+        //
+        // In neither arm do the retry fields of `node_options` take effect: the relay pool drops
+        // them, and the direct provider is given them as zero. Retrying is the export task's job,
+        // and it backs off per destination — a second retry loop underneath would multiply the
+        // delay before a failing validator is set aside.
+        match transport {
+            BlockExportTransport::Relay => {
+                let internal_network = &self.server_config.internal_network;
+                // All of this validator's proxies, rotated over by the provider: each export
+                // leaves through exactly one of them, but successive destinations draw different
+                // ones so the egress is spread rather than landing entirely on the first.
+                let relay_addresses = internal_network
+                    .proxies
+                    .iter()
+                    .map(|proxy| proxy.internal_address(&internal_network.protocol))
+                    .collect::<Vec<_>>();
+                assert!(
+                    !relay_addresses.is_empty(),
+                    "relaying exported blocks needs at least one proxy to relay through, but this \
+                     validator's internal network configures none; use \
+                     `--block-export-transport direct` to send without a proxy",
+                );
+                let node_provider =
+                    Arc::new(grpc::RelayNodeProvider::new(relay_addresses, node_options));
+                Arc::new(move |setup| {
+                    spawn_chain_exporter(
+                        setup,
+                        node_provider.clone(),
+                        export_config.clone(),
+                        Some(own_public_key),
+                    )
+                })
+            }
+            BlockExportTransport::Direct => {
+                let node_provider = Arc::new(linera_rpc::NodeProvider::new(node_options));
+                Arc::new(move |setup| {
+                    spawn_chain_exporter(
+                        setup,
+                        node_provider.clone(),
+                        export_config.clone(),
+                        Some(own_public_key),
+                    )
+                })
+            }
+        }
     }
 
     #[cfg_attr(not(with_metrics), allow(unused_variables))]
@@ -565,6 +589,17 @@ enum ServerCommand {
         )]
         export_blocks_to_committee: bool,
 
+        /// How exported blocks reach the other validators: relayed through this validator's own
+        /// proxy, or sent straight from the shards. Relaying keeps shards off the internet;
+        /// sending directly removes the proxy from the path if relaying proves too expensive.
+        #[arg(
+            long,
+            value_enum,
+            default_value_t = BlockExportTransport::Relay,
+            env = "LINERA_BLOCK_EXPORT_TRANSPORT"
+        )]
+        block_export_transport: BlockExportTransport,
+
         /// How many certificates are read from storage and pushed per batch when a block export
         /// has to catch a lagging validator up. Only used with `--export-blocks-to-committee`.
         #[arg(long, default_value_t = BlockExportConfig::default().certificate_upload_batch_size)]
@@ -754,6 +789,7 @@ async fn run(options: ServerOptions) {
             reset_on_corrupted_chain_state_mins,
             recovery_whitelist,
             export_blocks_to_committee,
+            block_export_transport,
             block_export_batch_size,
             block_export_max_catch_up_blocks,
             block_export_idle_interval,
@@ -809,6 +845,7 @@ async fn run(options: ServerOptions) {
                     config.check().expect("invalid block export configuration");
                     config
                 }),
+                block_export_transport,
                 block_export_node_options: NodeOptions {
                     send_timeout: block_export_send_timeout,
                     recv_timeout: block_export_recv_timeout,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -139,9 +139,18 @@ impl ServerContext {
             .first()
             .expect("a validator always has at least one proxy")
             .internal_address(&internal_network.protocol);
+        // `NodeOptions::default()` leaves every timeout at zero, which the transport turns into
+        // a deadline that has already passed; these are the values the block exporter used for
+        // the same validator-to-validator traffic.
         let node_provider = Arc::new(grpc::RelayNodeProvider::new(
             relay_address,
-            linera_rpc::NodeOptions::default(),
+            linera_rpc::NodeOptions {
+                send_timeout: linera_base::time::Duration::from_secs(4),
+                recv_timeout: linera_base::time::Duration::from_secs(4),
+                retry_delay: linera_base::time::Duration::from_secs(1),
+                max_retries: 10,
+                ..linera_rpc::NodeOptions::default()
+            },
         ));
         let own_public_key = self.server_config.validator_secret.public();
         Arc::new(move |setup| {

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -570,6 +570,37 @@ enum ServerCommand {
         #[arg(long, default_value_t = BlockExportConfig::default().certificate_upload_batch_size)]
         block_export_batch_size: u64,
 
+        /// How many missing blocks block export pushes to one validator per round. Bounds how
+        /// long a freshly-joined validator's backfill can delay a live block.
+        #[arg(long, default_value_t = BlockExportConfig::default().max_catch_up_blocks)]
+        block_export_max_catch_up_blocks: u64,
+
+        /// How long block export waits for a new block before spending a round backfilling
+        /// validators that are behind. With the catch-up bound, this sets the backfill rate.
+        #[arg(
+            long = "block-export-idle-interval-ms",
+            default_value = "200",
+            value_parser = util::parse_millis
+        )]
+        block_export_idle_interval: Duration,
+
+        /// How long block export skips a validator after a failed push, doubling up to
+        /// `--block-export-max-retry-delay-ms` while it keeps failing.
+        #[arg(
+            long = "block-export-retry-delay-ms",
+            default_value = "1000",
+            value_parser = util::parse_millis
+        )]
+        block_export_retry_delay: Duration,
+
+        /// The longest block export skips a failing validator for.
+        #[arg(
+            long = "block-export-max-retry-delay-ms",
+            default_value = "60000",
+            value_parser = util::parse_millis
+        )]
+        block_export_max_retry_delay: Duration,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -708,6 +739,10 @@ async fn run(options: ServerOptions) {
             recovery_whitelist,
             export_blocks_to_committee,
             block_export_batch_size,
+            block_export_max_catch_up_blocks,
+            block_export_idle_interval,
+            block_export_retry_delay,
+            block_export_max_retry_delay,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -732,7 +767,10 @@ async fn run(options: ServerOptions) {
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
                 block_export_config: export_blocks_to_committee.then(|| BlockExportConfig {
                     certificate_upload_batch_size: block_export_batch_size,
-                    ..BlockExportConfig::default()
+                    max_catch_up_blocks: block_export_max_catch_up_blocks,
+                    idle_catch_up_interval: block_export_idle_interval,
+                    retry_delay: block_export_retry_delay,
+                    max_retry_delay: block_export_max_retry_delay,
                 }),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -3,21 +3,17 @@
 
 //! End-to-end coverage of in-worker block export over a real network.
 //!
-//! The unit tests in `linera-core` drive the export task against in-process validators, so they
-//! say nothing about the transport. This exercises the part they cannot: real `linera-server`
-//! shards, real proxies, real gRPC, and — the point of the whole arrangement — shards that reach
-//! the other validators only by going through their own proxy.
+//! The `linera-core` unit tests drive the export task against in-process validators, so they say
+//! nothing about the transport. This covers what they cannot: real shards, proxies and gRPC.
 //!
 //! ```text
 //! cargo test -p linera-service --test block_export_tests --features storage-service,metrics \
 //!     -- --ignored
 //! ```
 //!
-//! The `metrics` feature is required: the assertions read the proxies' metrics endpoint, and
-//! `cargo test` rebuilds the binaries the harness spawns using whatever features the test command
-//! names. Like the other integration suites, each test takes `INTEGRATION_TEST_GUARD`, because
-//! every network derives its ports from the same `test_offset_port()` base and two of them at once
-//! collide.
+//! `metrics` is required because the assertions read the proxies' metrics endpoint, and `cargo
+//! test` rebuilds the spawned binaries with whatever features the command names. Each test takes
+//! `INTEGRATION_TEST_GUARD`: every network derives its ports from the same `test_offset_port()`.
 
 #![cfg(any(feature = "scylladb", feature = "storage-service"))]
 
@@ -38,12 +34,9 @@ use linera_service::{
 };
 use test_case::test_case;
 
-/// The number of requests the proxy of `validator` reports having carried to other validators on
-/// behalf of its shards.
-///
-/// Zero unless block export actually went through the relay, which is what makes this worth
-/// asserting on: every validator ends up holding every block either way, because the client talks
-/// to all of them, so the blocks alone prove nothing about the path they took.
+/// Requests the proxy of `validator` reports carrying to other validators for its shards. Worth
+/// asserting on because the client talks to every validator anyway, so the blocks arriving prove
+/// nothing about the path they took.
 async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
     let port = net.proxy_metrics_port(validator, 0);
     let metrics = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
@@ -119,10 +112,8 @@ async fn test_block_export_through_the_proxy(database: Database, network: Networ
 /// A validator admitted to the committee after a chain already has history is brought up to date
 /// by export alone.
 ///
-/// This is the case the cursor cannot short-circuit: the newcomer has never heard of the chain, so
-/// it answers a height query with 0 rather than an error, and every block has to be replayed to it
-/// through the relay. Catch-up is bounded per round on purpose, so what this asserts is that it
-/// *converges*, not that it happens in one shot.
+/// The newcomer has never heard of the chain, so it answers a height query with 0 and every block
+/// is replayed. Catch-up is bounded per round, so this asserts convergence, not one-shot.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
 #[test_log::test(tokio::test)]
@@ -192,9 +183,8 @@ async fn test_export_catches_up_a_newly_added_validator(
 
 /// Export keeps flowing when one of this validator's proxies dies.
 ///
-/// A destination is handed one proxy from the rotation and keeps it, so without the rebuild-on-
-/// failure path a dead proxy would strand every destination assigned to it — silently, since the
-/// other proxies would carry on and the chain would still look healthy from most angles.
+/// A destination keeps the proxy it was handed, so without the rebuild-on-failure path a dead
+/// proxy strands every destination assigned to it — silently, since the chain still looks healthy.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
 #[test_log::test(tokio::test)]
@@ -259,9 +249,8 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
 
 /// The proxy refuses to relay to a host that is not in any committee.
 ///
-/// Relaying exists so that shards — which hold the validator secret key — never open outbound
-/// connections. That only buys anything if the proxy will not dial wherever it is told, so this
-/// asserts the refusal directly rather than inferring it from export working.
+/// Relaying only buys anything if the proxy will not dial wherever it is told, so this asserts
+/// the refusal directly rather than inferring it from export working.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
 #[test_log::test(tokio::test)]
@@ -315,14 +304,9 @@ async fn test_relay_refuses_a_non_committee_destination(
 /// With `--block-export-transport direct`, shards reach the other validators themselves and the
 /// proxy carries nothing.
 ///
-/// This is the escape hatch for the case we cannot predict from the code: relaying every exported
-/// block puts load on this validator's own proxy, and if that turns out to be too expensive an
-/// operator needs a way to take the proxy out of the path. The assertion is the exact mirror of
-/// `test_block_export_through_the_proxy` — same blocks arriving everywhere, but the relay counters
-/// stay at zero — so the two together pin down which path each setting actually takes.
-///
-/// Note the trade-off this buys: shards hold the validator secret key, so sending directly means
-/// giving them outbound access to the other validators.
+/// The exact mirror of `test_block_export_through_the_proxy` — same blocks everywhere, but the
+/// relay counters stay at zero — so the two together pin down which path each setting takes. The
+/// trade-off: shards hold the validator secret key, so direct means giving them outbound access.
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
 #[test_log::test(tokio::test)]

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -143,8 +143,13 @@ async fn test_export_catches_up_a_newly_added_validator(
             .await?;
     }
     let (idle_chain, _) = client
-        .open_chain(chain, None, linera_base::data_types::Amount::from_tokens(1))
+        .open_chain(chain, None, linera_base::data_types::Amount::from_tokens(2))
         .await?;
+    for _ in 0..2 {
+        client
+            .transfer_with_silent_logs(1.into(), idle_chain, chain)
+            .await?;
+    }
 
     // Bring up a fifth validator and admit it. It starts knowing nothing of this chain.
     net.generate_validator_config(4).await?;
@@ -165,37 +170,57 @@ async fn test_export_catches_up_a_newly_added_validator(
         .await?
         .info
         .next_block_height;
-
     let idle_target = net
         .validator_client(0)?
         .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
         .await?
         .info
         .next_block_height;
+    assert!(
+        idle_target >= 2.into(),
+        "the idle chain needs history for its replay to be observable",
+    );
 
     for _ in 0..60 {
-        let info = net
+        // A query the newcomer cannot answer yet — it may not even hold a chain's description —
+        // is the transient this poll waits out, not a failure.
+        let height = net
             .validator_client(4)?
             .handle_chain_info_query(ChainInfoQuery::new(chain))
-            .await?;
-        let idle_info = net
+            .await
+            .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+                response.info.next_block_height
+            });
+        let idle_height = net
             .validator_client(4)?
             .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
-            .await?;
-        if info.info.next_block_height >= target && idle_info.info.next_block_height >= idle_target
-        {
+            .await
+            .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+                response.info.next_block_height
+            });
+        if height >= target && idle_height >= idle_target {
             net.terminate().await?;
             return Ok(());
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    let info = net
+    let height = net
         .validator_client(4)?
         .handle_chain_info_query(ChainInfoQuery::new(chain))
-        .await?;
+        .await
+        .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+            response.info.next_block_height
+        });
+    let idle_height = net
+        .validator_client(4)?
+        .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
+        .await
+        .map_or(linera_base::data_types::BlockHeight::ZERO, |response| {
+            response.info.next_block_height
+        });
     panic!(
-        "the newly added validator did not catch up to {target}; it is at {}",
-        info.info.next_block_height,
+        "the newly added validator did not catch up: active chain {height}/{target}, \
+         idle chain {idle_height}/{idle_target}",
     );
 }
 

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -69,6 +69,36 @@ async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
     Ok(total)
 }
 
+/// Export sends the first shard of `validator` reports having started, over all destinations.
+/// The counterpart of [`relayed_requests`] for the direct transport, where no proxy sees the
+/// traffic and only the sender itself can attest that any happened.
+async fn export_sends(net: &LocalNet, validator: usize) -> Result<u64> {
+    let port = net.shard_metrics_port(validator, 0);
+    let metrics = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
+        .await?
+        .text()
+        .await?;
+    anyhow::ensure!(
+        metrics.lines().any(|line| line.starts_with("# TYPE")),
+        "the metrics scrape of validator {validator}'s shard returned no Prometheus payload",
+    );
+    let mut total = 0;
+    for line in metrics.lines() {
+        // e.g. `linera_block_export_send_latency_count{remote_address="..."} 4`
+        if line.starts_with('#') || !line.contains("block_export_send_latency_count") {
+            continue;
+        }
+        let value = line
+            .rsplit(' ')
+            .next()
+            .expect("rsplit yields at least one piece");
+        total += value
+            .parse::<u64>()
+            .with_context(|| format!("unparseable metric line: {line}"))?;
+    }
+    Ok(total)
+}
+
 #[ignore]
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
@@ -277,8 +307,10 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
             .await?;
     }
 
-    // Every validator still converges, which can only happen if the destinations that were using
-    // the dead proxy were re-pointed at the surviving one.
+    // The load-bearing assertion is the surviving proxy's relay counter growing: the chains
+    // converging proves nothing, since the client broadcasts every block to every validator
+    // whether export works or not. New relay traffic on proxy 0 after proxy 1 died is what shows
+    // the destinations were re-pointed rather than stranded.
     let target = net
         .validator_client(0)?
         .handle_chain_info_query(ChainInfoQuery::new(chain))
@@ -286,7 +318,7 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
         .info
         .next_block_height;
     for _ in 0..60 {
-        let mut all = true;
+        let mut all = relayed_requests(&net, 0).await? > before;
         for validator in 1..4 {
             let info = net
                 .validator_client(validator)?
@@ -300,7 +332,11 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    panic!("export did not recover after one of the proxies was killed");
+    panic!(
+        "export did not recover after one of the proxies was killed: surviving-proxy relays \
+         {} (was {before} before the kill)",
+        relayed_requests(&net, 0).await?,
+    );
 }
 
 /// The proxy refuses to relay to a host that is not in any committee.
@@ -388,7 +424,23 @@ async fn test_block_export_direct_bypasses_the_proxy(
             .transfer_with_silent_logs(1.into(), chain, chain)
             .await?;
     }
-    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // The load-bearing positive assertion: the sender itself reports export sends. The blocks
+    // reaching every validator proves nothing (the client broadcasts to all of them), and the
+    // relay counters staying at zero is also satisfied by a transport that exports nothing —
+    // this is what rules that out.
+    let mut sends = 0;
+    for _ in 0..30 {
+        sends = export_sends(&net, 0).await?;
+        if sends > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    assert!(
+        sends > 0,
+        "the direct transport never started a single send"
+    );
 
     // The blocks still reach every validator...
     for validator in 0..4 {

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage of in-worker block export over a real network.
+//!
+//! The unit tests in `linera-core` drive the export task against in-process validators, so they
+//! say nothing about the transport. This exercises the part they cannot: real `linera-server`
+//! shards, real proxies, real gRPC, and — the point of the whole arrangement — shards that reach
+//! the other validators only by going through their own proxy.
+//!
+//! Must be run with the `metrics` feature, because the assertion reads the proxies' metrics
+//! endpoint, and because `cargo test` rebuilds the binaries the harness spawns using whatever
+//! features the test command names:
+//!
+//! ```text
+//! cargo test -p linera-service --test block_export_tests --features storage-service,metrics \
+//!     -- --ignored
+//! ```
+
+#![cfg(any(feature = "scylladb", feature = "storage-service"))]
+
+use anyhow::Result;
+use linera_base::time::Duration;
+use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
+use linera_service::{
+    cli_wrappers::{
+        local_net::{Database, LocalNet, LocalNetConfig},
+        LineraNet, LineraNetConfig, Network,
+    },
+    test_name,
+};
+use test_case::test_case;
+
+/// The number of requests the proxy of `validator` reports having carried to other validators on
+/// behalf of its shards.
+///
+/// Zero unless block export actually went through the relay, which is what makes this worth
+/// asserting on: every validator ends up holding every block either way, because the client talks
+/// to all of them, so the blocks alone prove nothing about the path they took.
+async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
+    let port = net.proxy_metrics_port(validator, 0);
+    let metrics = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
+        .await?
+        .text()
+        .await?;
+    let mut total = 0;
+    for line in metrics.lines() {
+        // e.g. `linera_proxy_relayed_request_count{method_name="relay_confirmed_certificate"} 7`
+        if line.starts_with('#') || !line.contains("proxy_relayed_request_count") {
+            continue;
+        }
+        if let Some(value) = line.rsplit(' ').next() {
+            total += value.parse::<u64>().unwrap_or(0);
+        }
+    }
+    Ok(total)
+}
+
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_block_export_through_the_proxy(database: Database, network: Network) -> Result<()> {
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    // Every one of these is executed by each validator's chain worker, which hands it to that
+    // chain's export task.
+    for _ in 0..3 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+
+    // Export is asynchronous, and the heights a worker records trail the tip by design, so give
+    // the tasks a moment to drain before looking.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Each validator pushed to the three others, so each proxy must have carried traffic. A shard
+    // that had opened its own connection to a peer — the thing this design exists to prevent —
+    // would leave these at zero while the blocks still propagated.
+    for validator in 0..4 {
+        let relayed = relayed_requests(&net, validator).await?;
+        assert!(
+            relayed > 0,
+            "validator {validator} exported nothing through its proxy",
+        );
+    }
+
+    // And the blocks really did land everywhere.
+    for validator in 0..4 {
+        let info = net
+            .validator_client(validator)?
+            .handle_chain_info_query(ChainInfoQuery::new(chain))
+            .await?;
+        assert_eq!(info.info.next_block_height, 3.into());
+    }
+
+    net.terminate().await?;
+    Ok(())
+}

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -69,10 +69,14 @@ async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
     Ok(total)
 }
 
-/// Export sends the first shard of `validator` reports having started, over all destinations.
-/// The counterpart of [`relayed_requests`] for the direct transport, where no proxy sees the
-/// traffic and only the sender itself can attest that any happened.
-async fn export_sends(net: &LocalNet, validator: usize) -> Result<u64> {
+/// Export sends each destination *acknowledged*, per destination address, from the first shard
+/// of `validator`. Successes, not attempts: the latency histogram counts failed sends too, so a
+/// transport that cannot deliver anything still moves it — this counter only moves when the
+/// destination answered.
+async fn export_successes(
+    net: &LocalNet,
+    validator: usize,
+) -> Result<std::collections::BTreeMap<String, u64>> {
     let port = net.shard_metrics_port(validator, 0);
     let metrics = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
         .await?
@@ -82,21 +86,23 @@ async fn export_sends(net: &LocalNet, validator: usize) -> Result<u64> {
         metrics.lines().any(|line| line.starts_with("# TYPE")),
         "the metrics scrape of validator {validator}'s shard returned no Prometheus payload",
     );
-    let mut total = 0;
+    let mut per_destination = std::collections::BTreeMap::new();
     for line in metrics.lines() {
-        // e.g. `linera_block_export_send_latency_count{remote_address="..."} 4`
-        if line.starts_with('#') || !line.contains("block_export_send_latency_count") {
+        // e.g. `linera_block_export_sends_succeeded{validator="grpc:127.0.0.1:9001"} 4`
+        if line.starts_with('#') || !line.contains("block_export_sends_succeeded") {
             continue;
         }
-        let value = line
-            .rsplit(' ')
-            .next()
-            .expect("rsplit yields at least one piece");
-        total += value
-            .parse::<u64>()
+        let (labels, value) = line
+            .rsplit_once(' ')
             .with_context(|| format!("unparseable metric line: {line}"))?;
+        per_destination.insert(
+            labels.to_owned(),
+            value
+                .parse::<u64>()
+                .with_context(|| format!("unparseable metric line: {line}"))?,
+        );
     }
-    Ok(total)
+    Ok(per_destination)
 }
 
 #[ignore]
@@ -297,46 +303,52 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
         before > 0,
         "export should be relaying before the proxy is killed"
     );
+    // Every destination must have been reached at least once before the kill, so that "its
+    // counter grew afterwards" is meaningful for all three.
+    let mut successes_before = std::collections::BTreeMap::new();
+    for _ in 0..30 {
+        successes_before = export_successes(&net, 0).await?;
+        if successes_before.len() >= 3 && successes_before.values().all(|count| *count > 0) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    assert!(
+        successes_before.len() >= 3 && successes_before.values().all(|count| *count > 0),
+        "not every destination was reached before the kill: {successes_before:?}",
+    );
 
     // Kill one of validator 0's two proxies. Destinations pinned to it must move to the other.
     net.kill_proxy(0, 1).await?;
 
-    for _ in 0..4 {
+    // The load-bearing assertion: *every* destination's acknowledged-send counter grows after
+    // the kill. The chains converging proves nothing (the client broadcasts every block to every
+    // validator whether export works or not), and total relay traffic on the surviving proxy
+    // proves little more — the destinations round-robined onto proxy 0 keep it growing even
+    // with the destination stranded on the dead proxy never re-pointed. A frozen per-destination
+    // counter is that stranding, directly. Blocks are produced inside the loop so a lagging
+    // recovery still has traffic to prove itself on.
+    for attempt in 0..30 {
         client
             .transfer_with_silent_logs(1.into(), chain, chain)
             .await?;
-    }
-
-    // The load-bearing assertion is the surviving proxy's relay counter growing: the chains
-    // converging proves nothing, since the client broadcasts every block to every validator
-    // whether export works or not. New relay traffic on proxy 0 after proxy 1 died is what shows
-    // the destinations were re-pointed rather than stranded.
-    let target = net
-        .validator_client(0)?
-        .handle_chain_info_query(ChainInfoQuery::new(chain))
-        .await?
-        .info
-        .next_block_height;
-    for _ in 0..60 {
-        let mut all = relayed_requests(&net, 0).await? > before;
-        for validator in 1..4 {
-            let info = net
-                .validator_client(validator)?
-                .handle_chain_info_query(ChainInfoQuery::new(chain))
-                .await?;
-            all &= info.info.next_block_height >= target;
-        }
-        if all {
+        let successes = export_successes(&net, 0).await?;
+        let all_grew = successes_before
+            .iter()
+            .all(|(address, before)| successes.get(address).is_some_and(|now| now > before));
+        if all_grew {
             net.terminate().await?;
             return Ok(());
         }
+        if attempt == 29 {
+            panic!(
+                "a destination stopped being reached after its proxy was killed: \
+                 {successes_before:?} before, {successes:?} after",
+            );
+        }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
-    panic!(
-        "export did not recover after one of the proxies was killed: surviving-proxy relays \
-         {} (was {before} before the kill)",
-        relayed_requests(&net, 0).await?,
-    );
+    unreachable!("the loop either returns or panics on its last attempt");
 }
 
 /// The proxy refuses to relay to a host that is not in any committee.
@@ -425,21 +437,21 @@ async fn test_block_export_direct_bypasses_the_proxy(
             .await?;
     }
 
-    // The load-bearing positive assertion: the sender itself reports export sends. The blocks
-    // reaching every validator proves nothing (the client broadcasts to all of them), and the
-    // relay counters staying at zero is also satisfied by a transport that exports nothing —
-    // this is what rules that out.
-    let mut sends = 0;
+    // The load-bearing positive assertion: every destination *acknowledged* a direct send. The
+    // blocks reaching every validator proves nothing (the client broadcasts to all of them), the
+    // relay counters staying at zero is also satisfied by a transport that exports nothing, and
+    // counting send *attempts* would also be satisfied by one that fails every time.
+    let mut successes = std::collections::BTreeMap::new();
     for _ in 0..30 {
-        sends = export_sends(&net, 0).await?;
-        if sends > 0 {
+        successes = export_successes(&net, 0).await?;
+        if successes.len() >= 3 && successes.values().all(|count| *count > 0) {
             break;
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
     assert!(
-        sends > 0,
-        "the direct transport never started a single send"
+        successes.len() >= 3 && successes.values().all(|count| *count > 0),
+        "the direct transport was not acknowledged by every destination: {successes:?}",
     );
 
     // The blocks still reach every validator...

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -33,6 +33,7 @@ use linera_service::{
         local_net::{Database, LocalNet, LocalNetConfig},
         LineraNet, LineraNetConfig, Network,
     },
+    config::BlockExportTransport,
     test_name,
 };
 use test_case::test_case;
@@ -306,6 +307,67 @@ async fn test_relay_refuses_a_non_committee_destination(
         tonic::Code::PermissionDenied,
         "expected a refusal, got: {status:?}",
     );
+
+    net.terminate().await?;
+    Ok(())
+}
+
+/// With `--block-export-transport direct`, shards reach the other validators themselves and the
+/// proxy carries nothing.
+///
+/// This is the escape hatch for the case we cannot predict from the code: relaying every exported
+/// block puts load on this validator's own proxy, and if that turns out to be too expensive an
+/// operator needs a way to take the proxy out of the path. The assertion is the exact mirror of
+/// `test_block_export_through_the_proxy` — same blocks arriving everywhere, but the relay counters
+/// stay at zero — so the two together pin down which path each setting actually takes.
+///
+/// Note the trade-off this buys: shards hold the validator secret key, so sending directly means
+/// giving them outbound access to the other validators.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_block_export_direct_bypasses_the_proxy(
+    database: Database,
+    network: Network,
+) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        block_export_transport: BlockExportTransport::Direct,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    for _ in 0..3 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // The blocks still reach every validator...
+    for validator in 0..4 {
+        let info = net
+            .validator_client(validator)?
+            .handle_chain_info_query(ChainInfoQuery::new(chain))
+            .await?;
+        assert_eq!(info.info.next_block_height, 3.into());
+    }
+
+    // ...without a single one of them going through a proxy's relay.
+    for validator in 0..4 {
+        let relayed = relayed_requests(&net, validator).await?;
+        assert_eq!(
+            relayed, 0,
+            "validator {validator} relayed {relayed} requests through its proxy despite \
+             --block-export-transport direct",
+        );
+    }
 
     net.terminate().await?;
     Ok(())

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -107,3 +107,142 @@ async fn test_block_export_through_the_proxy(database: Database, network: Networ
     net.terminate().await?;
     Ok(())
 }
+
+/// A validator admitted to the committee after a chain already has history is brought up to date
+/// by export alone.
+///
+/// This is the case the cursor cannot short-circuit: the newcomer has never heard of the chain, so
+/// it answers a height query with 0 rather than an error, and every block has to be replayed to it
+/// through the relay. Catch-up is bounded per round on purpose, so what this asserts is that it
+/// *converges*, not that it happens in one shot.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_export_catches_up_a_newly_added_validator(
+    database: Database,
+    network: Network,
+) -> Result<()> {
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    // History the newcomer will have to be told about in full.
+    for _ in 0..3 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+
+    // Bring up a fifth validator and admit it. It starts knowing nothing of this chain.
+    net.generate_validator_config(4).await?;
+    net.start_validator(4).await?;
+    client
+        .set_validator(
+            net.validator_keys(4).unwrap(),
+            net.proxy_public_port(4, 0),
+            100,
+        )
+        .await?;
+
+    // Nothing below drives the chain forward, so any progress the newcomer makes on it is export
+    // replaying the history to it.
+    let target = net
+        .validator_client(0)?
+        .handle_chain_info_query(ChainInfoQuery::new(chain))
+        .await?
+        .info
+        .next_block_height;
+
+    for _ in 0..60 {
+        let info = net
+            .validator_client(4)?
+            .handle_chain_info_query(ChainInfoQuery::new(chain))
+            .await?;
+        if info.info.next_block_height >= target {
+            net.terminate().await?;
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    let info = net
+        .validator_client(4)?
+        .handle_chain_info_query(ChainInfoQuery::new(chain))
+        .await?;
+    panic!(
+        "the newly added validator did not catch up to {target}; it is at {}",
+        info.info.next_block_height,
+    );
+}
+
+/// Export keeps flowing when one of this validator's proxies dies.
+///
+/// A destination is handed one proxy from the rotation and keeps it, so without the rebuild-on-
+/// failure path a dead proxy would strand every destination assigned to it — silently, since the
+/// other proxies would carry on and the chain would still look healthy from most angles.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_export_survives_a_dead_proxy(database: Database, network: Network) -> Result<()> {
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        num_proxies: 2,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    client
+        .transfer_with_silent_logs(1.into(), chain, chain)
+        .await?;
+    tokio::time::sleep(Duration::from_secs(3)).await;
+    let before = relayed_requests(&net, 0).await?;
+    assert!(
+        before > 0,
+        "export should be relaying before the proxy is killed"
+    );
+
+    // Kill one of validator 0's two proxies. Destinations pinned to it must move to the other.
+    net.kill_proxy(0, 1).await?;
+
+    for _ in 0..4 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+
+    // Every validator still converges, which can only happen if the destinations that were using
+    // the dead proxy were re-pointed at the surviving one.
+    let target = net
+        .validator_client(0)?
+        .handle_chain_info_query(ChainInfoQuery::new(chain))
+        .await?
+        .info
+        .next_block_height;
+    for _ in 0..60 {
+        let mut all = true;
+        for validator in 1..4 {
+            let info = net
+                .validator_client(validator)?
+                .handle_chain_info_query(ChainInfoQuery::new(chain))
+                .await?;
+            all &= info.info.next_block_height >= target;
+        }
+        if all {
+            net.terminate().await?;
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    panic!("export did not recover after one of the proxies was killed");
+}

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -133,12 +133,18 @@ async fn test_export_catches_up_a_newly_added_validator(
     let (mut net, client) = config.instantiate().await?;
     let chain = client.default_chain().expect("client has no default chain");
 
-    // History the newcomer will have to be told about in full.
+    // History the newcomer will have to be told about in full — on the client's chain, and on a
+    // second chain that stays completely idle from here on. The idle one is the harder case:
+    // nothing after the admission ever touches it, so only the export queue's own bookkeeping
+    // can tell the newcomer it exists.
     for _ in 0..3 {
         client
             .transfer_with_silent_logs(1.into(), chain, chain)
             .await?;
     }
+    let (idle_chain, _) = client
+        .open_chain(chain, None, linera_base::data_types::Amount::from_tokens(1))
+        .await?;
 
     // Bring up a fifth validator and admit it. It starts knowing nothing of this chain.
     net.generate_validator_config(4).await?;
@@ -160,12 +166,24 @@ async fn test_export_catches_up_a_newly_added_validator(
         .info
         .next_block_height;
 
+    let idle_target = net
+        .validator_client(0)?
+        .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
+        .await?
+        .info
+        .next_block_height;
+
     for _ in 0..60 {
         let info = net
             .validator_client(4)?
             .handle_chain_info_query(ChainInfoQuery::new(chain))
             .await?;
-        if info.info.next_block_height >= target {
+        let idle_info = net
+            .validator_client(4)?
+            .handle_chain_info_query(ChainInfoQuery::new(idle_chain))
+            .await?;
+        if info.info.next_block_height >= target && idle_info.info.next_block_height >= idle_target
+        {
             net.terminate().await?;
             return Ok(());
         }

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -19,7 +19,7 @@
 
 mod guard;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use guard::INTEGRATION_TEST_GUARD;
 use linera_base::time::Duration;
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
@@ -43,15 +43,28 @@ async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
         .await?
         .text()
         .await?;
+    // The scrape itself must have worked: an empty or non-Prometheus body would otherwise make
+    // every count read as zero — exactly what the direct-transport test asserts, for the wrong
+    // reason. A silent *rename* of the counter is indistinguishable from "never incremented"
+    // here, which is why `test_block_export_through_the_proxy` asserts the same counter is
+    // nonzero: the pair fails loudly if the name rots.
+    anyhow::ensure!(
+        metrics.lines().any(|line| line.starts_with("# TYPE")),
+        "the metrics scrape of validator {validator} returned no Prometheus payload",
+    );
     let mut total = 0;
     for line in metrics.lines() {
         // e.g. `linera_proxy_relayed_request_count{method_name="relay_confirmed_certificate"} 7`
         if line.starts_with('#') || !line.contains("proxy_relayed_request_count") {
             continue;
         }
-        if let Some(value) = line.rsplit(' ').next() {
-            total += value.parse::<u64>().unwrap_or(0);
-        }
+        let value = line
+            .rsplit(' ')
+            .next()
+            .expect("rsplit yields at least one piece");
+        total += value
+            .parse::<u64>()
+            .with_context(|| format!("unparseable metric line: {line}"))?;
     }
     Ok(total)
 }

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -22,6 +22,7 @@
 use anyhow::Result;
 use linera_base::time::Duration;
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
+use linera_rpc::grpc::api::{self, validator_relay_client::ValidatorRelayClient};
 use linera_service::{
     cli_wrappers::{
         local_net::{Database, LocalNet, LocalNetConfig},
@@ -245,4 +246,58 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
     panic!("export did not recover after one of the proxies was killed");
+}
+
+/// The proxy refuses to relay to a host that is not in any committee.
+///
+/// Relaying exists so that shards — which hold the validator secret key — never open outbound
+/// connections. That only buys anything if the proxy will not dial wherever it is told, so this
+/// asserts the refusal directly rather than inferring it from export working.
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_relay_refuses_a_non_committee_destination(
+    database: Database,
+    network: Network,
+) -> Result<()> {
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    // Produce a block so the proxy has certainly served some legitimate relay traffic; whatever
+    // rejection follows is therefore about the destination, not about the relay being unavailable.
+    client
+        .transfer_with_silent_logs(1.into(), chain, chain)
+        .await?;
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Speak to validator 0's relay port directly, as one of its own shards would, but name a host
+    // that is in no committee.
+    let relay = format!("http://127.0.0.1:{}", net.proxy_internal_port(0, 0));
+    let channel = tonic::transport::Channel::from_shared(relay)?
+        .connect()
+        .await?;
+    let mut relay_client = ValidatorRelayClient::new(channel);
+    let status = relay_client
+        .relay_chain_info_query(api::RelayChainInfoQueryRequest {
+            destination: "grpc:198.51.100.7:443".to_string(),
+            inner: Some(ChainInfoQuery::new(chain).try_into()?),
+        })
+        .await
+        .expect_err("the proxy should refuse a destination that is in no committee");
+    assert_eq!(
+        status.code(),
+        tonic::Code::PermissionDenied,
+        "expected a refusal, got: {status:?}",
+    );
+
+    net.terminate().await?;
+    Ok(())
 }

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -8,22 +8,23 @@
 //! shards, real proxies, real gRPC, and — the point of the whole arrangement — shards that reach
 //! the other validators only by going through their own proxy.
 //!
-//! Run these one at a time, with the `metrics` feature:
-//!
 //! ```text
 //! cargo test -p linera-service --test block_export_tests --features storage-service,metrics \
-//!     -- --ignored --test-threads=1
+//!     -- --ignored
 //! ```
 //!
-//! `metrics` because the assertions read the proxies' metrics endpoint, and because `cargo test`
-//! rebuilds the binaries the harness spawns using whatever features the test command names.
-//! `--test-threads=1` because every network here derives its ports from the same
-//! `test_offset_port()` base, so two of them running at once collide and the metrics server
-//! panics on `bind`.
+//! The `metrics` feature is required: the assertions read the proxies' metrics endpoint, and
+//! `cargo test` rebuilds the binaries the harness spawns using whatever features the test command
+//! names. Like the other integration suites, each test takes `INTEGRATION_TEST_GUARD`, because
+//! every network derives its ports from the same `test_offset_port()` base and two of them at once
+//! collide.
 
 #![cfg(any(feature = "scylladb", feature = "storage-service"))]
 
+mod guard;
+
 use anyhow::Result;
+use guard::INTEGRATION_TEST_GUARD;
 use linera_base::time::Duration;
 use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
 use linera_rpc::grpc::api::{self, validator_relay_client::ValidatorRelayClient};
@@ -66,6 +67,7 @@ async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
 #[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_block_export_through_the_proxy(database: Database, network: Network) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let config = LocalNetConfig {
@@ -127,6 +129,7 @@ async fn test_export_catches_up_a_newly_added_validator(
     database: Database,
     network: Network,
 ) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let config = LocalNetConfig {
@@ -195,6 +198,7 @@ async fn test_export_catches_up_a_newly_added_validator(
 #[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_export_survives_a_dead_proxy(database: Database, network: Network) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let config = LocalNetConfig {
@@ -264,6 +268,7 @@ async fn test_relay_refuses_a_non_committee_destination(
     database: Database,
     network: Network,
 ) -> Result<()> {
+    let _guard: tokio::sync::MutexGuard<'_, ()> = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let config = LocalNetConfig {

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -305,21 +305,26 @@ async fn test_export_survives_a_dead_proxy(database: Database, network: Network)
     );
     // Every destination must have been reached at least once before the kill, so that "its
     // counter grew afterwards" is meaningful for all three.
-    let mut successes_before = std::collections::BTreeMap::new();
+    let mut reached = std::collections::BTreeMap::new();
     for _ in 0..30 {
-        successes_before = export_successes(&net, 0).await?;
-        if successes_before.len() >= 3 && successes_before.values().all(|count| *count > 0) {
+        reached = export_successes(&net, 0).await?;
+        if reached.len() >= 3 && reached.values().all(|count| *count > 0) {
             break;
         }
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
     assert!(
-        successes_before.len() >= 3 && successes_before.values().all(|count| *count > 0),
-        "not every destination was reached before the kill: {successes_before:?}",
+        reached.len() >= 3 && reached.values().all(|count| *count > 0),
+        "not every destination was reached before the kill: {reached:?}",
     );
 
     // Kill one of validator 0's two proxies. Destinations pinned to it must move to the other.
     net.kill_proxy(0, 1).await?;
+
+    // The baseline is taken *after* the kill: a send that completed between an earlier snapshot
+    // and the proxy actually dying would count towards "grew afterwards" while proving nothing.
+    // Growth beyond this baseline can only come through the surviving proxy.
+    let successes_before = export_successes(&net, 0).await?;
 
     // The load-bearing assertion: *every* destination's acknowledged-send counter grows after
     // the kill. The chains converging proves nothing (the client broadcasts every block to every

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -8,14 +8,18 @@
 //! shards, real proxies, real gRPC, and — the point of the whole arrangement — shards that reach
 //! the other validators only by going through their own proxy.
 //!
-//! Must be run with the `metrics` feature, because the assertion reads the proxies' metrics
-//! endpoint, and because `cargo test` rebuilds the binaries the harness spawns using whatever
-//! features the test command names:
+//! Run these one at a time, with the `metrics` feature:
 //!
 //! ```text
 //! cargo test -p linera-service --test block_export_tests --features storage-service,metrics \
-//!     -- --ignored
+//!     -- --ignored --test-threads=1
 //! ```
+//!
+//! `metrics` because the assertions read the proxies' metrics endpoint, and because `cargo test`
+//! rebuilds the binaries the harness spawns using whatever features the test command names.
+//! `--test-threads=1` because every network here derives its ports from the same
+//! `test_offset_port()` base, so two of them running at once collide and the metrics server
+//! panics on `bind`.
 
 #![cfg(any(feature = "scylladb", feature = "storage-service"))]
 


### PR DESCRIPTION
## Motivation

The committee destination of the block exporter is the only validator-to-validator block
dissemination we have: consensus alone guarantees only that a *quorum* holds any given block, so
without it a validator is not a complete replica. It is disabled on every conway validator today
because the exporter persists its own unbounded `canonical_state` log under a single Scylla
partition (#4095).

Rather than fixing that partition, this removes the reason for it. The chain workers already hold
the certificate and its blobs in memory at the moment they execute a block, so the server can push
them to the other validators directly — no notification hop, no re-read from storage, no second
process, and no exporter state to grow.

## Proposal

**One export queue task per server process** (`linera-core/src/chain_worker/export.rs`), modeled
on `forward_cross_chain_queries`. Chain workers hand it each block they execute and otherwise own
nothing. Two invariants drove the design, both the result of review findings:

1. **Nothing on the export path may touch a chain worker.** A task that does resets the worker's
   keep-alive clock, so exporting workers never expire and worker memory grows without bound
   (`--chain-worker-ttl-ms` becomes a no-op). Everything here reads storage only; the export-side
   sender (`BlockSender`) is deliberately not the client's `RemoteNodeUpdater`, which holds a
   local node and is now client-only again, back to its #6645 shape.
2. **Destination state is shared, not per chain.** One connection, one backoff, and one AIMD
   window per destination, shared by all chains — with per-chain tasks, one struggling peer is
   independently discovered and hammered by every chain.

**The queue.** Bounded (`--block-export-queue-size`); a full queue drops the block rather than
blocking the worker. Dropping is safe because it is repaired: every `export` call announces the
chain's tip to a shared map *before* trying the queue, so even a dropped block raises the target
that catch-up measures destinations against. Per-chain height ordering is kept explicit: at most
one in-flight send per (chain, destination) pair.

**Rate limiting (AIMD).** Each destination has an in-flight window: +1 per success up to
`--block-export-max-in-flight` (default 8), halved per transport failure, floor 1. N validators
backfilling one newcomer converge on its real capacity the way N TCP flows share a bottleneck —
no protocol change, works against unmodified conway peers.

**Failure scoping.** Three scopes, because the three failures have nothing to do with each
other. A timeout or transport error is about the *destination*: it halves that destination's
window, backs it off exponentially, and re-resolves its node (which rotates to the next proxy on a
relayed transport). `EventsNotFound`/`BlobsNotFound` are about one *chain* on that destination and
back off only that pair — the admin chain is exported
like any other chain, and a newcomer's missing admin history must not throttle the very
admin-chain export that repairs it. There is no admin-chain replay inside another chain's push.
And a failure to read our *own* storage is neither: it leaves the peer's window untouched and
halves a queue-wide in-flight budget (`--block-export-max-in-flight-total`, default 64, restored
one slot per success). Classifying it per-pair throttles one pair at a time while every other pair
keeps reading at full rate — the control loop cannot see the bottleneck it is creating, which is
the shape that turns storage pressure into a cascade.

**Catch-up.** A tick fires every `--block-export-idle-interval-ms` *even under load* — off a
deadline carried across iterations, since a timer rebuilt per iteration never expires under
sustained traffic. It folds announced tips in, gives every destination a cursor on every tracked
chain whenever the destination set changed (so a validator admitted after a chain's last block is
still caught up on it), and periodically scans storage for committees no block has announced.
Rounds are bounded by `--block-export-max-catch-up-blocks` so a freshly joined validator's
backfill cannot hold up live blocks. Converged chains are forgotten after
`--block-export-converged-retention-ms`, so queue memory tracks recent and lagging chains, not
every chain the process ever served.

Each destination carries the set of chains it is behind on, updated as pairs fall behind and
converge. Membership *is* the "needs work" flag, so there is no second bit to fall out of step
with it, and a drain costs what there is to send rather than what the process is holding — the
tick previously rediscovered that set by scanning every (chain, destination) pair at 5 Hz, which
at a million lagging chains took **longer than the tick interval itself**, stopping export during
exactly the outage it exists to survive. Drains resume from a rotating cursor, because a set is
ordered and walking it from the start would hand the window to the same lowest chain ids forever.

**Scale.** Per-chain state is keyed by a dense destination index rather than by
`ValidatorPublicKey`, which is 88 bytes and whose `Ord` re-encodes the curve point on *every
comparison* — 36 ns against about 1 ns for an integer ([`elliptic-curve`'s own
`TODO(tarcieri): more efficient implementation?`](https://docs.rs/elliptic-curve/0.13.8/src/elliptic_curve/public_key.rs.html#356-368)).
Per-chain state is the one place that cost is multiplied by the number of chains a down
destination leaves behind. Measured against the real key type:

| tracked chains | committee | memory/chain | convergence sweep |
| --- | --- | --- | --- |
| 10k | 3 | 1654 B → **246 B** | 4.0 ms → **0.1 ms** |
| 100k | 3 | 1643 B → **235 B** | 89.8 ms → **10.2 ms** |
| 1M | 3 | 1669 B → **261 B** (1.67 GB → 261 MB) | 1800 ms → **68.5 ms** |
| 100k | 20 | 4939 B → **1323 B** | 2842 ms → **72.7 ms** |

The sweep also bounds how many chains it forgets per pass, since each removal takes the mutex
every chain worker uses on every block, and returns the map's capacity once a burst has drained.

Two full passes remain O(tracked chains × destinations) and are deliberately left that way, with
the numbers above as the justification: the sweep (68.5 ms at a million chains, once every 5 s,
against a 200 ms tick) and the refill that gives a newly admitted validator a cursor on every
chain (585 ms at a million chains, once per committee change). Both are ~10 ms at the scale a
shard actually reaches, and bounding them needs iteration resumable across ticks — state that can
desync from the sets it mirrors, which is the bug class this design removed.

**Cursors.** `ChainStateView::exported_heights` (appended last, so positional `RootView` tags
keep existing databases readable) persists how far each destination acknowledged, folded in by
the worker on its normal save — merge-max, so a late fold cannot regress it. Going the other way,
`seed_missing_cursors` fills any cursor the queue does not have from it, on every block and
whatever created the record; a stale seed costs one skipped re-offer, since the cursor follows
the destination's own reported height in both directions. Blocks a destination already holds are
never re-sent (`reset_and_reexecute_chain` re-offers a chain's whole history).

**Committees.** Exported blocks carry only their epoch; the queue loads committees from storage
(`get_or_load_committee`) and probes the admin chain's epoch event on a cadence, so a validator
admitted while every chain is idle still becomes a destination. Reading the full set of *active*
epochs (and the union of their validators) from storage is a natural follow-up.

**Shards never touch the internet.** A shard holds the validator's secret key, so instead of
dialing peers it sends each request to this validator's own proxy — on the same internal endpoint
shards already use for notifications — naming the intended validator, and the proxy performs it:

- a `ValidatorRelay` service on the proxy's existing internal listener (no new port, no infra
  change), limited to the four requests export makes, forwarding bytes as they arrived so the
  shard sees exactly the peer's answers, errors included;
- the proxy refuses to relay to any address not in a committee it can see (checked live: without
  the guard it happily dialed an arbitrary host), scans epochs outside its lock, and reports scan
  failures as `unavailable` rather than disguising them as `permission_denied`;
- unilateral and conway-compatible: the peer sees an ordinary inbound gRPC call on its public
  port. `--block-export-transport direct` bypasses the relay for operators who need to take the
  sending proxy out of the path (trade-off documented on the flag).

**Scheduling reads the storage clock**, not the wall clock: every cursor, backoff deadline and
sweep timestamp is a `Timestamp` from `Storage::clock()`, and the tick sleeps through it. Under a
`TestClock` the queue can therefore be driven in virtual time — the idle-catch-up tests now
advance the clock instead of sleeping through real milliseconds. The one exception is the
queue-latency histogram, which stays on the wall clock because a simulated clock would report a
delay no operator waited.

**Enablement.** Off by default, behind `--export-blocks-to-committee`. Metrics: queue depth and
blob bytes, dropped blocks, export/send latency, per-destination lag and AIMD window, tracked
chains (the work-list a down peer grows), chain-scoped backoffs (a destination that cannot accept
some chain yet), acknowledged sends per destination (attempts live in the latency histogram;
success rate needs its own numerator), the number of resolved destinations (zero with export
enabled is otherwise indistinguishable from healthy-and-idle), lagging chain-destination *pairs*
(what the memory actually tracks — a chain behind on ten destinations costs ten times one behind
on one), the queue-wide in-flight budget, and the proxy's relayed-request count. Per-validator series are removed when a
validator leaves, so a departed peer does not leave a gauge frozen at its last value.

**Review.** This went through fourteen adversarial rounds — @ma2bd's inline review and gist, plus
multi-agent passes carrying correctness *and* performance lenses. 61 confirmed defects fixed, 15
refuted by evidence rather than argument. The scheduler is largely a product of that loop:

| Round | Fixed | Shape |
| --- | --- | --- |
| ma2bd inline + gist | 16 + 14 | Design defects: the chain-worker TTL leak, the frozen foreign admin worker, a tick that could not fire under load |
| 2 | 8 | Three were regressions from round 1's own fixes |
| 3 | 3 | Two were regressions from round 2's fixes |
| 4 | 5 | Dominated by a regression in the fix meant to make the class impossible |
| 5 | 2 | Same seeding bug, third creation path |
| 6 | 0 confirmed | One split, adjudicated against the code: real mechanism, wrong consequence |
| 7 | 0 | Clean on correctness |
| 8 | 3 | Performance lenses added. Two findings measured and *declined* as below the threshold; one fix was a regression in round 7's own fairness fix, invisible because the test that named the mechanism was a copy of it |
| 9 | 0 | Scoped to round 8's fix commit |
| 10 | 6 | Full-breadth rerun of 9, plus distributed-semantics and test-adequacy lenses that had never run: a missing `shrink_to_fit` on the progress map (the sibling of one fixed eleven lines earlier), a wasted per-block lookup, a comment claiming drop coverage a counter proved false (0 drops), and two net-up tests whose every assertion a dead export path satisfied |
| 11 | 3 | All three were regressions in round 10's own fixes: the new shrink ran *under the mutex* whose hold `MAX_FORGET_PER_SWEEP` bounds (10–26 ms measured by three independent benchmarks); both strengthened tests still passed with the path they name broken, because attempts and totals are not successes. Fixed with a per-destination acknowledged-sends counter both tests now assert on |
| 12 | 3 | The round-11 shrink still freed the peak-sized table under the mutex (`forget_chains` now hands it back for freeing outside the lock, pinned by a unit test that fails against both historical shapes); the dead-proxy baseline raced the kill (now snapshotted after it); a peer oscillating its reported height could hold a pair in a zero-delay re-send loop (a regression now backs the pair off — a real restore pays one delay once) |
| 13 | 1 | Aborted on a session limit (9 of 10 agents died); its one surviving lens found that round 12's own regression backoff never escalated against an *alternating* peer, because the advance half reset the shared counter. Fixed with a regression counter an advance cannot clear. Re-running at full breadth |
| 13 (full) | 2 | Six of seven lenses independently caught that round 13's own fix commit had *silently deleted* the shrink budget added one commit earlier — a hunk its message never mentioned, and one the existing test could not distinguish. Also: a destination reporting a height above our tip was acknowledged at that height and the claim persisted, permanently ending export to that pair |
| 14 | 2 | Round 13's clamp turned out to be half a fix: the acknowledgement was clamped, the in-memory cursor was not, so an over-report still stranded the pair for the process lifetime (no "behind" predicate matches, and only a completed send rewrites a cursor). Clamped once at entry instead. The test was also satisfied by "always acknowledge tip - 1", so it gained the honest-report direction |
| 15 | 0 | First clean full-breadth round: all seven lenses ran and found nothing in the diff |
| post-approval | — | @ma2bd's review comments plus the actionable items from #6715: storage-pressure backpressure, the two gauges that issue asks for, and the storage clock |

Two findings were **refuted with evidence**: tokio's `Child::kill()` on a reaped child returns
`Ok`, so `kill_proxy` never broke `terminate()` (the vec-removal is hygiene); and
`make_nodes_from_list(iter::once(..))` is deliberate, because the test provider resolves by
public key, which only the list API carries — `make_node` would panic every export test.

The persisted-cursor seeding regressed three times, each time because it was tied to record
*creation* while a second path also creates records. It is now `ChainRecord::seed_missing_cursors`,
applied on every block, idempotent and path-independent — pinned by a test with a positive
control, which is what the previous two fixes lacked.

## Test Plan

Unit tests (in-process four-validator `TestBuilder`, all positive-controlled — each named test
fails when its mechanism is disabled):

- `test_chain_workers_expire_while_export_is_enabled` — a worker with export on expires at its
  TTL; failed with `1 chain workers still resident 10s after the last activity` before the fix.
- `test_blocks_are_exported_to_the_committee` / `test_blocks_are_not_exported_by_default`.
- `test_export_catches_a_lagging_validator_up_while_idle` and
  `test_export_catches_up_a_backlog_larger_than_the_bound` (queue_size 2, the smallest the config
  accepts; instrumenting the drop path showed the sequential burst never actually drops, so
  drop-and-repair rests on the announce-before-enqueue ordering, not on a test) — both fail with
  the idle requeue disabled.
- `test_catch_up_sends_at_most_the_bound_per_round` — the bound arithmetic directly; a
  convergence-only test passes with the bound ignored, this one fails (`left: 11, right: 3`).
- `test_send_block_skips_a_block_the_destination_already_has` — asserted against an *offline*
  destination, so skipping succeeds precisely because nothing was sent.
- `a_height_above_our_tip_is_acknowledged_only_up_to_it` — a peer claiming `u64::MAX` is
  acknowledged at our tip *and stored at our tip*; the second half matters because a cursor above
  the tip satisfies every "converged" predicate and no "behind" one, and only a completed send
  rewrites a cursor. It also pins the other direction — an honest report below the tip is taken at
  its word — since "always acknowledge tip - 1" would otherwise satisfy the clamp.
- `forgetting_a_drained_burst_returns_its_table` — exercises the state where the two halves of
  the shrink guard *disagree* (a table several times oversized while still holding more than one
  sweep's budget). Its previous shape returned `None` under both, which is how the budget went
  missing for a commit.
- `an_oscillating_peer_escalates_but_a_restored_one_does_not` — the regression penalty doubles
  per lie (`[100ms, 200ms, 400ms, 800ms]`) while a restore pays one delay and has it cleared by
  its next advance; against the previous shape the same sequence measures
  `[100ms, 100ms, 100ms, 100ms]`. Paired with a `size_of::<ChainDest>()` assertion, since the
  counter has to stay free at one per (chain, destination).
- `draining_rotates_through_the_backlog` and `a_round_that_visits_nothing_keeps_its_place` — the
  drain's fairness, both against the real `drain_candidates`/`advance_cursor`. The second pins the
  case that matters: a saturated round must not reset the rotation. An earlier version of the
  first tested a *copy* of the production ordering and so passed against a live starvation bug.
- `test_export_survives_an_unreachable_destination`, config validation per knob, backoff
  escalation.

Integration tests over a real network (`block_export_tests.rs`, wired into the
`storage-service-tests` CI job; each takes `INTEGRATION_TEST_GUARD`):

- `test_block_export_through_the_proxy` — proxies' relayed-request counters are the load-bearing
  assertion; blocks alone prove nothing since the client talks to every validator anyway.
- `test_export_catches_up_a_newly_added_validator` — includes a chain left **idle since before
  the admission**, so only the queue's own bookkeeping can deliver it; fails
  (`idle chain 0/3`) with the newcomer fill-in disabled.
- `test_export_survives_a_dead_proxy` — a killed proxy's traffic moves to the rotation's next.
  The load-bearing assertion is **every destination's acknowledged-send counter growing after the
  kill**, with blocks produced inside the polling loop: chain convergence is produced by the
  client broadcast whether export works or not, and the surviving proxy's total also grows with a
  destination stranded, since the others round-robin onto it. A frozen per-destination counter
  *is* the stranding.
- `test_relay_refuses_a_non_committee_destination` — the SSRF guard, asserted directly.
- `test_block_export_direct_bypasses_the_proxy` — the exact mirror of the through-proxy test:
  relay counters at zero, and every destination's acknowledged-send counter nonzero. Successes,
  not attempts: the latency histogram counts failed sends too, so a transport that exported
  nothing — or failed every send — would otherwise pass.

```
cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web
cargo clippy --locked --no-default-features
cargo clippy --locked --target wasm32-unknown-unknown --no-default-features --features web-default …
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
cargo test -p linera-core --lib          # 183 passed, 0 failed
cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored
cargo +nightly fmt -- --check
diff <(cargo run --locked --bin linera-schema-export) linera-service-graphql-client/gql/service_schema.graphql
bash scripts/check_chain_loads.sh
cargo machete
```

**Accepted limitations**, each documented at the code that owns it rather than left implicit:

- Catch-up covers chains seen since process start; a chain that never produces another block is
  not re-scanned from storage.
- The `exported_heights` fold is throttled, so a burst's tail may not be persisted — the cost is
  one query per destination when the cursor is rebuilt, against a whole-register write per block.
- A destination that regresses (restored from a backup) while we believe it converged waits for
  the chain's next block; probing converged pairs would cost a query per chain per destination
  forever, to catch something only a restore causes. A regressed report is believed but backs the
  pair off, so an oscillating (Byzantine) peer throttles itself instead of holding a re-send loop
  open. The penalty escalates on a regression counter an advance cannot clear: alternating
  advance with regression would otherwise reset the delay to its base value on every second
  answer — roughly two full catch-up rounds a second, indefinitely, every one of them counted as
  a success. A genuine restore regresses once and pays one delay.
- A pair deferred for a missing committee after a restart waits for the admin chain's next block
  or for client traffic, which pushes the admin chain on the same error. It retries indefinitely,
  and `block_export_chain_scoped_backoffs` makes it visible.
- Per-chain state is O(committee), not O(lagging pairs): every tracked chain carries a cursor for
  every destination, ~8.3 KB per chain at a committee of 100. Making it sparse would mean "absent
  = converged", which collides with today's "absent = ask the destination".
- `ProgressMap`'s removals and its shrink are both budgeted; its *growth* is not, so the map's
  own doubling rehash holds the progress mutex for ~10 ms at a million entries. That is inherent
  to the hash map and amortized over the inserts that caused it.
- A destination that advances one block per reply keeps its backoff cleared, so it can hold a
  pair re-reading catch-up windows. Bounded per round by `--block-export-max-catch-up-blocks` and
  across chains by the AIMD window, but not by the destination's rate of progress.
- A down destination retains the work-list of every chain active during its outage — that set is
  what its catch-up needs; `block_export_tracked_chains` exposes it.
- The tick's storage reads (the committee scan, every ~2 s) run on the queue task, so in-flight
  sends are not polled for the duration of one read — milliseconds against send timeouts measured
  in seconds. Driving the scan concurrently would need completions applied to shared state from
  two places; not worth it at that ratio.
- The `exported_heights` fold filters through the *chain's own* committee, while destinations come
  from the process-latest one. A newcomer the chain's epoch does not know yet is exported to, but
  its cursor is not persisted until the chain adopts the newer epoch — after a restart that pair
  pays one height query to rebuild it. Persisting it would mean sharing the live destination set
  across the progress mutex to keep pruning of departed validators exact.

Not covered: real-network scale. Nothing here has carried conway traffic; confirming there
(values-only deploy via `shardArgs`, no chart or infra change) is the step before the old
exporter code is deleted.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #4095 — the unbounded exporter partition this line of work removes
- #3668 — committee destination
- #6645 — the updater refactor this builds on (and returns `RemoteNodeUpdater` to)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)




