### PR TITLE
linera-core: collect LocalNodeLagging reports and pull after the quorum round

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2077,17 +2077,19 @@ impl<Env: Environment> ChainClient<Env> {
                 return Err(err);
             };
             if current == snapshot {
-                // The lazy per-validator pull on rejection (`Updater::send_block_proposal`) can be
-                // raced out: `communicate_with_quorum` breaks as soon as a quorum is impossible and
-                // drops the still-in-flight `synchronize_chain_state_from` calls, so a locking block
-                // held only by the slower-to-respond validators is never absorbed. Fall back once to
-                // an explicit quorum sync — guaranteed to reach a lock-holder — and retry if it
-                // absorbed anything; otherwise the rejection was genuine, so propagate it.
+                // The post-quorum pull on rejection (`Client::process_lag_reports`) only covers
+                // validators whose rejection was actually received: `communicate_with_quorum`
+                // breaks as soon as a quorum is impossible and drops still-in-flight requests, so
+                // a locking block held only by the slower-to-respond validators is never even
+                // reported. Fall back once to an explicit quorum sync — guaranteed to reach a
+                // lock-holder — and retry if it absorbed anything; otherwise the rejection was
+                // genuine, so propagate it.
                 //
-                // TODO(#6453): this fallback path has no deterministic regression test yet — forcing
-                // the lazy pull to miss needs a clock-driven per-validator response delay in the test
-                // harness (building on #6448); until then it is only covered indirectly by the (now
-                // non-flaky) `test_lazy_pull_absorbs_locking_block_on_proposal_rejection`.
+                // TODO(#6453): this fallback path has no deterministic regression test yet —
+                // forcing a lock-holder's response to be dropped needs a clock-driven
+                // per-validator response delay in the test harness (building on #6448); until
+                // then it is only covered indirectly by the (now non-flaky)
+                // `test_lazy_pull_absorbs_locking_block_on_proposal_rejection`.
                 if did_fallback_sync {
                     return Err(err);
                 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1329,9 +1329,11 @@ impl<Env: Environment> Client<Env> {
     async fn process_lag_reports(&self, mut reports: Vec<LagReport<Env::ValidatorNode>>) {
         reports.sort_by_key(|report| Reverse(report.remote_progress()));
         for report in reports {
-            if let Err(error) = self
-                .synchronize_chain_state_from(&report.remote_node, report.chain_id)
-                .await
+            // Boxed to keep this future small: the synchronization future is large, and it
+            // would otherwise be inlined into every caller of the quorum communication.
+            if let Err(error) =
+                Box::pin(self.synchronize_chain_state_from(&report.remote_node, report.chain_id))
+                    .await
             {
                 debug!(
                     remote_node = report.remote_node.address(),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    cmp::Ordering,
+    cmp::{Ordering, Reverse},
     collections::{BTreeMap, BTreeSet, HashSet},
     slice,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use custom_debug_derive::Debug;
@@ -1313,45 +1313,32 @@ impl<Env: Environment> Client<Env> {
         }
     }
 
-    /// Handles a [`chain_client::Error::LocalNodeLagging`] signal from a [`RemoteNodeUpdater`]:
-    /// pulls the missing chain state from the validator that turned out to be ahead of us, then
-    /// either retries the action once (when finalizing a block) or surfaces the validator's
-    /// original error so the outer logic can rebuild on top of the refreshed local state.
-    async fn sync_and_retry_chain_update(
-        self: &Arc<Self>,
-        mut updater: RemoteNodeUpdater<Env>,
-        action: CommunicateAction,
-        chain_id: ChainId,
-        error: NodeError,
-    ) -> Result<LiteVote, chain_client::Error> {
-        match &action {
-            CommunicateAction::SubmitBlock { .. } => {
-                // Pull the manager state that justified the proposal's rejection (signatures
-                // are checked locally, so the source can't fool us), best-effort, and surface
-                // the rejection either way. If our local state actually advanced,
-                // `execute_operations` will rebuild and re-propose.
-                if let Err(sync_err) = self
-                    .synchronize_chain_state_from(&updater.remote_node, chain_id)
-                    .await
-                {
-                    debug!(%sync_err, "failed to pull manager state from validator");
-                }
-                Err(error.into())
-            }
-            CommunicateAction::RequestTimeout { .. } => {
-                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
-                    .await?;
-                Err(error.into())
-            }
-            CommunicateAction::FinalizeBlock { .. } => {
-                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
-                    .await?;
-                match updater.send_chain_update(action).await {
-                    Err(chain_client::Error::LocalNodeLagging { error, .. }) => {
-                        Err((*error).into())
-                    }
-                    result => result,
-                }
+    /// Pulls the chain state that validators reported being ahead of the local node on,
+    /// during a failed quorum round.
+    ///
+    /// Reports are processed here, after `communicate_with_quorum` returns, rather than inside
+    /// the per-validator tasks: this keeps those tasks read-only for the local node — mutually
+    /// independent and fair to each validator — and means a pull can no longer be cancelled by
+    /// the quorum's early exit. Processing is best-effort: failures are only logged, and the
+    /// quorum outcome is surfaced unchanged either way, so the outer logic reacts on top of
+    /// whatever state was absorbed (e.g. `execute_operations` rebuilds and re-proposes).
+    ///
+    /// Validators that are further ahead are pulled from first, which makes later pulls cheap,
+    /// but every reporter is visited: a proposal rejection justified by a locking block can
+    /// only be absorbed from a validator that holds that block.
+    async fn process_lag_reports(&self, mut reports: Vec<LagReport<Env::ValidatorNode>>) {
+        reports.sort_by_key(|report| Reverse(report.remote_progress()));
+        for report in reports {
+            if let Err(error) = self
+                .synchronize_chain_state_from(&report.remote_node, report.chain_id)
+                .await
+            {
+                debug!(
+                    remote_node = report.remote_node.address(),
+                    chain_id = %report.chain_id,
+                    %error,
+                    "failed to pull chain state from a validator that reported being ahead",
+                );
             }
         }
     }
@@ -1398,19 +1385,29 @@ impl<Env: Environment> Client<Env> {
         action: CommunicateAction,
         value: T,
     ) -> Result<GenericCertificate<T>, chain_client::Error> {
+        // Validators that turn out to be ahead of the local node are recorded here and pulled
+        // from after the quorum round, so that each per-validator task stays read-only for the
+        // local node. The updater's original validator error re-enters the quorum aggregation
+        // below, keeping the round's error classification unchanged.
+        let lag_reports = Mutex::new(Vec::new());
         let nodes = self.make_nodes(committee)?;
-        let ((votes_hash, votes_round), votes) = communicate_with_quorum(
+        let result = communicate_with_quorum(
             &nodes,
             committee,
             |vote: &LiteVote| (vote.value.value_hash, vote.round),
             |remote_node| {
-                let mut updater = self.remote_node_updater(remote_node);
+                let mut updater = self.remote_node_updater(remote_node.clone());
                 let action = action.clone();
+                let lag_reports = &lag_reports;
                 Box::pin(async move {
-                    match updater.send_chain_update(action.clone()).await {
+                    match updater.send_chain_update(action).await {
                         Err(chain_client::Error::LocalNodeLagging { chain_id, error }) => {
-                            self.sync_and_retry_chain_update(updater, action, chain_id, *error)
-                                .await
+                            lag_reports.lock().unwrap().push(LagReport {
+                                remote_node,
+                                chain_id,
+                                error: (*error).clone(),
+                            });
+                            Err((*error).into())
                         }
                         result => result,
                     }
@@ -1418,7 +1415,17 @@ impl<Env: Environment> Client<Env> {
             },
             self.options.quorum_grace_period,
         )
-        .await?;
+        .await;
+        let ((votes_hash, votes_round), votes) = match result {
+            Ok(quorum) => quorum,
+            Err(err) => {
+                // The round failed; absorb whatever the more advanced validators hold before
+                // surfacing the outcome, so the caller retries on top of a synchronized state.
+                self.process_lag_reports(lag_reports.into_inner().unwrap())
+                    .await;
+                return Err(err.into());
+            }
+        };
         ensure!(
             (votes_hash, votes_round) == (value.hash(), action.round()),
             chain_client::Error::UnexpectedQuorum {
@@ -2630,6 +2637,29 @@ pub struct PendingProposal {
     /// The round in which this proposal was first submitted, if any.
     #[serde(default)]
     pub round: Option<Round>,
+}
+
+/// A validator's report, collected during a quorum round, that it is ahead of the local node
+/// on a chain (a [`chain_client::Error::LocalNodeLagging`] signal from the updater).
+struct LagReport<N> {
+    remote_node: RemoteNode<N>,
+    chain_id: ChainId,
+    error: NodeError,
+}
+
+impl<N> LagReport<N> {
+    /// The height and round the validator reported being at, as far as the error reveals them.
+    /// Used to pull from the most advanced validators first.
+    fn remote_progress(&self) -> (Option<BlockHeight>, Option<Round>) {
+        match &self.error {
+            NodeError::UnexpectedBlockHeight {
+                expected_block_height,
+                ..
+            } => (Some(*expected_block_height), None),
+            NodeError::WrongRound(round) => (None, Some(*round)),
+            _ => (None, None),
+        }
+    }
 }
 
 enum ReceiveCertificateMode {


### PR DESCRIPTION
## Motivation

Follow-up to #6645. The `LocalNodeLagging` signal introduced there is still handled *inside* each per-validator task of `communicate_with_quorum`: the task pulls the missing chain state from its validator before returning. That has two drawbacks. The pull mutates the local node concurrently with the other validators' tasks, which are reading it mid-push — so the tasks are not independent, and the recovery a validator gets depends on scheduling. And a pull can be silently cancelled: `communicate_with_quorum` drops in-flight tasks as soon as the round is decided, which is the race the fallback sync in `process_pending_block` (#6453) works around.

## Proposal

Process the lag reports outside the quorum round. The per-validator closure in `Client::communicate_chain_action` now only *records* a `LagReport { remote_node, chain_id, error }` and feeds the carried original validator error back into the quorum aggregation — so each per-validator task is read-only for the local node, mutually independent and fair to each validator, and the round's `Trusted`/`Sample` error classification is unchanged. If the round fails, the new `Client::process_lag_reports` pulls the missing state from the reporting validators before the outcome is surfaced: most advanced first (making later pulls cheap), but visiting every reporter, since a proposal rejection justified by a locking block can only be absorbed from a validator that holds it. A pull can no longer be cancelled by the quorum's early exit. `Client::sync_and_retry_chain_update` and its per-action cases dissolve into this one method.

Three deliberate behavior changes, each in the direction of simplicity:

- After a pull, the action is no longer retried in-round (previously `FinalizeBlock` retried once). A validator that is ahead has either moved to a later round — our validated certificate is stale — or past the height — the block is already confirmed, and the pull delivers it to us. The in-round retry therefore practically never produced a vote; the outer logic re-drives on top of the synchronized state in both cases.
- Pulls happen only when the quorum round fails. On a successful round the reports are dropped: the caller is waiting for its certificate, and a minority laggard catches up through the usual channels.
- Pulls are best-effort in all cases: failures are logged and the round's original error is surfaced (previously a `RequestTimeout` sync failure replaced the validator's error).

The fallback sync in `process_pending_block` stays, with its comment updated: the quorum's early exit can still drop a slow validator's *response* entirely, in which case no report exists and only a full quorum sync reaches the lock-holder. This change narrows the #6453 race to that response-dropped case.

## Test Plan

```
cargo test -p linera-core --lib      # 162 passed, 0 failed
cargo clippy -p linera-core --lib --all-features
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p linera-core --all-features
cargo +nightly fmt -- --check
```

`test_request_leader_timeout_client_behind_validators` covers the timeout path through the new post-quorum processing.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6645 introduced the `LocalNodeLagging` signal this builds on.
- #6646 is the `main` port of #6645 and includes this change.
- #6453 tracks the deterministic test for the (now narrowed) fallback race.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
