### PR TITLE
Drop redundant execution-site rejection log in block_tracker

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -18,7 +18,7 @@ use linera_execution::{
     TransactionTracker,
 };
 use linera_views::context::Context;
-use tracing::{debug, instrument};
+use tracing::instrument;
 
 #[cfg(with_metrics)]
 use crate::chain::metrics;
@@ -294,11 +294,6 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                         origin: incoming_bundle.origin,
                         posted_message: Box::new(posted_message.clone()),
                     }
-                );
-                debug!(
-                    chain_id = %self.chain_id,
-                    origin = %incoming_bundle.origin,
-                    "Rejecting incoming message"
                 );
                 let mut actor =
                     ExecutionStateActor::new(chain, txn_tracker, self.resource_controller);


### PR DESCRIPTION
## Motivation

#6473 added a `DEBUG` log in `BlockExecutionTracker` on the `MessageAction::Reject` arm.
As @afck pointed out reviewing the `testnet_conway` backport (#6565), that is the site
where a rejection is *executed*, not where it is *decided* — so it fires on every
execution of a block containing a rejected message, including confirmed-block
re-execution and catch-up sync replay, and it carries no reason.

Every rejection reaching that arm was already decided, and logged, at a decision site:

- policy → `IncomingBundle::apply_policy` (INFO, added in #6473)
- closed chain → `ChainWorkerState::prepare_chain_info_response` (INFO, added in #6473)
- execution failure, including during staging → `chain.rs` (pre-existing INFO,
  "Message bundle failed to execute and will be rejected")

The count is already covered by `rejected_bundle_count`.

## Proposal

Remove the log and revert the now-unneeded `debug` import. This makes `main` match
`testnet_conway`, where the same removal was already merged in #6565.

## Test Plan

- `cargo clippy -p linera-chain -p linera-core --features metrics -- -D warnings` — clean.
- Verified `debug!` had no other use in this file, so the import revert is safe.
- Full CI on this PR.

## Release Plan

- Nothing to do / These changes follow the usual release cycle. The equivalent change is
  already on `testnet_conway` (#6565), so no backport is needed.

## Links

- Follow-up to #6473
- Already applied on `testnet_conway` in #6565
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
