### PR TITLE
Avoid dirtying next_height_to_preprocess when the height does not advance

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -564,9 +564,8 @@ where
         hash: CryptoHash,
     ) -> Result<(), ChainError> {
         self.block_hashes.insert(&height, hash)?;
-        let next = self.next_height_to_preprocess.get_mut();
-        if *next <= height {
-            *next = height.try_add_one()?;
+        if *self.next_height_to_preprocess.get() <= height {
+            self.next_height_to_preprocess.set(height.try_add_one()?);
         }
         Ok(())
     }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -31,9 +31,10 @@ use linera_execution::{
     SystemOperation, TestExecutionRuntimeContext,
 };
 use linera_views::{
+    batch::Batch,
     context::{Context as _, MemoryContext, ViewContext},
     memory::MemoryStore,
-    views::View,
+    views::{RootView as _, View},
 };
 use test_case::test_case;
 
@@ -1191,5 +1192,33 @@ async fn test_reconcile_outbox_index_full_mode_reindexes_all() -> anyhow::Result
 
     // A second full-mode reconciliation is now a no-op.
     assert!(!chain.reconcile_outbox_index(None).await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_insert_block_hash_leaves_unchanged_preprocess_height_clean() -> anyhow::Result<()> {
+    let chain_id = ChainId(CryptoHash::test_hash("chain"));
+    let mut chain = ChainStateView::new(chain_id).await;
+
+    chain.insert_block_hash(BlockHeight(0), CryptoHash::test_hash("block0"))?;
+    chain.save().await?;
+    assert_eq!(*chain.next_height_to_preprocess.get(), BlockHeight(1));
+
+    chain.insert_block_hash(BlockHeight(0), CryptoHash::test_hash("block0"))?;
+    let mut batch = Batch::new();
+    chain.next_height_to_preprocess.pre_save(&mut batch)?;
+    assert!(
+        batch.is_empty(),
+        "re-inserting a height below `next_height_to_preprocess` must not write the register"
+    );
+
+    chain.insert_block_hash(BlockHeight(1), CryptoHash::test_hash("block1"))?;
+    let mut batch = Batch::new();
+    chain.next_height_to_preprocess.pre_save(&mut batch)?;
+    assert!(
+        !batch.is_empty(),
+        "advancing `next_height_to_preprocess` must still write the register"
+    );
+    assert_eq!(*chain.next_height_to_preprocess.get(), BlockHeight(2));
     Ok(())
 }


### PR DESCRIPTION
## Motivation

`RegisterView` tracks dirtiness by *touch*, not by *value*: `get_mut()` unconditionally sets
`update = Some(stored_value.clone())` (`linera-views/src/views/register_view.rs`), so the view is
marked dirty even when nothing is mutated. `pre_save` then emits a `Put`, and that byte-identical
write travels all the way to storage.

ScyllaDB cannot absorb such a write. There is no read-before-write — per the
[INSERT docs](https://docs.scylladb.com/manual/stable/cql/dml/insert.html), *"unlike in SQL, INSERT
does not check the prior existence of the row by default"* — so a redundant write costs a full
request plus a commitlog append, and leaves a duplicate cell for compaction to merge later. Our
validator keyspaces use `LeveledCompactionStrategy`, where ScyllaDB
[measured 13x write amplification](https://www.scylladb.com/2018/01/31/compaction-series-leveled-compaction/).

`insert_block_hash` hits this: it takes the mutable borrow *before* the guard that decides whether
to advance the register.

```rust
let next = self.next_height_to_preprocess.get_mut();   // dirties unconditionally
if *next <= height {
    *next = height.try_add_one()?;
}
```

Whenever `*next > height` the value is unchanged but the register is still written. That is exactly
the preprocessing-catchup case: a block preprocessed ahead of the tip advances
`next_height_to_preprocess`, and every later block re-executed at a height below it writes the
register again for nothing.

## Proposal

Read through `get()` for the comparison and `set()` only in the branch that actually advances the
height, so the register is dirtied only when its value changes. No behavioural change.

This is the same shape as the guard already used in `process_outgoing_messages`, which defers
`get_mut()` on `outbox_counters` / `nonempty_outboxes` until it knows something was scheduled; this
was the last remaining instance of the pattern in `linera-chain`.

## Test Plan

New unit test `test_insert_block_hash_leaves_unchanged_preprocess_height_clean` calls `pre_save`
on the register directly and asserts the emitted `Batch` is empty for a non-advancing insert, and
non-empty for an advancing one, so it cannot pass vacuously.

Validated against the unfixed code: with the `get_mut()` version restored the test fails on the
first assertion (*"re-inserting a height below `next_height_to_preprocess` must not write the
register"*); with the fix it passes.

```
cargo test -p linera-chain --all-features test_insert_block_hash_leaves_unchanged
cargo clippy --all-targets --all-features -p linera-chain -- -D warnings
cargo clippy --no-default-features -p linera-chain -- -D warnings
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

`testnet_conway` is unaffected: it exposes `next_height_to_preprocess` as an async method rather
than a `RegisterView` field, so this code path does not exist there.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
