### PR TITLE
Document the fast way to read the specification locally

### DIFF
--- a/linera-spec/README.md
+++ b/linera-spec/README.md
@@ -2,16 +2,32 @@
 
 This crate contains no code. It is the entry point to the correctness specification of the
 Linera microchain consensus protocol: the reading order, the conventions, and the index of every
-numbered result.
+statement.
 
 The statements themselves live next to the code they describe, in `linera_chain::manager::proof`,
 `linera_chain::data_types::proof`, `linera_chain::justification::proof` and `linera_core::proof`.
 This crate exists so that a single index can link to all of them — it depends on both
 `linera-chain` and `linera-core`, which neither of those crates can do.
 
+## Reading it
+
+Without cloning the repository, at <https://docs.rs/linera-spec/latest/linera_spec/>.
+
+Locally, document the crates the specification links into and open the index:
+
 ```bash
-cargo doc -p linera-spec --open
+cargo doc --no-deps -p linera-spec -p linera-chain -p linera-core \
+                    -p linera-base -p linera-execution -p linera-views
+open target/doc/linera_spec/index.html   # xdg-open on Linux
 ```
 
-Published so that the specification is readable without cloning the repository, at
-<https://docs.rs/linera-spec/latest/linera_spec/>.
+A few seconds on a warm workspace. Two things to note if you shorten it:
+
+- `--open` picks one package when several are passed, and it is not `linera-spec`; open the file
+  directly instead.
+- Dropping `--no-deps` documents the whole dependency closure — several hundred crates — instead
+  of six.
+
+All six are needed for the links to resolve: the statement pages reference `linera_base` heavily
+(rounds, ownership, block heights, crypto types) and `linera_execution` for committee thresholds,
+and clicking through to `ChainManager` itself reaches `linera_views`.


### PR DESCRIPTION
## Motivation

The README added in #6676 tells you to read the specification with:

```bash
cargo doc -p linera-spec --open
```

That is the slow way. Without `--no-deps` it documents the crate's entire dependency closure — several hundred crates — when six suffice.

It also leaves two traps for anyone who tries to shorten it, both of which cost me a while to find:

- **`--open` picks one package when several are passed, and it is not `linera-spec`.** Verified: `cargo doc -p linera-spec -p linera-chain --no-deps --open` opens `linera_chain/index.html`.
- **The obvious crate list is incomplete.** Counting the actual cross-crate `href`s across every generated proof page: `linera_chain` 340, **`linera_base` 105**, `linera_core` 50, `linera_execution` 29. `linera_base` is second — rounds, ownership, block heights, crypto types — and none of those links appear on the index page itself, only on the statement pages where you actually read. So a list that looks right when you check the index still leaves 105 dead links one click in. `linera_views` is needed too, for the click-through from a statement to `ChainManager`.

## Proposal

Replace the one-liner with the fast recipe, and record why it is shaped the way it is so nobody re-derives it:

```bash
cargo doc --no-deps -p linera-spec -p linera-chain -p linera-core \
                    -p linera-base -p linera-execution -p linera-views
open target/doc/linera_spec/index.html   # xdg-open on Linux
```

Also leads with docs.rs, which is the answer for anyone who does not want to build at all.

While in the file: it still said "the index of every **numbered** result", left over from before the section numbers were dropped in #6676. Now "every statement".

## Test Plan

Documentation-only.

- On a cold worktree, the recipe takes **38s** and produces all six crates' docs; **4.2s** incrementally on a warm workspace, which is what the README claims.
- Verified the `--open` claim: `BROWSER=echo cargo doc --no-deps -p linera-spec -p linera-chain --open` prints `…/target/doc/linera_chain/index.html`.
- Verified the crate list is exactly what the pages need, by extracting `/linera_*/` path segments from every `href` under the four `proof` module trees plus the index.
- `cargo doc --no-deps -p linera-spec` with `RUSTDOCFLAGS="-A rustdoc::redundant_explicit_links -D warnings"`, `cargo +nightly fmt --all -- --check` and `cargo machete` — all clean.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6676 — introduced the crate and this README.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
