### PR TITLE
Specify and prove the microchain consensus protocol correct in rustdoc

### DIFF
--- a/linera-chain/src/data_types/mod.rs
+++ b/linera-chain/src/data_types/mod.rs
@@ -2,6 +2,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Data types exchanged while proposing, voting on, and confirming blocks.
+//!
+//! The correctness specification's vocabulary — what a validator signs, what a proposal and a
+//! certificate are — and the quorum properties that everything else rests on are stated and
+//! proved in [`proof`]. See [`crate::spec`] for the intended reading order.
+
 use std::{
     collections::{BTreeMap, BTreeSet, HashSet},
     sync::Arc,
@@ -40,6 +46,7 @@ use crate::{
 };
 
 pub mod metadata;
+pub mod proof;
 
 pub use metadata::*;
 

--- a/linera-chain/src/data_types/proof/mod.rs
+++ b/linera-chain/src/data_types/proof/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol vocabulary and quorum properties of the microchain consensus specification.
+//!
+//! This is the base of the specification's dependency graph: [`objects`] fixes what the
+//! protocol's messages *are*, and [`quorum`] establishes what a quorum of signatures buys us.
+//! Nothing here depends on the chain manager, so the manager's voting, locking, commit, safety
+//! and pacemaker results ([`crate::manager::proof`]) may all cite these freely.
+//!
+//! See [`crate::spec`] for the full reading order and for the conventions governing statement
+//! names, proof obligations and dependency edges.
+
+pub mod objects;
+pub mod quorum;

--- a/linera-chain/src/data_types/proof/objects.rs
+++ b/linera-chain/src/data_types/proof/objects.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol objects: the definitions the rest of the specification is phrased in.
+//!
+//! These are definitions, not claims, so they carry no proof and no dependency edges. Each one
+//! pins a piece of specification vocabulary to the Rust item that realizes it, so that later
+//! statements can talk about "a validation vote in round `r`" while still being checkable
+//! against the implementation.
+
+/// **Definition (Signed vote payload).** A validator never signs a bare value; it signs a
+/// [`VoteValue`], the six-tuple
+///
+/// ```text
+/// (value_hash, round, kind, unlocking_round, first_round, justification_commitment)
+/// ```
+///
+/// where `kind` is a [`CertificateKind`]. [`VoteValue`] implements
+/// [`BcsSignable`](linera_base::crypto::BcsSignable), so the signed byte string is the BCS
+/// encoding of that tuple prefixed by the type name. Two payloads differing in any component are
+/// distinct signed messages, and a signature over one is not a signature over the other.
+///
+/// Throughout the specification, "a validator signed *X*" means: it produced a
+/// [`ValidatorSignature`](linera_base::crypto::ValidatorSignature) over the [`VoteValue`] whose
+/// components are *X*.
+///
+/// [`VoteValue`]: crate::data_types::VoteValue
+/// [`CertificateKind`]: crate::types::CertificateKind
+pub trait SignedVotePayload {}
+
+/// **Definition (Vote).** A *vote* by validator `v` is a [`Vote<T>`], or equivalently its
+/// projection [`LiteVote`], which keeps every signed field and drops only the value body. Its
+/// *round* is [`Vote::round`] and its *kind* is `T::KIND`. We say:
+///
+/// * a **validation vote**, when the kind is [`CertificateKind::Validated`] — the voter asserts
+///   the block is valid at this height;
+/// * a **confirmation vote**, when the kind is [`CertificateKind::Confirmed`] — the voter
+///   asserts the block is final;
+/// * a **timeout vote**, when the kind is [`CertificateKind::Timeout`] — the voter asserts its
+///   round timer for this height expired.
+///
+/// Votes are produced by exactly three constructors — [`Vote::new`],
+/// [`Vote::new_with_unlocking_round`] and [`Vote::new_with_first_round`] — each signing the
+/// [`SignedVotePayload`] built from its arguments. Which of them a correct validator may call,
+/// and when, is pinned down by [`VoteConstructionSites`].
+///
+/// [`Vote<T>`]: crate::data_types::Vote
+/// [`LiteVote`]: crate::data_types::LiteVote
+/// [`Vote::round`]: crate::data_types::Vote::round
+/// [`Vote::new`]: crate::data_types::Vote::new
+/// [`Vote::new_with_unlocking_round`]: crate::data_types::Vote::new_with_unlocking_round
+/// [`Vote::new_with_first_round`]: crate::data_types::Vote::new_with_first_round
+/// [`CertificateKind::Validated`]: crate::types::CertificateKind::Validated
+/// [`CertificateKind::Confirmed`]: crate::types::CertificateKind::Confirmed
+/// [`CertificateKind::Timeout`]: crate::types::CertificateKind::Timeout
+/// [`VoteConstructionSites`]: crate::manager::proof::voting::VoteConstructionSites
+pub trait ValidatorVote {}
+
+/// **Definition (Proposal).** A *proposal* is a [`BlockProposal`]: an owner's signature over a
+/// [`ProposalContent`] — a [`ProposedBlock`], a [`Round`](linera_base::data_types::Round) and an
+/// optional [`BlockExecutionOutcome`] — plus an optional [`OriginalProposal`] recording which
+/// earlier attempt it retries. The three retry shapes are:
+///
+/// * `original_proposal == None`: a **fresh proposal**, carrying no outcome;
+/// * [`OriginalProposal::Fast`]: a **fast retry**, re-proposing a block first proposed in
+///   [`Round::Fast`](linera_base::data_types::Round::Fast), carrying the super owner's original
+///   signature and no outcome;
+/// * [`OriginalProposal::Regular`]: a **regular retry**, re-proposing a block that already
+///   carries a [`ValidatedBlockCertificate`], carrying that certificate and the outcome it
+///   certifies.
+///
+/// [`BlockProposal::check_invariants`] enforces that exactly these three shapes are well-formed,
+/// that a retry's round is *strictly greater* than the round it retries, and that a regular
+/// retry's certificate certifies exactly the block and outcome being re-proposed. The
+/// specification uses all three facts.
+///
+/// [`BlockProposal`]: crate::data_types::BlockProposal
+/// [`BlockProposal::check_invariants`]: crate::data_types::BlockProposal::check_invariants
+/// [`ProposalContent`]: crate::data_types::ProposalContent
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`OriginalProposal`]: crate::data_types::OriginalProposal
+/// [`OriginalProposal::Fast`]: crate::data_types::OriginalProposal::Fast
+/// [`OriginalProposal::Regular`]: crate::data_types::OriginalProposal::Regular
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+pub trait SignedProposal {}
+
+/// **Definition (Certificate).** A *certificate* is a [`GenericCertificate<T>`] together with
+/// the [`JustificationChain`] its wrapper carries. The three instantiations are
+/// [`ValidatedBlockCertificate`], [`ConfirmedBlockCertificate`] and [`TimeoutCertificate`].
+///
+/// A certificate is **valid for a committee** when [`LiteCertificate::check`] returns `Ok` for
+/// it. Both block certificate types delegate their `check` to that one function, so it is the
+/// single place where a certificate's signatures, its justification chain, and the binding
+/// between the two are verified. Unless said otherwise, "certificate" in this specification
+/// means one that is valid for the committee of its epoch; what that buys us is
+/// [`CertificateEmbedsQuorum`] and [`CertificateCarriesCorrectVote`].
+///
+/// [`GenericCertificate<T>`]: crate::types::GenericCertificate
+/// [`JustificationChain`]: crate::justification::JustificationChain
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`CertificateEmbedsQuorum`]: super::quorum::CertificateEmbedsQuorum
+/// [`CertificateCarriesCorrectVote`]: super::quorum::CertificateCarriesCorrectVote
+pub trait Certificate {}
+
+/// **Definition (Unlocking round).** The *unlocking round* of a validation vote,
+/// [`Vote::unlocking_round`], is the round a validator signs to assert: *"I have not cast a
+/// confirmation vote for a block other than this one in any round at or above this one."*
+/// `None` denotes the strongest form of that claim, covering every round.
+///
+/// The unlocking round exists for **fault attribution**, not for agreement: it makes a validator
+/// that breaks its lock convictable from the certificates alone, via
+/// [`extract_equivocations`]. The agreement argument in [`crate::manager::proof::safety`]
+/// deliberately does *not* rely on it, and reasons instead about the state a correct validator
+/// keeps in its [`ChainManager`] — so that agreement holds even where the attribution machinery
+/// is only as strong as the honest-construction obligations recorded in
+/// [`crate::justification`].
+///
+/// [`Vote::unlocking_round`]: crate::data_types::Vote::unlocking_round
+/// [`extract_equivocations`]: crate::justification::extract_equivocations
+/// [`ChainManager`]: crate::manager::ChainManager
+pub trait UnlockingRound {}
+
+/// **Definition (Justification commitment).** The *justification commitment* of a vote is the
+/// hash of the [`CommittedQuorum`] it cites, which — because that struct embeds the commitment
+/// of the quorum below it — transitively commits to the entire chain of validated quorums
+/// underneath. It is one of the six components of the [`SignedVotePayload`], so votes citing
+/// different chains are votes on different payloads and never aggregate into one certificate.
+///
+/// [`CommittedQuorum`]: crate::justification::CommittedQuorum
+pub trait JustificationCommitment {}

--- a/linera-chain/src/data_types/proof/quorum.rs
+++ b/linera-chain/src/data_types/proof/quorum.rs
@@ -1,0 +1,172 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Quorum properties: what a quorum of validator signatures buys us.
+//!
+//! Throughout this module, fix a [`Committee`] and write
+//!
+//! * `N` for [`Committee::total_votes`],
+//! * `q` for [`Committee::quorum_threshold`],
+//! * `f⁺` for [`Committee::validity_threshold`],
+//! * `w(S)` for the sum of [`Committee::weight`] over a set `S` of validators.
+//!
+//! These are the only results in the specification that reason about weights arithmetically.
+//! Everything above this module consumes them through [`CorrectValidatorInIntersection`],
+//! [`CertificateCarriesCorrectVote`] and [`CorrectValidatorsFormQuorum`].
+//!
+//! [`Committee`]: linera_execution::committee::Committee
+//! [`Committee::total_votes`]: linera_execution::committee::Committee::total_votes
+//! [`Committee::quorum_threshold`]: linera_execution::committee::Committee::quorum_threshold
+//! [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+//! [`Committee::weight`]: linera_execution::committee::Committee::weight
+
+use crate::manager::proof::model::{MaxByzantineWeight, UnforgeableSignatures};
+
+/// **Definition (Quorum).** A *quorum* of a committee is a set `S` of pairwise distinct
+/// committee members with `w(S) ≥ q`.
+///
+/// Note that this is a statement about *weight*, not cardinality: [`Committee::weight`] returns
+/// `0` for a non-member, so a set containing non-members is never helped by them.
+///
+/// [`Committee::weight`]: linera_execution::committee::Committee::weight
+pub trait Quorum {}
+
+/// **Lemma (Threshold arithmetic).** `f⁺ = ⌈N/3⌉` and `2·q ≥ N + f⁺`.
+///
+/// *Proof.* [`Committee::new`] computes `validity_threshold = total_votes.div_ceil(3)`, which is
+/// `⌈N/3⌉` by definition of `div_ceil`, and
+/// `quorum_threshold = (total_votes + validity_threshold).div_ceil(2)`, i.e.
+/// `q = ⌈(N + f⁺)/2⌉ ≥ (N + f⁺)/2`. Multiplying the second by two gives the claim.
+///
+/// Both fields are stored rather than recomputed on use, so the proof needs them to be
+/// trustworthy on a committee that arrived over the network. They are: the `Deserialize` impl
+/// for [`Committee`] recomputes both from the validator weights and rejects the committee unless
+/// they agree with the serialized values (`CommitteeFull`'s `TryFrom` in
+/// `linera_execution::committee`). Hence every [`Committee`] reaching consensus code satisfies
+/// the two identities above. ∎
+///
+/// [`Committee`]: linera_execution::committee::Committee
+/// [`Committee::new`]: linera_execution::committee::Committee::new
+pub trait ThresholdArithmetic {}
+
+/// **Lemma (Quorum intersection).** Any two quorums `S₁`, `S₂` of the same committee satisfy
+/// `w(S₁ ∩ S₂) ≥ f⁺`.
+///
+/// *Proof.* `S₁ ∪ S₂` is a set of committee members, so `w(S₁ ∪ S₂) ≤ N`. Weights are additive
+/// over disjoint sets, so inclusion–exclusion gives
+///
+/// ```text
+/// w(S₁ ∩ S₂) = w(S₁) + w(S₂) − w(S₁ ∪ S₂) ≥ q + q − N ≥ (N + f⁺) − N = f⁺,
+/// ```
+///
+/// where the first inequality is [`Quorum`] applied to `S₁` and `S₂`, and the second is
+/// [`ThresholdArithmetic`]. ∎
+pub trait Intersection: ThresholdArithmetic {}
+
+/// **Corollary (A correct validator lies in every quorum intersection).** Any two quorums of the
+/// same committee share at least one correct validator.
+///
+/// *Proof.* By [`Intersection`] the intersection has weight at least `f⁺`. By
+/// [`MaxByzantineWeight`] the total weight of faulty validators is at most `f⁺ − 1 < f⁺`, so the
+/// intersection cannot consist of faulty validators alone. ∎
+pub trait CorrectValidatorInIntersection: Intersection + MaxByzantineWeight {}
+
+/// **Lemma (A valid certificate embeds a quorum of votes).** If [`LiteCertificate::check`]
+/// returns `Ok` for a certificate `c` against a committee, then the signers of `c.signatures`
+/// form a [`Quorum`] of that committee, and each of them holds a valid signature over the single
+/// [`SignedVotePayload`]
+///
+/// ```text
+/// (c.value.value_hash, c.round, c.value.kind, c.unlocking_round, c.first_round,
+///  c.justification_commitment)
+/// ```
+///
+/// *Proof.* [`LiteCertificate::check`] constructs exactly that
+/// [`VoteValue`](crate::data_types::VoteValue) and passes it, with `c.signatures`, to the
+/// crate-private helper `check_signatures`. That function, in order:
+///
+/// 1. rejects a repeated signer with [`ChainError::CertificateValidatorReuse`], establishing
+///    pairwise distinctness;
+/// 2. rejects any signer whose [`Committee::weight`] is `0` with
+///    [`ChainError::InvalidSigner`], establishing committee membership;
+/// 3. accumulates the signers' weights and rejects a total below
+///    [`Committee::quorum_threshold`] with [`ChainError::CertificateRequiresQuorum`],
+///    establishing `w(S) ≥ q`;
+/// 4. verifies every signature against the payload with `ValidatorSignature::verify_batch`,
+///    propagating any failure.
+///
+/// Steps 1–3 are precisely [`Quorum`]; step 4 is the signature claim. ∎
+///
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`SignedVotePayload`]: super::objects::SignedVotePayload
+/// [`ChainError::CertificateValidatorReuse`]: crate::ChainError::CertificateValidatorReuse
+/// [`ChainError::InvalidSigner`]: crate::ChainError::InvalidSigner
+/// [`ChainError::CertificateRequiresQuorum`]: crate::ChainError::CertificateRequiresQuorum
+/// [`Committee::weight`]: linera_execution::committee::Committee::weight
+/// [`Committee::quorum_threshold`]: linera_execution::committee::Committee::quorum_threshold
+pub trait CertificateEmbedsQuorum {}
+
+/// **Corollary (Every valid certificate carries a correct validator's vote).** For every
+/// certificate valid for its committee there is at least one *correct* validator that itself
+/// cast a vote with that certificate's exact signed payload.
+///
+/// This is the workhorse that turns "a certificate exists" into "a correct validator executed
+/// the code path that produces this vote", and thereby lets the local implementation properties
+/// of [`crate::manager::proof::voting`] constrain what certificates can exist at all.
+///
+/// *Proof.* By [`CertificateEmbedsQuorum`] the signers form a quorum, of weight at least `q`. By
+/// [`ThresholdArithmetic`], `q ≥ (N + f⁺)/2 ≥ f⁺`, using `N ≥ f⁺ = ⌈N/3⌉`. By
+/// [`MaxByzantineWeight`] faulty validators hold at most `f⁺ − 1`, so some signer is correct. By
+/// [`UnforgeableSignatures`] its signature cannot have been produced by anyone else, so that
+/// correct validator signed the payload itself. ∎
+pub trait CertificateCarriesCorrectVote:
+    CertificateEmbedsQuorum + ThresholdArithmetic + MaxByzantineWeight + UnforgeableSignatures
+{
+}
+
+/// **Lemma (The correct validators alone form a quorum).** The set of all correct validators of
+/// a committee is a [`Quorum`].
+///
+/// This is the availability counterpart of [`Intersection`]: it is what lets a correct proposer
+/// collect a certificate without any cooperation from faulty validators, and so it is a
+/// dependency of every progress result rather than of any safety result.
+///
+/// *Proof.* By [`MaxByzantineWeight`] the correct validators hold weight at least `N − f⁺ + 1`,
+/// so it suffices to show `N − f⁺ + 1 ≥ q`. Write `N = 3k + i` with `i ∈ {0, 1, 2}`; by
+/// [`ThresholdArithmetic`], `f⁺ = ⌈N/3⌉`.
+///
+/// ```text
+/// i = 0:  f⁺ = k,      q = ⌈(4k)/2⌉     = 2k,     N − f⁺ + 1 = 2k + 1 ≥ q.
+/// i = 1:  f⁺ = k + 1,  q = ⌈(4k+2)/2⌉   = 2k + 1, N − f⁺ + 1 = 2k + 1 ≥ q.
+/// i = 2:  f⁺ = k + 1,  q = ⌈(4k+3)/2⌉   = 2k + 2, N − f⁺ + 1 = 2k + 2 ≥ q.
+/// ```
+///
+/// In each case the correct validators reach the quorum threshold. ∎
+pub trait CorrectValidatorsFormQuorum: ThresholdArithmetic + MaxByzantineWeight {}
+
+/// **Remark (Where quorums are assembled, and why that is not load-bearing).** Certificates are
+/// built in two places, with different guarantees:
+///
+/// * [`SignatureAggregator::append`] performs the same three membership/distinctness/threshold
+///   checks as [`CertificateEmbedsQuorum`] incrementally, and verifies each signature as it is
+///   added, so a certificate it emits is valid by construction.
+/// * [`LiteCertificate::try_from_votes`] does **not** verify signatures, and instead requires
+///   its caller to have done so. Its one production caller,
+///   `linera_core::Client::communicate_chain_action`, verifies each vote against the responding
+///   validator's public key (in `linera_core::updater`) before aggregating, and groups incoming
+///   votes by their *full* signed payload — all six components of
+///   [`SignedVotePayload`](super::objects::SignedVotePayload) — so votes that disagree on the
+///   unlocking round, the first-round attestation or the justification commitment are never
+///   merged into one certificate.
+///
+/// Neither fact is load-bearing for safety. A certificate that a correct validator *acts on* is
+/// re-verified through [`LiteCertificate::check`] at every entry point that consumes one, so
+/// [`CertificateEmbedsQuorum`] applies to it however it was assembled; a malformed certificate
+/// that never passes `check` never influences a correct validator's state. The assembly path
+/// matters only for liveness, where a correct proposer needs its own certificates to be
+/// well-formed.
+///
+/// [`SignatureAggregator::append`]: crate::data_types::SignatureAggregator::append
+/// [`LiteCertificate::try_from_votes`]: crate::types::LiteCertificate::try_from_votes
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+pub trait QuorumAssembly {}

--- a/linera-chain/src/justification/mod.rs
+++ b/linera-chain/src/justification/mod.rs
@@ -36,7 +36,17 @@
 //! confirmation votes, or the two confirmation quorums intersect in validators that contradicted
 //! themselves. See [`extract_equivocations`].
 //!
+//! # Correctness specification
+//!
+//! The accountability guarantees this module provides are stated and proved in [`proof`]:
+//! [`ProofSoundness`](proof::ProofSoundness) (no correct validator is convictable),
+//! [`ConflictCompleteness`](proof::ConflictCompleteness) (a conflict convicts a validity
+//! threshold), and [`AccountableSafety`](proof::AccountableSafety) combining them with the safety
+//! theorem. See [`crate::spec`] for the reading order.
+//!
 //! [`VoteValue`]: crate::data_types::VoteValue
+
+pub mod proof;
 
 use std::collections::BTreeMap;
 
@@ -962,5 +972,5 @@ fn signature_of(
 }
 
 #[cfg(test)]
-#[path = "unit_tests/justification_tests.rs"]
+#[path = "../unit_tests/justification_tests.rs"]
 mod justification_tests;

--- a/linera-chain/src/justification/proof.rs
+++ b/linera-chain/src/justification/proof.rs
@@ -1,0 +1,487 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Accountability: convicting the validators responsible when agreement fails.
+//!
+//! [`CommitAgreement`] holds only while [`MaxByzantineWeight`] does. This module proves what
+//! happens when it does not: a violation leaves *self-contained evidence* naming validators of at
+//! least [`Committee::validity_threshold`] weight — more than the fault bound permits, so the
+//! conviction set is itself a proof that the assumption was broken.
+//!
+//! Two properties, deliberately independent:
+//!
+//! * **Soundness** ([`ProofSoundness`]) — a proof that [`EquivocationProof::check`] accepts names
+//!   a genuinely faulty validator. No correct validator is ever convictable.
+//! * **Completeness** ([`ConflictCompleteness`]) — two conflicting confirmed certificates yield
+//!   enough accepted proofs, from the certificates alone.
+//!
+//! **Neither depends on [`MaxByzantineWeight`]**, which is the point: both must hold precisely in
+//! the regime where the fault bound has failed. Soundness is per-validator and rests only on
+//! [`UnforgeableSignatures`]; completeness needs only [`Intersection`], which in turn needs only
+//! [`ThresholdArithmetic`]. Accountability therefore sits on a strictly weaker assumption base
+//! than the safety theorem it backstops.
+//!
+//! [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+//! [`CommitAgreement`]: crate::manager::proof::safety::CommitAgreement
+//! [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
+//! [`UnforgeableSignatures`]: crate::manager::proof::model::UnforgeableSignatures
+//! [`Intersection`]: crate::data_types::proof::quorum::Intersection
+//! [`ThresholdArithmetic`]: crate::data_types::proof::quorum::ThresholdArithmetic
+//! [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+
+use crate::{
+    data_types::proof::quorum::{CertificateEmbedsQuorum, Intersection, ThresholdArithmetic},
+    manager::proof::{
+        commit::{CertifiedBlockWasExecuted, CommitRestsOnValidation},
+        locking::{
+            ConfirmedVoteRoundMonotone, OneConfirmationVotePerRound, OneValidationVotePerRound,
+            SafetyStateRecovery,
+        },
+        model::{ConsensusInstance, DeterministicExecution, UnforgeableSignatures},
+        pacemaker::LeaderEligibility,
+        rounds::{CurrentRoundMonotone, RoundFloor, VoteRoundBelowCurrentRound},
+        safety::CommitAgreement,
+        voting::{
+            ConfirmationOnlyInCurrentRound, FastConfirmationNeedsEmptyLock,
+            UnlockingRequiresHigherCertificate, VoteConstructionSites,
+        },
+    },
+};
+
+/// **Definition (Proof of misbehaviour).** A *proof of misbehaviour* against validator `v` is an
+/// [`EquivocationProof`] naming `v` for which [`EquivocationProof::check`] returns `Ok` against a
+/// committee. There are four shapes, and each exhibits a pair of `v`'s own signatures — or, for
+/// [`InvalidJustification`], a single signature plus the opening it commits to.
+///
+/// **The committee matters.** [`EquivocationProof::check`] judges the exhibited signatures against
+/// whatever [`Committee`] the auditor supplies, and [`InvalidJustification`] in particular asks
+/// whether an opening was a quorum *of that committee*. A vote is honest relative to the committee
+/// of the epoch it was cast in, so throughout this module a proof is understood to be adjudicated
+/// against that committee. Judging a vote against a different epoch's committee could convict a
+/// correct validator, and nothing in [`EquivocationProof::check`] prevents an auditor from doing
+/// so — the epoch is not carried in the proof.
+///
+/// [`EquivocationProof`]: crate::justification::EquivocationProof
+/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+/// [`InvalidJustification`]: crate::justification::EquivocationProof::InvalidJustification
+/// [`Committee`]: linera_execution::committee::Committee
+pub trait MisbehaviourProof {}
+
+/// **Lemma (Double votes are never honest).** No correct validator is named by an accepted
+/// [`DoubleVote`] proof.
+///
+/// *Proof.* An accepted proof exhibits two signatures by `v` over [`VoteValue`]s that agree on
+/// round and kind, whose headers share a chain and height, and whose hashes differ; by
+/// [`UnforgeableSignatures`] only `v` could have produced them, so a correct `v` cast both votes.
+/// Sharing a chain and height means both votes belong to the same [`ConsensusInstance`] — a reset
+/// changes the height, and [`SafetyStateRecovery`] shows the one path that recreates an instance
+/// at an unchanged height preserves the votes rather than forgetting them. Then:
+///
+/// * `kind = Validated` contradicts [`OneValidationVotePerRound`];
+/// * `kind = Confirmed` contradicts [`OneConfirmationVotePerRound`];
+/// * `kind = Timeout` is not realizable at all: the proof carries [`BlockHeader`]s and checks the
+///   signature over `CryptoHash::new(header)`, whereas a timeout vote signs the hash of a
+///   [`Timeout`] value, so an accepted timeout-kind proof would require a block header colliding
+///   with a `Timeout` — excluded by [`UnforgeableSignatures`]. ∎
+///
+/// [`DoubleVote`]: crate::justification::EquivocationProof::DoubleVote
+/// [`VoteValue`]: crate::data_types::VoteValue
+/// [`BlockHeader`]: crate::block::BlockHeader
+/// [`Timeout`]: crate::block::Timeout
+pub trait DoubleVoteSoundness:
+    UnforgeableSignatures
+    + OneValidationVotePerRound
+    + OneConfirmationVotePerRound
+    + ConsensusInstance
+    + SafetyStateRecovery
+{
+}
+
+/// **Lemma (First-round attestations are never honestly contradicted).** No correct validator is
+/// named by an accepted [`FirstRoundViolation`] proof.
+///
+/// *Proof.* An accepted proof exhibits `v`'s confirmation vote at round `a` carrying the
+/// attestation, and `v`'s confirmation vote at a round `b < a` on the same chain and height; by
+/// [`UnforgeableSignatures`] a correct `v` cast both, in the same instance.
+///
+/// Both sites that set the attestation — the fast branch of [`ChainManager::create_vote`] and
+/// [`ChainManager::create_final_vote`] ([`VoteConstructionSites`]) — compute it as
+/// `round == self.ownership.get().first_round()`. The `ownership` register has exactly one
+/// writer, [`ChainManager::reset`], which by [`ConsensusInstance`] begins the instance, so
+/// `first_round()` is a constant `φ` throughout. The attestation at `a` therefore gives `a = φ`.
+///
+/// Now consider the vote at `b < a = φ`. By [`VoteConstructionSites`] it is either:
+///
+/// * [`ChainManager::create_final_vote`], which by [`ConfirmationOnlyInCurrentRound`] requires
+///   `current_round == b`. But [`RoundFloor`] makes `current_round ≥ φ = a > b` at all times.
+///   Contradiction.
+/// * the fast branch, so `b = Round::Fast`. Since `φ > b`, `φ` is not `Round::Fast`, which by
+///   [`ChainOwnership::first_round`] means `super_owners` is empty. But a fast-round proposal is
+///   rejected with `WorkerError::InvalidOwner` unless its proposer is a super owner
+///   ([`LeaderEligibility`]: `can_propose` returns `false` for `Round::Fast` for everyone else),
+///   so `v` never reaches the fast branch. Contradiction. ∎
+///
+/// [`FirstRoundViolation`]: crate::justification::EquivocationProof::FirstRoundViolation
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::reset`]: crate::manager::ChainManager::reset
+/// [`ChainOwnership::first_round`]: linera_base::ownership::ChainOwnership::first_round
+pub trait FirstRoundSoundness:
+    UnforgeableSignatures
+    + VoteConstructionSites
+    + ConfirmationOnlyInCurrentRound
+    + RoundFloor
+    + LeaderEligibility
+    + ConsensusInstance
+{
+}
+
+/// **Lemma (Lock violations are never honest).** No correct validator is named by an accepted
+/// [`LockViolation`] proof — subject to the residual obligation below.
+///
+/// *Proof.* An accepted proof exhibits `v`'s confirmation vote for `X` at round `r` and `v`'s
+/// validation vote for `Y` at round `s`, with `hash(X) ≠ hash(Y)`, the same chain and height,
+/// `r < s`, and a signed unlocking round `u` with `u ≤ r` (or `u = None`). Suppose `v` correct.
+///
+/// *The confirmation came first.* Otherwise, after the validation at `s`,
+/// [`VoteRoundBelowCurrentRound`] and [`CurrentRoundMonotone`] pin `v`'s current round at `≥ s`.
+/// A later confirmation at `r < s` is then impossible: via [`ChainManager::create_final_vote`] it
+/// would need `current_round == r` ([`ConfirmationOnlyInCurrentRound`]); via the fast branch it
+/// would need `r = Round::Fast` and, by [`FastConfirmationNeedsEmptyLock`], an empty lock and no
+/// validation vote — contradicting the floor `≥ s` that the validation at `s` established.
+///
+/// *So let `(X', p)` be `v`'s stored confirmation vote just before the validation at `s`.* It is
+/// present, and by [`ConfirmedVoteRoundMonotone`], `p ≥ r`. Apply
+/// [`UnlockingRequiresHigherCertificate`] to the validation vote, by the shape of its proposal:
+///
+/// * *Fresh proposal.* Rejected outright — `v` would not have voted.
+/// * *Regular retry with certificate `c`, and `X'` not matching `Y`'s proposal.* The guard is
+///   `p < c.round`, and `c.round` is exactly the signed `u`. With `u ≤ r ≤ p` this gives
+///   `p < u ≤ p`. Contradiction.
+/// * *Regular retry with `X'` matching `Y`'s proposal.* The guard is `p ≤ u`, so
+///   `p ≤ u ≤ r ≤ p` forces `p = u = r`.
+/// * *Fast retry.* The signed `u` is `None`, and the guard forces `p = Round::Fast` and `X'`
+///   matching `Y`'s proposal; with `Round::Fast` minimal and `p ≥ r`, again `p = r`.
+///
+/// The last two cases coincide: `v` confirmed `X` at round `r` and its stored confirmation at the
+/// same round `r = p` is `X'`, so [`OneConfirmationVotePerRound`] gives `X = X'`. Hence `X`
+/// matches `Y`'s [`ProposedBlock`] while `hash(X) ≠ hash(Y)` — the two blocks share a proposal and
+/// differ only in [`BlockExecutionOutcome`]. Sharing a proposal means sharing a
+/// `previous_block_hash`, so by [`UnforgeableSignatures`] (collision resistance) they have the
+/// same parent and hence the same ancestry and the same pre-state, and
+/// [`DeterministicExecution`] makes the outcome a function of that pre-state and the proposal.
+/// So `X = Y`, contradicting `hash(X) ≠ hash(Y)`. ∎
+///
+/// **Residual obligation.** Only the first two cases are unconditional; the last two are closed by
+/// [`DeterministicExecution`], the same hinge as [`FastRetryPreservesBlock`]. The ancestry
+/// argument avoids circularity — it follows `previous_block_hash` down rather than appealing to
+/// [`UniqueChain`] — but an execution engine whose outcome depends on the round without recording
+/// an `OracleResponse::Round` would make a correct validator convictable here.
+///
+/// [`LockViolation`]: crate::justification::EquivocationProof::LockViolation
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`FastRetryPreservesBlock`]: crate::manager::proof::safety::FastRetryPreservesBlock
+/// [`UniqueChain`]: crate::manager::proof::safety::UniqueChain
+pub trait LockViolationSoundness:
+    UnforgeableSignatures
+    + UnlockingRequiresHigherCertificate
+    + ConfirmedVoteRoundMonotone
+    + ConfirmationOnlyInCurrentRound
+    + FastConfirmationNeedsEmptyLock
+    + OneConfirmationVotePerRound
+    + VoteRoundBelowCurrentRound
+    + CurrentRoundMonotone
+    + DeterministicExecution
+{
+}
+
+/// **Lemma (Attested justifications are never honestly invalid).** No correct validator is named
+/// by an accepted [`InvalidJustification`] proof, when the proof is adjudicated against the
+/// committee of the vote's own epoch ([`MisbehaviourProof`]).
+///
+/// *Proof.* An accepted proof exhibits `v`'s signature over a [`VoteValue`] whose justification
+/// commitment is `opening.commitment()`, together with an `opening` on which `check_cited_quorum`
+/// fails. By [`UnforgeableSignatures`] a correct `v` produced that signature, so it is one of the
+/// five sites of [`VoteConstructionSites`]. Take them in turn.
+///
+/// * [`ChainManager::create_timeout_vote`], [`ChainManager::vote_fallback`], and the fast branch
+///   of [`ChainManager::create_vote`] all sign a commitment of `None`. A proof requires
+///   `Some(opening.commitment())`, so its signature check fails and it is not accepted.
+/// * *The non-fast branch of [`ChainManager::create_vote`], on a regular retry.* It signs
+///   `unlocking_round = Some(c.round)` and `Some(c.full_justification_commitment())`, whose
+///   opening is `c`'s own quorum. `check_cited_quorum` then asks exactly the four things that
+///   verifying `c` already established: that the opening's `value_hash` is the voted block's hash
+///   (given by [`BlockProposal::check_invariants`], which binds `c` to the proposed block); that
+///   `unlocking_round == Some(opening.round)` and `opening.round < round` (the first by
+///   construction, the second by `check_invariants`' `content.round > certificate.round`); that
+///   the opening's own unlocking round and previous commitment are both present or both absent
+///   (from [`LiteCertificate::check`], where a `Validated` certificate's `unlocking_round` equals
+///   its chain's top and its commitment is `None` exactly when the chain is empty); and that the
+///   opening's signatures form a quorum over the reconstructed `Validated` payload — which is
+///   verbatim the check [`LiteCertificate::check`] performed on `c`, the `first_round` component
+///   being `false` for every [`ValidatedBlockCertificate`]. A fresh or fast-retry proposal signs
+///   `None` and is covered by the first case.
+/// * *[`ChainManager::create_final_vote`].* It signs `unlocking_round = None`,
+///   `Some(validated.full_justification_commitment())` — or `None` in the chain's first round,
+///   again covered above — in the round `validated.round`. For `kind = Confirmed`
+///   `check_cited_quorum` requires `opening.round == round`, which holds since the vote's round
+///   *is* `validated.round`; the remaining conditions are as in the previous case, `validated`
+///   having been verified by the caller ([`ConfirmationNeedsValidatedCertificate`]). ∎
+///
+/// [`InvalidJustification`]: crate::justification::EquivocationProof::InvalidJustification
+/// [`VoteValue`]: crate::data_types::VoteValue
+/// [`ChainManager::create_timeout_vote`]: crate::manager::ChainManager::create_timeout_vote
+/// [`ChainManager::vote_fallback`]: crate::manager::ChainManager::vote_fallback
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`BlockProposal::check_invariants`]: crate::data_types::BlockProposal::check_invariants
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`ConfirmationNeedsValidatedCertificate`]: crate::manager::proof::voting::ConfirmationNeedsValidatedCertificate
+pub trait InvalidJustificationSoundness:
+    UnforgeableSignatures + VoteConstructionSites + MisbehaviourProof
+{
+}
+
+/// **Theorem (Soundness — no correct validator is convictable).** If
+/// [`EquivocationProof::check`] accepts a proof naming `v` against the committee of the epoch its
+/// votes were cast in, then `v` is faulty in the sense of [`CorrectValidator`].
+///
+/// *Proof.* By cases on the four variants: [`DoubleVoteSoundness`], [`FirstRoundSoundness`],
+/// [`LockViolationSoundness`] and [`InvalidJustificationSoundness`]. ∎
+///
+/// Note what this does *not* assume: no [`MaxByzantineWeight`], no synchrony, no bound on how many
+/// other validators misbehaved. Soundness is a statement about one validator's own signatures, so
+/// it survives arbitrary corruption of everyone else — which is what makes a conviction meaningful
+/// in the regime where accountability is invoked.
+///
+/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+/// [`CorrectValidator`]: crate::manager::proof::model::CorrectValidator
+/// [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
+pub trait ProofSoundness:
+    DoubleVoteSoundness + FirstRoundSoundness + LockViolationSoundness + InvalidJustificationSoundness
+{
+}
+
+/// **Definition (Sound justification chain).** A [`JustificationChain`] carried by a confirmed
+/// certificate for block `B` is *sound* when every link's signatures form a quorum over the
+/// `Validated` payload reconstructed for that link — the payload with `B`'s hash, the link's
+/// round, the previous link's round as unlocking round, and the previous link's commitment.
+///
+/// [`audit_confirmation`] returns an empty list exactly when the chain is sound: it reconstructs
+/// each link's payload in order and calls `check_signatures` on it, returning at the first
+/// failure. Soundness is *not* implied by the certificate verifying:
+/// [`LiteCertificate::check`] deliberately skips the links, relying instead on the attestation
+/// carried by the quorum above them, which is what makes [`ChainAuditability`] the fallback.
+///
+/// [`JustificationChain`]: crate::justification::JustificationChain
+/// [`audit_confirmation`]: crate::justification::audit_confirmation
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+pub trait SoundChain {}
+
+/// **Lemma (A sound chain tiles every round below the confirmation).** Let a valid
+/// [`ConfirmedBlockCertificate`] in round `s` carry a non-empty chain with link rounds
+/// `ρ₀ < ρ₁ < … < ρₖ`. Then `ρₖ = s`, link `i` was cast under unlocking round `ρᵢ₋₁` (and link `0`
+/// under `None`), and the half-open windows
+///
+/// ```text
+/// [⊥, ρ₀),  [ρ₀, ρ₁),  …,  [ρₖ₋₁, ρₖ)
+/// ```
+///
+/// partition the rounds strictly below `s`. In particular every round `r < s` lies in exactly one
+/// link's window.
+///
+/// *Proof.* [`JustificationChain::verify`] rejects unless the rounds strictly increase, and
+/// [`LiteCertificate::check`] on a `Confirmed` certificate with a non-empty chain requires
+/// `top == self.round`, i.e. `ρₖ = s`. [`JustificationChain::commitment`] folds the chain from the
+/// bottom, setting each link's `unlocking_round` to the round of the link below and `None` for the
+/// first — so the reconstructed payload of link `i` carries unlocking round `ρᵢ₋₁`, which is the
+/// window's lower bound; the upper bound `ρᵢ` is where the link's own votes were cast. Consecutive
+/// windows abut and the first is unbounded below, so their union is `[⊥, ρₖ) = [⊥, s)`. ∎
+///
+/// This is what makes the chain walk in [`extract_equivocations`] exhaustive rather than
+/// best-effort: a lower confirmation cannot slip between two links.
+///
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`JustificationChain::verify`]: crate::justification::JustificationChain::verify
+/// [`JustificationChain::commitment`]: crate::justification::JustificationChain::commitment
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`extract_equivocations`]: crate::justification::extract_equivocations
+pub trait ChainTilesRounds {}
+
+/// **Theorem (Completeness — a conflict convicts a validity threshold).** Let two valid
+/// [`ConfirmedBlockCertificate`]s for conflicting blocks at the same chain and height, valid for
+/// the *same* committee and carrying sound chains ([`SoundChain`]), be certified in rounds
+/// `r ≤ s`. Then [`extract_equivocations`] applied to their [`JustifiedConfirmation`]s returns
+/// proofs that [`EquivocationProof::check`] accepts, naming validators of total weight at least
+/// [`Committee::validity_threshold`].
+///
+/// *Proof.* By [`CertificateEmbedsQuorum`] each certificate's confirmation signatures form a
+/// quorum, and by [`ChainTilesRounds`] so does each link of a sound chain. Three cases, which are
+/// exactly the three the implementation tries.
+///
+/// * **`r = s`.** `double_confirm` walks the intersection of the two confirmation quorums, which
+///   by [`Intersection`] has weight at least `f⁺`, emitting a [`DoubleVote`] for each member. Each
+///   is accepted: the blocks differ, the chain and height agree, and both signatures were taken
+///   from verified quorums.
+/// * **`r < s` and the higher certificate carries a chain.** By [`ChainTilesRounds`] some link's
+///   window contains `r`, i.e. `link.round > r` and its unlocking round is `≤ r` — precisely
+///   `walk_chain`'s guard. That link is a quorum, so its intersection with the lower confirmation
+///   quorum has weight at least `f⁺` by [`Intersection`], and each member gets a
+///   [`LockViolation`]. Each is accepted: `check` re-derives the same window condition
+///   `confirmed_round < validated_round` and `validated_unlocking_round ≤ confirmed_round`.
+/// * **`r < s` and the higher certificate carries no chain.** Then [`LiteCertificate::check`]
+///   accepted it only because its `first_round` attestation is set. `first_round_violation` walks
+///   the intersection of the two confirmation quorums — weight at least `f⁺` — emitting a
+///   [`FirstRoundViolation`] for each, accepted since `earlier_round = r < s = attested_round`.
+///
+/// In every case the blamed set is a full quorum intersection. ∎
+///
+/// *Depends on the shared-committee hypothesis.* [`Intersection`] compares quorums of one
+/// committee; [`extract_equivocations`] checks only the chain and height, not the epoch, so two
+/// certificates declaring different epochs could yield no intersection at all. An auditor must
+/// establish that both certificates are valid for the same committee before drawing the
+/// conclusion.
+///
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`extract_equivocations`]: crate::justification::extract_equivocations
+/// [`JustifiedConfirmation`]: crate::justification::JustifiedConfirmation
+/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+/// [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+/// [`DoubleVote`]: crate::justification::EquivocationProof::DoubleVote
+/// [`LockViolation`]: crate::justification::EquivocationProof::LockViolation
+/// [`FirstRoundViolation`]: crate::justification::EquivocationProof::FirstRoundViolation
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+pub trait ConflictCompleteness:
+    ChainTilesRounds + SoundChain + Intersection + CertificateEmbedsQuorum + ThresholdArithmetic
+{
+}
+
+/// **Lemma (An unsound chain convicts its attesters).** If a confirmed certificate's chain is not
+/// sound ([`SoundChain`]), [`audit_confirmation`] returns a non-empty list of proofs that
+/// [`EquivocationProof::check`] accepts.
+///
+/// *Proof.* [`audit_confirmation`] walks the links upward and stops at the lowest one whose
+/// reconstructed payload fails `check_signatures`. Every validator at the level immediately above
+/// — the next link, or the confirmation quorum if the bad link is the top one — signed a payload
+/// whose justification commitment is that link's `CommittedQuorum` hash, so each receives an
+/// [`InvalidJustification`] carrying that signature and that opening. Each is accepted:
+/// [`EquivocationProof::check`] verifies the signature against the reconstructed payload and then
+/// requires `check_cited_quorum` to fail, which it does, the opening's signatures not forming a
+/// quorum. ∎
+///
+/// **Weaker than [`ConflictCompleteness`], deliberately.** The blamed set is a quorum only when
+/// the bad link is the top one, where the accusers are the certificate's own — verified —
+/// confirmation quorum. Lower down, the accusers are the next link, whose own signatures the audit
+/// has not yet reached, so they may be fewer than a quorum. Each individual proof is still
+/// accepted, and an unsound level above is itself auditable one step further up; what is not
+/// guaranteed is a `f⁺`-weight blame set from a single pass. Repairing that would mean verifying
+/// links during certificate checking, which is the cost the attestation scheme exists to avoid.
+///
+/// [`audit_confirmation`]: crate::justification::audit_confirmation
+/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+/// [`InvalidJustification`]: crate::justification::EquivocationProof::InvalidJustification
+pub trait ChainAuditability: SoundChain + CertificateEmbedsQuorum {}
+
+/// **Lemma (Two validated blocks in one round convict a validity threshold).** If two valid
+/// [`ValidatedBlockCertificate`]s for conflicting blocks are certified in the *same* round and are
+/// valid for the same committee, [`extract_double_validations`] returns accepted [`DoubleVote`]
+/// proofs naming validators of total weight at least [`Committee::validity_threshold`].
+///
+/// *Proof.* By [`CertificateEmbedsQuorum`] both signature sets are quorums; by [`Intersection`]
+/// their intersection has weight at least `f⁺`; `double_vote` emits a proof for each member, with
+/// `kind = Validated` and the round both share. Each is accepted, the blocks differing and the
+/// chain and height agreeing. ∎
+///
+/// This is the accountability counterpart of
+/// [`UniqueValidatedBlockPerRound`](crate::manager::proof::locking::UniqueValidatedBlockPerRound):
+/// that lemma says the situation cannot arise below the fault bound, this one says it is
+/// attributable if it does. Note the round equality is required — validating conflicting blocks in
+/// *different* rounds is legitimate, which is exactly what locks exist to regulate.
+///
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`extract_double_validations`]: crate::justification::extract_double_validations
+/// [`DoubleVote`]: crate::justification::EquivocationProof::DoubleVote
+/// [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+pub trait DoubleValidationCompleteness:
+    Intersection + CertificateEmbedsQuorum + ThresholdArithmetic
+{
+}
+
+/// **Theorem (Accountable safety).** For every chain and height, one of the following holds:
+///
+/// 1. at most one block is committed there ([`CommitAgreement`]); or
+/// 2. two conflicting confirmed certificates exist, and then — from those certificates alone,
+///    with no further observation of the network — validators of total weight at least
+///    [`Committee::validity_threshold`] are convictable by proofs that
+///    [`EquivocationProof::check`] accepts, every one of them genuinely faulty
+///    ([`ProofSoundness`]); or
+/// 3. a certificate's justification chain is unsound, and then its attesters are convictable
+///    ([`ChainAuditability`]) with no conflict required at all.
+///
+/// *Proof.* Case 1 is [`CommitAgreement`], which holds whenever
+/// [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight) does. If it fails,
+/// there are conflicting confirmed certificates; if both carry sound chains, case 2 is
+/// [`ConflictCompleteness`] together with [`ProofSoundness`], and otherwise case 3 is
+/// [`ChainAuditability`]. ∎
+///
+/// Case 2 convicts strictly more weight than the fault bound permits — `f⁺` against a permitted
+/// `f⁺ − 1` — so a conviction set is itself evidence that the assumption underpinning
+/// [`CommitAgreement`] was violated, rather than merely that some validator misbehaved.
+///
+/// [`CommitAgreement`]: crate::manager::proof::safety::CommitAgreement
+/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+/// [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+pub trait AccountableSafety:
+    ProofSoundness + ConflictCompleteness + ChainAuditability + CommitAgreement
+{
+}
+
+/// **Remark (What accountability does not cover).** Four exclusions, the third being the
+/// substantive one.
+///
+/// * **There is no adjudicator.** [`EquivocationProof`] is constructed and verified nowhere
+///   outside this module and its tests: no slashing operation consumes one, and no chain records
+///   one. [`AccountableSafety`] establishes *convictability* — that the evidence exists, is
+///   self-contained and verifies — not any protocol consequence. Wiring an adjudicator in would
+///   need a place to submit proofs and a stake to forfeit, neither of which exists today.
+///
+/// * **Only equivocation is attributable, not silence.** A validator that simply stops voting, or
+///   answers some clients and not others, produces no contradictory signature and is unconvictable.
+///   Liveness faults are outside the scheme by construction, which is why
+///   `linera_core::proof::assumptions::CorrectValidatorAvailability` is an assumption rather than
+///   something enforced.
+///
+/// * **Incorrect execution is not attributable.** Nothing in [`EquivocationProof`] relates a
+///   block's [`ProposedBlock`] to its [`BlockExecutionOutcome`]. A validator that votes for
+///   exactly one block per round, with a sound chain, but whose block carries a fabricated
+///   `state_hash`, yields no proof at all. What the implementation has instead is *local
+///   detection*: `ChainWorkerState::execute_contiguous_block` re-executes the block and rejects a
+///   mismatch with [`ChainError::CorruptedChainState`]. That is unilateral — the detecting node
+///   holds nothing transferable, and any peer must redo the work — and it is incomplete in three
+///   ways: the certificate's `oracle_responses` are *replayed* into the re-execution rather than
+///   re-derived, so a fabricated oracle answer reproduces the same state hash and is never caught;
+///   `preprocess_certified_block` does not execute at all; and the `execution_state_cache` hit
+///   path skips re-execution. The property that does protect against a bad outcome is
+///   [`CertifiedBlockWasExecuted`], and unlike everything else in this module it needs
+///   [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight): validity degrades
+///   above the fault bound with no forensic residue, whereas agreement degrades with one.
+///
+/// * **The blame set is a threshold, not a census.** [`ConflictCompleteness`] names *a* quorum
+///   intersection; other validators may have equivocated without appearing in it, and running
+///   [`extract_equivocations`] on further certificate pairs may name more.
+///
+/// [`EquivocationProof`]: crate::justification::EquivocationProof
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`ChainError::CorruptedChainState`]: crate::ChainError::CorruptedChainState
+/// [`extract_equivocations`]: crate::justification::extract_equivocations
+pub trait AccountabilityScope:
+    AccountableSafety
+    + DoubleValidationCompleteness
+    + CertifiedBlockWasExecuted
+    + CommitRestsOnValidation
+{
+}

--- a/linera-chain/src/justification/proof.rs
+++ b/linera-chain/src/justification/proof.rs
@@ -32,7 +32,9 @@
 use crate::{
     data_types::proof::quorum::{CertificateEmbedsQuorum, Intersection, ThresholdArithmetic},
     manager::proof::{
-        commit::{CertifiedBlockWasExecuted, CommitRestsOnValidation},
+        commit::{
+            CertifiedBlockWasExecuted, CommitRestsOnValidation, IncomingBundlesAreSelfDerived,
+        },
         locking::{
             ConfirmedVoteRoundMonotone, OneConfirmationVotePerRound, OneValidationVotePerRound,
             SafetyStateRecovery,
@@ -454,18 +456,34 @@ pub trait AccountableSafety:
 ///   `linera_core::proof::assumptions::CorrectValidatorAvailability` is an assumption rather than
 ///   something enforced.
 ///
-/// * **Incorrect execution is not attributable.** Nothing in [`EquivocationProof`] relates a
-///   block's [`ProposedBlock`] to its [`BlockExecutionOutcome`]. A validator that votes for
-///   exactly one block per round, with a sound chain, but whose block carries a fabricated
-///   `state_hash`, yields no proof at all. What the implementation has instead is *local
-///   detection*: `ChainWorkerState::execute_contiguous_block` re-executes the block and rejects a
-///   mismatch with [`ChainError::CorruptedChainState`]. That is unilateral — the detecting node
-///   holds nothing transferable, and any peer must redo the work — and it is incomplete in three
-///   ways: the certificate's `oracle_responses` are *replayed* into the re-execution rather than
+/// * **Incorrect execution is not attributable, and its effects are not confined to one chain.**
+///   Nothing in [`EquivocationProof`] relates a block's [`ProposedBlock`] to its
+///   [`BlockExecutionOutcome`]. A validator that votes for exactly one block per round, with a
+///   sound chain, but whose block carries a fabricated outcome, yields no proof at all.
+///
+///   This is worse than it first looks, because the outcome is eight separately committed
+///   components ([`CertifiedBlockWasExecuted`]) and they differ sharply in reach. A wrong
+///   `state_hash` stays on the chain. A wrong `messages` or `events` field *leaves* it: the
+///   bundles are delivered into other chains' inboxes and consumed by their blocks, and the events
+///   are read across chains through `OracleResponse::Event`. Those downstream blocks are then
+///   themselves properly certified and are evidence of nobody's fault. So even a hypothetical
+///   fraud proof would convict one block's executors while leaving a transitively corrupted
+///   subgraph standing — and since Linera finalizes on confirmation rather than after a challenge
+///   window, none of it can be reverted. Of the eight, only `blobs` are self-verifying, being
+///   content-addressed.
+///
+///   What the implementation has instead is *local detection*:
+///   `ChainWorkerState::execute_contiguous_block` re-executes the block and rejects a mismatch
+///   with [`ChainError::CorruptedChainState`]. That is unilateral — the detecting node holds
+///   nothing transferable, and any peer must redo the work — and it is incomplete in three ways:
+///   the certificate's `oracle_responses` are *replayed* into the re-execution rather than
 ///   re-derived, so a fabricated oracle answer reproduces the same state hash and is never caught;
-///   `preprocess_certified_block` does not execute at all; and the `execution_state_cache` hit
-///   path skips re-execution. The property that does protect against a bad outcome is
-///   [`CertifiedBlockWasExecuted`], and unlike everything else in this module it needs
+///   `preprocess_certified_block` does not execute at all, taking `messages` and `events` from the
+///   certificate; and the `execution_state_cache` hit path skips re-execution.
+///
+///   The properties that do protect against a bad outcome are [`CertifiedBlockWasExecuted`] and,
+///   for the cross-chain component, [`IncomingBundlesAreSelfDerived`]. Unlike everything else in
+///   this module both need
 ///   [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight): validity degrades
 ///   above the fault bound with no forensic residue, whereas agreement degrades with one.
 ///
@@ -478,10 +496,13 @@ pub trait AccountableSafety:
 /// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
 /// [`ChainError::CorruptedChainState`]: crate::ChainError::CorruptedChainState
 /// [`extract_equivocations`]: crate::justification::extract_equivocations
+/// [`CertifiedBlockWasExecuted`]: crate::manager::proof::commit::CertifiedBlockWasExecuted
+/// [`IncomingBundlesAreSelfDerived`]: crate::manager::proof::commit::IncomingBundlesAreSelfDerived
 pub trait AccountabilityScope:
     AccountableSafety
     + DoubleValidationCompleteness
     + CertifiedBlockWasExecuted
+    + IncomingBundlesAreSelfDerived
     + CommitRestsOnValidation
 {
 }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -2,6 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module manages the state of a Linera chain, including cross-chain communication.
+//!
+//! The consensus protocol implemented here is specified and proved correct in [`spec`], whose
+//! statements live next to the code they describe in [`manager::proof`] and
+//! [`data_types::proof`].
 
 #![deny(missing_docs)]
 
@@ -16,13 +20,13 @@ pub mod types {
 
 mod block_tracker;
 mod chain;
-/// Data types exchanged while proposing, voting on, and confirming blocks.
 pub mod data_types;
 mod inbox;
 pub mod justification;
 pub mod manager;
 mod outbox;
 mod pending_blobs;
+pub mod spec;
 #[cfg(with_testing)]
 pub mod test;
 

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -99,6 +99,8 @@ use crate::{
     ChainError,
 };
 
+pub mod proof;
+
 /// The result of verifying a (valid) query.
 #[derive(Eq, PartialEq)]
 pub enum Outcome {

--- a/linera-chain/src/manager/proof/commit.rs
+++ b/linera-chain/src/manager/proof/commit.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The commit rule: what it takes for a block to become final, and what a node does about it.
+//!
+//! The protocol has a two-step commit rule outside the fast round — validate, then confirm — and
+//! a one-step rule inside it. This module pins down both, and connects "a confirmed block
+//! certificate exists" to the observable state a node reaches.
+
+use crate::{
+    data_types::proof::quorum::CertificateCarriesCorrectVote,
+    manager::proof::voting::ConfirmationNeedsValidatedCertificate,
+};
+
+/// **Definition (Committed block).** A block `B` at height `h` of a chain is *committed* when a
+/// [`ConfirmedBlockCertificate`] for `B`, valid for the committee of its epoch, exists — that
+/// is, when a quorum has cast confirmation votes for `B`.
+///
+/// The commit rule is therefore:
+///
+/// | round | rule |
+/// |---|---|
+/// | [`Round::Fast`] | a quorum of confirmation votes on a super owner's fast proposal, with no validation step |
+/// | any other round `r` | a quorum of validation votes for `B` in round `r`, then a quorum of confirmation votes for `B` in round `r` |
+///
+/// Commitment is a property of the *world*, not of any one node: a block can be committed before
+/// any particular correct validator learns of it. The node-local reflection of it is
+/// [`TipAdvancesOnlyOnValidCertificate`].
+///
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+pub trait CommittedBlock {}
+
+/// **Lemma (A commit outside the fast round rests on a validated block certificate).** If a
+/// [`ConfirmedBlockCertificate`] for `B` is certified in a round `r` other than
+/// [`Round::Fast`](linera_base::data_types::Round::Fast), then a valid
+/// [`ValidatedBlockCertificate`] for `B` in the *same* round `r` exists.
+///
+/// *Proof.* By [`CertificateCarriesCorrectVote`] some correct validator cast a confirmation vote
+/// for `B` in round `r`. By [`ConfirmationNeedsValidatedCertificate`], since `r` is not the fast
+/// round, a valid [`ValidatedBlockCertificate`] for `B` in round `r` existed when it did so. ∎
+///
+/// This is what lets the safety argument reason exclusively about *validated* certificates:
+/// every commit above the fast round is backed by one, in its own round.
+///
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+pub trait CommitRestsOnValidation:
+    CertificateCarriesCorrectVote + ConfirmationNeedsValidatedCertificate
+{
+}
+
+/// **Lemma (The tip advances only on a verified certificate).** A correct validator's
+/// [`ChainTipState::next_block_height`] passes from `h` to `h + 1`, and its
+/// [`block_hashes`](crate::ChainStateView) records a hash at `h`, only for a block carried by a
+/// [`ConfirmedBlockCertificate`] that has passed [`check`] against the committee of the block's
+/// epoch.
+///
+/// *Proof.* The tip register is advanced in one place in `linera_chain::chain`, at the end of
+/// the private `ChainStateView::apply_confirmed_block` (`tip.next_block_height.
+/// try_add_assign_one()`), reached only from `ChainWorkerState::execute_contiguous_block` and
+/// `execute_block_with_checkpoint_restore`. Both are reached only through
+/// `ChainWorkerState::process_confirmed_block`, whose every non-early-return path first
+/// evaluates `certificate.check(&committee)?` with `committee` fetched for `block.header.epoch`.
+/// The early returns — the `tip.next_block_height > height` skip and the `Preprocess` dispatch —
+/// do not advance the tip. ∎
+///
+/// Two paths deserve explicit mention because they weaken the *precondition* without weakening
+/// this lemma. `pre_checkpoint_block_trust` lets a hash recorded by an earlier checkpoint
+/// certificate bypass the already-processed skip; and a checkpoint block may install a state
+/// snapshot rather than replay its ancestors. Neither bypasses `certificate.check`, so a block
+/// entering the tip is always quorum-certified; what they bypass is the *re-execution* of
+/// ancestors, which is a matter of state-transition correctness rather than of agreement.
+///
+/// [`ChainTipState::next_block_height`]: crate::ChainTipState::next_block_height
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`check`]: crate::types::ConfirmedBlockCertificate::check
+pub trait TipAdvancesOnlyOnValidCertificate {}

--- a/linera-chain/src/manager/proof/commit.rs
+++ b/linera-chain/src/manager/proof/commit.rs
@@ -114,6 +114,16 @@ pub trait TipAdvancesOnlyOnValidCertificate {}
 ///   `certificate.check(&committee)`. The induction hypothesis at that strictly lower round
 ///   supplies the correct validator that executed `B`. ∎
 ///
+/// **All eight outputs, not just the state.** [`BlockHeader`] commits to each component of the
+/// outcome separately — [`state_hash`], [`messages_hash`], [`events_hash`], [`blobs_hash`],
+/// [`oracle_responses_hash`], [`operation_results_hash`], [`previous_message_blocks_hash`] and
+/// [`previous_event_blocks_hash`] — and this lemma covers all of them, since the correct validator
+/// computed the whole [`BlockExecutionOutcome`]. That matters because the components differ
+/// sharply in reach: `state_hash` is local to the chain, whereas `messages` and `events` leave it
+/// and are consumed by other chains, and `blobs` are content-addressed
+/// ([`BlobId`](linera_base::identifiers::BlobId) is a hash of the content) and so are the only
+/// component that is self-verifying without any execution at all.
+///
 /// **What this does not give.** The correct validator executed the proposal, but the execution
 /// *replays* whatever oracle answers it recorded; a later re-execution of the confirmed block
 /// feeds `outcome.oracle_responses` back in rather than re-deriving them. So the lemma certifies
@@ -127,9 +137,70 @@ pub trait TipAdvancesOnlyOnValidCertificate {}
 /// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
 /// [`BlockProposal::check_invariants`]: crate::data_types::BlockProposal::check_invariants
 /// [`OriginalProposal::Regular`]: crate::data_types::OriginalProposal::Regular
+/// [`BlockHeader`]: crate::block::BlockHeader
+/// [`state_hash`]: crate::block::BlockHeader::state_hash
+/// [`messages_hash`]: crate::block::BlockHeader::messages_hash
+/// [`events_hash`]: crate::block::BlockHeader::events_hash
+/// [`blobs_hash`]: crate::block::BlockHeader::blobs_hash
+/// [`oracle_responses_hash`]: crate::block::BlockHeader::oracle_responses_hash
+/// [`operation_results_hash`]: crate::block::BlockHeader::operation_results_hash
+/// [`previous_message_blocks_hash`]: crate::block::BlockHeader::previous_message_blocks_hash
+/// [`previous_event_blocks_hash`]: crate::block::BlockHeader::previous_event_blocks_hash
 /// [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
 /// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
 pub trait CertifiedBlockWasExecuted:
     CertificateCarriesCorrectVote + ProposalGate + MaxByzantineWeight + CommitRestsOnValidation
 {
 }
+
+/// **Lemma (Incoming bundles are matched against the validator's own inbox).** A correct
+/// validator casts a validation or fast-confirmation vote for a block only if every
+/// [`IncomingBundle`] the block consumes is already present in its own inbox for that origin, and
+/// is *equal* to the bundle it holds there.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | `ChainStateView::remove_bundles_from_inboxes`, called from `ChainWorkerState::try_handle_block_proposal` with `must_be_present = true` |
+/// | reads | the chain's inboxes, the block's timestamp and incoming bundles |
+/// | writes | the inboxes (rolled back before voting — `try_handle_block_proposal` calls `chain.rollback()`) |
+/// | precondition | none beyond [`ProposalGate`] |
+///
+/// *Proof.* `try_handle_block_proposal` calls
+/// `remove_bundles_from_inboxes(block.timestamp, true, block.incoming_bundles())` before executing
+/// and voting. For each bundle that helper calls `Inbox::remove_bundle` and, because
+/// `must_be_present` is set, rejects with [`ChainError::MissingCrossChainUpdate`] unless it
+/// returned `true` — which happens only on the branch that found a bundle already in
+/// `added_bundles` and checked `bundle == &previous_bundle`. So a bundle the validator has not
+/// received, or one that differs in any field from what it received, blocks the vote. ∎
+///
+/// **The flag is deliberately not set when applying a certified block.**
+/// `ChainWorkerState::execute_contiguous_block` passes `must_be_present = false`, so a bundle that
+/// has not arrived yet is recorded in `removed_bundles` and reconciled when it does. That is the
+/// right asymmetry — by then a quorum has already voted, and this lemma has done its work at
+/// voting time — but it means the guarantee lives in the *proposal* path only.
+///
+/// **What populates the inbox decides what this is worth.** Bundles enter through
+/// `ChainWorkerState::process_cross_chain_update`, fed by the *same validator's* worker for the
+/// sending chain. That worker derives them from the sending block's `messages` field, and whether
+/// that field is the validator's own work depends on how it processed the sender:
+///
+/// * if it **executed** the sender's block, `execute_contiguous_block` re-executed it and rejected
+///   a mismatch against the certificate ([`CertifiedBlockWasExecuted`] and the note there), so the
+///   bundles are self-derived;
+/// * if it only **preprocessed** the sender's block, `preprocess_certified_block` updated outboxes
+///   and event streams *without executing*, so the bundles are taken from the sender's certificate
+///   at face value.
+///
+/// So cross-chain integrity degrades with how much of the chain graph each validator executes —
+/// a deployment property, not a protocol one. Under [`MaxByzantineWeight`] this is still sound,
+/// since [`CertifiedBlockWasExecuted`] guarantees *some* correct validator executed the sending
+/// block; above the fault bound it is not, and the resulting damage is not confined to one chain
+/// (see [`AccountabilityScope`]).
+///
+/// [`IncomingBundle`]: crate::data_types::IncomingBundle
+/// [`ChainError::MissingCrossChainUpdate`]: crate::ChainError::MissingCrossChainUpdate
+/// [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
+/// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
+pub trait IncomingBundlesAreSelfDerived: ProposalGate + CertifiedBlockWasExecuted {}

--- a/linera-chain/src/manager/proof/commit.rs
+++ b/linera-chain/src/manager/proof/commit.rs
@@ -9,7 +9,10 @@
 
 use crate::{
     data_types::proof::quorum::CertificateCarriesCorrectVote,
-    manager::proof::voting::ConfirmationNeedsValidatedCertificate,
+    manager::proof::{
+        model::MaxByzantineWeight,
+        voting::{ConfirmationNeedsValidatedCertificate, ProposalGate},
+    },
 };
 
 /// **Definition (Committed block).** A block `B` at height `h` of a chain is *committed* when a
@@ -76,3 +79,57 @@ pub trait CommitRestsOnValidation:
 /// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
 /// [`check`]: crate::types::ConfirmedBlockCertificate::check
 pub trait TipAdvancesOnlyOnValidCertificate {}
+
+/// **Lemma (Every certified block was executed by a correct validator).** If a valid
+/// [`ValidatedBlockCertificate`] for a block `B` exists, then some correct validator executed
+/// `B`'s [`ProposedBlock`] itself and obtained `B`'s [`BlockExecutionOutcome`]. The same follows
+/// for a [`ConfirmedBlockCertificate`] outside the fast round, by
+/// [`CommitRestsOnValidation`]; inside the fast round it holds directly, a fast proposal carrying
+/// no outcome.
+///
+/// This is what stands between the protocol and a committed block whose outcome is fabricated.
+/// It is *not* accountability: a validator that votes for a mis-executed block leaves no
+/// extractable proof (see [`AccountabilityScope`]). And unlike the results in
+/// [`crate::justification::proof`], it needs [`MaxByzantineWeight`] — so validity, unlike
+/// agreement, degrades above the fault bound with no forensic residue.
+///
+/// *Proof.* Induction on the certificate's round, well founded because rounds are totally
+/// ordered. By [`CertificateCarriesCorrectVote`] some correct validator `v` cast a validation vote
+/// for `B` in that round, so by [`ProposalGate`] it ran `ChainWorkerState::try_handle_block_proposal`
+/// to acceptance on a proposal for `B`. That function computes the block as
+///
+/// ```text
+/// let block = if let Some(outcome) = outcome { outcome.clone().with(proposal.content.block.clone()) }
+///             else { self.execute_block(…).await? };
+/// ```
+///
+/// and [`BlockProposal::check_invariants`] admits a carried `outcome` only together with an
+/// [`OriginalProposal::Regular`] certificate. So:
+///
+/// * a **fresh** proposal and a **fast retry** both carry `outcome: None` and are therefore
+///   executed by `v` itself — the base case;
+/// * a **regular retry** is not re-executed, but `check_invariants` requires its certificate to
+///   satisfy `certificate.check_value(&ValidatedBlock::new(outcome.with(block)))`, i.e. to certify
+///   exactly this `B`, and `content.round > certificate.round`; the caller verified it with
+///   `certificate.check(&committee)`. The induction hypothesis at that strictly lower round
+///   supplies the correct validator that executed `B`. ∎
+///
+/// **What this does not give.** The correct validator executed the proposal, but the execution
+/// *replays* whatever oracle answers it recorded; a later re-execution of the confirmed block
+/// feeds `outcome.oracle_responses` back in rather than re-deriving them. So the lemma certifies
+/// that the outcome follows from the proposal *and those oracle answers*, not that the answers
+/// were truthful. Oracle results are attested by quorum, which is inherent — they are not
+/// reproducible functions of the chain state.
+///
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`BlockProposal::check_invariants`]: crate::data_types::BlockProposal::check_invariants
+/// [`OriginalProposal::Regular`]: crate::data_types::OriginalProposal::Regular
+/// [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
+/// [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
+pub trait CertifiedBlockWasExecuted:
+    CertificateCarriesCorrectVote + ProposalGate + MaxByzantineWeight + CommitRestsOnValidation
+{
+}

--- a/linera-chain/src/manager/proof/locking.rs
+++ b/linera-chain/src/manager/proof/locking.rs
@@ -1,0 +1,380 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Locking invariants: what a correct validator's committed-to state can look like.
+//!
+//! These are *protocol invariants*: each is proved by induction over the transitions of one
+//! consensus instance ([`ConsensusInstance`]), and each proof discharges the induction by
+//! enumerating every method that writes the relevant field. The enumerations are the
+//! load-bearing part — a new writer invalidates them — so each invariant names its writers
+//! explicitly.
+//!
+//! The writer sets, for reference:
+//!
+//! | field | writers |
+//! |---|---|
+//! | [`locking_block`] | private `update_locking` (from [`create_vote`] ×3 and [`create_final_vote`]); [`ManagerSafetySnapshot::restore`]; [`reset`] |
+//! | [`confirmed_vote`] | [`create_vote`] (fast branch); [`create_final_vote`]; [`ManagerSafetySnapshot::restore`]; [`reset`] |
+//! | [`validated_vote`] | [`create_vote`] (both branches); [`create_final_vote`]; [`ManagerSafetySnapshot::restore`]; [`reset`] |
+//! | [`timeout_vote`] | [`create_timeout_vote`]; [`ManagerSafetySnapshot::restore`]; [`reset`] |
+//! | [`fallback_vote`] | [`vote_fallback`]; [`ManagerSafetySnapshot::restore`]; [`reset`] |
+//! | [`timeout`] | [`handle_timeout_certificate`]; [`reset`] |
+//! | [`proposed`] | private `update_proposed` (from [`create_vote`]); [`reset`] |
+//! | [`signed_proposal`] | [`update_signed_proposal`]; private `update_proposed` (clears it); [`reset`] |
+//!
+//! [`ConsensusInstance`]: crate::manager::proof::model::ConsensusInstance
+//! [`locking_block`]: crate::manager::ChainManager::locking_block
+//! [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+//! [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+//! [`timeout_vote`]: crate::manager::ChainManager::timeout_vote
+//! [`fallback_vote`]: crate::manager::ChainManager::fallback_vote
+//! [`timeout`]: crate::manager::ChainManager::timeout
+//! [`proposed`]: crate::manager::ChainManager::proposed
+//! [`signed_proposal`]: crate::manager::ChainManager::signed_proposal
+//! [`create_vote`]: crate::manager::ChainManager::create_vote
+//! [`create_final_vote`]: crate::manager::ChainManager::create_final_vote
+//! [`create_timeout_vote`]: crate::manager::ChainManager::create_timeout_vote
+//! [`vote_fallback`]: crate::manager::ChainManager::vote_fallback
+//! [`handle_timeout_certificate`]: crate::manager::ChainManager::handle_timeout_certificate
+//! [`update_signed_proposal`]: crate::manager::ChainManager::update_signed_proposal
+//! [`reset`]: crate::manager::ChainManager::reset
+//! [`ManagerSafetySnapshot::restore`]: crate::manager::ManagerSafetySnapshot::restore
+
+use crate::{
+    data_types::proof::quorum::{CertificateCarriesCorrectVote, CorrectValidatorInIntersection},
+    manager::proof::{
+        model::{ConsensusInstance, DurablePersistence, EpochAgreement},
+        rounds::{CurrentRoundMonotone, RoundFloor, VoteRoundBelowCurrentRound},
+        voting::{
+            ConfirmationNeedsValidatedCertificate, ConfirmationOnlyInCurrentRound,
+            FastConfirmationNeedsEmptyLock, NoValidationInFastRound, ProposalGate,
+            ValidationRoundStrictlyIncreases, VoteConstructionSites,
+        },
+    },
+};
+
+/// **Definition (Lock).** The *lock* of an instance is [`ChainManager::locking_block`], and its
+/// *lock round* is [`LockingBlock::round`] of that value, or `⊥` when the field is `None`, with
+/// `⊥` below every round.
+///
+/// A lock records the most recent block this validator may already have helped confirm: either a
+/// [`LockingBlock::Regular`] — a [`ValidatedBlockCertificate`], proof that a quorum validated
+/// that block in that round — or a [`LockingBlock::Fast`], the super owner's original fast-round
+/// proposal. Both are re-proposable: a client reads the lock out of
+/// [`ChainManagerInfo::requested_locking`] and re-proposes it in a higher round.
+///
+/// [`ChainManager::locking_block`]: crate::manager::ChainManager::locking_block
+/// [`LockingBlock::round`]: crate::manager::LockingBlock::round
+/// [`LockingBlock::Regular`]: crate::manager::LockingBlock::Regular
+/// [`LockingBlock::Fast`]: crate::manager::LockingBlock::Fast
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`ChainManagerInfo::requested_locking`]: crate::manager::ChainManagerInfo::requested_locking
+pub trait Lock {}
+
+/// **Invariant (The lock round never decreases).** Within one consensus instance, the lock round
+/// is non-decreasing.
+///
+/// *Proof.* By the writer table in the [module documentation](self), [`locking_block`] is
+/// written only by the private `update_locking`, by [`ManagerSafetySnapshot::restore`], and by
+/// [`reset`] (which by [`ConsensusInstance`] ends the instance).
+///
+/// `update_locking` begins with
+///
+/// ```text
+/// if let Some(old_locked) = self.locking_block.get() {
+///     if old_locked.round() >= locking.round() { return Ok(()); }
+/// }
+/// ```
+///
+/// so it writes only a strictly higher round. All four call sites go through it: the two
+/// `update_locking` calls in the `Regular` and `Fast` arms of [`create_vote`]'s `match`, the one
+/// in the `None` arm, and the one in [`create_final_vote`].
+///
+/// [`ManagerSafetySnapshot::restore`] is handled by [`SafetyStateRecovery`]. ∎
+///
+/// [`locking_block`]: crate::manager::ChainManager::locking_block
+/// [`create_vote`]: crate::manager::ChainManager::create_vote
+/// [`create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`reset`]: crate::manager::ChainManager::reset
+/// [`ManagerSafetySnapshot::restore`]: crate::manager::ManagerSafetySnapshot::restore
+/// [`ConsensusInstance`]: crate::manager::proof::model::ConsensusInstance
+pub trait LockRoundMonotone: Lock + ConsensusInstance {}
+
+/// **Invariant (The confirmed-vote round never decreases).** Within one consensus instance, if
+/// [`confirmed_vote`] is `Some` with round `p`, it never later holds a vote with round `< p`.
+///
+/// *Proof.* By the writer table in the [module documentation](self) the field has three
+/// in-instance writers.
+///
+/// *[`create_final_vote`] at round `r`.* By [`ConfirmationOnlyInCurrentRound`] it writes only
+/// when `current_round == r`. If a previous confirmation vote had round `p`, then by
+/// [`VoteRoundBelowCurrentRound`] the current round was `≥ p` at that time, and by
+/// [`CurrentRoundMonotone`] it still is. Hence `r = current_round ≥ p`.
+///
+/// *[`create_vote`], fast branch.* Writes a vote in [`Round::Fast`], the minimum round — but by
+/// [`FastConfirmationNeedsEmptyLock`] this branch is reachable only when [`confirmed_vote`] was
+/// `None`, so there is no earlier round to undercut.
+///
+/// *[`ManagerSafetySnapshot::restore`].* See [`SafetyStateRecovery`]. ∎
+///
+/// [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+/// [`create_vote`]: crate::manager::ChainManager::create_vote
+/// [`create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`ManagerSafetySnapshot::restore`]: crate::manager::ManagerSafetySnapshot::restore
+pub trait ConfirmedVoteRoundMonotone:
+    ConfirmationOnlyInCurrentRound
+    + FastConfirmationNeedsEmptyLock
+    + VoteRoundBelowCurrentRound
+    + CurrentRoundMonotone
+{
+}
+
+/// **Invariant (Cast validation rounds leave a floor).** If a correct validator has ever cast a
+/// validation vote in round `s` during an instance, then from that moment on
+///
+/// ```text
+/// max(validated_vote.round, lock round) ≥ s
+/// ```
+///
+/// where an absent field contributes `⊥`.
+///
+/// This is the invariant that survives [`create_final_vote`] clearing [`validated_vote`], and it
+/// is what makes [`OneValidationVotePerRound`] hold over a whole instance rather than only
+/// between confirmations.
+///
+/// *Proof.* Induction over the transitions of the instance.
+///
+/// *Base.* Immediately after the vote, [`validated_vote`] is `Some(_, s)` — the non-fast branch
+/// of [`create_vote`] ends with `self.validated_vote.get_mut().insert(vote)`.
+///
+/// *Step.* Only two transitions can lower either side of the maximum. The lock round is
+/// non-decreasing by [`LockRoundMonotone`], so only [`validated_vote`] can fall, and by the
+/// writer table it is set to `None` in exactly two places:
+///
+/// * [`create_vote`], fast branch (`self.validated_vote.set(None)`). Unreachable here: that
+///   branch requires [`ChainManager::check_proposed_block`] to have accepted a proposal in
+///   [`Round::Fast`] ([`ProposalGate`]), whose [`validated_vote`] guard
+///   `ensure!(new_round > vote.round)` is unsatisfiable for the minimum round unless
+///   [`validated_vote`] is already `None`; and if it is `None`, the induction hypothesis is
+///   carried by the lock, which this branch does not lower.
+/// * [`create_final_vote`] at some round `r`. It clears the field only after
+///   `update_locking(LockingBlock::Regular(validated), blobs)` and only on the branch where a
+///   vote is cast, which by [`ConfirmationOnlyInCurrentRound`] requires `current_round == r`. By
+///   [`VoteRoundBelowCurrentRound`] and [`CurrentRoundMonotone`], `current_round ≥ s`, so
+///   `r ≥ s`. By [`RoundFloor`] and [`LockRoundMonotone`], after `update_locking` the lock round
+///   is `≥ r ≥ s`. So the maximum is preserved by the lock. ∎
+///
+/// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+/// [`create_vote`]: crate::manager::ChainManager::create_vote
+/// [`create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+pub trait CastValidationRoundFloor:
+    LockRoundMonotone
+    + ProposalGate
+    + ConfirmationOnlyInCurrentRound
+    + VoteRoundBelowCurrentRound
+    + CurrentRoundMonotone
+    + RoundFloor
+{
+}
+
+/// **Lemma (One validation vote per round).** A correct validator casts at most one validation
+/// vote per round of an instance.
+///
+/// *Proof.* Suppose it casts validation votes for `B₁` and then `B₂` in the same round `s`. By
+/// [`ProposalGate`] the second was preceded by [`ChainManager::check_proposed_block`] returning
+/// `Accept` for a proposal in round `s`, so both of its round guards held at that moment:
+///
+/// * `ensure!(new_round > vote.round)` for [`validated_vote`], and
+/// * `ensure!(locking_block.round() < new_round)` for the lock.
+///
+/// Together these give `max(validated_vote.round, lock round) < s`, contradicting
+/// [`CastValidationRoundFloor`], which the first vote established. (Where "the same vote" is
+/// re-submitted rather than a different block, [`ChainManager::check_proposed_block`] returns
+/// [`Outcome::Skip`] on its first branch and nothing is signed.)
+///
+/// The argument needs the two votes to be observed by the *same* manager state, which is
+/// [`DurablePersistence`] — a validator that lost its state across a crash could sign twice —
+/// and [`SerializedChainState`], which rules out two concurrent handlers each seeing the
+/// pre-vote state. ∎
+///
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+/// [`Outcome::Skip`]: crate::manager::Outcome::Skip
+/// [`SerializedChainState`]: crate::manager::proof::model::SerializedChainState
+pub trait OneValidationVotePerRound:
+    ProposalGate + CastValidationRoundFloor + ValidationRoundStrictlyIncreases + DurablePersistence
+{
+}
+
+/// **Lemma (One confirmation vote per round).** A correct validator casts at most one
+/// confirmation vote per round of an instance.
+///
+/// *Proof.* Two cases on the round `r`.
+///
+/// *`r` is [`Round::Fast`].* By [`FastConfirmationNeedsEmptyLock`], such a vote requires the lock
+/// to be `None` beforehand and installs a [`LockingBlock::Fast`] — of round [`Round::Fast`] —
+/// afterwards. A second fast confirmation would again require the lock to be `None`,
+/// contradicting [`LockRoundMonotone`]. (Directly: the lock guard
+/// `ensure!(locking_block.round() < Round::Fast)` in [`ChainManager::check_proposed_block`] is
+/// unsatisfiable.)
+///
+/// *`r` is not [`Round::Fast`].* By [`ConfirmationNeedsValidatedCertificate`] the vote comes from
+/// [`create_final_vote`], which is guarded by [`ChainManager::check_validated_block`]
+/// ([`ProposalGate`]). That guard contains
+///
+/// ```text
+/// if let Some(locking) = self.locking_block.get() {
+///     ensure!(new_round > locking.round(), ChainError::InsufficientRoundStrict(locking.round()));
+/// }
+/// ```
+///
+/// The first confirmation at round `r` ran `update_locking(LockingBlock::Regular(validated), …)`
+/// with `validated.round == r`, so afterwards the lock round is `≥ r` by [`RoundFloor`] and
+/// [`LockRoundMonotone`]. A second certificate in round `r` therefore fails `new_round >
+/// locking.round()` and no second vote is cast. (If the second certificate is for the same block
+/// and round, [`ChainManager::check_validated_block`] returns [`Outcome::Skip`] on its first
+/// branch instead.)
+///
+/// As in [`OneValidationVotePerRound`], the argument consumes [`DurablePersistence`] and
+/// [`SerializedChainState`]. ∎
+///
+/// **Where this is fragile.** In the non-fast case the guard lives in
+/// [`ChainManager::check_validated_block`], i.e. at the *call site*, not inside
+/// [`create_final_vote`] — which re-checks only [`ChainManager::current_round`] and would sign
+/// again for a different block certified in the same round. See [`ProposalGate`].
+///
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`LockingBlock::Fast`]: crate::manager::LockingBlock::Fast
+/// [`create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`ChainManager::check_validated_block`]: crate::manager::ChainManager::check_validated_block
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`Outcome::Skip`]: crate::manager::Outcome::Skip
+/// [`SerializedChainState`]: crate::manager::proof::model::SerializedChainState
+pub trait OneConfirmationVotePerRound:
+    ProposalGate
+    + FastConfirmationNeedsEmptyLock
+    + ConfirmationNeedsValidatedCertificate
+    + LockRoundMonotone
+    + RoundFloor
+    + DurablePersistence
+{
+}
+
+/// **Corollary (At most one validated block per round).** For a given chain and height, all
+/// valid [`ValidatedBlockCertificate`]s certified in the same round certify the same block.
+///
+/// *Proof.* Let two such certificates certify `B₁` and `B₂` in round `s`. By
+/// [`EpochAgreement`] they are judged against the same committee, so by
+/// [`CertificateEmbedsQuorum`] their signer sets are two quorums of it, and by
+/// [`CorrectValidatorInIntersection`] some correct validator `v` signed both. By
+/// [`CertificateCarriesCorrectVote`], `v` cast validation votes for `B₁` and for `B₂`, both in
+/// round `s`. By [`OneValidationVotePerRound`], `B₁ = B₂`. ∎
+///
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`CertificateEmbedsQuorum`]: crate::data_types::proof::quorum::CertificateEmbedsQuorum
+pub trait UniqueValidatedBlockPerRound:
+    OneValidationVotePerRound
+    + CorrectValidatorInIntersection
+    + CertificateCarriesCorrectVote
+    + EpochAgreement
+{
+}
+
+/// **Lemma (No validated block certificate in the fast round).** No valid
+/// [`ValidatedBlockCertificate`] is certified in
+/// [`Round::Fast`](linera_base::data_types::Round::Fast).
+///
+/// *Proof.* By [`CertificateCarriesCorrectVote`] such a certificate would require a correct
+/// validator to have cast a validation vote in [`Round::Fast`](linera_base::data_types::Round::Fast),
+/// which [`NoValidationInFastRound`] forbids. ∎
+///
+/// This is why the fast round is not a "round" in the ordinary sense: it has a confirmation step
+/// but no validation step, and therefore no certificate a later round could be unlocked by.
+///
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+pub trait NoValidatedBlockInFastRound:
+    NoValidationInFastRound + CertificateCarriesCorrectVote
+{
+}
+
+/// **Lemma (Safety state survives a local reset).** After
+/// `ChainWorkerState::reset_and_reexecute_chain`, the manager's lock and cast votes are at least
+/// what they were before the reset, and no invariant of this module is broken.
+///
+/// This is the one transition that writes [`locking_block`], [`confirmed_vote`] and
+/// [`validated_vote`] without going through the voting path, so [`LockRoundMonotone`],
+/// [`ConfirmedVoteRoundMonotone`] and [`CastValidationRoundFloor`] each owe it an argument.
+///
+/// *Proof.* The procedure captures [`ManagerSafetySnapshot::capture`] *before* wiping storage,
+/// replays the chain's confirmed blocks from storage, and then calls
+/// [`ManagerSafetySnapshot::restore`] — but only under the explicit guard
+/// `new_tip_height == tip_height`, so the restored fields belong to the same pending height and
+/// hence the same consensus instance in the sense of [`ConsensusInstance`].
+///
+/// Replay only feeds [`ConfirmedBlockCertificate`]s to `process_confirmed_block`, which casts no
+/// vote and calls [`reset`] once per replayed height; so at the moment of restore the five
+/// snapshot fields are exactly what the final `reset` left them — `None`. The restore therefore
+/// re-installs the pre-reset values rather than overwriting newer ones, and each field returns to
+/// a value it genuinely held. The three invariants above are stated over the values a correct
+/// validator has committed to, so restoring them re-establishes rather than violates them.
+///
+/// The subtle point is [`current_round`], which the snapshot does **not** capture or restore: it
+/// is left at [`ChainOwnership::first_round`] by the last [`reset`], potentially far below the
+/// restored lock. That cannot be exploited, because every path that could act on the lower round
+/// re-derives the round from the lock first:
+///
+/// * [`create_final_vote`] calls `update_locking` then `update_current_round` before comparing
+///   against `round`, so by [`RoundFloor`] the comparison sees a round `≥` the restored lock
+///   round — this is exactly [`ConfirmationOnlyInCurrentRound`];
+/// * [`ChainManager::check_proposed_block`] rejects any proposal not strictly above the lock
+///   round, regardless of [`current_round`].
+///
+/// So the restored lock, not the round register, is what binds. ∎
+///
+/// **Residual obligation.** [`ManagerSafetySnapshot`] records no height of its own; the
+/// correspondence between snapshot and instance rests entirely on the caller's
+/// `new_tip_height == tip_height` guard. A future caller of
+/// [`ManagerSafetySnapshot::restore`] must reproduce it.
+///
+/// [`locking_block`]: crate::manager::ChainManager::locking_block
+/// [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+/// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`reset`]: crate::manager::ChainManager::reset
+/// [`ManagerSafetySnapshot`]: crate::manager::ManagerSafetySnapshot
+/// [`ManagerSafetySnapshot::capture`]: crate::manager::ManagerSafetySnapshot::capture
+/// [`ManagerSafetySnapshot::restore`]: crate::manager::ManagerSafetySnapshot::restore
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`ConsensusInstance`]: crate::manager::proof::model::ConsensusInstance
+/// [`ChainOwnership::first_round`]: linera_base::ownership::ChainOwnership::first_round
+pub trait SafetyStateRecovery:
+    ConsensusInstance + LockRoundMonotone + RoundFloor + ConfirmationOnlyInCurrentRound
+{
+}
+
+/// **Remark (Votes a correct validator may hold simultaneously).** Nothing above forbids a
+/// correct validator from holding a [`confirmed_vote`] and a [`validated_vote`] at once — it
+/// does, whenever it validates in a round above its last confirmation. What the invariants
+/// forbid is *two of the same kind in the same round*. The reporting projection
+/// [`ChainManagerInfo::pending`] picks whichever is higher, which is why a client observing a
+/// validator sees a single "pending" vote even though two are stored.
+///
+/// Similarly, [`timeout_vote`] and [`fallback_vote`] may both be set: they are votes on the same
+/// [`Timeout`] value in different rounds ([`FallbackVote`]), so they are not conflicting votes in
+/// the sense of [`OneValidationVotePerRound`] — and if their rounds coincide, so do their
+/// payloads, and hence their signatures.
+///
+/// [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+/// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+/// [`timeout_vote`]: crate::manager::ChainManager::timeout_vote
+/// [`fallback_vote`]: crate::manager::ChainManager::fallback_vote
+/// [`ChainManagerInfo::pending`]: crate::manager::ChainManagerInfo::pending
+/// [`Timeout`]: crate::block::Timeout
+/// [`FallbackVote`]: crate::manager::proof::pacemaker::FallbackVote
+pub trait SimultaneousVotes: VoteConstructionSites {}

--- a/linera-chain/src/manager/proof/mod.rs
+++ b/linera-chain/src/manager/proof/mod.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The consensus correctness argument for the chain manager, from the system model to the
+//! safety theorem.
+//!
+//! This is the chain-crate half of the specification; the progress and liveness half lives in
+//! `linera_core::proof`, which cites into here. [`crate::spec`] gives the reading order across
+//! both and explains the conventions.
+//!
+//! # Layout
+//!
+//! | module | contents |
+//! |---|---|
+//! | [`model`] | system model, and the assumptions safety rests on |
+//! | [`voting`] | voting rules: what a correct validator's state must be for it to sign |
+//! | [`rounds`] | the round register: what it means, and why it only grows |
+//! | [`locking`] | locking invariants, proved by induction over an instance's transitions |
+//! | [`commit`] | the commit rule, and what a node does when a block commits |
+//! | [`safety`] | the safety theorem: at most one block per chain and height |
+//! | [`pacemaker`] | view changes: how a height leaves a round, for the progress argument |
+//!
+//! The single most important statement is [`safety::CommitAgreement`]; the single most
+//! substantial proof is [`safety::LockPreservation`].
+//!
+//! # What is proved, in one paragraph
+//!
+//! A correct validator will not cast a validation vote for a block it has not been shown a
+//! justification for, and will not confirm a block that a quorum has not validated in the very
+//! round it confirms in ([`voting`]). Its lock and its cast-vote rounds only ever move up
+//! ([`rounds`], [`locking`]), so it votes at most once per round and per kind. Any two quorums
+//! share a correct validator ([`crate::data_types::proof::quorum`]), so those per-validator
+//! limits become per-round limits on the certificates that can exist. Finally, a validator
+//! abandons a block it confirmed only in exchange for a certificate strictly above its own
+//! confirmation round, which lets an induction over rounds show that once a block is committed,
+//! no later round validates anything else ([`safety::LockPreservation`]) — hence at most one
+//! block per height is ever committed ([`safety::CommitAgreement`]).
+
+pub mod commit;
+pub mod locking;
+pub mod model;
+pub mod pacemaker;
+pub mod rounds;
+pub mod safety;
+pub mod voting;

--- a/linera-chain/src/manager/proof/model.rs
+++ b/linera-chain/src/manager/proof/model.rs
@@ -1,0 +1,219 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! System model and the assumptions the safety argument rests on.
+//!
+//! The definitions here fix what a consensus instance is and what it means for two blocks to
+//! conflict; the assumptions are the things the implementation does *not* prove and that a
+//! deployment must supply. Everything in this module is a leaf of the dependency graph.
+//!
+//! The assumptions needed only for progress — synchrony, availability, leader fairness, an
+//! active driver — are stated separately in `linera_core::proof::assumptions`, because their
+//! evidence lives in that crate. Safety depends on none of them.
+
+/// **Definition (Consensus instance).** The protocol decides one block at a time, per chain.
+/// A *consensus instance* is a pair `(chain, height)`, and its state is one [`ChainManager`],
+/// reachable as [`ChainStateView::manager`], whose height is
+/// [`ChainTipState::next_block_height`].
+///
+/// [`ChainManager::reset`] destroys an instance and creates the next one: it calls `clear()` on
+/// every view, re-derives the leader distributions from the new ownership, and sets
+/// [`ChainManager::current_round`] to [`ChainOwnership::first_round`]. It is called from exactly
+/// two places in `linera_chain::chain`: `initialize_if_needed`, when the chain becomes active at
+/// height `0`, and `reset_chain_manager`, immediately after a confirmed block at height `h` has
+/// been executed, for height `h + 1`.
+///
+/// Consequently **every invariant in [`crate::manager::proof::locking`] is scoped to a single
+/// instance**: it holds from the moment the instance is created until it is reset, and says
+/// nothing across a reset. That is sound because a reset happens only once the height's block is
+/// committed, so a later instance decides a different height. Restoring state *across* a reset
+/// is the one exception, handled by [`SafetyStateRecovery`].
+///
+/// [`ChainManager`]: crate::manager::ChainManager
+/// [`ChainManager::reset`]: crate::manager::ChainManager::reset
+/// [`ChainManager::current_round`]: crate::manager::ChainManager::current_round
+/// [`ChainStateView::manager`]: crate::ChainStateView::manager
+/// [`ChainTipState::next_block_height`]: crate::ChainTipState::next_block_height
+/// [`ChainOwnership::first_round`]: linera_base::ownership::ChainOwnership::first_round
+/// [`SafetyStateRecovery`]: crate::manager::proof::locking::SafetyStateRecovery
+pub trait ConsensusInstance {}
+
+/// **Definition (Round order).** Rounds are [`Round`] values, totally ordered by the derived
+/// [`Ord`] on the enum, which orders first by variant and then by the contained `u32`:
+///
+/// ```text
+/// Round::Fast  <  Round::MultiLeader(0) < Round::MultiLeader(1) < …
+///              <  Round::SingleLeader(0) < Round::SingleLeader(1) < …
+///              <  Round::Validator(0)  < Round::Validator(1)  < …
+/// ```
+///
+/// In particular [`Round::Fast`] is the global minimum, which several arguments use directly:
+/// a guard of the form `x.round() < Round::Fast` is unsatisfiable.
+///
+/// The successor function is [`ChainOwnership::next_round`], which is *not* the successor of
+/// this order — it skips the multi-leader rounds a chain is not configured for and saturates
+/// into [`Round::Validator`]. It is monotone, which is all the pacemaker results need.
+///
+/// [`Round`]: linera_base::data_types::Round
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`Round::Validator`]: linera_base::data_types::Round::Validator
+/// [`ChainOwnership::next_round`]: linera_base::ownership::ChainOwnership::next_round
+pub trait RoundOrder {}
+
+/// **Definition (Correct validator).** A validator is *correct* in an execution if every
+/// signature it produces was produced by an unmodified build of this code, driven through the
+/// public entry points of `linera_core::worker::WorkerState`, with a private key no other party
+/// holds. A validator that is not correct is *faulty*, and may sign anything at any time,
+/// including contradictory statements.
+///
+/// This is what licenses the arguments in [`crate::manager::proof::voting`]: for a correct
+/// validator, "it signed a validation vote for `B` in round `r`" implies its
+/// [`ChainManager`](crate::manager::ChainManager) state satisfied the guards on the path that
+/// produces such a vote, because that path is the only one that can produce it
+/// ([`VoteConstructionSites`]).
+///
+/// Note this is a statement about *signing*, not about liveness: a correct validator may be
+/// slow, unreachable, or permanently crashed without becoming faulty.
+///
+/// [`VoteConstructionSites`]: crate::manager::proof::voting::VoteConstructionSites
+pub trait CorrectValidator {}
+
+/// **Definition (Conflicting blocks).** Two [`Block`]s *conflict* when they have the same
+/// [`chain_id`] and [`height`] but different hashes. Certificates certify [`ConfirmedBlock`] and
+/// [`ValidatedBlock`] values, each of which wraps a [`Block`] and hashes to that block's hash,
+/// so "certificates for conflicting blocks" is well defined.
+///
+/// Note that a [`Block`] is a [`ProposedBlock`] *together with* its
+/// [`BlockExecutionOutcome`]. Two blocks with the same proposal but different outcomes therefore
+/// conflict. This is deliberate: they lead to different chain states, so agreement must exclude
+/// them, and the exclusion is discharged by [`DeterministicExecution`].
+///
+/// Ancestry needs no separate definition here: [`ChainTipState::verify_block_chaining`] requires
+/// a proposal's height to equal the tip's next height and its `previous_block_hash` to equal the
+/// tip's block hash, so the committed blocks of a chain form a hash-linked list, one per height.
+///
+/// [`Block`]: crate::block::Block
+/// [`chain_id`]: crate::block::BlockHeader::chain_id
+/// [`height`]: crate::block::BlockHeader::height
+/// [`ConfirmedBlock`]: crate::block::ConfirmedBlock
+/// [`ValidatedBlock`]: crate::block::ValidatedBlock
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`ChainTipState::verify_block_chaining`]: crate::ChainTipState::verify_block_chaining
+pub trait ConflictingBlocks {}
+
+/// **Assumption (Maximum Byzantine weight).** In the committee governing a chain's epoch, the
+/// total [`Committee::weight`] of faulty validators is strictly less than
+/// [`Committee::validity_threshold`], i.e. at most `f⁺ − 1` where `f⁺ = ⌈N/3⌉`.
+///
+/// Equivalently, faulty weight is strictly below one third of the total. This is the only fault
+/// bound assumed anywhere in the specification.
+///
+/// [`Committee::weight`]: linera_execution::committee::Committee::weight
+/// [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+pub trait MaxByzantineWeight {}
+
+/// **Assumption (Epoch agreement).** All correct validators evaluate a given consensus instance
+/// against the same [`Committee`].
+///
+/// This is what makes [`Intersection`] applicable to two certificates for the same height: two
+/// quorums of *different* committees need not intersect at all. It is close to enforced rather
+/// than assumed. A proposal is rejected unless `check_block_epoch` finds
+/// [`ProposedBlock::epoch`] equal to the chain's current epoch, and
+/// `ChainWorkerState::process_validated_block` and `process_confirmed_block` apply the same
+/// check to the certified block before verifying signatures against that epoch's committee. The
+/// chain's current epoch at height `h` is a function of the committed blocks below `h`, which
+/// [`UniqueChain`] shows is unique — so the assumption is discharged for height `h` by the
+/// agreement result at heights below `h`, and the induction in [`UniqueChain`] is what makes
+/// that non-circular.
+///
+/// What remains genuinely assumed is that the committee for an epoch is itself agreed, which
+/// holds because it is published by a committed block on the admin chain.
+///
+/// [`Committee`]: linera_execution::committee::Committee
+/// [`ProposedBlock::epoch`]: crate::data_types::ProposedBlock::epoch
+/// [`Intersection`]: crate::data_types::proof::quorum::Intersection
+/// [`UniqueChain`]: crate::manager::proof::safety::UniqueChain
+pub trait EpochAgreement {}
+
+/// **Assumption (Cryptographic soundness).** [`ValidatorSignature`] is existentially unforgeable:
+/// no party without a validator's secret key produces a signature that
+/// [`ValidatorSignature::check`] accepts for that validator's public key. [`CryptoHash`] is
+/// collision resistant, so distinct values — in particular distinct [`Block`]s and distinct
+/// [`VoteValue`]s — have distinct hashes.
+///
+/// Collision resistance is what lets the specification move between "the certificate's
+/// `value_hash`" and "the block", and between block equality and hash equality.
+///
+/// [`ValidatorSignature`]: linera_base::crypto::ValidatorSignature
+/// [`ValidatorSignature::check`]: linera_base::crypto::ValidatorSignature::check
+/// [`CryptoHash`]: linera_base::crypto::CryptoHash
+/// [`Block`]: crate::block::Block
+/// [`VoteValue`]: crate::data_types::VoteValue
+pub trait UnforgeableSignatures {}
+
+/// **Assumption (Durable persistence).** A correct validator persists its
+/// [`ChainManager`](crate::manager::ChainManager) state before releasing a vote to the network,
+/// and that state survives a crash.
+///
+/// The implementation is structured to make this hold: every path in
+/// `linera_core::chain_worker::state` that mutates the manager calls `self.save()` before
+/// returning the chain info response that carries the vote — `try_handle_block_proposal` after
+/// `create_vote`, `process_validated_block` after `create_final_vote`,
+/// `vote_for_leader_timeout` after `create_timeout_vote`, and `vote_for_fallback` after
+/// `vote_fallback`. The response projection is [`ChainManagerInfo`].
+///
+/// Without this, a crash could lose the record of a vote and let the validator vote again,
+/// breaking [`OneValidationVotePerRound`] and [`OneConfirmationVotePerRound`], which are the
+/// only places where the assumption is consumed. A validator that violates it is faulty in the
+/// sense of [`CorrectValidator`], and is counted against [`MaxByzantineWeight`].
+///
+/// [`OneValidationVotePerRound`]: crate::manager::proof::locking::OneValidationVotePerRound
+/// [`OneConfirmationVotePerRound`]: crate::manager::proof::locking::OneConfirmationVotePerRound
+/// [`ChainManagerInfo`]: crate::manager::ChainManagerInfo
+pub trait DurablePersistence {}
+
+/// **Assumption (Serialized instance state).** The transitions of one consensus instance are
+/// mutually exclusive and each runs to completion: no two of them interleave their reads and
+/// writes of the same [`ChainManager`](crate::manager::ChainManager).
+///
+/// This is enforced, not hoped for: `linera_core::worker::WorkerState` routes every mutating
+/// request for a chain through `chain_write`, which holds a per-chain write lock for the whole
+/// transition, and the manager is `!Sync`-by-construction behind that guard. The specification
+/// relies on it whenever it reasons about "the state immediately before" a vote — for instance
+/// in [`UnlockingJustification`], where the guard evaluated by
+/// [`ChainManager::check_proposed_block`] must still describe the state when
+/// [`ChainManager::create_vote`] runs a few statements later.
+///
+/// [`UnlockingJustification`]: crate::manager::proof::safety::UnlockingJustification
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+pub trait SerializedChainState {}
+
+/// **Assumption (Deterministic execution).** For a fixed chain state at a height, a fixed
+/// [`ProposedBlock`], a fixed set of published blobs and a fixed multi-leader round argument,
+/// block execution returns a unique [`BlockExecutionOutcome`].
+///
+/// This is what makes [`ConflictingBlocks`] a property of the *proposal* in the cases where the
+/// protocol re-executes rather than re-uses a certified outcome. Two correct validators handed
+/// the same proposal at the same height therefore compute the same [`Block`].
+///
+/// **Residual obligation.** The round argument is
+/// [`Round::multi_leader`](linera_base::data_types::Round::multi_leader), so an outcome may in
+/// principle depend on the round — the round is readable as an oracle
+/// ([`OracleResponse::Round`]). This matters in exactly one place,
+/// [`FastRetryPreservesBlock`], where a block confirmed in [`Round::Fast`] is re-executed in a
+/// later round. The gap is closed there by the fast round's own restriction
+/// (`WorkerError::FastBlockUsingOracles` rejects a fast block that recorded any oracle
+/// response), plus determinism: an execution that never queried the round oracle cannot diverge
+/// on the round's value. Note that the restriction is checked only when the *proposal's* round
+/// is fast, so the retry itself is not re-checked; the argument leans on determinism of the
+/// execution engine rather than on a runtime check at the retry.
+///
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`Block`]: crate::block::Block
+/// [`OracleResponse::Round`]: linera_base::data_types::OracleResponse::Round
+/// [`FastRetryPreservesBlock`]: crate::manager::proof::safety::FastRetryPreservesBlock
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+pub trait DeterministicExecution {}

--- a/linera-chain/src/manager/proof/pacemaker.rs
+++ b/linera-chain/src/manager/proof/pacemaker.rs
@@ -1,0 +1,249 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pacemaker and view changes: how a height leaves a round it cannot finish in.
+//!
+//! Nothing here is needed for safety — [`CommitAgreement`] holds however rounds advance, and
+//! indeed whether or not they advance at all. These results exist to be consumed by the progress
+//! lemmas in `linera_core::proof::progress`, and to record precisely which rounds can be left by
+//! which means. The last statement, [`RoundsWithoutTimeout`], is a caveat rather than a
+//! guarantee, and is the main reason the liveness theorem is conditional in the way it is.
+//!
+//! **The pacemaker is not autonomous.** A validator never advances a round on its own initiative:
+//! it signs a timeout vote only when a client asks it to, through
+//! `ChainInfoQuery::request_leader_timeout`, and it never proposes a block at all. Round
+//! advancement is therefore driven entirely from `linera_core::client`, which is why the
+//! corresponding assumption (`ActiveCorrectDriver`) lives in that crate.
+//!
+//! [`CommitAgreement`]: crate::manager::proof::safety::CommitAgreement
+
+use crate::{
+    data_types::proof::quorum::CertificateCarriesCorrectVote,
+    manager::proof::{
+        model::ConsensusInstance,
+        rounds::{CurrentRoundMonotone, RoundFloor},
+    },
+};
+
+/// **Lemma (Timeout vote conditions).** A correct validator signs a
+/// [`Timeout`](crate::block::Timeout) vote in round `r` only if, at that moment:
+///
+/// 1. `r` equals its [`ChainManager::current_round`];
+/// 2. its [`round_timeout`] is `Some(t)` with `local_time ≥ t`;
+/// 3. it has not already signed a timeout vote in round `r`;
+///
+/// and the value it signs is `Timeout::new(chain_id, height, epoch)` for the chain's pending
+/// height and current epoch.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | [`ChainManager::create_timeout_vote`] |
+/// | reads | [`current_round`], [`round_timeout`], [`timeout_vote`] |
+/// | writes | [`timeout_vote`] |
+/// | precondition | `height` equals `ChainTipState::next_block_height`, checked by the caller `ChainWorkerState::vote_for_leader_timeout` |
+///
+/// *Proof.* Direct reading of [`ChainManager::create_timeout_vote`]: it returns `Ok(false)`
+/// without a key pair, then `ensure!(round == self.current_round())`, then
+/// `let Some(round_timeout) = *self.round_timeout.get() else { return Err(RoundDoesNotTimeOut) }`,
+/// then `ensure!(local_time >= round_timeout)`, then returns `Ok(false)` if
+/// `timeout_vote.round == round`. Only after all four does it construct the vote. ∎
+///
+/// [`ChainManager::create_timeout_vote`]: crate::manager::ChainManager::create_timeout_vote
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`round_timeout`]: crate::manager::ChainManager::round_timeout
+/// [`timeout_vote`]: crate::manager::ChainManager::timeout_vote
+pub trait TimeoutVoteConditions {}
+
+/// **Lemma (A timeout certificate proves a correct validator's round expired).** If a valid
+/// [`TimeoutCertificate`] is certified in round `r` for a chain and height, then some correct
+/// validator was in round `r` at that height, with a configured round timeout that had elapsed.
+///
+/// *Proof.* By [`CertificateCarriesCorrectVote`] a correct validator cast a timeout vote with
+/// the certificate's payload, whose round is `r`. By [`TimeoutVoteConditions`] its
+/// [`ChainManager::current_round`] was `r` and its [`round_timeout`] had elapsed. ∎
+///
+/// This is what makes a timeout certificate meaningful rather than merely well-formed: it cannot
+/// be manufactured by faulty validators ahead of time, because a quorum contains a correct
+/// validator whose own clock had to have passed the deadline.
+///
+/// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`round_timeout`]: crate::manager::ChainManager::round_timeout
+pub trait TimeoutCertificateProvesRoundReached:
+    TimeoutVoteConditions + CertificateCarriesCorrectVote
+{
+}
+
+/// **Lemma (A timeout certificate advances the round).** After a correct validator processes a
+/// valid [`TimeoutCertificate`] for round `r` at its pending height, its
+/// [`ChainManager::current_round`] is at least `ChainOwnership::next_round(r)`, or
+/// `Round::Validator(u32::MAX)` if that is `None`.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | [`ChainManager::handle_timeout_certificate`] |
+/// | reads | [`timeout`] |
+/// | writes | [`timeout`], and via `update_current_round`: [`current_round`], [`round_timeout`] |
+/// | precondition | `certificate.check(committee)`, epoch equality and pending-height equality, all checked by `ChainWorkerState::process_timeout` |
+///
+/// *Proof.* [`ChainManager::handle_timeout_certificate`] returns early when the stored
+/// [`timeout`] is already in a round `≥ r`; otherwise it stores the certificate and calls
+/// `update_current_round`. In the first case the stored certificate's round `r' ≥ r`, and a
+/// previous application of this lemma already raised the round to `next_round(r') ≥ next_round(r)`
+/// by monotonicity of [`ChainOwnership::next_round`] together with [`CurrentRoundMonotone`]. In
+/// the second, [`RoundFloor`] includes `next_round(timeout.round)` in the maximum. ∎
+///
+/// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`ChainManager::handle_timeout_certificate`]: crate::manager::ChainManager::handle_timeout_certificate
+/// [`ChainOwnership::next_round`]: linera_base::ownership::ChainOwnership::next_round
+/// [`timeout`]: crate::manager::ChainManager::timeout
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`round_timeout`]: crate::manager::ChainManager::round_timeout
+pub trait TimeoutCertificateAdvancesRound: RoundFloor + CurrentRoundMonotone {}
+
+/// **Lemma (Which rounds can be skipped without a timeout).** For a correct validator:
+///
+/// * a [`SingleLeader`] round above `SingleLeader(0)`, and any [`Validator`] round, is left only
+///   via a [`TimeoutCertificate`] or a locking block in a higher round;
+/// * [`Round::Fast`] and [`MultiLeader`] rounds are additionally left by any authenticated
+///   proposal in a higher round.
+///
+/// *Proof.* By [`RoundFloor`] the round can rise only from a timeout certificate, the lock, or
+/// [`proposed`] / [`signed_proposal`]. For the proposal inputs:
+///
+/// * [`ChainManager::update_signed_proposal`] returns `false` immediately for
+///   `proposal.content.round > Round::SingleLeader(0)`, so [`signed_proposal`] never carries a
+///   higher round;
+/// * [`proposed`] is written only by the private `update_proposed`, called from
+///   [`ChainManager::create_vote`], which by [`ProposalGate`] runs only after
+///   [`ChainManager::check_proposed_block`] returned `Accept`; and that method requires
+///   `new_round == current_round` on the `Round::SingleLeader(_) | Round::Validator(_)` arm, so
+///   it cannot raise the round either. On the `MultiLeader(_) | SingleLeader(0)` arm it requires
+///   only `new_round >= current_round`, which can raise it.
+///
+/// The lock case is not an exception to the intent: a [`LockingBlock::Regular`] in round `r` is a
+/// [`ValidatedBlockCertificate`], hence by [`CertificateCarriesCorrectVote`] evidence that a
+/// quorum — including a correct validator — was already in round `r`. So the validator is
+/// following the round the chain has demonstrably reached, not being pushed past a leader's turn.
+/// ∎
+///
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`Validator`]: linera_base::data_types::Round::Validator
+/// [`MultiLeader`]: linera_base::data_types::Round::MultiLeader
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`LockingBlock::Regular`]: crate::manager::LockingBlock::Regular
+/// [`ChainManager::update_signed_proposal`]: crate::manager::ChainManager::update_signed_proposal
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ProposalGate`]: crate::manager::proof::voting::ProposalGate
+/// [`proposed`]: crate::manager::ChainManager::proposed
+/// [`signed_proposal`]: crate::manager::ChainManager::signed_proposal
+pub trait SingleLeaderRoundsNeedTimeout: RoundFloor + CertificateCarriesCorrectVote {}
+
+/// **Lemma (Leader eligibility).** In a [`SingleLeader`] or [`Validator`] round, exactly one
+/// owner may propose, namely `ChainManager::round_leader(round)`; in a [`MultiLeader`] round any
+/// chain owner may (or anyone, when
+/// [`open_multi_leader_rounds`](linera_base::ownership::ChainOwnership::open_multi_leader_rounds));
+/// in [`Round::Fast`] only a super owner may. A super owner may additionally propose in any
+/// non-[`Validator`] round.
+///
+/// The leader of round `n` is drawn by seeding a [`ChaCha8Rng`](rand_chacha::ChaCha8Rng) with
+/// `u64::from(n).rotate_left(32) + seed` and sampling the stake-weighted
+/// [`WeightedAliasIndex`](rand_distr::WeightedAliasIndex) built from the owners — or, for a
+/// [`Validator`] round, from [`fallback_owners`], which
+/// [`ChainManager::reset`] populates with the committee's account keys and weights. The seed is
+/// the block height, so the leader schedule is fixed per instance and identical at every correct
+/// validator.
+///
+/// *Proof.* [`ChainManager::can_propose`] returns `!round.is_validator()` for a super owner, and
+/// otherwise dispatches: `false` for [`Round::Fast`],
+/// `ownership.can_propose_in_multi_leader_round(owner)` for [`MultiLeader`], and
+/// `self.round_leader(round) == Some(owner)` for the other two. It is enforced at the entry
+/// point: `ChainWorkerState::try_handle_block_proposal` rejects a proposal with
+/// `WorkerError::InvalidOwner` unless `chain.manager.can_propose(&owner, proposal.content.round)`,
+/// where `owner` is recovered from the proposal's signature. The leader computation is the
+/// private `compute_round_leader` / `round_leader_index` pair. ∎
+///
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`Validator`]: linera_base::data_types::Round::Validator
+/// [`MultiLeader`]: linera_base::data_types::Round::MultiLeader
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`fallback_owners`]: crate::manager::ChainManager::fallback_owners
+/// [`ChainManager::reset`]: crate::manager::ChainManager::reset
+/// [`ChainManager::can_propose`]: crate::manager::ChainManager::can_propose
+pub trait LeaderEligibility {}
+
+/// **Lemma (Fallback).** [`ChainManager::vote_fallback`] signs a timeout vote in the fixed round
+/// `Round::SingleLeader(u32::MAX)`, at most once per instance, and only while
+/// [`ChainManager::current_round`] is below `Round::Validator(0)`. A quorum of such votes forms a
+/// [`TimeoutCertificate`] whose `next_round` is `Round::Validator(0)`, moving the height into
+/// validator-led rounds.
+///
+/// *Proof.* The method returns `false` if [`fallback_vote`] is already set or
+/// `current_round >= Round::Validator(0)`, and otherwise signs `Timeout::new(chain_id, height,
+/// epoch)` at `Round::SingleLeader(u32::MAX)`. By [`ChainOwnership::next_round`], the successor
+/// of `SingleLeader(r)` is `SingleLeader(r + 1)` unless that overflows, and it does at
+/// `u32::MAX`, so the successor is `Round::Validator(0)`; combine with
+/// [`TimeoutCertificateAdvancesRound`]. ∎
+///
+/// Note what is *not* checked here, unlike [`TimeoutVoteConditions`]: there is no
+/// [`round_timeout`] comparison. The precondition is external — `ChainWorkerState::
+/// vote_for_fallback` only calls it after reading the admin chain's epoch event and confirming
+/// that `fallback_duration` has elapsed since the next epoch was created. The method's own
+/// documentation states this obligation.
+///
+/// [`ChainManager::vote_fallback`]: crate::manager::ChainManager::vote_fallback
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`TimeoutCertificate`]: crate::types::TimeoutCertificate
+/// [`fallback_vote`]: crate::manager::ChainManager::fallback_vote
+/// [`round_timeout`]: crate::manager::ChainManager::round_timeout
+/// [`ChainOwnership::next_round`]: linera_base::ownership::ChainOwnership::next_round
+pub trait FallbackVote: TimeoutCertificateAdvancesRound + ConsensusInstance {}
+
+/// **Caveat (Rounds that never time out).** [`ChainOwnership::round_timeout`] returns `None` —
+/// so that [`ChainManager::create_timeout_vote`] fails with
+/// [`ChainError::RoundDoesNotTimeOut`] and no timeout certificate can ever form — in three cases:
+///
+/// | round | `round_timeout` is `None` when |
+/// |---|---|
+/// | [`Round::Fast`] | `timeout_config.fast_round_duration` is `None`, **which is the default**, or `owners` is empty |
+/// | [`MultiLeader(r)`] | `r + 1 != multi_leader_rounds`, i.e. every multi-leader round but the last |
+/// | [`SingleLeader`], [`Validator`] | never |
+///
+/// Consequences, which the liveness argument must and does respect:
+///
+/// * A non-final multi-leader round is left only by a proposal in a higher round
+///   ([`SingleLeaderRoundsNeedTimeout`]). This is by design — multi-leader rounds are skippable —
+///   but it means "wait for the timeout" is not a strategy there.
+/// * With a super owner and the default [`TimeoutConfig`], the fast round has **no timeout at
+///   all**. If the super owner issues two conflicting fast proposals, correct validators split
+///   between them ([`FastConfirmationNeedsEmptyLock`] pins each to the first it sees), neither
+///   reaches a quorum, and — since only a super owner may open a later round while the current
+///   round is fast, by the `is_super(&proposal.owner()) || !current_round.is_fast()` guard in
+///   [`ChainManager::check_proposed_block`] — the height cannot progress until that same super
+///   owner proposes again in a higher round. A super owner that stops there wedges the chain
+///   permanently. This is the caveat the module documentation of [`crate::manager`] states as
+///   "super owners must be careful to make only one block proposal", stated precisely.
+///
+/// Both are liveness properties; [`CommitAgreement`](crate::manager::proof::safety::CommitAgreement)
+/// is unaffected.
+///
+/// [`ChainOwnership::round_timeout`]: linera_base::ownership::ChainOwnership::round_timeout
+/// [`ChainManager::create_timeout_vote`]: crate::manager::ChainManager::create_timeout_vote
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`ChainError::RoundDoesNotTimeOut`]: crate::ChainError::RoundDoesNotTimeOut
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`MultiLeader(r)`]: linera_base::data_types::Round::MultiLeader
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`Validator`]: linera_base::data_types::Round::Validator
+/// [`TimeoutConfig`]: linera_base::ownership::TimeoutConfig
+/// [`FastConfirmationNeedsEmptyLock`]: crate::manager::proof::voting::FastConfirmationNeedsEmptyLock
+pub trait RoundsWithoutTimeout: TimeoutVoteConditions + SingleLeaderRoundsNeedTimeout {}

--- a/linera-chain/src/manager/proof/rounds.rs
+++ b/linera-chain/src/manager/proof/rounds.rs
@@ -1,0 +1,120 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The round register: what [`current_round`] means, and why it only ever grows.
+//!
+//! These are the first genuinely inductive results: they quantify over all reachable states of
+//! one consensus instance ([`ConsensusInstance`]). They are used by both the locking invariants
+//! and the pacemaker, so they are stated once, here.
+//!
+//! [`current_round`]: field@crate::manager::ChainManager::current_round
+//! [`ConsensusInstance`]: crate::manager::proof::model::ConsensusInstance
+
+use crate::manager::proof::{
+    model::ConsensusInstance,
+    voting::{ProposalGate, VoteConstructionSites},
+};
+
+/// **Definition (Current round).** The *current round* of an instance is
+/// [`ChainManager::current_round`], the lowest round in which the validator is still willing to
+/// vote. It is the round to which [`round_timeout`] applies.
+///
+/// It is a *derived* quantity: the register caches the maximum of the evidence the validator has
+/// seen that the chain has entered a round — a timeout certificate for the previous round, a
+/// locking block, or an authenticated proposal — floored at
+/// [`ChainOwnership::first_round`]. `RoundFloor` states exactly that.
+///
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`round_timeout`]: crate::manager::ChainManager::round_timeout
+/// [`ChainOwnership::first_round`]: linera_base::ownership::ChainOwnership::first_round
+pub trait CurrentRound {}
+
+/// **Lemma (Round floor).** Let `M` denote
+///
+/// ```text
+/// M = max( { ownership.first_round() }
+///        ∪ { ownership.next_round(timeout.round)  (or Round::Validator(u32::MAX) if none) }
+///        ∪ { locking_block.round() }
+///        ∪ { proposed.content.round }
+///        ∪ { signed_proposal.content.round } )
+/// ```
+///
+/// over whichever of the four optional fields are `Some`. Then the private
+/// `ChainManager::update_current_round` sets [`current_round`] to `max(current_round, M)`, and
+/// resets [`round_timeout`] from [`ChainOwnership::round_timeout`] exactly when that raises the
+/// value.
+///
+/// *Proof.* Direct reading of the method: it builds an iterator over the four optional fields,
+/// mapping the timeout certificate through `ownership.next_round(..).unwrap_or(Round::Validator(
+/// u32::MAX))`, takes `.max()`, applies `.unwrap_or_default()` — and `Round::default()` is
+/// [`Round::Fast`], the minimum ([`RoundOrder`]), so this adds nothing — and then
+/// `.max(self.ownership.get().first_round())`. That is `M`. It then returns early on
+/// `current_round <= self.current_round()`, and otherwise sets both
+/// [`round_timeout`] and [`current_round`]. ∎
+///
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`round_timeout`]: crate::manager::ChainManager::round_timeout
+/// [`ChainOwnership::round_timeout`]: linera_base::ownership::ChainOwnership::round_timeout
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`RoundOrder`]: crate::manager::proof::model::RoundOrder
+pub trait RoundFloor {}
+
+/// **Invariant (The current round never decreases).** Within one consensus instance,
+/// [`current_round`] is non-decreasing over time.
+///
+/// *Proof.* The register has exactly two writers in the crate:
+///
+/// * `ChainManager::update_current_round`, which by [`RoundFloor`] assigns
+///   `max(current_round, M) ≥ current_round`;
+/// * [`ChainManager::reset`], which by [`ConsensusInstance`] ends the instance and begins the
+///   next one, so it is outside the scope of this invariant.
+///
+/// Every other mutation of the manager reaches the register only through
+/// `update_current_round`: it is called from [`ChainManager::create_vote`],
+/// [`ChainManager::create_final_vote`], [`ChainManager::handle_timeout_certificate`],
+/// [`ChainManager::update_signed_proposal`], and nowhere else. Note in particular that
+/// [`ManagerSafetySnapshot::restore`] does **not** write it — see [`SafetyStateRecovery`] for
+/// why that is nonetheless safe. ∎
+///
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`ChainManager::reset`]: crate::manager::ChainManager::reset
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::handle_timeout_certificate`]: crate::manager::ChainManager::handle_timeout_certificate
+/// [`ChainManager::update_signed_proposal`]: crate::manager::ChainManager::update_signed_proposal
+/// [`ManagerSafetySnapshot::restore`]: crate::manager::ManagerSafetySnapshot::restore
+/// [`SafetyStateRecovery`]: crate::manager::proof::locking::SafetyStateRecovery
+pub trait CurrentRoundMonotone: RoundFloor + ConsensusInstance {}
+
+/// **Invariant (A cast vote never exceeds the current round).** Immediately after a correct
+/// validator casts a validation or confirmation vote in round `r`, its [`current_round`] is at
+/// least `r`; and by [`CurrentRoundMonotone`] it stays at least `r` for the rest of the
+/// instance.
+///
+/// *Proof.* By [`VoteConstructionSites`] there are three cases.
+///
+/// *Validation vote in round `r` (non-fast branch of [`ChainManager::create_vote`]).* Before
+/// signing, the method calls `update_proposed(proposal.clone(), blobs)` and then
+/// `update_current_round(local_time)`. After `update_proposed`, [`proposed`] is `Some` with a
+/// round `≥ r`: either it was `None` or held a lower round, and the proposal was stored with
+/// round `r`; or it already held a round `≥ r` and the write was skipped. By [`RoundFloor`],
+/// `update_current_round` then raises [`current_round`] to at least `proposed.content.round ≥ r`.
+///
+/// *Confirmation vote in [`Round::Fast`] (fast branch of [`ChainManager::create_vote`]).* Same
+/// call sequence; and [`Round::Fast`] is the minimum round ([`RoundOrder`]), so the claim is
+/// immediate.
+///
+/// *Confirmation vote in round `r` ([`ChainManager::create_final_vote`]).* Immediate from
+/// [`ConfirmationOnlyInCurrentRound`], which gives `current_round == r`. ∎
+///
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`proposed`]: crate::manager::ChainManager::proposed
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`RoundOrder`]: crate::manager::proof::model::RoundOrder
+/// [`ConfirmationOnlyInCurrentRound`]: crate::manager::proof::voting::ConfirmationOnlyInCurrentRound
+pub trait VoteRoundBelowCurrentRound:
+    VoteConstructionSites + ProposalGate + RoundFloor + CurrentRoundMonotone
+{
+}

--- a/linera-chain/src/manager/proof/safety.rs
+++ b/linera-chain/src/manager/proof/safety.rs
@@ -237,34 +237,24 @@ pub trait UniqueChain:
 {
 }
 
-/// **Corollary (Agreement failure is attributable).** If [`CommitAgreement`] is ever violated —
-/// two valid [`ConfirmedBlockCertificate`]s for conflicting blocks at one height — then
-/// [`extract_equivocations`], applied to the two certificates reduced to
-/// [`JustifiedConfirmation`]s, returns proofs naming validators of total weight at least
-/// [`validity_threshold`], each of which passes [`EquivocationProof::check`].
+/// **Corollary (Agreement failure is attributable).** The converse of [`CommitAgreement`]: when
+/// it fails, the failure is not silent. Two conflicting confirmed certificates are self-contained
+/// evidence convicting validators of at least
+/// [`validity_threshold`](linera_execution::committee::Committee::validity_threshold) weight, and
+/// no correct validator is ever convictable.
 ///
-/// *Proof sketch, and its status.* This is not a consequence of the results above but a
-/// *converse* to them, and it is proved in [`crate::justification`] rather than here; the
-/// argument is the case analysis recorded on [`extract_equivocations`] (equal rounds ⇒ a
-/// double-vote across the two confirmation quorums; unequal rounds ⇒ either a link of the higher
-/// block's justification chain whose unlocking window straddles the lower confirmation, or a
-/// first-round attestation contradicted by the lower confirmation). Each case blames a full
-/// quorum intersection, which by [`Intersection`] has weight at least
-/// [`validity_threshold`].
+/// This is stated and proved in [`crate::justification::proof`] rather than here, because its
+/// assumption base is deliberately *weaker*: it must hold precisely when
+/// [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight) has failed, which is
+/// the one regime this module says nothing about. See
+/// [`AccountableSafety`](crate::justification::proof::AccountableSafety) for the theorem and
+/// [`AccountabilityScope`](crate::justification::proof::AccountabilityScope) for what it excludes
+/// — notably that incorrect block execution is *not* attributable.
 ///
-/// It is stated here because it explains *why* certificates carry an unlocking round
-/// ([`UnlockingRound`]) and a justification chain at all, given that
-/// [`CommitAgreement`] does not use them: they buy accountability, not agreement. Its
-/// preconditions are correspondingly weaker — it must hold even when
-/// [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight) fails, since that is
-/// the only case in which it has anything to do.
+/// It is worth stating here nonetheless, because it explains why certificates carry an unlocking
+/// round ([`UnlockingRound`]) and a justification chain at all, given that [`CommitAgreement`]
+/// uses neither: they buy accountability, not agreement.
 ///
-/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
-/// [`extract_equivocations`]: crate::justification::extract_equivocations
-/// [`JustifiedConfirmation`]: crate::justification::JustifiedConfirmation
-/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
-/// [`validity_threshold`]: linera_execution::committee::Committee::validity_threshold
-/// [`Intersection`]: crate::data_types::proof::quorum::Intersection
 /// [`UnlockingRound`]: crate::data_types::proof::objects::UnlockingRound
 pub trait Accountability {}
 

--- a/linera-chain/src/manager/proof/safety.rs
+++ b/linera-chain/src/manager/proof/safety.rs
@@ -1,0 +1,286 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The safety proof: at most one block is ever committed per chain and height.
+//!
+//! The argument has one non-trivial step, [`LockPreservation`], an induction over rounds showing
+//! that once a block is committed no *later* round can validate anything else. Everything before
+//! it is local implementation properties and per-round uniqueness; everything after it is
+//! bookkeeping.
+//!
+//! Nothing in this module depends on synchrony, on message delivery, or on any validator being
+//! responsive. Safety holds in every execution permitted by
+//! [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight), including ones where
+//! the protocol makes no progress at all.
+
+use crate::{
+    data_types::proof::quorum::{CertificateCarriesCorrectVote, CorrectValidatorInIntersection},
+    manager::proof::{
+        commit::{CommitRestsOnValidation, TipAdvancesOnlyOnValidCertificate},
+        locking::{
+            CastValidationRoundFloor, ConfirmedVoteRoundMonotone, NoValidatedBlockInFastRound,
+            OneConfirmationVotePerRound, OneValidationVotePerRound, SafetyStateRecovery,
+            UniqueValidatedBlockPerRound,
+        },
+        model::{ConflictingBlocks, DeterministicExecution, EpochAgreement, UnforgeableSignatures},
+        rounds::{CurrentRoundMonotone, VoteRoundBelowCurrentRound},
+        voting::{
+            ConfirmationNeedsValidatedCertificate, FastConfirmationNeedsEmptyLock,
+            UnlockingRequiresHigherCertificate,
+        },
+    },
+};
+
+/// **Lemma (A fast retry cannot change the block).** Let a block `A` be confirmed in
+/// [`Round::Fast`], and let a correct validator later cast a validation vote for a block `B` on a
+/// proposal whose [`OriginalProposal::Fast`] retries `A`'s proposal. Then `B = A`.
+///
+/// *Proof.* By [`UnlockingRequiresHigherCertificate`], the fast-retry arm of
+/// [`ChainManager::check_proposed_block`] accepts only if the validator's stored confirmation
+/// vote is in the fast round and its value satisfies `matches_proposed_block(new_block)`. That
+/// predicate compares the [`ProposedBlock`] components only — chain, epoch, transactions,
+/// height, timestamp, authenticated owner, parent hash — so it leaves open that `A` and `B`
+/// share a proposal but differ in [`BlockExecutionOutcome`], which by [`ConflictingBlocks`]
+/// would make them conflicting blocks.
+///
+/// That gap is closed by [`DeterministicExecution`]. The retry re-executes the proposal
+/// (`try_handle_block_proposal` takes the `else` branch of `if let Some(outcome) = outcome`,
+/// since a fast retry carries no outcome), at the same height with the same parent, so the only
+/// input that differs from the original fast execution is the round argument
+/// [`Round::multi_leader`]. A block accepted in the fast round recorded no oracle responses —
+/// `try_handle_block_proposal` rejects one that did with `WorkerError::FastBlockUsingOracles` —
+/// and the round is observable only as [`OracleResponse::Round`]. An execution that never
+/// queried the round therefore cannot branch on it, so by determinism the two executions agree
+/// and `B = A`. ∎
+///
+/// **Residual obligation.** The no-oracle check is applied when the *proposal's* round is fast,
+/// not when a fast block is retried, so this step relies on determinism of the execution engine
+/// rather than on a runtime check at the retry. An execution engine that made an outcome depend
+/// on the round without recording an [`OracleResponse::Round`] would break it. This is the one
+/// place in the safety argument that reaches outside consensus into execution.
+///
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`Round::multi_leader`]: linera_base::data_types::Round::multi_leader
+/// [`OriginalProposal::Fast`]: crate::data_types::OriginalProposal::Fast
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`BlockExecutionOutcome`]: crate::data_types::BlockExecutionOutcome
+/// [`OracleResponse::Round`]: linera_base::data_types::OracleResponse::Round
+pub trait FastRetryPreservesBlock:
+    UnlockingRequiresHigherCertificate + DeterministicExecution + ConflictingBlocks
+{
+}
+
+/// **Lemma (Unlocking justification).** Let a correct validator cast a validation vote for `B` in
+/// round `s`, and let `(A, p)` be its stored confirmation vote immediately before, with `A ≠ B`.
+/// Then a valid [`ValidatedBlockCertificate`] for `B` exists in some round `t` with
+/// `p < t < s`.
+///
+/// *Proof.* By [`UnlockingRequiresHigherCertificate`], with a stored confirmation vote present
+/// the proposal must carry an [`OriginalProposal`], and:
+///
+/// * a fresh proposal (`None`) is rejected;
+/// * a fast retry requires `A` to match `B`'s proposal, which by [`FastRetryPreservesBlock`]
+///   forces `A = B`, contradicting the hypothesis;
+/// * a regular retry carries a certificate `c` which — by the caller's `certificate.check(&
+///   committee)` and [`BlockProposal::check_invariants`] — is a valid
+///   [`ValidatedBlockCertificate`] for exactly `B`, with `c.round < s`; and since `A` does not
+///   match `B`, the accepted branch is `vote.round < certificate.round`, i.e. `p < c.round`.
+///
+/// Take `t = c.round`. ∎
+///
+/// This is the hinge of [`LockPreservation`]: a correct validator abandons a block it confirmed
+/// only in exchange for a quorum that validated the replacement *strictly above* its own
+/// confirmation — which lets the induction step down into a strictly smaller round.
+///
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`OriginalProposal`]: crate::data_types::OriginalProposal
+/// [`BlockProposal::check_invariants`]: crate::data_types::BlockProposal::check_invariants
+pub trait UnlockingJustification:
+    UnlockingRequiresHigherCertificate + FastRetryPreservesBlock
+{
+}
+
+/// **Theorem (Lock preservation).** Suppose a valid [`ConfirmedBlockCertificate`] for a block `A`
+/// is certified in round `r`, at some height of some chain. Then for every round `s ≥ r`, every
+/// valid [`ValidatedBlockCertificate`] at that height and round `s` certifies `A`.
+///
+/// *Proof.* Strong induction on `s ≥ r`. Assume the claim for all `t` with `r ≤ t < s`, and let
+/// `C'` be a valid [`ValidatedBlockCertificate`] for `B` in round `s`. By [`EpochAgreement`] the
+/// confirmed certificate and `C'` are judged against the same committee, so by
+/// [`CorrectValidatorInIntersection`] their signer sets share a correct validator `v`, and by
+/// [`CertificateCarriesCorrectVote`] and [`UnforgeableSignatures`] `v` itself cast both votes:
+/// a confirmation vote for `A` in round `r` (call it **(a)**) and a validation vote for `B` in
+/// round `s` (call it **(b)**).
+///
+/// **Case `s = r`.** By [`NoValidatedBlockInFastRound`], `s` is not the fast round, so `r` is
+/// not either; by [`CommitRestsOnValidation`] a valid [`ValidatedBlockCertificate`] for `A` in
+/// round `r` exists. By [`UniqueValidatedBlockPerRound`] applied to it and `C'`, `B = A`.
+///
+/// **Case `s > r`.** Consider the order of **(a)** and **(b)** in `v`'s execution.
+///
+/// *Suppose **(b)** preceded **(a)**.* By [`VoteRoundBelowCurrentRound`] and
+/// [`CurrentRoundMonotone`], from **(b)** onwards `v`'s current round is `≥ s > r`. If `r` is not
+/// the fast round, **(a)** comes from [`ChainManager::create_final_vote`], which by
+/// [`ConfirmationNeedsValidatedCertificate`] and [`ConfirmationOnlyInCurrentRound`] casts a vote
+/// only when the current round *equals* `r` — impossible. If `r` is the fast round, **(a)** comes
+/// from the fast branch of [`ChainManager::create_vote`], which by
+/// [`FastConfirmationNeedsEmptyLock`] requires an empty lock and an absent validation vote — but
+/// [`CastValidationRoundFloor`], established by **(b)**, forces
+/// `max(validated_vote.round, lock round) ≥ s > Round::Fast`. Also impossible. So **(a)**
+/// preceded **(b)**.
+///
+/// *So **(a)** preceded **(b)**.* Let `(A', p)` be `v`'s stored confirmation vote immediately
+/// before **(b)**. It is present, since **(a)** stored one; and by
+/// [`ConfirmedVoteRoundMonotone`], `p ≥ r`.
+///
+/// * If `A' ≠ B`, then [`UnlockingJustification`] yields a valid
+///   [`ValidatedBlockCertificate`] for `B` in a round `t` with `p < t < s`. Then `r ≤ p < t < s`,
+///   so the induction hypothesis applies at `t` and gives `B = A`.
+/// * If `A' = B`, then `v` confirmed `B` in round `p ≥ r`.
+///   * If `p = r`: `v` also confirmed `A` in round `r` by **(a)**, so [`OneConfirmationVotePerRound`]
+///     gives `A = B`.
+///   * If `p > r`: then `p` is not the fast round (it exceeds `r ≥ Round::Fast`), so by
+///     [`ConfirmationNeedsValidatedCertificate`] a valid [`ValidatedBlockCertificate`] for `B` in
+///     round `p` existed. Moreover [`UnlockingRequiresHigherCertificate`] applied to **(b)** — in
+///     the branch where the stored vote's value matches the proposed block — gives
+///     `p ≤ c.round < s` for the certificate `c` the proposal carries, hence `p < s`. So
+///     `r < p < s`, the induction hypothesis applies at `p`, and `B = A`. ∎
+///
+/// The induction is well founded because rounds are totally ordered and every appeal to the
+/// hypothesis is at a round strictly between `r` and `s`.
+///
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ConfirmationOnlyInCurrentRound`]: crate::manager::proof::voting::ConfirmationOnlyInCurrentRound
+pub trait LockPreservation:
+    UnlockingJustification
+    + CommitRestsOnValidation
+    + UniqueValidatedBlockPerRound
+    + NoValidatedBlockInFastRound
+    + OneConfirmationVotePerRound
+    + ConfirmedVoteRoundMonotone
+    + CastValidationRoundFloor
+    + FastConfirmationNeedsEmptyLock
+    + ConfirmationNeedsValidatedCertificate
+    + VoteRoundBelowCurrentRound
+    + CurrentRoundMonotone
+    + CorrectValidatorInIntersection
+    + CertificateCarriesCorrectVote
+    + UnforgeableSignatures
+    + EpochAgreement
+{
+}
+
+/// **Theorem (Commit agreement).** For a given chain and height, all valid
+/// [`ConfirmedBlockCertificate`]s certify the same block. Equivalently: no two conflicting blocks
+/// ([`ConflictingBlocks`]) are ever both committed.
+///
+/// *Proof.* Let valid confirmed certificates for `A` in round `r` and for `B` in round `s`
+/// exist, with `r ≤ s` after renaming.
+///
+/// * If `r = s`: by [`EpochAgreement`] and [`CorrectValidatorInIntersection`] a correct validator
+///   signed both, and by [`CertificateCarriesCorrectVote`] cast confirmation votes for `A` and
+///   for `B` in round `r`. By [`OneConfirmationVotePerRound`], `A = B`.
+/// * If `r < s`: then `s` is not [`Round::Fast`], so [`CommitRestsOnValidation`] gives a valid
+///   [`ValidatedBlockCertificate`] for `B` in round `s`. By [`LockPreservation`], applied to the
+///   commit of `A` in round `r` and to `s > r`, that certificate certifies `A`. Hence `B = A`. ∎
+///
+/// *In observable terms.* Combining with [`TipAdvancesOnlyOnValidCertificate`]: if any correct
+/// validator's [`ChainTipState`] records a block hash at height `h`, then no correct validator
+/// ever records a different hash at `h` — whatever the network does, and whatever the faulty
+/// validators sign.
+///
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`ChainTipState`]: crate::ChainTipState
+pub trait CommitAgreement:
+    LockPreservation
+    + CommitRestsOnValidation
+    + OneConfirmationVotePerRound
+    + CorrectValidatorInIntersection
+    + CertificateCarriesCorrectVote
+    + ConflictingBlocks
+    + EpochAgreement
+    + TipAdvancesOnlyOnValidCertificate
+{
+}
+
+/// **Corollary (The committed chain is unique).** For each chain there is at most one sequence of
+/// committed blocks: the committed blocks at heights `0, 1, 2, …` form a single hash-linked list,
+/// and any two correct validators' [`block_hashes`](crate::ChainStateView) agree wherever both
+/// are defined. In particular the committed prefixes observed by correct validators are always
+/// compatible — one is a prefix of the other.
+///
+/// *Proof.* Induction on the height `h`.
+///
+/// At each height, [`CommitAgreement`] gives uniqueness of the committed block, *provided*
+/// [`EpochAgreement`] holds there. That proviso is what the induction supplies: the chain's epoch
+/// and committee at height `h` are functions of the execution state after height `h − 1`, which
+/// by the induction hypothesis (uniqueness below `h`) and [`DeterministicExecution`] is unique.
+/// The base case `h = 0` is the genesis configuration, which is agreed by construction. Applying
+/// [`CommitAgreement`] at `h` closes the step.
+///
+/// Linkage: by [`TipAdvancesOnlyOnValidCertificate`] a correct validator records a hash at `h`
+/// only for a certified block, and `ChainTipState::verify_block_chaining` requires a proposal's
+/// `previous_block_hash` to equal the tip's hash, so the unique committed block at `h` has the
+/// unique committed block at `h − 1` as its parent. ∎
+///
+/// This is the point where the specification's per-instance scoping
+/// ([`ConsensusInstance`](crate::manager::proof::model::ConsensusInstance)) is discharged: each
+/// consensus instance decides one height, and the heights compose into a chain.
+pub trait UniqueChain:
+    CommitAgreement + EpochAgreement + DeterministicExecution + TipAdvancesOnlyOnValidCertificate
+{
+}
+
+/// **Corollary (Agreement failure is attributable).** If [`CommitAgreement`] is ever violated —
+/// two valid [`ConfirmedBlockCertificate`]s for conflicting blocks at one height — then
+/// [`extract_equivocations`], applied to the two certificates reduced to
+/// [`JustifiedConfirmation`]s, returns proofs naming validators of total weight at least
+/// [`validity_threshold`], each of which passes [`EquivocationProof::check`].
+///
+/// *Proof sketch, and its status.* This is not a consequence of the results above but a
+/// *converse* to them, and it is proved in [`crate::justification`] rather than here; the
+/// argument is the case analysis recorded on [`extract_equivocations`] (equal rounds ⇒ a
+/// double-vote across the two confirmation quorums; unequal rounds ⇒ either a link of the higher
+/// block's justification chain whose unlocking window straddles the lower confirmation, or a
+/// first-round attestation contradicted by the lower confirmation). Each case blames a full
+/// quorum intersection, which by [`Intersection`] has weight at least
+/// [`validity_threshold`].
+///
+/// It is stated here because it explains *why* certificates carry an unlocking round
+/// ([`UnlockingRound`]) and a justification chain at all, given that
+/// [`CommitAgreement`] does not use them: they buy accountability, not agreement. Its
+/// preconditions are correspondingly weaker — it must hold even when
+/// [`MaxByzantineWeight`](crate::manager::proof::model::MaxByzantineWeight) fails, since that is
+/// the only case in which it has anything to do.
+///
+/// [`ConfirmedBlockCertificate`]: crate::types::ConfirmedBlockCertificate
+/// [`extract_equivocations`]: crate::justification::extract_equivocations
+/// [`JustifiedConfirmation`]: crate::justification::JustifiedConfirmation
+/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+/// [`validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+/// [`Intersection`]: crate::data_types::proof::quorum::Intersection
+/// [`UnlockingRound`]: crate::data_types::proof::objects::UnlockingRound
+pub trait Accountability {}
+
+/// **Remark (What safety does not claim).** Three exclusions are worth stating explicitly,
+/// because each is a property a reader may expect [`CommitAgreement`] to carry and it does not.
+///
+/// * **Nothing is claimed about faulty validators' state.** A faulty validator may record any
+///   block at any height. [`CommitAgreement`] constrains which *certificates* can exist; the
+///   observable consequence in [`TipAdvancesOnlyOnValidCertificate`] is about correct validators.
+/// * **Nothing is claimed about progress.** An execution in which no block is ever committed
+///   satisfies every result in this module. In particular a super owner that issues two
+///   conflicting fast proposals can split the vote and wedge the height permanently, and that is
+///   a liveness failure, not a safety one — see `linera_core::proof::liveness`.
+/// * **Nothing is claimed when [`MaxByzantineWeight`] fails.** Above the fault bound,
+///   [`CorrectValidatorInIntersection`] fails and conflicting commits become possible. What
+///   remains is [`Accountability`].
+///
+/// [`MaxByzantineWeight`]: crate::manager::proof::model::MaxByzantineWeight
+pub trait SafetyScope: CommitAgreement + SafetyStateRecovery + OneValidationVotePerRound {}

--- a/linera-chain/src/manager/proof/voting.rs
+++ b/linera-chain/src/manager/proof/voting.rs
@@ -1,0 +1,330 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Voting rules: what a correct validator's state must look like for it to sign.
+//!
+//! These are *local implementation properties*. Each one follows from a single method's control
+//! flow together with the guards its call sites apply, with no induction over executions. They
+//! are what [`crate::manager::proof::locking`] inducts over, and what
+//! [`CertificateCarriesCorrectVote`] converts into constraints on the certificates that can
+//! exist at all.
+//!
+//! Every statement below is accompanied by a *code correspondence* table naming the method that
+//! implements the transition, the fields it reads and writes, and the preconditions its callers
+//! establish.
+//!
+//! [`CertificateCarriesCorrectVote`]: crate::data_types::proof::quorum::CertificateCarriesCorrectVote
+
+use crate::manager::proof::model::{CorrectValidator, SerializedChainState};
+
+/// **Lemma (Vote construction sites).** A correct validator signs a block-related vote only in
+/// [`ChainManager::create_vote`] and [`ChainManager::create_final_vote`], and a timeout vote only
+/// in [`ChainManager::create_timeout_vote`] and [`ChainManager::vote_fallback`]. Specifically:
+///
+/// | vote kind | round of the vote | sole producer |
+/// |---|---|---|
+/// | [`Validated`] | `proposal.content.round`, never [`Round::Fast`] | [`ChainManager::create_vote`], `else` branch |
+/// | [`Confirmed`] | [`Round::Fast`] | [`ChainManager::create_vote`], `if round.is_fast()` branch |
+/// | [`Confirmed`] | `validated.round` | [`ChainManager::create_final_vote`] |
+/// | [`Timeout`] | [`ChainManager::current_round`] | [`ChainManager::create_timeout_vote`] |
+/// | [`Timeout`] | `Round::SingleLeader(u32::MAX)` | [`ChainManager::vote_fallback`] |
+///
+/// *Proof.* By [`ValidatorVote`], a vote exists only if one of [`Vote::new`],
+/// [`Vote::new_with_unlocking_round`] or [`Vote::new_with_first_round`] was called with the
+/// validator's key. Outside test-only code there are exactly five such calls in the workspace,
+/// all in `linera_chain::manager`, and they are the five rows above: `Vote::new` in
+/// [`create_timeout_vote`] and in [`vote_fallback`]; `Vote::new_with_first_round` in the
+/// fast-round branch of [`create_vote`] and in [`create_final_vote`];
+/// `Vote::new_with_unlocking_round` in the non-fast branch of [`create_vote`]. In each case the
+/// round passed is the one tabulated: [`create_vote`] passes `proposal.content.round`, guarded
+/// by `round.is_fast()` into one branch or the other; [`create_final_vote`] passes
+/// `validated.round`; [`create_timeout_vote`] passes its `round` argument, which it has just
+/// checked to equal [`ChainManager::current_round`]; [`vote_fallback`] passes the constant
+/// `Round::SingleLeader(u32::MAX)`. By [`CorrectValidator`] no other code path of a correct
+/// validator holds its key. ∎
+///
+/// **Where this is fragile.** The claim is an exhaustive-search argument over call sites, so it
+/// is invalidated by adding a sixth call. A new signing site must either be shown to preserve
+/// [`OneValidationVotePerRound`] and [`OneConfirmationVotePerRound`], or be added to this table.
+///
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::create_timeout_vote`]: crate::manager::ChainManager::create_timeout_vote
+/// [`ChainManager::vote_fallback`]: crate::manager::ChainManager::vote_fallback
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`create_vote`]: crate::manager::ChainManager::create_vote
+/// [`create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`create_timeout_vote`]: crate::manager::ChainManager::create_timeout_vote
+/// [`vote_fallback`]: crate::manager::ChainManager::vote_fallback
+/// [`Validated`]: crate::types::CertificateKind::Validated
+/// [`Confirmed`]: crate::types::CertificateKind::Confirmed
+/// [`Timeout`]: crate::types::CertificateKind::Timeout
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`ValidatorVote`]: crate::data_types::proof::objects::ValidatorVote
+/// [`Vote::new`]: crate::data_types::Vote::new
+/// [`Vote::new_with_unlocking_round`]: crate::data_types::Vote::new_with_unlocking_round
+/// [`Vote::new_with_first_round`]: crate::data_types::Vote::new_with_first_round
+/// [`OneValidationVotePerRound`]: crate::manager::proof::locking::OneValidationVotePerRound
+/// [`OneConfirmationVotePerRound`]: crate::manager::proof::locking::OneConfirmationVotePerRound
+pub trait VoteConstructionSites: CorrectValidator {}
+
+/// **Lemma (Proposal gate).** A correct validator reaches [`ChainManager::create_vote`] for a
+/// proposal `p` only after [`ChainManager::check_proposed_block`] returned
+/// [`Outcome::Accept`] for `p` against the same manager state.
+///
+/// Similarly, it reaches [`ChainManager::create_final_vote`] for a certificate `c` only after
+/// [`ChainManager::check_validated_block`] returned [`Outcome::Accept`] for `c`, and after
+/// `c.check(committee)` succeeded.
+///
+/// *Proof.* Both methods have exactly one caller in the workspace outside tests, in
+/// `linera_core::chain_worker::state`:
+///
+/// * `create_vote` is called at the end of `ChainWorkerState::try_handle_block_proposal`, which
+///   earlier `match`es on `chain.manager.check_proposed_block(&proposal)` and returns without
+///   voting on both non-`Accept` arms — `Ok(Outcome::Skip)` returns the unchanged chain info,
+///   and `Err(_)` returns the error (after, at most, recording the proposal via
+///   [`ChainManager::update_signed_proposal`], which casts no vote).
+/// * `create_final_vote` is called at the end of `ChainWorkerState::process_validated_block`,
+///   which earlier evaluates `certificate.check(&committee)?` and then
+///   `should_skip_validated_block()?`, a closure wrapping
+///   `chain.manager.check_validated_block(&certificate)`. A `Skip` outcome returns early; an
+///   `Err` propagates via `?`. Only `Ok(Accept)` falls through.
+///
+/// By [`SerializedChainState`] no other transition on this instance interleaves, so the state
+/// the guard inspected is the state `create_vote` / `create_final_vote` then mutates. ∎
+///
+/// **Where this is fragile.** The guards are at the call sites, not inside the signing methods:
+/// `create_final_vote` in particular re-checks only [`ChainManager::current_round`], and would
+/// happily sign a second confirmation in the same round if invoked directly. A new caller must
+/// replicate the guards. This is the single largest gap between "the module is correct" and "the
+/// module cannot be misused".
+///
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`ChainManager::check_validated_block`]: crate::manager::ChainManager::check_validated_block
+/// [`ChainManager::update_signed_proposal`]: crate::manager::ChainManager::update_signed_proposal
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`Outcome::Accept`]: crate::manager::Outcome::Accept
+pub trait ProposalGate: SerializedChainState {}
+
+/// **Lemma (Validation rounds strictly increase).** If a correct validator's
+/// [`validated_vote`] holds a vote in round `s`, it casts no further validation vote in any
+/// round `≤ s` while that field still holds that vote.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | [`ChainManager::check_proposed_block`] |
+/// | reads | [`proposed`], [`validated_vote`], [`locking_block`], [`confirmed_vote`], [`current_round`], [`ownership`] |
+/// | writes | nothing |
+/// | precondition | none |
+/// | establishes | this lemma, [`UnlockingRequiresHigherCertificate`] |
+///
+/// *Proof.* By [`ProposalGate`] a validation vote in round `r` requires
+/// [`ChainManager::check_proposed_block`] to have returned `Accept` for a proposal in round `r`.
+/// That method contains
+///
+/// ```text
+/// if let Some(vote) = self.validated_vote() {
+///     ensure!(new_round > vote.round, ChainError::InsufficientRoundStrict(vote.round));
+/// }
+/// ```
+///
+/// so `Accept` with `validated_vote == Some(_, s)` requires `r > s`. ∎
+///
+/// Note the qualifier "while that field still holds that vote":
+/// [`ChainManager::create_final_vote`] clears [`validated_vote`], so this lemma alone does not
+/// give a per-round bound over the whole life of an instance. [`CastValidationRoundFloor`]
+/// supplies what is missing.
+///
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+/// [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`locking_block`]: crate::manager::ChainManager::locking_block
+/// [`proposed`]: crate::manager::ChainManager::proposed
+/// [`ownership`]: crate::manager::ChainManager::ownership
+/// [`UnlockingRequiresHigherCertificate`]: self::UnlockingRequiresHigherCertificate
+/// [`CastValidationRoundFloor`]: crate::manager::proof::locking::CastValidationRoundFloor
+pub trait ValidationRoundStrictlyIncreases: ProposalGate {}
+
+/// **Lemma (A validation vote past a lock needs a higher certificate).** Suppose a correct
+/// validator casts a validation vote for block `B` in round `r`, and let `(A, p)` be the value
+/// of its [`confirmed_vote`] immediately before. Then `p` is defined only if the proposal
+/// carried an [`OriginalProposal`], and:
+///
+/// * if the proposal is a **regular retry** carrying a certificate `c` (necessarily a valid
+///   [`ValidatedBlockCertificate`] for `B`, in a round `c.round < r`), then
+///   `p ≤ c.round` when `A` matches `B`'s proposal, and `p < c.round` otherwise;
+/// * if the proposal is a **fast retry**, then `p` is [`Round::Fast`] and `A` matches `B`'s
+///   proposal;
+/// * a **fresh** proposal is rejected outright.
+///
+/// This is the hinge of the safety argument: it says a correct validator abandons a block it has
+/// confirmed only when shown a quorum that validated the new block in a round *strictly above*
+/// its own confirmation.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | [`ChainManager::check_proposed_block`], final `ensure!` |
+/// | reads | [`confirmed_vote`], `proposal.original_proposal` |
+/// | writes | nothing |
+/// | precondition | the proposal passed `check_invariants`, `check_signature` and — for a regular retry — `certificate.check(committee)`, all in `try_handle_block_proposal` |
+///
+/// *Proof.* By [`ProposalGate`], `Accept` was returned, so the final `ensure!` of
+/// [`ChainManager::check_proposed_block`] held. With `vote = (A, p)` it evaluates
+///
+/// ```text
+/// match proposal.original_proposal.as_ref() {
+///     None => false,
+///     Some(OriginalProposal::Regular { certificate }) =>
+///         if vote.value().matches_proposed_block(new_block) {
+///             vote.round <= certificate.round
+///         } else {
+///             vote.round < certificate.round
+///         },
+///     Some(OriginalProposal::Fast(_)) =>
+///         vote.round.is_fast() && vote.value().matches_proposed_block(new_block),
+/// }
+/// ```
+///
+/// which is the case distinction claimed. That the retried certificate is *valid* and certifies
+/// exactly `B` comes from the caller: `try_handle_block_proposal` calls
+/// `certificate.check(&committee)?` on the `Regular` arm, and
+/// [`BlockProposal::check_invariants`] — also called there — requires
+/// `certificate.check_value(&ValidatedBlock::new(outcome.with(block)))`, i.e. the certificate
+/// certifies the very block being proposed, and `content.round > certificate.round`. ∎
+///
+/// Note `matches_proposed_block` compares the [`ProposedBlock`] only, not the execution outcome;
+/// [`FastRetryPreservesBlock`] is where that gap is closed.
+///
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+/// [`OriginalProposal`]: crate::data_types::OriginalProposal
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`BlockProposal::check_invariants`]: crate::data_types::BlockProposal::check_invariants
+/// [`ProposedBlock`]: crate::data_types::ProposedBlock
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`FastRetryPreservesBlock`]: crate::manager::proof::safety::FastRetryPreservesBlock
+pub trait UnlockingRequiresHigherCertificate: ProposalGate {}
+
+/// **Lemma (No validation vote in the fast round).** A correct validator never casts a
+/// [`Validated`](crate::types::CertificateKind::Validated) vote in
+/// [`Round::Fast`](linera_base::data_types::Round::Fast).
+///
+/// *Proof.* By [`VoteConstructionSites`] validation votes are produced only in the `else` branch
+/// of `if round.is_fast()` in [`ChainManager::create_vote`], where `round` is the vote's round.
+/// ∎
+///
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+pub trait NoValidationInFastRound: VoteConstructionSites {}
+
+/// **Lemma (A fast confirmation requires an empty lock and no prior vote).** If a correct
+/// validator casts a confirmation vote in [`Round::Fast`], then immediately before that vote its
+/// [`locking_block`], [`validated_vote`] and [`confirmed_vote`] were all `None`; and immediately
+/// after, [`locking_block`] holds a [`LockingBlock::Fast`] for the very block confirmed.
+///
+/// *Proof.* By [`VoteConstructionSites`] such a vote comes from the `if round.is_fast()` branch
+/// of [`ChainManager::create_vote`], so the proposal's round is [`Round::Fast`]. By
+/// [`ProposalGate`], [`ChainManager::check_proposed_block`] returned `Accept` for it. Since
+/// [`Round::Fast`] is the minimum of the round order ([`RoundOrder`]):
+///
+/// * the [`locking_block`] guard `ensure!(locking_block.round() < new_round)` is unsatisfiable
+///   for `new_round == Round::Fast`, so [`locking_block`] was `None`;
+/// * the [`validated_vote`] guard `ensure!(new_round > vote.round)` is likewise unsatisfiable,
+///   so [`validated_vote`] was `None`;
+/// * for [`confirmed_vote`], [`BlockProposal::check_invariants`] forces a fast-round proposal to
+///   have `original_proposal == None` — a `Fast` original requires `content.round > Round::Fast`
+///   and a `Regular` original requires `content.round > certificate.round ≥ Round::Fast` — so
+///   the `ensure!` of [`UnlockingRequiresHigherCertificate`] takes the `None => false` arm and
+///   would reject. Hence [`confirmed_vote`] was `None`.
+///
+/// For the post-state: with `original_proposal == None` and `round.is_fast()`, the third arm of
+/// the `match` in [`ChainManager::create_vote`] runs `update_locking(LockingBlock::Fast(
+/// proposal.clone()), …)` under `self.locking_block.get().is_none()`, which we just established,
+/// so the lock is installed on the proposal being confirmed. ∎
+///
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`ChainManager::create_vote`]: crate::manager::ChainManager::create_vote
+/// [`ChainManager::check_proposed_block`]: crate::manager::ChainManager::check_proposed_block
+/// [`BlockProposal::check_invariants`]: crate::data_types::BlockProposal::check_invariants
+/// [`LockingBlock::Fast`]: crate::manager::LockingBlock::Fast
+/// [`locking_block`]: crate::manager::ChainManager::locking_block
+/// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+/// [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+/// [`RoundOrder`]: crate::manager::proof::model::RoundOrder
+pub trait FastConfirmationNeedsEmptyLock:
+    VoteConstructionSites + ProposalGate + UnlockingRequiresHigherCertificate
+{
+}
+
+/// **Lemma (A non-fast confirmation requires a validated certificate in the same round).** If a
+/// correct validator casts a confirmation vote for block `A` in a round `r` other than
+/// [`Round::Fast`](linera_base::data_types::Round::Fast), then a [`ValidatedBlockCertificate`]
+/// for `A` in round `r`, valid for the committee, existed at that moment.
+///
+/// *Code correspondence.*
+///
+/// | | |
+/// |---|---|
+/// | transition | [`ChainManager::create_final_vote`] |
+/// | reads | [`locking_block`], [`current_round`], [`ownership`] |
+/// | writes | [`locking_block`], [`locking_blobs`], [`current_round`], [`round_timeout`], [`confirmed_vote`], [`validated_vote`] |
+/// | precondition | `certificate.check(committee)` and [`ChainManager::check_validated_block`] both succeeded ([`ProposalGate`]) |
+/// | preserves | [`LockRoundMonotone`], [`ConfirmedVoteRoundMonotone`], [`CastValidationRoundFloor`] |
+///
+/// *Proof.* By [`VoteConstructionSites`] a confirmation vote in a non-fast round comes from
+/// [`ChainManager::create_final_vote`], whose vote round is `validated.round` for its
+/// [`ValidatedBlockCertificate`] argument `validated`, and whose voted value is
+/// `ConfirmedBlock::new(validated.inner().block().clone())` — the same block. By
+/// [`ProposalGate`] the caller verified `certificate.check(&committee)` before passing it in. ∎
+///
+/// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::check_validated_block`]: crate::manager::ChainManager::check_validated_block
+/// [`locking_block`]: crate::manager::ChainManager::locking_block
+/// [`locking_blobs`]: crate::manager::ChainManager::locking_blobs
+/// [`current_round`]: field@crate::manager::ChainManager::current_round
+/// [`round_timeout`]: crate::manager::ChainManager::round_timeout
+/// [`ownership`]: crate::manager::ChainManager::ownership
+/// [`confirmed_vote`]: field@crate::manager::ChainManager::confirmed_vote
+/// [`validated_vote`]: field@crate::manager::ChainManager::validated_vote
+/// [`LockRoundMonotone`]: crate::manager::proof::locking::LockRoundMonotone
+/// [`ConfirmedVoteRoundMonotone`]: crate::manager::proof::locking::ConfirmedVoteRoundMonotone
+/// [`CastValidationRoundFloor`]: crate::manager::proof::locking::CastValidationRoundFloor
+pub trait ConfirmationNeedsValidatedCertificate: VoteConstructionSites + ProposalGate {}
+
+/// **Lemma (A non-fast confirmation happens only in the current round).** When
+/// [`ChainManager::create_final_vote`] casts a confirmation vote in round `r`,
+/// [`ChainManager::current_round`] equals `r` at that moment — and it had already been raised to
+/// at least `r` earlier in the same call.
+///
+/// *Proof.* [`ChainManager::create_final_vote`] executes, in order:
+/// `update_locking(LockingBlock::Regular(validated), blobs)`, which by [`RoundFloor`] leaves the
+/// lock at a round `≥ r`; then `update_current_round(local_time)`, which by the same result
+/// leaves [`ChainManager::current_round`] at least the lock's round, hence `≥ r`; then
+///
+/// ```text
+/// if self.current_round() != round { return Ok(()); }
+/// ```
+///
+/// so the vote is cast only when the two are equal. ∎
+///
+/// This ordering is what makes the guard safe against a stale
+/// [`current_round`](field@crate::manager::ChainManager::current_round): the lock is folded back
+/// into the round *before* the comparison, so a manager whose round register was reset below its
+/// lock cannot be induced to confirm in the lower round. [`SafetyStateRecovery`] uses this.
+///
+/// [`ChainManager::create_final_vote`]: crate::manager::ChainManager::create_final_vote
+/// [`ChainManager::current_round`]: method@crate::manager::ChainManager::current_round
+/// [`RoundFloor`]: crate::manager::proof::rounds::RoundFloor
+/// [`SafetyStateRecovery`]: crate::manager::proof::locking::SafetyStateRecovery
+pub trait ConfirmationOnlyInCurrentRound:
+    VoteConstructionSites + crate::manager::proof::rounds::RoundFloor
+{
+}

--- a/linera-chain/src/spec.rs
+++ b/linera-chain/src/spec.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Microchain consensus: correctness specification
+//!
+//! Linera runs one consensus instance per *microchain* and *block height*. This module is the
+//! entry point to a specification of that consensus protocol — its system model, its assumptions,
+//! and proofs of its safety and liveness properties — written as rustdoc next to the code it
+//! describes.
+//!
+//! This crate holds the model, the voting and locking arguments, the commit rule, the safety
+//! theorem and the pacemaker. Progress and liveness depend on the client driver and so live in
+//! `linera_core::proof`, which cites back into here; that crate's `spec` module carries the same
+//! index with those two sections filled in.
+//!
+//! # Reading order
+//!
+//! The proofs live next to the code they are about, but they are written to be read in this
+//! order, and each statement cites only statements above it.
+//!
+//! | | section | where |
+//! |---|---|---|
+//! | 1 | System model | [`manager::proof::model`] |
+//! | 2 | Fault and network assumptions | [`manager::proof::model`], and `linera_core::proof::assumptions` for the ones only liveness needs |
+//! | 3 | Protocol objects and definitions | [`data_types::proof::objects`] |
+//! | 4 | Quorum properties | [`data_types::proof::quorum`] |
+//! | 5 | Voting rules | [`manager::proof::voting`] |
+//! | 6 | Locking and certificate invariants | [`manager::proof::rounds`], then [`manager::proof::locking`] |
+//! | 7 | Commit rule | [`manager::proof::commit`] |
+//! | 8 | Safety proof | [`manager::proof::safety`] |
+//! | 9 | Pacemaker and view changes | [`manager::proof::pacemaker`] |
+//! | 10 | Progress lemmas | `linera_core::proof::progress` |
+//! | 11 | Liveness proof | `linera_core::proof::liveness` |
+//!
+//! The two headline results are [`CommitAgreement`] — at most one block is ever committed per
+//! chain and height — and `linera_core::proof::liveness::UnboundedProgress`.
+//!
+//! # How to read a statement
+//!
+//! Every claim is a public marker trait with no members, no implementors and no runtime
+//! footprint. Its **name is its identity**; its doc comment carries the statement and, unless it
+//! is a definition or an assumption, a proof.
+//!
+//! ```text
+//! pub trait UniqueValidatedBlockPerRound:
+//!     OneValidationVotePerRound + CorrectValidatorInIntersection + …
+//! //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//! //  the statements this proof consumes
+//! ```
+//!
+//! **Supertraits are proof dependencies.** A statement lists as supertraits exactly those earlier
+//! statements whose truth its proof consumes. Definitions and forward pointers are cited in prose
+//! instead, so that the supertrait graph stays a proof-dependency graph rather than a vocabulary
+//! graph.
+//!
+//! This shape was chosen for what the compiler and rustdoc then check for free, with no bespoke
+//! tooling:
+//!
+//! | property | checked by |
+//! |---|---|
+//! | statement identifiers are unique | Rust name resolution |
+//! | every cited statement exists | `rustdoc::broken_intra_doc_links`, denied in CI |
+//! | every cited Rust item exists | the same lint — a renamed field or method breaks the doc build |
+//! | the dependency graph is acyclic | `rustc` (`E0391`, cycle in supertraits) |
+//! | dependencies are visible to a reader | rustdoc renders each supertrait as a link |
+//!
+//! There is deliberately **no numbering**. Names are stable under insertion and are what
+//! citations resolve against, so a statement can be added, split or moved without touching
+//! unrelated text; a stale citation is a build failure rather than a silently wrong cross
+//! reference.
+//!
+//! What is *not* mechanically checked is the thing that matters most: that the prose proof is
+//! correct, and that the code it cites still does what the proof says. Several statements carry
+//! an explicit **"where this is fragile"** or **"residual obligation"** paragraph naming the
+//! change that would invalidate them — see [`ProposalGate`], [`VoteConstructionSites`],
+//! [`SafetyStateRecovery`] and [`FastRetryPreservesBlock`].
+//!
+//! # Scope and non-goals
+//!
+//! The specification covers agreement on the *sequence of blocks* of a single microchain. It does
+//! not cover:
+//!
+//! * **State-transition correctness** — that executing the agreed blocks yields the right state.
+//!   [`DeterministicExecution`] is assumed, not proved.
+//! * **Cross-chain messaging** — inboxes, outboxes and delivery are outside consensus; the
+//!   relevant guarantee is that each chain's own block sequence is unique, which
+//!   [`UniqueChain`] provides.
+//! * **Committee reconfiguration** — epoch changes are agreed *by* this protocol on the admin
+//!   chain; [`EpochAgreement`] records what is assumed about them.
+//! * **Fault attribution** — a converse property, proved in [`crate::justification`] and stated
+//!   here as [`Accountability`].
+//!
+//! [`manager::proof::model`]: crate::manager::proof::model
+//! [`manager::proof::voting`]: crate::manager::proof::voting
+//! [`manager::proof::rounds`]: crate::manager::proof::rounds
+//! [`manager::proof::locking`]: crate::manager::proof::locking
+//! [`manager::proof::commit`]: crate::manager::proof::commit
+//! [`manager::proof::safety`]: crate::manager::proof::safety
+//! [`manager::proof::pacemaker`]: crate::manager::proof::pacemaker
+//! [`data_types::proof::objects`]: crate::data_types::proof::objects
+//! [`data_types::proof::quorum`]: crate::data_types::proof::quorum
+//! [`CommitAgreement`]: crate::manager::proof::safety::CommitAgreement
+//! [`UniqueChain`]: crate::manager::proof::safety::UniqueChain
+//! [`Accountability`]: crate::manager::proof::safety::Accountability
+//! [`FastRetryPreservesBlock`]: crate::manager::proof::safety::FastRetryPreservesBlock
+//! [`ProposalGate`]: crate::manager::proof::voting::ProposalGate
+//! [`VoteConstructionSites`]: crate::manager::proof::voting::VoteConstructionSites
+//! [`SafetyStateRecovery`]: crate::manager::proof::locking::SafetyStateRecovery
+//! [`DeterministicExecution`]: crate::manager::proof::model::DeterministicExecution
+//! [`EpochAgreement`]: crate::manager::proof::model::EpochAgreement

--- a/linera-chain/src/spec.rs
+++ b/linera-chain/src/spec.rs
@@ -28,12 +28,15 @@
 //! | 6 | Locking and certificate invariants | [`manager::proof::rounds`], then [`manager::proof::locking`] |
 //! | 7 | Commit rule | [`manager::proof::commit`] |
 //! | 8 | Safety proof | [`manager::proof::safety`] |
+//! | 8b | Accountability | [`justification::proof`] |
 //! | 9 | Pacemaker and view changes | [`manager::proof::pacemaker`] |
 //! | 10 | Progress lemmas | `linera_core::proof::progress` |
 //! | 11 | Liveness proof | `linera_core::proof::liveness` |
 //!
-//! The two headline results are [`CommitAgreement`] — at most one block is ever committed per
-//! chain and height — and `linera_core::proof::liveness::UnboundedProgress`.
+//! The three headline results are [`CommitAgreement`] — at most one block is ever committed per
+//! chain and height — [`AccountableSafety`], which says that if agreement *does* fail the
+//! certificates themselves convict validators of more weight than the fault bound permits, and
+//! `linera_core::proof::liveness::UnboundedProgress`.
 //!
 //! # How to read a statement
 //!
@@ -81,14 +84,18 @@
 //! not cover:
 //!
 //! * **State-transition correctness** — that executing the agreed blocks yields the right state.
-//!   [`DeterministicExecution`] is assumed, not proved.
+//!   [`DeterministicExecution`] is assumed, not proved. What the protocol does guarantee is
+//!   [`CertifiedBlockWasExecuted`]: every certified block was executed by at least one correct
+//!   validator. Unlike agreement, this degrades above the fault bound with no forensic residue —
+//!   incorrect execution is not attributable, as [`AccountabilityScope`] records.
 //! * **Cross-chain messaging** — inboxes, outboxes and delivery are outside consensus; the
 //!   relevant guarantee is that each chain's own block sequence is unique, which
 //!   [`UniqueChain`] provides.
 //! * **Committee reconfiguration** — epoch changes are agreed *by* this protocol on the admin
 //!   chain; [`EpochAgreement`] records what is assumed about them.
-//! * **Fault attribution** — a converse property, proved in [`crate::justification`] and stated
-//!   here as [`Accountability`].
+//! * **Fault attribution** — a *converse* property rather than an omission: it is proved in
+//!   [`justification::proof`], on a deliberately weaker assumption base, since it must hold
+//!   exactly when the fault bound has failed.
 //!
 //! [`manager::proof::model`]: crate::manager::proof::model
 //! [`manager::proof::voting`]: crate::manager::proof::voting
@@ -101,7 +108,10 @@
 //! [`data_types::proof::quorum`]: crate::data_types::proof::quorum
 //! [`CommitAgreement`]: crate::manager::proof::safety::CommitAgreement
 //! [`UniqueChain`]: crate::manager::proof::safety::UniqueChain
-//! [`Accountability`]: crate::manager::proof::safety::Accountability
+//! [`justification::proof`]: crate::justification::proof
+//! [`AccountableSafety`]: crate::justification::proof::AccountableSafety
+//! [`AccountabilityScope`]: crate::justification::proof::AccountabilityScope
+//! [`CertifiedBlockWasExecuted`]: crate::manager::proof::commit::CertifiedBlockWasExecuted
 //! [`FastRetryPreservesBlock`]: crate::manager::proof::safety::FastRetryPreservesBlock
 //! [`ProposalGate`]: crate::manager::proof::voting::ProposalGate
 //! [`VoteConstructionSites`]: crate::manager::proof::voting::VoteConstructionSites

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module defines the core Linera protocol.
+//!
+//! The consensus protocol it drives is specified and proved correct in [`spec`], which indexes
+//! both halves of the argument: safety in `linera_chain`, and progress and liveness in
+//! [`proof`], next to the client code that discharges them.
 
 #![recursion_limit = "256"]
 #![deny(missing_docs)]
@@ -22,7 +26,9 @@ mod local_node;
 pub mod node;
 /// Utilities for notifying subscribers about chain events.
 pub mod notifier;
+pub mod proof;
 mod remote_node;
+pub mod spec;
 /// Helpers for writing tests against the core protocol.
 #[cfg(with_testing)]
 #[path = "unit_tests/test_utils.rs"]

--- a/linera-core/src/proof/assumptions.rs
+++ b/linera-core/src/proof/assumptions.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The assumptions that progress needs and safety does not.
+//!
+//! Safety rests only on the assumptions in [`linera_chain::manager::proof::model`], all of which
+//! remain in force here. This module adds the ones that mention time, responsiveness, or the
+//! existence of somebody willing to drive the protocol. Every one of them can fail without
+//! endangering [`CommitAgreement`]; each failure costs progress only.
+//!
+//! [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
+
+/// **Assumption (Eventual synchrony).** There is a time GST and a bound Δ, both unknown to the
+/// protocol, such that every message sent between correct participants after GST is delivered
+/// within Δ, and every message sent before GST is delivered by GST + Δ.
+///
+/// "Participants" here includes clients: a Linera consensus round is driven by a client
+/// ([`ActiveCorrectDriver`]), so the relevant round trips are client-to-validator, not
+/// validator-to-validator.
+///
+/// Before GST nothing is claimed. In particular a network that reorders, delays or drops
+/// messages arbitrarily can keep [`ChainTipState::next_block_height`] fixed forever without
+/// violating any result in this specification.
+///
+/// [`ChainTipState::next_block_height`]: linera_chain::ChainTipState::next_block_height
+pub trait EventualSynchrony {}
+
+/// **Assumption (Correct validator availability).** After GST, every correct validator accepts
+/// requests and answers them within Δ, and its `linera_core::worker::WorkerState` completes each
+/// request in bounded local time.
+///
+/// This is stronger than [`CorrectValidator`], which permits a correct validator to be
+/// permanently crashed. It is needed because [`CorrectValidatorsFormQuorum`] only says the
+/// correct validators *hold* enough weight; progress needs them to answer.
+///
+/// The per-chain serialization of [`SerializedChainState`] means "bounded local time" also
+/// requires that no single chain's queue grows without bound — a chain saturated by requests can
+/// starve its own consensus without any validator being faulty.
+///
+/// [`CorrectValidator`]: linera_chain::manager::proof::model::CorrectValidator
+/// [`SerializedChainState`]: linera_chain::manager::proof::model::SerializedChainState
+/// [`CorrectValidatorsFormQuorum`]: linera_chain::data_types::proof::quorum::CorrectValidatorsFormQuorum
+pub trait CorrectValidatorAvailability {}
+
+/// **Assumption (An active correct driver).** Some correct owner of the chain runs a
+/// [`ChainClient`] that, from some point on, repeatedly and without giving up calls
+/// [`ChainClient::process_pending_block`] (or an operation that does, such as
+/// [`ChainClient::execute_operations`]) with a block to propose, and holds the signing key for
+/// the owner it proposes as.
+///
+/// **This assumption has no counterpart in most BFT protocols and is the single most important
+/// thing to understand about Linera's liveness.** A validator here never proposes a block and
+/// never advances a round on its own: it signs a timeout vote only when asked, through
+/// `ChainInfoQuery::request_leader_timeout` (see [`TimeoutVoteConditions`]), and there is no code
+/// path in `linera_core::worker` that constructs a [`BlockProposal`]. A microchain with no
+/// running client is not a chain that is slow; it is a chain that is stopped, by design.
+///
+/// In [`Round::Validator`] rounds the leaders are drawn from
+/// [`ChainManager::fallback_owners`], which [`ChainManager::reset`] populates with the
+/// committee's account keys — so the driver of a fallback round is a client run by a validator
+/// *operator*, still a client, and still assumed to exist.
+///
+/// [`ChainClient`]: crate::client::ChainClient
+/// [`ChainClient::process_pending_block`]: crate::client::ChainClient::process_pending_block
+/// [`ChainClient::execute_operations`]: crate::client::ChainClient::execute_operations
+/// [`BlockProposal`]: linera_chain::data_types::BlockProposal
+/// [`Round::Validator`]: linera_base::data_types::Round::Validator
+/// [`ChainManager::fallback_owners`]: linera_chain::manager::ChainManager::fallback_owners
+/// [`ChainManager::reset`]: linera_chain::manager::ChainManager::reset
+/// [`TimeoutVoteConditions`]: linera_chain::manager::proof::pacemaker::TimeoutVoteConditions
+pub trait ActiveCorrectDriver {}
+
+/// **Assumption (Leader fairness).** The leader schedule selects the correct owner of
+/// [`ActiveCorrectDriver`] in infinitely many [`SingleLeader`] rounds.
+///
+/// The schedule is deterministic and identical at every validator: by [`LeaderEligibility`], the
+/// leader of `SingleLeader(n)` is drawn by seeding a `ChaCha8Rng` with
+/// `u64::from(n).rotate_left(32) + seed`, where `seed` is the block height, and sampling the
+/// stake-weighted `WeightedAliasIndex` over [`ChainOwnership::owners`]. The assumption is therefore about the generator, not about the
+/// protocol: it holds if ChaCha8, over the round-indexed seed sequence, selects each positive
+/// weight infinitely often. An owner of weight `0` is never selected, and
+/// `ChainOwnership::first_leader`, if set, deterministically owns `SingleLeader(0)`.
+///
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`ChainOwnership::owners`]: linera_base::ownership::ChainOwnership::owners
+/// [`LeaderEligibility`]: linera_chain::manager::proof::pacemaker::LeaderEligibility
+pub trait LeaderFairness {}
+
+/// **Assumption (Round timeouts eventually exceed the round trip).** The round timeout grows
+/// without bound over successive rounds, so that eventually a round lasts longer than the time a
+/// correct leader needs to complete it after GST.
+///
+/// This is what [`ChainOwnership::round_timeout`] implements for the rounds that matter: for
+/// `SingleLeader(r)` and `Validator(r)` it returns
+/// `base_timeout + timeout_increment · r`, which is unbounded in `r` as long as
+/// [`TimeoutConfig::timeout_increment`] is non-zero. **With `timeout_increment` set to zero the
+/// assumption fails**, and a deployment whose round trip exceeds `base_timeout` can advance
+/// rounds forever without any of them lasting long enough to finish — the classic
+/// livelock this growth exists to prevent.
+///
+/// [`ChainOwnership::round_timeout`]: linera_base::ownership::ChainOwnership::round_timeout
+/// [`TimeoutConfig::timeout_increment`]: linera_base::ownership::TimeoutConfig::timeout_increment
+pub trait RoundTimeoutGrowth {}
+
+/// **Assumption (Clock accuracy).** Correct validators' clocks
+/// (`linera_storage::Clock::current_time`) advance in real time and agree within a bound small
+/// compared to the round timeout.
+///
+/// Two places consume this. A validator refuses to sign a timeout vote before its own
+/// [`round_timeout`] has passed ([`TimeoutVoteConditions`]), so a quorum's clocks must
+/// approximately agree for a timeout certificate to form at all. And a validator rejects a
+/// proposal whose timestamp is further in the future than
+/// `ChainWorkerConfig::block_time_grace_period` with `WorkerError::InvalidTimestamp`, so a
+/// leader whose clock runs fast cannot get its blocks accepted. The client reports the latter
+/// back: `Client::submit_block_proposal` warns once a
+/// [`validity_threshold`](linera_execution::committee::Committee::validity_threshold) of
+/// validators have reported skew.
+///
+/// [`round_timeout`]: linera_chain::manager::ChainManager::round_timeout
+/// [`TimeoutVoteConditions`]: linera_chain::manager::proof::pacemaker::TimeoutVoteConditions
+pub trait ClockAccuracy {}
+
+/// **Assumption (Full reachability during synchronization).** After GST, a correct driver's
+/// [`ChainClient::synchronize_chain_state`] reaches *every* correct validator, not merely a
+/// quorum of them.
+///
+/// This is the weakest link in the liveness argument, and it is stated separately for that
+/// reason. [`LockRecovery`] needs the proposer to learn the highest lock held by *any* correct
+/// validator, because a single correct validator holding a lock above the proposer's will reject
+/// the proposal ([`UnlockingRequiresHigherCertificate`]) and may be exactly the weight that a
+/// quorum was missing.
+///
+/// **What the implementation actually guarantees is weaker.**
+/// `Client::synchronize_chain_from_committee` dispatches
+/// `synchronize_chain_state_from` to every validator but aggregates through
+/// `communicate_with_quorum`, which stops once a quorum has answered plus a grace period of
+/// `quorum_grace_period` (default [`DEFAULT_QUORUM_GRACE_PERIOD`], 0.2) times the time that took;
+/// still-pending responses are then dropped. A correct but slow validator holding the highest
+/// lock can therefore be missed.
+///
+/// **Why this is usually not observable.** A validator holds a lock at round `p` only because it
+/// received a [`ValidatedBlockCertificate`] at `p`, which the client that assembled it pushes to
+/// every validator; so the ordinary way for a lock to exist at one validator and not at a quorum
+/// is a partition that GST has since healed, followed by that validator being slow in exactly the
+/// synchronization that matters. `ChainClient::process_pending_block` also retries: on a rejection
+/// whose consensus-state snapshot is unchanged it performs one explicit fallback
+/// `synchronize_chain_state` and retries, and the caller's loop re-enters the whole procedure. The
+/// combination makes the assumption hold with probability tending to one over retries rather than
+/// deterministically.
+///
+/// **Residual obligation.** Making this a theorem rather than an assumption requires the
+/// synchronization step to wait for all correct validators — or, more cheaply, for a rejection
+/// carrying [`ChainError::HasIncompatibleConfirmedVote`] to trigger a targeted pull from the
+/// rejecting validator, as `NodeError::WrongRound` already does through
+/// `chain_client::Error::LocalNodeLagging`. It does not: the lag-report path in
+/// `RemoteNodeUpdater::sync_remote_if_needed` matches only the round and height mismatches. The
+/// fallback path is also noted as untested in the source (`TODO(#6453)`).
+///
+/// [`ChainClient::synchronize_chain_state`]: crate::client::ChainClient::synchronize_chain_state
+/// [`DEFAULT_QUORUM_GRACE_PERIOD`]: crate::DEFAULT_QUORUM_GRACE_PERIOD
+/// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+/// [`ChainError::HasIncompatibleConfirmedVote`]: linera_chain::ChainError::HasIncompatibleConfirmedVote
+/// [`LockRecovery`]: super::progress::LockRecovery
+/// [`UnlockingRequiresHigherCertificate`]: linera_chain::manager::proof::voting::UnlockingRequiresHigherCertificate
+pub trait FullReachability {}

--- a/linera-core/src/proof/liveness.rs
+++ b/linera-core/src/proof/liveness.rs
@@ -1,0 +1,171 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The liveness theorems, and a precise account of what they exclude.
+//!
+//! Everything here is conditional on the assumptions in [`super::assumptions`], all of which can
+//! fail without endangering [`CommitAgreement`]. Read [`LivenessScope`] alongside
+//! [`UnboundedProgress`]: several natural readings of "the protocol makes progress" are *not*
+//! implied, and the differences are design choices rather than oversights.
+//!
+//! [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
+
+use linera_chain::manager::proof::{
+    commit::{CommittedBlock, TipAdvancesOnlyOnValidCertificate},
+    pacemaker::RoundsWithoutTimeout,
+    safety::{CommitAgreement, UniqueChain},
+};
+
+use super::{
+    assumptions::ActiveCorrectDriver,
+    progress::{
+        EventuallyCorrectLeader, FinalizationQuorumForms, LockRecovery, ProposalAccepted,
+        TimeoutCertificateForms, ValidationQuorumForms,
+    },
+};
+
+/// **Theorem (Round progress).** Consider a chain with at least one regular owner, at a height
+/// whose consensus instance has not yet committed. Under [`ActiveCorrectDriver`] and the other
+/// assumptions of [`super::assumptions`], there is a round `r` beginning after GST such that the
+/// height commits during `r`.
+///
+/// *Proof.* By [`RoundAdvancement`] the correct validators' common round grows without bound
+/// after GST, and by [`RoundTimeoutGrowth`] the timeout of round number `n` is
+/// `base_timeout + timeout_increment · n`, unbounded in `n`. Let `T` be the wall-clock time a
+/// correct leader needs to complete one round after GST: by
+/// [`ProposalAccepted`], [`ValidationQuorumForms`] and [`FinalizationQuorumForms`] this is
+/// `O(Δ)` plus bounded local processing, hence finite. Choose `n` with
+/// `base_timeout + timeout_increment · n > T`.
+///
+/// By [`EventuallyCorrectLeader`] there is a [`SingleLeader`] round `r` with number at least `n`,
+/// beginning after GST, whose leader is the correct driver's owner. By [`RoundAdvancement`] every
+/// correct validator is in `r` when it begins, and by [`LockRecovery`] the driver enters `r`
+/// holding a lock at least as high as every correct validator's confirmation. Then:
+///
+/// 1. by [`ProposalAccepted`], every correct validator accepts the driver's proposal in `r`;
+/// 2. by [`ValidationQuorumForms`], a [`ValidatedBlockCertificate`] for the proposed block forms
+///    in round `r`;
+/// 3. by [`FinalizationQuorumForms`], a [`ConfirmedBlockCertificate`] for it forms in round `r`.
+///
+/// All three complete within `T < ` the round's timeout, so no correct validator signs a timeout
+/// vote for `r` in the meantime ([`TimeoutVoteConditions`]) and the round is not cut short. The
+/// block is therefore a [`CommittedBlock`]. ∎
+///
+/// Step 3's precondition that no correct validator has left `r` is what the timeout comparison
+/// buys: without [`RoundTimeoutGrowth`] the round could expire mid-flight, every attempt could
+/// fail the same way, and rounds would advance forever without committing.
+///
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+/// [`ConfirmedBlockCertificate`]: linera_chain::types::ConfirmedBlockCertificate
+/// [`RoundTimeoutGrowth`]: super::assumptions::RoundTimeoutGrowth
+/// [`TimeoutVoteConditions`]: linera_chain::manager::proof::pacemaker::TimeoutVoteConditions
+/// [`RoundAdvancement`]: super::progress::RoundAdvancement
+pub trait RoundProgress:
+    EventuallyCorrectLeader
+    + LockRecovery
+    + ProposalAccepted
+    + ValidationQuorumForms
+    + FinalizationQuorumForms
+    + TimeoutCertificateForms
+    + CommittedBlock
+{
+}
+
+/// **Theorem (Height progress).** Under the same assumptions, once the driver has a block to
+/// propose at height `h`, a block at height `h` is committed within finite time after GST, and
+/// every correct validator's [`ChainTipState::next_block_height`] reaches `h + 1` — provided it
+/// is reachable and receives the certificate.
+///
+/// *Proof.* Commitment at `h` is [`RoundProgress`]. For the observable half: the driver's
+/// `ChainClient::process_pending_block` ends by calling `Client::update_validators` with the new
+/// [`ConfirmedBlockCertificate`], which delivers it to every validator; a correct recipient runs
+/// `ChainWorkerState::process_confirmed_block`, which verifies it and — since the block is
+/// contiguous with the recipient's tip, `h` being the pending height — executes it and advances
+/// [`ChainTipState::next_block_height`] to `h + 1` ([`TipAdvancesOnlyOnValidCertificate`]). By
+/// [`CommitAgreement`] the block it records is the same at all of them. ∎
+///
+/// The proviso is not removable and is not a defect: a validator that is partitioned away, or
+/// that has been down since before GST, simply has not received the certificate yet. It catches
+/// up through the ordinary certificate-download path, since the certificate is by then durable at
+/// a quorum.
+///
+/// [`ChainTipState::next_block_height`]: linera_chain::ChainTipState::next_block_height
+/// [`ConfirmedBlockCertificate`]: linera_chain::types::ConfirmedBlockCertificate
+pub trait HeightProgress:
+    RoundProgress + TipAdvancesOnlyOnValidCertificate + CommitAgreement
+{
+}
+
+/// **Theorem (Unbounded progress).** If a correct driver ([`ActiveCorrectDriver`]) keeps
+/// supplying blocks to propose — never exhausting its stream of operations — then under the
+/// assumptions of [`super::assumptions`] every correct, reachable validator's
+/// [`ChainTipState::next_block_height`] grows without bound, and by [`UniqueChain`] the
+/// validators' committed prefixes remain identical throughout.
+///
+/// *Proof.* Induction on the height. Given that height `h` has committed and every correct
+/// reachable validator has advanced to `h + 1` ([`HeightProgress`]), each such validator's
+/// `ChainStateView::reset_chain_manager` has created the consensus instance for `h + 1`
+/// ([`ConsensusInstance`]) with its round reset to
+/// [`ChainOwnership::first_round`]. The hypotheses of [`RoundProgress`] then hold again at
+/// `h + 1`: GST has passed, the driver has a block, and [`EventuallyCorrectLeader`] applies to
+/// the fresh instance since the leader seed is the new height. So `h + 1` commits, and the
+/// induction continues. Uniqueness of what is committed at each height is [`UniqueChain`]. ∎
+///
+/// Note that the round numbering restarts at each height, so the round-timeout argument of
+/// [`RoundProgress`] restarts too: each height may again spend a bounded number of rounds before
+/// its timeout exceeds `T`. This costs latency, not liveness.
+///
+/// [`ChainTipState::next_block_height`]: linera_chain::ChainTipState::next_block_height
+/// [`ConsensusInstance`]: linera_chain::manager::proof::model::ConsensusInstance
+/// [`ChainOwnership::first_round`]: linera_base::ownership::ChainOwnership::first_round
+pub trait UnboundedProgress: HeightProgress + UniqueChain {}
+
+/// **Remark (What liveness does not claim).** Five exclusions, each of which a reader may
+/// reasonably expect [`UnboundedProgress`] to cover.
+///
+/// * **No progress without a client.** [`ActiveCorrectDriver`] is indispensable: a validator
+///   never proposes and never advances a round unprompted. A microchain whose owners have all
+///   gone away makes no progress and is not thereby faulty. This is the deepest structural
+///   difference from a validator-driven BFT protocol, and it is what makes a Linera validator's
+///   per-chain cost proportional to use.
+///
+/// * **The fast round can wedge a height permanently.** By [`RoundsWithoutTimeout`], with the
+///   default [`TimeoutConfig`] the fast round has no timeout at all, and while the current round
+///   is fast only a super owner may open a later one. A super owner that issues two conflicting
+///   fast proposals splits the correct validators — each locks onto the first it sees, by
+///   [`FastConfirmationNeedsEmptyLock`] — so neither reaches a quorum, and the height stops until
+///   that same super owner proposes again in a higher round. [`CommitAgreement`] is untouched;
+///   this is exactly the trade the fast path makes, and the reason
+///   `ChainClient::process_pending_block_inner` refuses to replace a pending fast proposal whose
+///   signing key it no longer holds.
+///
+/// * **Multi-leader rounds are not covered by [`RoundProgress`].** The theorem is stated for
+///   [`SingleLeader`] and [`Validator`] rounds, where a unique leader is guaranteed by
+///   [`LeaderEligibility`]. In a multi-leader round several owners may propose simultaneously;
+///   correct validators then vote for whichever proposal they see first, quorums may not form,
+///   and by [`RoundsWithoutTimeout`] a non-final multi-leader round has no timeout — it is left
+///   only by a proposal in a higher round. This is by design (multi-leader rounds are the
+///   uncontended fast path) and costs nothing, because the round sequence passes through them
+///   into single-leader rounds where the theorem applies.
+///
+/// * **No bound on the number of rounds, and no bound before GST.** [`RoundProgress`] asserts the
+///   existence of a successful round, not a bound on how many precede it. Faulty leaders and
+///   pre-GST delays each cost rounds.
+///
+/// * **Nothing is claimed about the *content* of the committed blocks.** A driver competing with
+///   other owners may find its own block superseded: [`LockRecovery`] obliges it to re-propose
+///   whatever is locked rather than its own pending block. `process_pending_block` then returns
+///   the committed certificate for the other block and keeps the driver's proposal pending for a
+///   later height. Liveness of the *chain* does not imply liveness of any particular
+///   transaction.
+///
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`Validator`]: linera_base::data_types::Round::Validator
+/// [`TimeoutConfig`]: linera_base::ownership::TimeoutConfig
+/// [`FastConfirmationNeedsEmptyLock`]: linera_chain::manager::proof::voting::FastConfirmationNeedsEmptyLock
+/// [`LeaderEligibility`]: linera_chain::manager::proof::pacemaker::LeaderEligibility
+pub trait LivenessScope:
+    UnboundedProgress + RoundsWithoutTimeout + ActiveCorrectDriver + LockRecovery
+{
+}

--- a/linera-core/src/proof/mod.rs
+++ b/linera-core/src/proof/mod.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The progress and liveness half of the microchain consensus correctness specification.
+//!
+//! The safety half is in [`linera_chain::manager::proof`] and does not depend on anything here.
+//! This half does the reverse: it cites the chain crate's voting, locking and pacemaker results
+//! throughout, and adds the assumptions that mention time and availability.
+//!
+//! | module | contents |
+//! |---|---|
+//! | [`assumptions`] | synchrony, availability, leader fairness, timeout growth, reachability |
+//! | [`progress`] | the individual steps a correct driver can force after GST |
+//! | [`liveness`] | the liveness theorems, and what they exclude |
+//!
+//! See [`crate::spec`] for the reading order across both crates.
+//!
+//! # Why liveness lives in this crate
+//!
+//! A Linera validator does not propose blocks and does not advance rounds on its own. Both are
+//! done by a [`ChainClient`](crate::client::ChainClient) run by a chain owner — which is why
+//! [`assumptions::ActiveCorrectDriver`] is an assumption rather than a lemma, and why the
+//! progress lemmas cite `linera_core::client` rather than `linera_chain::manager`. Placing them
+//! here keeps every statement next to the code that discharges it.
+
+pub mod assumptions;
+pub mod liveness;
+pub mod progress;

--- a/linera-core/src/proof/progress.rs
+++ b/linera-core/src/proof/progress.rs
@@ -1,0 +1,314 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Progress lemmas: the individual steps a correct driver can force after GST.
+//!
+//! Each result here says that one step of the protocol *completes*, given that the previous ones
+//! did. They are assembled into the liveness theorems in [`super::liveness`].
+//!
+//! The driver is [`ChainClient::process_pending_block`], whose body
+//! (`process_pending_block_inner`) performs, in order: request a timeout if the round has expired
+//! ([`TimeoutCertificateForms`], [`RoundAdvancement`]); finalize a locking block already in the
+//! current round; otherwise choose a block — the locking block if there is one
+//! ([`LockRecovery`]) — and a round ([`EventuallyCorrectLeader`]); submit the proposal
+//! ([`ProposalAccepted`], [`ValidationQuorumForms`]); and finalize it
+//! ([`FinalizationQuorumForms`]).
+//!
+//! [`ChainClient::process_pending_block`]: crate::client::ChainClient::process_pending_block
+
+use linera_chain::{
+    data_types::proof::quorum::CorrectValidatorsFormQuorum,
+    manager::proof::{
+        commit::CommittedBlock,
+        locking::{LockRoundMonotone, UniqueValidatedBlockPerRound},
+        pacemaker::{
+            LeaderEligibility, RoundsWithoutTimeout, SingleLeaderRoundsNeedTimeout,
+            TimeoutCertificateAdvancesRound, TimeoutVoteConditions,
+        },
+        rounds::CurrentRoundMonotone,
+        voting::{
+            ConfirmationNeedsValidatedCertificate, ConfirmationOnlyInCurrentRound, ProposalGate,
+            UnlockingRequiresHigherCertificate,
+        },
+    },
+};
+
+use super::assumptions::{
+    ActiveCorrectDriver, ClockAccuracy, CorrectValidatorAvailability, EventualSynchrony,
+    FullReachability, LeaderFairness, RoundTimeoutGrowth,
+};
+
+/// **Lemma (A timeout certificate forms).** Suppose that after GST every correct validator is in
+/// the same round `r` at the chain's pending height, that `r` has a configured timeout
+/// ([`RoundsWithoutTimeout`]), and that the timeout has elapsed on every correct validator's
+/// clock. Then a correct driver's [`ChainClient::request_leader_timeout`] returns a valid
+/// [`TimeoutCertificate`] for round `r` within `2Δ` plus local processing.
+///
+/// *Proof.* [`ChainClient::request_leader_timeout`] issues
+/// `CommunicateAction::RequestTimeout { chain_id, height, round }` with `round` read from its
+/// local [`ChainManagerInfo::current_round`] and `height` from `ChainInfo::next_block_height`,
+/// through `Client::communicate_chain_action`. Each recipient runs
+/// `ChainWorkerState::vote_for_leader_timeout`, which checks the height against
+/// [`ChainTipState::next_block_height`] and calls
+/// [`ChainManager::create_timeout_vote`]. By [`TimeoutVoteConditions`] its four conditions hold
+/// under the hypotheses, so every correct validator signs; by
+/// [`CorrectValidatorAvailability`] and [`EventualSynchrony`] every such vote arrives within Δ
+/// of the request.
+///
+/// The votes aggregate: `communicate_with_quorum` groups by the full signed payload
+/// `(value_hash, round, unlocking_round, first_round, justification_commitment)`, and every
+/// timeout vote for this height carries the same `Timeout::new(chain_id, height, epoch)` value
+/// — identical by [`ClockAccuracy`]-independent construction, since the epoch is the chain's —
+/// with `unlocking_round: None`, `first_round: false` and no justification commitment. So all
+/// correct votes land in one group, which by [`CorrectValidatorsFormQuorum`] reaches
+/// [`quorum_threshold`], and `communicate_with_quorum` returns it. ∎
+///
+/// The hypothesis "every correct validator is in round `r`" is not free — see
+/// [`RoundAdvancement`], which is what establishes it for the next round.
+///
+/// [`ChainClient::request_leader_timeout`]: crate::client::ChainClient::request_leader_timeout
+/// [`TimeoutCertificate`]: linera_chain::types::TimeoutCertificate
+/// [`ChainManagerInfo::current_round`]: linera_chain::manager::ChainManagerInfo::current_round
+/// [`ChainTipState::next_block_height`]: linera_chain::ChainTipState::next_block_height
+/// [`ChainManager::create_timeout_vote`]: linera_chain::manager::ChainManager::create_timeout_vote
+/// [`quorum_threshold`]: linera_execution::committee::Committee::quorum_threshold
+pub trait TimeoutCertificateForms:
+    TimeoutVoteConditions
+    + RoundsWithoutTimeout
+    + CorrectValidatorsFormQuorum
+    + CorrectValidatorAvailability
+    + EventualSynchrony
+    + ClockAccuracy
+{
+}
+
+/// **Lemma (Round advancement).** After GST, a correct driver can bring every correct validator
+/// into a common round strictly above `r`, within `O(Δ)`, provided `r` has a configured timeout.
+/// Consequently the common round grows without bound as long as the driver keeps trying.
+///
+/// *Proof.* By [`TimeoutCertificateForms`] the driver obtains a [`TimeoutCertificate`] for `r`.
+/// [`ChainClient::request_leader_timeout`] then feeds it to its own node and calls
+/// `Client::communicate_chain_updates`, which delivers it to the validators; each correct
+/// recipient runs `ChainWorkerState::process_timeout`, which verifies it against the committee
+/// and calls [`ChainManager::handle_timeout_certificate`]. By
+/// [`TimeoutCertificateAdvancesRound`] each then has a current round of at least
+/// `ChainOwnership::next_round(r) > r`, and by [`CurrentRoundMonotone`] it stays there.
+///
+/// They are in a *common* round because [`RoundFloor`] makes the round a deterministic function
+/// of the evidence held, and after this step every correct validator holds the same highest
+/// timeout certificate — unless some hold additional evidence (a higher lock or proposal), which
+/// only moves them higher, and which the driver's own synchronization
+/// ([`FullReachability`]) then propagates. Unboundedness follows by induction, using
+/// [`RoundTimeoutGrowth`] to know that each successive round again has a finite timeout. ∎
+///
+/// **This is strictly weaker than liveness.** It says rounds advance, not that a block is
+/// committed; an execution in which the driver forever advances rounds without ever committing
+/// satisfies this lemma. Turning it into progress is what [`RoundProgress`] does, and it needs
+/// [`EventuallyCorrectLeader`] and [`LockRecovery`] besides.
+///
+/// [`TimeoutCertificate`]: linera_chain::types::TimeoutCertificate
+/// [`ChainClient::request_leader_timeout`]: crate::client::ChainClient::request_leader_timeout
+/// [`ChainManager::handle_timeout_certificate`]: linera_chain::manager::ChainManager::handle_timeout_certificate
+/// [`RoundFloor`]: linera_chain::manager::proof::rounds::RoundFloor
+/// [`RoundProgress`]: super::liveness::RoundProgress
+pub trait RoundAdvancement:
+    TimeoutCertificateForms
+    + TimeoutCertificateAdvancesRound
+    + CurrentRoundMonotone
+    + RoundTimeoutGrowth
+    + SingleLeaderRoundsNeedTimeout
+{
+}
+
+/// **Lemma (Eventually a correct owner leads a round that starts after GST).** Under
+/// [`ActiveCorrectDriver`], [`LeaderFairness`] and [`RoundAdvancement`], there are infinitely
+/// many [`SingleLeader`] rounds after GST whose leader is the correct driver's owner.
+///
+/// *Proof.* By [`RoundAdvancement`] the common round grows without bound after GST, so infinitely
+/// many single-leader rounds begin after GST — the round sequence passes through
+/// `SingleLeader(0), SingleLeader(1), …` by [`ChainOwnership::next_round`], and only leaves them
+/// for [`Validator`] rounds on `u32` overflow or via fallback. By [`LeaderFairness`] the driver's
+/// owner is the leader of infinitely many of them, and by [`LeaderEligibility`] being the leader
+/// is exactly what `ChainManager::can_propose` requires. ∎
+///
+/// In [`Validator`] rounds the same argument applies with the committee's account keys as the
+/// owner set; the correct driver is then a validator operator's client.
+///
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`Validator`]: linera_base::data_types::Round::Validator
+/// [`ChainOwnership::next_round`]: linera_base::ownership::ChainOwnership::next_round
+pub trait EventuallyCorrectLeader:
+    RoundAdvancement + LeaderFairness + ActiveCorrectDriver + LeaderEligibility
+{
+}
+
+/// **Lemma (Lock recovery).** Under [`FullReachability`], after a correct driver completes
+/// [`ChainClient::synchronize_chain_state`] its local
+/// [`ChainManagerInfo::requested_locking`] has a round at least as high as the
+/// [`confirmed_vote`] round of every correct validator — and, if any correct validator holds a
+/// lock at all, is a [`ValidatedBlockCertificate`] for the same block that the highest such
+/// validator locked.
+///
+/// *Proof.* Two steps.
+///
+/// *Every correct validator's lock dominates its own confirmation.* If a correct validator's
+/// [`confirmed_vote`] is in round `p`, then either `p` is [`Round::Fast`] — and by
+/// [`FastConfirmationNeedsEmptyLock`] it then holds a `LockingBlock::Fast` at that same round —
+/// or by [`ConfirmationNeedsValidatedCertificate`] it confirmed via
+/// [`ChainManager::create_final_vote`], which installs the certificate as the lock *before*
+/// signing ([`ConfirmationOnlyInCurrentRound`]). Either way its lock round is `≥ p`, and stays so
+/// by [`LockRoundMonotone`].
+///
+/// *The driver collects the maximum.* `Client::synchronize_chain_state_from` reads each
+/// validator's [`ChainManagerInfo`] with manager values, and for a
+/// `LockingBlock::Regular(cert)` calls `try_process_locking_block_from`, which feeds the
+/// certificate to the local node's `process_validated_block`; that calls
+/// [`ChainManager::create_final_vote`], whose `update_locking` keeps the higher of the two by
+/// [`LockRoundMonotone`]. A `LockingBlock::Fast` is instead replayed as a proposal. Iterating
+/// over the validators reached — all of the correct ones, by [`FullReachability`] — leaves the
+/// local lock at the maximum. That it is a certificate *for the locked block* is immediate,
+/// since a lock *is* the certificate; and by [`UniqueValidatedBlockPerRound`] two correct
+/// validators locked at the same round hold certificates for the same block. ∎
+///
+/// This is what makes [`ProposalAccepted`] possible: the driver re-proposes the block it just
+/// recovered, so no correct validator's [`UnlockingRequiresHigherCertificate`] guard can reject
+/// it.
+///
+/// [`ChainClient::synchronize_chain_state`]: crate::client::ChainClient::synchronize_chain_state
+/// [`ChainManagerInfo`]: linera_chain::manager::ChainManagerInfo
+/// [`ChainManagerInfo::requested_locking`]: linera_chain::manager::ChainManagerInfo::requested_locking
+/// [`confirmed_vote`]: field@linera_chain::manager::ChainManager::confirmed_vote
+/// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+/// [`Round::Fast`]: linera_base::data_types::Round::Fast
+/// [`ChainManager::create_final_vote`]: linera_chain::manager::ChainManager::create_final_vote
+/// [`FastConfirmationNeedsEmptyLock`]: linera_chain::manager::proof::voting::FastConfirmationNeedsEmptyLock
+pub trait LockRecovery:
+    FullReachability
+    + ConfirmationNeedsValidatedCertificate
+    + ConfirmationOnlyInCurrentRound
+    + LockRoundMonotone
+    + UniqueValidatedBlockPerRound
+{
+}
+
+/// **Lemma (A recovered proposal is accepted).** Let `r` be a [`SingleLeader`] or [`Validator`]
+/// round beginning after GST whose leader is the correct driver's owner
+/// ([`EventuallyCorrectLeader`]), let every correct validator be in round `r`
+/// ([`RoundAdvancement`]), and let the driver have completed lock recovery
+/// ([`LockRecovery`]). Then the proposal the driver submits in round `r` passes
+/// [`ChainManager::check_proposed_block`] at every correct validator.
+///
+/// *Proof.* By [`ProposalGate`] acceptance is exactly `check_proposed_block` returning
+/// [`Accept`], so we take its guards in order, for a correct validator `v` in round `r`.
+///
+/// * *Proposer eligibility.* `try_handle_block_proposal` requires
+///   `chain.manager.can_propose(&owner, r)`, which holds by [`LeaderEligibility`] since the
+///   driver is `r`'s leader; the driver selects `r` through `ChainClient::round_for_new_proposal`,
+///   which consults the same `ChainManagerInfo::should_propose`.
+/// * *Round.* The `SingleLeader(_) | Validator(_)` arm requires `r == v.current_round()`, which
+///   is the hypothesis.
+/// * *Validation vote.* Requires `r > v.validated_vote.round`. By [`VoteRoundBelowCurrentRound`]
+///   any earlier validation vote of `v` is in a round `≤ v.current_round() = r`, and `= r` is
+///   excluded: a vote in round `r` needs a proposal in round `r` accepted by `v`, and by
+///   [`LeaderEligibility`] the only proposer `v` accepts in `r` is the driver, which has made no
+///   other proposal in `r`.
+/// * *Lock.* Requires `r > v.locking_block.round()`. A lock round above `r` would by
+///   [`RoundFloor`] put `v.current_round()` above `r`, contradicting the hypothesis; and a lock
+///   round *equal* to `r` would require a [`ValidatedBlockCertificate`] in round `r`, which by
+///   [`CertificateCarriesCorrectVote`] would require a correct validator's validation vote in
+///   round `r` — excluded by the previous point.
+/// * *Confirmed vote.* This is the one that needs [`LockRecovery`]. If `v` has a confirmed vote
+///   in round `p`, then by [`LockRecovery`] the driver's recovered lock has round `t ≥ p` and
+///   certifies the same block `B` that `v` confirmed if `t = p`. The driver proposes `B` as a
+///   [`Regular`] retry carrying that certificate (`process_pending_block_inner` takes the
+///   `if let Some(locking) = info.manager.requested_locking` branch and builds
+///   `BlockProposal::new_retry_regular`). By [`UnlockingRequiresHigherCertificate`] the guard
+///   then requires `p ≤ t` when the blocks match, which holds. (When `t > p` and the blocks
+///   differ, the guard requires `p < t`, which also holds.)
+///
+/// A `LockingBlock::Fast` lock is retried as `BlockProposal::new_retry_fast`, and the same guard
+/// requires `v.confirmed_vote.round.is_fast()` and a matching block, which holds because a fast
+/// confirmation is the only confirmation possible below the fast round's successor. ∎
+///
+/// [`SingleLeader`]: linera_base::data_types::Round::SingleLeader
+/// [`Validator`]: linera_base::data_types::Round::Validator
+/// [`ChainManager::check_proposed_block`]: linera_chain::manager::ChainManager::check_proposed_block
+/// [`Accept`]: linera_chain::manager::Outcome::Accept
+/// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+/// [`Regular`]: linera_chain::data_types::OriginalProposal::Regular
+/// [`VoteRoundBelowCurrentRound`]: linera_chain::manager::proof::rounds::VoteRoundBelowCurrentRound
+/// [`CertificateCarriesCorrectVote`]: linera_chain::data_types::proof::quorum::CertificateCarriesCorrectVote
+/// [`RoundFloor`]: linera_chain::manager::proof::rounds::RoundFloor
+pub trait ProposalAccepted:
+    EventuallyCorrectLeader
+    + RoundAdvancement
+    + LockRecovery
+    + ProposalGate
+    + UnlockingRequiresHigherCertificate
+    + LeaderEligibility
+{
+}
+
+/// **Lemma (The validation quorum forms).** Under the hypotheses of [`ProposalAccepted`], the
+/// driver obtains a valid [`ValidatedBlockCertificate`] for its block in round `r` within `2Δ`
+/// plus local processing.
+///
+/// *Proof.* By [`ProposalAccepted`] every correct validator accepts the proposal, so
+/// `ChainWorkerState::try_handle_block_proposal` reaches
+/// [`ChainManager::create_vote`], which — `r` not being the fast round — signs a validation vote
+/// for the block in round `r`. Every such vote carries the same signed payload: same block hash,
+/// same round, and the same `unlocking_round`/`justification_commitment` pair, which
+/// [`ChainManager::create_vote`] derives from the proposal's own
+/// [`Regular`](linera_chain::data_types::OriginalProposal::Regular) certificate — identical
+/// across validators because the proposal is. So all correct votes fall into one group of
+/// `communicate_with_quorum`, which by [`CorrectValidatorsFormQuorum`] reaches the quorum
+/// threshold; by [`CorrectValidatorAvailability`] and [`EventualSynchrony`] they arrive within Δ.
+/// `Client::submit_block_proposal` assembles them into a certificate, whose justification chain
+/// is the retried certificate's `full_justification`. ∎
+///
+/// Note the blob preconditions: a validator missing a blob the proposal requires answers
+/// `WorkerError::BlobsNotFound` instead of voting, and the driver uploads the blobs and retries
+/// (`Client::submit_block_proposal`'s retry on `BlobsNotFound`). This is bounded work — the blob
+/// set is fixed by the proposal — so it does not affect the argument beyond a constant number of
+/// extra round trips.
+///
+/// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+/// [`ChainManager::create_vote`]: linera_chain::manager::ChainManager::create_vote
+pub trait ValidationQuorumForms:
+    ProposalAccepted + CorrectValidatorsFormQuorum + CorrectValidatorAvailability + EventualSynchrony
+{
+}
+
+/// **Lemma (The finalization quorum forms).** Given a valid [`ValidatedBlockCertificate`] for
+/// block `B` in round `r`, and every correct validator in round `r` after GST, the driver obtains
+/// a valid [`ConfirmedBlockCertificate`] for `B` within `2Δ` plus local processing — so `B`
+/// becomes a [`CommittedBlock`].
+///
+/// *Proof.* `Client::finalize_block` sends `CommunicateAction::FinalizeBlock` to every validator.
+/// A correct recipient runs `ChainWorkerState::process_validated_block`, which verifies the
+/// certificate, checks [`ChainManager::check_validated_block`] — whose guards are
+/// `new_round ≥ validated_vote.round`, satisfied since no correct validator voted above `r`, and
+/// `new_round > locking_block.round()`, satisfied since no lock in round `r` existed before this
+/// certificate — and calls [`ChainManager::create_final_vote`]. That signs, because by
+/// [`ConfirmationOnlyInCurrentRound`] it requires the current round to equal `r`, which holds by
+/// hypothesis and is re-established by its own `update_locking`/`update_current_round` prelude.
+///
+/// All confirmation votes again share one payload: the value is `ConfirmedBlock::new(B)`, the
+/// round is `r`, and the `first_round` flag and justification commitment are derived from `r` and
+/// the certificate, identically at every validator. So they aggregate;
+/// [`CorrectValidatorsFormQuorum`] gives the threshold. `Client::finalize_block` then attaches
+/// the justification chain the quorum committed to and returns the certificate, which is a
+/// [`CommittedBlock`] by definition. ∎
+///
+/// [`ValidatedBlockCertificate`]: linera_chain::types::ValidatedBlockCertificate
+/// [`ConfirmedBlockCertificate`]: linera_chain::types::ConfirmedBlockCertificate
+/// [`ChainManager::check_validated_block`]: linera_chain::manager::ChainManager::check_validated_block
+/// [`ChainManager::create_final_vote`]: linera_chain::manager::ChainManager::create_final_vote
+pub trait FinalizationQuorumForms:
+    ValidationQuorumForms
+    + ConfirmationOnlyInCurrentRound
+    + ConfirmationNeedsValidatedCertificate
+    + CommittedBlock
+    + CorrectValidatorsFormQuorum
+{
+}

--- a/linera-core/src/spec.rs
+++ b/linera-core/src/spec.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Microchain consensus: correctness specification
+//!
+//! Linera runs one consensus instance per *microchain* and *block height*. This is the complete
+//! index to a specification of that protocol — its system model, its assumptions, and proofs of
+//! its safety and liveness properties — written as rustdoc next to the code it describes, across
+//! [`linera_chain`] and this crate.
+//!
+//! The two headline results are:
+//!
+//! * **Safety** — [`CommitAgreement`]: for any chain and height, all valid confirmed block
+//!   certificates certify the same block. No synchrony, availability or fairness assumption is
+//!   used; only [`MaxByzantineWeight`] and the cryptographic and persistence assumptions.
+//! * **Liveness** — [`UnboundedProgress`]: with an active correct client and after GST, every
+//!   correct reachable validator's [`ChainTipState::next_block_height`] grows without bound.
+//!
+//! # Reading order
+//!
+//! The proofs live next to the code they are about, but they are written to be read in this
+//! order, and each statement cites only statements above it.
+//!
+//! | | section | where |
+//! |---|---|---|
+//! | 1 | System model | [`linera_chain::manager::proof::model`] |
+//! | 2 | Fault and network assumptions | [`linera_chain::manager::proof::model`], then [`proof::assumptions`] |
+//! | 3 | Protocol objects and definitions | [`linera_chain::data_types::proof::objects`] |
+//! | 4 | Quorum properties | [`linera_chain::data_types::proof::quorum`] |
+//! | 5 | Voting rules | [`linera_chain::manager::proof::voting`] |
+//! | 6 | Locking and certificate invariants | [`linera_chain::manager::proof::rounds`], then [`linera_chain::manager::proof::locking`] |
+//! | 7 | Commit rule | [`linera_chain::manager::proof::commit`] |
+//! | 8 | Safety proof | [`linera_chain::manager::proof::safety`] |
+//! | 9 | Pacemaker and view changes | [`linera_chain::manager::proof::pacemaker`] |
+//! | 10 | Progress lemmas | [`proof::progress`] |
+//! | 11 | Liveness proof | [`proof::liveness`] |
+//!
+//! Sections 1–9 are also indexed, on their own, in [`linera_chain::spec`], which explains the
+//! conventions in full. The essentials:
+//!
+//! # How to read a statement
+//!
+//! Every claim is a public marker trait with no members, no implementors and no runtime
+//! footprint. Its **name is its identity**; its doc comment carries the statement and, unless it
+//! is a definition or an assumption, a proof. **Supertraits are proof dependencies**: a statement
+//! lists as supertraits exactly the earlier statements whose truth its proof consumes.
+//!
+//! ```text
+//! pub trait RoundProgress:
+//!     EventuallyCorrectLeader + LockRecovery + ProposalAccepted + …
+//! //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//! //  the statements this proof consumes
+//! ```
+//!
+//! That shape buys five checks with no bespoke tooling: unique identifiers (Rust name
+//! resolution), existence of every cited statement and every cited Rust item
+//! (`rustdoc::broken_intra_doc_links`, denied in CI), acyclicity of the dependency graph
+//! (`rustc`, `E0391`), and a rendered, clickable dependency list on each statement's page. There
+//! is deliberately no numbering: names are stable under insertion, and a stale citation is a
+//! build failure rather than a silently wrong cross reference.
+//!
+//! # The safety/liveness split
+//!
+//! The two arguments are deliberately disjoint in their assumptions, and the module layout
+//! reflects that:
+//!
+//! ```text
+//!  MaxByzantineWeight, UnforgeableSignatures,           EventualSynchrony, ClockAccuracy,
+//!  DurablePersistence, SerializedChainState,            CorrectValidatorAvailability,
+//!  EpochAgreement, DeterministicExecution               ActiveCorrectDriver, LeaderFairness,
+//!         |                                             RoundTimeoutGrowth, FullReachability
+//!         v                                                     |
+//!   quorum properties                                           |
+//!         |                                                     |
+//!         v                                                     v
+//!   voting rules  -->  rounds  -->  locking  -->  commit  -->  progress
+//!                                       |                        |
+//!                                       v                        v
+//!                                    SAFETY                   LIVENESS
+//!                              CommitAgreement            UnboundedProgress
+//! ```
+//!
+//! Everything in the right-hand column can fail — the network can partition forever, every client
+//! can go away, clocks can drift — without endangering [`CommitAgreement`]. Nothing in the
+//! left-hand column can fail without endangering it.
+//!
+//! # Known gaps
+//!
+//! The specification records, rather than papers over, the places where the implementation does
+//! not quite discharge what a proof wants. In rough order of significance:
+//!
+//! * [`FullReachability`] — the lock-recovery step wants the proposer to reach *every* correct
+//!   validator, while `synchronize_chain_state` guarantees only a quorum plus a grace period.
+//!   Affects liveness only.
+//! * [`FastRetryPreservesBlock`] — closing the gap between "same proposal" and "same block" for a
+//!   fast-round retry relies on [`DeterministicExecution`] rather than on a runtime check at the
+//!   retry. Affects safety, and is the one step that reaches outside consensus into execution.
+//! * [`ProposalGate`] — several safety-critical guards live at the call site in
+//!   `chain_worker::state` rather than inside the [`ChainManager`] methods they protect; in
+//!   particular [`create_final_vote`] would sign twice in a round if invoked directly.
+//! * [`SafetyStateRecovery`] — the correspondence between a
+//!   [`ManagerSafetySnapshot`] and the instance it is restored into rests on a height check at
+//!   the single call site, not on anything the type enforces.
+//! * [`VoteConstructionSites`] — an exhaustive-search argument over the five signing sites, which
+//!   a sixth would invalidate.
+//!
+//! [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
+//! [`UnboundedProgress`]: crate::proof::liveness::UnboundedProgress
+//! [`ChainTipState::next_block_height`]: linera_chain::ChainTipState::next_block_height
+//! [`MaxByzantineWeight`]: linera_chain::manager::proof::model::MaxByzantineWeight
+//! [`DeterministicExecution`]: linera_chain::manager::proof::model::DeterministicExecution
+//! [`FullReachability`]: crate::proof::assumptions::FullReachability
+//! [`FastRetryPreservesBlock`]: linera_chain::manager::proof::safety::FastRetryPreservesBlock
+//! [`ProposalGate`]: linera_chain::manager::proof::voting::ProposalGate
+//! [`VoteConstructionSites`]: linera_chain::manager::proof::voting::VoteConstructionSites
+//! [`SafetyStateRecovery`]: linera_chain::manager::proof::locking::SafetyStateRecovery
+//! [`ChainManager`]: linera_chain::manager::ChainManager
+//! [`create_final_vote`]: linera_chain::manager::ChainManager::create_final_vote
+//! [`ManagerSafetySnapshot`]: linera_chain::manager::ManagerSafetySnapshot
+//! [`proof::assumptions`]: crate::proof::assumptions
+//! [`proof::progress`]: crate::proof::progress
+//! [`proof::liveness`]: crate::proof::liveness

--- a/linera-core/src/spec.rs
+++ b/linera-core/src/spec.rs
@@ -13,6 +13,10 @@
 //! * **Safety** — [`CommitAgreement`]: for any chain and height, all valid confirmed block
 //!   certificates certify the same block. No synchrony, availability or fairness assumption is
 //!   used; only [`MaxByzantineWeight`] and the cryptographic and persistence assumptions.
+//! * **Accountability** — [`AccountableSafety`]: if agreement *does* fail, the two conflicting
+//!   certificates alone convict validators of weight at least `validity_threshold` — more than
+//!   [`MaxByzantineWeight`] permits — and no correct validator is ever convictable. It assumes
+//!   strictly less than safety does, since it must hold precisely where safety does not.
 //! * **Liveness** — [`UnboundedProgress`]: with an active correct client and after GST, every
 //!   correct reachable validator's [`ChainTipState::next_block_height`] grows without bound.
 //!
@@ -31,6 +35,7 @@
 //! | 6 | Locking and certificate invariants | [`linera_chain::manager::proof::rounds`], then [`linera_chain::manager::proof::locking`] |
 //! | 7 | Commit rule | [`linera_chain::manager::proof::commit`] |
 //! | 8 | Safety proof | [`linera_chain::manager::proof::safety`] |
+//! | 8b | Accountability | [`linera_chain::justification::proof`] |
 //! | 9 | Pacemaker and view changes | [`linera_chain::manager::proof::pacemaker`] |
 //! | 10 | Progress lemmas | [`proof::progress`] |
 //! | 11 | Liveness proof | [`proof::liveness`] |
@@ -106,6 +111,7 @@
 //!
 //! [`CommitAgreement`]: linera_chain::manager::proof::safety::CommitAgreement
 //! [`UnboundedProgress`]: crate::proof::liveness::UnboundedProgress
+//! [`AccountableSafety`]: linera_chain::justification::proof::AccountableSafety
 //! [`ChainTipState::next_block_height`]: linera_chain::ChainTipState::next_block_height
 //! [`MaxByzantineWeight`]: linera_chain::manager::proof::model::MaxByzantineWeight
 //! [`DeterministicExecution`]: linera_chain::manager::proof::model::DeterministicExecution


### PR DESCRIPTION
## Motivation

The microchain consensus protocol had no written correctness argument. The `linera_chain::manager` module documentation sketched safety and liveness in prose, but nothing tied the claims to the code: which guard establishes which property, which methods may mutate a safety-critical field, and what exactly a deployment has to assume. That makes the protocol hard to review, and makes it easy for a refactor to silently invalidate an argument nobody had written down.

## Proposal

A correctness specification for the protocol, embedded as rustdoc next to the code it describes, with proofs of safety, accountability and liveness.

**Statements are marker traits, not prose headings.** rustdoc validates paths but not `#fragment`s, so a numbered heading rots silently when it is renamed. Every claim here is instead a public marker trait with no members, no implementors and no runtime footprint; its name is its identity and its doc comment carries the statement and its proof. **Supertraits are proof dependencies** — a statement lists exactly the earlier statements whose truth its proof consumes.

That shape buys five checks with no bespoke tooling:

| property | checked by |
|---|---|
| statement identifiers are unique | Rust name resolution |
| every cited statement exists | `rustdoc::broken_intra_doc_links`, denied in CI |
| every cited Rust item exists | the same lint — a renamed field or method breaks the doc build |
| the dependency graph is acyclic | `rustc` (`E0391`, cycle in supertraits) |
| dependencies are visible to a reader | rustdoc renders each supertrait as a link |

There is deliberately no numbering: names are stable under insertion, and a stale citation is a build failure rather than a silently wrong cross-reference.

96 statements across 13 modules, placed next to the code they describe:

| crate | modules |
|---|---|
| `linera_chain::data_types::proof` | `objects`, `quorum` |
| `linera_chain::manager::proof` | `model`, `voting`, `rounds`, `locking`, `commit`, `safety`, `pacemaker` |
| `linera_chain::justification::proof` | accountability: soundness, completeness, scope |
| `linera_core::proof` | `assumptions`, `progress`, `liveness` |

`linera_chain::spec` and `linera_core::spec` give the reading order (system model → assumptions → objects → quorums → voting → locking → commit rule → safety → accountability → pacemaker → progress → liveness); the latter is the complete index across both crates.

The three headline results:

- **`safety::CommitAgreement`** — for any chain and height, all valid `ConfirmedBlockCertificate`s certify the same block. It uses no synchrony, availability or fairness assumption. The substantial step is `safety::LockPreservation`, a strong induction over rounds, hinging on `safety::UnlockingJustification`: `check_proposed_block`'s confirmed-vote guard forces a replacement certificate *strictly above* the validator's own confirmation, which is what lets the induction descend.
- **`justification::proof::AccountableSafety`** — if agreement *does* fail, the two conflicting certificates alone convict validators of weight at least `validity_threshold` (more than the fault bound permits), and no correct validator is ever convictable. Both halves deliberately avoid `MaxByzantineWeight`: soundness rests only on `UnforgeableSignatures`, completeness only on `quorum::Intersection`. Accountability therefore sits on a *strictly weaker* assumption base than the theorem it backstops, which is what makes it meaningful in the regime where safety has already failed.
- **`liveness::UnboundedProgress`** — `ChainTipState::next_block_height` grows without bound at every correct reachable validator.

Liveness lives in `linera-core` because that is where it is discharged: a Linera validator never proposes a block and never advances a round unprompted, so `assumptions::ActiveCorrectDriver` is an assumption about a running `ChainClient`, not a lemma. The two assumption sets are disjoint, and `spec` shows the split explicitly — everything liveness adds can fail without endangering safety.

**Gaps recorded rather than papered over.** Where the implementation does not quite discharge what a proof wants, the statement says so in a "residual obligation" or "where this is fragile" paragraph, and `linera_core::spec` collects them:

- `assumptions::FullReachability` (liveness) — `progress::LockRecovery` needs the proposer to reach *every* correct validator, but `synchronize_chain_state` aggregates through `communicate_with_quorum`, which stops at a quorum plus a `0.2` grace period. A correct validator holding the highest lock can be missed, and can be exactly the weight a quorum was short. Compounding it, `HasIncompatibleConfirmedVote` does not trigger the `LocalNodeLagging` pull that `WrongRound` does, so the rejecting validator is never targeted; the fallback path is already marked `TODO(#6453)` as untested.
- `safety::FastRetryPreservesBlock` (safety) — `matches_proposed_block` compares only the `ProposedBlock`, so the fast-retry unlock branch admits a different `BlockExecutionOutcome`. Closing it relies on `model::DeterministicExecution`: `FastBlockUsingOracles` is checked when the *proposal's* round is fast, not when a fast block is retried. This is the one safety step that reaches outside consensus into execution.
- `voting::ProposalGate` — several safety-critical guards live at the call sites in `chain_worker::state` rather than in the `ChainManager` methods they protect. In particular `create_final_vote` re-checks only `current_round`, and would sign twice in a round if invoked directly.
- `locking::SafetyStateRecovery` — `ManagerSafetySnapshot` records no height of its own; the snapshot/instance correspondence rests entirely on the caller's `new_tip_height == tip_height` guard.
- `pacemaker::RoundsWithoutTimeout` — with the default `TimeoutConfig`, `fast_round_duration` is `None`, so the fast round never times out and a super owner issuing two conflicting fast proposals wedges the height permanently. `assumptions::RoundTimeoutGrowth` likewise fails outright if `timeout_increment` is zero.
- `justification::proof::AccountabilityScope` — **incorrect block execution is not attributable, and its effects are not confined to one chain**. Nothing in `EquivocationProof` relates a block's `ProposedBlock` to its `BlockExecutionOutcome`, so a validator voting for a single well-justified block with a fabricated outcome leaves no proof. The outcome is eight separately committed components (`BlockHeader` carries `state_hash`, `messages_hash`, `events_hash`, `blobs_hash`, …) and they differ sharply in reach: a wrong `state_hash` stays local, but wrong `messages`/`events` are consumed by *other* chains whose resulting blocks are themselves properly certified and evidence of nobody's fault. Only `blobs` are self-verifying, being content-addressed. What exists is *local detection* — `execute_contiguous_block` re-executes and rejects on mismatch — which is unilateral and has three holes: `oracle_responses` are replayed rather than re-derived (so a fabricated oracle answer reproduces the same state hash), `preprocess_certified_block` never executes and takes `messages`/`events` from the certificate, and the `execution_state_cache` hit path skips re-execution. The properties that do protect validity are the new `commit::CertifiedBlockWasExecuted` and `commit::IncomingBundlesAreSelfDerived`, and unlike the accountability results both need `MaxByzantineWeight` — validity degrades above the fault bound with no forensic residue, whereas agreement degrades with one.
- `commit::IncomingBundlesAreSelfDerived` — a correct validator refuses to *vote* on a block consuming a cross-chain bundle it has not itself received (`must_be_present = true` in `try_handle_block_proposal`), and requires exact equality with what its inbox holds. But whether that inbox content is self-derived depends on whether the validator *executed* the sending chain or only *preprocessed* it. So cross-chain integrity degrades with how much of the chain graph each validator executes — a deployment property, not a protocol one, and one that was not previously written down anywhere.
- `justification::proof::MisbehaviourProof` — `EquivocationProof::check` judges signatures against whatever committee the auditor supplies, and the epoch is not carried in the proof, so adjudicating against the wrong epoch's committee could convict a correct validator.

No behavioural change: the only non-documentation edits are the `pub mod` declarations, and the `data_types` module doc moving from `lib.rs` into the module file.

## Test Plan

Documentation-only, so the checks are that it builds, that every citation resolves, and that the dependency graph is acyclic:

- `cargo doc --locked --all-features --no-deps` with `RUSTDOCFLAGS="-A rustdoc::redundant_explicit_links -D warnings"` — clean across the workspace. This is what validates every `[...]` citation, both within and across crates.
- `cargo check -p linera-chain -p linera-core` — clean; supertrait cycles would fail here with `E0391`.
- `cargo clippy -p linera-chain -p linera-core --all-targets` — clean.
- `cargo +nightly fmt --all -- --check` — clean.
- `cargo test -p linera-chain --lib` — 79 passed, 0 failed.
- The dependency DAG was extracted from `rustdoc --output-format json` and inspected: 96 statements, 210 edges, 38 leaves (assumptions and definitions), no cycles.

Two design assumptions were checked empirically in a scratch two-crate workspace before committing to them: that a supertrait cycle is an `E0391` compile error, and that `#[cfg(doc)]` items are *not* visible to a dependent crate's rustdoc (which is why the proof modules are always compiled rather than doc-only — otherwise `linera_core`'s liveness proof could not cite `linera_chain`'s safety theorem).

The proofs themselves are prose: precise and cross-referenced, but not machine-checked. What the build enforces is that every cited statement and every cited Rust item exists, and that the dependencies form a DAG.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- `TODO(#6453)` is cited by `assumptions::FullReachability` as the untested fallback path.
