### PR TITLE
install-protoc: pick the release asset matching the runner OS and arch

### DIFF
--- a/.github/actions/install-protoc/action.yml
+++ b/.github/actions/install-protoc/action.yml
@@ -14,7 +14,29 @@ runs:
         PB_VER: ${{ inputs.version }}
       run: |
         set -euo pipefail
+
+        # protoc release assets are named <version>-<os>-<arch>, and both halves
+        # use spellings that match neither uname nor Rust target triples:
+        # the OS is `osx` (not darwin/macos) and 64-bit ARM is `aarch_64` with an
+        # UNDERSCORE (not aarch64/arm64). Getting either wrong yields a 404 that
+        # only shows up on the platform you did not test.
+        case "$(uname -s)" in
+          Linux)  os=linux ;;
+          Darwin) os=osx ;;
+          *) echo "install-protoc: unsupported OS '$(uname -s)'" >&2; exit 1 ;;
+        esac
+
+        # macOS reports arm64, Linux reports aarch64 — both map to aarch_64.
+        case "$(uname -m)" in
+          x86_64|amd64)  arch=x86_64 ;;
+          aarch64|arm64) arch=aarch_64 ;;
+          *) echo "install-protoc: unsupported architecture '$(uname -m)'" >&2; exit 1 ;;
+        esac
+
+        asset="protoc-${PB_VER}-${os}-${arch}.zip"
+        echo "install-protoc: $(uname -s)/$(uname -m) -> ${asset}"
+
         curl -fsSL -o /tmp/protoc.zip \
-          "https://github.com/protocolbuffers/protobuf/releases/download/v${PB_VER}/protoc-${PB_VER}-linux-x86_64.zip"
+          "https://github.com/protocolbuffers/protobuf/releases/download/v${PB_VER}/${asset}"
         sudo unzip -o /tmp/protoc.zip -d /usr/local
         protoc --version


### PR DESCRIPTION
## Motivation

`.github/actions/install-protoc` hardcodes the `linux-x86_64` release asset, so it only ever worked
on x64 Linux runners. That was invisible until #6643 added `Client Binaries`, which builds the
`linera` client natively on four runners. Its first run on `main`
([31200574857](https://github.com/linera-io/linera-protocol/actions/runs/31200574857)) failed on
three of them, all at the same step:

```
failure  aarch64-apple-darwin      Install Protoc
failure  x86_64-apple-darwin       Install Protoc
failure  aarch64-unknown-linux-gnu Install Protoc
         x86_64-unknown-linux-gnu  (the one platform the action supported)
```

## Proposal

Derive the asset name from `uname` instead of hardcoding it.

Both halves of protoc's asset naming use spellings that match neither `uname` nor Rust target
triples, which is exactly why this is worth a comment in the file rather than a clever one-liner:

- the OS is **`osx`**, not `darwin` or `macos`
- 64-bit ARM is **`aarch_64`** — with an **underscore** — not `aarch64` or `arm64`
- and `uname -m` itself disagrees across platforms: macOS reports `arm64`, Linux reports `aarch64`

Unsupported OS/arch now fails with a clear message rather than a 404 from `curl` midway through a
job.

The x64 Linux path resolves to the identical asset it used before, so every existing caller is
unaffected.

## Test Plan

Every URL the mapping can generate was checked against the real GitHub release, per runner label
used in this repo:

```
ubuntu-latest      Linux/x86_64   -> protoc-34.1-linux-x86_64.zip     HTTP 200
ubuntu-24.04-arm   Linux/aarch64  -> protoc-34.1-linux-aarch_64.zip   HTTP 200
macos-latest       Darwin/arm64   -> protoc-34.1-osx-aarch_64.zip     HTTP 200
macos-15-intel     Darwin/x86_64  -> protoc-34.1-osx-x86_64.zip       HTTP 200
```

Negative control, to confirm the underscore is load-bearing rather than incidental:

```
protoc-34.1-osx-aarch64.zip  (no underscore)  HTTP 404
```

The action's script passes `bash -n`, and the YAML parses.

`Client Binaries` is dispatched against this branch — that run, exercising all four runners, is the
real gate here, since the failure this fixes is by definition invisible on x64 Linux.

## Release Plan

- These changes follow the usual release cycle.

Also needed on `testnet_conway`: that branch has its own copy of this action with the same
hardcoded asset, and the backport of #6643 will put the same four-platform workflow there.

## Links

- Fixes the first run of `Client Binaries`, added in #6643
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
