### PR TITLE
linera-core: route proposal round and height mismatches through sync_remote_if_needed

### DIFF
--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -75,7 +75,7 @@ use crate::{
         ValidatorNodeProvider as _,
     },
     remote_node::RemoteNode,
-    updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
+    updater::{communicate_with_quorum, CommunicateAction, CommunicationError},
     worker::{Notification, Reason, WorkerError},
 };
 
@@ -250,6 +250,14 @@ pub enum Error {
 
     #[error("Remote node operation failed: {0}")]
     RemoteNodeError(#[from] NodeError),
+
+    /// A validator reported state ahead of the local node for this chain. The caller may pull
+    /// the missing state from that validator, then retry or surface the carried error.
+    #[error("The local node is lagging behind a validator on chain {chain_id}: {error}")]
+    LocalNodeLagging {
+        chain_id: ChainId,
+        error: Box<NodeError>,
+    },
 
     #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
@@ -2054,8 +2062,8 @@ impl<Env: Environment> ChainClient<Env> {
                 return Err(err);
             };
             if current == snapshot {
-                // The lazy per-validator pull on rejection (`Updater::send_block_proposal`) can be
-                // raced out: `communicate_with_quorum` breaks as soon as a quorum is impossible and
+                // The lazy per-validator pull on rejection (`Client::sync_and_retry_chain_update`)
+                // can be raced out: `communicate_with_quorum` breaks as soon as a quorum is impossible and
                 // drops the still-in-flight `synchronize_chain_state_from` calls, so a locking block
                 // held only by the slower-to-respond validators is never absorbed. Fall back once to
                 // an explicit quorum sync — guaranteed to reach a lock-holder — and retry if it
@@ -3474,11 +3482,9 @@ impl<Env: Environment> ChainClient<Env> {
         node: Env::ValidatorNode,
     ) -> Result<(), Error> {
         let local_next_block_height = self.chain_info().await?.next_block_height;
-        let mut updater = ValidatorUpdater {
-            remote_node: RemoteNode { public_key, node },
-            client: self.client.clone(),
-            admin_chain_id: self.client.admin_chain_id,
-        };
+        let mut updater = self
+            .client
+            .remote_node_updater(RemoteNode { public_key, node });
         updater
             .send_chain_information(
                 self.chain_id,

--- a/linera-core/src/client/chain_client/mod.rs
+++ b/linera-core/src/client/chain_client/mod.rs
@@ -2062,17 +2062,19 @@ impl<Env: Environment> ChainClient<Env> {
                 return Err(err);
             };
             if current == snapshot {
-                // The lazy per-validator pull on rejection (`Client::sync_and_retry_chain_update`)
-                // can be raced out: `communicate_with_quorum` breaks as soon as a quorum is impossible and
-                // drops the still-in-flight `synchronize_chain_state_from` calls, so a locking block
-                // held only by the slower-to-respond validators is never absorbed. Fall back once to
-                // an explicit quorum sync — guaranteed to reach a lock-holder — and retry if it
-                // absorbed anything; otherwise the rejection was genuine, so propagate it.
+                // The post-quorum pull on rejection (`Client::process_lag_reports`) only covers
+                // validators whose rejection was actually received: `communicate_with_quorum`
+                // breaks as soon as a quorum is impossible and drops still-in-flight requests, so
+                // a locking block held only by the slower-to-respond validators is never even
+                // reported. Fall back once to an explicit quorum sync — guaranteed to reach a
+                // lock-holder — and retry if it absorbed anything; otherwise the rejection was
+                // genuine, so propagate it.
                 //
-                // TODO(#6453): this fallback path has no deterministic regression test yet — forcing
-                // the lazy pull to miss needs a clock-driven per-validator response delay in the test
-                // harness (building on #6448); until then it is only covered indirectly by the (now
-                // non-flaky) `test_lazy_pull_absorbs_locking_block_on_proposal_rejection`.
+                // TODO(#6453): this fallback path has no deterministic regression test yet —
+                // forcing a lock-holder's response to be dropped needs a clock-driven
+                // per-validator response delay in the test harness (building on #6448); until
+                // then it is only covered indirectly by the (now non-flaky)
+                // `test_lazy_pull_absorbs_locking_block_on_proposal_rejection`.
                 if did_fallback_sync {
                     return Err(err);
                 }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    cmp::Ordering,
+    cmp::{Ordering, Reverse},
     collections::{BTreeMap, BTreeSet, HashSet},
     slice,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
 };
 
 use custom_debug_derive::Debug;
@@ -1441,45 +1441,32 @@ impl<Env: Environment> Client<Env> {
         }
     }
 
-    /// Handles a [`chain_client::Error::LocalNodeLagging`] signal from a [`RemoteNodeUpdater`]:
-    /// pulls the missing chain state from the validator that turned out to be ahead of us, then
-    /// either retries the action once (when finalizing a block) or surfaces the validator's
-    /// original error so the outer logic can rebuild on top of the refreshed local state.
-    async fn sync_and_retry_chain_update(
-        self: &Arc<Self>,
-        mut updater: RemoteNodeUpdater<Env>,
-        action: CommunicateAction,
-        chain_id: ChainId,
-        error: NodeError,
-    ) -> Result<LiteVote, chain_client::Error> {
-        match &action {
-            CommunicateAction::SubmitBlock { .. } => {
-                // Pull the manager state that justified the proposal's rejection (signatures
-                // are checked locally, so the source can't fool us), best-effort, and surface
-                // the rejection either way. If our local state actually advanced,
-                // `execute_operations` will rebuild and re-propose.
-                if let Err(sync_err) = self
-                    .synchronize_chain_state_from(&updater.remote_node, chain_id)
-                    .await
-                {
-                    debug!(%sync_err, "failed to pull manager state from validator");
-                }
-                Err(error.into())
-            }
-            CommunicateAction::RequestTimeout { .. } => {
-                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
-                    .await?;
-                Err(error.into())
-            }
-            CommunicateAction::FinalizeBlock { .. } => {
-                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
-                    .await?;
-                match updater.send_chain_update(action).await {
-                    Err(chain_client::Error::LocalNodeLagging { error, .. }) => {
-                        Err((*error).into())
-                    }
-                    result => result,
-                }
+    /// Pulls the chain state that validators reported being ahead of the local node on,
+    /// during a failed quorum round.
+    ///
+    /// Reports are processed here, after `communicate_with_quorum` returns, rather than inside
+    /// the per-validator tasks: this keeps those tasks read-only for the local node — mutually
+    /// independent and fair to each validator — and means a pull can no longer be cancelled by
+    /// the quorum's early exit. Processing is best-effort: failures are only logged, and the
+    /// quorum outcome is surfaced unchanged either way, so the outer logic reacts on top of
+    /// whatever state was absorbed (e.g. `execute_operations` rebuilds and re-proposes).
+    ///
+    /// Validators that are further ahead are pulled from first, which makes later pulls cheap,
+    /// but every reporter is visited: a proposal rejection justified by a locking block can
+    /// only be absorbed from a validator that holds that block.
+    async fn process_lag_reports(&self, mut reports: Vec<LagReport<Env::ValidatorNode>>) {
+        reports.sort_by_key(|report| Reverse(report.remote_progress()));
+        for report in reports {
+            if let Err(error) = self
+                .synchronize_chain_state_from(&report.remote_node, report.chain_id)
+                .await
+            {
+                debug!(
+                    remote_node = report.remote_node.address(),
+                    chain_id = %report.chain_id,
+                    %error,
+                    "failed to pull chain state from a validator that reported being ahead",
+                );
             }
         }
     }
@@ -1526,12 +1513,17 @@ impl<Env: Environment> Client<Env> {
         action: CommunicateAction,
         value: T,
     ) -> Result<GenericCertificate<T>, chain_client::Error> {
+        // Validators that turn out to be ahead of the local node are recorded here and pulled
+        // from after the quorum round, so that each per-validator task stays read-only for the
+        // local node. The updater's original validator error re-enters the quorum aggregation
+        // below, keeping the round's error classification unchanged.
+        let lag_reports = Mutex::new(Vec::new());
         let nodes = self.make_nodes(committee)?;
         // Group votes by their full signed payload: signatures only aggregate into a
         // certificate if they are unanimous on all signed fields, so a vote that diverges in
         // the unlocking round, first-round attestation or justification commitment belongs to
         // a separate candidate quorum.
-        let ((votes_hash, votes_round, _, _, _), votes) = communicate_with_quorum(
+        let result = communicate_with_quorum(
             &nodes,
             committee,
             |vote: &LiteVote| {
@@ -1544,13 +1536,18 @@ impl<Env: Environment> Client<Env> {
                 )
             },
             |remote_node| {
-                let mut updater = self.remote_node_updater(remote_node);
+                let mut updater = self.remote_node_updater(remote_node.clone());
                 let action = action.clone();
+                let lag_reports = &lag_reports;
                 Box::pin(async move {
-                    match updater.send_chain_update(action.clone()).await {
+                    match updater.send_chain_update(action).await {
                         Err(chain_client::Error::LocalNodeLagging { chain_id, error }) => {
-                            self.sync_and_retry_chain_update(updater, action, chain_id, *error)
-                                .await
+                            lag_reports.lock().unwrap().push(LagReport {
+                                remote_node,
+                                chain_id,
+                                error: (*error).clone(),
+                            });
+                            Err((*error).into())
                         }
                         result => result,
                     }
@@ -1558,7 +1555,17 @@ impl<Env: Environment> Client<Env> {
             },
             self.options.quorum_grace_period,
         )
-        .await?;
+        .await;
+        let ((votes_hash, votes_round, _, _, _), votes) = match result {
+            Ok(quorum) => quorum,
+            Err(err) => {
+                // The round failed; absorb whatever the more advanced validators hold before
+                // surfacing the outcome, so the caller retries on top of a synchronized state.
+                self.process_lag_reports(lag_reports.into_inner().unwrap())
+                    .await;
+                return Err(err.into());
+            }
+        };
         ensure!(
             (votes_hash, votes_round) == (value.hash(), action.round()),
             chain_client::Error::UnexpectedQuorum {
@@ -2757,6 +2764,29 @@ pub struct PendingProposal {
     /// The round in which this proposal was first submitted, if any.
     #[serde(default)]
     pub round: Option<Round>,
+}
+
+/// A validator's report, collected during a quorum round, that it is ahead of the local node
+/// on a chain (a [`chain_client::Error::LocalNodeLagging`] signal from the updater).
+struct LagReport<N> {
+    remote_node: RemoteNode<N>,
+    chain_id: ChainId,
+    error: NodeError,
+}
+
+impl<N> LagReport<N> {
+    /// The height and round the validator reported being at, as far as the error reveals them.
+    /// Used to pull from the most advanced validators first.
+    fn remote_progress(&self) -> (Option<BlockHeight>, Option<Round>) {
+        match &self.error {
+            NodeError::UnexpectedBlockHeight {
+                expected_block_height,
+                ..
+            } => (Some(*expected_block_height), None),
+            NodeError::WrongRound(round) => (None, Some(*round)),
+            _ => (None, None),
+        }
+    }
 }
 
 enum ReceiveCertificateMode {

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -1457,9 +1457,11 @@ impl<Env: Environment> Client<Env> {
     async fn process_lag_reports(&self, mut reports: Vec<LagReport<Env::ValidatorNode>>) {
         reports.sort_by_key(|report| Reverse(report.remote_progress()));
         for report in reports {
-            if let Err(error) = self
-                .synchronize_chain_state_from(&report.remote_node, report.chain_id)
-                .await
+            // Boxed to keep this future small: the synchronization future is large, and it
+            // would otherwise be inlined into every caller of the quorum communication.
+            if let Err(error) =
+                Box::pin(self.synchronize_chain_state_from(&report.remote_node, report.chain_id))
+                    .await
             {
                 debug!(
                     remote_node = report.remote_node.address(),

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -57,7 +57,7 @@ use crate::{
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode as _, ValidatorNodeProvider as _},
     notifier::{ChannelNotifier, Notifier as _},
     remote_node::RemoteNode,
-    updater::{communicate_with_quorum, CommunicateAction, ValidatorUpdater},
+    updater::{communicate_with_quorum, CommunicateAction, RemoteNodeUpdater},
     worker::{Notification, ProcessableCertificate, Reason, WorkerError, WorkerState},
     ChainWorkerConfig, ProcessConfirmedBlockMode, CHAIN_INFO_MAX_RECEIVED_LOG_ENTRIES,
 };
@@ -487,10 +487,6 @@ impl<Env: Environment> Client<Env> {
     /// Returns the provider used to connect to validator nodes.
     pub fn validator_node_provider(&self) -> &Env::Network {
         self.environment.network()
-    }
-
-    pub(crate) fn options(&self) -> &chain_client::Options {
-        &self.options
     }
 
     /// Handles any pending local cross-chain requests, notifying subscribers.
@@ -1432,6 +1428,62 @@ impl<Env: Environment> Client<Env> {
         Ok(certificate)
     }
 
+    /// Creates a [`RemoteNodeUpdater`] for the given validator, backed by our local node.
+    fn remote_node_updater(
+        &self,
+        remote_node: RemoteNode<Env::ValidatorNode>,
+    ) -> RemoteNodeUpdater<Env> {
+        RemoteNodeUpdater {
+            remote_node,
+            local_node: self.local_node.clone(),
+            admin_chain_id: self.admin_chain_id,
+            certificate_upload_batch_size: self.options.certificate_upload_batch_size,
+        }
+    }
+
+    /// Handles a [`chain_client::Error::LocalNodeLagging`] signal from a [`RemoteNodeUpdater`]:
+    /// pulls the missing chain state from the validator that turned out to be ahead of us, then
+    /// either retries the action once (when finalizing a block) or surfaces the validator's
+    /// original error so the outer logic can rebuild on top of the refreshed local state.
+    async fn sync_and_retry_chain_update(
+        self: &Arc<Self>,
+        mut updater: RemoteNodeUpdater<Env>,
+        action: CommunicateAction,
+        chain_id: ChainId,
+        error: NodeError,
+    ) -> Result<LiteVote, chain_client::Error> {
+        match &action {
+            CommunicateAction::SubmitBlock { .. } => {
+                // Pull the manager state that justified the proposal's rejection (signatures
+                // are checked locally, so the source can't fool us), best-effort, and surface
+                // the rejection either way. If our local state actually advanced,
+                // `execute_operations` will rebuild and re-propose.
+                if let Err(sync_err) = self
+                    .synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await
+                {
+                    debug!(%sync_err, "failed to pull manager state from validator");
+                }
+                Err(error.into())
+            }
+            CommunicateAction::RequestTimeout { .. } => {
+                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await?;
+                Err(error.into())
+            }
+            CommunicateAction::FinalizeBlock { .. } => {
+                self.synchronize_chain_state_from(&updater.remote_node, chain_id)
+                    .await?;
+                match updater.send_chain_update(action).await {
+                    Err(chain_client::Error::LocalNodeLagging { error, .. }) => {
+                        Err((*error).into())
+                    }
+                    result => result,
+                }
+            }
+        }
+    }
+
     /// Broadcasts certified blocks to validators.
     #[instrument(level = "trace", skip_all, fields(chain_id, block_height, delivery))]
     async fn communicate_chain_updates(
@@ -1448,11 +1500,7 @@ impl<Env: Environment> Client<Env> {
             committee,
             |_: &()| (),
             |remote_node| {
-                let mut updater = ValidatorUpdater {
-                    remote_node,
-                    client: self.clone(),
-                    admin_chain_id: self.admin_chain_id,
-                };
+                let mut updater = self.remote_node_updater(remote_node);
                 let certificate = latest_certificate.clone();
                 Box::pin(async move {
                     updater
@@ -1496,13 +1544,17 @@ impl<Env: Environment> Client<Env> {
                 )
             },
             |remote_node| {
-                let mut updater = ValidatorUpdater {
-                    remote_node,
-                    client: self.clone(),
-                    admin_chain_id: self.admin_chain_id,
-                };
+                let mut updater = self.remote_node_updater(remote_node);
                 let action = action.clone();
-                Box::pin(async move { updater.send_chain_update(action).await })
+                Box::pin(async move {
+                    match updater.send_chain_update(action.clone()).await {
+                        Err(chain_client::Error::LocalNodeLagging { chain_id, error }) => {
+                            self.sync_and_retry_chain_update(updater, action, chain_id, *error)
+                                .await
+                        }
+                        result => result,
+                    }
+                })
             },
             self.options.quorum_grace_period,
         )

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -2520,6 +2520,135 @@ where
     Ok(())
 }
 
+/// The updater must signal `LocalNodeLagging` — rather than pushing chain information —
+/// when a validator rejects a proposal because it is *ahead* of the proposal's round or
+/// height.
+///
+/// Drives a `RemoteNodeUpdater` directly. A full client cannot reach this state without
+/// clock skew: whenever validators advanced by timeout, the shared clock has also expired
+/// the client's own round, so the client requests a timeout certificate before ever
+/// proposing at the stale round.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "storage-service", test_case(ServiceStorageBuilder::new(); "storage_service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_stale_proposal_signals_local_node_lagging<B>(storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+{
+    use linera_chain::test::{make_first_block, BlockTestExt as _};
+
+    use crate::{
+        local_node::LocalNodeClient,
+        remote_node::RemoteNode,
+        test_utils::NodeProvider,
+        updater::{CommunicateAction, RemoteNodeUpdater},
+        worker::WorkerState,
+        ChainWorkerConfig,
+    };
+
+    let signer = InMemorySigner::new(None);
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 1, signer).await?;
+    let client = builder.add_root_chain(1, Amount::from_tokens(3)).await?;
+    let chain_id = client.chain_id();
+    let owner0 = client.identity().await.unwrap();
+    let owner1: AccountOwner = builder.signer.generate_new().into();
+
+    // Set up a multi-owner chain with single-leader rounds only.
+    let owners = [(owner0, 100), (owner1, 100)];
+    let ownership = ChainOwnership::multiple(owners, 0, TimeoutConfig::default());
+    client.change_ownership(ownership).await.unwrap();
+    let info = client.chain_info().await.unwrap();
+
+    // Advance the validators by two rounds, recording each round's leader: proposals must
+    // be signed by their round's leader for the round check to even be reached. The stale
+    // proposal targets the intermediate round rather than `SingleLeader(0)`, whose
+    // obsolete proposals are rejected with `InsufficientRound` instead of `WrongRound`.
+    let client2 = builder
+        .make_client(chain_id, None, BlockHeight::ZERO)
+        .await?;
+    client2.synchronize_from_validators().await?;
+    let manager = client2.chain_info().await.unwrap().manager;
+    clock.set(manager.round_timeout.unwrap());
+    client2.request_leader_timeout().await.unwrap();
+    let manager = client2.chain_info().await.unwrap().manager;
+    let (stale_round, stale_leader) = (manager.current_round, manager.leader.unwrap());
+    assert_matches!(stale_round, Round::SingleLeader(n) if n >= 1);
+    clock.set(manager.round_timeout.unwrap());
+    client2.request_leader_timeout().await.unwrap();
+    let manager = client2.chain_info().await.unwrap().manager;
+    let (validator_round, validator_leader) = (manager.current_round, manager.leader.unwrap());
+
+    // Drive the updater directly against an honest validator (validator 0 is the faulty
+    // one). An empty local node is enough: a validator that is ahead must produce the
+    // signal before anything is read from the local node.
+    let state = WorkerState::new(
+        builder.make_storage().await?,
+        ChainWorkerConfig::default(),
+        None,
+    );
+    let node = builder.node(1);
+    let mut updater =
+        RemoteNodeUpdater::<crate::environment::Impl<B::Storage, NodeProvider<B::Storage>>> {
+            remote_node: RemoteNode {
+                public_key: node.name(),
+                node,
+            },
+            local_node: LocalNodeClient::new(state),
+            admin_chain_id: builder.admin_chain_id(),
+            certificate_upload_batch_size: 100,
+        };
+    let submit = |proposal| {
+        let (clock_skew_sender, _receiver) = tokio::sync::mpsc::unbounded_channel();
+        CommunicateAction::SubmitBlock {
+            proposal: Box::new(proposal),
+            blob_ids: vec![],
+            clock_skew_sender,
+        }
+    };
+
+    // A proposal in an older round than the validator's: `WrongRound`, validator ahead.
+    let mut block = make_first_block(chain_id);
+    block.height = info.next_block_height;
+    block.previous_block_hash = info.block_hash;
+    block.timestamp = clock.current_time();
+    let proposal = block
+        .clone()
+        .into_proposal_with_round(stale_leader, &builder.signer, stale_round)
+        .await?;
+    let result = updater.send_chain_update(submit(proposal)).await;
+    assert_matches!(
+        result,
+        Err(chain_client::Error::LocalNodeLagging { chain_id: id, error })
+            if id == chain_id && matches!(*error, NodeError::WrongRound(round) if round == validator_round)
+    );
+
+    // A proposal at an older height than the validator's: `UnexpectedBlockHeight`,
+    // validator ahead.
+    block.height = BlockHeight::ZERO;
+    block.previous_block_hash = None;
+    let proposal = block
+        .into_proposal_with_round(validator_leader, &builder.signer, validator_round)
+        .await?;
+    let result = updater.send_chain_update(submit(proposal)).await;
+    assert_matches!(
+        result,
+        Err(chain_client::Error::LocalNodeLagging { chain_id: id, error })
+            if id == chain_id
+                && matches!(
+                    *error,
+                    NodeError::UnexpectedBlockHeight {
+                        expected_block_height: BlockHeight(1),
+                        found_block_height: BlockHeight(0),
+                    }
+                )
+    );
+
+    Ok(())
+}
+
 /// Exercises the lazy locking-block fetch on proposal rejection.
 ///
 /// Sets up a state where validators 2 and 3 hold a `Regular` locking block at

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -575,7 +575,11 @@ where
         clock_skew_sender: mpsc::UnboundedSender<ClockSkewReport>,
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let chain_id = proposal.content.block.chain_id;
+        // `sent_cross_chain_updates` tracks per-origin progress for the
+        // `MissingCrossChainUpdate` path; `synced_round_and_height` is the one-shot guard
+        // for the round/height mismatch path.
         let mut sent_cross_chain_updates = BTreeMap::new();
+        let mut synced_round_and_height = false;
         let mut publisher_chain_ids_sent = BTreeSet::new();
         let storage = self.local_node.storage_client();
         loop {
@@ -586,39 +590,26 @@ where
                 .await
             {
                 Ok(info) => return Ok(info),
-                Err(NodeError::WrongRound(_round)) => {
-                    // The proposal is for a different round, so we need to update the validator.
-                    // TODO: this should probably be more specific as to which rounds are retried.
-                    tracing::debug!(
-                        remote_node = self.remote_node.address(),
-                        %chain_id,
-                        "wrong round; sending chain to validator",
-                    );
-                    self.send_chain_information(
-                        chain_id,
-                        proposal.content.block.height,
-                        CrossChainMessageDelivery::NonBlocking,
-                        None,
-                    )
-                    .await?;
-                }
-                Err(NodeError::UnexpectedBlockHeight {
-                    expected_block_height,
-                    found_block_height,
-                }) if expected_block_height < found_block_height
-                    && found_block_height == proposal.content.block.height =>
+                Err(err @ (NodeError::WrongRound(_) | NodeError::UnexpectedBlockHeight { .. }))
+                    if !synced_round_and_height =>
                 {
+                    // The validator disagrees with the proposal's round or height. If it is
+                    // behind, `sync_remote_if_needed` pushes the chain and we retry; if it is
+                    // ahead, the `LocalNodeLagging` signal propagates so the caller can pull
+                    // its state and rebuild the proposal. One-shot: if the validator still
+                    // disagrees after a sync, retrying would not make progress.
+                    synced_round_and_height = true;
                     tracing::debug!(
                         remote_node = self.remote_node.address(),
                         %chain_id,
-                        "wrong height; sending chain to validator",
+                        %err,
+                        "validator disagrees on round or height; synchronizing",
                     );
-                    // The proposal is for a later block height, so we need to update the validator.
-                    self.send_chain_information(
+                    self.sync_remote_if_needed(
                         chain_id,
-                        found_block_height,
-                        CrossChainMessageDelivery::NonBlocking,
-                        None,
+                        proposal.content.round,
+                        proposal.content.block.height,
+                        &err,
                     )
                     .await?;
                 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -7,7 +7,6 @@ use std::{
     fmt,
     hash::Hash,
     mem,
-    sync::Arc,
 };
 
 use futures::{future, Future, StreamExt};
@@ -30,9 +29,10 @@ use tokio::sync::mpsc;
 use tracing::{instrument, Level};
 
 use crate::{
-    client::{chain_client, Client},
+    client::chain_client,
     data_types::{ChainInfo, ChainInfoQuery},
     environment::Environment,
+    local_node::LocalNodeClient,
     node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     remote_node::RemoteNode,
     LocalNodeError,
@@ -131,21 +131,29 @@ impl CommunicateAction {
     }
 }
 
-pub struct ValidatorUpdater<Env>
+/// Pushes data to a single validator to bring it up to date with the local node.
+///
+/// This deliberately holds a [`LocalNodeClient`] rather than a full client: updating another
+/// node must not mutate the client's own state. When a validator turns out to be *ahead* of the
+/// local node, the updater signals that with [`chain_client::Error::LocalNodeLagging`] and lets
+/// the caller decide whether to pull the missing state.
+pub struct RemoteNodeUpdater<Env>
 where
     Env: Environment,
 {
     pub remote_node: RemoteNode<Env::ValidatorNode>,
-    pub client: Arc<Client<Env>>,
+    pub local_node: LocalNodeClient<Env::Storage>,
     pub admin_chain_id: ChainId,
+    pub certificate_upload_batch_size: usize,
 }
 
-impl<Env: Environment> Clone for ValidatorUpdater<Env> {
+impl<Env: Environment> Clone for RemoteNodeUpdater<Env> {
     fn clone(&self) -> Self {
-        ValidatorUpdater {
+        RemoteNodeUpdater {
             remote_node: self.remote_node.clone(),
-            client: self.client.clone(),
+            local_node: self.local_node.clone(),
             admin_chain_id: self.admin_chain_id,
+            certificate_upload_batch_size: self.certificate_upload_batch_size,
         }
     }
 }
@@ -310,7 +318,7 @@ where
     })
 }
 
-impl<Env> ValidatorUpdater<Env>
+impl<Env> RemoteNodeUpdater<Env>
 where
     Env: Environment + 'static,
 {
@@ -361,11 +369,7 @@ where
                     let cert: &ConfirmedBlockCertificate = certificate;
                     self.remote_node.check_blobs_not_found(cert, &blob_ids)?;
                     // The certificate is confirmed, so the blobs must be in storage.
-                    let maybe_blobs = self
-                        .client
-                        .local_node
-                        .read_blobs_from_storage(&blob_ids)
-                        .await?;
+                    let maybe_blobs = self.local_node.read_blobs_from_storage(&blob_ids).await?;
                     let blobs = maybe_blobs.ok_or(NodeError::BlobsNotFound(blob_ids))?;
                     self.remote_node
                         .node
@@ -379,7 +383,7 @@ where
                     // bytes. Upload each from local storage; the worker's
                     // trust-mark accept path lets them through regardless of their
                     // (possibly revoked) epoch.
-                    let storage = self.client.local_node.storage_client();
+                    let storage = self.local_node.storage_client();
                     let certificates = storage.read_certificates(&hashes).await?;
                     for (hash, maybe_cert) in hashes.iter().zip(certificates) {
                         let cert = maybe_cert.ok_or_else(|| {
@@ -423,7 +427,6 @@ where
                 // The certificate is for a validated block, i.e. for our locking block.
                 // Take the missing blobs from our local chain manager.
                 let blobs = self
-                    .client
                     .local_node
                     .get_locking_blobs(blob_ids, chain_id)
                     .await?
@@ -473,7 +476,11 @@ where
         Ok(result?)
     }
 
-    /// Synchronizes either the local node or the remote node, if one of them is lagging behind.
+    /// Sends chain information to the remote node if it is the one lagging behind.
+    ///
+    /// If the error reveals that the *local* node is behind instead, returns
+    /// [`chain_client::Error::LocalNodeLagging`] carrying the original error: pulling remote
+    /// state is a client-level decision, not something updating another node may do.
     async fn sync_if_needed(
         &mut self,
         chain_id: ChainId,
@@ -486,11 +493,12 @@ where
             NodeError::WrongRound(validator_round) if *validator_round > round => {
                 tracing::debug!(
                     address, %chain_id, %validator_round, %round,
-                    "validator is at a higher round; synchronizing",
+                    "validator is at a higher round; local node needs to synchronize",
                 );
-                self.client
-                    .synchronize_chain_state_from(&self.remote_node, chain_id)
-                    .await?;
+                return Err(chain_client::Error::LocalNodeLagging {
+                    chain_id,
+                    error: Box::new(error.clone()),
+                });
             }
             NodeError::UnexpectedBlockHeight {
                 expected_block_height,
@@ -501,11 +509,12 @@ where
                     %chain_id,
                     %expected_block_height,
                     %found_block_height,
-                    "validator is at a higher height; synchronizing",
+                    "validator is at a higher height; local node needs to synchronize",
                 );
-                self.client
-                    .synchronize_chain_state_from(&self.remote_node, chain_id)
-                    .await?;
+                return Err(chain_client::Error::LocalNodeLagging {
+                    chain_id,
+                    error: Box::new(error.clone()),
+                });
             }
             NodeError::WrongRound(validator_round) if *validator_round < round => {
                 tracing::debug!(
@@ -567,7 +576,7 @@ where
         let chain_id = proposal.content.block.chain_id;
         let mut sent_cross_chain_updates = BTreeMap::new();
         let mut publisher_chain_ids_sent = BTreeSet::new();
-        let storage = self.client.local_node.storage_client();
+        let storage = self.local_node.storage_client();
         loop {
             let local_time = storage.clock().current_time();
             match self
@@ -653,7 +662,6 @@ where
                     ensure!(!chain_ids.is_empty(), NodeError::EventsNotFound(event_ids));
                     for chain_id in chain_ids {
                         let height = self
-                            .client
                             .local_node
                             .get_next_height_to_preprocess(chain_id)
                             .await?;
@@ -669,27 +677,22 @@ where
                 Err(error @ NodeError::ChainError { .. }) => {
                     // The validator rejected the proposal because of its local chain
                     // manager state — most commonly an incompatible confirmed vote tied
-                    // to a locking block we don't yet have. Pull manager values from
-                    // this validator so the local node absorbs whatever justified the
-                    // rejection (signatures are checked locally, so the source can't
-                    // fool us), then surface the error. If our local state actually
-                    // advanced, `execute_operations` will rebuild and re-propose; if
+                    // to a locking block we don't yet have. The caller should pull
+                    // manager values from this validator so the local node absorbs
+                    // whatever justified the rejection; if the local state actually
+                    // advances, `execute_operations` will rebuild and re-propose; if
                     // not, the error propagates as usual.
                     self.warn_if_unexpected(&error);
                     tracing::debug!(
                         remote_node = self.remote_node.address(),
                         %chain_id,
                         %error,
-                        "validator rejected proposal; pulling manager state",
+                        "validator rejected proposal; manager state needs to be pulled",
                     );
-                    if let Err(sync_err) = self
-                        .client
-                        .synchronize_chain_state_from(&self.remote_node, chain_id)
-                        .await
-                    {
-                        tracing::debug!(%sync_err, "failed to pull manager state from validator");
-                    }
-                    return Err(error.into());
+                    return Err(chain_client::Error::LocalNodeLagging {
+                        chain_id,
+                        error: Box::new(error),
+                    });
                 }
                 Err(NodeError::BlobsNotFound(_) | NodeError::InactiveChain(_))
                     if !blob_ids.is_empty() =>
@@ -702,7 +705,6 @@ where
                         BTreeSet::from_iter(proposal.content.block.published_blob_ids());
                     blob_ids.retain(|blob_id| !published_blob_ids.contains(blob_id));
                     let published_blobs = self
-                        .client
                         .local_node
                         .get_proposed_blobs(chain_id, published_blob_ids.into_iter().collect())
                         .await?;
@@ -761,11 +763,7 @@ where
     }
 
     async fn update_admin_chain(&mut self) -> Result<(), chain_client::Error> {
-        let local_admin_info = self
-            .client
-            .local_node
-            .chain_info(self.admin_chain_id)
-            .await?;
+        let local_admin_info = self.local_node.chain_info(self.admin_chain_id).await?;
         Box::pin(self.send_chain_information(
             self.admin_chain_id,
             local_admin_info.next_block_height,
@@ -825,7 +823,7 @@ where
         // the consensus round at this height.
         let (remote_height, remote_round) = (info.next_block_height, info.manager.current_round);
         let query = ChainInfoQuery::new(chain_id).with_manager_values();
-        let local_info = match self.client.local_node.handle_chain_info_query(query).await {
+        let local_info = match self.local_node.handle_chain_info_query(query).await {
             Ok(response) => response.info,
             // If we don't have the full chain description locally, we can't help the
             // validator with round synchronization. This is not an error - the validator
@@ -906,7 +904,7 @@ where
             return Ok(info);
         }
 
-        let batch_size = self.client.options().certificate_upload_batch_size;
+        let batch_size = self.certificate_upload_batch_size;
         for chunk in heights.chunks(batch_size) {
             let certificates = self
                 .read_certificates_for_heights(chain_id, chunk.to_vec())
@@ -927,7 +925,7 @@ where
         chain_id: ChainId,
         heights: Vec<BlockHeight>,
     ) -> Result<Vec<CacheArc<ConfirmedBlockCertificate>>, chain_client::Error> {
-        let storage = self.client.local_node.storage_client();
+        let storage = self.local_node.storage_client();
 
         let certificates_by_height = storage
             .read_certificates_by_heights(chain_id, &heights)
@@ -951,7 +949,6 @@ where
     ) -> Result<Box<ChainInfo>, chain_client::Error> {
         let local_query = ChainInfoQuery::new(chain_id).with_latest_checkpoint_height();
         let local_info = self
-            .client
             .local_node
             .handle_chain_info_query(local_query)
             .await?
@@ -1100,7 +1097,6 @@ where
         delivery: CrossChainMessageDelivery,
     ) -> Result<(), chain_client::Error> {
         let blob_states = self
-            .client
             .local_node
             .read_blob_states_from_storage(blob_ids)
             .await?;
@@ -1143,7 +1139,6 @@ where
                 // Get all block hashes for this chain at the specified heights in one call
                 let heights_vec = heights.into_iter().collect::<Vec<_>>();
                 let certificates = updater
-                    .client
                     .local_node
                     .storage_client()
                     .read_certificates_by_heights(chain_id, &heights_vec)

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -434,7 +434,7 @@ where
                 self.remote_node.send_pending_blobs(chain_id, blobs).await?;
             }
             Err(error) => {
-                self.sync_if_needed(
+                self.sync_remote_if_needed(
                     chain_id,
                     certificate.round,
                     certificate.block().header.height,
@@ -470,7 +470,8 @@ where
             .handle_chain_info_query(query.clone())
             .await;
         if let Err(err) = &result {
-            self.sync_if_needed(chain_id, round, height, err).await?;
+            self.sync_remote_if_needed(chain_id, round, height, err)
+                .await?;
             self.warn_if_unexpected(err);
         }
         Ok(result?)
@@ -481,7 +482,7 @@ where
     /// If the error reveals that the *local* node is behind instead, returns
     /// [`chain_client::Error::LocalNodeLagging`] carrying the original error: pulling remote
     /// state is a client-level decision, not something updating another node may do.
-    async fn sync_if_needed(
+    async fn sync_remote_if_needed(
         &mut self,
         chain_id: ChainId,
         round: Round,

--- a/linera-service/src/cli/main.rs
+++ b/linera-service/src/cli/main.rs
@@ -2190,7 +2190,7 @@ fn main() -> anyhow::Result<process::ExitCode> {
         builder
     };
 
-    // The default stack size 2 MiB causes some stack overflows in ValidatorUpdater methods.
+    // The default stack size 2 MiB causes some stack overflows in RemoteNodeUpdater methods.
     runtime.thread_stack_size(4 << 20);
     if let Some(blocking_threads) = options.common.tokio_blocking_threads {
         runtime.max_blocking_threads(blocking_threads);


### PR DESCRIPTION
## Motivation

Port of #6653 to `main`, stacked on #6646 (once #6646 lands, this retargets to `main`). Extends the `LocalNodeLagging` signal to the proposal path.

`send_block_proposal` handles round and height disagreements worse than the other two actions:

- Its `WrongRound` arm is direction-blind: it pushes `send_chain_information` and retries, with no one-shot guard. If the validator is round-*behind*, this converges. If the validator is round-*ahead*, the push accomplishes nothing — the round synchronization half of `send_chain_information` only transmits evidence when the *local* round is higher — so the retry hits the same `WrongRound` and the loop spins, bounded only by outer timeouts (the `TODO` above the arm acknowledged the fuzziness).
- Its `UnexpectedBlockHeight` arm only matches the validator-*behind* case. A validator that is *ahead* — it already confirmed a block at this height, so the proposal is doomed and the local node is stale — falls to the catch-all and surfaces a raw error, with no pull and no report.

## Proposal

Match `WrongRound | UnexpectedBlockHeight` in the proposal loop and delegate to `sync_remote_if_needed`, like `FinalizeBlock` and `RequestTimeout` already do. Push cases (validator behind) continue the retry loop exactly as before; pull cases (validator ahead) propagate the `LocalNodeLagging` signal into the post-quorum lag processing from #6647. A new one-shot guard (`synced_round_and_height`, mirroring the existing `synced_cross_chain_updates`) bounds the loop: if the validator still disagrees after a sync, retrying would not make progress, so the error surfaces.

Two scope notes:

- In multi-leader rounds an obsolete proposal is rejected with `InsufficientRound`, a different error deliberately left to the catch-all; `WrongRound` in that arm of the chain manager means the validator is still in the fast round, i.e. behind — the push direction.
- The old height arm's `found_block_height == proposal.height` guard is dropped: it is tautological for well-formed responses, and a malformed response can at worst trigger a harmless push or a spurious lag report — pulls verify signatures, so there is no safety exposure.

The regression test drives a `RemoteNodeUpdater` directly — constructible against a bare `LocalNodeClient` since #6645 — because a full client cannot reach this state without clock skew: whenever validators advanced by timeout, the shared test clock has also expired the client's own round, so the client requests a timeout certificate (the #4912 path) before ever proposing at the stale round. In production the trigger is exactly that skew: a client whose clock runs behind still believes its round is current. The test asserts the `LocalNodeLagging` signal, with the original error carried, for both the round-ahead and height-ahead rejections; it fails against the previous code.

## Test Plan

```
cargo test -p linera-core --lib      # 165 passed, 0 failed, includes the new
                                     # test_stale_proposal_signals_local_node_lagging
cargo clippy -p linera-core --lib --all-features
cargo +nightly fmt -- --check
```

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6653 is the `testnet_conway` version of this change.
- #6646 (base) is the `main` port of the post-quorum lag processing this feeds into.
- #6645 (merged) introduced the `LocalNodeLagging` signal.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
