### PR TITLE
Run the merge-queue test suites on pushes to main

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -2,7 +2,7 @@ name: Benchmark Test
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*' ]
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/bridge-check.yml
+++ b/.github/workflows/bridge-check.yml
@@ -1,6 +1,13 @@
 name: Bridge check
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -5,7 +5,7 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [ 'testnet_*' ]
+    branches: [ main, 'testnet_*' ]
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'

--- a/.github/workflows/docker-compose.yml
+++ b/.github/workflows/docker-compose.yml
@@ -2,7 +2,7 @@ name: Docker Compose
 
 on:
   push:
-    branches: ["devnet_*", "testnet_*"]
+    branches: [main, "devnet_*", "testnet_*"]
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/explorer-rust-check.yml
+++ b/.github/workflows/explorer-rust-check.yml
@@ -1,6 +1,13 @@
 name: Explorer Rust check
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'mdbook/**'
+      - 'kubernetes/**'
+      - 'docker/dashboards/**'
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/indexer.yml
+++ b/.github/workflows/indexer.yml
@@ -1,6 +1,8 @@
 name: Indexer Tests
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches:
       - "**"
@@ -75,7 +77,7 @@ jobs:
         cargo test --locked -p linera-indexer --lib -- --skip db::postgres
 
   indexer-integration-tests:
-    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/lint-check-all-features.yml
+++ b/.github/workflows/lint-check-all-features.yml
@@ -2,7 +2,7 @@ name: Lint check all features
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*' ]
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -2,7 +2,7 @@ name: Long Faucet chain test
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*' ]
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/remote-net-test.yml
+++ b/.github/workflows/remote-net-test.yml
@@ -2,7 +2,7 @@ name: Remote Net Test
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*' ]
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*' ]
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   merge_group:
   pull_request:
     branches:

--- a/.github/workflows/test-readmes.yml
+++ b/.github/workflows/test-readmes.yml
@@ -2,7 +2,7 @@ name: Run README tests
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*' ]
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -2,7 +2,7 @@ name: Web
 
 on:
   push:
-    branches: [ 'devnet_*', 'testnet_*' ]
+    branches: [ main, 'devnet_*', 'testnet_*' ]
   merge_group:
   pull_request:
     branches:


### PR DESCRIPTION
## Motivation

We are turning off the merge queue on `main`. With two engineers, serializing every
merge behind a full queue cycle costs more than it buys, and post-merge breakage is
something we can detect and react to via alerting.

The catch: the heavy suites were wired to `merge_group` and nothing else. Twelve
workflows have no `main` push trigger at all, so disabling the queue without this
change would not move those tests to post-merge — it would stop them running on
merged code entirely.

Observed on `main` before this change (`gh run list -e push -b main`): only Forge
Deploy Scripts, Explorer tests, Book, ScyllaDB tests, Docker Image, Documentation and
Dockerfile Lint run. No Rust, no Remote Net Test, no Bridge E2E, no Docker Compose.

Two workflows already covered `main` and are untouched: `dockerfile-lint.yml` and
`forge-deploy-scripts.yml`.

## Proposal

Add `main` to the `push` trigger of the twelve `merge_group` workflows that lacked it.

Nine already had a `push` block, so `main` is added to the existing branch list:

- `benchmark-test.yml`, `lint-check-all-features.yml`, `long_faucet_chain_test.yml`,
  `remote-net-test.yml`, `rust.yml`, `test-readmes.yml`, `web.yml`,
  `docker-compose.yml` — were `['devnet_*', 'testnet_*']`
- `bridge-e2e.yml` — was `['testnet_*']`

Three had no `push` trigger at all and get one. Each mirrors the filtering its own
`pull_request` trigger already uses, so post-merge scope matches PR scope:

- `bridge-check.yml`, `explorer-rust-check.yml` — `branches: [main]` plus the same
  `paths-ignore` list
- `indexer.yml` — `branches: [main]`; this workflow filters via its `changed-files`
  job rather than `paths-ignore`

One job-level gate also needed fixing. `indexer.yml`'s `indexer-integration-tests` was
gated on `merge_group || workflow_dispatch`, with no `push`, so the new trigger alone
would have left it permanently skipped. It now admits `push` as well.

The `merge_group:` triggers are deliberately left in place. They are inert while the
queue is off and keep re-enabling it a settings change rather than a code change.

### Not changed, and why

- Concurrency groups are `${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}`.
  On `push` the first two are empty, so the group falls through to the unique
  `run_id` and `cancel-in-progress` can never cancel a `main` run. Back-to-back
  merges both complete.
- `dorny/paths-filter` in the `changed-files` jobs needs no `base`. Its default is the
  repository default branch, and per its README, "If it references the same branch it
  was pushed to, changes are detected against the most recent commit before the push."
  Pushing to `main` with base `main` yields exactly the merged PR's diff.
- `lint-check-all-features.yml`'s `check-all-features-partition` is gated
  `github.event_name != 'pull_request'`, which already admits `push`. The trigger
  change is sufficient. This job is a good illustration of the problem: it is
  deliberately excluded from PRs, so the merge queue was its only validation.

## Test Plan

- All twelve workflows parse, and the `main` trigger was asserted programmatically by
  loading each `on:` block with PyYAML and `fnmatch`-ing `main` against
  `push.branches`. All twelve report `main` as matching; every workflow in
  `.github/workflows` parses without error.
- Grepped every `event_name` gate across `.github/workflows` to confirm none of the
  changed workflows still excludes `push`. The only remaining non-`push` gates are in
  `instruction-count-benchmarks.yml`, which has no `merge_group` trigger and is out of
  scope.
- Real verification is the first merge into `main` after this lands: `gh run list -e
  push -b main` should show Rust, Remote Net Test, Bridge E2E, Docker Compose, Long
  Faucet chain test, Run README tests, Web, Benchmark Test, Lint check all features,
  Bridge check, Explorer Rust check and Indexer Tests.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
