### PR TITLE
Publish linera-client for arm64 and ship prebuilt client binaries

### DIFF
--- a/.github/workflows/client-binaries.yml
+++ b/.github/workflows/client-binaries.yml
@@ -37,6 +37,16 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  # The root Cargo.toml sets `[profile.release] debug = true` so production
+  # binaries can be profiled. For something people download it is the difference
+  # between a 368 MB and a 42 MB tarball (1693 MB vs 123 MB on disk), and it
+  # keeps ~212k symbols either way, so panic backtraces still symbolicate.
+  #
+  # This has to be a CARGO_PROFILE_* override rather than RUSTFLAGS: setting
+  # RUSTFLAGS in the environment REPLACES the per-target rustflags in
+  # .cargo/config.toml, which would silently drop `-fuse-ld=lld` and
+  # `force-frame-pointers` from the x86_64-linux build.
+  CARGO_PROFILE_RELEASE_DEBUG: "false"
 
 jobs:
   build:
@@ -73,6 +83,21 @@ jobs:
 
       - name: Install Protoc
         uses: ./.github/actions/install-protoc
+
+      # .cargo/config.toml pins `linker = "aarch64-linux-gnu-gcc"` for this
+      # target. Nothing in this repo builds on arm64 today, so do not assume the
+      # runner image ships that exact name — a missing linker only surfaces at
+      # the very end of an hour-long build.
+      - name: Ensure the pinned aarch64 linker exists
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          set -euo pipefail
+          if ! command -v aarch64-linux-gnu-gcc >/dev/null; then
+            echo "aarch64-linux-gnu-gcc not found; installing it"
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+          fi
+          aarch64-linux-gnu-gcc --version | head -1
 
       - name: Build the client
         run: cargo build --locked --release --bin linera --target ${{ matrix.target }}

--- a/.github/workflows/client-binaries.yml
+++ b/.github/workflows/client-binaries.yml
@@ -1,0 +1,115 @@
+name: Client Binaries
+
+# Prebuilt `linera` client binaries so nobody has to compile the client to use
+# it. Each target is built NATIVELY on its own runner — no cross-compilation and
+# no QEMU, both of which are painful here because the client pulls in rocksdb
+# (C++), wasmer and protobuf.
+#
+# Every runner label below is a STANDARD GitHub-hosted runner, and standard
+# runners are free and unlimited on public repositories (linera-protocol is
+# public). Do NOT switch any of these to a larger runner: larger runners are
+# billed even for public repos.
+#
+# Windows is deliberately absent — we do not support it.
+
+on:
+  # Deliberately NOT `push: tags:`. Releases here are created by hand after the
+  # tag lands (v0.15.20: tag 01:38Z, release published 04:19Z, prerelease=true),
+  # so a tag-triggered upload would find no release and CREATE one, overriding
+  # the prerelease flag and title. Reacting to `published` means the release
+  # already exists and we only ever add assets to it.
+  release:
+    types: [published]
+  # Build the binaries for any ref on demand — this is how to get a build for an
+  # arbitrary commit without putting four ~1h native builds on every merge.
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.release.tag_name || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: write # required to attach assets to a release
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    # The smallest leg here is macos-latest at 3 cores / 7 GB, building the whole
+    # dependency graph in release mode from a cold cache.
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          # On a release event the default ref is the default branch, not the
+          # tag — build the code that was actually released.
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+          # Cache per target so the four jobs don't fight over one key.
+          cache-key: client-${{ matrix.target }}
+
+      - name: Install Protoc
+        uses: ./.github/actions/install-protoc
+
+      - name: Build the client
+        run: cargo build --locked --release --bin linera --target ${{ matrix.target }}
+
+      # Sanity-check the artifact actually runs on the machine that built it.
+      # `--version` is enough to catch a bad link or a missing shared library,
+      # which is the whole failure mode this workflow exists to prevent.
+      - name: Smoke-test the binary
+        run: ./target/${{ matrix.target }}/release/linera --version
+
+      - name: Package
+        id: package
+        run: |
+          set -euo pipefail
+          NAME="linera-${{ matrix.target }}"
+          mkdir -p "dist/${NAME}"
+          cp "target/${{ matrix.target }}/release/linera" "dist/${NAME}/linera"
+          tar -C dist -czf "${NAME}.tar.gz" "${NAME}"
+          # Checksums so a download can be verified without trusting the transport.
+          shasum -a 256 "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256"
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+
+      # Always available per-commit via `gh run download`, independent of releases.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.name }}
+          path: |
+            ${{ steps.package.outputs.name }}.tar.gz
+            ${{ steps.package.outputs.name }}.tar.gz.sha256
+          retention-days: 30
+
+      # `gh release upload` only ever adds assets. Creating the release, and
+      # choosing its title and prerelease flag, stays with whoever cuts it.
+      - name: Attach to the release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          NAME: ${{ steps.package.outputs.name }}
+        run: gh release upload "${TAG}" "${NAME}.tar.gz" "${NAME}.tar.gz.sha256" --clobber

--- a/.github/workflows/client-binaries.yml
+++ b/.github/workflows/client-binaries.yml
@@ -12,24 +12,19 @@ name: Client Binaries
 #
 # Windows is deliberately absent — we do not support it.
 
+# Same triggers as the Docker Image workflow, so a commit that gets images also
+# gets binaries.
 on:
-  # Deliberately NOT `push: tags:`. Releases here are created by hand after the
-  # tag lands (v0.15.20: tag 01:38Z, release published 04:19Z, prerelease=true),
-  # so a tag-triggered upload would find no release and CREATE one, overriding
-  # the prerelease flag and title. Reacting to `published` means the release
-  # already exists and we only ever add assets to it.
-  release:
-    types: [published]
-  # Build the binaries for any ref on demand — this is how to get a build for an
-  # arbitrary commit without putting four ~1h native builds on every merge.
+  push:
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   workflow_dispatch:
 
 concurrency:
-  group: "${{ github.workflow }} @ ${{ github.event.release.tag_name || github.ref }}"
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
   cancel-in-progress: true
 
 permissions:
-  contents: write # required to attach assets to a release
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -70,10 +65,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.2
-        with:
-          # On a release event the default ref is the default branch, not the
-          # tag — build the code that was actually released.
-          ref: ${{ github.event.release.tag_name || github.ref }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -120,7 +111,7 @@ jobs:
           shasum -a 256 "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256"
           echo "name=${NAME}" >> "$GITHUB_OUTPUT"
 
-      # Always available per-commit via `gh run download`, independent of releases.
+      # One downloadable artifact per commit, per platform.
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.package.outputs.name }}
@@ -128,13 +119,3 @@ jobs:
             ${{ steps.package.outputs.name }}.tar.gz
             ${{ steps.package.outputs.name }}.tar.gz.sha256
           retention-days: 30
-
-      # `gh release upload` only ever adds assets. Creating the release, and
-      # choosing its title and prerelease flag, stays with whoever cuts it.
-      - name: Attach to the release
-        if: github.event_name == 'release'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
-          NAME: ${{ steps.package.outputs.name }}
-        run: gh release upload "${TAG}" "${NAME}.tar.gz" "${NAME}.tar.gz.sha256" --clobber

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -210,14 +210,10 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            runner: linera-io-self-hosted-builder
             # The self-hosted builder keeps warm BuildKit cache mounts.
-            reclaim_disk: false
+            runner: linera-io-self-hosted-builder
           - arch: arm64
             runner: ubuntu-24.04-arm
-            # Hosted runners give 14 GB of disk, which a release build of this
-            # workspace can exhaust. Reclaim what the image ships unused.
-            reclaim_disk: true
     runs-on: ${{ matrix.runner }}
     # No warm cache on the hosted arm runner: this is a from-scratch release
     # build of the whole dependency graph on 4 cores.
@@ -246,16 +242,14 @@ jobs:
           echo "Docker daemon did not become ready in 120s"
           exit 1
 
-      # Log free space either way: "no space left on device" partway through a
-      # 60-minute cargo build is otherwise indistinguishable from a build error.
-      - name: Reclaim disk space
+      # A build that dies from exhausted disk or memory looks nothing like a
+      # compile error in the log, so record both up front. (The hosted arm64
+      # runner reports 145 GB free, not the 14 GB the docs table lists — disk is
+      # not the constraint here, memory during the final link is.)
+      - name: Log available resources
         run: |
-          echo "Before:"; df -h /
-          if [ "${{ matrix.reclaim_disk }}" = "true" ]; then
-            sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                        /usr/local/share/powershell /usr/share/swift || true
-            echo "After:"; df -h /
-          fi
+          df -h /
+          free -h
 
       - name: Build and push the arch-specific image
         env:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -65,7 +65,7 @@ jobs:
 
           REGISTRY_BASE="us-docker.pkg.dev/linera-io-dev/linera-public-registry"
 
-          for IMAGE_VAR in LINERA_VALIDATOR:linera-validator LINERA_CLIENT:linera-client LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
+          for IMAGE_VAR in LINERA_VALIDATOR:linera-validator LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
             VAR="${IMAGE_VAR%%:*}"
             NAME="${IMAGE_VAR##*:}"
             echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_TAG}" >> "$GITHUB_ENV"
@@ -131,14 +131,6 @@ jobs:
             "${LINERA_VALIDATOR_IMAGE_BRANCH}" "${LINERA_VALIDATOR_IMAGE_SHORT}" "${LINERA_VALIDATOR_IMAGE_LONG}" "LineraValidator" "validator" &
           PID_LINERA_VALIDATOR=$!
 
-          # linera-client: the client binary only. Also what the validator
-          # chart's *-initializer init containers need (they run
-          # `linera storage check-existence`), so they can stop pulling the
-          # all-three image.
-          build_and_push "docker/Dockerfile" \
-            "${LINERA_CLIENT_IMAGE_BRANCH}" "${LINERA_CLIENT_IMAGE_SHORT}" "${LINERA_CLIENT_IMAGE_LONG}" "LineraClient" "client" &
-          PID_LINERA_CLIENT=$!
-
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
           # the remote-net integration test binary on top of the runtime.
@@ -168,7 +160,7 @@ jobs:
 
           SUCCESS_NAMES=""
           FAILED_NAMES=""
-          for NAME_PID in LineraValidator:$PID_LINERA_VALIDATOR LineraClient:$PID_LINERA_CLIENT LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
+          for NAME_PID in LineraValidator:$PID_LINERA_VALIDATOR LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
             if wait "$PID"; then
@@ -198,3 +190,150 @@ jobs:
           fi
 
           echo "All image builds completed successfully!"
+
+  # ── linera-client: multi-platform ──
+  # linera-client is the one image end users pull directly, so it ships for both
+  # linux/amd64 and linux/arm64 (Apple Silicon, Graviton). Each platform builds
+  # NATIVELY on a runner of its own architecture — cross-building this workspace
+  # under QEMU turns a ~1h Rust build into a multi-hour one.
+  #
+  # Each leg publishes only an arch-suffixed tag; merge-client-image below
+  # stitches them into a manifest list under the real tags, so the tags people
+  # actually pull are never transiently single-platform.
+  #
+  # ubuntu-24.04-arm is a STANDARD GitHub-hosted runner, and standard runners are
+  # free and unlimited on public repositories. Do NOT move this to a larger
+  # runner: those are billed even on public repos.
+  build-client-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: linera-io-self-hosted-builder
+            # The self-hosted builder keeps warm BuildKit cache mounts.
+            reclaim_disk: false
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            # Hosted runners give 14 GB of disk, which a release build of this
+            # workspace can exhaust. Reclaim what the image ships unused.
+            reclaim_disk: true
+    runs-on: ${{ matrix.runner }}
+    # No warm cache on the hosted arm runner: this is a from-scratch release
+    # build of the whole dependency graph on 4 cores.
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/gcp-auth
+        with:
+          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+          configure_docker_for: us-docker.pkg.dev
+
+      - name: Wait for docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if docker info >/dev/null 2>&1; then
+              echo "Docker ready after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Waiting for docker daemon ($i/60)..."
+            sleep 2
+          done
+          echo "Docker daemon did not become ready in 120s"
+          exit 1
+
+      # Log free space either way: "no space left on device" partway through a
+      # 60-minute cargo build is otherwise indistinguishable from a build error.
+      - name: Reclaim disk space
+        run: |
+          echo "Before:"; df -h /
+          if [ "${{ matrix.reclaim_disk }}" = "true" ]; then
+            sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                        /usr/local/share/powershell /usr/share/swift || true
+            echo "After:"; df -h /
+          fi
+
+      - name: Build and push the arch-specific image
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          IMAGE="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-client:${GITHUB_SHA:0:7}-${ARCH}"
+
+          DOCKER_BUILDKIT=1 docker build \
+            -t "${IMAGE}" \
+            -f docker/Dockerfile \
+            --target client \
+            --build-arg "git_commit=${GITHUB_SHA}" \
+            --build-arg "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+            --build-arg "build_flag=--release" \
+            --build-arg "build_folder=release" \
+            .
+
+          # A binary that cannot start is worse than a missing image, and this is
+          # the first arm64 build we ship — check it actually runs.
+          docker run --rm "${IMAGE}" /linera --version
+
+          docker push "${IMAGE}"
+
+  merge-client-image:
+    # Runs even when a leg failed so a single-platform outage degrades to a
+    # single-platform image rather than to no linera-client tag at all, which
+    # would break every consumer pinning this commit.
+    needs: build-client-image
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: ./.github/actions/gcp-auth
+        with:
+          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+          configure_docker_for: us-docker.pkg.dev
+
+      - name: Merge the per-arch images into one manifest list
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          BRANCH_NAME="${HEAD_REF:-${REF_NAME}}"
+          # Docker tags forbid '/'; same substitution as the build-and-push job.
+          BRANCH_TAG="${BRANCH_NAME//\//-}"
+          REPO="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-client"
+
+          # Ask the registry which arches actually landed rather than trusting
+          # job results: that is the state the manifest list is built from.
+          SOURCES=()
+          for ARCH in amd64 arm64; do
+            SRC="${REPO}:${GITHUB_SHA:0:7}-${ARCH}"
+            if docker buildx imagetools inspect "${SRC}" >/dev/null 2>&1; then
+              echo "found ${SRC}"
+              SOURCES+=("${SRC}")
+            else
+              echo "::warning::${SRC} is missing — its build leg failed"
+            fi
+          done
+
+          if [ ${#SOURCES[@]} -eq 0 ]; then
+            echo "::error::no linera-client image was built for any architecture"
+            exit 1
+          fi
+          if [ ${#SOURCES[@]} -lt 2 ]; then
+            echo "::warning::publishing linera-client with only ${#SOURCES[@]} architecture(s)"
+          fi
+
+          docker buildx imagetools create \
+            -t "${REPO}:${BRANCH_TAG}" \
+            -t "${REPO}:${GITHUB_SHA:0:7}" \
+            -t "${REPO}:${GITHUB_SHA}" \
+            "${SOURCES[@]}"
+
+          docker buildx imagetools inspect "${REPO}:${GITHUB_SHA:0:7}"

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -201,17 +201,18 @@ jobs:
   # stitches them into a manifest list under the real tags, so the tags people
   # actually pull are never transiently single-platform.
   #
-  # ubuntu-24.04-arm is a STANDARD GitHub-hosted runner, and standard runners are
-  # free and unlimited on public repositories. Do NOT move this to a larger
-  # runner: those are billed even on public repos.
+  # Both legs use STANDARD GitHub-hosted runners, which are free and unlimited on
+  # public repositories. Do NOT move either to a larger runner: those are billed
+  # even on public repos. Deliberately NOT the self-hosted builder — it is busy
+  # with build-and-push, and an amd64 client build that queues behind it holds up
+  # the merge below. Without debuginfo this builds in ~22 min on a hosted runner.
   build-client-image:
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: amd64
-            # The self-hosted builder keeps warm BuildKit cache mounts.
-            runner: linera-io-self-hosted-builder
+            runner: ubuntu-latest
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
@@ -275,11 +276,11 @@ jobs:
           docker push "${IMAGE}"
 
   merge-client-image:
-    # Runs even when a leg failed so a single-platform outage degrades to a
-    # single-platform image rather than to no linera-client tag at all, which
-    # would break every consumer pinning this commit.
+    # Plain `needs`, no `if`: this must run only when BOTH legs succeeded.
+    # Publishing whatever happened to be ready is worse than publishing nothing —
+    # a missing tag fails loudly at deploy time, while a tag that silently lacks
+    # amd64 fails at runtime on every machine we actually run on.
     needs: build-client-image
-    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -303,26 +304,18 @@ jobs:
           BRANCH_TAG="${BRANCH_NAME//\//-}"
           REPO="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-client"
 
-          # Ask the registry which arches actually landed rather than trusting
-          # job results: that is the state the manifest list is built from.
           SOURCES=()
           for ARCH in amd64 arm64; do
             SRC="${REPO}:${GITHUB_SHA:0:7}-${ARCH}"
-            if docker buildx imagetools inspect "${SRC}" >/dev/null 2>&1; then
-              echo "found ${SRC}"
-              SOURCES+=("${SRC}")
-            else
-              echo "::warning::${SRC} is missing — its build leg failed"
+            # Both legs succeeded for this job to run at all, so a missing tag
+            # here means something else went wrong — never paper over it.
+            if ! docker buildx imagetools inspect "${SRC}" >/dev/null 2>&1; then
+              echo "::error::${SRC} is missing despite its build leg succeeding"
+              exit 1
             fi
+            echo "found ${SRC}"
+            SOURCES+=("${SRC}")
           done
-
-          if [ ${#SOURCES[@]} -eq 0 ]; then
-            echo "::error::no linera-client image was built for any architecture"
-            exit 1
-          fi
-          if [ ${#SOURCES[@]} -lt 2 ]; then
-            echo "::warning::publishing linera-client with only ${#SOURCES[@]} architecture(s)"
-          fi
 
           docker buildx imagetools create \
             -t "${REPO}:${BRANCH_TAG}" \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -224,6 +224,14 @@ ARG build_flag
 ARG build_folder
 ARG build_features
 
+# `[profile.release] debug = true` (root Cargo.toml) is there so production
+# binaries can be profiled, and it costs a LOT: the client links to 1693 MB with
+# debuginfo versus 123 MB without, while keeping ~212k symbols either way, so
+# panic backtraces still symbolicate. Linking that with thin LTO does not fit in
+# a 16 GB arm64 runner. The validator keeps debuginfo — it is the one being
+# profiled — so this is set on the client stage only, not in cook_base.
+ENV CARGO_PROFILE_RELEASE_DEBUG=false
+
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,12 @@ ARG build_date
 ARG build_flag=--release
 ARG build_folder=release
 ARG build_features=scylladb,metrics,jemalloc
-ARG rustflags="-C force-frame-pointers=yes -L /usr/lib/x86_64-linux-gnu"
+# The `-L` lets the linker find libunwind, jemalloc's stack-trace backend (#5602).
+# Debian's multiarch lib dir is arch-dependent (x86_64-linux-gnu vs
+# aarch64-linux-gnu), so this points at a stable symlink that cook_base resolves
+# from the build machine. Hardcoding one arch would silently drop libunwind on
+# the other.
+ARG rustflags="-C force-frame-pointers=yes -L /usr/lib/deb-multiarch"
 
 # ── Stage 0: chef base (rust + cargo-chef + system deps) ──
 FROM rust:1.86-slim-bookworm AS chef
@@ -129,6 +134,10 @@ COPY linera-sdk/wit linera-sdk/wit
 COPY --from=planner /examples-stubs examples
 
 ENV GIT_COMMIT=${git_commit}
+
+# Resolve the multiarch lib dir from the machine actually doing the build, so
+# `rustflags` above stays arch-agnostic and amd64/arm64 need no separate value.
+RUN ln -s "/usr/lib/$(uname -m)-linux-gnu" /usr/lib/deb-multiarch
 ENV RUSTFLAGS=${rustflags}
 
 # ── Stage 3a: builder_src — all three binaries, for the `tests` image only ──


### PR DESCRIPTION
## Motivation

Stacked on #6633, which splits the image into `linera-validator` and `linera-client`.

`linera-client` is the one image end users pull directly, and it is published for `linux/amd64`
only — so anyone on Apple Silicon or Graviton gets an emulated image, or builds from source. There
is also no way to get the `linera` client at all without either Docker or a full Rust toolchain:
we publish no binaries.

## Proposal

**1. `linera-client` becomes a multi-platform image (`linux/amd64` + `linux/arm64`).**

Each platform builds **natively** on a runner of its own architecture, and a merge job stitches the
results into one manifest list. Cross-building under QEMU is not viable here — this workspace pulls
in rocksdb (C++), wasmer and protobuf, and emulated it turns a ~1h build into a multi-hour one.

- `build-client-image` (matrix): `amd64` on `ubuntu-latest`, `arm64` on `ubuntu-24.04-arm` — both
  standard hosted runners. Each pushes only an arch-suffixed tag. Deliberately NOT the self-hosted
  builder: it is busy with `build-and-push`, and an amd64 leg queued behind it holds up the merge.
  Measured on hosted runners with debuginfo off: amd64 27m29s, arm64 20m58s.
- `merge-client-image`: `docker buildx imagetools create` publishes the real tags
  (`:<branch>`, `:<short-sha>`, `:<sha>`) as a manifest list.

The client leg is removed from the single-arch `build-and-push` job; everything else there is
untouched.

Publishing only arch-suffixed tags from the build legs means the tags people actually pull are
never transiently single-platform. The merge runs under a plain `needs:` with no `if:`, so
GitHub's default gate applies and it fires **only when both legs succeeded** — publishing whatever
happened to be ready is worse than publishing nothing, because a missing tag fails loudly at deploy
time while a tag silently lacking amd64 fails at runtime on every machine we run on.

**2. A `Client Binaries` workflow publishes prebuilt `linera` binaries** for
`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin` and
`x86_64-apple-darwin`, as `.tar.gz` + `.sha256`. No Windows — we do not support it.

**Both drop debuginfo from the client**, via `CARGO_PROFILE_RELEASE_DEBUG=false` (on the
`client_builder` stage and in the binaries workflow). The root `Cargo.toml` sets
`[profile.release] debug = true` so production binaries can be profiled, and for the client that
costs an enormous amount:

| | binary | tarball | symbols |
|---|---|---|---|
| as built today | 1693 MB | 368 MB | 213,715 |
| **no debuginfo** | **123 MB** | **42 MB** | **211,774** |
| fully stripped | 92 MB | 36 MB | 0 |

A 368 MB download defeats the point of publishing binaries, and linking a 1.7 GB binary with thin
LTO is what killed the first arm64 attempt (below). Symbols are kept — the ~6 MB saved by full
stripping is not worth losing symbolicated panic backtraces. **The validator keeps debuginfo**: it
is the thing being profiled, so this is set on the client stage only, never in `cook_base`.

It has to be a `CARGO_PROFILE_*` override rather than `RUSTFLAGS`. Setting `RUSTFLAGS` in the
environment *replaces* the per-target `rustflags` in `.cargo/config.toml`, which would silently
drop `-fuse-ld=lld` and `force-frame-pointers` from the x86_64-linux build.

**3. Fixes an architecture assumption in the Dockerfile.** `rustflags` hardcoded
`-L /usr/lib/x86_64-linux-gnu`, added in #5602 so the linker finds libunwind (jemalloc's
stack-trace backend). That directory is arch-dependent, so on arm64 the flag would have pointed at
a directory that does not exist. `cook_base` now symlinks the real one, resolved from the build
machine via `uname -m`, so `rustflags` stays arch-agnostic and neither arch needs its own value.

### Cost

Every runner used here is a **standard** GitHub-hosted runner, and
[standard runners are free and unlimited on public repositories](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).
`linera-protocol` is public. Please do not switch any of these to a larger runner —
[larger runners are billed even on public repos](https://docs.github.com/en/billing/managing-billing-for-your-products/about-billing-for-github-actions).

`Client Binaries` uses the **same triggers as `Docker Image`** — push to `main`/`devnet_*`/
`testnet_*`, plus `workflow_dispatch` — so a commit that gets images also gets binaries, and the
branches we actually deploy produce binaries for the commit that was deployed.

There is room for this: `main` took 4 commits in the last 14 days, and `Docker Image` already
builds 6-7 images on every one of them.

## Test Plan

No docker daemon in my environment, so the Dockerfile change is verified by extracting the real
Debian packages rather than by building.

The `linera` client binary itself was built and run on real aarch64 Linux here:
`cargo build --locked --release --bin linera --target aarch64-unknown-linux-gnu` finished in
27m02s, and the packaged tarball round-trips (extract, `--version`, `shasum -c`). The
`CARGO_PROFILE_RELEASE_DEBUG` override was verified against a control crate with
`[profile.release] debug = true`: the binary shrank 89%, so the env var does beat the manifest.

**The `-L` fix is necessary and correct.** `libunwind-dev` 1.6.2-3 (bookworm — same base as the
image), unpacked for both arches:

```
amd64:  ./usr/lib/x86_64-linux-gnu/libunwind.so  -> libunwind.so.8.0.1
arm64:  ./usr/lib/aarch64-linux-gnu/libunwind.so -> libunwind.so.8.0.1
```

`uname -m` returns exactly `x86_64` / `aarch64`, so the symlink resolves to the correct directory
on both, and to today's path on amd64.

**Gate for the parent PR.** `Docker Image` never runs on pull requests (it triggers on push to
`main`/`devnet_*`/`testnet_*` plus `workflow_dispatch`), so green PR checks do not mean the images
built. I dispatched it against #6633 and it published all three:

```
linera-validator @572c5f1  sha256:4156ae6cb54a12b43cf96e56073cbc17d11bc7671246f8fc5de575e154f288ea
linera-client    @572c5f1  sha256:42bc387324b4bbc542d7024868b243dff7890dfda4c163cbfaca9cf3bc13367d
linera-tests     @572c5f1  sha256:4c7eede12eb6390f68da7889d7b53b27e293d54b58d6b214d3a035cfbd95918c
linera           @572c5f1  <not published, as intended>
```

**The arm64 leg was proven the hard way.** The first dispatch on this branch failed exactly there:
the build reached the final link of `linera` and then went silent for 8 minutes before a job-level
SIGTERM with no BuildKit error — the runner dying, not the build erroring.

I measured the link rather than inferring it. Sampling the RSS of the whole cargo/rustc/linker
process tree through a relink of `--bin linera` with debuginfo:

```
PEAK_RSS_MB=23296        # 22.8 GB, and this is the *lighter* default-features build
```

`ubuntu-24.04-arm` has 16 GB. That is the failure, and it is why
`CARGO_PROFILE_RELEASE_DEBUG=false` is part of this PR rather than a follow-up.

**With the fix, the dispatched run is green on every job** — including arm64 — and the published
tag is a real multi-platform index:

```
linera-client:9ba76c5   application/vnd.docker.distribution.manifest.list.v2+json
    linux/amd64  sha256:bcca5e5bbf317d991…
    linux/arm64  sha256:4c6ed13e3063e610f…
linera-validator:9ba76c5   single manifest (amd64), unchanged by design
```

Dropping debuginfo also shrank what every consumer pulls — PM workers, the `*-initializer` init
containers, the faucet, CLI users — by nearly 5x:

```
linera-client amd64, 8eaf2a2 (debuginfo):    428 MB compressed
linera-client amd64, 9ba76c5 (no debuginfo):  89 MB compressed
```

Worth recording: **disk was never the constraint.** GitHub's runner table lists 14 GB of SSD for
`ubuntu-24.04-arm`, but the job reported `145G` total with `108G` free. An earlier revision of this
PR reclaimed preinstalled toolchains on that basis; that step is gone, replaced by logging `df -h`
and `free -h`, since a build killed by exhausted memory looks nothing like a compile error in the
log.

An earlier revision let the merge run when a leg had not finished, and the GitHub Actions outage on
2026-08-06 proved why that was wrong: with amd64 stuck queued, it published an **arm64-only**
`linera-client` under the real tag. A tag that has not been built yet is indistinguishable from one
whose build failed, so probing the registry could not tell them apart. With the `needs:` gate
above, the same conditions later produced the correct outcome — both per-arch tags present, the
real tag simply absent (404) until the merge could run.

Each leg also runs `/linera --version` on the image it just built before pushing it.

`.cargo/config.toml` pins `linker = "aarch64-linux-gnu-gcc"` for the arm64 target and nothing in
this repo builds on arm64 today, so the binaries workflow verifies that linker up front instead of
discovering it missing at the end of an hour-long build.

Both workflows parse, every `run` block passes `bash -n`, and hadolint is clean at the repo's
`--failure-threshold error`.

Verified against primary sources rather than assumed:
- `setup-gcloud@v2` works on arm64 — it maps node's `arm64` to the `linux-arm` SDK tarball
  (`archMap` in `google-github-actions/setup-cloud-sdk/src/format-url.ts`), and
  `google-cloud-sdk-568.0.0-linux-arm.tar.gz` resolves.
- `ubuntu-24.04-arm`, `macos-15-intel` and `macos-latest` are all in the public-repo standard
  runner table; `macos-13` is retired.
- `ubuntu-24.04-arm` ships Docker 28.0.4 and Buildx 0.35.0 preinstalled.

## Release Plan

- These changes follow the usual release cycle.

Needs the same coordinated rollout as #6633 — no new `linera:<commit>` tag is published, so
linera-infra and linera-artifacts must move to `linera-validator` / `linera-client` in step.

## Links

- Stacked on #6633
- The hardcoded `-L` came from #5602
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

## Verified end state

```
linera-client:ef92a7c -> ['linux/amd64', 'linux/arm64']
```
