### PR TITLE
faucet: count daily-claim refusals under their own result labels

### DIFF
--- a/linera-faucet/server/src/lib.rs
+++ b/linera-faucet/server/src/lib.rs
@@ -166,6 +166,29 @@ mod metrics {
     });
 }
 
+/// Refusal messages returned by the claim paths. Shared as constants because the
+/// front-door checks in `do_claim`/`do_daily_claim` and the batch-time re-validation
+/// in `validate_request` both produce them, and the metrics side classifies a
+/// refusal by exact message (see `refusal_label`) so each request is counted
+/// exactly once, under the right `result` label, at the point its response is
+/// received.
+const DAILY_DISABLED_MSG: &str = "Daily claims are not enabled on this faucet";
+const DAILY_NO_CHAIN_MSG: &str = "You must claim a chain before making daily claims";
+const DAILY_LIMIT_MSG: &str = "You have already claimed tokens for this period";
+const DUPLICATE_CHAIN_MSG: &str = "This user already has a chain";
+
+/// Maps a refusal error to its `faucet_claim_requests_total` result label, or
+/// `None` if the error is a genuine failure rather than a refusal.
+#[cfg(with_metrics)]
+fn refusal_label(error: &Error) -> Option<&'static str> {
+    match error.message.as_str() {
+        DAILY_NO_CHAIN_MSG => Some("daily_no_chain"),
+        DAILY_LIMIT_MSG => Some("daily_limit"),
+        DUPLICATE_CHAIN_MSG => Some("duplicate"),
+        _ => None,
+    }
+}
+
 /// Returns an HTML response constructing the GraphiQL web page for the given URI.
 pub(crate) async fn graphiql(uri: axum::http::Uri) -> impl axum::response::IntoResponse {
     axum::response::Html(
@@ -477,9 +500,13 @@ where
 
         #[cfg(with_metrics)]
         {
+            // Refusals detected during batch validation (e.g. a duplicate that
+            // raced past the front-door check) arrive here as errors; classify
+            // them by message so they are counted once, under their own label.
             let label = match &response {
                 PendingResponse::Initial(Ok(_)) => "success",
-                _ => "error",
+                PendingResponse::Initial(Err(error)) => refusal_label(error).unwrap_or("error"),
+                PendingResponse::Daily(_) => "error",
             };
             metrics::CLAIM_REQUESTS_TOTAL
                 .with_label_values(&[label])
@@ -493,16 +520,27 @@ where
     }
 
     async fn do_daily_claim(&self, owner: AccountOwner) -> Result<ClaimOutcome, Error> {
+        // Each early return below is a *refusal*, not a failure, and must be counted
+        // under its own `result` label: these paths return before the queue round-trip
+        // that increments `CLAIM_REQUESTS_TOTAL`, so without the explicit counters
+        // refusals are invisible in metrics (they only appear as unlabelled
+        // `claim_latency_ms{result="error"}` observations).
         if self.daily_claim_amount == Amount::ZERO {
-            return Err(Error::new("Daily claims are not enabled on this faucet"));
+            #[cfg(with_metrics)]
+            metrics::CLAIM_REQUESTS_TOTAL
+                .with_label_values(&["daily_disabled"])
+                .inc();
+            return Err(Error::new(DAILY_DISABLED_MSG));
         }
 
         // The user must have done the initial claim first.
-        let initial_claim = self
-            .faucet_storage
-            .initial_claim(&owner)
-            .await?
-            .ok_or_else(|| Error::new("You must claim a chain before making daily claims"))?;
+        let Some(initial_claim) = self.faucet_storage.initial_claim(&owner).await? else {
+            #[cfg(with_metrics)]
+            metrics::CLAIM_REQUESTS_TOTAL
+                .with_label_values(&["daily_no_chain"])
+                .inc();
+            return Err(Error::new(DAILY_NO_CHAIN_MSG));
+        };
 
         let now = self.storage.clock().current_time();
         let period = current_daily_period(initial_claim.timestamp.micros(), now.micros());
@@ -513,9 +551,11 @@ where
             .unwrap_or(0);
 
         if period <= last_period {
-            return Err(Error::new(
-                "You have already claimed tokens for this period",
-            ));
+            #[cfg(with_metrics)]
+            metrics::CLAIM_REQUESTS_TOTAL
+                .with_label_values(&["daily_limit"])
+                .inc();
+            return Err(Error::new(DAILY_LIMIT_MSG));
         }
 
         self.enqueue_daily_request(
@@ -566,9 +606,13 @@ where
 
         #[cfg(with_metrics)]
         {
+            // Daily refusals that raced past the front-door check are refused
+            // during batch validation and arrive here; classify them by message
+            // so they land under daily_limit/daily_no_chain, not "error".
             let label = match &response {
                 PendingResponse::Daily(Ok(_)) => "success",
-                _ => "error",
+                PendingResponse::Daily(Err(error)) => refusal_label(error).unwrap_or("error"),
+                PendingResponse::Initial(_) => "error",
             };
             metrics::CLAIM_REQUESTS_TOTAL
                 .with_label_values(&[label])
@@ -759,9 +803,7 @@ where
             let initial_claim = match self.faucet_storage.initial_claim(&request.owner).await {
                 Ok(Some(record)) => record,
                 Ok(None) => {
-                    return Err(Error::new(
-                        "You must claim a chain before making daily claims",
-                    ));
+                    return Err(Error::new(DAILY_NO_CHAIN_MSG));
                 }
                 Err(err) => {
                     tracing::error!("Database error: {err}");
@@ -779,19 +821,16 @@ where
                 .unwrap_or(0);
 
             if period <= last_period {
-                return Err(Error::new(
-                    "You have already claimed tokens for this period",
-                ));
+                return Err(Error::new(DAILY_LIMIT_MSG));
             }
         } else {
             match self.faucet_storage.get_chain_id(&request.owner).await {
                 Ok(None) => {}
                 Ok(Some(_)) => {
-                    #[cfg(with_metrics)]
-                    metrics::CLAIM_REQUESTS_TOTAL
-                        .with_label_values(&["duplicate"])
-                        .inc();
-                    return Err(Error::new("This user already has a chain"));
+                    // Not counted here: the requester side classifies this
+                    // refusal by message and counts it once as "duplicate"
+                    // (counting at both sites double-counted the request).
+                    return Err(Error::new(DUPLICATE_CHAIN_MSG));
                 }
                 Err(err) => {
                     tracing::error!("Database error: {err}");


### PR DESCRIPTION
## Motivation

During the 2026-08-10 native-token exhaustion incident on testnet-conway (users could no longer pay execution fees; fixed operationally by linera-infra#1692), the faucet's daily-cap refusals turned out to be invisible in metrics: `do_daily_claim` returns its three refusals **before** the queue round-trip that increments `faucet_claim_requests_total`, so ~12k refusals/day (measured over 14 days) appeared only as unlabelled `faucet_claim_latency_ms_count{result="error"}` observations — a histogram count with no reason, on no dashboard panel, alertable by nothing.

## Proposal

Count each pre-queue refusal in `faucet_claim_requests_total` under its own `result` label:

- `daily_limit` — already claimed this period (the operationally interesting one: its steady-state level is the "how many users live at the allowance ceiling" signal)
- `daily_no_chain` — daily claim without a prior initial claim
- `daily_disabled` — daily claims not enabled on this faucet

The refusal messages are lifted into shared constants, and the requester side (the single point that already counts success/error after the queue round-trip) classifies an error response by exact message via `refusal_label`. This makes the batch-time re-validation refusals land under the right label too — a request that races past the front-door check and is refused during batch validation counts as `daily_limit`/`daily_no_chain`/`duplicate` instead of `error`. It also fixes a pre-existing double count on the same metric: a batch-time duplicate used to increment `result="duplicate"` inside `validate_request` *and* `result="error"` on the requester side — one request, two increments; counting only at the requester side restores "one increment per request", which is what the metric's help string claims.

No user-visible behavior change: every path returns the same error message as before (the `ok_or_else` → `let..else` rewrite only makes room for the counter; the `?` on the storage lookup still propagates storage errors unchanged). The grafana "Claim Request Rate by Result" panel groups `by (result)` and picks the new labels up with no dashboard change.

## Test Plan

- `cargo check -p linera-faucet-server` (default features — `with_metrics` off) and `cargo clippy --locked --all-targets --all-features -p linera-faucet-server` + `--no-default-features` variant, clean.
- `cargo test --locked -p linera-faucet-server --all-features` — includes `test_daily_claim_flow`, which exercises all three refusal paths.
- CI.

## Release Plan

- These changes should be backported to the latest `testnet` branch (the deployed testnet-conway faucet builds from it; without the backport the counters don't reach production).

## Links

- linera-infra#1692 (operational fix), linera-infra#1695 (client-side alert on the incident signature)
