### PR TITLE
linera-service: relay block export through the proxy so shards need no internet access

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -383,6 +383,9 @@ jobs:
     - name: Run the exporter integration test
       run: |
         cargo test -p linera-service --test exporter_tests --features storage-service -- --ignored --nocapture
+    - name: Run the block export integration test
+      run: |
+        cargo test -p linera-service --test block_export_tests --features storage-service,metrics -- --ignored --nocapture
 
   check-wit-files:
     needs: changed-files

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -10,6 +10,57 @@ service NotifierService {
   rpc NotifyBatch(NotificationBatch) returns (google.protobuf.Empty);
 }
 
+// A service run by the proxy which forwards a shard's requests to another validator.
+//
+// Shards must not have a route to the internet: they hold the validator's secret key, so the
+// proxy is the only component that opens outbound connections. A shard exporting a block it has
+// just executed sends each request here instead, naming the validator it is meant for, and the
+// proxy performs it on the shard's behalf and returns the answer.
+//
+// Deliberately limited to the operations block export needs, so that reaching this service does
+// not confer the ability to make the proxy issue arbitrary requests to arbitrary validators.
+service ValidatorRelay {
+  // Forward a lite certificate to another validator.
+  rpc RelayLiteCertificate(RelayLiteCertificateRequest) returns (ChainInfoResult);
+
+  // Forward a confirmed certificate to another validator.
+  rpc RelayConfirmedCertificate(RelayConfirmedCertificateRequest) returns (ChainInfoResult);
+
+  // Ask another validator for the state of a chain.
+  rpc RelayChainInfoQuery(RelayChainInfoQueryRequest) returns (ChainInfoResult);
+
+  // Upload a blob to another validator.
+  rpc RelayUploadBlob(RelayUploadBlobRequest) returns (BlobId);
+}
+
+// A lite certificate, and the validator it is for.
+message RelayLiteCertificateRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  LiteCertificate inner = 2;
+}
+
+// A confirmed certificate, and the validator it is for.
+message RelayConfirmedCertificateRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  HandleConfirmedCertificateRequest inner = 2;
+}
+
+// A chain info query, and the validator it is for.
+message RelayChainInfoQueryRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  ChainInfoQuery inner = 2;
+}
+
+// A blob, and the validator it is for.
+message RelayUploadBlobRequest {
+  // The public network address of the destination validator.
+  string destination = 1;
+  BlobContent inner = 2;
+}
+
 // Interface provided by each physical shard (aka "worker") of a validator or a local node.
 // * All commands return either the current chain info or an error.
 // * Repeating commands produces no changes and returns no error.

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -6,6 +6,7 @@ mod conversions;
 mod node_provider;
 /// A pool of reusable gRPC transport channels.
 pub mod pool;
+mod relay;
 #[cfg(with_server)]
 mod server;
 /// Transport-level configuration and channel construction for gRPC.
@@ -14,6 +15,7 @@ pub mod transport;
 pub use client::*;
 pub use conversions::*;
 pub use node_provider::*;
+pub use relay::{RelayClient, RelayNodeProvider};
 #[cfg(with_server)]
 pub use server::*;
 

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -1,0 +1,329 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reaching other validators through this validator's own proxy.
+//!
+//! Shards must not have a route to the internet: they hold the validator's secret key, so the
+//! proxy is the only component that should open outbound connections. A shard that needs to talk
+//! to another validator — which today means a chain worker exporting a block it has just executed
+//! — sends its request to the proxy's existing internal port instead, naming the validator it is
+//! meant for, and the proxy performs it and returns the answer.
+//!
+//! [`RelayClient`] therefore implements [`ValidatorNode`] only for the operations block export
+//! uses. Everything else is refused rather than silently doing something else, because a caller
+//! reaching for them through a relay is a mistake, not a fallback.
+//!
+//! Retries are deliberately absent: the caller (the chain worker's export task) already backs off
+//! per destination, and a second layer of retries underneath it would multiply the delays it is
+//! trying to control.
+
+use std::{collections::BTreeMap, str::FromStr as _};
+
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::{BlobContent, BlockHeight, NetworkDescription},
+    identifiers::{BlobId, ChainId, StreamId},
+};
+use linera_chain::{data_types, types};
+use linera_core::node::{
+    BlobStream, CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
+    ValidatorNodeProvider,
+};
+use linera_version::VersionInfo;
+use tonic::Request;
+use tracing::{debug, instrument, Level};
+
+use super::{
+    api::{self, validator_relay_client::ValidatorRelayClient},
+    pool::GrpcConnectionPool,
+    transport, GrpcError,
+};
+use crate::{
+    config::ValidatorPublicNetworkConfig, node_provider::NodeOptions,
+    HandleConfirmedCertificateRequest, HandleLiteCertRequest,
+};
+
+/// Refuses an operation that the relay deliberately does not carry.
+fn unsupported(operation: &str) -> NodeError {
+    NodeError::GrpcError {
+        error: format!(
+            "{operation} is not available through the validator relay, which only carries the \
+             requests needed to export blocks"
+        ),
+    }
+}
+
+/// A validator reached through this validator's proxy.
+#[derive(Clone)]
+pub struct RelayClient {
+    /// The public address of the validator this client talks to. Sent with every request so the
+    /// proxy knows where to forward it, and reported by [`ValidatorNode::address`] so that logs
+    /// and metrics name the destination rather than the relay.
+    destination: String,
+    client: ValidatorRelayClient<transport::Channel>,
+}
+
+impl RelayClient {
+    /// Turns the proxy's answer into the chain info the caller expects.
+    fn try_into_chain_info(
+        result: api::ChainInfoResult,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = result.inner.ok_or_else(|| NodeError::GrpcError {
+            error: "missing body from response".to_string(),
+        })?;
+        match inner {
+            api::chain_info_result::Inner::ChainInfoResponse(response) => {
+                Ok(response.try_into().map_err(|error| NodeError::GrpcError {
+                    error: format!("failed to unmarshal response: {error}"),
+                })?)
+            }
+            api::chain_info_result::Inner::Error(error) => Err(bcs::from_bytes(&error).map_err(
+                |error| NodeError::GrpcError {
+                    error: format!("failed to unmarshal error message: {error}"),
+                },
+            )?),
+        }
+    }
+}
+
+impl ValidatorNode for RelayClient {
+    type NotificationStream = NotificationStream;
+
+    fn address(&self) -> String {
+        self.destination.clone()
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn handle_lite_certificate(
+        &self,
+        certificate: types::LiteCertificate<'_>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = HandleLiteCertRequest {
+            certificate,
+            wait_for_outgoing_messages: delivery.wait_for_outgoing_messages(),
+        };
+        let request = api::RelayLiteCertificateRequest {
+            destination: self.destination.clone(),
+            inner: Some(inner.try_into()?),
+        };
+        debug!(handler = "relay_lite_certificate", "sending gRPC request");
+        let result = self
+            .client
+            .clone()
+            .relay_lite_certificate(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn handle_confirmed_certificate(
+        &self,
+        certificate: linera_storage::Arc<types::GenericCertificate<types::ConfirmedBlock>>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let inner = HandleConfirmedCertificateRequest {
+            certificate: linera_storage::Arc::unwrap_or_clone(certificate),
+            wait_for_outgoing_messages: delivery.wait_for_outgoing_messages(),
+        };
+        let request = api::RelayConfirmedCertificateRequest {
+            destination: self.destination.clone(),
+            inner: Some(inner.try_into()?),
+        };
+        debug!(
+            handler = "relay_confirmed_certificate",
+            "sending gRPC request"
+        );
+        let result = self
+            .client
+            .clone()
+            .relay_confirmed_certificate(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn handle_chain_info_query(
+        &self,
+        query: linera_core::data_types::ChainInfoQuery,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let request = api::RelayChainInfoQueryRequest {
+            destination: self.destination.clone(),
+            inner: Some(query.try_into()?),
+        };
+        debug!(handler = "relay_chain_info_query", "sending gRPC request");
+        let result = self
+            .client
+            .clone()
+            .relay_chain_info_query(Request::new(request))
+            .await?
+            .into_inner();
+        Self::try_into_chain_info(result)
+    }
+
+    #[instrument(target = "relay_client", skip(self), err(level = Level::DEBUG), fields(destination = self.destination))]
+    async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
+        let request = api::RelayUploadBlobRequest {
+            destination: self.destination.clone(),
+            inner: Some(content.try_into()?),
+        };
+        debug!(handler = "relay_upload_blob", "sending gRPC request");
+        let blob_id = self
+            .client
+            .clone()
+            .relay_upload_blob(Request::new(request))
+            .await?
+            .into_inner();
+        Ok(blob_id.try_into()?)
+    }
+
+    async fn handle_block_proposal(
+        &self,
+        _proposal: data_types::BlockProposal,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_block_proposal"))
+    }
+
+    async fn handle_validated_certificate(
+        &self,
+        _certificate: types::GenericCertificate<types::ValidatedBlock>,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_validated_certificate"))
+    }
+
+    async fn handle_timeout_certificate(
+        &self,
+        _certificate: types::GenericCertificate<types::Timeout>,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_timeout_certificate"))
+    }
+
+    async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
+        Err(unsupported("get_version_info"))
+    }
+
+    async fn get_network_description(&self) -> Result<NetworkDescription, NodeError> {
+        Err(unsupported("get_network_description"))
+    }
+
+    async fn subscribe(
+        &self,
+        _chains: Vec<ChainId>,
+    ) -> Result<Self::NotificationStream, NodeError> {
+        Err(unsupported("subscribe"))
+    }
+
+    async fn download_blob(&self, _blob_id: BlobId) -> Result<BlobContent, NodeError> {
+        Err(unsupported("download_blob"))
+    }
+
+    async fn download_blobs(&self, _blob_ids: Vec<BlobId>) -> Result<BlobStream, NodeError> {
+        Err(unsupported("download_blobs"))
+    }
+
+    async fn download_pending_blob(
+        &self,
+        _chain_id: ChainId,
+        _blob_id: BlobId,
+    ) -> Result<BlobContent, NodeError> {
+        Err(unsupported("download_pending_blob"))
+    }
+
+    async fn handle_pending_blob(
+        &self,
+        _chain_id: ChainId,
+        _blob: BlobContent,
+    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        Err(unsupported("handle_pending_blob"))
+    }
+
+    async fn download_certificate(
+        &self,
+        _hash: CryptoHash,
+    ) -> Result<types::ConfirmedBlockCertificate, NodeError> {
+        Err(unsupported("download_certificate"))
+    }
+
+    async fn download_certificates(
+        &self,
+        _hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<types::ConfirmedBlockCertificate>, NodeError> {
+        Err(unsupported("download_certificates"))
+    }
+
+    async fn blob_last_used_by(&self, _blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+        Err(unsupported("blob_last_used_by"))
+    }
+
+    async fn missing_blob_ids(&self, _blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, NodeError> {
+        Err(unsupported("missing_blob_ids"))
+    }
+
+    async fn blob_last_used_by_certificate(
+        &self,
+        _blob_id: BlobId,
+    ) -> Result<types::ConfirmedBlockCertificate, NodeError> {
+        Err(unsupported("blob_last_used_by_certificate"))
+    }
+
+    async fn download_certificates_by_heights(
+        &self,
+        _chain_id: ChainId,
+        _heights: Vec<BlockHeight>,
+    ) -> Result<Vec<types::ConfirmedBlockCertificate>, NodeError> {
+        Err(unsupported("download_certificates_by_heights"))
+    }
+
+    async fn previous_event_blocks(
+        &self,
+        _chain_id: ChainId,
+        _stream_ids: Vec<StreamId>,
+    ) -> Result<BTreeMap<StreamId, (BlockHeight, CryptoHash)>, NodeError> {
+        Err(unsupported("previous_event_blocks"))
+    }
+}
+
+/// A node provider that reaches every validator through this validator's own proxy.
+#[derive(Clone)]
+pub struct RelayNodeProvider {
+    /// The internal address of this validator's proxy — the same one shards already send
+    /// notifications to.
+    relay_address: String,
+    pool: GrpcConnectionPool,
+}
+
+impl RelayNodeProvider {
+    /// Creates a provider that relays through the proxy listening at `relay_address`.
+    pub fn new(relay_address: String, options: NodeOptions) -> Self {
+        Self {
+            relay_address,
+            pool: GrpcConnectionPool::new(transport::Options::from(&options)),
+        }
+    }
+}
+
+impl ValidatorNodeProvider for RelayNodeProvider {
+    type Node = RelayClient;
+
+    fn make_node(&self, address: &str) -> Result<Self::Node, NodeError> {
+        // Parsed even though the proxy is the one that dials it, so that a malformed committee
+        // entry is rejected here rather than on every request.
+        let network = ValidatorPublicNetworkConfig::from_str(address).map_err(|_| {
+            NodeError::CannotResolveValidatorAddress {
+                address: address.to_string(),
+            }
+        })?;
+        let channel =
+            self.pool
+                .channel(self.relay_address.clone())
+                .map_err(|error: GrpcError| NodeError::GrpcError {
+                    error: format!("error creating channel to the relay: {error}"),
+                })?;
+        Ok(RelayClient {
+            destination: network.http_address(),
+            client: ValidatorRelayClient::new(channel),
+        })
+    }
+}

--- a/linera-rpc/src/grpc/relay.rs
+++ b/linera-rpc/src/grpc/relay.rs
@@ -56,10 +56,13 @@ fn unsupported(operation: &str) -> NodeError {
 /// A validator reached through this validator's proxy.
 #[derive(Clone)]
 pub struct RelayClient {
-    /// The public address of the validator this client talks to. Sent with every request so the
-    /// proxy knows where to forward it, and reported by [`ValidatorNode::address`] so that logs
-    /// and metrics name the destination rather than the relay.
+    /// The destination validator's address exactly as the committee spells it, e.g.
+    /// `grpc:host:port`. Sent with every request so the proxy knows where to forward it, and kept
+    /// in the committee's own form so the proxy resolves it the same way any other consumer of
+    /// the committee would.
     destination: String,
+    /// The same validator as a URL, used only to name it in logs and metrics.
+    address: String,
     client: ValidatorRelayClient<transport::Channel>,
 }
 
@@ -90,10 +93,10 @@ impl ValidatorNode for RelayClient {
     type NotificationStream = NotificationStream;
 
     fn address(&self) -> String {
-        self.destination.clone()
+        self.address.clone()
     }
 
-    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
     async fn handle_lite_certificate(
         &self,
         certificate: types::LiteCertificate<'_>,
@@ -117,7 +120,7 @@ impl ValidatorNode for RelayClient {
         Self::try_into_chain_info(result)
     }
 
-    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
     async fn handle_confirmed_certificate(
         &self,
         certificate: linera_storage::Arc<types::GenericCertificate<types::ConfirmedBlock>>,
@@ -144,7 +147,7 @@ impl ValidatorNode for RelayClient {
         Self::try_into_chain_info(result)
     }
 
-    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip_all, err(level = Level::DEBUG), fields(destination = self.address))]
     async fn handle_chain_info_query(
         &self,
         query: linera_core::data_types::ChainInfoQuery,
@@ -163,7 +166,7 @@ impl ValidatorNode for RelayClient {
         Self::try_into_chain_info(result)
     }
 
-    #[instrument(target = "relay_client", skip(self), err(level = Level::DEBUG), fields(destination = self.destination))]
+    #[instrument(target = "relay_client", skip(self), err(level = Level::DEBUG), fields(destination = self.address))]
     async fn upload_blob(&self, content: BlobContent) -> Result<BlobId, NodeError> {
         let request = api::RelayUploadBlobRequest {
             destination: self.destination.clone(),
@@ -322,7 +325,8 @@ impl ValidatorNodeProvider for RelayNodeProvider {
                     error: format!("error creating channel to the relay: {error}"),
                 })?;
         Ok(RelayClient {
-            destination: network.http_address(),
+            destination: address.to_owned(),
+            address: network.http_address(),
             client: ValidatorRelayClient::new(channel),
         })
     }

--- a/linera-service/src/cli/net_up_utils.rs
+++ b/linera-service/src/cli/net_up_utils.rs
@@ -153,6 +153,7 @@ pub async fn handle_net_up_service(
         block_exporter_port,
     );
     let config = LocalNetConfig {
+        export_blocks_to_committee: false,
         network,
         database,
         testing_prng_seed,

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -224,6 +224,9 @@ pub struct LocalNetConfig {
     pub path_provider: PathProvider,
     /// The setup describing how block exporters are run or reached.
     pub block_exporters: ExportersSetup,
+    /// Whether the validators push each block they execute to the rest of the committee,
+    /// through their own proxies.
+    pub export_blocks_to_committee: bool,
 }
 
 /// The setup for the block exporters.
@@ -268,6 +271,7 @@ pub struct LocalNet {
     cross_chain_config: CrossChainConfig,
     path_provider: PathProvider,
     block_exporters: ExportersSetup,
+    export_blocks_to_committee: bool,
 }
 
 /// The name of the environment variable that allows specifying additional arguments to be passed
@@ -378,6 +382,7 @@ impl LocalNetConfig {
             path_provider,
             block_exporters: ExportersSetup::Local(vec![]),
             http_request_allow_list: Some(vec!["localhost".to_string()]),
+            export_blocks_to_committee: false,
         }
     }
 }
@@ -399,6 +404,7 @@ impl LineraNetConfig for LocalNetConfig {
             self.cross_chain_config,
             self.path_provider,
             self.block_exporters,
+            self.export_blocks_to_committee,
         );
         let client = net.make_client().await;
         ensure!(
@@ -473,6 +479,7 @@ impl LocalNet {
         cross_chain_config: CrossChainConfig,
         path_provider: PathProvider,
         block_exporters: ExportersSetup,
+        export_blocks_to_committee: bool,
     ) -> Self {
         Self {
             network,
@@ -489,6 +496,7 @@ impl LocalNet {
             cross_chain_config,
             path_provider,
             block_exporters,
+            export_blocks_to_committee,
         }
     }
 
@@ -518,7 +526,8 @@ impl LocalNet {
         test_offset_port() + 2000 + validator * self.num_shards + shard + 1
     }
 
-    fn proxy_metrics_port(&self, validator: usize, proxy_id: usize) -> usize {
+    /// Returns the metrics port of the given proxy of the given validator.
+    pub fn proxy_metrics_port(&self, validator: usize, proxy_id: usize) -> usize {
         test_offset_port() + 3000 + validator * self.num_proxies + proxy_id + 1
     }
 
@@ -949,6 +958,9 @@ impl LocalNet {
             .args(["--server", &format!("server_{validator}.json")])
             .args(["--shard", &shard.to_string()])
             .args(self.cross_chain_config.to_args());
+        if self.export_blocks_to_committee {
+            command.arg("--export-blocks-to-committee");
+        }
         let child = command.spawn_into()?;
 
         let port = self.shard_port(validator, shard);

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::Debug,
     marker::PhantomData,
     net::SocketAddr,
+    str::FromStr as _,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -31,12 +32,17 @@ use linera_rpc::propagation::get_traffic_type_from_request;
 #[cfg(feature = "opentelemetry")]
 use linera_rpc::propagation::OtelContextLayer;
 use linera_rpc::{
-    config::{ProxyConfig, ShardConfig, TlsConfig, ValidatorInternalNetworkConfig},
+    config::{
+        ProxyConfig, ShardConfig, TlsConfig, ValidatorInternalNetworkConfig,
+        ValidatorPublicNetworkConfig,
+    },
     grpc::{
         api::{
             self,
             notifier_service_server::{NotifierService, NotifierServiceServer},
+            validator_node_client::ValidatorNodeClient,
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
+            validator_relay_server::{ValidatorRelay, ValidatorRelayServer},
             validator_worker_client::ValidatorWorkerClient,
             BlobContent, BlobId, BlobIds, BlockProposal, Certificate, CertificatesBatchRequest,
             CertificatesBatchResponse, ChainInfoResult, CryptoHash, HandlePendingBlobRequest,
@@ -201,6 +207,10 @@ pub struct GrpcProxy<S>(Arc<GrpcProxyInner<S>>);
 struct GrpcProxyInner<S> {
     internal_config: ValidatorInternalNetworkConfig,
     worker_connection_pool: GrpcConnectionPool,
+    /// Connections to the other validators, used to carry requests on behalf of this validator's
+    /// shards, which have no route to the internet of their own. Pooled, so a peer costs one
+    /// connection for the whole process rather than one per shard.
+    peer_connection_pool: GrpcConnectionPool,
     notifier: ChannelNotifier<Result<Notification, Status>>,
     tls: TlsConfig,
     storage: S,
@@ -222,6 +232,9 @@ where
         Self(Arc::new(GrpcProxyInner {
             internal_config,
             worker_connection_pool: GrpcConnectionPool::default()
+                .with_connect_timeout(connect_timeout)
+                .with_timeout(timeout),
+            peer_connection_pool: GrpcConnectionPool::default()
                 .with_connect_timeout(connect_timeout)
                 .with_timeout(timeout),
             notifier: ChannelNotifier::default(),
@@ -247,6 +260,30 @@ where
 
     fn as_notifier_service(&self) -> NotifierServiceServer<Self> {
         NotifierServiceServer::new(self.clone())
+    }
+
+    fn as_validator_relay(&self) -> ValidatorRelayServer<Self> {
+        ValidatorRelayServer::new(self.clone())
+            .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+    }
+
+    /// Returns a client for the validator a relayed request names.
+    ///
+    /// Relayed requests are forwarded as they arrived, without being decoded into their Rust
+    /// types and re-encoded: the proxy is carrying the shard's request, not making its own.
+    fn peer(&self, destination: &str) -> Result<ValidatorNodeClient<Channel>, Status> {
+        let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
+            Status::invalid_argument(format!("invalid destination validator: {destination}"))
+        })?;
+        let channel = self
+            .0
+            .peer_connection_pool
+            .channel(network.http_address())
+            .map_err(|error| Status::unavailable(format!("cannot reach {destination}: {error}")))?;
+        Ok(ValidatorNodeClient::new(channel)
+            .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
+            .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE))
     }
 
     fn public_address(&self) -> SocketAddr {
@@ -319,6 +356,7 @@ where
         let internal_server = join_set.spawn_task(
             Server::builder()
                 .add_service(self.as_notifier_service())
+                .add_service(self.as_validator_relay())
                 .serve(self.internal_address())
                 .in_current_span(),
         );
@@ -955,6 +993,79 @@ where
         let cert_hash = self.blob_last_used_by(request).await?;
         let request = Request::new(cert_hash.into_inner());
         self.download_certificate(request).await
+    }
+}
+
+/// Performs, on behalf of this validator's shards, the requests they need to send to other
+/// validators.
+///
+/// Shards hold the validator's secret key and so must not be able to open outbound connections;
+/// the proxy is the one component that may. Each method here dials the validator named in the
+/// request and returns its answer verbatim, so that the shard sees exactly what it would have
+/// seen had it made the call itself — including the peer's errors, which the export logic
+/// depends on to decide what to send next.
+///
+/// Served only on the internal listener, and deliberately limited to the four requests block
+/// export makes.
+#[async_trait]
+impl<S> ValidatorRelay for GrpcProxy<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+{
+    #[instrument(skip_all, err(Display), fields(method = "relay_lite_certificate"))]
+    async fn relay_lite_certificate(
+        &self,
+        request: Request<api::RelayLiteCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing lite certificate"))?;
+        self.peer(&request.destination)?
+            .handle_lite_certificate(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_confirmed_certificate"))]
+    async fn relay_confirmed_certificate(
+        &self,
+        request: Request<api::RelayConfirmedCertificateRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing confirmed certificate"))?;
+        self.peer(&request.destination)?
+            .handle_confirmed_certificate(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_chain_info_query"))]
+    async fn relay_chain_info_query(
+        &self,
+        request: Request<api::RelayChainInfoQueryRequest>,
+    ) -> Result<Response<ChainInfoResult>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing chain info query"))?;
+        self.peer(&request.destination)?
+            .handle_chain_info_query(Request::new(inner))
+            .await
+    }
+
+    #[instrument(skip_all, err(Display), fields(method = "relay_upload_blob"))]
+    async fn relay_upload_blob(
+        &self,
+        request: Request<api::RelayUploadBlobRequest>,
+    ) -> Result<Response<api::BlobId>, Status> {
+        let request = request.into_inner();
+        let inner = request
+            .inner
+            .ok_or_else(|| Status::invalid_argument("missing blob"))?;
+        self.peer(&request.destination)?
+            .upload_blob(Request::new(inner))
+            .await
     }
 }
 

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -88,6 +88,18 @@ mod metrics {
             linear_bucket_interval(1.0, 50.0, 5000.0),
         )
     });
+    /// Requests this proxy has carried to another validator on behalf of one of its shards.
+    ///
+    /// Shards have no route to the internet, so this counting up is what shows that
+    /// validator-to-validator traffic is flowing, and through the relay rather than around it.
+    pub static RELAYED_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "proxy_relayed_request_count",
+            "Requests forwarded to another validator on behalf of a shard",
+            &[METHOD_NAME_LABEL],
+        )
+    });
+
     pub static PROXY_REQUEST_COUNT: LazyLock<IntCounterVec> = LazyLock::new(|| {
         register_int_counter_vec(
             "proxy_request_count",
@@ -272,7 +284,15 @@ where
     ///
     /// Relayed requests are forwarded as they arrived, without being decoded into their Rust
     /// types and re-encoded: the proxy is carrying the shard's request, not making its own.
-    fn peer(&self, destination: &str) -> Result<ValidatorNodeClient<Channel>, Status> {
+    fn peer(
+        &self,
+        destination: &str,
+        #[cfg_attr(not(with_metrics), allow(unused_variables))] method: &str,
+    ) -> Result<ValidatorNodeClient<Channel>, Status> {
+        #[cfg(with_metrics)]
+        metrics::RELAYED_REQUEST_COUNT
+            .with_label_values(&[method])
+            .inc();
         let network = ValidatorPublicNetworkConfig::from_str(destination).map_err(|_| {
             Status::invalid_argument(format!("invalid destination validator: {destination}"))
         })?;
@@ -1021,7 +1041,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing lite certificate"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_lite_certificate")?
             .handle_lite_certificate(Request::new(inner))
             .await
     }
@@ -1035,7 +1055,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing confirmed certificate"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_confirmed_certificate")?
             .handle_confirmed_certificate(Request::new(inner))
             .await
     }
@@ -1049,7 +1069,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing chain info query"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_chain_info_query")?
             .handle_chain_info_query(Request::new(inner))
             .await
     }
@@ -1063,7 +1083,7 @@ where
         let inner = request
             .inner
             .ok_or_else(|| Status::invalid_argument("missing blob"))?;
-        self.peer(&request.destination)?
+        self.peer(&request.destination, "relay_upload_blob")?
             .upload_blob(Request::new(inner))
             .await
     }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -33,7 +33,8 @@ use linera_base::{
 };
 use linera_client::config::{CommitteeConfig, ValidatorConfig, ValidatorServerConfig};
 use linera_core::{
-    worker::WorkerState, ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
+    spawn_chain_exporter, worker::WorkerState, BlockExportConfig, ChainExporterFactory,
+    ChainWorkerConfig, JoinSetExt as _, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
 use linera_execution::{WasmRuntime, WithWasmDefault};
 #[cfg(with_metrics)]
@@ -73,6 +74,8 @@ struct ServerContext {
     allow_revert_confirm: bool,
     reset_on_corrupted_chain_state_mins: Option<u64>,
     recovery_whitelist: Option<HashSet<ChainId>>,
+    /// How to push executed blocks to the other committee validators, or `None` to not push them.
+    block_export_config: Option<BlockExportConfig>,
     #[cfg(with_metrics)]
     enable_memory_profiling: bool,
 }
@@ -112,8 +115,43 @@ impl ServerContext {
             cross_chain_message_chunk_limit: self.cross_chain_message_chunk_limit,
             ..ChainWorkerConfig::default()
         };
-        let state = WorkerState::new(storage, config, None);
+        let mut state = WorkerState::new(storage, config, None);
+        if let Some(export_config) = self.block_export_config.clone() {
+            state = state.with_chain_exporter_factory(self.chain_exporter_factory(export_config));
+        }
         (state, shard_id, shard.clone())
+    }
+
+    /// Builds the factory that gives each chain worker its export task.
+    ///
+    /// Every validator is reached through this validator's own proxy: a shard holds the validator
+    /// secret key, so it must not be able to open outbound connections itself. The proxy is
+    /// addressed at the same internal endpoint the shards already send their notifications to,
+    /// and the provider is shared across chain workers so a peer costs one pooled connection
+    /// rather than one per chain.
+    fn chain_exporter_factory<S>(&self, export_config: BlockExportConfig) -> ChainExporterFactory<S>
+    where
+        S: Storage + Clone + Send + Sync + 'static,
+    {
+        let internal_network = &self.server_config.internal_network;
+        let relay_address = internal_network
+            .proxies
+            .first()
+            .expect("a validator always has at least one proxy")
+            .internal_address(&internal_network.protocol);
+        let node_provider = Arc::new(grpc::RelayNodeProvider::new(
+            relay_address,
+            linera_rpc::NodeOptions::default(),
+        ));
+        let own_public_key = self.server_config.validator_secret.public();
+        Arc::new(move |setup| {
+            spawn_chain_exporter(
+                setup,
+                node_provider.clone(),
+                export_config.clone(),
+                Some(own_public_key),
+            )
+        })
     }
 
     #[cfg_attr(not(with_metrics), allow(unused_variables))]
@@ -499,6 +537,22 @@ enum ServerCommand {
         #[arg(long, value_delimiter = ',')]
         recovery_whitelist: Option<Vec<ChainId>>,
 
+        /// Push each block this validator executes to the other validators in the committee, so
+        /// that every validator ends up holding every chain rather than only the quorum that
+        /// signed each block. The pushes go out through this validator's proxy; shards never
+        /// connect to another validator themselves.
+        #[arg(
+            long,
+            default_value_t = false,
+            env = "LINERA_EXPORT_BLOCKS_TO_COMMITTEE"
+        )]
+        export_blocks_to_committee: bool,
+
+        /// How many certificates are read from storage and pushed per batch when a block export
+        /// has to catch a lagging validator up. Only used with `--export-blocks-to-committee`.
+        #[arg(long, default_value_t = BlockExportConfig::default().certificate_upload_batch_size)]
+        block_export_batch_size: u64,
+
         /// OpenTelemetry OTLP exporter endpoint (requires opentelemetry feature).
         #[arg(long, env = "LINERA_OTLP_EXPORTER_ENDPOINT")]
         otlp_exporter_endpoint: Option<String>,
@@ -635,6 +689,8 @@ async fn run(options: ServerOptions) {
             allow_revert_confirm,
             reset_on_corrupted_chain_state_mins,
             recovery_whitelist,
+            export_blocks_to_committee,
+            block_export_batch_size,
             otlp_exporter_endpoint: _,
         } => {
             linera_version::VERSION_INFO.log();
@@ -657,6 +713,10 @@ async fn run(options: ServerOptions) {
                 allow_revert_confirm,
                 reset_on_corrupted_chain_state_mins,
                 recovery_whitelist: recovery_whitelist.map(HashSet::from_iter),
+                block_export_config: export_blocks_to_committee.then(|| BlockExportConfig {
+                    certificate_upload_batch_size: block_export_batch_size,
+                    ..BlockExportConfig::default()
+                }),
                 #[cfg(with_metrics)]
                 enable_memory_profiling,
             };

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -139,9 +139,18 @@ impl ServerContext {
             .first()
             .expect("a validator always has at least one proxy")
             .internal_address(&internal_network.protocol);
+        // `NodeOptions::default()` leaves every timeout at zero, which the transport turns into
+        // a deadline that has already passed; these are the values the block exporter used for
+        // the same validator-to-validator traffic.
         let node_provider = Arc::new(grpc::RelayNodeProvider::new(
             relay_address,
-            linera_rpc::NodeOptions::default(),
+            linera_rpc::NodeOptions {
+                send_timeout: linera_base::time::Duration::from_secs(4),
+                recv_timeout: linera_base::time::Duration::from_secs(4),
+                retry_delay: linera_base::time::Duration::from_secs(1),
+                max_retries: 10,
+                ..linera_rpc::NodeOptions::default()
+            },
         ));
         let own_public_key = self.server_config.validator_secret.public();
         Arc::new(move |setup| {

--- a/linera-service/tests/block_export_tests.rs
+++ b/linera-service/tests/block_export_tests.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage of in-worker block export over a real network.
+//!
+//! The unit tests in `linera-core` drive the export task against in-process validators, so they
+//! say nothing about the transport. This exercises the part they cannot: real `linera-server`
+//! shards, real proxies, real gRPC, and — the point of the whole arrangement — shards that reach
+//! the other validators only by going through their own proxy.
+//!
+//! Must be run with the `metrics` feature, because the assertion reads the proxies' metrics
+//! endpoint, and because `cargo test` rebuilds the binaries the harness spawns using whatever
+//! features the test command names:
+//!
+//! ```text
+//! cargo test -p linera-service --test block_export_tests --features storage-service,metrics \
+//!     -- --ignored
+//! ```
+
+#![cfg(any(feature = "scylladb", feature = "storage-service"))]
+
+use anyhow::Result;
+use linera_base::time::Duration;
+use linera_core::{data_types::ChainInfoQuery, node::ValidatorNode};
+use linera_service::{
+    cli_wrappers::{
+        local_net::{Database, LocalNet, LocalNetConfig},
+        LineraNet, LineraNetConfig, Network,
+    },
+    test_name,
+};
+use test_case::test_case;
+
+/// The number of requests the proxy of `validator` reports having carried to other validators on
+/// behalf of its shards.
+///
+/// Zero unless block export actually went through the relay, which is what makes this worth
+/// asserting on: every validator ends up holding every block either way, because the client talks
+/// to all of them, so the blocks alone prove nothing about the path they took.
+async fn relayed_requests(net: &LocalNet, validator: usize) -> Result<u64> {
+    let port = net.proxy_metrics_port(validator, 0);
+    let metrics = reqwest::get(format!("http://127.0.0.1:{port}/metrics"))
+        .await?
+        .text()
+        .await?;
+    let mut total = 0;
+    for line in metrics.lines() {
+        // e.g. `linera_proxy_relayed_request_count{method_name="relay_confirmed_certificate"} 7`
+        if line.starts_with('#') || !line.contains("proxy_relayed_request_count") {
+            continue;
+        }
+        if let Some(value) = line.rsplit(' ').next() {
+            total += value.parse::<u64>().unwrap_or(0);
+        }
+    }
+    Ok(total)
+}
+
+#[ignore]
+#[cfg_attr(feature = "storage-service", test_case(Database::Service, Network::Grpc ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_block_export_through_the_proxy(database: Database, network: Network) -> Result<()> {
+    tracing::info!("Starting test {}", test_name!());
+
+    let config = LocalNetConfig {
+        num_initial_validators: 4,
+        num_shards: 1,
+        export_blocks_to_committee: true,
+        ..LocalNetConfig::new_test(database, network)
+    };
+    let (mut net, client) = config.instantiate().await?;
+    let chain = client.default_chain().expect("client has no default chain");
+
+    // Every one of these is executed by each validator's chain worker, which hands it to that
+    // chain's export task.
+    for _ in 0..3 {
+        client
+            .transfer_with_silent_logs(1.into(), chain, chain)
+            .await?;
+    }
+
+    // Export is asynchronous, and the heights a worker records trail the tip by design, so give
+    // the tasks a moment to drain before looking.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    // Each validator pushed to the three others, so each proxy must have carried traffic. A shard
+    // that had opened its own connection to a peer — the thing this design exists to prevent —
+    // would leave these at zero while the blocks still propagated.
+    for validator in 0..4 {
+        let relayed = relayed_requests(&net, validator).await?;
+        assert!(
+            relayed > 0,
+            "validator {validator} exported nothing through its proxy",
+        );
+    }
+
+    // And the blocks really did land everywhere.
+    for validator in 0..4 {
+        let info = net
+            .validator_client(validator)?
+            .handle_chain_info_query(ChainInfoQuery::new(chain))
+            .await?;
+        assert_eq!(info.info.next_block_height, 3.into());
+    }
+
+    net.terminate().await?;
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

#6639 gives the chain workers the machinery to push each executed block to the rest of the
committee, but installs no factory in `linera-server`, so nothing constructs an exporter outside
tests. This is the piece that makes it reachable — and it does so without giving shards a route to
the internet.

That constraint is the point. A shard holds the validator's secret key (`make_shard_state` copies
`validator_secret` into every `ChainWorkerConfig`), so it is the last component that should be able
to open outbound connections. Before this work the only pod egressing to peers was the block
exporter; putting export inside the shard would have moved that egress to the shards themselves.

Instead the shard sends each request to its own proxy, naming the validator it is meant for, and
the proxy performs it. This is the same shape the shards already use to reach the proxy for client
notifications.

## Proposal

**A `ValidatorRelay` service on the proxy's existing internal listener.** No new port, no new
config, and no infra change: the shard already knows the proxy's internal address — it is the one
it sends notifications to — and the service is added next to `NotifierService` with a single
`.add_service(...)`.

The service carries exactly the four requests block export makes:

| | |
|---|---|
| `RelayLiteCertificate` | for destinations that signed the certificate |
| `RelayConfirmedCertificate` | for those that did not |
| `RelayChainInfoQuery` | the cursor query before a catch-up |
| `RelayUploadBlob` | dependencies the destination is missing |

Deliberately limited: reaching this service does not confer the ability to make the proxy issue
arbitrary requests to arbitrary validators. Requests are forwarded **as they arrived**, without
being decoded into their Rust types and re-encoded — the proxy carries the shard's request rather
than making its own, so the shard sees exactly what it would have seen had it called the peer
directly, including the peer's errors, which the export logic depends on to decide what to send
next.

**`RelayClient` / `RelayNodeProvider`** implement `ValidatorNode`/`ValidatorNodeProvider` over that
service. Because #6639 takes its transport as an injected `ValidatorNodeProvider`, this drops in
without touching a line of the export logic. Operations outside the four are refused rather than
silently doing something else, and there are no retries here on purpose: the export task already
backs off per destination, and a second layer underneath would multiply the delays it is trying to
control.

**`--export-blocks-to-committee`** (off by default) plus `--block-export-batch-size` finally wire
the factory in. Because the provider is the relay one, there is no configuration in which enabling
export causes a shard to dial a peer.

Two properties worth noting for review:

- **Conway-compatible and unilateral.** The peer receives an ordinary inbound gRPC call on its
  public port, indistinguishable from a client's. No peer-side change, no protocol bump, no
  coordinated upgrade — only this validator's own deployment differs.
- **Connection fan-out collapses.** Direct egress would have been S shards × V peers; relaying makes
  it one pooled connection per peer for the whole process.

## Test Plan

```
cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web
cargo clippy --locked -p linera-core -p linera-rpc --no-default-features
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
cargo test -p linera-core --lib          # 160 passed, 0 failed
cargo test -p linera-rpc --test format   # wire-format snapshot unchanged
cargo +nightly fmt -- --check
diff <(cargo run --locked --bin linera-schema-export) linera-service-graphql-client/gql/service_schema.graphql
bash scripts/check_chain_loads.sh
cargo machete
```

**Not covered, and why this stays a draft:** the relay path itself has no automated test. The
in-process test network in `linera-core` has no proxy, so #6639's export tests exercise the direct
provider; nothing here drives a shard through a real proxy to a real peer. For a control whose
whole purpose is to keep shards off the internet, that is not good enough to enable anywhere. It
needs an integration test through `linera net up` before `--export-blocks-to-committee` is turned
on, and I would rather add that than argue the code is obviously right.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Stacked on #6639, which is stacked on #6624
- #4095 — the unbounded exporter partition this line of work removes