### PR TITLE
linera-core: select peers by score band instead of a fixed top 3

### DIFF
--- a/linera-core/src/client/requests_scheduler/mod.rs
+++ b/linera-core/src/client/requests_scheduler/mod.rs
@@ -29,6 +29,18 @@ pub const MAX_REQUEST_TTL_MS: u64 = 200;
 pub const ALPHA_SMOOTHING_FACTOR: f64 = 0.1;
 /// Default delay in milliseconds between starting requests to different peers.
 pub const STAGGERED_DELAY_MS: u64 = 150;
+/// How far below the best peer's score a peer may sit and still be eligible for
+/// selection, as a fraction of the best score.
+///
+/// Scores are compressed into a narrow band: `max_accepted_latency_ms`
+/// normalizes latency against 5000 ms, so a peer answering in 171 ms scores only
+/// about 1.2% below one answering in 55 ms. Selecting a fixed number of peers by
+/// rank therefore behaves as a cliff rather than as a preference — on a
+/// committee of five, the fifth-ranked peer received no traffic at all despite
+/// answering every request it was given. Comparing against the best score keeps
+/// peers that are merely slightly slower in rotation, while still excluding one
+/// that is genuinely degraded.
+pub const PEER_SELECTION_SCORE_TOLERANCE: f64 = 0.05;
 
 /// Configuration for the `RequestsScheduler`.
 #[derive(Debug, Clone)]

--- a/linera-core/src/client/requests_scheduler/scheduler.rs
+++ b/linera-core/src/client/requests_scheduler/scheduler.rs
@@ -26,7 +26,9 @@ use super::{
 use crate::{
     client::{
         communicate_concurrently,
-        requests_scheduler::{in_flight_tracker::Subscribed, request::Cacheable},
+        requests_scheduler::{
+            in_flight_tracker::Subscribed, request::Cacheable, PEER_SELECTION_SCORE_TOLERANCE,
+        },
         ClockOf, RequestsSchedulerConfig,
     },
     environment::Environment,
@@ -818,31 +820,40 @@ impl<Env: Environment> RequestsScheduler<Env> {
     ///
     /// This method:
     /// 1. Sorts nodes by performance score
-    /// 2. Performs weighted random selection from the top 3 performers
+    /// 2. Performs weighted random selection among the peers whose score is within
+    ///    [`PEER_SELECTION_SCORE_TOLERANCE`] of the best score
     ///
     /// This approach balances between choosing high-performing nodes and distributing
-    /// load across multiple validators to avoid creating hotspots.
+    /// load across multiple validators to avoid creating hotspots. The eligible set is
+    /// bounded by how far a peer's score has actually fallen behind, not by a fixed
+    /// number of peers, so growing the committee does not starve its slowest members.
     ///
     /// Returns `None` if no nodes are available.
     async fn select_best_peer(&self) -> Option<RemoteNode<Env::ValidatorNode>> {
         let scored_nodes = self.peers_by_score().await;
+        let best_score = scored_nodes.first()?.0;
 
-        if scored_nodes.is_empty() {
-            return None;
-        }
-
-        // Use weighted random selection from top performers (top 3 or all if less)
-        let top_count = scored_nodes.len().min(3);
-        let top_nodes = &scored_nodes[..top_count];
+        // `scored_nodes` is sorted by descending score, so the eligible peers are a
+        // prefix of it. The best peer always clears its own cutoff, so this is never
+        // empty.
+        let cutoff = best_score * (1.0 - PEER_SELECTION_SCORE_TOLERANCE);
+        let eligible_count = scored_nodes
+            .iter()
+            .take_while(|(score, _)| *score >= cutoff)
+            .count();
+        let eligible_nodes = &scored_nodes[..eligible_count];
 
         // Create weights based on normalized scores
         // Add small epsilon to prevent zero weights
-        let weights: Vec<f64> = top_nodes.iter().map(|(score, _)| score.max(0.01)).collect();
+        let weights: Vec<f64> = eligible_nodes
+            .iter()
+            .map(|(score, _)| score.max(0.01))
+            .collect();
 
         if let Ok(dist) = WeightedIndex::new(&weights) {
             let mut rng = rand::thread_rng();
             let index = dist.sample(&mut rng);
-            Some(top_nodes[index].1.clone())
+            Some(eligible_nodes[index].1.clone())
         } else {
             // Fallback to the best node if weights are invalid
             tracing::warn!("failed to create weighted distribution, defaulting to best node");
@@ -879,7 +890,9 @@ mod tests {
 
     use super::{super::request::RequestKey, *};
     use crate::{
-        client::requests_scheduler::{MAX_REQUEST_TTL_MS, STAGGERED_DELAY_MS},
+        client::requests_scheduler::{
+            MAX_ACCEPTED_LATENCY_MS, MAX_REQUEST_TTL_MS, STAGGERED_DELAY_MS,
+        },
         node::NodeError,
     };
 
@@ -1429,5 +1442,142 @@ mod tests {
             order.contains(&node2_key),
             "Retry should have reached the working peer (node 2)"
         );
+    }
+
+    /// Builds a scheduler over `count` validators, normalizing latency against the
+    /// production `MAX_ACCEPTED_LATENCY_MS` so the scores the test reasons about are
+    /// the ones the deployed client computes.
+    async fn create_scored_manager(
+        count: usize,
+    ) -> (
+        Arc<RequestsScheduler<TestEnvironment>>,
+        Vec<RemoteNode<<TestEnvironment as Environment>::ValidatorNode>>,
+    ) {
+        use crate::test_utils::{MemoryStorageBuilder, TestBuilder};
+
+        let mut builder = TestBuilder::new(
+            MemoryStorageBuilder::default(),
+            count,
+            0,
+            InMemorySigner::new(None),
+        )
+        .await
+        .unwrap();
+
+        let nodes: Vec<_> = (0..count)
+            .map(|index| {
+                let node = builder.node(index);
+                let public_key = node.name();
+                RemoteNode { public_key, node }
+            })
+            .collect();
+
+        let manager = Arc::new(RequestsScheduler::<TestEnvironment>::with_config(
+            nodes.clone(),
+            ScoringWeights::default(),
+            0.1,
+            MAX_ACCEPTED_LATENCY_MS,
+            Duration::from_secs(60),
+            100,
+            Duration::from_millis(MAX_REQUEST_TTL_MS),
+            Duration::from_millis(STAGGERED_DELAY_MS),
+            TestClock::new(),
+        ));
+
+        (manager, nodes)
+    }
+
+    /// Drives a peer's EMAs to convergence. With alpha = 0.1, 200 observations leave
+    /// the residual at 0.9^200 (~7e-10), and take `total_requests` past the 10-sample
+    /// cold-start threshold so the confidence factor is 1.0.
+    async fn settle_peer(
+        manager: &RequestsScheduler<TestEnvironment>,
+        public_key: ValidatorPublicKey,
+        success: bool,
+        response_time_ms: u64,
+    ) {
+        let mut nodes = manager.nodes.write().await;
+        let info = nodes.get_mut(&public_key).expect("peer must be registered");
+        for _ in 0..200 {
+            info.update_metrics(success, response_time_ms);
+        }
+    }
+
+    /// A healthy-but-slower validator must keep receiving traffic.
+    ///
+    /// These are the latencies measured on testnet_conway on 2026-08-05: four
+    /// validators answering in 50-57 ms and a fifth, geographically distant one
+    /// answering in 171 ms at a 1.000 success ratio. Because latency is normalized
+    /// against 5000 ms, the distant validator scores 0.78632 against the best peer's
+    /// 0.79600 — under 1.3% behind. Selecting a fixed top 3 by rank made that
+    /// sub-1.3% gap mean zero traffic, so it was never selected at all.
+    #[tokio::test]
+    async fn test_slightly_slower_peer_stays_eligible() {
+        let (manager, nodes) = create_scored_manager(5).await;
+
+        for (index, response_time_ms) in [50, 52, 55, 57].into_iter().enumerate() {
+            settle_peer(&manager, nodes[index].public_key, true, response_time_ms).await;
+        }
+        let distant_key = nodes[4].public_key;
+        settle_peer(&manager, distant_key, true, 171).await;
+
+        let scored = manager.peers_by_score().await;
+        assert_eq!(
+            scored
+                .last()
+                .expect("five peers are registered")
+                .1
+                .public_key,
+            distant_key,
+            "the distant validator should rank last, which is what made it starve"
+        );
+
+        let mut selected_distant = false;
+        for _ in 0..500 {
+            if manager
+                .select_best_peer()
+                .await
+                .expect("a peer is available")
+                .public_key
+                == distant_key
+            {
+                selected_distant = true;
+                break;
+            }
+        }
+
+        assert!(
+            selected_distant,
+            "a validator 1.3% behind on score must stay in rotation; ranking it 5th of 5 \
+             must not exclude it"
+        );
+    }
+
+    /// The tolerance must not turn into "select anyone". A validator that is failing
+    /// requests scores far enough below the best peer to fall outside the band, and
+    /// must never be selected.
+    #[tokio::test]
+    async fn test_degraded_peer_is_excluded() {
+        let (manager, nodes) = create_scored_manager(5).await;
+
+        for (index, response_time_ms) in [50, 52, 55, 57].into_iter().enumerate() {
+            settle_peer(&manager, nodes[index].public_key, true, response_time_ms).await;
+        }
+        // Same latency as its peers, but failing every request: success EMA -> 0, which
+        // removes the 0.4 success term and halves the score.
+        let failing_key = nodes[4].public_key;
+        settle_peer(&manager, failing_key, false, 55).await;
+
+        for _ in 0..500 {
+            assert_ne!(
+                manager
+                    .select_best_peer()
+                    .await
+                    .expect("a peer is available")
+                    .public_key,
+                failing_key,
+                "a validator failing every request must fall outside the score band"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Motivation

`select_best_peer` picks from a fixed top 3 by rank:

```rust
let top_count = scored_nodes.len().min(3);
let top_nodes = &scored_nodes[..top_count];
```

`3` is a literal, not a config knob. For a committee of N > 3, the bottom N−3
peers receive **zero** traffic — this is a cut by rank, so a peer either is in
the set or gets nothing.

That would be defensible if scores separated good peers from bad ones. They do
not: `calculate_score` normalizes latency against `max_accepted_latency_ms`,
which defaults to **5000 ms**, so realistic latency differences barely move the
score.

Observed on testnet_conway, 2026-08-05. Five validators, four of ours answering
in 52–56 ms and a third-party one answering in 171 ms:

| | third-party | ours |
| --- | --- | --- |
| requests over 24h | 37,118 | 630k – 831k |
| **success ratio over 24h** | **1.000** | 1.000 |
| p95 | 171 ms | 52 – 56 ms |
| `rate(requests[15m])` at the time of writing | **0** | 5.5 – 7.7 /s |

Scores with the shipped defaults (`latency: 0.4`, `success: 0.4`, cold-start
confidence factor saturated at 1.0):

- ours: `0.4·(1 − 55/5000) + 0.4·1.0` = **0.79560**
- third-party: `0.4·(1 − 171/5000) + 0.4·1.0` = **0.78632**

**A 1.2% score gap becomes 100% vs 0% of traffic.** The validator answered every
single request it was given, at a 1.000 success ratio, and still received
nothing — it simply ranked 5th of 5. A 3x real latency difference moves the
score by ~1%, but the rank cut treats that as all-or-nothing.

This gets worse as committees grow: at larger committee sizes most validators
would receive no client read traffic at all, which is both a load-distribution
and a decentralization concern.

## Proposal

Select from every peer whose score is within `PEER_SELECTION_SCORE_TOLERANCE`
(5%) of the best peer's score, instead of the top 3 by rank. Weighted-random
selection within that set is unchanged.

```rust
let cutoff = best_score * (1.0 - PEER_SELECTION_SCORE_TOLERANCE);
let eligible_count = scored_nodes
    .iter()
    .take_while(|(score, _)| *score >= cutoff)
    .count();
```

`scored_nodes` is already sorted descending, so the eligible peers are a prefix
and the best peer always clears its own cutoff — the set is never empty, which
also lets the explicit `is_empty` check collapse into `first()?`.

The eligible set is now bounded by how far a peer has actually fallen behind
rather than by a fixed count, so:

- peers that are merely a little slower stay in rotation (the case above: 0.78632
  vs a 0.75582 cutoff);
- a genuinely degraded peer is still excluded — a validator failing its requests
  loses the entire 0.4 success term and lands at ~0.3956, far outside the band;
- growing the committee no longer starves its slowest members.

5% is a starting point, not a tuned value — it is ~4x the gap we measured, and
comfortably inside the ~50% gap a failing peer shows. Happy to change it, or to
plumb it through `RequestsSchedulerConfig` if you would rather have it runtime
tunable; I kept it as a module constant because `with_config` already carries
`#[expect(clippy::too_many_arguments)]`.

This is a **draft** — the behavior question (score band vs. widening the rank
cut vs. leaving selection alone and treating this purely as an alerting issue)
is yours and Matt's call. Opening it with the measurement attached so there is
something concrete to react to.

## Test Plan

Two tests in `requests_scheduler::scheduler::tests`, both driving the EMAs to
convergence through `update_metrics` (200 observations at alpha = 0.1 leaves a
~7e-10 residual and clears the 10-sample cold-start threshold), and normalizing
against the production `MAX_ACCEPTED_LATENCY_MS` so the scores under test are the
ones the deployed client computes:

- `test_slightly_slower_peer_stays_eligible` — reproduces the measurement above
  (four peers at 50/52/55/57 ms, one at 171 ms). Asserts the distant peer ranks
  last, then that it is still selected within 500 draws.
- `test_degraded_peer_is_excluded` — same latencies, but the fifth peer fails
  every request. Asserts it is never selected across 500 draws, so the tolerance
  does not degenerate into "select anyone".

**The first test was confirmed to fail against the pre-change code.** I
temporarily restored `scored_nodes.len().min(3)` and re-ran it:

```
test client::requests_scheduler::scheduler::tests::test_slightly_slower_peer_stays_eligible ... FAILED
panicked at linera-core/src/client/requests_scheduler/scheduler.rs:1538:9:
a validator 1.3% behind on score must stay in rotation; ranking it 5th of 5 must not exclude it
```

500 draws, never selected once — so the test pins the actual regression rather
than passing vacuously.

Full run: `cargo test -p linera-core --lib requests_scheduler` → **31 passed, 0
failed**.

Post-change protocol: `cargo clippy --all-targets --all-features --locked
--workspace --exclude linera-web -- -D warnings` (clean), `cargo clippy
--no-default-features -p linera-core -- -D warnings` (clean), `cargo doc
--all-features -p linera-core` (clean), `cargo fmt` on nightly with the
toolchain symlink restored to stable afterwards.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Companion PR muting the resulting alert noise on the infra side while this is
  decided: linera-io/linera-infra#1661
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
