### PR TITLE
documentation: raise the publish-docs timeout above the current build time

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,14 @@ jobs:
 
   publish-docs:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    # `cargo doc --all-features` documents ~565 crates and has been creeping up
+    # on this budget: the last success took 36m37s against a 40m limit, and the
+    # next run hit the wall at 40m15s. A timeout here is quiet — the job reports
+    # `cancelled` (indistinguishable at a glance from a concurrency cancellation)
+    # and `Deploy` is simply skipped, so the published docs go stale without
+    # anything going red. Caching is not the lever: rust-cache already reports a
+    # full hit and restores ~718 MB in 17s.
+    timeout-minutes: 75
 
     # We only publish docs for the main branch.
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Motivation

`publish-docs` has stopped publishing. It timed out on `main` at `1704fae`, and because a
timed-out job reports `cancelled` — visually identical to the concurrency cancellations that
`cancel-in-progress: true` produces on back-to-back pushes — it looked like normal churn rather
than a failure.

The measurements say the job simply outgrew its budget:

```
bdb31c4 (success):    15:36:47 -> 16:13:24  =  36m37s     against timeout-minutes: 40
1704fae (timed out):  18:04:00 -> 18:44:15  =  40m15s     killed mid-`cargo doc`
```

Three minutes of headroom, then none. When it trips, `Deploy` is skipped and the published docs
silently go stale — nothing turns red.

## Proposal

Raise `publish-docs` to `timeout-minutes: 75`, and record in a comment why this is the right lever,
so the next person does not re-derive it.

**Caching is already optimal and is not the problem.** The timed-out run restored a full cache:

```
Cache hit for: v0-rust-publish-docs-Linux-x64-…   full match: true
Cache Size: ~718 MB, restored in 16.6s
```

It then documented ~565 crates before `cargo` and four `rustdoc` processes were killed at the
40-minute mark. `rust-cache` deliberately evicts workspace-crate artifacts before saving, so the
workspace is re-documented every run by design; that is inherent, not a misconfiguration.

**`cargo doc --no-deps` would be far faster but is not a CI fix** — it would drop dependency
documentation from the published site, changing what we publish. That is a docs decision, not a
timeout decision, so it is deliberately not bundled here.

75 rather than a tighter 45: the point is to stop tracking a moving number. The job is on
`ubuntu-latest`, which is free and unlimited on public repositories, so a larger ceiling costs
nothing and only matters in the case where the job is genuinely stuck.

## Test Plan

The change is a job-level timeout, so there is nothing to execute locally — the evidence is the
measured durations above, taken from the job records:

- last success `36m37s`, subsequent run killed at `40m15s` against a 40-minute limit
- the failing step was `Compute docs`; `Deploy` was `skipped`, which is exactly how the published
  docs went stale without a red check
- `Install Protoc` succeeded in that job, so #6668 is confirmed a no-op for existing x64 callers

The workflow YAML parses, and `test-crates-and-docrs` is untouched (it already allows 90 minutes).

No backport needed: `publish-docs` is gated `if: github.ref == 'refs/heads/main'`, so it never runs
on `devnet_*` / `testnet_*`.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- Surfaced while verifying the `main` builds after #6643 and #6668
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
