### PR TITLE
Backport #6633: split into linera-validator and linera-client images

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -88,6 +88,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
+          target: tests
           tags: linera-test
           load: true
           build-args: |

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -77,9 +77,15 @@ jobs:
         continue-on-error: true
         run: |
           BRANCH="${{ github.base_ref || github.ref_name }}"
-          docker pull "${GCP_REGISTRY}/linera:${BRANCH}"
+          # linera-tests, not linera: this wants the all-three-binaries image
+          # that `linera net up` needs, which is now published under that name.
+          # Pulling `linera` would keep SUCCEEDING against the tag frozen at the
+          # last pre-split build — and since this step is continue-on-error and
+          # only a failed pull falls through to building, that would silently
+          # test stale code forever instead of failing.
+          docker pull "${GCP_REGISTRY}/linera-tests:${BRANCH}"
           docker pull "${GCP_REGISTRY}/linera-exporter:${BRANCH}"
-          docker tag "${GCP_REGISTRY}/linera:${BRANCH}" linera-test
+          docker tag "${GCP_REGISTRY}/linera-tests:${BRANCH}" linera-test
           docker tag "${GCP_REGISTRY}/linera-exporter:${BRANCH}" linera-exporter
 
       - name: Build linera image

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -12,12 +12,13 @@ on:
         required: true
         type: choice
         options:
-          - main
+          - validator
+          - client
           - indexer
           - explorer
           - exporter
           - all
-        default: main
+        default: validator
       image_tag:
         description: 'Image tag (e.g., testnet_conway, a branch name, or arbitrary label)'
         required: true
@@ -94,6 +95,10 @@ jobs:
             local DOCKERFILE=$1
             local IMAGE_NAME=$2
             local BUILD_NAME=$3
+            # Optional. docker/Dockerfile now REQUIRES an explicit --target (a
+            # guard stage fails the build otherwise); the single-target
+            # Dockerfiles (indexer/explorer/exporter/bridge) pass nothing.
+            local TARGET=${4:-}
             local LOG_FILE="/tmp/build-${BUILD_NAME}.log"
 
             local IMAGE_TAGGED="${REGISTRY_BASE}/${IMAGE_NAME}:${IMAGE_TAG}"
@@ -110,6 +115,7 @@ jobs:
                 -t "${IMAGE_SHORT}" \
                 -t "${IMAGE_LONG}" \
                 -f "${DOCKERFILE}" \
+                ${TARGET:+--target "${TARGET}"} \
                 --build-arg "git_commit=${GIT_COMMIT_LONG}" \
                 --build-arg "build_date=${BUILD_DATE}" \
                 --build-arg "build_flag=${BUILD_FLAG}" \
@@ -128,7 +134,8 @@ jobs:
           build_image_by_type() {
             local TYPE=$1
             case "${TYPE}" in
-              main)     build_and_push "docker/Dockerfile"           "linera"          "main"     ;;
+              validator) build_and_push "docker/Dockerfile"          "linera-validator" "validator" "validator" ;;
+              client)   build_and_push "docker/Dockerfile"           "linera-client"   "client"   "client"  ;;
               indexer)  build_and_push "docker/Dockerfile.indexer"   "linera-indexer"  "indexer"  ;;
               explorer) build_and_push "docker/Dockerfile.explorer"  "linera-explorer" "explorer" ;;
               exporter) build_and_push "docker/Dockerfile.exporter"  "linera-exporter" "exporter" ;;
@@ -137,7 +144,7 @@ jobs:
           }
 
           if [ "${IMAGE_TYPE}" = "all" ]; then
-            TYPES="main indexer explorer exporter"
+            TYPES="validator client indexer explorer exporter"
           else
             TYPES="${IMAGE_TYPE}"
           fi

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -67,7 +67,7 @@ jobs:
 
           REGISTRY_BASE="us-docker.pkg.dev/linera-io-dev/linera-public-registry"
 
-          for IMAGE_VAR in LINERA:linera LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
+          for IMAGE_VAR in LINERA_VALIDATOR:linera-validator LINERA_CLIENT:linera-client LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
             VAR="${IMAGE_VAR%%:*}"
             NAME="${IMAGE_VAR##*:}"
             echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_TAG}" >> "$GITHUB_ENV"
@@ -127,9 +127,19 @@ jobs:
 
           echo "Starting parallel builds..."
 
+          # linera-validator: linera-server + linera-proxy. Same feature set as
+          # `linera` — this split changes which binaries ship, not features.
           build_and_push "docker/Dockerfile" \
-            "${LINERA_IMAGE_BRANCH}" "${LINERA_IMAGE_SHORT}" "${LINERA_IMAGE_LONG}" "Linera" "runtime" &
-          PID_LINERA=$!
+            "${LINERA_VALIDATOR_IMAGE_BRANCH}" "${LINERA_VALIDATOR_IMAGE_SHORT}" "${LINERA_VALIDATOR_IMAGE_LONG}" "LineraValidator" "validator" &
+          PID_LINERA_VALIDATOR=$!
+
+          # linera-client: the client binary only. Also what the validator
+          # chart's *-initializer init containers need (they run
+          # `linera storage check-existence`), so they can stop pulling the
+          # all-three image.
+          build_and_push "docker/Dockerfile" \
+            "${LINERA_CLIENT_IMAGE_BRANCH}" "${LINERA_CLIENT_IMAGE_SHORT}" "${LINERA_CLIENT_IMAGE_LONG}" "LineraClient" "client" &
+          PID_LINERA_CLIENT=$!
 
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
@@ -160,7 +170,7 @@ jobs:
 
           SUCCESS_NAMES=""
           FAILED_NAMES=""
-          for NAME_PID in Linera:$PID_LINERA LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
+          for NAME_PID in LineraValidator:$PID_LINERA_VALIDATOR LineraClient:$PID_LINERA_CLIENT LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
             if wait "$PID"; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,21 +4,43 @@
 #
 # - `git_commit` is the hash of the current git commit — used for
 #   versioning information inside the binaries.
-# - `build_date` is the date and time of when the docker image was
-#   built
-# - `binaries` is the path to the directory containing the Linera
-#   binaries. Leave unset to build the binaries from scratch.
+# - `build_date` is the date and time of when the docker image was built.
 # - `build_flag` is either "--release" or an empty string.
 # - `build_folder` is either "release" or "debug".
-# - `build_features` is a comma-separated list of features to build the binaries with.
+# - `build_features` is the feature set for EVERY target. Built WITHOUT
+#   --no-default-features, so the crate defaults (wasmer, rocksdb,
+#   storage-service) are added on top, exactly as before this file was split.
+#
+# This split changes WHICH BINARIES each image carries — deliberately NOT which
+# features they are built with. Curating features per image (dropping
+# storage-service / rocksdb from the validator) is a separate follow-up with its
+# own runtime gate, so a regression can never be ambiguous between the two.
+#
+# Targets — ALWAYS pass --target. A bare `docker build` with no --target hits
+# the `default` guard stage and fails fast (see the end of this file). Before
+# the guard existed, `tests` was the last stage and therefore the implicit
+# default, so most call sites silently paid `cargo test --no-run` of
+# linera_net_tests:
+#
+#   validator   linera-server + linera-proxy   -> linera-validator
+#   client      linera                         -> linera-client
+#   tests       all three + remote-net test binary + linera-benchmark + example wasm
+#
+# There is no combined image. Every consumer takes exactly one of the two:
+# anything running the client (the validator chart's *-initializer init
+# containers, the faucet, PM workers, CLI users) takes linera-client; anything
+# running server/proxy takes linera-validator. `tests` is the sole place needing
+# all three in one filesystem, because `linera net up` spawns linera-server and
+# linera-proxy as child processes (cli_wrappers/local_net.rs command_for_binary).
+#
+# `--target X` builds only X's FROM-chain, so a validator build never compiles
+# the client binary or the tests stage, and vice versa.
 #
 # Requires BuildKit for `RUN --mount=type=cache` (DOCKER_BUILDKIT=1, `docker buildx`,
 # or recent Docker Desktop/Engine).
 
 ARG git_commit
 ARG build_date
-ARG binaries=
-ARG copy=${binaries:+_copy}
 ARG build_flag=--release
 ARG build_folder=release
 ARG build_features=scylladb,metrics,opentelemetry,jemalloc
@@ -81,13 +103,14 @@ RUN set -e && \
         done; \
     done
 
-# ── Stage 2: builder — cook deps (cached), then build source ──
+# ── Stage 2: cook_base — shared pre-cook setup ──
+# Everything the per-binary builder stages need BEFORE `cargo chef cook`, so the
+# fragile bits (build.rs include!() inputs, examples stubs, env) are written
+# ONCE and shared by every builder. Only the cook/build RUN lines differ per
+# binary set.
 
-FROM chef AS builder_src
+FROM chef AS cook_base
 ARG git_commit
-ARG build_flag
-ARG build_folder
-ARG build_features
 ARG rustflags
 
 COPY --from=planner /app/recipe.json recipe.json
@@ -108,9 +131,17 @@ COPY --from=planner /examples-stubs examples
 ENV GIT_COMMIT=${git_commit}
 ENV RUSTFLAGS=${rustflags}
 
+# ── Stage 3a: builder_src — all three binaries, for the `tests` image only ──
+# `tests` needs the client AND server/proxy in one filesystem (linera net up
+# spawns them), so it builds them together here rather than composing the two
+# split images, which would mean three separate cargo builds for one image.
+
+FROM cook_base AS builder_src
+ARG build_flag
+ARG build_folder
+ARG build_features
+
 # Cook dependencies — cached until Cargo.toml / Cargo.lock change.
-# The three cache mounts persist cargo's registry, git deps, and the
-# compilation target/ across builds so unchanged deps never recompile.
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
@@ -121,10 +152,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --bin linera \
     ${build_features:+--features $build_features}
 
-# Copy full source and build (only changed crates recompile).
+# Copy full source and build (only changed crates recompile). target/ is a
+# cache mount — build + copy binaries OUT of it in the same RUN so they persist
+# in the image layer (cache mounts don't survive the RUN).
 COPY . .
-# target/ is a cache mount — build + copy binaries OUT of it in the same RUN
-# so they persist in the image layer (cache mounts don't survive the RUN).
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/app/target,sharing=locked \
@@ -139,23 +170,75 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         target/"$build_folder"/linera-server \
         /
 
-# Optionally copy binaries instead of using the build stage above
-FROM scratch AS builder_src_copy
-ARG binaries
-COPY \
-    "$binaries"/linera \
-    "$binaries"/linera-server \
-    "$binaries"/linera-proxy \
-    /
+# ── Stage 3b: validator_builder — the two validator binaries ──
+# Same feature set as every other stage. This PR splits WHICH BINARIES each
+# image carries, deliberately not which features they are built with: curating
+# features (dropping storage-service / rocksdb, adding --no-default-features)
+# is a separate change with its own runtime gate, so that if something breaks
+# it is never ambiguous whether the split or a feature did it.
+# The win here is that `--target validator` never builds the `linera` binary,
+# nor the tests stage.
 
-FROM builder_src$copy AS binaries
+FROM cook_base AS validator_builder
+ARG build_flag
+ARG build_folder
+ARG build_features
 
-# ── Stage 3: runtime ──
-FROM debian:bookworm-slim AS runtime
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo chef cook ${build_flag:+"$build_flag"} \
+    --recipe-path recipe.json \
+    --bin linera-proxy \
+    --bin linera-server \
+    ${build_features:+--features $build_features}
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build ${build_flag:+"$build_flag"} \
+        --bin linera-proxy \
+        --bin linera-server \
+        ${build_features:+--features $build_features} \
+    && cp \
+        target/"$build_folder"/linera-proxy \
+        target/"$build_folder"/linera-server \
+        /
+
+# ── Stage 3c: client_builder — the client binary only ──
+# Same features as everything else (see the note on validator_builder).
+# `--target client` never compiles linera-server or linera-proxy.
+
+FROM cook_base AS client_builder
+ARG build_flag
+ARG build_folder
+ARG build_features
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo chef cook ${build_flag:+"$build_flag"} \
+    --recipe-path recipe.json \
+    --bin linera \
+    ${build_features:+--features $build_features}
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    cargo build ${build_flag:+"$build_flag"} \
+        --bin linera \
+        ${build_features:+--features $build_features} \
+    && cp \
+        target/"$build_folder"/linera \
+        /
+
+# ── Stage 4: runtime_base — OS deps shared by every runtime image ──
+FROM debian:bookworm-slim AS runtime_base
 
 ARG git_commit
 LABEL git_commit=$git_commit
-
 ARG build_date
 LABEL build_date=$build_date
 
@@ -166,18 +249,39 @@ RUN apt-get update && apt-get install -y \
     && update-ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=binaries \
-    /linera \
+# ── Stage 4a: validator runtime — linera-server + linera-proxy ──
+# Published as `linera-validator`. Note the validator Helm chart also invokes
+# the CLIENT binary (`linera storage check-existence` / `initialize`) — but only
+# from init containers (linera-server-initializer, linera-proxy-initializer,
+# linera-exporter-initializer), which take their own image. Those move to
+# `linera-client`; this image does not need the client binary.
+FROM runtime_base AS validator
+COPY --from=validator_builder \
     /linera-server \
     /linera-proxy \
     ./
 
-# ── Stage 4: tests-builder — compile the remote-net integration test ──
-# Builds /linera_net_tests and /linera-benchmark; also pre-compiles all
-# example Wasm contracts so the test binary can publish them without needing
-# cargo or source code at runtime.  The test binary lives in
-# /app/target/release/deps/ (a cache mount) so it must be copied out in the
-# same RUN.
+# ── Stage 4b: client runtime — the linera client binary only ──
+# Published as `linera-client`.
+FROM runtime_base AS client
+COPY --from=client_builder \
+    /linera \
+    ./
+
+# ── Stage 4c: nothing. There is no all-three image.
+# Every consumer maps to exactly one of the two above: anything running the
+# client (validator *-initializer init containers, the faucet, PM workers, CLI
+# users) takes linera-client; anything running server/proxy takes
+# linera-validator. `tests` is the one place that needs all three in a single
+# filesystem — `linera net up` spawns linera-server/linera-proxy as child
+# processes (cli_wrappers/local_net.rs command_for_binary) — and it gets them by
+# copying from both builders below, not from a published combined image.
+
+# ── Stage 5: tests-builder — remote-net test binary + benchmark + example wasm ──
+# Builds /linera_net_tests and /linera-benchmark; also pre-compiles all example
+# Wasm contracts so the test binary can publish them without needing cargo or
+# source at runtime. The test binary lives in /app/target/release/deps/ (a cache
+# mount) so it must be copied out in the same RUN.
 
 FROM builder_src AS tests-builder
 ARG build_flag
@@ -216,12 +320,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
         -maxdepth 1 -name "*.wasm" \
         -exec cp {} /wasm-examples/ \;
 
-# ── Stage 5: tests runtime — runtime image + remote-net test binary ──
-# Used by linera-infra's network-health-check CronJob; production image
-# `linera:<tag>` (target=runtime) is unchanged. The test binary spawns
+# ── Stage 6: tests runtime — runtime image + remote-net test binary ──
+# Used by linera-infra's network-health-check CronJob. The test binary spawns
 # the linera CLI via PATH, so /linera is symlinked into /usr/local/bin.
 
-FROM runtime AS tests
+FROM runtime_base AS tests
+COPY --from=builder_src \
+    /linera \
+    /linera-server \
+    /linera-proxy \
+    ./
 RUN ln -s /linera /usr/local/bin/linera
 COPY --from=tests-builder /linera_net_tests /usr/local/bin/linera-net-tests
 COPY --from=tests-builder /linera-benchmark /usr/local/bin/linera-benchmark
@@ -237,3 +345,11 @@ RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/cargo && chmod +x /usr/local/b
 # source tree (.dockerignore strips target/) and overlay the pre-built wasm.
 COPY examples /examples
 COPY --from=tests-builder /wasm-examples/ /examples/target/wasm32-unknown-unknown/release/
+
+# ── Final stage: guard ──
+# Building with no --target used to silently build the expensive `tests` image.
+# There is no "build everything" production image — every caller must choose a
+# target. Placed last so a bare `docker build` resolves here and fails fast
+# (this stage has no builder ancestors, so chef/planner/cargo never run).
+FROM debian:bookworm-slim AS default
+RUN echo "ERROR: this Dockerfile requires an explicit --target (validator | client | tests)" >&2 && exit 1

--- a/docker/build-image.yaml
+++ b/docker/build-image.yaml
@@ -14,6 +14,11 @@ steps:
         "${_IMAGE_NAME_LONG_COMMIT}",
         "-f",
         "docker/Dockerfile",
+        # docker/Dockerfile now requires an explicit --target; without one the
+        # guard stage fails the build. `runtime` is the all-three-binaries
+        # image this config has always produced.
+        "--target",
+        "tests",
         ".",
         "--build-arg",
         "git_commit=${_GIT_COMMIT}",

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -41,11 +41,11 @@ GIT_COMMIT=$(git rev-parse --short HEAD)
 export DOCKER_BUILDKIT=1
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build --build-arg git_commit="$GIT_COMMIT" -f docker/Dockerfile . -t linera || exit 1
+    docker build --build-arg git_commit="$GIT_COMMIT" --target tests -f docker/Dockerfile . -t linera || exit 1
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
     if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera . || exit 1
+        docker build --build-arg git_commit="$GIT_COMMIT" --build-arg target=aarch64-unknown-linux-gnu --target tests -f docker/Dockerfile -t linera . || exit 1
     else
         echo "Unsupported Architecture: $CPU_ARCH"
         exit 1

--- a/docker/make-all-build.sh
+++ b/docker/make-all-build.sh
@@ -4,7 +4,7 @@ echo "Building linera images..."
 set -e
 docker build -f ./Dockerfile.indexer -t linera-indexer ..
 docker build -f ./Dockerfile.exporter -t linera-exporter ..
-docker build -f ./Dockerfile -t linera-test ..
+docker build -f ./Dockerfile --target tests -t linera-test ..
 docker build -f ./Dockerfile.explorer -t linera-explorer-new .. --build-arg VITE_API_BASE_URL=http://localhost:3002/api
 
 echo "Done building images"

--- a/scripts/deploy-validator.sh
+++ b/scripts/deploy-validator.sh
@@ -287,12 +287,13 @@ build_local_image() {
 	log INFO "Building local Docker image from commit ${git_commit}..."
 
 	if [[ "${DRY_RUN:-0}" == "1" ]]; then
-		log INFO "[DRY RUN] Would build: docker build --build-arg git_commit=${git_commit} -f docker/Dockerfile . -t ${image_tag}"
+		log INFO "[DRY RUN] Would build: docker build --build-arg git_commit=${git_commit} --target validator -f docker/Dockerfile . -t ${image_tag}"
 		return 0
 	fi
 
 	if ! docker build \
 		--build-arg git_commit="${git_commit}" \
+		--target validator \
 		-f "${REPO_ROOT}/docker/Dockerfile" \
 		"${REPO_ROOT}" \
 		-t "${image_tag}"; then


### PR DESCRIPTION
## Motivation

Backport of #6633 (merged to `main` as d1609fb) to `testnet_conway`, so next week's deploy can use
the new `linera-validator` / `linera-client` images on this branch.

## Proposal

Cherry-pick of d1609fb, plus the two adjustments this branch needs. `testnet_conway` has diverged
from `main` in ways that matter here, so this is not a clean replay:

**`build_image.yml` — resolved conflict.** Three-way was:

```
testnet_conway : TYPES="main indexer explorer exporter"                     (no bridge here)
main (before)  : TYPES="main indexer explorer exporter bridge"
main (after)   : TYPES="validator client indexer explorer exporter bridge"
```

Resolved to `TYPES="validator client indexer explorer exporter"` — takes the `main` →
`validator client` split while preserving this branch's absence of a `bridge` type (there is no
`bridge)` case in `build_image_by_type` here).

**`bridge-e2e.yml` — separate commit, and the reason it is not optional.** This branch has a
`Pull linera & exporter images` step that `main` does not have. It pulled
`${GCP_REGISTRY}/linera:${BRANCH}`, and after this backport that image is no longer published.

The tag does not disappear, though — it stays frozen at the last pre-split build. The step is
`continue-on-error: true`, and the build step below it only runs `if steps.pull-images.outcome ==
'failure'`, so a *successful* pull of a stale tag means bridge-e2e silently tests old code forever,
green. It now pulls `linera-tests:${BRANCH}`, which is where the all-three-binaries image that
`linera net up` needs actually lives.

### What did NOT need changing

- `docker/ci-compose.sh` does not exist here; the equivalent is `docker/compose.sh`, and git
  followed the rename — both of its `docker build` calls picked up `--target tests`.
- There is no `bridge` image type on this branch.

### Preserved branch-specific values

`ARG build_features` on this branch is `scylladb,metrics,opentelemetry,jemalloc` — `main` has no
`opentelemetry`. The cherry-pick kept this branch's value; that is the sort of thing a backport
silently overwrites, so it is called out explicitly.

## Test Plan

**Stage-graph closure, parsed from the Dockerfile on this branch** — the property the split rests
on, that no image compiles a binary it does not ship:

```
--target validator  ->  validator_builder      (never builder_src, never client_builder)
--target client     ->  client_builder         (never validator_builder)
--target tests      ->  builder_src, tests-builder
--target default    ->  nothing (guard stage, no builder ancestors)
```

**Every build of `docker/Dockerfile` on this branch passes a target** — the guard stage turns a
missing one into an immediate failure rather than a silent `tests` build:

| call site | target |
|---|---|
| `docker/compose.sh` (x2) | `tests` |
| `docker/make-all-build.sh` | `tests` |
| `.github/workflows/bridge-e2e.yml` (`build-push-action`) | `tests` |
| `scripts/deploy-validator.sh` | `validator` |
| `docker_image.yml` / `build_image.yml` | passed per image |

hadolint passes at the repo's `--failure-threshold error`; all three workflow files parse; the
three shell scripts pass `bash -n`.

`Docker Image` does not run on pull requests, so green PR checks here do not mean the images built.
I will dispatch it against this branch before merge — that run is the gate, exactly as it was for
#6633 on `main`, where it published all three images and the arm64 leg was proven separately.

## Release Plan

- These changes should be backported to the latest `testnet` branch — this **is** that backport.

**Coordinated change.** `linera` is no longer published from this branch either, so the floating
`linera:testnet_conway` / `linera:testnet_conway_release` tags stop moving forward. Consumers must
move to `linera-validator` / `linera-client` in step.

**Known follow-up, not in this PR** (it is a pre-existing gap on `main` too, so it gets its own
change rather than riding along here): `docker/docker-compose.yml` — the external validator
operator surface — still defaults all six services to
`linera:testnet_conway_release`, and `docker/db-v1-migration.sh` references
`linera:testnet_conway_release` / `linera:testnet_conway_db_migration`. Those services split
cleanly — `proxy` and `shard-0..3` run `linera-proxy`/`linera-server` and want
`linera-validator`; `shard-init` runs `linera storage check-existence` and wants `linera-client` —
but they currently share one `${LINERA_IMAGE}` override, so splitting them changes the documented
operator contract and needs a matching update in linera-artifacts.

## Links

- Backports #6633 (merged as d1609fb)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
