### PR TITLE
bridge-e2e: always build the test image instead of pulling a feature-stripped one

### DIFF
--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -72,24 +72,7 @@ jobs:
       - name: Configure Docker for GCP
         run: gcloud auth configure-docker us-docker.pkg.dev
 
-      - name: Pull linera & exporter images
-        id: pull-images
-        continue-on-error: true
-        run: |
-          BRANCH="${{ github.base_ref || github.ref_name }}"
-          # linera-tests, not linera: this wants the all-three-binaries image
-          # that `linera net up` needs, which is now published under that name.
-          # Pulling `linera` would keep SUCCEEDING against the tag frozen at the
-          # last pre-split build — and since this step is continue-on-error and
-          # only a failed pull falls through to building, that would silently
-          # test stale code forever instead of failing.
-          docker pull "${GCP_REGISTRY}/linera-tests:${BRANCH}"
-          docker pull "${GCP_REGISTRY}/linera-exporter:${BRANCH}"
-          docker tag "${GCP_REGISTRY}/linera-tests:${BRANCH}" linera-test
-          docker tag "${GCP_REGISTRY}/linera-exporter:${BRANCH}" linera-exporter
-
       - name: Build linera image
-        if: steps.pull-images.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -102,7 +85,6 @@ jobs:
             build_folder=debug
 
       - name: Build exporter image
-        if: steps.pull-images.outcome == 'failure'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/bridge-e2e.yml
+++ b/.github/workflows/bridge-e2e.yml
@@ -27,7 +27,11 @@ permissions:
 jobs:
   bridge-e2e:
     runs-on: linera-io-self-hosted-ci
-    timeout-minutes: 60
+    # 90, matching main. The old 60 was sized for the pull-the-image path that
+    # this workflow no longer takes: building linera-test locally costs ~23 min,
+    # which pushed a run to 60m50s and got it killed. main does the same work
+    # without a pull and lands at ~81 min.
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
## Motivation

`Bridge E2E` has been failing on `testnet_conway` since #6649, and the monitoring alert
(`CIWorkflowFailingCluster`) has been firing for ~24h. This is a regression I introduced in that
backport.

```
a06a62d  2026-08-05 21:34  success     <- last good
#6649 merged 2026-08-06 19:17
9c2cc10  2026-08-06 21:25  FAILURE     <- first failure
... every run since: failure
```

The failure:

```
linera-network-1 | ERROR linera: Error is The input has not matched: scylladb:tcp:scylla:9042:table_default
test test_auto_deposit_scan ... FAILED
```

**What went wrong.** This branch (unlike `main`) has a `Pull linera & exporter images` step that
short-circuits the image build, with the build steps gated on
`if: steps.pull-images.outcome == 'failure'`. It used to pull `linera:${BRANCH}`. After the image
split that name is no longer published, so #6649 repointed it at `linera-tests:${BRANCH}` — the
image that carries all three binaries.

But `linera-tests` is deliberately built with **no features**: `docker_image.yml` passes an empty
`build_features`, on the reasoning that "the linera binary here is a client-side tool used by the
test harness and does not need a DB backend". Without `scylladb` compiled in, the storage-URL
parser does not recognise the `scylladb:` scheme — hence "The input has not matched".

The image the workflow *pulls* and the image it would *build* had different feature sets, and
nothing tied them together. Fixing a silent-staleness bug, I introduced a feature-mismatch one.

## Proposal

Delete the pull short-circuit and always build, which is exactly what `main` does — `main` has no
`pull-images` step at all, so its `Build linera image` runs unconditionally with the Dockerfile's
default features (including `scylladb`).

This removes the whole class of bug rather than repointing the pull again: there is no longer a
second image that has to agree with the built one. It also converges this branch with `main`,
removing a divergence that made the backport hazardous in the first place.

Not touched: the separate `Pull bridge image` / `Build bridge image` pair. That one is gated on
`bridge-check` source-change detection and falls through to a build when the pull fails, so reusing
a prebuilt image is correct there — it is only used when `linera-bridge/` and `Dockerfile.bridge`
are unchanged. That is a real cache with a correctness gate, unlike the `linera` pull, which had
none.

The cost is that `Bridge E2E` now always builds the test image. `main` already accepts that, and a
green test is worth more than the saved minutes.

## Test Plan

The diff is a pure deletion — the pull step plus the two `if:` gates that referenced it, 18 lines,
no additions:

```
- name: Pull linera & exporter images        (removed)
- if: steps.pull-images.outcome == 'failure' (removed from Build linera image)
- if: steps.pull-images.outcome == 'failure' (removed from Build exporter image)
```

`grep pull-images` returns nothing, and the YAML parses. `Build linera image` and
`Build exporter image` now run unconditionally with `build_flag=` / `build_folder=debug`, matching
`main` byte for byte.

`Bridge E2E` runs on `merge_group` / `workflow_dispatch` / `push`, so it does not run on this pull
request. I am dispatching it against this branch — that run is the gate, and the failing test
(`test_auto_deposit_scan`) is the thing to watch.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

`main` is unaffected: it never had the pull step, which is why it never failed this way.

## Links

- Regression from #6649
- Alert: `CIWorkflowFailingCluster` / `bridge_e2e` on `testnet_conway`
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
