### PR TITLE
docker: fix the dead Block Execution Latency panel in the dev dashboard

### DIFF
--- a/docker/dashboards/linera-general.json
+++ b/docker/dashboards/linera-general.json
@@ -925,11 +925,11 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": false,
-          "expr": "rate(block_execution_latency_bucket{service=\"shards\"}[$__rate_interval])",
+          "expr": "rate(linera_block_execution_latency_bucket{job=\"shards\"}[$__rate_interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
-          "legendFormat": "{{pod}} - {{le}}",
+          "legendFormat": "{{instance}} - {{le}}",
           "range": true,
           "refId": "A",
           "useBackend": false


### PR DESCRIPTION
## Motivation

The "Block Execution Latency" panel in the local docker-compose dev dashboard has never rendered anything. Its query references a metric name and two labels that do not exist:

```
rate(block_execution_latency_bucket{service="shards"}[$__rate_interval])
legendFormat: {{pod}} - {{le}}
```

Three separate defects:

1. **Missing `linera_` prefix.** Every metric is registered through `linera_base::prometheus_util`, which stamps the `linera` namespace on all of them (`LINERA_NAMESPACE`), so the exported name is `linera_block_execution_latency_bucket`. The bare name matches nothing.
2. **`service` label does not exist.** `docker/prometheus.yml` scrapes via `job_name: 'shards'`, which produces `job="shards"`. There is no relabeling that creates a `service` label. This panel is the only one in the dashboard using `service=`; no panel uses `job=`.
3. **`pod` label does not exist.** The docker scrape uses `static_configs`, so the target labels are `job` and `instance`. `{{pod}}` renders empty. (The `{{pod}}` in the *Loki* panel is a different label source and is left alone.)

The dashboard is live dev-facing config: `docker/docker-compose.yml` mounts `./dashboards` into Grafana.

## Proposal

Fix all three in the one panel:

```
rate(linera_block_execution_latency_bucket{job="shards"}[$__rate_interval])
legendFormat: {{instance}} - {{le}}
```

The `job="shards"` filter preserves the original intent (block execution happens on the shards, not the proxy) using the label name the scrape config actually produces. The panel's shape (per-bucket rate) is kept as-is; converting it to a `histogram_quantile` panel matching the sibling p50/p90/p99 latency panels would be a reasonable follow-up, but this PR is a bug fix, not a redesign.

## Test Plan

- Verified the namespace: `linera_base::prometheus_util` applies `LINERA_NAMESPACE = "linera"` to every registered metric, and the metric exists in Mimir as `linera_block_execution_latency_bucket`.
- Verified the labels against `docker/prometheus.yml`: `job_name: 'shards'` with `static_configs`, no `relabel_configs` — so `job` and `instance` are the available target labels, and neither `service` nor `pod` exists.
- Swept every Prometheus target in every `docker/**/*.json` dashboard for other prefix-less linera metrics: this was the only instance.
- `python3 -m json.tool` passes on the modified dashboard.

## Release Plan

- Nothing to do / These changes follow the usual release cycle. (Local dev dashboard only; no protocol, storage, or production-monitoring change.)

## Links

- Found while self-reviewing #6471.
