### PR TITLE
docker: fix the three dead panels in the shipped validator dashboard

### DIFF
--- a/docker/dashboards/linera-general.json
+++ b/docker/dashboards/linera-general.json
@@ -925,7 +925,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "rate(block_execution_latency_bucket{service=\"shards\"}[$__rate_interval])",
+          "expr": "rate(linera_block_execution_latency_bucket{job=\"linera-shard\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
@@ -940,8 +940,8 @@
     },
     {
       "datasource": {
-        "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "type": "prometheus",
+        "uid": "prometheus"
       },
       "fieldConfig": {
         "defaults": {
@@ -990,24 +990,22 @@
       "pluginVersion": "11.2.0",
       "targets": [
         {
+          "refId": "A",
           "datasource": {
-            "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "editorMode": "code",
-          "expr": "sum by (pod) (count_over_time({app=\"shards\"} |= `OpenChain` [24h]))",
-          "legendFormat": "{{pod}}",
-          "queryType": "range",
-          "refId": "A"
+          "expr": "sum by (shard) (linera_open_chain_count{job=\"linera-shard\"})",
+          "legendFormat": "shard {{shard}}"
         }
       ],
-      "title": "Chains per Shard (24h)",
+      "title": "Open Chains per Shard",
       "type": "gauge"
     },
     {
       "datasource": {
-        "type": "loki",
-        "uid": "P8E80F9AEF21F6940"
+        "type": "prometheus",
+        "uid": "prometheus"
       },
       "description": "Shard and proxy panics",
       "fieldConfig": {
@@ -1058,28 +1056,16 @@
       "pluginVersion": "11.2.0",
       "targets": [
         {
+          "refId": "A",
           "datasource": {
-            "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
+            "type": "prometheus",
+            "uid": "prometheus"
           },
-          "editorMode": "builder",
-          "expr": "{app=\"shards\"} |= `panic`",
-          "queryType": "range",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
-          },
-          "editorMode": "builder",
-          "expr": "{app=\"proxy\"} |= `panic`",
-          "hide": false,
-          "queryType": "range",
-          "refId": "B"
+          "expr": "up{job=~\"linera-.*\"}",
+          "legendFormat": "{{job}} {{instance}} {{shard}}"
         }
       ],
-      "title": "Panics",
+      "title": "Service Up (a panicking process flaps here)",
       "type": "table"
     },
     {

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,15 +1,27 @@
 global:
   scrape_interval: 15s
 
+# Job names and the `shard` label are deliberately identical to the ones
+# alloy-config.river attaches, so a dashboard written against one scrape path
+# works unchanged on the other. `shard` is NOT emitted by the binaries — it
+# only exists because the scrape config adds it here, and every per-shard
+# dashboard panel groups by it.
 scrape_configs:
-  - job_name: 'proxy'
+  - job_name: 'linera-proxy'
     static_configs:
       - targets: ['proxy:21100']
 
-  - job_name: 'shards'
+  - job_name: 'linera-shard'
     static_configs:
-      - targets:
-        - 'docker-shard-1:21100'
-        - 'docker-shard-2:21100'
-        - 'docker-shard-3:21100'
-        - 'docker-shard-4:21100'
+      - targets: ['docker-shard-1:21100']
+        labels:
+          shard: '0'
+      - targets: ['docker-shard-2:21100']
+        labels:
+          shard: '1'
+      - targets: ['docker-shard-3:21100']
+        labels:
+          shard: '2'
+      - targets: ['docker-shard-4:21100']
+        labels:
+          shard: '3'


### PR DESCRIPTION
## Motivation

An external validator operator asked which Prometheus metrics they should watch.
The honest answer turned out to be that the dashboard we ship them has three
panels that can never render — including **Panics**, which is exactly the panel
you would look at first when asking "is my node healthy".

`docker/docker-compose.yml` starts Prometheus and Grafana and auto-provisions
`docker/dashboards/linera-general.json`. In that stack:

| panel | why it is permanently empty |
| --- | --- |
| Block Execution Latency | queries `block_execution_latency_bucket`, missing the `linera_` namespace prefix that `prometheus_util.rs` applies to every metric. Also filters `service="shards"`, a label the scrape config never produces. |
| Panics | uses a **Loki** datasource (`uid: P8E80F9AEF21F6940`). There is no Loki service in this compose file. |
| Chains per Shard (24h) | same missing Loki datasource. |

Confirmed against live data — over the last hour, `block_execution_latency_bucket`
has **0** series and `linera_block_execution_latency_bucket` has **546**.

Separately, `docker/prometheus.yml` and `docker/alloy-config.river` label the
same targets differently. Alloy attaches `job="linera-proxy"` / `job="linera-shard"`
plus a `shard` label; the Prometheus config attaches `job="proxy"` / `job="shards"`
and no `shard` at all. A dashboard therefore cannot work on both scrape paths, and
`shard` — which every per-shard panel groups by — is not emitted by the binaries,
so it only exists if the scrape config adds it.

## Proposal

Align `docker/prometheus.yml` with the labels `alloy-config.river` already uses,
then fix the three panels:

- **Block Execution Latency** → `linera_block_execution_latency_bucket{job="linera-shard"}`.
- **Chains per Shard (24h)** → **Open Chains per Shard**, using the real metric
  `linera_open_chain_count` instead of counting `OpenChain` log lines. Strictly
  better than the LogQL version even where Loki exists.
- **Panics** → **Service Up (a panicking process flaps here)**, using `up{job=~"linera-.*"}`.
  There is no panic counter anywhere in the codebase, so a Prometheus-only stack
  cannot count panics directly — but a panicking process takes its scrape target
  down, which `up` shows for free.

Deliberately **not** done here: adding cAdvisor and the richer
`docker-validator-health.json`. cAdvisor needs `privileged: true` plus host mounts,
and linera-artifacts intentionally keeps that behind an opt-in
`docker-compose.local-monitoring.yml`. Quietly adding a privileged container to the
default stack is not a call this PR should make.

## Test Plan

Metric names checked against live data rather than read from the dashboard:

| series (last 1h) | count |
| --- | --- |
| `block_execution_latency_bucket` (the buggy name) | **0** |
| `linera_block_execution_latency_bucket` | 546 |
| `linera_open_chain_count` | 33 |

`up` is synthesised by Prometheus for every target, so it needs no such check.

The `job` values are correct by construction: Prometheus sets `job` from
`job_name`, and the new names are copied from `alloy-config.river` (which is also
what `docker-validator-health.json` in linera-artifacts already expects).

Also verified: the dashboard still parses as JSON, still has 13 panels, and now
references only `prometheus` datasources (previously 5 Loki references). No panel
in this dashboard filters on `job=`, so renaming the scrape jobs breaks nothing
else — the only `service=` reference in the file was the broken one fixed above.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

The same `block_execution_latency` bug exists in the linera-artifacts copy of
`linera-general.json` — fixed separately, since it is a different repo.
