### PR TITLE
Separate the pointwise and existential certificate-signer lemmas

### DIFF
--- a/linera-chain/src/data_types/proof/quorum.rs
+++ b/linera-chain/src/data_types/proof/quorum.rs
@@ -12,7 +12,8 @@
 //!
 //! These are the only results in the specification that reason about weights arithmetically.
 //! Everything above this module consumes them through [`CorrectValidatorInIntersection`],
-//! [`CertificateCarriesCorrectVote`] and [`CorrectValidatorsFormQuorum`].
+//! [`CorrectSignerCastItsVote`], [`CertificateCarriesCorrectVote`] and
+//! [`CorrectValidatorsFormQuorum`].
 //!
 //! [`Committee`]: linera_execution::committee::Committee
 //! [`Committee::total_votes`]: linera_execution::committee::Committee::total_votes
@@ -20,7 +21,7 @@
 //! [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
 //! [`Committee::weight`]: linera_execution::committee::Committee::weight
 
-use crate::manager::proof::model::{MaxByzantineWeight, UnforgeableSignatures};
+use crate::manager::proof::model::{CorrectValidator, MaxByzantineWeight, UnforgeableSignatures};
 
 /// **Definition (Quorum).** A *quorum* of a committee is a set `S` of pairwise distinct
 /// committee members with `w(S) ≥ q`.
@@ -71,34 +72,23 @@ pub trait Intersection: ThresholdArithmetic {}
 /// intersection cannot consist of faulty validators alone. ∎
 pub trait CorrectValidatorInIntersection: Intersection + MaxByzantineWeight {}
 
-/// **Lemma (A valid certificate embeds a quorum of votes).** If [`LiteCertificate::check`]
-/// returns `Ok` for a certificate `c` against a committee, then the signers of `c.signatures`
-/// form a [`Quorum`] of that committee, and each of them holds a valid signature over the single
-/// [`SignedVotePayload`]
+/// **Lemma (A valid certificate embeds a quorum).** If [`LiteCertificate::check`] returns `Ok`
+/// for a certificate `c` against a committee, then the signers of `c.signatures` form a
+/// [`Quorum`] of that committee.
 ///
-/// ```text
-/// (c.value.value_hash, c.round, c.value.kind, c.unlocking_round, c.first_round,
-///  c.justification_commitment)
-/// ```
+/// *Proof.* [`LiteCertificate::check`] passes `c.signatures` to the crate-private helper
+/// `check_signatures`, which (1) rejects a repeated signer with
+/// [`ChainError::CertificateValidatorReuse`], establishing pairwise distinctness; (2) rejects any
+/// signer whose [`Committee::weight`] is `0` with [`ChainError::InvalidSigner`], establishing
+/// committee membership; and (3) accumulates the signers' weights and rejects a total below
+/// [`Committee::quorum_threshold`] with [`ChainError::CertificateRequiresQuorum`], establishing
+/// `w(S) ≥ q`. Those three are precisely [`Quorum`]. ∎
 ///
-/// *Proof.* [`LiteCertificate::check`] constructs exactly that
-/// [`VoteValue`](crate::data_types::VoteValue) and passes it, with `c.signatures`, to the
-/// crate-private helper `check_signatures`. That function, in order:
-///
-/// 1. rejects a repeated signer with [`ChainError::CertificateValidatorReuse`], establishing
-///    pairwise distinctness;
-/// 2. rejects any signer whose [`Committee::weight`] is `0` with
-///    [`ChainError::InvalidSigner`], establishing committee membership;
-/// 3. accumulates the signers' weights and rejects a total below
-///    [`Committee::quorum_threshold`] with [`ChainError::CertificateRequiresQuorum`],
-///    establishing `w(S) ≥ q`;
-/// 4. verifies every signature against the payload with `ValidatorSignature::verify_batch`,
-///    propagating any failure.
-///
-/// Steps 1–3 are precisely [`Quorum`]; step 4 is the signature claim. ∎
+/// This says nothing about the signatures themselves; that is [`CertificateSignaturesVerify`],
+/// kept apart because the two halves are consumed by different arguments and rest on different
+/// things.
 ///
 /// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
-/// [`SignedVotePayload`]: super::objects::SignedVotePayload
 /// [`ChainError::CertificateValidatorReuse`]: crate::ChainError::CertificateValidatorReuse
 /// [`ChainError::InvalidSigner`]: crate::ChainError::InvalidSigner
 /// [`ChainError::CertificateRequiresQuorum`]: crate::ChainError::CertificateRequiresQuorum
@@ -106,21 +96,98 @@ pub trait CorrectValidatorInIntersection: Intersection + MaxByzantineWeight {}
 /// [`Committee::quorum_threshold`]: linera_execution::committee::Committee::quorum_threshold
 pub trait CertificateEmbedsQuorum {}
 
-/// **Corollary (Every valid certificate carries a correct validator's vote).** For every
-/// certificate valid for its committee there is at least one *correct* validator that itself
-/// cast a vote with that certificate's exact signed payload.
+/// **Lemma (Every signature on a valid certificate verifies).** If [`LiteCertificate::check`]
+/// returns `Ok` for a certificate `c`, then *each individual* signer of `c.signatures` holds a
+/// signature that verifies over the single [`SignedVotePayload`]
 ///
-/// This is the workhorse that turns "a certificate exists" into "a correct validator executed
-/// the code path that produces this vote", and thereby lets the local implementation properties
-/// of [`crate::manager::proof::voting`] constrain what certificates can exist at all.
+/// ```text
+/// (c.value.value_hash, c.round, c.value.kind, c.unlocking_round, c.first_round,
+///  c.justification_commitment)
+/// ```
+///
+/// *Proof.* [`LiteCertificate::check`] constructs exactly that
+/// [`VoteValue`](crate::data_types::VoteValue) and passes it, with `c.signatures`, to
+/// `check_signatures`, whose final step calls `ValidatorSignature::verify_batch` and propagates
+/// any failure. For [`ValidatorSignature`] — an alias of `Secp256k1Signature` — that function is
+/// a loop of individual verifications returning on the first failure:
+///
+/// ```text
+/// for (author, signature) in votes {
+///     signature.verify_inner::<T>(prehash, *author)?;
+/// }
+/// ```
+///
+/// so acceptance of the whole is acceptance of each. ∎
+///
+/// **This is a property of the signature scheme, not of `check_signatures`.** The inference "the
+/// batch verified, therefore this particular signature verified" is a tautology only for a loop.
+/// `Ed25519Signature::verify_batch` — present in the crate, and marked unused in consensus — is a
+/// genuine batch scheme that differs in two ways:
+///
+/// * its soundness is *probabilistic*: it draws a random 128-bit scalar per signature and checks
+///   one aggregate equation, so an invalid signature survives with negligible but nonzero
+///   probability;
+/// * it does not accept the same set as single verification. `VerifyingKey::verify_strict`
+///   rejects small-order components explicitly and the batch path does not, and `ed25519-dalek`'s
+///   own documentation describes a malleability under which a mutated signature passes the batch
+///   though it "will not pass single signature verification".
+///
+/// Switching [`ValidatorSignature`] to such a scheme would leave
+/// [`CertificateCarriesCorrectVote`] standing — it needs only that *some* signature was produced
+/// by a correct validator — while silently invalidating this lemma and everything pointwise built
+/// on it. [`ConflictCompleteness`] is the sharp end: it extracts signatures out of certificates
+/// and re-verifies them *individually* through [`EquivocationProof::check`], so a batch/single
+/// divergence would make [`extract_equivocations`] emit proofs that verification rejects,
+/// breaking accountability completeness exactly where it is needed.
+///
+/// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`SignedVotePayload`]: super::objects::SignedVotePayload
+/// [`ValidatorSignature`]: linera_base::crypto::ValidatorSignature
+/// [`ConflictCompleteness`]: crate::justification::proof::ConflictCompleteness
+/// [`EquivocationProof::check`]: crate::justification::EquivocationProof::check
+/// [`extract_equivocations`]: crate::justification::extract_equivocations
+pub trait CertificateSignaturesVerify {}
+
+/// **Lemma (A correct signer of a valid certificate cast its vote).** If a certificate `c` is
+/// valid for a committee and a *correct* validator `v` is among its signers, then `v` itself cast
+/// a vote with `c`'s exact signed payload.
+///
+/// This is the *pointwise* form, about a validator identified by other means — in practice by
+/// [`CorrectValidatorInIntersection`]. It is what every quorum-intersection argument in the
+/// specification actually uses. [`CertificateCarriesCorrectVote`] is the weaker existential form,
+/// which names no particular validator and so cannot discharge those arguments.
+///
+/// *Proof.* By [`CertificateSignaturesVerify`], `v`'s signature verifies over `c`'s payload. By
+/// [`UnforgeableSignatures`] no party without `v`'s secret key produces a signature that verifies
+/// for `v`, so `v` produced it. By [`CorrectValidator`], a correct validator's signatures are
+/// produced only by this code driven through its public entry points, so producing that signature
+/// means casting that vote. ∎
+///
+/// Note what this does *not* need: no [`MaxByzantineWeight`], no [`ThresholdArithmetic`], no
+/// [`Quorum`]. The hypothesis already hands us the validator, so none of the weight machinery is
+/// involved — which is why this form, unlike the existential one, is available to
+/// [`crate::justification::proof`], where the fault bound is assumed *not* to hold.
+pub trait CorrectSignerCastItsVote:
+    CertificateSignaturesVerify + UnforgeableSignatures + CorrectValidator
+{
+}
+
+/// **Corollary (Every valid certificate carries a correct validator's vote).** For every
+/// certificate valid for its committee there is at least one *correct* validator that itself cast
+/// a vote with that certificate's exact signed payload.
+///
+/// This is the *existential* form. It turns "a certificate exists" into "a correct validator
+/// executed the code path that produces this vote", and thereby lets the local implementation
+/// properties of [`crate::manager::proof::voting`] constrain what certificates can exist at all.
+/// Where an argument needs a *particular* validator — every quorum-intersection argument — use
+/// [`CorrectSignerCastItsVote`] instead.
 ///
 /// *Proof.* By [`CertificateEmbedsQuorum`] the signers form a quorum, of weight at least `q`. By
 /// [`ThresholdArithmetic`], `q ≥ (N + f⁺)/2 ≥ f⁺`, using `N ≥ f⁺ = ⌈N/3⌉`. By
-/// [`MaxByzantineWeight`] faulty validators hold at most `f⁺ − 1`, so some signer is correct. By
-/// [`UnforgeableSignatures`] its signature cannot have been produced by anyone else, so that
-/// correct validator signed the payload itself. ∎
+/// [`MaxByzantineWeight`] faulty validators hold at most `f⁺ − 1`, so some signer is correct.
+/// Apply [`CorrectSignerCastItsVote`] to it. ∎
 pub trait CertificateCarriesCorrectVote:
-    CertificateEmbedsQuorum + ThresholdArithmetic + MaxByzantineWeight + UnforgeableSignatures
+    CorrectSignerCastItsVote + CertificateEmbedsQuorum + ThresholdArithmetic + MaxByzantineWeight
 {
 }
 

--- a/linera-chain/src/data_types/proof/quorum.rs
+++ b/linera-chain/src/data_types/proof/quorum.rs
@@ -84,9 +84,7 @@ pub trait CorrectValidatorInIntersection: Intersection + MaxByzantineWeight {}
 /// [`Committee::quorum_threshold`] with [`ChainError::CertificateRequiresQuorum`], establishing
 /// `w(S) ≥ q`. Those three are precisely [`Quorum`]. ∎
 ///
-/// This says nothing about the signatures themselves; that is [`CertificateSignaturesVerify`],
-/// kept apart because the two halves are consumed by different arguments and rest on different
-/// things.
+/// The signatures themselves are [`CertificateSignaturesVerify`].
 ///
 /// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
 /// [`ChainError::CertificateValidatorReuse`]: crate::ChainError::CertificateValidatorReuse
@@ -152,10 +150,8 @@ pub trait CertificateSignaturesVerify {}
 /// valid for a committee and a *correct* validator `v` is among its signers, then `v` itself cast
 /// a vote with `c`'s exact signed payload.
 ///
-/// This is the *pointwise* form, about a validator identified by other means — in practice by
-/// [`CorrectValidatorInIntersection`]. It is what every quorum-intersection argument in the
-/// specification actually uses. [`CertificateCarriesCorrectVote`] is the weaker existential form,
-/// which names no particular validator and so cannot discharge those arguments.
+/// The validator is identified by other means — in practice by
+/// [`CorrectValidatorInIntersection`]. [`CertificateCarriesCorrectVote`] is the existential form.
 ///
 /// *Proof.* By [`CertificateSignaturesVerify`], `v`'s signature verifies over `c`'s payload. By
 /// [`UnforgeableSignatures`] no party without `v`'s secret key produces a signature that verifies
@@ -176,11 +172,10 @@ pub trait CorrectSignerCastItsVote:
 /// certificate valid for its committee there is at least one *correct* validator that itself cast
 /// a vote with that certificate's exact signed payload.
 ///
-/// This is the *existential* form. It turns "a certificate exists" into "a correct validator
-/// executed the code path that produces this vote", and thereby lets the local implementation
-/// properties of [`crate::manager::proof::voting`] constrain what certificates can exist at all.
-/// Where an argument needs a *particular* validator — every quorum-intersection argument — use
-/// [`CorrectSignerCastItsVote`] instead.
+/// This turns "a certificate exists" into "a correct validator executed the code path that
+/// produces this vote", and thereby lets the local implementation properties of
+/// [`crate::manager::proof::voting`] constrain what certificates can exist at all. An argument
+/// about a *particular* validator needs [`CorrectSignerCastItsVote`].
 ///
 /// *Proof.* By [`CertificateEmbedsQuorum`] the signers form a quorum, of weight at least `q`. By
 /// [`ThresholdArithmetic`], `q ≥ (N + f⁺)/2 ≥ f⁺`, using `N ≥ f⁺ = ⌈N/3⌉`. By

--- a/linera-chain/src/justification/proof.rs
+++ b/linera-chain/src/justification/proof.rs
@@ -30,7 +30,9 @@
 //! [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
 
 use crate::{
-    data_types::proof::quorum::{CertificateEmbedsQuorum, Intersection, ThresholdArithmetic},
+    data_types::proof::quorum::{
+        CertificateEmbedsQuorum, CertificateSignaturesVerify, Intersection, ThresholdArithmetic,
+    },
     manager::proof::{
         commit::{
             CertifiedBlockWasExecuted, CommitRestsOnValidation, IncomingBundlesAreSelfDerived,
@@ -326,8 +328,9 @@ pub trait ChainTilesRounds {}
 ///
 /// * **`r = s`.** `double_confirm` walks the intersection of the two confirmation quorums, which
 ///   by [`Intersection`] has weight at least `f⁺`, emitting a [`DoubleVote`] for each member. Each
-///   is accepted: the blocks differ, the chain and height agree, and both signatures were taken
-///   from verified quorums.
+///   is accepted: the blocks differ, the chain and height agree, and by
+///   [`CertificateSignaturesVerify`] both extracted signatures verify individually — which is
+///   what [`EquivocationProof::check`] re-checks.
 /// * **`r < s` and the higher certificate carries a chain.** By [`ChainTilesRounds`] some link's
 ///   window contains `r`, i.e. `link.round > r` and its unlocking round is `≤ r` — precisely
 ///   `walk_chain`'s guard. That link is a quorum, so its intersection with the lower confirmation
@@ -356,8 +359,14 @@ pub trait ChainTilesRounds {}
 /// [`LockViolation`]: crate::justification::EquivocationProof::LockViolation
 /// [`FirstRoundViolation`]: crate::justification::EquivocationProof::FirstRoundViolation
 /// [`LiteCertificate::check`]: crate::types::LiteCertificate::check
+/// [`CertificateSignaturesVerify`]: crate::data_types::proof::quorum::CertificateSignaturesVerify
 pub trait ConflictCompleteness:
-    ChainTilesRounds + SoundChain + Intersection + CertificateEmbedsQuorum + ThresholdArithmetic
+    ChainTilesRounds
+    + SoundChain
+    + Intersection
+    + CertificateEmbedsQuorum
+    + CertificateSignaturesVerify
+    + ThresholdArithmetic
 {
 }
 
@@ -394,8 +403,9 @@ pub trait ChainAuditability: SoundChain + CertificateEmbedsQuorum {}
 ///
 /// *Proof.* By [`CertificateEmbedsQuorum`] both signature sets are quorums; by [`Intersection`]
 /// their intersection has weight at least `f⁺`; `double_vote` emits a proof for each member, with
-/// `kind = Validated` and the round both share. Each is accepted, the blocks differing and the
-/// chain and height agreeing. ∎
+/// `kind = Validated` and the round both share. Each is accepted: the blocks differ, the chain and
+/// height agree, and by [`CertificateSignaturesVerify`] the extracted signatures verify
+/// individually. ∎
 ///
 /// This is the accountability counterpart of
 /// [`UniqueValidatedBlockPerRound`](crate::manager::proof::locking::UniqueValidatedBlockPerRound):
@@ -407,8 +417,9 @@ pub trait ChainAuditability: SoundChain + CertificateEmbedsQuorum {}
 /// [`extract_double_validations`]: crate::justification::extract_double_validations
 /// [`DoubleVote`]: crate::justification::EquivocationProof::DoubleVote
 /// [`Committee::validity_threshold`]: linera_execution::committee::Committee::validity_threshold
+/// [`CertificateSignaturesVerify`]: crate::data_types::proof::quorum::CertificateSignaturesVerify
 pub trait DoubleValidationCompleteness:
-    Intersection + CertificateEmbedsQuorum + ThresholdArithmetic
+    Intersection + CertificateEmbedsQuorum + CertificateSignaturesVerify + ThresholdArithmetic
 {
 }
 

--- a/linera-chain/src/manager/proof/locking.rs
+++ b/linera-chain/src/manager/proof/locking.rs
@@ -277,11 +277,6 @@ pub trait OneConfirmationVotePerRound:
 /// [`CorrectSignerCastItsVote`], `v` cast validation votes for `B₁` and for `B₂`, both in
 /// round `s`. By [`OneValidationVotePerRound`], `B₁ = B₂`. ∎
 ///
-/// The pointwise [`CorrectSignerCastItsVote`] is essential here, and its existential counterpart
-/// [`CertificateCarriesCorrectVote`] would not do: the latter yields *some* correct signer of
-/// each certificate, with no reason the two are the same validator, whereas the contradiction
-/// needs the one the intersection handed us.
-///
 /// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
 /// [`CertificateEmbedsQuorum`]: crate::data_types::proof::quorum::CertificateEmbedsQuorum
 pub trait UniqueValidatedBlockPerRound:

--- a/linera-chain/src/manager/proof/locking.rs
+++ b/linera-chain/src/manager/proof/locking.rs
@@ -41,7 +41,10 @@
 //! [`ManagerSafetySnapshot::restore`]: crate::manager::ManagerSafetySnapshot::restore
 
 use crate::{
-    data_types::proof::quorum::{CertificateCarriesCorrectVote, CorrectValidatorInIntersection},
+    data_types::proof::quorum::{
+        CertificateCarriesCorrectVote, CertificateEmbedsQuorum, CorrectSignerCastItsVote,
+        CorrectValidatorInIntersection,
+    },
     manager::proof::{
         model::{ConsensusInstance, DurablePersistence, EpochAgreement},
         rounds::{CurrentRoundMonotone, RoundFloor, VoteRoundBelowCurrentRound},
@@ -271,15 +274,21 @@ pub trait OneConfirmationVotePerRound:
 /// [`EpochAgreement`] they are judged against the same committee, so by
 /// [`CertificateEmbedsQuorum`] their signer sets are two quorums of it, and by
 /// [`CorrectValidatorInIntersection`] some correct validator `v` signed both. By
-/// [`CertificateCarriesCorrectVote`], `v` cast validation votes for `B₁` and for `B₂`, both in
+/// [`CorrectSignerCastItsVote`], `v` cast validation votes for `B₁` and for `B₂`, both in
 /// round `s`. By [`OneValidationVotePerRound`], `B₁ = B₂`. ∎
+///
+/// The pointwise [`CorrectSignerCastItsVote`] is essential here, and its existential counterpart
+/// [`CertificateCarriesCorrectVote`] would not do: the latter yields *some* correct signer of
+/// each certificate, with no reason the two are the same validator, whereas the contradiction
+/// needs the one the intersection handed us.
 ///
 /// [`ValidatedBlockCertificate`]: crate::types::ValidatedBlockCertificate
 /// [`CertificateEmbedsQuorum`]: crate::data_types::proof::quorum::CertificateEmbedsQuorum
 pub trait UniqueValidatedBlockPerRound:
     OneValidationVotePerRound
     + CorrectValidatorInIntersection
-    + CertificateCarriesCorrectVote
+    + CertificateEmbedsQuorum
+    + CorrectSignerCastItsVote
     + EpochAgreement
 {
 }

--- a/linera-chain/src/manager/proof/safety.rs
+++ b/linera-chain/src/manager/proof/safety.rs
@@ -14,7 +14,9 @@
 //! the protocol makes no progress at all.
 
 use crate::{
-    data_types::proof::quorum::{CertificateCarriesCorrectVote, CorrectValidatorInIntersection},
+    data_types::proof::quorum::{
+        CertificateEmbedsQuorum, CorrectSignerCastItsVote, CorrectValidatorInIntersection,
+    },
     manager::proof::{
         commit::{CommitRestsOnValidation, TipAdvancesOnlyOnValidCertificate},
         locking::{
@@ -22,7 +24,7 @@ use crate::{
             OneConfirmationVotePerRound, OneValidationVotePerRound, SafetyStateRecovery,
             UniqueValidatedBlockPerRound,
         },
-        model::{ConflictingBlocks, DeterministicExecution, EpochAgreement, UnforgeableSignatures},
+        model::{ConflictingBlocks, DeterministicExecution, EpochAgreement},
         rounds::{CurrentRoundMonotone, VoteRoundBelowCurrentRound},
         voting::{
             ConfirmationNeedsValidatedCertificate, FastConfirmationNeedsEmptyLock,
@@ -107,9 +109,10 @@ pub trait UnlockingJustification:
 ///
 /// *Proof.* Strong induction on `s ≥ r`. Assume the claim for all `t` with `r ≤ t < s`, and let
 /// `C'` be a valid [`ValidatedBlockCertificate`] for `B` in round `s`. By [`EpochAgreement`] the
-/// confirmed certificate and `C'` are judged against the same committee, so by
-/// [`CorrectValidatorInIntersection`] their signer sets share a correct validator `v`, and by
-/// [`CertificateCarriesCorrectVote`] and [`UnforgeableSignatures`] `v` itself cast both votes:
+/// confirmed certificate and `C'` are judged against the same committee; by
+/// [`CertificateEmbedsQuorum`] both signer sets are quorums of it, so by
+/// [`CorrectValidatorInIntersection`] they share a correct validator `v`, and by
+/// [`CorrectSignerCastItsVote`] `v` itself cast both votes:
 /// a confirmation vote for `A` in round `r` (call it **(a)**) and a validation vote for `B` in
 /// round `s` (call it **(b)**).
 ///
@@ -168,8 +171,8 @@ pub trait LockPreservation:
     + VoteRoundBelowCurrentRound
     + CurrentRoundMonotone
     + CorrectValidatorInIntersection
-    + CertificateCarriesCorrectVote
-    + UnforgeableSignatures
+    + CertificateEmbedsQuorum
+    + CorrectSignerCastItsVote
     + EpochAgreement
 {
 }
@@ -181,12 +184,20 @@ pub trait LockPreservation:
 /// *Proof.* Let valid confirmed certificates for `A` in round `r` and for `B` in round `s`
 /// exist, with `r ≤ s` after renaming.
 ///
-/// * If `r = s`: by [`EpochAgreement`] and [`CorrectValidatorInIntersection`] a correct validator
-///   signed both, and by [`CertificateCarriesCorrectVote`] cast confirmation votes for `A` and
-///   for `B` in round `r`. By [`OneConfirmationVotePerRound`], `A = B`.
+/// * If `r = s`: by [`EpochAgreement`] both are judged against the same committee, and by
+///   [`CertificateEmbedsQuorum`] their signer sets are quorums of it, so by
+///   [`CorrectValidatorInIntersection`] a correct validator `v` signed both. By
+///   [`CorrectSignerCastItsVote`], `v` cast confirmation votes for `A` and for `B` in round `r`.
+///   By [`OneConfirmationVotePerRound`], `A = B`.
 /// * If `r < s`: then `s` is not [`Round::Fast`], so [`CommitRestsOnValidation`] gives a valid
 ///   [`ValidatedBlockCertificate`] for `B` in round `s`. By [`LockPreservation`], applied to the
 ///   commit of `A` in round `r` and to `s > r`, that certificate certifies `A`. Hence `B = A`. ∎
+///
+/// The two cases look asymmetric in their use of [`CorrectValidatorInIntersection`], but only the
+/// first uses it *directly*: the second delegates to [`LockPreservation`], whose own proof opens
+/// with the same intersection step. Nor could the first case be folded into the second — the
+/// delegation route runs through [`CommitRestsOnValidation`], which says nothing about
+/// [`Round::Fast`], so `r = s = Round::Fast` would be left uncovered.
 ///
 /// *In observable terms.* Combining with [`TipAdvancesOnlyOnValidCertificate`]: if any correct
 /// validator's [`ChainTipState`] records a block hash at height `h`, then no correct validator
@@ -202,7 +213,8 @@ pub trait CommitAgreement:
     + CommitRestsOnValidation
     + OneConfirmationVotePerRound
     + CorrectValidatorInIntersection
-    + CertificateCarriesCorrectVote
+    + CertificateEmbedsQuorum
+    + CorrectSignerCastItsVote
     + ConflictingBlocks
     + EpochAgreement
     + TipAdvancesOnlyOnValidCertificate

--- a/linera-chain/src/manager/proof/safety.rs
+++ b/linera-chain/src/manager/proof/safety.rs
@@ -193,12 +193,6 @@ pub trait LockPreservation:
 ///   [`ValidatedBlockCertificate`] for `B` in round `s`. By [`LockPreservation`], applied to the
 ///   commit of `A` in round `r` and to `s > r`, that certificate certifies `A`. Hence `B = A`. ∎
 ///
-/// The two cases look asymmetric in their use of [`CorrectValidatorInIntersection`], but only the
-/// first uses it *directly*: the second delegates to [`LockPreservation`], whose own proof opens
-/// with the same intersection step. Nor could the first case be folded into the second — the
-/// delegation route runs through [`CommitRestsOnValidation`], which says nothing about
-/// [`Round::Fast`], so `r = s = Round::Fast` would be left uncovered.
-///
 /// *In observable terms.* Combining with [`TipAdvancesOnlyOnValidCertificate`]: if any correct
 /// validator's [`ChainTipState`] records a block hash at height `h`, then no correct validator
 /// ever records a different hash at `h` — whatever the network does, and whatever the faulty


### PR DESCRIPTION
## Motivation

Two defects in the consensus proofs, both found by reading `safety::CommitAgreement` closely.

**1. An existential statement is cited where a pointwise one is needed.**

`quorum::CertificateCarriesCorrectVote` says: *there is at least one* correct validator that cast a vote with the certificate's payload. It names no particular validator. But three proofs use it to make a claim about a validator identified by **other** means — the one a quorum intersection handed them:

```
* If `r = s`: by EpochAgreement and CorrectValidatorInIntersection a correct validator
  signed both, and by CertificateCarriesCorrectVote cast confirmation votes for `A` and
  for `B` in round `r`.
```

The corollary gives *some* correct signer of certificate A and *some* correct signer of certificate B, with no reason either is the `v` the intersection produced. The inference does not go through as cited. Same shape in `safety::LockPreservation` and `locking::UniqueValidatedBlockPerRound`. The other five uses of the corollary are genuinely existential and are fine.

The conclusions are all true — what those proofs need is available — so this is a defect in the proof's dependency structure, not a soundness hole. The supertrait lists were not *unsound* either, since the corollary transitively pulls in the right statements; but that was luck, and it made `UniqueValidatedBlockPerRound` look as though it depended on `MaxByzantineWeight` *through the certificate*, when the real fault-bound dependency is `CorrectValidatorInIntersection`.

**2. `CommitAgreement`'s two cases looked asymmetric in their use of the intersection.**

The `r < s` case never mentions `CorrectValidatorInIntersection`, which is surprising until you notice it delegates to `LockPreservation`, whose own proof opens with exactly that step. Nothing said so.

## Proposal

**Split `CertificateEmbedsQuorum` into its two independent halves.** It asserted four things — distinctness, membership, quorum weight, and signature validity — and different arguments consume different halves:

- `CertificateEmbedsQuorum` — the signers form a `Quorum` (steps 1–3 of `check_signatures`).
- `CertificateSignaturesVerify` — *each individual* signature verifies over the payload (step 4).

**Add the pointwise lemma** the intersection arguments actually use:

> **Lemma (A correct signer of a valid certificate cast its vote).** If a certificate is valid and a *correct* validator `v` is among its signers, then `v` itself cast a vote with that certificate's exact payload.

```rust
CorrectSignerCastItsVote:      CertificateSignaturesVerify + UnforgeableSignatures + CorrectValidator
CertificateCarriesCorrectVote: CorrectSignerCastItsVote + CertificateEmbedsQuorum
                               + ThresholdArithmetic + MaxByzantineWeight
```

Note what the pointwise form does **not** need: no `MaxByzantineWeight`, no `ThresholdArithmetic`, no `Quorum`. The hypothesis already hands over the validator, so no weight machinery is involved — which is why it, unlike the existential form, is available to `justification::proof`, where the fault bound is assumed *not* to hold. The existential becomes a two-line corollary of it plus the counting argument, which is what it always was.

The three call sites now cite `CertificateEmbedsQuorum` (to know the signer sets are quorums, previously left implicit) and `CorrectSignerCastItsVote`. `CommitAgreement` gains a paragraph on why the cases differ, including why the first cannot be folded into the second: the delegation route runs through `CommitRestsOnValidation`, which says nothing about `Round::Fast`, so `r = s = Round::Fast` would be uncovered.

## The batch-verification hazard, now recorded

Splitting the lemma exposed something worth writing down. `CertificateSignaturesVerify` rests on "the batch verified, therefore *this* signature verified" — a tautology only because `ValidatorSignature = Secp256k1Signature`, whose `verify_batch` is a loop returning on first failure. It is a property of the **signature scheme**, not of `check_signatures`.

`Ed25519Signature::verify_batch` is in the crate (marked unused in consensus) and is a genuine batch scheme that differs twice over: its soundness is probabilistic (a random 128-bit scalar per signature against one aggregate equation), and it does not accept the same set as single verification — `verify_strict` rejects small-order components and the batch path does not, and `ed25519-dalek`'s own docs describe a malleability where a mutated signature passes the batch though it "will not pass single signature verification".

The consequence is sharper than proof hygiene, and it is why the pointwise/existential split matters beyond citation tidiness: `ConflictCompleteness` extracts signatures out of certificates and re-verifies them *individually* through `EquivocationProof::check`. Under a batch/single divergence, `extract_equivocations` would emit proofs that verification rejects — breaking accountability completeness exactly where it is needed — while the existential statement, and everything resting only on it, would stand unaffected.

`ConflictCompleteness` and `DoubleValidationCompleteness` now cite `CertificateSignaturesVerify` explicitly for that re-verification step.

## Test Plan

Documentation-only.

- `cargo doc --no-deps -p linera-chain -p linera-core -p linera-spec` with `RUSTDOCFLAGS="-A rustdoc::redundant_explicit_links -D warnings"` — clean.
- `cargo check -p linera-chain` — clean. A supertrait cycle would fail here (`E0391`).
- `cargo clippy -p linera-chain --all-targets`, `cargo +nightly fmt --all -- --check` — clean.
- `cargo test -p linera-chain --lib` — 80 passed, 0 failed.
- Dependency DAG re-extracted from `rustdoc --output-format json`: 98 statements, 217 edges, 39 leaves. `CorrectSignerCastItsVote` depends on `CertificateSignaturesVerify + CorrectValidator + UnforgeableSignatures` — no weight statements — and is used by `CertificateCarriesCorrectVote`, `CommitAgreement`, `LockPreservation`, `UniqueValidatedBlockPerRound`, which is exactly the intended shape.

## Release Plan

- Nothing to do / These changes follow the usual release cycle.

## Links

- #6674 — the specification.
- #6589 — also touches `manager/proof/safety.rs`; the hunks are in different regions, but expect a small rebase on whichever lands second.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
