### PR TITLE
core: repair the admin chain up to the preprocess frontier, as publisher chains do

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -764,10 +764,25 @@ where
     }
 
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
-        let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
+        // The preprocess frontier, not the executed tip: we learn about a new epoch
+        // through `download_certificates_for_events`, which fetches only the
+        // event-bearing block and does not download its ancestors. That leaves a gap,
+        // and `ProcessConfirmedBlockMode::Auto` over a gap preprocesses rather than
+        // executes — so the very block carrying the committee the validator is missing
+        // sits *above* the executed tip and would be left out of the range.
+        //
+        // Preprocessed certificates are ordinary confirmed certificates: already
+        // signature-checked and written to storage before the frontier advances. The
+        // validator preprocesses anything above its own gap and writes the events
+        // either way, which is what resolves the missing committee. This mirrors the
+        // publisher-chain repair above, which uses the same height for the same reason.
+        let height = self
+            .local_node
+            .get_next_height_to_preprocess(self.admin_chain_id)
+            .await?;
         Box::pin(self.send_chain_information(
             self.admin_chain_id,
-            local_admin_info.next_block_height,
+            height,
             CrossChainMessageDelivery::NonBlocking,
             None,
         ))


### PR DESCRIPTION
## Motivation

Two sibling code paths in `updater.rs` repair a validator that reports
`EventsNotFound`, and they disagree about which local height to push up to.

Publisher chains, `updater.rs:664-671`:

```rust
let height = self
    .local_node
    .get_next_height_to_preprocess(chain_id)
    .await?;
```

Admin chain, `update_admin_chain`, `updater.rs:766-775`:

```rust
let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
Box::pin(self.send_chain_information(
    self.admin_chain_id,
    local_admin_info.next_block_height,
```

`next_height_to_preprocess()` is `max(preprocessed) + 1` falling back to the
executed tip, so it is always `>=` `next_block_height`.

Both were introduced by the **same commit** — `dfc8d4625f75`, 2025-09-08,
"Clients update validators about missing committees. (#4493)" — whose description
says:

> the validator updater is sending the wrong blocks in some cases for sparse
> event publisher chains … **Use the correct block heights.**

That diff changed the publisher path *away* from `next_block_height` for exactly
that reason, and in the same change introduced the admin path using it. `git
blame` still attributes the admin line to that commit while everything around it
has been rewritten by four later commits — the height was never revisited.

## Proposal

Use the preprocess frontier on the admin path too, making the two identical.

The reason the frontier is the right height: a client learns about a new epoch
via `download_certificates_for_events`, which fetches only the event-bearing
block and not its ancestors. Landing a certificate above the local tip means
`ProcessConfirmedBlockMode::Auto` preprocesses rather than executes, so the tip
does not move — and the block carrying the committee a lagging validator needs
would fall outside a range bounded by the tip.

Safe by construction:

- preprocessed certificates are ordinary confirmed certificates, already
  signature-checked and written to storage before the frontier advances, so
  nothing unverified can enter the range and the certificate at `frontier - 1` is
  guaranteed present;
- the receiving validator preprocesses anything above its own gap and writes the
  block's events either way, which is what resolves a missing committee;
- the frontier is always `>=` the tip, so this can only ever send *more*, never
  less — it cannot regress the current behaviour;
- volume is unchanged: `read_certificates_by_heights` returns `None` for heights
  the client lacks and those are dropped, so only certificates we actually hold
  are sent. This is the profile the publisher path has run with since 2025-09.

## Test Plan

`cargo check`, `cargo clippy --all-targets` (0 issues) and `cargo fmt --check`
all pass in both feature configurations, since `--no-default-features` turns
`with_metrics` off. The existing regression test for this area,
`test_synchronize_downloads_admin_chain_events`, still passes.

**No new test, and I want to be straight about why.** I wrote one to pin the
precondition — a second `stage_new_committee` so the epoch event lands at admin
height >= 1, then asserting the fresh client's admin frontier exceeds its
executed tip — and **it failed: both heights were 4.** `synchronize_from_validators`
on a `FullChain` admin chain syncs contiguously and executes, closing any gap the
events path opens. I could not construct a case where the two heights diverge, so
I removed the test rather than ship one asserting something I had not
demonstrated.

**So this should be read as a consistency fix, not a confirmed bug fix.** The
divergence is reachable in principle from the code paths, but I have not
reproduced it, and the obvious client flow heals it. What I can state with
confidence is narrower: the two repair paths should not disagree about a height
for no reason, the author's own commit message says the frontier is the correct
choice, and the change cannot send less than it does today.

If a reviewer knows a client flow that reaches `update_admin_chain` without a
prior contiguous admin sync, that would turn this into a reproducible bug and is
worth adding as a test. `ChainListener` calls `synchronize_chain_state` for the
admin chain at startup, so long-lived services are covered; short-lived CLI
invocations were where I expected to find it and did not.

## Release Plan

- These changes should be backported to the latest `testnet` branch.

`testnet_conway` has the identical asymmetry (`updater.rs:810` vs `:736`).
