### PR TITLE
core: count per-validator errors so a silently failing validator is visible

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -240,7 +240,9 @@ pub trait ValidatorNodeProvider: 'static {
 ///
 /// This error is meant to be serialized over the network and aggregated by clients (i.e.
 /// clients will track validator votes on each error value).
-#[derive(Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash)]
+#[derive(
+    Eq, PartialEq, Clone, Debug, Serialize, Deserialize, Error, Hash, strum::IntoStaticStr,
+)]
 #[allow(missing_docs)]
 pub enum NodeError {
     #[error("Cryptographic error: {error}")]
@@ -417,6 +419,15 @@ impl NodeError {
             | NodeError::NoValidators => false,
         }
     }
+
+    /// Returns the qualified error variant name for the `error_type` metric label.
+    ///
+    /// The variant name only — never the `Display` text, which embeds chain ids, blob ids
+    /// and heights and would give the label unbounded cardinality.
+    pub fn error_type(&self) -> String {
+        let variant: &'static str = self.into();
+        format!("NodeError::{variant}")
+    }
 }
 
 impl From<tonic::Status> for NodeError {
@@ -534,5 +545,42 @@ impl From<WorkerError> for NodeError {
                 error: error.to_string(),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_base::identifiers::{ApplicationId, GenericApplicationId, StreamId, StreamName};
+
+    use super::*;
+
+    #[test]
+    fn error_type_is_the_variant_name() {
+        assert_eq!(
+            NodeError::InvalidChainInfoResponse.error_type(),
+            "NodeError::InvalidChainInfoResponse"
+        );
+    }
+
+    /// The label must not vary with the error's payload — `Display` embeds chain, blob and
+    /// event ids, and using it would give the `error_type` series unbounded cardinality.
+    #[test]
+    fn error_type_does_not_depend_on_the_payload() {
+        let event_id = |index: u32| EventId {
+            chain_id: ChainId(CryptoHash::test_hash("chain")),
+            stream_id: StreamId {
+                application_id: GenericApplicationId::User(ApplicationId::new(
+                    CryptoHash::test_hash("app"),
+                )),
+                stream_name: StreamName(b"epoch".to_vec()),
+            },
+            index,
+        };
+        let one = NodeError::EventsNotFound(vec![event_id(1)]);
+        let other = NodeError::EventsNotFound(vec![event_id(2), event_id(3)]);
+
+        assert_eq!(one.error_type(), "NodeError::EventsNotFound");
+        assert_eq!(one.error_type(), other.error_type());
+        assert_ne!(one.to_string(), other.to_string());
     }
 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -88,6 +88,30 @@ mod metrics {
         )
     });
 
+    /// Errors returned by each validator while communicating with a quorum.
+    ///
+    /// Counts *every* error, including the ones [`NodeError::is_expected`] classifies as
+    /// expected. That classification means "the client recovers from this automatically",
+    /// which is a claim about the client, not about the validator being healthy — so an
+    /// expected error repeating forever is exactly the case nothing else surfaces. It is
+    /// deliberately not logged (see `warn_if_unexpected`), and `communicate_with_quorum`
+    /// returns `Ok` regardless as long as the remaining validators reach a quorum, so
+    /// without this counter a validator can fail every request indefinitely in silence.
+    ///
+    /// `error_type` is the error's variant name via [`NodeError::error_type`], never its
+    /// `Display` text, which embeds chain and blob ids and would be unbounded.
+    ///
+    /// Alert on a sustained rate for a single `address`. Unlike the unanswered share
+    /// derived from the two counters above, this distinguishes a validator that is
+    /// *failing* from one that is merely far away and routinely misses the grace period.
+    pub(super) static QUORUM_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        register_int_counter_vec(
+            "communicate_with_quorum_errors_total",
+            "Errors returned by each validator while communicating with a quorum",
+            &["validator", "address", "error_type"],
+        )
+    });
+
     /// Time each validator took to respond while communicating with a quorum.
     pub(super) static QUORUM_RESPONSE_TIME: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
@@ -268,6 +292,14 @@ where
                         error: err.to_string(),
                     },
                 };
+                #[cfg(with_metrics)]
+                metrics::QUORUM_ERRORS
+                    .with_label_values(&[
+                        &name.to_string(),
+                        addresses.get(&name).map_or("", String::as_str),
+                        &err.error_type(),
+                    ])
+                    .inc();
                 let entry = error_scores.entry(err.clone()).or_insert(0);
                 *entry += committee.weight(&name);
             }


### PR DESCRIPTION
## Motivation

An external validator joined testnet-conway on 2026-08-01 and then failed
**99.7% of the certificates our clients sent it, for two days**, without anything
alerting. It was found because the operator asked about log noise on their side.

It stayed invisible because every layer treats the failure as normal:

1. The validator answered `EventsNotFound` (it had no admin-chain history, so it
   could not verify blocks from any chain still on an older epoch).
2. `NodeError::is_expected` classifies `EventsNotFound` as **expected**, with the
   comment *"validators return these during normal operation and the client
   handles them automatically by supplying missing data and retrying."*
3. `warn_if_unexpected` therefore does not log it, so the Loki-derived
   `ValidatorClientErrors` alert — which counts `"unexpected error from
   validator"` lines — never sees it.
4. `communicate_with_quorum` folds the error into an in-memory `error_scores`
   map and returns `Ok`, because the other validators still formed a quorum.

The classification in (2) is a claim about *the client*, not about the validator
being healthy. When the client's automatic recovery does not actually work, an
"expected" error repeats forever and nothing anywhere says so.

## Proposal

Count every error a validator returns while communicating with a quorum:

```
communicate_with_quorum_errors_total{validator, address, error_type}
```

Incremented in the one place these errors are already tallied — the `Err` arm in
`communicate_with_quorum` that feeds `error_scores` — so it captures expected and
unexpected errors alike, from every call path, at a single site.

`error_type` comes from a new `NodeError::error_type()`, following the existing
convention on `WorkerError`, `LocalNodeError`, `ChainError`, `ExecutionError` and
`chain_client::Error`: the **variant name** via `strum::IntoStaticStr`, never the
`Display` text. `Display` embeds chain ids, blob ids, event ids and heights, and
would give the label unbounded cardinality.

The `validator` and `address` labels match the two counters already in this
module, so the new series joins them without an out-of-band key lookup.

### Why not the existing metrics

The unanswered share derivable from `communicate_with_quorum_requests_total` and
`..._responses_total` did surface this, but it cannot be alerted on: it conflates
*failing* with *far away*. The repair window is `0.2 × time-to-quorum` (~8 ms when
quorum is set by co-located validators), so a healthy validator on another
continent — this one is in Strasbourg, ~118 ms away — also misses it routinely.
An error counter separates the two: a healthy validator, near or far, does not
return `EventsNotFound` on every request.

`BLOCK_STAGING_FAILURES_TOTAL{error_type}` already exists but covers local block
staging and has no validator dimension.

## Test Plan

Two unit tests in `linera-core/src/node.rs`, matching the existing
`error_type` tests in `local_node.rs`:

- `error_type_is_the_variant_name` — the qualified variant name is returned.
- `error_type_does_not_depend_on_the_payload` — two `EventsNotFound` values with
  different event ids produce the *same* `error_type` while their `Display` text
  differs. This is the cardinality guarantee, asserted rather than assumed.

Both were negative-tested: replacing the body with `format!("NodeError::{}", self)`
makes them fail, and the failure output is the exact unbounded label the guard
exists to prevent —

```
left:  "NodeError::Events not found: [EventId { chain_id: 27ac7f45…, stream_id: …, index: 1 }]"
right: "NodeError::EventsNotFound"
```

Checked in both feature configurations, since `--no-default-features` turns
`with_metrics` off:

| command | result |
| --- | --- |
| `cargo check -p linera-core --features metrics` | ok |
| `cargo check -p linera-core --no-default-features` | ok |
| `cargo clippy -p linera-core --features metrics --all-targets` | 0 |
| `cargo clippy -p linera-core --no-default-features --all-targets` | 0 |
| `cargo fmt --all -- --check` | clean |
| `cargo test -p linera-core --lib node::tests` | 4 passed |

## Release Plan

- These changes should be backported to the latest `testnet` branch.

The validator this was found on is on `testnet_conway`, so the metric is only
useful there once backported.

## Links

This makes the failure *visible*; it does not fix it. The underlying reason the
client's automatic recovery never completes is that `update_admin_chain` runs
inside `communicate_with_quorum`, which drops the future once quorum plus a
`0.2 × time-to-quorum` grace period elapses — about 8 ms against a 118 ms
round-trip, so it cannot finish a single certificate send. That fix is being
designed separately.
