### PR TITLE
Backport #6643 and #6668: multi-platform linera-client and prebuilt client binaries

### DIFF
--- a/.github/actions/install-protoc/action.yml
+++ b/.github/actions/install-protoc/action.yml
@@ -14,7 +14,29 @@ runs:
         PB_VER: ${{ inputs.version }}
       run: |
         set -euo pipefail
+
+        # protoc release assets are named <version>-<os>-<arch>, and both halves
+        # use spellings that match neither uname nor Rust target triples:
+        # the OS is `osx` (not darwin/macos) and 64-bit ARM is `aarch_64` with an
+        # UNDERSCORE (not aarch64/arm64). Getting either wrong yields a 404 that
+        # only shows up on the platform you did not test.
+        case "$(uname -s)" in
+          Linux)  os=linux ;;
+          Darwin) os=osx ;;
+          *) echo "install-protoc: unsupported OS '$(uname -s)'" >&2; exit 1 ;;
+        esac
+
+        # macOS reports arm64, Linux reports aarch64 — both map to aarch_64.
+        case "$(uname -m)" in
+          x86_64|amd64)  arch=x86_64 ;;
+          aarch64|arm64) arch=aarch_64 ;;
+          *) echo "install-protoc: unsupported architecture '$(uname -m)'" >&2; exit 1 ;;
+        esac
+
+        asset="protoc-${PB_VER}-${os}-${arch}.zip"
+        echo "install-protoc: $(uname -s)/$(uname -m) -> ${asset}"
+
         curl -fsSL -o /tmp/protoc.zip \
-          "https://github.com/protocolbuffers/protobuf/releases/download/v${PB_VER}/protoc-${PB_VER}-linux-x86_64.zip"
+          "https://github.com/protocolbuffers/protobuf/releases/download/v${PB_VER}/${asset}"
         sudo unzip -o /tmp/protoc.zip -d /usr/local
         protoc --version

--- a/.github/workflows/client-binaries.yml
+++ b/.github/workflows/client-binaries.yml
@@ -1,0 +1,121 @@
+name: Client Binaries
+
+# Prebuilt `linera` client binaries so nobody has to compile the client to use
+# it. Each target is built NATIVELY on its own runner — no cross-compilation and
+# no QEMU, both of which are painful here because the client pulls in rocksdb
+# (C++), wasmer and protobuf.
+#
+# Every runner label below is a STANDARD GitHub-hosted runner, and standard
+# runners are free and unlimited on public repositories (linera-protocol is
+# public). Do NOT switch any of these to a larger runner: larger runners are
+# billed even for public repos.
+#
+# Windows is deliberately absent — we do not support it.
+
+# Same triggers as the Docker Image workflow, so a commit that gets images also
+# gets binaries.
+on:
+  push:
+    branches: [ main, 'devnet_*', 'testnet_*' ]
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+  # The root Cargo.toml sets `[profile.release] debug = true` so production
+  # binaries can be profiled. For something people download it is the difference
+  # between a 368 MB and a 42 MB tarball (1693 MB vs 123 MB on disk), and it
+  # keeps ~212k symbols either way, so panic backtraces still symbolicate.
+  #
+  # This has to be a CARGO_PROFILE_* override rather than RUSTFLAGS: setting
+  # RUSTFLAGS in the environment REPLACES the per-target rustflags in
+  # .cargo/config.toml, which would silently drop `-fuse-ld=lld` and
+  # `force-frame-pointers` from the x86_64-linux build.
+  CARGO_PROFILE_RELEASE_DEBUG: "false"
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    # The smallest leg here is macos-latest at 3 cores / 7 GB, building the whole
+    # dependency graph in release mode from a cold cache.
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: ${{ matrix.target }}
+          # Cache per target so the four jobs don't fight over one key.
+          cache-key: client-${{ matrix.target }}
+
+      - name: Install Protoc
+        uses: ./.github/actions/install-protoc
+
+      # .cargo/config.toml pins `linker = "aarch64-linux-gnu-gcc"` for this
+      # target. Nothing in this repo builds on arm64 today, so do not assume the
+      # runner image ships that exact name — a missing linker only surfaces at
+      # the very end of an hour-long build.
+      - name: Ensure the pinned aarch64 linker exists
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          set -euo pipefail
+          if ! command -v aarch64-linux-gnu-gcc >/dev/null; then
+            echo "aarch64-linux-gnu-gcc not found; installing it"
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu
+          fi
+          aarch64-linux-gnu-gcc --version | head -1
+
+      - name: Build the client
+        run: cargo build --locked --release --bin linera --target ${{ matrix.target }}
+
+      # Sanity-check the artifact actually runs on the machine that built it.
+      # `--version` is enough to catch a bad link or a missing shared library,
+      # which is the whole failure mode this workflow exists to prevent.
+      - name: Smoke-test the binary
+        run: ./target/${{ matrix.target }}/release/linera --version
+
+      - name: Package
+        id: package
+        run: |
+          set -euo pipefail
+          NAME="linera-${{ matrix.target }}"
+          mkdir -p "dist/${NAME}"
+          cp "target/${{ matrix.target }}/release/linera" "dist/${NAME}/linera"
+          tar -C dist -czf "${NAME}.tar.gz" "${NAME}"
+          # Checksums so a download can be verified without trusting the transport.
+          shasum -a 256 "${NAME}.tar.gz" > "${NAME}.tar.gz.sha256"
+          echo "name=${NAME}" >> "$GITHUB_OUTPUT"
+
+      # One downloadable artifact per commit, per platform.
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.name }}
+          path: |
+            ${{ steps.package.outputs.name }}.tar.gz
+            ${{ steps.package.outputs.name }}.tar.gz.sha256
+          retention-days: 30

--- a/.github/workflows/client-binaries.yml
+++ b/.github/workflows/client-binaries.yml
@@ -16,7 +16,7 @@ name: Client Binaries
 # gets binaries.
 on:
   push:
-    branches: [ main, 'devnet_*', 'testnet_*' ]
+    branches: [ 'devnet_*', 'testnet_*' ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -67,7 +67,7 @@ jobs:
 
           REGISTRY_BASE="us-docker.pkg.dev/linera-io-dev/linera-public-registry"
 
-          for IMAGE_VAR in LINERA_VALIDATOR:linera-validator LINERA_CLIENT:linera-client LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
+          for IMAGE_VAR in LINERA_VALIDATOR:linera-validator LINERA_TESTS:linera-tests INDEXER:linera-indexer EXPLORER:linera-explorer EXPORTER:linera-exporter PLAYGROUND:linera-playground; do
             VAR="${IMAGE_VAR%%:*}"
             NAME="${IMAGE_VAR##*:}"
             echo "${VAR}_IMAGE_BRANCH=${REGISTRY_BASE}/${NAME}:${BRANCH_TAG}" >> "$GITHUB_ENV"
@@ -133,14 +133,6 @@ jobs:
             "${LINERA_VALIDATOR_IMAGE_BRANCH}" "${LINERA_VALIDATOR_IMAGE_SHORT}" "${LINERA_VALIDATOR_IMAGE_LONG}" "LineraValidator" "validator" &
           PID_LINERA_VALIDATOR=$!
 
-          # linera-client: the client binary only. Also what the validator
-          # chart's *-initializer init containers need (they run
-          # `linera storage check-existence`), so they can stop pulling the
-          # all-three image.
-          build_and_push "docker/Dockerfile" \
-            "${LINERA_CLIENT_IMAGE_BRANCH}" "${LINERA_CLIENT_IMAGE_SHORT}" "${LINERA_CLIENT_IMAGE_LONG}" "LineraClient" "client" &
-          PID_LINERA_CLIENT=$!
-
           # linera-tests shares the Dockerfile and chef cache mounts with
           # linera; --target tests builds the overlay stage that bundles
           # the remote-net integration test binary on top of the runtime.
@@ -170,7 +162,7 @@ jobs:
 
           SUCCESS_NAMES=""
           FAILED_NAMES=""
-          for NAME_PID in LineraValidator:$PID_LINERA_VALIDATOR LineraClient:$PID_LINERA_CLIENT LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
+          for NAME_PID in LineraValidator:$PID_LINERA_VALIDATOR LineraTests:$PID_LINERA_TESTS Indexer:$PID_INDEXER Explorer:$PID_EXPLORER Exporter:$PID_EXPORTER Playground:$PID_PLAYGROUND; do
             NAME="${NAME_PID%%:*}"
             PID="${NAME_PID##*:}"
             if wait "$PID"; then
@@ -200,3 +192,137 @@ jobs:
           fi
 
           echo "All image builds completed successfully!"
+
+  # ── linera-client: multi-platform ──
+  # linera-client is the one image end users pull directly, so it ships for both
+  # linux/amd64 and linux/arm64 (Apple Silicon, Graviton). Each platform builds
+  # NATIVELY on a runner of its own architecture — cross-building this workspace
+  # under QEMU turns a ~1h Rust build into a multi-hour one.
+  #
+  # Each leg publishes only an arch-suffixed tag; merge-client-image below
+  # stitches them into a manifest list under the real tags, so the tags people
+  # actually pull are never transiently single-platform.
+  #
+  # Both legs use STANDARD GitHub-hosted runners, which are free and unlimited on
+  # public repositories. Do NOT move either to a larger runner: those are billed
+  # even on public repos. Deliberately NOT the self-hosted builder — it is busy
+  # with build-and-push, and an amd64 client build that queues behind it holds up
+  # the merge below. Without debuginfo this builds in ~22 min on a hosted runner.
+  build-client-image:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    # No warm cache on the hosted arm runner: this is a from-scratch release
+    # build of the whole dependency graph on 4 cores.
+    timeout-minutes: 180
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/gcp-auth
+        with:
+          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+          configure_docker_for: us-docker.pkg.dev
+
+      - name: Wait for docker daemon
+        run: |
+          for i in $(seq 1 60); do
+            if docker info >/dev/null 2>&1; then
+              echo "Docker ready after ${i} attempt(s)"
+              exit 0
+            fi
+            echo "Waiting for docker daemon ($i/60)..."
+            sleep 2
+          done
+          echo "Docker daemon did not become ready in 120s"
+          exit 1
+
+      # A build that dies from exhausted disk or memory looks nothing like a
+      # compile error in the log, so record both up front. (The hosted arm64
+      # runner reports 145 GB free, not the 14 GB the docs table lists — disk is
+      # not the constraint here, memory during the final link is.)
+      - name: Log available resources
+        run: |
+          df -h /
+          free -h
+
+      - name: Build and push the arch-specific image
+        env:
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          IMAGE="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-client:${GITHUB_SHA:0:7}-${ARCH}"
+
+          DOCKER_BUILDKIT=1 docker build \
+            -t "${IMAGE}" \
+            -f docker/Dockerfile \
+            --target client \
+            --build-arg "git_commit=${GITHUB_SHA}" \
+            --build-arg "build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+            --build-arg "build_flag=--release" \
+            --build-arg "build_folder=release" \
+            .
+
+          # A binary that cannot start is worse than a missing image, and this is
+          # the first arm64 build we ship — check it actually runs.
+          docker run --rm "${IMAGE}" /linera --version
+
+          docker push "${IMAGE}"
+
+  merge-client-image:
+    # Plain `needs`, no `if`: this must run only when BOTH legs succeeded.
+    # Publishing whatever happened to be ready is worse than publishing nothing —
+    # a missing tag fails loudly at deploy time, while a tag that silently lacks
+    # amd64 fails at runtime on every machine we actually run on.
+    needs: build-client-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: ./.github/actions/gcp-auth
+        with:
+          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
+          configure_docker_for: us-docker.pkg.dev
+
+      - name: Merge the per-arch images into one manifest list
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          BRANCH_NAME="${HEAD_REF:-${REF_NAME}}"
+          # Docker tags forbid '/'; same substitution as the build-and-push job.
+          BRANCH_TAG="${BRANCH_NAME//\//-}"
+          REPO="us-docker.pkg.dev/linera-io-dev/linera-public-registry/linera-client"
+
+          SOURCES=()
+          for ARCH in amd64 arm64; do
+            SRC="${REPO}:${GITHUB_SHA:0:7}-${ARCH}"
+            # Both legs succeeded for this job to run at all, so a missing tag
+            # here means something else went wrong — never paper over it.
+            if ! docker buildx imagetools inspect "${SRC}" >/dev/null 2>&1; then
+              echo "::error::${SRC} is missing despite its build leg succeeding"
+              exit 1
+            fi
+            echo "found ${SRC}"
+            SOURCES+=("${SRC}")
+          done
+
+          docker buildx imagetools create \
+            -t "${REPO}:${BRANCH_TAG}" \
+            -t "${REPO}:${GITHUB_SHA:0:7}" \
+            -t "${REPO}:${GITHUB_SHA}" \
+            "${SOURCES[@]}"
+
+          docker buildx imagetools inspect "${REPO}:${GITHUB_SHA:0:7}"

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -227,10 +227,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: ./.github/actions/gcp-auth
+      - name: Auth service account
+        uses: google-github-actions/auth@v1
         with:
-          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
-          configure_docker_for: us-docker.pkg.dev
+          credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Configure Docker to push to Artifact Registry
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
       - name: Wait for docker daemon
         run: |
@@ -289,10 +295,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: ./.github/actions/gcp-auth
+      - name: Auth service account
+        uses: google-github-actions/auth@v1
         with:
-          service_account: actions-runner@linera-io-dev.iam.gserviceaccount.com
-          configure_docker_for: us-docker.pkg.dev
+          credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Configure Docker to push to Artifact Registry
+        run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
       - name: Merge the per-arch images into one manifest list
         env:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,12 @@ ARG build_date
 ARG build_flag=--release
 ARG build_folder=release
 ARG build_features=scylladb,metrics,opentelemetry,jemalloc
-ARG rustflags="-C force-frame-pointers=yes -L /usr/lib/x86_64-linux-gnu"
+# The `-L` lets the linker find libunwind, jemalloc's stack-trace backend (#5602).
+# Debian's multiarch lib dir is arch-dependent (x86_64-linux-gnu vs
+# aarch64-linux-gnu), so this points at a stable symlink that cook_base resolves
+# from the build machine. Hardcoding one arch would silently drop libunwind on
+# the other.
+ARG rustflags="-C force-frame-pointers=yes -L /usr/lib/deb-multiarch"
 
 # ── Stage 0: chef base (rust + cargo-chef + system deps) ──
 FROM rust:1.86-slim-bookworm AS chef
@@ -129,6 +134,10 @@ COPY linera-sdk/wit linera-sdk/wit
 COPY --from=planner /examples-stubs examples
 
 ENV GIT_COMMIT=${git_commit}
+
+# Resolve the multiarch lib dir from the machine actually doing the build, so
+# `rustflags` above stays arch-agnostic and amd64/arm64 need no separate value.
+RUN ln -s "/usr/lib/$(uname -m)-linux-gnu" /usr/lib/deb-multiarch
 ENV RUSTFLAGS=${rustflags}
 
 # ── Stage 3a: builder_src — all three binaries, for the `tests` image only ──
@@ -214,6 +223,14 @@ FROM cook_base AS client_builder
 ARG build_flag
 ARG build_folder
 ARG build_features
+
+# `[profile.release] debug = true` (root Cargo.toml) is there so production
+# binaries can be profiled, and it costs a LOT: the client links to 1693 MB with
+# debuginfo versus 123 MB without, while keeping ~212k symbols either way, so
+# panic backtraces still symbolicate. Linking that with thin LTO does not fit in
+# a 16 GB arm64 runner. The validator keeps debuginfo — it is the one being
+# profiled — so this is set on the client stage only, not in cook_base.
+ENV CARGO_PROFILE_RELEASE_DEBUG=false
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \


### PR DESCRIPTION
## Motivation

Backport of #6643 (multi-platform `linera-client` image + prebuilt client binaries) and #6668
(the `install-protoc` fix it depends on) to `testnet_conway`.

The two go together deliberately. `install-protoc` on this branch has the same hardcoded
`linux-x86_64` asset that `main` had, so backporting #6643 alone would reproduce its first-run
failure here exactly: three of the four `Client Binaries` legs dying at `Install Protoc`.

## Proposal

Cherry-picks of d5682a9 (#6643) and 1704fae (#6668), plus the adaptations this branch needs.
`testnet_conway` has diverged from `main` in ways that would have failed silently or loudly:

**GCP auth — the one that would have broken outright.** `main` authenticates through the
`./.github/actions/gcp-auth` composite action (Workload Identity Federation). **That action does not
exist on this branch** — `.github/actions/` here contains only `get-solc` and `install-protoc`. The
two new jobs referenced it, so they would have failed immediately with "can't find action.yml",
after the PR looked entirely clean. They now use this branch's own pattern, matching `build-and-push`
right above them:

```yaml
- name: Auth service account
  uses: google-github-actions/auth@v1
  with:
    credentials_json: ${{ secrets.GCP_SA_ACTIONS_RUNNER_KEY }}
- name: Set up Google Cloud SDK
  uses: google-github-actions/setup-gcloud@v1
- name: Configure Docker to push to Artifact Registry
  run: gcloud auth configure-docker us-docker.pkg.dev --quiet
```

Consequently no `id-token: write` permission is needed here (that is a WIF requirement), and this
branch's `permissions: contents: read` is unchanged.

**Branch filters.** `Client Binaries` triggers on `['devnet_*', 'testnet_*']`, matching this
branch's `docker_image.yml`, which deliberately omits `main`.

**`build_features` preserved.** This branch builds with
`scylladb,metrics,opentelemetry,jemalloc`; `main` has no `opentelemetry`. The conflict landed on
exactly that line because #6643 rewrites the adjacent `rustflags`, and the resolution keeps this
branch's feature list with the new `rustflags`.

## Test Plan

**Every locally-referenced action verified to exist on this branch** — the check that caught the
`gcp-auth` problem:

```
client-binaries.yml   ./.github/actions/install-protoc   EXISTS
docker_image.yml      (no local actions remain)
```

**Stage-graph closure, parsed from this branch's Dockerfile:**

```
--target validator  -> validator_builder      (never builder_src, never client_builder)
--target client     -> client_builder
--target tests      -> builder_src, tests-builder
--target default    -> nothing (guard stage)
```

**The three fixes are present and intact:**

```
docker/Dockerfile:52   ARG rustflags=… -L /usr/lib/deb-multiarch
docker/Dockerfile:140  RUN ln -s "/usr/lib/$(uname -m)-linux-gnu" /usr/lib/deb-multiarch
docker/Dockerfile:233  ENV CARGO_PROFILE_RELEASE_DEBUG=false   (client stage only)
```

Client image matrix is `amd64→ubuntu-latest`, `arm64→ubuntu-24.04-arm`, and `merge-client-image`
uses a plain `needs:` with no `if:`, so it publishes only when both legs succeed.

Both workflows parse, every `run` block passes `bash -n`, hadolint passes at the repo's
`--failure-threshold error`.

**What was already proven on `main`** and is unchanged by this backport:

```
Client Binaries, all four platforms:      success
  linera-x86_64-apple-darwin        41 MB
  linera-aarch64-apple-darwin       38 MB
  linera-aarch64-unknown-linux-gnu  41 MB
  linera-x86_64-unknown-linux-gnu   44 MB
linera-client:main -> ['linux/amd64', 'linux/arm64']
```

An anonymous (unauthenticated) download of the macOS arm64 artifact returns HTTP 200 and unpacks to
the tarball plus its `.sha256`, so these are usable by people outside the org.

`Docker Image` does not run on pull requests, so green PR checks here do not mean the images built.
I am dispatching it against this branch — that run is the gate, as it was for #6633/#6643.

## Release Plan

- These changes should be backported to the latest `testnet` branch — this **is** that backport.

No consumer-visible change beyond `linera-client` gaining `linux/arm64` and shrinking
substantially (dropping debuginfo took the amd64 image from 428 MB to 89 MB compressed on `main`).
The image names are unchanged from #6649, which is already on this branch.

## Links

- Backports #6643 (merged as d5682a9) and #6668 (merged as 1704fae)
- Follows #6649, the backport of #6633
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
