### PR TITLE
Re-raise panics from supervisory task sets instead of discarding them

### DIFF
--- a/linera-core/src/join_set_ext.rs
+++ b/linera-core/src/join_set_ext.rs
@@ -30,7 +30,16 @@ mod implementation {
         fn spawn_task<F: Future + 'static>(&mut self, future: F) -> TaskHandle<F::Output>;
 
         /// Awaits all tasks spawned in this [`JoinSet`].
+        ///
+        /// Unlike its native counterpart this cannot re-raise a panic: on the Web a task's
+        /// panic aborts the whole Wasm instance, so there is nothing left to re-raise.
         fn await_all_tasks(&mut self) -> impl Future<Output = ()>;
+
+        /// Awaits all tasks spawned in this [`JoinSet`].
+        ///
+        /// Identical to [`JoinSetExt::await_all_tasks`] here; the two differ only on
+        /// native targets, where a task's panic does not stop the process.
+        fn await_all_tasks_logging_panics(&mut self) -> impl Future<Output = ()>;
 
         /// Reaps tasks that have finished.
         fn reap_finished_tasks(&mut self);
@@ -65,6 +74,10 @@ mod implementation {
                 .await
         }
 
+        async fn await_all_tasks_logging_panics(&mut self) {
+            self.await_all_tasks().await
+        }
+
         fn reap_finished_tasks(&mut self) {
             self.0.retain_mut(|task| task.try_recv() == Ok(None));
         }
@@ -92,8 +105,22 @@ mod implementation {
             future: F,
         ) -> TaskHandle<F::Output>;
 
-        /// Awaits all tasks spawned in this [`JoinSet`].
+        /// Awaits all tasks spawned in this [`JoinSet`], re-raising the panic of any task
+        /// that panicked.
+        ///
+        /// Tokio catches a task's panic instead of stopping the runtime, so a set of
+        /// long-lived tasks that is merely drained leaves the process running with one of
+        /// its subsystems silently gone. Re-raising turns that into an exit, which a
+        /// supervisor can act on.
+        ///
+        /// For sets of tasks that each serve a single request or connection, where losing
+        /// one is recoverable and exiting would let one caller stop the process, use
+        /// [`JoinSetExt::await_all_tasks_logging_panics`] instead.
         async fn await_all_tasks(&mut self);
+
+        /// Awaits all tasks spawned in this [`JoinSet`], logging rather than re-raising
+        /// the panic of any task that panicked.
+        async fn await_all_tasks_logging_panics(&mut self);
 
         /// Reaps tasks that have finished.
         fn reap_finished_tasks(&mut self);
@@ -119,7 +146,28 @@ mod implementation {
         }
 
         async fn await_all_tasks(&mut self) {
-            while self.join_next().await.is_some() {}
+            while let Some(result) = self.join_next().await {
+                if let Err(error) = result {
+                    match error.try_into_panic() {
+                        // Tokio contained the panic, so the process is still running
+                        // without whatever this task was doing. Put it back.
+                        Ok(payload) => std::panic::resume_unwind(payload),
+                        Err(error) => tracing::debug!(%error, "Task was cancelled"),
+                    }
+                }
+            }
+        }
+
+        async fn await_all_tasks_logging_panics(&mut self) {
+            while let Some(result) = self.join_next().await {
+                if let Err(error) = result {
+                    if error.is_panic() {
+                        tracing::error!(%error, "Task panicked");
+                    } else {
+                        tracing::debug!(%error, "Task was cancelled");
+                    }
+                }
+            }
         }
 
         fn reap_finished_tasks(&mut self) {
@@ -162,5 +210,52 @@ impl<Output> TaskHandle<Output> {
     /// Returns [`true`] if the task is still running.
     pub fn is_running(&mut self) -> bool {
         self.output_receiver.try_recv().is_err()
+    }
+}
+
+#[cfg(all(test, not(web)))]
+mod tests {
+    use futures::future;
+
+    use super::*;
+
+    /// A set of long-lived tasks must not lose one silently: the panic reaches whoever
+    /// awaits the set, and from there the process.
+    #[tokio::test]
+    async fn test_await_all_tasks_reraises_a_panic() {
+        let joined = tokio::spawn(async {
+            let mut join_set = JoinSet::new();
+            join_set.spawn_task(async {
+                panic!("task panicked");
+            });
+            join_set.await_all_tasks().await;
+        })
+        .await;
+
+        assert!(
+            joined.expect_err("the panic reached the caller").is_panic(),
+            "await_all_tasks re-raised the task's panic",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_await_all_tasks_logging_panics_keeps_going() {
+        let mut join_set = JoinSet::new();
+        join_set.spawn_task(async {
+            panic!("task panicked");
+        });
+        join_set.spawn_task(async {});
+
+        join_set.await_all_tasks_logging_panics().await;
+    }
+
+    /// Aborting a task is how shutdown works, so it must not be mistaken for a failure.
+    #[tokio::test]
+    async fn test_await_all_tasks_ignores_cancelled_tasks() {
+        let mut join_set = JoinSet::new();
+        let handle = join_set.spawn_task(future::pending::<()>());
+        handle.abort();
+
+        join_set.await_all_tasks().await;
     }
 }

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -342,7 +342,7 @@ where
             }
         }
 
-        self.join_set.await_all_tasks().await;
+        self.join_set.await_all_tasks_logging_panics().await;
     }
 }
 
@@ -429,7 +429,7 @@ where
         loop {
             tokio::select! { biased;
                 _ = shutdown_signal.cancelled() => {
-                    join_set.await_all_tasks().await;
+                    join_set.await_all_tasks_logging_panics().await;
                     return Ok(());
                 }
                 maybe_socket = accept_stream.next() => match maybe_socket {
@@ -443,7 +443,7 @@ where
                         reap_countdown -= 1;
                     }
                     Some(Err(error)) => {
-                        join_set.await_all_tasks().await;
+                        join_set.await_all_tasks_logging_panics().await;
                         return Err(error);
                     }
                     None => unreachable!(


### PR DESCRIPTION
## Motivation

`JoinSetExt::await_all_tasks` discarded the outcome of every task it awaited:

```rust
async fn await_all_tasks(&mut self) {
    while self.join_next().await.is_some() {}   // Some(Err(JoinError)) satisfies is_some()
}
```

Tokio catches a task's panic instead of stopping the runtime, so this is the point where a
panic in a long-lived task would have been noticed — and it was thrown away. Two of the three
places that call it are the last statement of a binary's `run()`:

- `linera-service/src/server.rs:292` — the shard server's task set, which holds the cross-chain
  message forwarder and the notification forwarders;
- `linera-service/src/proxy/main.rs:336` — the proxy's internal and public servers.

So if the cross-chain forwarder panicked, the shard kept serving RPCs and answering chain info
queries while forwarding **no cross-chain messages at all**, indefinitely, with no signal beyond
a line on standard error. That is the failure mode we want least: alive enough to stay in the
committee, not alive enough to make progress.

## Proposal

Split the two cases that were being conflated, per the policy added to `CONTRIBUTING.md` in the
preceding PR:

- `await_all_tasks` now re-raises a panicking task's payload with `resume_unwind`, so the
  process exits and a supervisor restarts it. This is the default because these sets normally
  hold long-lived tasks whose silent death disables a subsystem. Cancellation is expected during
  shutdown and is logged at `debug!`, not treated as a failure.
- `await_all_tasks_logging_panics` is new, and logs at `error!` instead of re-raising. It is for
  sets of tasks that each serve one connection or one message, where losing one is recoverable
  and exiting would let a single caller stop the process.

The three call sites in `linera-rpc/src/simple/transport.rs` are switched to the new method:
those sets hold per-connection and per-message handlers. Their panics were previously ignored
entirely, so they are strictly better off — logged rather than silent, without gaining the
ability to take the process down.

Behaviour changes at exactly five call sites: the shard server and the proxy now exit on a task
panic; the three simple-transport sites now log one. Nothing else calls `await_all_tasks`.

On the Web the two methods are the same function: a task's panic aborts the Wasm instance, so
there is nothing left to re-raise.

## Test Plan

Three unit tests, which the module had none of before:

- `test_await_all_tasks_reraises_a_panic`
- `test_await_all_tasks_logging_panics_keeps_going`
- `test_await_all_tasks_ignores_cancelled_tasks` — aborting is how shutdown works, so it must
  not be mistaken for a failure.

```
cargo test -p linera-core join_set_ext                      # 3 passed
cargo clippy --all-targets                                  # clean
cargo +nightly fmt -- --check && taplo fmt --check          # clean
```

## Release Plan

- These changes should be backported to the latest `testnet` branch.

## Links

- Depends on the **Panics** section of `CONTRIBUTING.md` for the crash-vs-contain rule.
- Related: #6659, the same class of bug one level down — a panic in `handle_request` wedging a
  single cross-chain queue rather than the whole forwarder.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
