### PR TITLE
[testnet] Label block-execution metrics by phase (#6471)

### DIFF
--- a/linera-chain/src/block_tracker.rs
+++ b/linera-chain/src/block_tracker.rs
@@ -23,7 +23,7 @@ use tracing::instrument;
 #[cfg(with_metrics)]
 use crate::chain::metrics;
 use crate::{
-    chain::EMPTY_BLOCK_SIZE,
+    chain::{BlockExecutionPhase, EMPTY_BLOCK_SIZE},
     data_types::{
         IncomingBundle, MessageAction, OperationResult, PostedMessage, ProposedBlock, Transaction,
     },
@@ -35,6 +35,10 @@ use crate::{
 #[derive(Debug)]
 pub struct BlockExecutionTracker<'resources, 'blobs> {
     chain_id: ChainId,
+    /// The protocol phase this block is executed in (staging a proposal, validating a
+    /// received proposal, or executing a confirmed certificate). Recorded on execution
+    /// spans and used to label execution metrics.
+    phase: BlockExecutionPhase,
     block_height: BlockHeight,
     timestamp: Timestamp,
     authenticated_signer: Option<AccountOwner>,
@@ -72,6 +76,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         local_time: Timestamp,
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         proposal: &ProposedBlock,
+        phase: BlockExecutionPhase,
     ) -> Result<Self, ChainError> {
         resource_controller
             .track_block_size(EMPTY_BLOCK_SIZE)
@@ -79,6 +84,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
 
         Ok(Self {
             chain_id: proposal.chain_id,
+            phase,
             block_height: proposal.height,
             timestamp: proposal.timestamp,
             authenticated_signer: proposal.authenticated_signer,
@@ -101,6 +107,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id,
         block_height = %self.block_height,
+        phase = self.phase.as_str(),
         transaction_index = %self.transaction_index,
         transaction_type = %transaction.as_ref(),
     ))]
@@ -140,7 +147,10 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
                     .track_block_size_of(&operation)
                     .with_execution_context(chain_execution_context)?;
                 #[cfg(with_metrics)]
-                let _operation_latency = metrics::OPERATION_EXECUTION_LATENCY.measure_latency_us();
+                let operation_latency =
+                    metrics::OPERATION_EXECUTION_LATENCY.with_label_values(&[self.phase.as_str()]);
+                #[cfg(with_metrics)]
+                let _operation_latency = operation_latency.measure_latency_us();
                 let context = OperationContext {
                     chain_id: self.chain_id,
                     height: self.block_height,
@@ -202,7 +212,10 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         C::Extra: ExecutionRuntimeContext,
     {
         #[cfg(with_metrics)]
-        let _message_latency = metrics::MESSAGE_EXECUTION_LATENCY.measure_latency_us();
+        let message_latency =
+            metrics::MESSAGE_EXECUTION_LATENCY.with_label_values(&[self.phase.as_str()]);
+        #[cfg(with_metrics)]
+        let _message_latency = message_latency.measure_latency_us();
         let context = MessageContext {
             chain_id: self.chain_id,
             origin: incoming_bundle.origin,
@@ -467,7 +480,7 @@ impl<'resources, 'blobs> BlockExecutionTracker<'resources, 'blobs> {
         assert_eq!(self.blobs.len(), expected_outcomes_count);
 
         #[cfg(with_metrics)]
-        crate::chain::metrics::track_block_metrics(&self.resource_controller.tracker);
+        crate::chain::metrics::track_block_metrics(&self.resource_controller.tracker, self.phase);
 
         let resource_tracker = self.resource_controller.tracker;
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -59,6 +59,36 @@ mod chain_tests;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::MeasureLatency;
 
+/// The protocol phase a block is executed in. Recorded as the `phase` label on the
+/// block-execution metrics so the three distinct paths — staging a proposal, validating a
+/// received proposal, and committing a confirmed certificate — are separate time series in
+/// Prometheus.
+///
+/// Every path that executes a block must name its phase explicitly: there is no `Default`,
+/// so a new caller cannot compile without choosing one, and no execution can land in an
+/// unlabeled or silently-mislabeled bucket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BlockExecutionPhase {
+    /// A block proposer staging (building) its own block (`stage_block_execution`).
+    StageProposal,
+    /// A validator validating a received block proposal (`handle_block_proposal`).
+    HandleProposal,
+    /// A validator executing a confirmed certificate before committing it
+    /// (`process_confirmed_block`).
+    HandleConfirmed,
+}
+
+impl BlockExecutionPhase {
+    /// The Prometheus `phase` label value for this execution phase.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BlockExecutionPhase::StageProposal => "stage_proposal",
+            BlockExecutionPhase::HandleProposal => "handle_proposal",
+            BlockExecutionPhase::HandleConfirmed => "handle_confirmed",
+        }
+    }
+}
+
 #[cfg(with_metrics)]
 pub(crate) mod metrics {
     use std::sync::LazyLock;
@@ -70,14 +100,18 @@ pub(crate) mod metrics {
     use prometheus::{HistogramVec, IntCounterVec};
 
     pub static NUM_BLOCKS_EXECUTED: LazyLock<IntCounterVec> = LazyLock::new(|| {
-        register_int_counter_vec("num_blocks_executed", "Number of blocks executed", &[])
+        register_int_counter_vec(
+            "num_blocks_executed",
+            "Number of blocks executed",
+            &["phase"],
+        )
     });
 
     pub static BLOCK_EXECUTION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
         register_histogram_vec(
             "block_execution_latency",
             "Block execution latency",
-            &[],
+            &["phase"],
             exponential_bucket_interval(50.0_f64, 10_000_000.0),
         )
     });
@@ -87,7 +121,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "message_execution_latency",
             "Message execution latency",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1_f64, 1_000_000.0),
         )
     });
@@ -96,7 +130,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "operation_execution_latency",
             "Operation execution latency",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1_f64, 1_000_000.0),
         )
     });
@@ -105,7 +139,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "wasm_fuel_used_per_block",
             "Wasm fuel used per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
@@ -114,7 +148,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "evm_fuel_used_per_block",
             "EVM fuel used per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(10.0, 100_000_000.0),
         )
     });
@@ -123,7 +157,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "vm_num_reads_per_block",
             "VM number of reads per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1, 100.0),
         )
     });
@@ -132,7 +166,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "vm_bytes_read_per_block",
             "VM number of bytes read per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1, 10_000_000.0),
         )
     });
@@ -141,7 +175,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "vm_bytes_written_per_block",
             "VM number of bytes written per block",
-            &[],
+            &["phase"],
             exponential_bucket_interval(0.1, 10_000_000.0),
         )
     });
@@ -150,7 +184,7 @@ pub(crate) mod metrics {
         register_histogram_vec(
             "state_hash_computation_latency",
             "Time to recompute the state hash, in microseconds",
-            &[],
+            &["phase"],
             exponential_bucket_interval(1.0, 2_000_000.0),
         )
     });
@@ -173,23 +207,27 @@ pub(crate) mod metrics {
         )
     });
 
-    /// Tracks block execution metrics in Prometheus.
-    pub(crate) fn track_block_metrics(tracker: &ResourceTracker) {
-        NUM_BLOCKS_EXECUTED.with_label_values(&[]).inc();
+    /// Tracks block execution metrics in Prometheus, labeled by the execution `phase`.
+    pub(crate) fn track_block_metrics(
+        tracker: &ResourceTracker,
+        phase: super::BlockExecutionPhase,
+    ) {
+        let phase = &[phase.as_str()];
+        NUM_BLOCKS_EXECUTED.with_label_values(phase).inc();
         WASM_FUEL_USED_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.wasm_fuel as f64);
         EVM_FUEL_USED_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.evm_fuel as f64);
         VM_NUM_READS_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.read_operations as f64);
         VM_BYTES_READ_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.bytes_read as f64);
         VM_BYTES_WRITTEN_PER_BLOCK
-            .with_label_values(&[])
+            .with_label_values(phase)
             .observe(tracker.bytes_written as f64);
     }
 }
@@ -817,6 +855,7 @@ where
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         exec_policy: BundleExecutionPolicy,
+        phase: BlockExecutionPhase,
     ) -> Result<(BlockExecutionOutcome, ResourceTracker, HashSet<ChainId>), ChainError> {
         // AutoRetry is incompatible with replaying oracle responses because discarding or
         // rejecting bundles would change which transactions execute.
@@ -828,7 +867,10 @@ where
         }
 
         #[cfg(with_metrics)]
-        let _execution_latency = metrics::BLOCK_EXECUTION_LATENCY.measure_latency_us();
+        let block_execution_latency =
+            metrics::BLOCK_EXECUTION_LATENCY.with_label_values(&[phase.as_str()]);
+        #[cfg(with_metrics)]
+        let _execution_latency = block_execution_latency.measure_latency_us();
         chain.system.timestamp.set(block.timestamp);
 
         let committee_policy = chain
@@ -864,6 +906,7 @@ where
             local_time,
             replaying_oracle_responses,
             block,
+            phase,
         )?;
 
         // Extract failure-policy parameters from exec_policy.
@@ -1053,7 +1096,10 @@ where
 
         let state_hash = {
             #[cfg(with_metrics)]
-            let _hash_latency = metrics::STATE_HASH_COMPUTATION_LATENCY.measure_latency_us();
+            let state_hash_latency =
+                metrics::STATE_HASH_COMPUTATION_LATENCY.with_label_values(&[phase.as_str()]);
+            #[cfg(with_metrics)]
+            let _hash_latency = state_hash_latency.measure_latency_us();
             chain.crypto_hash_mut().await?
         };
 
@@ -1105,6 +1151,7 @@ where
     /// - After `max_failures` failed bundles, all remaining message bundles are discarded.
     ///
     /// The block may be modified to reflect the actual executed transactions.
+    #[expect(clippy::too_many_arguments)]
     #[instrument(skip_all, fields(
         chain_id = %self.chain_id(),
         block_height = %block.height
@@ -1117,6 +1164,7 @@ where
         published_blobs: &[Blob],
         replaying_oracle_responses: Option<Vec<Vec<OracleResponse>>>,
         policy: BundleExecutionPolicy,
+        phase: BlockExecutionPhase,
     ) -> Result<
         (
             ProposedBlock,
@@ -1184,6 +1232,7 @@ where
             published_blobs,
             replaying_oracle_responses,
             policy,
+            phase,
         )
         .await
         .map(|(outcome, tracker, never_reject_origins)| {

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -25,7 +25,7 @@ mod pending_blobs;
 #[cfg(with_testing)]
 pub mod test;
 
-pub use chain::{ChainIdSet, ChainStateView, ChainTipState};
+pub use chain::{BlockExecutionPhase, ChainIdSet, ChainStateView, ChainTipState};
 use data_types::{MessageBundle, PostedMessage};
 use linera_base::{
     bcs,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -45,7 +45,7 @@ use crate::{
         PostedMessage, ProposedBlock,
     },
     test::{make_child_block, make_first_block, BlockTestExt, HttpServer},
-    ChainError, ChainExecutionContext, ChainStateView,
+    BlockExecutionPhase, ChainError, ChainExecutionContext, ChainStateView,
 };
 
 impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
@@ -76,6 +76,7 @@ impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>> {
                 published_blobs,
                 None,
                 BundleExecutionPolicy::committed(),
+                BlockExecutionPhase::StageProposal,
             )
             .await?;
         Ok((block, outcome, tracker))

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -32,8 +32,8 @@ use linera_chain::{
         Block, ConfirmedBlock, ConfirmedBlockCertificate, TimeoutCertificate,
         ValidatedBlockCertificate,
     },
-    ChainError, ChainExecutionContext, ChainIdSet, ChainStateView, ChainTipState,
-    ExecutionResultExt as _,
+    BlockExecutionPhase, ChainError, ChainExecutionContext, ChainIdSet, ChainStateView,
+    ChainTipState, ExecutionResultExt as _,
 };
 use linera_execution::{
     system::EventSubscriptions, ExecutionRuntimeContext as _, ExecutionStateView, Query,
@@ -1085,6 +1085,7 @@ where
                     &published_blobs,
                     oracle_responses,
                     BundleExecutionPolicy::committed(),
+                    BlockExecutionPhase::HandleConfirmed,
                 )
                 .await?;
             // We should always agree on the messages and state hash.
@@ -2085,7 +2086,15 @@ where
             .remove_bundles_from_inboxes(block.timestamp, true, block.incoming_bundles())
             .await?;
         let (executed_block, resource_tracker, never_reject_origins) =
-            Box::pin(self.execute_block(block, local_time, round, published_blobs, policy)).await?;
+            Box::pin(self.execute_block(
+                block,
+                local_time,
+                round,
+                published_blobs,
+                policy,
+                BlockExecutionPhase::StageProposal,
+            ))
+            .await?;
 
         // No need to sign: only used internally.
         let info = ChainInfo::from_chain_view(&self.chain).await?;
@@ -2291,6 +2300,7 @@ where
                 round.multi_leader(),
                 &published_blobs,
                 BundleExecutionPolicy::committed(),
+                BlockExecutionPhase::HandleProposal,
             ))
             .await?;
             executed_block
@@ -2465,12 +2475,19 @@ where
         round: Option<u32>,
         published_blobs: &[Blob],
         policy: BundleExecutionPolicy,
+        phase: BlockExecutionPhase,
     ) -> Result<(Block, ResourceTracker, HashSet<ChainId>), WorkerError> {
-        let (proposed_block, outcome, resource_tracker, never_reject_origins) = Box::pin(
-            self.chain
-                .execute_block(block, local_time, round, published_blobs, None, policy),
-        )
-        .await?;
+        let (proposed_block, outcome, resource_tracker, never_reject_origins) =
+            Box::pin(self.chain.execute_block(
+                block,
+                local_time,
+                round,
+                published_blobs,
+                None,
+                policy,
+                phase,
+            ))
+            .await?;
         let executed_block = Block::new(proposed_block, outcome);
         let block_hash = CryptoHash::new(&executed_block);
         if let Some(cache) = &self.execution_state_cache {


### PR DESCRIPTION
## Motivation

Backport of #6471 to `testnet_conway`.

The three distinct block-execution paths — staging a proposal, validating a received proposal, and executing a confirmed certificate — all record into the same Prometheus time series, so a latency or resource sample gives no way to tell which path produced it.

This is not currently observable on the testnet fleet: validators deploy from `testnet_conway`, and #6471 landed on `main` only. Verified against central Mimir — `linera_block_execution_latency` exists on all three clusters (infra, OVH prod, testnet-conway) and **none of them carry a `phase` label**, because no deployed image contains the change.

## Proposal

Cherry-pick of `9bb3dd3f8b6` (#6471). Adds a `phase` label to the ten execution metrics, with values `stage_proposal` / `handle_proposal` / `handle_confirmed`:

`block_execution_latency`, `num_blocks_executed`, `wasm_fuel_used_per_block`, `evm_fuel_used_per_block`, `vm_num_reads_per_block`, `vm_bytes_read_per_block`, `vm_bytes_written_per_block`, `message_execution_latency`, `operation_execution_latency`, `state_hash_computation_latency`.

A `BlockExecutionPhase` enum (no `Default`, exactly three variants) is threaded as a **required** argument, so a new execution path cannot compile without naming a phase.

Existing flat queries keep working (they aggregate over `phase`); new dashboards can split per phase, e.g.:

```
histogram_quantile(0.99, sum by (le, phase) (rate(linera_block_execution_latency_bucket[5m])))
```

### Conflict resolution (5 conflicts — conway divergences preserved)

This is not a clean cherry-pick. Each resolution kept conway's state and added only the label:

- **`message_execution_latency` / `operation_execution_latency` bucket ceilings**: conway uses `exponential_bucket_interval(0.1, 1_000_000.0)`; main uses `50_000.0`. Kept conway's widened ceilings — taking the incoming side would have silently reverted them.
- **`StreamCounts`**: does not exist on conway. Omitted from both the `linera-chain` re-export and the `linera-core` import (main's version exports it).
- **`execute_block_inner` checkpoint params** (`checkpoint_origin_cursors`, `checkpoint_inbox_cursors`, `checkpoint_outbox_block_hashes`): do not exist on conway. Added only `phase`.
- **`chain.system.timestamp.set(block.timestamp)`**: conway still sets the timestamp here (main moved it into `progress` in #6551). Preserved, ungated, after the two `#[cfg(with_metrics)]` metric bindings.

## Test Plan

- `cargo clippy --locked --all-targets --all-features --workspace --exclude linera-web -- -D warnings` (the exact `rust.yml:546` command) — exit 0, no warnings.
- `cargo clippy -p linera-core -p linera-chain --features "metrics test" --all-targets` — 0 warnings.
- `cargo build -p linera-chain -p linera-core` (default features, metrics off) — clean.
- `cargo test -p linera-chain --features "metrics test" --lib` — 51 passed.
- `cargo test -p linera-core --features "metrics test" --lib -- test_handle_block_proposal test_handle_certificate` — 22 passed.
- nightly fmt clean.
- Verified the port explicitly: all 10 metrics carry `&["phase"]`, all three phases wired at their call sites, conway's `1_000_000.0` ceilings intact, `StreamCounts` absent.

Prometheus panics at runtime on a label-count mismatch, so the suites passing under `--features metrics` is direct evidence the labels are wired consistently across all three paths.

## Release Plan

- These changes should be deployed with the next `testnet_conway` validator image so the `phase` label becomes available on the testnet fleet.

## Links

- Backport of #6471 (merged to `main`).
