### PR TITLE
linera-core: have the updater hold only a local node, signaling LocalNodeLagging instead of pulling chain state

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -75,7 +75,7 @@ use crate::{
         ValidatorNodeProvider as _,
     },
     remote_node::RemoteNode,
-    updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
+    updater::{communicate_with_quorum, CommunicateAction, CommunicationError},
     worker::{Notification, Reason, WorkerError},
 };
 
@@ -250,6 +250,14 @@ pub enum Error {
 
     #[error("Remote node operation failed: {0}")]
     RemoteNodeError(#[from] NodeError),
+
+    /// A validator reported state ahead of the local node for this chain. The caller may pull
+    /// the missing state from that validator, then retry or surface the carried error.
+    #[error("The local node is lagging behind a validator on chain {chain_id}: {error}")]
+    LocalNodeLagging {
+        chain_id: ChainId,
+        error: Box<NodeError>,
+    },
 
     #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
@@ -2054,8 +2062,8 @@ impl<Env: Environment> ChainClient<Env> {
                 return Err(err);
             };
             if current == snapshot {
-                // The lazy per-validator pull on rejection (`Updater::send_block_proposal`) can be
-                // raced out: `communicate_with_quorum` breaks as soon as a quorum is impossible and
+                // The lazy per-validator pull on rejection (`Client::sync_and_retry_chain_update`)
+                // can be raced out: `communicate_with_quorum` breaks as soon as a quorum is impossible and
                 // drops the still-in-flight `synchronize_chain_state_from` calls, so a locking block
                 // held only by the slower-to-respond validators is never absorbed. Fall back once to
                 // an explicit quorum sync — guaranteed to reach a lock-holder — and retry if it
@@ -3474,11 +3482,9 @@ impl<Env: Environment> ChainClient<Env> {
         node: Env::ValidatorNode,
     ) -> Result<(), Error> {
         let local_next_block_height = self.chain_info().await?.next_block_height;
-        let mut updater = ValidatorUpdater {
-            remote_node: RemoteNode { public_key, node },
-            client: self.client.clone(),
-            admin_chain_id: self.client.admin_chain_id,
-        };
+        let mut updater = self
+            .client
+            .remote_node_updater(RemoteNode { public_key, node });
         updater
             .send_chain_information(
                 self.chain_id,

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -57,7 +57,7 @@ use crate::{
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode as _, ValidatorNodeProvider as _},
     notifier::{ChannelNotifier, Notifier as _},
     remote_node::RemoteNode,
-    updater::{communicate_with_quorum, CommunicateAction, ValidatorUpdater},
+    updater::{communicate_with_quorum, CommunicateAction, RemoteNodeUpdater},
     worker::{Notification, ProcessableCertificate, Reason, WorkerError, WorkerState},
     ChainWorkerConfig, ProcessConfirmedBlockMode, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
@@ -487,10 +487,6 @@ impl<Env: Environment> Client<Env> {
     /// Returns the provider used to connect to validator nodes.
     pub fn validator_node_provider(&self) -> &Env::Network {
         self.environment.network()
-    }
-
-    pub(crate) fn options(&self) -> &chain_client::Options {
-        &self.options
     }
 
     /// Handles any pending local cross-chain requests, notifying subscribers.
@@ -1432,6 +1428,62 @@ impl<Env: Environment> Client<Env> {
         Ok(certificate)
     }
 
+    /// Creates a [`RemoteNodeUpdater`] for the given validator, backed by our local node.
+    fn remote_node_updater(
+        &self,
+        remote_node: RemoteNode<Env::ValidatorNode>,
+    ) -> RemoteNodeUpdater<Env> {
+        RemoteNodeUpdater {
+            remote_node,
+            local_node: self.local_node.clone(),
+            admin_chain_id: self.admin_chain_id,
+            certificate_upload_batch_size: self.options.certificate_upload_batch_size,
+        }
+    }
+
+    /// Handles a [`chain_client::Error::LocalNodeLagging`] signal from a [`RemoteNodeUpdater`]:
+    /// pulls the missing chain state from the validator that turned out to be ahead of us, then
+    /// either retries the action once (when finalizing a block) or surfaces the validator's
+    /// original error so the outer logic can rebuild on top of the refreshed local state.
+    async fn sync_and_retry_chain_update(
+        self: &Arc<Self>,
+        mut updater: RemoteNodeUpdater<Env>,
+        action: CommunicateAction,
+        chain_id: ChainId,
+        error: NodeError,
+    ) -> Result<LiteVote, chain_client::Error> {
+        match &action {
+            CommunicateAction::SubmitBlock { .. } => {
+                // Pull the manager state that justified the proposal's rejection (signatures
+                // are checked locally, so the source can't fool us), best-effort, and surface
+                // the rejection either way. If our local state actually advanced,
+                // `execute_operations` will rebuild and re-propose.
+                if let Err(sync_err) = self
+                    .synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await
+                {
+                    debug!(%sync_err, "failed to pull manager state from validator");
+                }
+                Err(error.into())
+            }
+            CommunicateAction::RequestTimeout { .. } => {
+                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await?;
+                Err(error.into())
+            }
+            CommunicateAction::FinalizeBlock { .. } => {
+                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await?;
+                match updater.send_chain_update(action).await {
+                    Err(chain_client::Error::LocalNodeLagging { error, .. }) => {
+                        Err((*error).into())
+                    }
+                    result => result,
+                }
+            }
+        }
+    }
+
     /// Broadcasts certified blocks to validators.
     #[instrument(level = "trace", skip_all, fields(chain_id, block_height, delivery))]
     async fn communicate_chain_updates(
@@ -1448,11 +1500,7 @@ impl<Env: Environment> Client<Env> {
             committee,
             |_: &()| (),
             |remote_node| {
-                let mut updater = ValidatorUpdater {
-                    remote_node,
-                    client: self.clone(),
-                    admin_chain_id: self.admin_chain_id,
-                };
+                let mut updater = self.remote_node_updater(remote_node);
                 let certificate = latest_certificate.clone();
                 Box::pin(async move {
                     updater
@@ -1496,13 +1544,17 @@ impl<Env: Environment> Client<Env> {
                 )
             },
             |remote_node| {
-                let mut updater = ValidatorUpdater {
-                    remote_node,
-                    client: self.clone(),
-                    admin_chain_id: self.admin_chain_id,
-                };
+                let mut updater = self.remote_node_updater(remote_node);
                 let action = action.clone();
-                Box::pin(async move { updater.send_chain_update(action).await })
+                Box::pin(async move {
+                    match updater.send_chain_update(action.clone()).await {
+                        Err(chain_client::Error::LocalNodeLagging { chain_id, error }) => {
+                            self.sync_and_retry_chain_update(updater, action, chain_id, *error)
+                                .await
+                        }
+                        result => result,
+                    }
+                })
             },
             self.options.quorum_grace_period,
         )

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -7,7 +7,6 @@ use std::{
     fmt,
     hash::Hash,
     mem,
-    sync::Arc,
 };
 
 use futures::{future, Future, StreamExt};
@@ -30,9 +29,10 @@ use tokio::sync::mpsc;
 use tracing::{instrument, Level};
 
 use crate::{
-    client::{chain_client, Client},
+    client::chain_client,
     data_types::{ChainInfo, ChainInfoQuery},
     environment::Environment,
+    local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
     LocalNodeError,
@@ -131,21 +131,29 @@ impl CommunicateAction {
     }
 }
 
-pub struct ValidatorUpdater<Env>
+/// Pushes data to a single validator to bring it up to date with the local node.
+///
+/// This deliberately holds a [`LocalNodeClient`] rather than a full client: updating another
+/// node must not mutate the client's own state. When a validator turns out to be *ahead* of the
+/// local node, the updater signals that with [`chain_client::Error::LocalNodeLagging`] and lets
+/// the caller decide whether to pull the missing state.
+pub struct RemoteNodeUpdater<Env>
 where
     Env: Environment,
 {
     pub remote_node: RemoteNode<Env::ValidatorNode>,
-    pub client: Arc<Client<Env>>,
+    pub local_node: LocalNodeClient<Env::Storage>,
     pub admin_chain_id: ChainId,
+    pub certificate_upload_batch_size: usize,
 }
 
-impl<Env: Environment> Clone for ValidatorUpdater<Env> {
+impl<Env: Environment> Clone for RemoteNodeUpdater<Env> {
     fn clone(&self) -> Self {
-        ValidatorUpdater {
+        RemoteNodeUpdater {
             remote_node: self.remote_node.clone(),
-            client: self.client.clone(),
+            local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
+            certificate_upload_batch_size: self.certificate_upload_batch_size,
         }
     }
 }
@@ -310,7 +318,7 @@ where
     })
 }
 
-impl<Env> ValidatorUpdater<Env>
+impl<Env> RemoteNodeUpdater<Env>
 where
     Env: Environment + 'static,
 {
@@ -361,11 +369,7 @@ where
                     let cert: &ConfirmedBlockCertificate = certificate;
                     self.remote_node.check_blobs_not_found(cert, &blob_ids)?;
                     // The certificate is confirmed, so the blobs must be in storage.
-                    let maybe_blobs = self
-                        .client
-                        .local_node
-                        .read_blobs_from_storage(&blob_ids)
-                        .await?;
+                    let maybe_blobs = self.local_node.read_blobs_from_storage(&blob_ids).await?;
                     let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
                     self.remote_node
                         .node
@@ -379,7 +383,7 @@ where
                     // bytes. Upload each from local storage; the worker's
                     // trust-mark accept path lets them through regardless of their
                     // (possibly revoked) epoch.
-                    let storage = self.client.local_node.storage_client();
+                    let storage = self.local_node.storage_client();
                     let certificates = storage.read_certificates(&hashes).await?;
                     for (hash, maybe_cert) in hashes.iter().zip(certificates) {
                         let cert = maybe_cert.ok_or_else(|| {
@@ -423,7 +427,6 @@ where
                 // The certificate is for a validated block, i.e. for our locking block.
                 // Take the missing blobs from our local chain manager.
                 let blobs = self
-                    .client
                     .local_node
                     .get_locking_blobs(blob_ids, chain_id)
                     .await?
@@ -473,7 +476,11 @@ where
         Ok(result?)
     }
 
-    /// Synchronizes either the local node or the remote node, if one of them is lagging behind.
+    /// Sends chain information to the remote node if it is the one lagging behind.
+    ///
+    /// If the error reveals that the *local* node is behind instead, returns
+    /// [`chain_client::Error::LocalNodeLagging`] carrying the original error: pulling remote
+    /// state is a client-level decision, not something updating another node may do.
     async fn sync_if_needed(
         &mut self,
         chain_id: ChainId,
@@ -486,11 +493,12 @@ where
             NodeError::WrongRound(validator_round) if *validator_round > round => {
                 tracing::debug!(
                     address, %chain_id, %validator_round, %round,
-                    "validator is at a higher round; synchronizing",
+                    "validator is at a higher round; local node needs to synchronize",
                 );
-                self.client
-                    .synchronize_chain_state_from(&self.remote_node, chain_id)
-                    .await?;
+                return Err(chain_client::Error::LocalNodeLagging {
+                    chain_id,
+                    error: Box::new(error.clone()),
+                });
             }
             NodeError::UnexpectedBlockHeight {
                 expected_block_height,
@@ -501,11 +509,12 @@ where
                     %chain_id,
                     %expected_block_height,
                     %found_block_height,
-                    "validator is at a higher height; synchronizing",
+                    "validator is at a higher height; local node needs to synchronize",
                 );
-                self.client
-                    .synchronize_chain_state_from(&self.remote_node, chain_id)
-                    .await?;
+                return Err(chain_client::Error::LocalNodeLagging {
+                    chain_id,
+                    error: Box::new(error.clone()),
+                });
             }
             NodeError::WrongRound(validator_round) if *validator_round < round => {
                 tracing::debug!(
@@ -567,7 +576,7 @@ where
         let chain_id = proposal.content.block.chain_id;
         let mut sent_cross_chain_updates = BTreeMap::new();
         let mut publisher_chain_ids_sent = BTreeSet::new();
-        let storage = self.client.local_node.storage_client();
+        let storage = self.local_node.storage_client();
         loop {
             let local_time = storage.clock().current_time();
             match self
@@ -653,7 +662,6 @@ where
                     ensure!(!chain_ids.is_empty(), NodeError::EventsNotFound(event_ids));
                     for chain_id in chain_ids {
                         let height = self
-                            .client
                             .local_node
                             .get_next_height_to_preprocess(chain_id)
                             .await?;
@@ -669,27 +677,22 @@ where
                 Err(error @ NodeError::ChainError { .. }) => {
                     // The validator rejected the proposal because of its local chain
                     // manager state — most commonly an incompatible confirmed vote tied
-                    // to a locking block we don't yet have. Pull manager values from
-                    // this validator so the local node absorbs whatever justified the
-                    // rejection (signatures are checked locally, so the source can't
-                    // fool us), then surface the error. If our local state actually
-                    // advanced, `execute_operations` will rebuild and re-propose; if
+                    // to a locking block we don't yet have. The caller should pull
+                    // manager values from this validator so the local node absorbs
+                    // whatever justified the rejection; if the local state actually
+                    // advances, `execute_operations` will rebuild and re-propose; if
                     // not, the error propagates as usual.
                     self.warn_if_unexpected(&error);
                     tracing::debug!(
                         remote_node = self.remote_node.address(),
                         %chain_id,
                         %error,
-                        "validator rejected proposal; pulling manager state",
+                        "validator rejected proposal; manager state needs to be pulled",
                     );
-                    if let Err(sync_err) = self
-                        .client
-                        .synchronize_chain_state_from(&self.remote_node, chain_id)
-                        .await
-                    {
-                        tracing::debug!(%sync_err, "failed to pull manager state from validator");
-                    }
-                    return Err(error.into());
+                    return Err(chain_client::Error::LocalNodeLagging {
+                        chain_id,
+                        error: Box::new(error),
+                    });
                 }
                 Err(NodeError::BlobsNotFound(_) | NodeError::InactiveChain(_))
                     if !blob_ids.is_empty() =>
@@ -702,7 +705,6 @@ where
                         BTreeSet::from_iter(proposal.content.block.published_blob_ids());
                     blob_ids.retain(|blob_id| !published_blob_ids.contains(blob_id));
                     let published_blobs = self
-                        .client
                         .local_node
                         .get_proposed_blobs(chain_id, published_blob_ids.into_iter().collect())
                         .await?;
@@ -761,11 +763,7 @@ where
     }
 
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
-        let local_admin_info = self
-            .client
-            .local_node
-            .chain_info(self.admin_chain_id)
-            .await?;
+        let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
         Box::pin(self.send_chain_information(
             self.admin_chain_id,
             local_admin_info.next_block_height,
@@ -825,7 +823,7 @@ where
         // the consensus round at this height.
         let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
         let query = ChainInfoQuery::new(chain_id).with_manager_values();
-        let local_info = match self.client.local_node.handle_chain_info_query(query).await {
+        let local_info = match self.local_node.handle_chain_info_query(query).await {
             Ok(response) => response.info,
             // If we don't have the full chain description locally, we can't help the
             // validator with round synchronization. This is not an error - the validator
@@ -906,7 +904,7 @@ where
             return Ok(info);
         }
 
-        let batch_size = self.client.options().certificate_upload_batch_size;
+        let batch_size = self.certificate_upload_batch_size;
         for chunk in heights.chunks(batch_size) {
             let certificates = self
                 .read_certificates_for_heights(chain_id, chunk.to_vec())
@@ -927,7 +925,7 @@ where
         chain_id: ChainId,
         heights: Vec<BlockHeight>,
     ) -> Result<Vec<CacheArc<ConfirmedBlockCertificate>>, chain_client::Error> {
-        let storage = self.client.local_node.storage_client();
+        let storage = self.local_node.storage_client();
 
         let certificates_by_height = storage
             .read_certificates_by_heights(chain_id, &heights)
@@ -951,7 +949,6 @@ where
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let local_query = ChainInfoQuery::new(chain_id).with_latest_checkpoint_height();
         let local_info = self
-            .client
             .local_node
             .handle_chain_info_query(local_query)
             .await?
@@ -1100,7 +1097,6 @@ where
         delivery: CrossChainMessageDelivery,
     ) -> Result<(), chain_client::Error> {
         let blob_states = self
-            .client
             .local_node
             .read_blob_states_from_storage(blob_ids)
             .await?;
@@ -1143,7 +1139,6 @@ where
                 // Get all block hashes for this chain at the specified heights in one call
                 let heights_vec = heights.into_iter().collect::<Vec<_>>();
                 let certificates = updater
-                    .client
                     .local_node
                     .storage_client()
                     .read_certificates_by_heights(chain_id, &heights_vec)

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -434,7 +434,7 @@ where
                 self.remote_node.send_pending_blobs(chain_id, blobs).await?;
             }
             Err(error) => {
-                self.sync_if_needed(
+                self.sync_remote_if_needed(
                     chain_id,
                     certificate.round,
                     certificate.block().header.height,
@@ -470,7 +470,8 @@ where
             .handle_chain_info_query(query.clone())
             .await;
         if let Err(err) = &result {
-            self.sync_if_needed(chain_id, round, height, err).await?;
+            self.sync_remote_if_needed(chain_id, round, height, err)
+                .await?;
             self.warn_if_unexpected(err);
         }
         Ok(result?)
@@ -481,7 +482,7 @@ where
     /// If the error reveals that the *local* node is behind instead, returns
     /// [`chain_client::Error::LocalNodeLagging`] carrying the original error: pulling remote
     /// state is a client-level decision, not something updating another node may do.
-    async fn sync_if_needed(
+    async fn sync_remote_if_needed(
         &mut self,
         chain_id: ChainId,
         round: Round,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2190,7 +2190,7 @@ fn main() -> anyhow::Result<process::ExitCode> {
         builder
     };
 
-    // The default stack size 2 MiB causes some stack overflows in ValidatorUpdater methods.
+    // The default stack size 2 MiB causes some stack overflows in RemoteNodeUpdater methods.
     runtime.thread_stack_size(4 << 20);
     if let Some(blocking_threads) = options.common.tokio_blocking_threads {
         runtime.max_blocking_threads(blocking_threads);


### PR DESCRIPTION
## Motivation

Port of #6645 to `main`.

Since #4912, the updater holds a full `Arc<Client>` instead of a `LocalNodeClient`. That was a concession made so the updater could call `Client::synchronize_chain_state_from` when a validator turns out to be *ahead* of the local node. It breaks modularity: a component whose job is to bring another node up to date can silently mutate the client's own state (download and process certificates, manager values, and blobs) as a side effect.

## Proposal

Make the updater hold only what it needs: a `RemoteNode`, a `LocalNodeClient`, the admin chain id, and the certificate upload batch size. The struct is renamed to `RemoteNodeUpdater` accordingly, since nothing in it is validator-specific.

The three call sites that pulled remote state through the client — the two "validator is ahead" arms of `sync_if_needed` (now `sync_remote_if_needed`, since it no longer synchronizes the local node) and the `ChainError` arm of `send_block_proposal` — now return a new signal, `chain_client::Error::LocalNodeLagging { chain_id, error }`, carrying the validator error that revealed the lag. The push half of `sync_remote_if_needed` (validator behind → send chain information) stays in the updater and needs only the local node.

The signal is handled in the per-validator closure of `Client::communicate_chain_action`, by the new `Client::sync_and_retry_chain_update`, which reproduces the previous per-site behavior:

- `SubmitBlock` (`ChainError`): pull the manager state best-effort (failures only logged), then surface the validator's rejection either way, as before.
- `RequestTimeout`: pull the missing state, then surface the original error so the outer logic reacts on top of the refreshed local state.
- `FinalizeBlock`: pull the missing state, then retry the action once. A second `LocalNodeLagging` on the retry surfaces the carried error, so there is no loop.

(#6646, stacked on this PR, then moves this handling out of the per-validator tasks entirely, processing lag reports after the quorum round — the `main` port of #6647.)

`communicate_chain_updates` and `ChainClient::sync_validator` need no handling: `send_chain_information` never produces the signal. Since the closures and `sync_validator` were the updater's only consumers, `Client::options()` became dead and is removed.

Differences from the `testnet_conway` version (#6645), beyond mechanical rebasing:

- `certificate_upload_batch_size` is `usize` here, matching this branch's `Options` field.
- `ChainClient::sync_validator` (not present on `testnet_conway`) now builds the updater through the new `Client::remote_node_updater` helper.
- The checkpoint-push path (`push_checkpoint_if_useful`, the `BlocksNotFound` arm) reads through `local_node` directly.
- The lazy-pull comment in `process_pending_block` now points at the pull's new home.

One deliberate nuance: the `FinalizeBlock` retry now re-enters through `send_chain_update`, i.e. via `handle_optimized_validated_certificate`, rather than the bare `handle_validated_certificate` call the old in-place retry used — same outcome, one extra lite-certificate optimization attempt.

This restores the pre-#4912 boundary: pulling state is now visibly a client-level decision, made where the client already owns its state transitions, and the updater can no longer mutate client state at all.

## Test Plan

```
cargo test -p linera-core --lib      # 164 passed, 0 failed
cargo clippy -p linera-core --lib --all-features
cargo clippy --locked -p linera-core --no-default-features
RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p linera-core --all-features
cargo +nightly fmt -- --check
bash scripts/check_chain_loads.sh
```

The #4912 regression test `test_request_leader_timeout_client_behind_validators` covers the `RequestTimeout` path of the relocated synchronization, and `test_lazy_pull_absorbs_locking_block_on_proposal_rejection` covers the `SubmitBlock` path.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6645 (merged) is the `testnet_conway` version of this change.
- #6646, stacked on this PR, is the `main` port of the post-quorum follow-up #6647.
- #4912 introduced the `Arc<Client>` dependency this removes.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
