### PR TITLE
[testnet_conway] Report panics through tracing and a metric, and document our panic policy (#6660)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,37 @@ Two things to keep in mind:
   unawaited futures or unhandled errors. `let _x =` should only be used for RAII guards.
 
 
+## Panics
+
+We build with unwinding, and Tokio catches a panic at the task boundary rather than
+stopping the runtime. A panicking task therefore does not stop the process by itself: what
+happens next is decided entirely by whoever joins that task. Choose deliberately.
+
+* **Report every panic.** `linera_base::panic_hook::init` is installed by
+  `linera_base::tracing::init`, so panics reach the log as a `tracing` event and
+  increment `linera_panics_total`. Do not add a panic hook of your own to a binary that
+  already calls it.
+
+* **Prefer crashing over running degraded.** When a task's death silently disables a
+  subsystem — a cross-chain message forwarder, a notification fan-out, a chain listener —
+  the process should exit and be restarted rather than keep serving without it. Await such
+  tasks with `JoinSetExt::await_all_tasks`, which re-raises the panic.
+
+* **Except for work that is scoped to one request or one chain.** Handling a single RPC,
+  or executing a block for a single chain, must not be able to take the process down: a
+  panic reachable from user input would otherwise be a way for one crafted message to stop
+  every validator at once. Contain those panics and let the caller retry, using
+  `JoinSetExt::await_all_tasks_logging_panics` for sets of such tasks.
+
+* **Never swallow a panic silently.** `catch_unwind` is acceptable at a boundary where the
+  containment is the point, but log at `error!` and say in a comment why continuing is
+  safer than exiting.
+
+* `panic!`, `unwrap` and `expect` are for invariants that a bug in *our* code would break,
+  never for input we receive from a peer, a client or an application. Prefer returning an
+  error for anything reachable from outside the process.
+
+
 ## Hash-consed types and `linera_cache::Arc<T>`
 
 Any content-addressed immutable data (also known as hash-consed data) — for

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -28,6 +28,8 @@ pub mod identifiers;
 mod limited_writer;
 pub mod ownership;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod panic_hook;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod port;
 #[cfg(with_metrics)]
 pub mod prometheus_util;

--- a/linera-base/src/panic_hook.rs
+++ b/linera-base/src/panic_hook.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Process-wide reporting of panics.
+//!
+//! Tokio catches a panic at the task boundary and hands it to whoever joins the task, so a
+//! panicking task neither stops the runtime nor, on its own, produces anything a monitoring
+//! system can act on: the default hook writes to standard error and nothing else. The hook
+//! installed here reports the panic through `tracing` and the metrics registry first, so
+//! that panics are visible wherever the process's other logs and metrics are collected.
+
+use std::{
+    panic::PanicHookInfo,
+    sync::{Mutex, Once},
+};
+
+#[cfg(with_metrics)]
+mod metrics {
+    use std::sync::LazyLock;
+
+    use prometheus::IntCounter;
+
+    use crate::prometheus_util::register_int_counter;
+
+    /// Panics observed by the hook installed by [`super::init`].
+    ///
+    /// A panic does not stop the process, so this counter is often the only durable signal
+    /// that one happened: whatever the panicking task was responsible for has stopped, and
+    /// the effect on the rest of the process depends entirely on who was joining it. Any
+    /// increase deserves investigation.
+    pub(super) static PANICS: LazyLock<IntCounter> =
+        LazyLock::new(|| register_int_counter("linera_panics_total", "Number of panics observed"));
+}
+
+/// A panic hook, in the form [`std::panic::take_hook`] returns it.
+type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send>;
+
+/// The hook that was installed before ours, which we delegate to so that the standard
+/// message and the `RUST_BACKTRACE` backtrace are still printed.
+static PREVIOUS_HOOK: Mutex<Option<PanicHook>> = Mutex::new(None);
+
+static INIT: Once = Once::new();
+
+/// Installs a panic hook that reports panics through `tracing` and the metrics registry
+/// before delegating to the hook that was previously installed.
+///
+/// Calling this more than once has no further effect. It does not change what a panic
+/// *does* — the process still unwinds the panicking task and keeps running — only what is
+/// recorded about it.
+pub fn init() {
+    INIT.call_once(|| {
+        *PREVIOUS_HOOK.lock().expect("hook mutex is never poisoned") =
+            Some(std::panic::take_hook());
+        std::panic::set_hook(Box::new(report_panic));
+    });
+}
+
+/// The panic message, for the two payload types `panic!` produces.
+///
+/// `PanicHookInfo::payload_as_str` does the same thing, but is not yet stable in the
+/// toolchain the release branches pin, and this code is backported to them.
+fn payload_message<'a>(info: &'a PanicHookInfo<'_>) -> &'a str {
+    let payload = info.payload();
+    payload
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("<non-string payload>")
+}
+
+fn report_panic(info: &PanicHookInfo<'_>) {
+    #[cfg(with_metrics)]
+    metrics::PANICS.inc();
+
+    let thread = std::thread::current();
+    tracing::error!(
+        thread = thread.name().unwrap_or("<unnamed>"),
+        location = info.location().map(tracing::field::display),
+        message = payload_message(info),
+        "Panic",
+    );
+
+    // The lock is only ever held while installing the hook, and the hook is installed
+    // once, so a panic here would mean a panic inside `init` itself.
+    if let Ok(guard) = PREVIOUS_HOOK.lock() {
+        if let Some(previous) = guard.as_ref() {
+            previous(info);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::AssertUnwindSafe,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+
+    /// Installing the hook twice must not chain it to itself, which would make every panic
+    /// report grow by one line per call.
+    #[test]
+    fn test_init_is_idempotent() {
+        static DELEGATIONS: AtomicUsize = AtomicUsize::new(0);
+
+        std::panic::set_hook(Box::new(|_| {
+            DELEGATIONS.fetch_add(1, Ordering::SeqCst);
+        }));
+        init();
+        init();
+
+        let panicked = std::panic::catch_unwind(AssertUnwindSafe(|| panic!("boom"))).is_err();
+
+        assert!(panicked);
+        assert_eq!(
+            DELEGATIONS.load(Ordering::SeqCst),
+            1,
+            "the hook installed before `init` ran exactly once",
+        );
+    }
+}

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -82,6 +82,11 @@ impl EnvConfig {
 /// The `LINERA_LOG_DIR` environment variable can be used to configure a directory to
 /// store log files. If it is set, a file named `log_name` with the `log` extension is
 /// created in the directory.
+///
+/// This also installs the panic hook from [`crate::panic_hook`], so that panics are
+/// reported through the subscriber set up here rather than to standard error alone. Every
+/// binary reaches this function, which is why the hook is installed from it rather than
+/// from each `main`.
 pub fn init(log_name: &str) {
     let config = get_env_config(log_name);
     let maybe_log_file_layer = config.maybe_log_file_layer();
@@ -92,6 +97,8 @@ pub fn init(log_name: &str) {
         .with(maybe_log_file_layer)
         .with(stderr_layer)
         .init();
+
+    crate::panic_hook::init();
 }
 
 pub(crate) fn get_env_config(log_name: &str) -> EnvConfig {

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -83,10 +83,10 @@ impl EnvConfig {
 /// store log files. If it is set, a file named `log_name` with the `log` extension is
 /// created in the directory.
 ///
-/// This also installs the panic hook from [`crate::panic_hook`], so that panics are
-/// reported through the subscriber set up here rather than to standard error alone. Every
-/// binary reaches this function, which is why the hook is installed from it rather than
-/// from each `main`.
+/// On native targets this also installs the panic hook from [`crate::panic_hook`], so that
+/// panics are reported through the subscriber set up here rather than to standard error
+/// alone. Every binary reaches this function, which is why the hook is installed from it
+/// rather than from each `main`.
 pub fn init(log_name: &str) {
     let config = get_env_config(log_name);
     let maybe_log_file_layer = config.maybe_log_file_layer();
@@ -98,6 +98,9 @@ pub fn init(log_name: &str) {
         .with(stderr_layer)
         .init();
 
+    // Applications compile this module for `wasm32` too, where reporting panics is the Wasm
+    // runtime's job and `panic_hook` is not built.
+    #[cfg(not(target_arch = "wasm32"))]
     crate::panic_hook::init();
 }
 

--- a/linera-base/src/tracing_opentelemetry.rs
+++ b/linera-base/src/tracing_opentelemetry.rs
@@ -73,6 +73,8 @@ fn init_with_tracer_provider(log_name: &str, tracer_provider: &SdkTracerProvider
         .with(maybe_log_file_layer)
         .with(stderr_layer)
         .init();
+
+    crate::panic_hook::init();
 }
 
 /// Builds an OpenTelemetry layer with the opentelemetry.skip filter.


### PR DESCRIPTION
Backport of #6660 to `testnet_conway`.

## Motivation

We build with unwinding, and Tokio catches a panic at the task boundary rather than stopping
the runtime. So a panicking task does not stop the process — and nothing in the codebase reacts
to it. The default hook writes the message and backtrace to standard error and that is all:
there is no `tracing` event carrying the panic through whatever subscriber the binary set up,
and no metric, so a panic cannot be alerted on and does not show up in any dashboard.

That matters because the *consequence* of a contained panic is usually invisible too. Whatever
the task was responsible for has simply stopped, and how much that costs depends entirely on who
was joining it — which today is often nobody (see #6659, and the `JoinSetExt` change that
follows this PR).

## Proposal

Add `linera_base::panic_hook::init`, which installs a hook that reports each panic through
`tracing::error!` (thread, location, message) and increments a new `linera_panics_total`
counter, then delegates to the hook that was installed before it, so the standard message and
the `RUST_BACKTRACE` backtrace are still printed. It is idempotent and does not change what a
panic *does* — only what is recorded about it.

It is installed from `linera_base::tracing::init` and its OpenTelemetry counterpart, which every
binary reaches, rather than from each `main`. (On `main` these live in `linera-service` and
`linera-exporter` builds its own subscriber, so that branch also patches the exporter; here the
exporter already goes through the shared init and needs no change.)

Also adds a **Panics** section to `CONTRIBUTING.md`, which had nothing on the subject. It writes
down the policy this PR and its follow-up implement:

- report every panic (this PR);
- prefer crashing over running degraded, for tasks whose death silently disables a subsystem;
- except for work scoped to one request or one chain, where a panic reachable from user input
  must not become a way for one crafted message to stop every validator at once;
- never swallow a panic silently;
- `panic!` / `unwrap` / `expect` are for our own invariants, not for input from peers, clients
  or applications.

## Test Plan

```
cargo test -p linera-base --features metrics panic_hook     # 1 passed (on Rust 1.86)
cargo clippy -p linera-base -p linera-service \
    -p linera-exporter --all-targets                        # clean
cargo +nightly fmt -- --check && taplo fmt --check          # clean
```

The unit test covers idempotence — installing twice must not chain the hook to itself, which
would make every panic report grow a line per call.

Manual check that the wiring works end to end is worth doing at review time by panicking a task
in a locally-running validator and confirming both the `error!` event and the counter; I have
not done that here.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

This *is* the backport. It is observability only, with no behaviour change, and
`linera_panics_total` is exactly the signal that is missing when diagnosing stalls on this
network.

## Links

- Backport of #6660.
- Follow-up: #6663, `JoinSetExt::await_all_tasks` re-raising panics for supervisory task sets.
- Context: #6662, where a contained panic stops the shard forwarding cross-chain messages.

Note this branch pins Rust 1.86, where `PanicHookInfo::payload_as_str` is not yet stable, so the
payload is read by hand. `main` carries the identical code so the two do not drift.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
