### PR TITLE
linera-core: have the updater hold only a local node, signaling LocalNodeLagging instead of pulling chain state

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -256,6 +256,14 @@ pub enum Error {
     #[error("Remote node operation failed: {0}")]
     RemoteNodeError(#[from] NodeError),
 
+    /// A validator reported state ahead of the local node for this chain. The caller may pull
+    /// the missing state from that validator, then retry or surface the carried error.
+    #[error("The local node is lagging behind a validator on chain {chain_id}: {error}")]
+    LocalNodeLagging {
+        chain_id: ChainId,
+        error: Box<NodeError>,
+    },
+
     #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
 

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -53,7 +53,7 @@ use crate::{
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode, ValidatorNodeProvider as _},
     notifier::{ChannelNotifier, Notifier as _},
     remote_node::RemoteNode,
-    updater::{communicate_with_quorum, CommunicateAction, ValidatorUpdater},
+    updater::{communicate_with_quorum, CommunicateAction, RemoteNodeUpdater},
     worker::{Notification, ProcessableCertificate, Reason, WorkerError, WorkerState},
     ChainWorkerConfig, ProcessConfirmedBlockMode, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
@@ -476,10 +476,6 @@ impl<Env: Environment> Client<Env> {
     /// Returns the provider used to connect to validator nodes.
     pub fn validator_node_provider(&self) -> &Env::Network {
         self.environment.network()
-    }
-
-    pub(crate) fn options(&self) -> &chain_client::Options {
-        &self.options
     }
 
     /// Handles any pending local cross-chain requests, notifying subscribers.
@@ -1304,6 +1300,62 @@ impl<Env: Environment> Client<Env> {
         Ok(certificate)
     }
 
+    /// Creates a [`RemoteNodeUpdater`] for the given validator, backed by our local node.
+    fn remote_node_updater(
+        &self,
+        remote_node: RemoteNode<Env::ValidatorNode>,
+    ) -> RemoteNodeUpdater<Env> {
+        RemoteNodeUpdater {
+            remote_node,
+            local_node: self.local_node.clone(),
+            admin_chain_id: self.admin_chain_id,
+            certificate_upload_batch_size: self.options.certificate_upload_batch_size,
+        }
+    }
+
+    /// Handles a [`chain_client::Error::LocalNodeLagging`] signal from a [`RemoteNodeUpdater`]:
+    /// pulls the missing chain state from the validator that turned out to be ahead of us, then
+    /// either retries the action once (when finalizing a block) or surfaces the validator's
+    /// original error so the outer logic can rebuild on top of the refreshed local state.
+    async fn sync_and_retry_chain_update(
+        self: &Arc<Self>,
+        mut updater: RemoteNodeUpdater<Env>,
+        action: CommunicateAction,
+        chain_id: ChainId,
+        error: NodeError,
+    ) -> Result<LiteVote, chain_client::Error> {
+        match &action {
+            CommunicateAction::SubmitBlock { .. } => {
+                // Pull the manager state that justified the proposal's rejection (signatures
+                // are checked locally, so the source can't fool us), best-effort, and surface
+                // the rejection either way. If our local state actually advanced,
+                // `execute_operations` will rebuild and re-propose.
+                if let Err(sync_err) = self
+                    .synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await
+                {
+                    debug!(%sync_err, "failed to pull manager state from validator");
+                }
+                Err(error.into())
+            }
+            CommunicateAction::RequestTimeout { .. } => {
+                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await?;
+                Err(error.into())
+            }
+            CommunicateAction::FinalizeBlock { .. } => {
+                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await?;
+                match updater.send_chain_update(action).await {
+                    Err(chain_client::Error::LocalNodeLagging { error, .. }) => {
+                        Err((*error).into())
+                    }
+                    result => result,
+                }
+            }
+        }
+    }
+
     /// Broadcasts certified blocks to validators.
     #[instrument(level = "trace", skip_all, fields(chain_id, block_height, delivery))]
     async fn communicate_chain_updates(
@@ -1320,11 +1372,7 @@ impl<Env: Environment> Client<Env> {
             committee,
             |_: &()| (),
             |remote_node| {
-                let mut updater = ValidatorUpdater {
-                    remote_node,
-                    client: self.clone(),
-                    admin_chain_id: self.admin_chain_id,
-                };
+                let mut updater = self.remote_node_updater(remote_node);
                 let certificate = latest_certificate.clone();
                 Box::pin(async move {
                     updater
@@ -1356,13 +1404,17 @@ impl<Env: Environment> Client<Env> {
             committee,
             |vote: &LiteVote| (vote.value.value_hash, vote.round),
             |remote_node| {
-                let mut updater = ValidatorUpdater {
-                    remote_node,
-                    client: self.clone(),
-                    admin_chain_id: self.admin_chain_id,
-                };
+                let mut updater = self.remote_node_updater(remote_node);
                 let action = action.clone();
-                Box::pin(async move { updater.send_chain_update(action).await })
+                Box::pin(async move {
+                    match updater.send_chain_update(action.clone()).await {
+                        Err(chain_client::Error::LocalNodeLagging { chain_id, error }) => {
+                            self.sync_and_retry_chain_update(updater, action, chain_id, *error)
+                                .await
+                        }
+                        result => result,
+                    }
+                })
             },
             self.options.quorum_grace_period,
         )

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -7,7 +7,6 @@ use std::{
     fmt,
     hash::Hash,
     mem,
-    sync::Arc,
 };
 
 use futures::{future, Future, StreamExt};
@@ -30,9 +29,10 @@ use tokio::sync::mpsc;
 use tracing::{instrument, Level};
 
 use crate::{
-    client::{chain_client, Client},
+    client::chain_client,
     data_types::{ChainInfo, ChainInfoQuery},
     environment::Environment,
+    local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
     LocalNodeError,
@@ -131,21 +131,29 @@ impl CommunicateAction {
     }
 }
 
-pub struct ValidatorUpdater<Env>
+/// Pushes data to a single validator to bring it up to date with the local node.
+///
+/// This deliberately holds a [`LocalNodeClient`] rather than a full client: updating another
+/// node must not mutate the client's own state. When a validator turns out to be *ahead* of the
+/// local node, the updater signals that with [`chain_client::Error::LocalNodeLagging`] and lets
+/// the caller decide whether to pull the missing state.
+pub struct RemoteNodeUpdater<Env>
 where
     Env: Environment,
 {
     pub remote_node: RemoteNode<Env::ValidatorNode>,
-    pub client: Arc<Client<Env>>,
+    pub local_node: LocalNodeClient<Env::Storage>,
     pub admin_chain_id: ChainId,
+    pub certificate_upload_batch_size: u64,
 }
 
-impl<Env: Environment> Clone for ValidatorUpdater<Env> {
+impl<Env: Environment> Clone for RemoteNodeUpdater<Env> {
     fn clone(&self) -> Self {
-        ValidatorUpdater {
+        RemoteNodeUpdater {
             remote_node: self.remote_node.clone(),
-            client: self.client.clone(),
+            local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
+            certificate_upload_batch_size: self.certificate_upload_batch_size,
         }
     }
 }
@@ -327,7 +335,7 @@ where
     })
 }
 
-impl<Env> ValidatorUpdater<Env>
+impl<Env> RemoteNodeUpdater<Env>
 where
     Env: Environment + 'static,
 {
@@ -377,11 +385,7 @@ where
                     self.remote_node
                         .check_blobs_not_found(certificate, &blob_ids)?;
                     // The certificate is confirmed, so the blobs must be in storage.
-                    let maybe_blobs = self
-                        .client
-                        .local_node
-                        .read_blobs_from_storage(&blob_ids)
-                        .await?;
+                    let maybe_blobs = self.local_node.read_blobs_from_storage(&blob_ids).await?;
                     let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
                     self.remote_node
                         .node
@@ -421,7 +425,6 @@ where
                 // The certificate is for a validated block, i.e. for our locking block.
                 // Take the missing blobs from our local chain manager.
                 let blobs = self
-                    .client
                     .local_node
                     .get_locking_blobs(blob_ids, chain_id)
                     .await?
@@ -471,7 +474,11 @@ where
         Ok(result?)
     }
 
-    /// Synchronizes either the local node or the remote node, if one of them is lagging behind.
+    /// Sends chain information to the remote node if it is the one lagging behind.
+    ///
+    /// If the error reveals that the *local* node is behind instead, returns
+    /// [`chain_client::Error::LocalNodeLagging`] carrying the original error: pulling remote
+    /// state is a client-level decision, not something updating another node may do.
     async fn sync_if_needed(
         &mut self,
         chain_id: ChainId,
@@ -484,11 +491,12 @@ where
             NodeError::WrongRound(validator_round) if *validator_round > round => {
                 tracing::debug!(
                     address, %chain_id, %validator_round, %round,
-                    "validator is at a higher round; synchronizing",
+                    "validator is at a higher round; local node needs to synchronize",
                 );
-                self.client
-                    .synchronize_chain_state_from(&self.remote_node, chain_id)
-                    .await?;
+                return Err(chain_client::Error::LocalNodeLagging {
+                    chain_id,
+                    error: Box::new(error.clone()),
+                });
             }
             NodeError::UnexpectedBlockHeight {
                 expected_block_height,
@@ -499,11 +507,12 @@ where
                     %chain_id,
                     %expected_block_height,
                     %found_block_height,
-                    "validator is at a higher height; synchronizing",
+                    "validator is at a higher height; local node needs to synchronize",
                 );
-                self.client
-                    .synchronize_chain_state_from(&self.remote_node, chain_id)
-                    .await?;
+                return Err(chain_client::Error::LocalNodeLagging {
+                    chain_id,
+                    error: Box::new(error.clone()),
+                });
             }
             NodeError::WrongRound(validator_round) if *validator_round < round => {
                 tracing::debug!(
@@ -569,7 +578,7 @@ where
         let mut sent_cross_chain_updates = BTreeMap::new();
         let mut synced_cross_chain_updates = false;
         let mut publisher_chain_ids_sent = BTreeSet::new();
-        let storage = self.client.local_node.storage_client();
+        let storage = self.local_node.storage_client();
         loop {
             let local_time = storage.clock().current_time();
             match self
@@ -722,7 +731,6 @@ where
                     ensure!(!chain_ids.is_empty(), NodeError::EventsNotFound(event_ids));
                     for chain_id in chain_ids {
                         let height = self
-                            .client
                             .local_node
                             .get_next_height_to_preprocess(chain_id)
                             .await?;
@@ -738,27 +746,22 @@ where
                 Err(error @ NodeError::ChainError { .. }) => {
                     // The validator rejected the proposal because of its local chain
                     // manager state — most commonly an incompatible confirmed vote tied
-                    // to a locking block we don't yet have. Pull manager values from
-                    // this validator so the local node absorbs whatever justified the
-                    // rejection (signatures are checked locally, so the source can't
-                    // fool us), then surface the error. If our local state actually
-                    // advanced, `execute_operations` will rebuild and re-propose; if
+                    // to a locking block we don't yet have. The caller should pull
+                    // manager values from this validator so the local node absorbs
+                    // whatever justified the rejection; if the local state actually
+                    // advances, `execute_operations` will rebuild and re-propose; if
                     // not, the error propagates as usual.
                     self.warn_if_unexpected(&error);
                     tracing::debug!(
                         remote_node = self.remote_node.address(),
                         %chain_id,
                         %error,
-                        "validator rejected proposal; pulling manager state",
+                        "validator rejected proposal; manager state needs to be pulled",
                     );
-                    if let Err(sync_err) = self
-                        .client
-                        .synchronize_chain_state_from(&self.remote_node, chain_id)
-                        .await
-                    {
-                        tracing::debug!(%sync_err, "failed to pull manager state from validator");
-                    }
-                    return Err(error.into());
+                    return Err(chain_client::Error::LocalNodeLagging {
+                        chain_id,
+                        error: Box::new(error),
+                    });
                 }
                 Err(NodeError::BlobsNotFound(_) | NodeError::InactiveChain(_))
                     if !blob_ids.is_empty() =>
@@ -771,7 +774,6 @@ where
                         BTreeSet::from_iter(proposal.content.block.published_blob_ids());
                     blob_ids.retain(|blob_id| !published_blob_ids.contains(blob_id));
                     let published_blobs = self
-                        .client
                         .local_node
                         .get_proposed_blobs(chain_id, published_blob_ids.into_iter().collect())
                         .await?;
@@ -801,11 +803,7 @@ where
     }
 
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
-        let local_admin_info = self
-            .client
-            .local_node
-            .chain_info(self.admin_chain_id)
-            .await?;
+        let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
         Box::pin(self.send_chain_information(
             self.admin_chain_id,
             local_admin_info.next_block_height,
@@ -881,7 +879,7 @@ where
         // the consensus round at this height.
         let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
         let query = ChainInfoQuery::new(chain_id).with_manager_values();
-        let local_info = match self.client.local_node.handle_chain_info_query(query).await {
+        let local_info = match self.local_node.handle_chain_info_query(query).await {
             Ok(response) => response.info,
             // If we don't have the full chain description locally, we can't help the
             // validator with round synchronization. This is not an error - the validator
@@ -960,7 +958,7 @@ where
             return Ok(info);
         }
 
-        let batch_size = self.client.options().certificate_upload_batch_size as usize;
+        let batch_size = self.certificate_upload_batch_size as usize;
         for chunk in heights.chunks(batch_size) {
             let certificates = self
                 .read_certificates_for_heights(chain_id, chunk.to_vec())
@@ -993,7 +991,7 @@ where
         chain_id: ChainId,
         heights: Vec<BlockHeight>,
     ) -> Result<Vec<CacheArc<GenericCertificate<ConfirmedBlock>>>, chain_client::Error> {
-        let storage = self.client.local_node.storage_client();
+        let storage = self.local_node.storage_client();
 
         // First, try the direct height-based lookup
         let certificates_by_height = storage
@@ -1010,7 +1008,6 @@ where
 
         // Fallback to the traditional approach
         let hashes = self
-            .client
             .local_node
             .get_block_hashes(chain_id, heights.clone())
             .await?;
@@ -1161,7 +1158,6 @@ where
         delivery: CrossChainMessageDelivery,
     ) -> Result<(), chain_client::Error> {
         let blob_states = self
-            .client
             .local_node
             .read_blob_states_from_storage(blob_ids)
             .await?;
@@ -1197,7 +1193,6 @@ where
                 // Get all block hashes for this chain at the specified heights in one call
                 let heights_vec = heights.into_iter().collect::<Vec<_>>();
                 let certificates = updater
-                    .client
                     .local_node
                     .storage_client()
                     .read_certificates_by_heights(chain_id, &heights_vec)

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -432,7 +432,7 @@ where
                 self.remote_node.send_pending_blobs(chain_id, blobs).await?;
             }
             Err(error) => {
-                self.sync_if_needed(
+                self.sync_remote_if_needed(
                     chain_id,
                     certificate.round,
                     certificate.block().header.height,
@@ -468,7 +468,8 @@ where
             .handle_chain_info_query(query.clone())
             .await;
         if let Err(err) = &result {
-            self.sync_if_needed(chain_id, round, height, err).await?;
+            self.sync_remote_if_needed(chain_id, round, height, err)
+                .await?;
             self.warn_if_unexpected(err);
         }
         Ok(result?)
@@ -479,7 +480,7 @@ where
     /// If the error reveals that the *local* node is behind instead, returns
     /// [`chain_client::Error::LocalNodeLagging`] carrying the original error: pulling remote
     /// state is a client-level decision, not something updating another node may do.
-    async fn sync_if_needed(
+    async fn sync_remote_if_needed(
         &mut self,
         chain_id: ChainId,
         round: Round,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2034,7 +2034,7 @@ fn main() -> anyhow::Result<process::ExitCode> {
         builder
     };
 
-    // The default stack size 2 MiB causes some stack overflows in ValidatorUpdater methods.
+    // The default stack size 2 MiB causes some stack overflows in RemoteNodeUpdater methods.
     runtime.thread_stack_size(4 << 20);
     if let Some(blocking_threads) = options.common.tokio_blocking_threads {
         runtime.max_blocking_threads(blocking_threads);


### PR DESCRIPTION
## Motivation

Since #4912, `ValidatorUpdater` holds a full `Arc<Client>` instead of a `LocalNodeClient`. That was a concession made so the updater could call `Client::synchronize_chain_state_from` when a validator turns out to be *ahead* of the local node. It breaks modularity: a component whose job is to bring another node up to date can silently mutate the client's own state (download and process certificates, manager values, and blobs) as a side effect.

## Proposal

Make the updater hold only what it needs: a `RemoteNode`, a `LocalNodeClient`, the admin chain id, and the certificate upload batch size. The struct is renamed to `RemoteNodeUpdater` accordingly, since nothing in it is validator-specific.

The three call sites that pulled remote state through the client — the two "validator is ahead" arms of `sync_if_needed` and the `ChainError` arm of `send_block_proposal` — now return a new signal, `chain_client::Error::LocalNodeLagging { chain_id, error }`, carrying the validator error that revealed the lag. The push half of `sync_if_needed` (validator behind → send chain information) stays in the updater and needs only the local node.

The signal is handled in the per-validator closure of `Client::communicate_chain_action`, by the new `Client::sync_and_retry_chain_update`, which reproduces the previous per-site behavior:

- `SubmitBlock` (`ChainError`): pull the manager state best-effort (failures only logged), then surface the validator's rejection either way, as before.
- `RequestTimeout`: pull the missing state, then surface the original error so the outer logic reacts on top of the refreshed local state.
- `FinalizeBlock`: pull the missing state, then retry the action once. A second `LocalNodeLagging` on the retry surfaces the carried error, so there is no loop.

`communicate_chain_updates` needs no handling: `send_chain_information` never produces the signal. Since the closures were the updater's only consumers, `Client::options()` became dead and is removed.

One deliberate nuance: the `FinalizeBlock` retry now re-enters through `send_chain_update`, i.e. via `handle_optimized_validated_certificate`, rather than the bare `handle_validated_certificate` call the old in-place retry used — same outcome, one extra lite-certificate optimization attempt.

This restores the pre-#4912 boundary: pulling state is now visibly a client-level decision, made where the client already owns its state transitions, and the updater can no longer mutate client state at all.

## Test Plan

```
cargo test -p linera-core --lib      # 162 passed, 0 failed
cargo clippy -p linera-core --lib --all-features
cargo clippy --locked -p linera-core --no-default-features
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p linera-core --all-features
cargo +nightly fmt -- --check
bash scripts/check_chain_loads.sh
```

The #4912 regression test `test_request_leader_timeout_client_behind_validators` passes, covering the `RequestTimeout` path of the relocated synchronization.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #4912 introduced the `Arc<Client>` dependency this removes.
- #6624 extracts the confirmed-certificate push path from the same file; the two conflict trivially in `updater.rs`, and whichever lands second rebases mechanically.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
